### PR TITLE
Add scoring criteria to Free Response Widget

### DIFF
--- a/.changeset/mean-items-share.md
+++ b/.changeset/mean-items-share.md
@@ -1,0 +1,8 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus-score": patch
+---
+
+Add scoring criteria to the Free Response Widget

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1677,7 +1677,7 @@ export type PerseusFreeResponseWidgetScoringCriterion = {
 export type PerseusFreeResponseWidgetOptions = {
     // The question text that will be displayed to the user.
     question: string;
-    // A list of scoring criteria for the free-response question. This is a list
+    // A list of scoring criteria for the free response question. This is a list
     // of things the answer should contain to be considered correct.
     scoringCriteria: ReadonlyArray<PerseusFreeResponseWidgetScoringCriterion>;
 };

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1666,8 +1666,20 @@ export type PerseusPythonProgramWidgetOptions = {
     height: number;
 };
 
+// This is an object instead of just a string because we think we'll want to add more
+// fields in the future, like a weight, which would allow us to give partial credit
+// and weight each criterion separately.
+export type PerseusFreeResponseWidgetScoringCriterion = {
+    // An English-language description of how to score the response for this criterion.
+    text: string;
+};
+
 export type PerseusFreeResponseWidgetOptions = {
+    // The question text that will be displayed to the user.
     question: string;
+    // A list of scoring criteria for the free-response question. This is a list
+    // of things the answer should contain to be considered correct.
+    scoringCriteria: ReadonlyArray<PerseusFreeResponseWidgetScoringCriterion>;
 };
 
 export type PerseusIFrameWidgetOptions = {

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -129,6 +129,7 @@ export {default as getOrdererPublicWidgetOptions} from "./widgets/orderer/ordere
 export {default as getCategorizerPublicWidgetOptions} from "./widgets/categorizer/categorizer-util";
 export {default as getCSProgramPublicWidgetOptions} from "./widgets/cs-program/cs-program-util";
 export {default as getExpressionPublicWidgetOptions} from "./widgets/expression/expression-util";
+export {default as getFreeResponsePublicWidgetOptions} from "./widgets/free-response/free-response-util";
 export {default as getGrapherPublicWidgetOptions} from "./widgets/grapher/grapher-util";
 export {
     default as getInteractiveGraphPublicWidgetOptions,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/free-response-widget.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/free-response-widget.test.ts
@@ -14,6 +14,11 @@ describe("freeResponseWidget", () => {
             graded: false,
             options: {
                 question: "What is your favorite color?",
+                scoringCriteria: [
+                    {
+                        text: "test-criterion",
+                    },
+                ],
             },
         };
 
@@ -27,6 +32,11 @@ describe("freeResponseWidget", () => {
                 graded: false,
                 options: {
                     question: "What is your favorite color?",
+                    scoringCriteria: [
+                        {
+                            text: "test-criterion",
+                        },
+                    ],
                 },
             }),
         );

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/free-response-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/free-response-widget.ts
@@ -1,4 +1,4 @@
-import {constant, object, string} from "../general-purpose-parsers";
+import {array, constant, object, string} from "../general-purpose-parsers";
 
 import {parseWidget} from "./widget";
 
@@ -9,5 +9,10 @@ export const parseFreeResponseWidget: Parser<FreeResponseWidget> = parseWidget(
     constant("free-response"),
     object({
         question: string,
+        scoringCriteria: array(
+            object({
+                text: string,
+            }),
+        ),
     }),
 );

--- a/packages/perseus-core/src/widgets/free-response/free-response-util.test.ts
+++ b/packages/perseus-core/src/widgets/free-response/free-response-util.test.ts
@@ -1,0 +1,25 @@
+import getFreeResponsePublicWidgetOptions from "./free-response-util";
+
+import type {PerseusFreeResponseWidgetOptions} from "../../data-schema";
+
+describe("getFreeResponsePublicWidgetOptions", () => {
+    it("should return the correct public options without any answer data", () => {
+        // Arrange
+        const options: PerseusFreeResponseWidgetOptions = {
+            question: "What is the wind speed velocity of an unladen swallow?",
+            scoringCriteria: [
+                {
+                    text: "Depends on whether it's an African or European swallow",
+                },
+            ],
+        };
+
+        // Act
+        const publicWidgetOptions = getFreeResponsePublicWidgetOptions(options);
+
+        // Assert
+        expect(publicWidgetOptions).toEqual({
+            question: "What is the wind speed velocity of an unladen swallow?",
+        });
+    });
+});

--- a/packages/perseus-core/src/widgets/free-response/free-response-util.ts
+++ b/packages/perseus-core/src/widgets/free-response/free-response-util.ts
@@ -2,7 +2,7 @@ import type {PerseusFreeResponseWidgetOptions} from "@khanacademy/perseus-core";
 
 /**
  * For details on the individual options, see the
- * PerseusFreeResponseWidgetOptions type
+ * {@link PerseusFreeResponseWidgetOptions} type
  */
 export type FreeResponsePublicWidgetOptions = {
     question: PerseusFreeResponseWidgetOptions["question"];

--- a/packages/perseus-core/src/widgets/free-response/free-response-util.ts
+++ b/packages/perseus-core/src/widgets/free-response/free-response-util.ts
@@ -1,0 +1,23 @@
+import type {PerseusFreeResponseWidgetOptions} from "@khanacademy/perseus-core";
+
+/**
+ * For details on the individual options, see the
+ * PerseusFreeResponseWidgetOptions type
+ */
+export type FreeResponsePublicWidgetOptions = {
+    question: PerseusFreeResponseWidgetOptions["question"];
+};
+
+/**
+ * Given a FreeResponsePublicWidgetOptions object, return a new object with only
+ * the public options that should be exposed to the client.
+ */
+function getFreeResponsePublicWidgetOptions(
+    options: PerseusFreeResponseWidgetOptions,
+): FreeResponsePublicWidgetOptions {
+    return {
+        question: options.question,
+    };
+}
+
+export default getFreeResponsePublicWidgetOptions;

--- a/packages/perseus-core/src/widgets/free-response/index.ts
+++ b/packages/perseus-core/src/widgets/free-response/index.ts
@@ -3,11 +3,19 @@ import type {WidgetLogic} from "../logic-export.types";
 
 export type FreeResponseDefaultWidgetOptions = Pick<
     PerseusFreeResponseWidgetOptions,
-    "question"
+    "question" | "scoringCriteria"
 >;
 
 const defaultWidgetOptions: FreeResponseDefaultWidgetOptions = {
     question: "",
+
+    // Always display one criterion, since the user will always have to input
+    // at least one.
+    scoringCriteria: [
+        {
+            text: "",
+        },
+    ],
 };
 
 const freeResponseWidgetLogic: WidgetLogic = {

--- a/packages/perseus-core/src/widgets/free-response/index.ts
+++ b/packages/perseus-core/src/widgets/free-response/index.ts
@@ -1,3 +1,5 @@
+import getFreeResponsePublicWidgetOptions from "./free-response-util";
+
 import type {PerseusFreeResponseWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
@@ -21,6 +23,7 @@ const defaultWidgetOptions: FreeResponseDefaultWidgetOptions = {
 const freeResponseWidgetLogic: WidgetLogic = {
     name: "free-response",
     defaultWidgetOptions,
+    getPublicWidgetOptions: getFreeResponsePublicWidgetOptions,
 };
 
 export default freeResponseWidgetLogic;

--- a/packages/perseus-core/src/widgets/logic-export.types.ts
+++ b/packages/perseus-core/src/widgets/logic-export.types.ts
@@ -2,6 +2,7 @@ import type getCategorizerPublicWidgetOptions from "./categorizer/categorizer-ut
 import type getCSProgramPublicWidgetOptions from "./cs-program/cs-program-util";
 import type getDropdownPublicWidgetOptions from "./dropdown/dropdown-util";
 import type getExpressionPublicWidgetOptions from "./expression/expression-util";
+import type getFreeResponsePublicWidgetOptions from "./free-response/free-response-util";
 import type getGrapherPublicWidgetOptions from "./grapher/grapher-util";
 import type getIFramePublicWidgetOptions from "./iframe/iframe-util";
 import type getInteractiveGraphPublicWidgetOptions from "./interactive-graph/interactive-graph-util";
@@ -30,23 +31,24 @@ export type WidgetOptionsUpgradeMap = {
  * so reliant on a set group of widgets
  */
 export type PublicWidgetOptionsFunction =
-    | typeof getMatcherPublicWidgetOptions
-    | typeof getPlotterPublicWidgetOptions
-    | typeof getIFramePublicWidgetOptions
-    | typeof getRadioPublicWidgetOptions
-    | typeof getNumericInputPublicWidgetOptions
-    | typeof getDropdownPublicWidgetOptions
+    | typeof getCSProgramPublicWidgetOptions
     | typeof getCategorizerPublicWidgetOptions
-    | typeof getOrdererPublicWidgetOptions
+    | typeof getDropdownPublicWidgetOptions
     | typeof getExpressionPublicWidgetOptions
+    | typeof getFreeResponsePublicWidgetOptions
+    | typeof getGrapherPublicWidgetOptions
+    | typeof getIFramePublicWidgetOptions
     | typeof getInteractiveGraphPublicWidgetOptions
     | typeof getLabelImagePublicWidgetOptions
-    | typeof getSorterPublicWidgetOptions
-    | typeof getCSProgramPublicWidgetOptions
+    | typeof getMatcherPublicWidgetOptions
+    | typeof getMatrixPublicWidgetOptions
     | typeof getNumberLinePublicWidgetOptions
-    | typeof getTablePublicWidgetOptions
-    | typeof getGrapherPublicWidgetOptions
-    | typeof getMatrixPublicWidgetOptions;
+    | typeof getNumericInputPublicWidgetOptions
+    | typeof getOrdererPublicWidgetOptions
+    | typeof getPlotterPublicWidgetOptions
+    | typeof getRadioPublicWidgetOptions
+    | typeof getSorterPublicWidgetOptions
+    | typeof getTablePublicWidgetOptions;
 
 export type WidgetLogic = {
     name: string;

--- a/packages/perseus-editor/src/widgets/__stories__/free-response-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/free-response-editor.stories.tsx
@@ -1,6 +1,12 @@
+import * as React from "react";
+
 import FreeResponseEditor from "../free-response-editor";
 
+import type {PerseusFreeResponseWidgetOptions} from "@khanacademy/perseus-core";
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 import type {Meta, StoryObj} from "@storybook/react";
+
+type StoryArgs = Record<any, any>;
 
 const meta: Meta<typeof FreeResponseEditor> = {
     component: FreeResponseEditor,
@@ -10,6 +16,51 @@ const meta: Meta<typeof FreeResponseEditor> = {
 export default meta;
 type Story = StoryObj<typeof FreeResponseEditor>;
 
-export const Primary: Story = {
+export const NoCriteria: Story = {
     args: {},
+};
+
+export const OneCriterion: Story = {
+    args: {
+        scoringCriteria: [
+            {
+                text: "50 points for Gryffindor!",
+            },
+        ],
+    },
+};
+
+export const ThreeCriteria: Story = {
+    args: {
+        scoringCriteria: [
+            {
+                text: "50 points for Gryffindor!",
+            },
+            {
+                text: "50 points for Slytherin!",
+            },
+            {
+                text: "50 points for Hufflepuff!",
+            },
+        ],
+    },
+};
+
+const WithState = () => {
+    const [state, setState] = React.useState<
+        Partial<PropsFor<typeof FreeResponseEditor>>
+    >({
+        question: "What is is the truth?",
+        scoringCriteria: [{text: ""}],
+    });
+
+    const onChange = (options: Partial<PerseusFreeResponseWidgetOptions>) => {
+        setState({...state, ...options});
+    };
+
+    return <FreeResponseEditor {...state} onChange={onChange} />;
+};
+
+export const Editable = (args: StoryArgs): React.ReactElement => {
+    return <WithState />;
 };

--- a/packages/perseus-editor/src/widgets/__stories__/free-response-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/free-response-editor.stories.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 
 import FreeResponseEditor from "../free-response-editor";
 
-import type {PerseusFreeResponseWidgetOptions} from "@khanacademy/perseus-core";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 import type {Meta, StoryObj} from "@storybook/react";
 
@@ -46,15 +45,15 @@ export const ThreeCriteria: Story = {
     },
 };
 
+type State = Partial<PropsFor<typeof FreeResponseEditor>>;
+
 const WithState = () => {
-    const [state, setState] = React.useState<
-        Partial<PropsFor<typeof FreeResponseEditor>>
-    >({
-        question: "What is is the truth?",
+    const [state, setState] = React.useState<State>({
+        question: "What is the truth?",
         scoringCriteria: [{text: ""}],
     });
 
-    const onChange = (options: Partial<PerseusFreeResponseWidgetOptions>) => {
+    const onChange = (options: State) => {
         setState({...state, ...options});
     };
 

--- a/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
@@ -43,6 +43,25 @@ describe("free-response editor", () => {
         expect(onChangeMock).toBeCalledWith({question: "2"});
     });
 
+    it("calls onChange when a criterion is changed", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+
+        // Act
+        render(
+            <FreeResponseEditor
+                onChange={onChangeMock}
+                scoringCriteria={[{text: ""}]}
+            />,
+        );
+        await userEvent.type(screen.getByTestId("criterion-input-0"), "2");
+
+        // Assert
+        expect(onChangeMock).toBeCalledWith({
+            scoringCriteria: [{text: "2"}],
+        });
+    });
+
     it("returns a warning when the question is empty", async () => {
         // Arrange
         const ref = React.createRef<FreeResponseEditor>();
@@ -72,8 +91,34 @@ describe("free-response editor", () => {
         );
 
         // Assert
-        expect(ref.current?.serialize()).toEqual({
+        expect(ref.current?.serialize()).toMatchObject({
             question: "test-question",
+        });
+    });
+
+    it("serializes the criteria values", async () => {
+        // Arrange
+        const ref = React.createRef<FreeResponseEditor>();
+
+        // Act
+        render(
+            <FreeResponseEditor
+                ref={ref}
+                question="test-question"
+                scoringCriteria={[
+                    {text: "test-criterion-1"},
+                    {text: "test-criterion-2"},
+                ]}
+                onChange={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(ref.current?.serialize()).toMatchObject({
+            scoringCriteria: [
+                {text: "test-criterion-1"},
+                {text: "test-criterion-2"},
+            ],
         });
     });
 
@@ -85,8 +130,78 @@ describe("free-response editor", () => {
         render(<FreeResponseEditor ref={ref} onChange={() => {}} />);
 
         // Assert
-        expect(ref.current?.serialize()).toEqual({
+        expect(ref.current?.serialize()).toMatchObject({
             question: "",
+        });
+    });
+
+    it("the scoringCriteria defaults to an array with one empty value", async () => {
+        // Arrange
+        const ref = React.createRef<FreeResponseEditor>();
+
+        // Act
+        render(<FreeResponseEditor ref={ref} onChange={() => {}} />);
+
+        // Assert
+        expect(ref.current?.serialize()).toMatchObject({
+            scoringCriteria: [{text: ""}],
+        });
+    });
+
+    it("adds another criterion when the add button is clicked", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+
+        // Act
+        render(
+            <FreeResponseEditor
+                scoringCriteria={[{text: "criterion-1"}]}
+                onChange={onChangeMock}
+            />,
+        );
+        await userEvent.click(
+            screen.getByRole("button", {name: /Add an item/i}),
+        );
+
+        // Assert
+        expect(onChangeMock).toBeCalledWith({
+            scoringCriteria: [{text: "criterion-1"}, {text: ""}],
+        });
+    });
+
+    it("prevents deleting the only criterion", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+
+        // Act
+        render(
+            <FreeResponseEditor
+                scoringCriteria={[{text: "criterion-1"}]}
+                onChange={onChangeMock}
+            />,
+        );
+        await userEvent.click(screen.getByRole("button", {name: /Delete/i}));
+
+        // Assert
+        expect(onChangeMock).not.toBeCalled();
+    });
+
+    it("deletes a criterion when the delete button is clicked", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+
+        // Act
+        render(
+            <FreeResponseEditor
+                scoringCriteria={[{text: "criterion-1"}, {text: "criterion-2"}]}
+                onChange={onChangeMock}
+            />,
+        );
+        await userEvent.click(screen.getByTestId("criterion-delete-button-0"));
+
+        // Assert
+        expect(onChangeMock).toBeCalledWith({
+            scoringCriteria: [{text: "criterion-2"}],
         });
     });
 });

--- a/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
@@ -54,7 +54,7 @@ describe("free-response editor", () => {
                 scoringCriteria={[{text: ""}]}
             />,
         );
-        await userEvent.type(screen.getByTestId("criterion-input-0"), "2");
+        await userEvent.type(screen.getByLabelText("Criterion 1"), "2");
 
         // Assert
         expect(onChangeMock).toBeCalledWith({
@@ -197,7 +197,9 @@ describe("free-response editor", () => {
                 onChange={onChangeMock}
             />,
         );
-        await userEvent.click(screen.getByTestId("criterion-delete-button-0"));
+        await userEvent.click(
+            screen.getByRole("button", {name: /Delete criterion 1/i}),
+        );
 
         // Assert
         expect(onChangeMock).toBeCalledWith({

--- a/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
@@ -169,7 +169,7 @@ describe("free-response editor", () => {
         });
     });
 
-    it("prevents deleting the only criterion", async () => {
+    it("prevents deleting the only criterion by hiding the delete button", async () => {
         // Arrange
         const onChangeMock = jest.fn();
 
@@ -180,7 +180,10 @@ describe("free-response editor", () => {
                 onChange={onChangeMock}
             />,
         );
-        await userEvent.click(screen.getByRole("button", {name: /Delete/i}));
+
+        expect(
+            screen.queryByRole("button", {name: /Delete/i}),
+        ).not.toBeInTheDocument();
 
         // Assert
         expect(onChangeMock).not.toBeCalled();

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -39,7 +39,7 @@ class FreeResponseEditor extends React.Component<Props> {
         return warnings;
     }
 
-    handleCriterionUpdate = (
+    handleUpdateCriterion = (
         index: number,
         criterion: PerseusFreeResponseWidgetScoringCriterion,
     ) => {
@@ -55,7 +55,7 @@ class FreeResponseEditor extends React.Component<Props> {
         });
     };
 
-    handleCriterionDelete = (index: number) => {
+    handleDeleteCriterion = (index: number) => {
         this.props.onChange({
             scoringCriteria: this.props.scoringCriteria.filter(
                 (_, i) => i !== index,
@@ -77,8 +77,8 @@ class FreeResponseEditor extends React.Component<Props> {
                     index={index}
                     key={index}
                     numCriteria={this.props.scoringCriteria.length}
-                    onChange={this.handleCriterionUpdate}
-                    onDelete={this.handleCriterionDelete}
+                    onChange={this.handleUpdateCriterion}
+                    onDelete={this.handleDeleteCriterion}
                 />
             );
         });

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -130,7 +130,7 @@ const CriterionEditor = function (props: {
     return (
         <View style={styles.criterionContainer}>
             <textarea
-                data-testid={`criterion-input-${props.index}`}
+                aria-label={`Criterion ${props.index + 1}`}
                 onChange={(e) =>
                     props.onChange(props.index, {
                         text: e.target.value,
@@ -140,8 +140,8 @@ const CriterionEditor = function (props: {
             />
             <View style={styles.deleteButtonContainer}>
                 <Button
+                    aria-label={`Delete criterion ${props.index + 1}`}
                     color="destructive"
-                    data-testid={`criterion-delete-button-${props.index}`}
                     disabled={isOnlyCriterion}
                     kind="tertiary"
                     onClick={() => props.onDelete(props.index)}

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -1,11 +1,17 @@
 import {freeResponseLogic} from "@khanacademy/perseus-core";
-import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import Button from "@khanacademy/wonder-blocks-button";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {spacing, semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {HeadingSmall} from "@khanacademy/wonder-blocks-typography";
+import plusCircleIcon from "@phosphor-icons/core/regular/plus-circle.svg";
+import trashIcon from "@phosphor-icons/core/regular/trash.svg";
+import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
 
 import type {
     PerseusFreeResponseWidgetOptions,
     FreeResponseDefaultWidgetOptions,
+    PerseusFreeResponseWidgetScoringCriterion,
 } from "@khanacademy/perseus-core";
 
 type Props = PerseusFreeResponseWidgetOptions & {
@@ -21,6 +27,7 @@ class FreeResponseEditor extends React.Component<Props> {
     serialize(): PerseusFreeResponseWidgetOptions {
         return {
             question: this.props.question,
+            scoringCriteria: this.props.scoringCriteria,
         };
     }
 
@@ -32,18 +39,141 @@ class FreeResponseEditor extends React.Component<Props> {
         return warnings;
     }
 
+    handleCriterionUpdate = (
+        index: number,
+        criterion: PerseusFreeResponseWidgetScoringCriterion,
+    ) => {
+        const newCriteria = this.props.scoringCriteria.map((c, i) => {
+            if (i === index) {
+                return criterion;
+            }
+            return c;
+        });
+
+        this.props.onChange({
+            scoringCriteria: newCriteria,
+        });
+    };
+
+    handleCriterionDelete = (index: number) => {
+        this.props.onChange({
+            scoringCriteria: this.props.scoringCriteria.filter(
+                (_, i) => i !== index,
+            ),
+        });
+    };
+
+    handleAddCriterion = () => {
+        this.props.onChange({
+            scoringCriteria: [...this.props.scoringCriteria, {text: ""}],
+        });
+    };
+
     render(): React.ReactNode {
+        const criteria = this.props.scoringCriteria.map((criterion, index) => {
+            return (
+                <CriterionEditor
+                    criterion={criterion}
+                    index={index}
+                    key={index}
+                    numCriteria={this.props.scoringCriteria.length}
+                    onChange={this.handleCriterionUpdate}
+                    onDelete={this.handleCriterionDelete}
+                />
+            );
+        });
+
         return (
-            <LabeledTextField
-                label={"Question"}
-                value={this.props.question}
-                onChange={(question: string) => this.props.onChange({question})}
-                style={{
-                    marginBottom: spacing.large_24,
-                }}
-            />
+            <View>
+                <label className={css(styles.questionContainer)}>
+                    <HeadingSmall>Question</HeadingSmall>
+                    <textarea
+                        value={this.props.question}
+                        onChange={(e) =>
+                            this.props.onChange({question: e.target.value})
+                        }
+                    />
+                </label>
+                <View>
+                    <HeadingSmall>Scoring criteria</HeadingSmall>
+                    <View style={styles.criteriaList}>{criteria}</View>
+                    <View>
+                        <Button
+                            onClick={this.handleAddCriterion}
+                            startIcon={plusCircleIcon}
+                        >
+                            Add an item
+                        </Button>
+                    </View>
+                </View>
+            </View>
         );
     }
 }
+
+const CriterionEditor = function (props: {
+    index: number;
+    numCriteria: number;
+    criterion: PerseusFreeResponseWidgetScoringCriterion;
+    onChange: (
+        index: number,
+        criterion: PerseusFreeResponseWidgetScoringCriterion,
+    ) => void;
+    onDelete: (index: number) => void;
+}): React.ReactNode {
+    const isOnlyCriterion = props.numCriteria <= 1;
+
+    return (
+        <View style={styles.criterionContainer}>
+            <textarea
+                data-testid={`criterion-input-${props.index}`}
+                onChange={(e) =>
+                    props.onChange(props.index, {
+                        text: e.target.value,
+                    })
+                }
+                value={props.criterion.text}
+            />
+            <View style={styles.deleteButtonContainer}>
+                <Button
+                    color="destructive"
+                    data-testid={`criterion-delete-button-${props.index}`}
+                    disabled={isOnlyCriterion}
+                    kind="tertiary"
+                    onClick={() => props.onDelete(props.index)}
+                    size="small"
+                    startIcon={trashIcon}
+                >
+                    Delete
+                </Button>
+            </View>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    questionContainer: {
+        display: "flex",
+        flexDirection: "column",
+        gap: spacing.xSmall_8,
+        paddingBottom: spacing.medium_16,
+    },
+    criteriaList: {
+        gap: spacing.small_12,
+    },
+    criterionContainer: {
+        paddingTop: spacing.xSmall_8,
+        paddingBottom: spacing.xSmall_8,
+        borderBottom: `1px solid ${semanticColor.border.primary}`,
+        ":last-child": {
+            borderBottom: "none",
+        },
+    },
+    deleteButtonContainer: {
+        display: "flex",
+        flexDirection: "row",
+        justifyContent: "flex-end",
+    },
+});
 
 export default FreeResponseEditor;

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -70,13 +70,15 @@ class FreeResponseEditor extends React.Component<Props> {
     };
 
     renderCriteriaList = () => {
+        const isDeletable = this.props.scoringCriteria.length > 1;
+
         return this.props.scoringCriteria.map((criterion, index) => {
             return (
                 <CriterionEditor
                     criterion={criterion}
                     index={index}
+                    isDeletable={isDeletable}
                     key={index}
-                    numCriteria={this.props.scoringCriteria.length}
                     onChange={this.handleUpdateCriterion}
                     onDelete={this.handleDeleteCriterion}
                 />
@@ -117,7 +119,7 @@ class FreeResponseEditor extends React.Component<Props> {
 
 const CriterionEditor = function (props: {
     index: number;
-    numCriteria: number;
+    isDeletable: boolean;
     criterion: PerseusFreeResponseWidgetScoringCriterion;
     onChange: (
         index: number,
@@ -125,8 +127,6 @@ const CriterionEditor = function (props: {
     ) => void;
     onDelete: (index: number) => void;
 }): React.ReactNode {
-    const isOnlyCriterion = props.numCriteria <= 1;
-
     return (
         <View style={styles.criterionContainer}>
             <textarea
@@ -139,12 +139,12 @@ const CriterionEditor = function (props: {
                 value={props.criterion.text}
             />
 
-            {!isOnlyCriterion && (
+            {props.isDeletable && (
                 <View style={styles.deleteButtonContainer}>
                     <Button
                         aria-label={`Delete criterion ${props.index + 1}`}
                         color="destructive"
-                        disabled={isOnlyCriterion}
+                        disabled={!props.isDeletable}
                         kind="tertiary"
                         onClick={() => props.onDelete(props.index)}
                         size="small"

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -69,8 +69,8 @@ class FreeResponseEditor extends React.Component<Props> {
         });
     };
 
-    render(): React.ReactNode {
-        const criteria = this.props.scoringCriteria.map((criterion, index) => {
+    renderCriteriaList = () => {
+        return this.props.scoringCriteria.map((criterion, index) => {
             return (
                 <CriterionEditor
                     criterion={criterion}
@@ -82,7 +82,9 @@ class FreeResponseEditor extends React.Component<Props> {
                 />
             );
         });
+    };
 
+    render(): React.ReactNode {
         return (
             <View>
                 <label className={css(styles.questionContainer)}>
@@ -96,7 +98,9 @@ class FreeResponseEditor extends React.Component<Props> {
                 </label>
                 <View>
                     <HeadingSmall>Scoring criteria</HeadingSmall>
-                    <View style={styles.criteriaList}>{criteria}</View>
+                    <View style={styles.criteriaList}>
+                        {this.renderCriteriaList()}
+                    </View>
                     <View>
                         <Button
                             onClick={this.handleAddCriterion}

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -138,19 +138,22 @@ const CriterionEditor = function (props: {
                 }
                 value={props.criterion.text}
             />
-            <View style={styles.deleteButtonContainer}>
-                <Button
-                    aria-label={`Delete criterion ${props.index + 1}`}
-                    color="destructive"
-                    disabled={isOnlyCriterion}
-                    kind="tertiary"
-                    onClick={() => props.onDelete(props.index)}
-                    size="small"
-                    startIcon={trashIcon}
-                >
-                    Delete
-                </Button>
-            </View>
+
+            {!isOnlyCriterion && (
+                <View style={styles.deleteButtonContainer}>
+                    <Button
+                        aria-label={`Delete criterion ${props.index + 1}`}
+                        color="destructive"
+                        disabled={isOnlyCriterion}
+                        kind="tertiary"
+                        onClick={() => props.onDelete(props.index)}
+                        size="small"
+                        startIcon={trashIcon}
+                    >
+                        Delete
+                    </Button>
+                </View>
+            )}
         </View>
     );
 };

--- a/packages/perseus/src/widgets/free-response/free-response.testdata.ts
+++ b/packages/perseus/src/widgets/free-response/free-response.testdata.ts
@@ -12,6 +12,11 @@ export function getFreeResponseItemData(): PerseusRenderer {
                 type: "free-response",
                 options: {
                     question: "test-question",
+                    scoringCriteria: [
+                        {
+                            text: "test-criterion",
+                        },
+                    ],
                 },
                 alignment: "default",
             },


### PR DESCRIPTION
## Summary:
This commit adds a new scoringCriteria option to the Free Response
Widget editor. It allows users to input one or more scoring criteria
texts, which can be used when grading the answers to a Free Response
question.

This commit also changes the "Question" input to be a textarea instead
of an input element. This allows longer questions to wrap and be fully
visible even when the widget editor is narrow.

Issue: https://khanacademy.atlassian.net/browse/LIT-1663

## Test plan:
- Run `pnpm test packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx`
- Open Storybook.
- Open the Free Response Editor stories.
- Verify that the rendered stories look right.
- Interact with the "Editable" story, verifying that it's possible to
  add new criteria and delete existing ones.
- Verify that the "Delete" button is grayed out on the "One Criterion" story.
![image](https://github.com/user-attachments/assets/5e431b75-e017-400a-8534-4471b82e2c27)
