### PR TITLE
[LX] Make static graphs' interactive elements visually disabled

### DIFF
--- a/.changeset/rotten-cups-pay.md
+++ b/.changeset/rotten-cups-pay.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[LX] Make static graphs' interactive elements visually disabled

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -1201,7 +1201,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                             points="3.5 2 2.5 4 1.5 2"
                             stroke-linejoin="round"
                             stroke-width="var(--movable-line-stroke-weight)"
-                            style="fill: transparent; fill-opacity: 0.15; stroke: var(--movable-line-stroke-color); stroke-opacity: 1; vector-effect: non-scaling-stroke; transform: var(--mafs-view-transform);"
+                            style="fill: transparent; fill-opacity: 0.15; stroke: var(--mafs-blue); stroke-opacity: 1; vector-effect: non-scaling-stroke; transform: var(--mafs-view-transform);"
                           />
                           <text
                             class="mafs-shadow"
@@ -1268,7 +1268,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                               aria-hidden="true"
                               class="movable-point"
                               data-testid="movable-point"
-                              style="--movable-point-color: #1865f2;"
+                              style="--movable-point-color: var(--mafs-blue);"
                             >
                               <circle
                                 class="movable-point-hitbox"
@@ -1296,7 +1296,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                                 cx="200"
                                 cy="-114.28571428571429"
                                 data-testid="movable-point__center"
-                                style="fill: #1865f2;"
+                                style="fill: var(--mafs-blue);"
                               />
                             </g>
                             <g
@@ -1329,7 +1329,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                               aria-hidden="true"
                               class="movable-point"
                               data-testid="movable-point"
-                              style="--movable-point-color: #1865f2;"
+                              style="--movable-point-color: var(--mafs-blue);"
                             >
                               <circle
                                 class="movable-point-hitbox"
@@ -1357,7 +1357,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                                 cx="142.85714285714286"
                                 cy="-228.57142857142858"
                                 data-testid="movable-point__center"
-                                style="fill: #1865f2;"
+                                style="fill: var(--mafs-blue);"
                               />
                             </g>
                             <g
@@ -1390,7 +1390,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                               aria-hidden="true"
                               class="movable-point"
                               data-testid="movable-point"
-                              style="--movable-point-color: #1865f2;"
+                              style="--movable-point-color: var(--mafs-blue);"
                             >
                               <circle
                                 class="movable-point-hitbox"
@@ -1418,7 +1418,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                                 cx="85.71428571428572"
                                 cy="-114.28571428571429"
                                 data-testid="movable-point__center"
-                                style="fill: #1865f2;"
+                                style="fill: var(--mafs-blue);"
                               />
                             </g>
                             <g
@@ -1641,7 +1641,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                             points="3 -2 0 3 -3 -2"
                             stroke-linejoin="round"
                             stroke-width="var(--movable-line-stroke-weight)"
-                            style="fill: transparent; fill-opacity: 0.15; stroke: var(--movable-line-stroke-color); stroke-opacity: 1; vector-effect: non-scaling-stroke; transform: var(--mafs-view-transform);"
+                            style="fill: transparent; fill-opacity: 0.15; stroke: var(--mafs-blue); stroke-opacity: 1; vector-effect: non-scaling-stroke; transform: var(--mafs-view-transform);"
                           />
                           <polygon
                             aria-label="A polygon with 3 points."
@@ -1669,7 +1669,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                               aria-hidden="true"
                               class="movable-point"
                               data-testid="movable-point"
-                              style="--movable-point-color: #1865f2;"
+                              style="--movable-point-color: var(--mafs-blue);"
                             >
                               <circle
                                 class="movable-point-hitbox"
@@ -1697,7 +1697,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                                 cx="75"
                                 cy="50"
                                 data-testid="movable-point__center"
-                                style="fill: #1865f2;"
+                                style="fill: var(--mafs-blue);"
                               />
                             </g>
                             <g
@@ -1730,7 +1730,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                               aria-hidden="true"
                               class="movable-point"
                               data-testid="movable-point"
-                              style="--movable-point-color: #1865f2;"
+                              style="--movable-point-color: var(--mafs-blue);"
                             >
                               <circle
                                 class="movable-point-hitbox"
@@ -1758,7 +1758,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                                 cx="0"
                                 cy="-75"
                                 data-testid="movable-point__center"
-                                style="fill: #1865f2;"
+                                style="fill: var(--mafs-blue);"
                               />
                             </g>
                             <g
@@ -1791,7 +1791,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                               aria-hidden="true"
                               class="movable-point"
                               data-testid="movable-point"
-                              style="--movable-point-color: #1865f2;"
+                              style="--movable-point-color: var(--mafs-blue);"
                             >
                               <circle
                                 class="movable-point-hitbox"
@@ -1819,7 +1819,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                                 cx="-75"
                                 cy="50"
                                 data-testid="movable-point__center"
-                                style="fill: #1865f2;"
+                                style="fill: var(--mafs-blue);"
                               />
                             </g>
                             <g
@@ -2310,7 +2310,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                             points=""
                             stroke-linejoin="round"
                             stroke-width="var(--movable-line-stroke-weight)"
-                            style="fill: transparent; fill-opacity: 0; stroke: var(--movable-line-stroke-color); stroke-opacity: 1; vector-effect: non-scaling-stroke; transform: var(--mafs-view-transform);"
+                            style="fill: transparent; fill-opacity: 0; stroke: var(--mafs-blue); stroke-opacity: 1; vector-effect: non-scaling-stroke; transform: var(--mafs-view-transform);"
                           />
                           <rect
                             aria-hidden="true"
@@ -2525,7 +2525,7 @@ exports[`Interactive Graph question Should render predictably: first render 1`] 
                             points="3.5 2 2.5 4 1.5 2"
                             stroke-linejoin="round"
                             stroke-width="var(--movable-line-stroke-weight)"
-                            style="fill: transparent; fill-opacity: 0.15; stroke: var(--movable-line-stroke-color); stroke-opacity: 1; vector-effect: non-scaling-stroke; transform: var(--mafs-view-transform);"
+                            style="fill: transparent; fill-opacity: 0.15; stroke: var(--mafs-blue); stroke-opacity: 1; vector-effect: non-scaling-stroke; transform: var(--mafs-view-transform);"
                           />
                           <text
                             class="mafs-shadow"
@@ -2592,7 +2592,7 @@ exports[`Interactive Graph question Should render predictably: first render 1`] 
                               aria-hidden="true"
                               class="movable-point"
                               data-testid="movable-point"
-                              style="--movable-point-color: #1865f2;"
+                              style="--movable-point-color: var(--mafs-blue);"
                             >
                               <circle
                                 class="movable-point-hitbox"
@@ -2620,7 +2620,7 @@ exports[`Interactive Graph question Should render predictably: first render 1`] 
                                 cx="200"
                                 cy="-114.28571428571429"
                                 data-testid="movable-point__center"
-                                style="fill: #1865f2;"
+                                style="fill: var(--mafs-blue);"
                               />
                             </g>
                             <g
@@ -2653,7 +2653,7 @@ exports[`Interactive Graph question Should render predictably: first render 1`] 
                               aria-hidden="true"
                               class="movable-point"
                               data-testid="movable-point"
-                              style="--movable-point-color: #1865f2;"
+                              style="--movable-point-color: var(--mafs-blue);"
                             >
                               <circle
                                 class="movable-point-hitbox"
@@ -2681,7 +2681,7 @@ exports[`Interactive Graph question Should render predictably: first render 1`] 
                                 cx="142.85714285714286"
                                 cy="-228.57142857142858"
                                 data-testid="movable-point__center"
-                                style="fill: #1865f2;"
+                                style="fill: var(--mafs-blue);"
                               />
                             </g>
                             <g
@@ -2714,7 +2714,7 @@ exports[`Interactive Graph question Should render predictably: first render 1`] 
                               aria-hidden="true"
                               class="movable-point"
                               data-testid="movable-point"
-                              style="--movable-point-color: #1865f2;"
+                              style="--movable-point-color: var(--mafs-blue);"
                             >
                               <circle
                                 class="movable-point-hitbox"
@@ -2742,7 +2742,7 @@ exports[`Interactive Graph question Should render predictably: first render 1`] 
                                 cx="85.71428571428572"
                                 cy="-114.28571428571429"
                                 data-testid="movable-point__center"
-                                style="fill: #1865f2;"
+                                style="fill: var(--mafs-blue);"
                               />
                             </g>
                             <g
@@ -2965,7 +2965,7 @@ exports[`Interactive Graph question Should render predictably: first render 2`] 
                             points="3 -2 0 3 -3 -2"
                             stroke-linejoin="round"
                             stroke-width="var(--movable-line-stroke-weight)"
-                            style="fill: transparent; fill-opacity: 0.15; stroke: var(--movable-line-stroke-color); stroke-opacity: 1; vector-effect: non-scaling-stroke; transform: var(--mafs-view-transform);"
+                            style="fill: transparent; fill-opacity: 0.15; stroke: var(--mafs-blue); stroke-opacity: 1; vector-effect: non-scaling-stroke; transform: var(--mafs-view-transform);"
                           />
                           <polygon
                             aria-label="A polygon with 3 points."
@@ -2993,7 +2993,7 @@ exports[`Interactive Graph question Should render predictably: first render 2`] 
                               aria-hidden="true"
                               class="movable-point"
                               data-testid="movable-point"
-                              style="--movable-point-color: #1865f2;"
+                              style="--movable-point-color: var(--mafs-blue);"
                             >
                               <circle
                                 class="movable-point-hitbox"
@@ -3021,7 +3021,7 @@ exports[`Interactive Graph question Should render predictably: first render 2`] 
                                 cx="75"
                                 cy="50"
                                 data-testid="movable-point__center"
-                                style="fill: #1865f2;"
+                                style="fill: var(--mafs-blue);"
                               />
                             </g>
                             <g
@@ -3054,7 +3054,7 @@ exports[`Interactive Graph question Should render predictably: first render 2`] 
                               aria-hidden="true"
                               class="movable-point"
                               data-testid="movable-point"
-                              style="--movable-point-color: #1865f2;"
+                              style="--movable-point-color: var(--mafs-blue);"
                             >
                               <circle
                                 class="movable-point-hitbox"
@@ -3082,7 +3082,7 @@ exports[`Interactive Graph question Should render predictably: first render 2`] 
                                 cx="0"
                                 cy="-75"
                                 data-testid="movable-point__center"
-                                style="fill: #1865f2;"
+                                style="fill: var(--mafs-blue);"
                               />
                             </g>
                             <g
@@ -3115,7 +3115,7 @@ exports[`Interactive Graph question Should render predictably: first render 2`] 
                               aria-hidden="true"
                               class="movable-point"
                               data-testid="movable-point"
-                              style="--movable-point-color: #1865f2;"
+                              style="--movable-point-color: var(--mafs-blue);"
                             >
                               <circle
                                 class="movable-point-hitbox"
@@ -3143,7 +3143,7 @@ exports[`Interactive Graph question Should render predictably: first render 2`] 
                                 cx="-75"
                                 cy="50"
                                 data-testid="movable-point__center"
-                                style="fill: #1865f2;"
+                                style="fill: var(--mafs-blue);"
                               />
                             </g>
                             <g
@@ -3634,7 +3634,7 @@ exports[`Interactive Graph question Should render predictably: first render 4`] 
                             points=""
                             stroke-linejoin="round"
                             stroke-width="var(--movable-line-stroke-weight)"
-                            style="fill: transparent; fill-opacity: 0; stroke: var(--movable-line-stroke-color); stroke-opacity: 1; vector-effect: non-scaling-stroke; transform: var(--mafs-view-transform);"
+                            style="fill: transparent; fill-opacity: 0; stroke: var(--mafs-blue); stroke-opacity: 1; vector-effect: non-scaling-stroke; transform: var(--mafs-view-transform);"
                           />
                           <rect
                             aria-hidden="true"

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/angle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/angle.tsx
@@ -45,7 +45,7 @@ export function renderAngleGraph(
 
 function AngleGraph(props: AngleGraphProps) {
     const {dispatch, graphState} = props;
-    const {graphDimensionsInPixels} = useGraphConfig();
+    const {graphDimensionsInPixels, interactiveColor} = useGraphConfig();
     const i18n = usePerseusI18n();
     const id = React.useId();
     const descriptionId = id + "-description";
@@ -83,14 +83,15 @@ function AngleGraph(props: AngleGraphProps) {
                     start={startPtPx}
                     end={endPtPx}
                     style={{
-                        stroke: "var(--movable-line-stroke-color)",
+                        stroke: interactiveColor,
                         strokeWidth: "var(--movable-line-stroke-weight)",
                     }}
+                    testId="angle-graph__line"
                 />
                 <Vector
                     tail={angleLines[i][1]}
                     tip={endExtend}
-                    color={"var(--movable-line-stroke-color)"}
+                    testId="angle-graph__vector"
                 />
             </g>
         );

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -129,7 +129,8 @@ function MovableCircle(props: {
     onMove: (newCenter: vec.Vector2) => unknown;
 }) {
     const {id, ariaLabel, ariaDescribedBy, center, radius, onMove} = props;
-    const {snapStep, disableKeyboardInteraction} = useGraphConfig();
+    const {snapStep, disableKeyboardInteraction, interactiveColor} =
+        useGraphConfig();
     const [focused, setFocused] = React.useState(false);
 
     const draggableRef = useRef<SVGGElement>(null);
@@ -170,6 +171,8 @@ function MovableCircle(props: {
                 cy={centerPx[Y]}
                 rx={radiiPx[X]}
                 ry={radiiPx[Y]}
+                stroke={interactiveColor}
+                data-testid="movable-circle__circle"
             />
             <DragHandle center={center} dragging={dragging} focused={focused} />
         </g>
@@ -186,7 +189,7 @@ function DragHandle(props: {
     const {center, dragging, focused} = props;
 
     const [centerPx] = useTransformVectorsToPixels(center);
-    const {markings} = useGraphConfig();
+    const {markings, interactiveColor} = useGraphConfig();
 
     const cornerRadius = Math.min(...dragHandleDimensions) / 2;
     const topLeft = vec.sub(centerPx, vec.scale(dragHandleDimensions, 0.5));
@@ -204,6 +207,8 @@ function DragHandle(props: {
                 height={dragHandleDimensions[Y]}
                 rx={cornerRadius}
                 ry={cornerRadius}
+                fill={interactiveColor}
+                data-testid="movable-circle__handle"
             />
             {dragHandleDotPositions.map((offsetPx) => {
                 const [xPx, yPx] = vec.add(offsetPx, centerPx);

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/__snapshots__/movable-line.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/__snapshots__/movable-line.test.tsx.snap
@@ -58,7 +58,7 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
           aria-hidden="true"
           class=""
           data-testid="movable-line__line"
-          style="stroke: var(--movable-line-stroke-color); stroke-width: var(--movable-line-stroke-weight);"
+          style="stroke: var(--mafs-blue); stroke-width: var(--movable-line-stroke-weight);"
           x1="0"
           x2="0"
           y1="0"
@@ -77,7 +77,7 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
         aria-hidden="true"
         class="movable-point"
         data-testid="movable-point"
-        style="--movable-point-color: #1865f2;"
+        style="--movable-point-color: var(--mafs-blue);"
       >
         <circle
           class="movable-point-hitbox"
@@ -105,14 +105,14 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
           cx="0"
           cy="0"
           data-testid="movable-point__center"
-          style="fill: #1865f2;"
+          style="fill: var(--mafs-blue);"
         />
       </g>
       <g
         aria-hidden="true"
         class="movable-point"
         data-testid="movable-point"
-        style="--movable-point-color: #1865f2;"
+        style="--movable-point-color: var(--mafs-blue);"
       >
         <circle
           class="movable-point-hitbox"
@@ -140,7 +140,7 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
           cx="0"
           cy="0"
           data-testid="movable-point__center"
-          style="fill: #1865f2;"
+          style="fill: var(--mafs-blue);"
         />
       </g>
     </svg>
@@ -206,7 +206,7 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
           aria-hidden="true"
           class=""
           data-testid="movable-line__line"
-          style="stroke: var(--movable-line-stroke-color); stroke-width: var(--movable-line-stroke-weight);"
+          style="stroke: var(--mafs-blue); stroke-width: var(--movable-line-stroke-weight);"
           x1="0"
           x2="0"
           y1="0"
@@ -225,7 +225,7 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
         aria-hidden="true"
         class="movable-point"
         data-testid="movable-point"
-        style="--movable-point-color: #1865f2;"
+        style="--movable-point-color: var(--mafs-blue);"
       >
         <circle
           class="movable-point-hitbox"
@@ -253,14 +253,14 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
           cx="0"
           cy="0"
           data-testid="movable-point__center"
-          style="fill: #1865f2;"
+          style="fill: var(--mafs-blue);"
         />
       </g>
       <g
         aria-hidden="true"
         class="movable-point"
         data-testid="movable-point"
-        style="--movable-point-color: #1865f2;"
+        style="--movable-point-color: var(--mafs-blue);"
       >
         <circle
           class="movable-point-hitbox"
@@ -288,7 +288,7 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
           cx="0"
           cy="0"
           data-testid="movable-point__center"
-          style="fill: #1865f2;"
+          style="fill: var(--mafs-blue);"
         />
       </g>
     </svg>
@@ -354,7 +354,7 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
           aria-hidden="true"
           class=""
           data-testid="movable-line__line"
-          style="stroke: var(--movable-line-stroke-color); stroke-width: var(--movable-line-stroke-weight);"
+          style="stroke: var(--mafs-blue); stroke-width: var(--movable-line-stroke-weight);"
           x1="0"
           x2="0"
           y1="0"
@@ -362,7 +362,8 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
         />
       </g>
       <g
-        style="stroke: var(--movable-line-stroke-color); stroke-width: 2;"
+        data-testid="movable-line__vector"
+        style="stroke: var(--mafs-blue); stroke-width: 2;"
       >
         <line
           aria-hidden="true"
@@ -385,13 +386,14 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
               stroke-linecap="round"
               stroke-linejoin="round"
               stroke-width="2px"
-              style="stroke: var(--movable-line-stroke-color);"
+              style="stroke: var(--mafs-blue);"
             />
           </g>
         </g>
       </g>
       <g
-        style="stroke: var(--movable-line-stroke-color); stroke-width: 2;"
+        data-testid="movable-line__vector"
+        style="stroke: var(--mafs-blue); stroke-width: 2;"
       >
         <line
           aria-hidden="true"
@@ -414,7 +416,7 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
               stroke-linecap="round"
               stroke-linejoin="round"
               stroke-width="2px"
-              style="stroke: var(--movable-line-stroke-color);"
+              style="stroke: var(--mafs-blue);"
             />
           </g>
         </g>
@@ -431,7 +433,7 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
         aria-hidden="true"
         class="movable-point"
         data-testid="movable-point"
-        style="--movable-point-color: #1865f2;"
+        style="--movable-point-color: var(--mafs-blue);"
       >
         <circle
           class="movable-point-hitbox"
@@ -459,14 +461,14 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
           cx="0"
           cy="0"
           data-testid="movable-point__center"
-          style="fill: #1865f2;"
+          style="fill: var(--mafs-blue);"
         />
       </g>
       <g
         aria-hidden="true"
         class="movable-point"
         data-testid="movable-point"
-        style="--movable-point-color: #1865f2;"
+        style="--movable-point-color: var(--mafs-blue);"
       >
         <circle
           class="movable-point-hitbox"
@@ -494,7 +496,7 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
           cx="0"
           cy="0"
           data-testid="movable-point__center"
-          style="fill: #1865f2;"
+          style="fill: var(--mafs-blue);"
         />
       </g>
     </svg>

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.tsx
@@ -4,6 +4,7 @@ import {vec} from "mafs";
 import * as React from "react";
 
 import {segmentsIntersect} from "../../math";
+import useGraphConfig from "../../reducer/use-graph-config";
 import {getIntersectionOfRayWithBox as getRangeIntersectionVertex} from "../utils";
 
 import {MafsCssTransformWrapper} from "./css-transform-wrapper";
@@ -222,6 +223,12 @@ export const Angle = ({
         radius,
     );
 
+    // Determine the color style for the arc when interactive vs disabled
+    const {disableKeyboardInteraction} = useGraphConfig();
+    const arcClassName = disableKeyboardInteraction
+        ? "angle-arc-static"
+        : "angle-arc-interactive";
+
     return (
         <>
             <defs>
@@ -242,10 +249,10 @@ export const Angle = ({
                     start={[x1, y1]}
                     vertex={[x2, y2]}
                     end={[x3, y3]}
-                    className={"arc-right-angle"}
+                    className={arcClassName}
                 />
             ) : (
-                <Arc arc={arc} className={"angle-arc"} />
+                <Arc arc={arc} className={arcClassName} />
             )}
             {showAngles && (
                 <TextLabel x={textX} y={textY} color={color.blue}>
@@ -282,6 +289,7 @@ const RightAngleSquare = ({
             strokeWidth={0.02}
             fill="none"
             className={className}
+            data-testid="angle-indicators__right-angle"
         />
     </MafsCssTransformWrapper>
 );
@@ -301,6 +309,7 @@ const Arc = ({arc, className}: {arc: string; className?: string}) => {
                 strokeWidth={0.02}
                 fill="none"
                 className={className}
+                data-testid="angle-indicators__arc"
             />
         </MafsCssTransformWrapper>
     );

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -25,7 +25,6 @@ type Props = {
     };
     // Extra graph information to be read by screen readers
     ariaDescribedBy?: string;
-    color?: string;
     /* Extends the line to the edge of the graph with an arrow */
     extend?: {
         start: boolean;
@@ -40,7 +39,6 @@ export const MovableLine = (props: Props) => {
         points: [start, end],
         ariaLabels,
         ariaDescribedBy,
-        color,
         extend,
         onMoveLine = () => {},
         onMovePoint = () => {},
@@ -76,7 +74,6 @@ export const MovableLine = (props: Props) => {
             ariaLive: ariaLives[0],
             point: start,
             sequenceNumber: 1,
-            color,
             onMove: (p) => {
                 setAriaLives(["polite", "off", "off"]);
                 onMovePoint(0, p);
@@ -94,7 +91,6 @@ export const MovableLine = (props: Props) => {
             ariaLive: ariaLives[1],
             point: end,
             sequenceNumber: 2,
-            color,
             onMove: (p) => {
                 setAriaLives(["off", "polite", "off"]);
                 onMovePoint(1, p);
@@ -113,7 +109,6 @@ export const MovableLine = (props: Props) => {
             ariaLive={ariaLives[2]}
             start={start}
             end={end}
-            stroke={color}
             extend={extend}
             onMove={(delta) => {
                 setAriaLives(["off", "off", "polite"]);
@@ -133,8 +128,6 @@ export const MovableLine = (props: Props) => {
     );
 };
 
-const defaultStroke = "var(--movable-line-stroke-color)";
-
 type LineProps = {
     start: vec.Vector2;
     end: vec.Vector2;
@@ -148,21 +141,12 @@ type LineProps = {
               start: boolean;
               end: boolean;
           };
-    stroke?: string | undefined;
     onMove: (delta: vec.Vector2) => unknown;
 };
 
 const Line = (props: LineProps) => {
-    const {
-        start,
-        end,
-        ariaLabel,
-        ariaDescribedBy,
-        ariaLive,
-        extend,
-        stroke = defaultStroke,
-        onMove,
-    } = props;
+    const {start, end, ariaLabel, ariaDescribedBy, ariaLive, extend, onMove} =
+        props;
 
     const [startPtPx, endPtPx] = useTransformVectorsToPixels(start, end);
     const {
@@ -170,6 +154,7 @@ const Line = (props: LineProps) => {
         graphDimensionsInPixels,
         snapStep,
         disableKeyboardInteraction,
+        interactiveColor,
     } = useGraphConfig();
 
     let startExtend: vec.Vector2 | undefined = undefined;
@@ -235,7 +220,7 @@ const Line = (props: LineProps) => {
                     start={startPtPx}
                     end={endPtPx}
                     style={{
-                        stroke,
+                        stroke: interactiveColor,
                         strokeWidth: "var(--movable-line-stroke-weight)",
                     }}
                     className={dragging ? "movable-dragging" : ""}
@@ -245,9 +230,19 @@ const Line = (props: LineProps) => {
 
             {/* Draw extension vectors outside of movable area */}
             {startExtend && (
-                <Vector tail={start} tip={startExtend} color={stroke} />
+                <Vector
+                    tail={start}
+                    tip={startExtend}
+                    testId="movable-line__vector"
+                />
             )}
-            {endExtend && <Vector tail={end} tip={endExtend} color={stroke} />}
+            {endExtend && (
+                <Vector
+                    tail={end}
+                    tip={endExtend}
+                    testId="movable-line__vector"
+                />
+            )}
         </>
     );
 };

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -32,10 +32,10 @@ const hitboxSizePx = 48;
 // on an interactive graph.
 export const MovablePointView = forwardRef(
     (props: Props, hitboxRef: ForwardedRef<SVGGElement>) => {
-        const {markings, showTooltips} = useGraphConfig();
+        const {markings, showTooltips, interactiveColor} = useGraphConfig();
         const {
             point,
-            color = WBColor.blue,
+            color = interactiveColor,
             dragging,
             focused,
             cursor,

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/vector.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/vector.tsx
@@ -1,7 +1,12 @@
+/**
+ * Used to visualize vectors for both interative elements
+ * as well as locked figures within an Interactive Graph widget.
+ */
 import {angles} from "@khanacademy/kmath";
 import {vec} from "mafs";
 import * as React from "react";
 
+import useGraphConfig from "../../reducer/use-graph-config";
 import {useTransformVectorsToPixels} from "../use-transform";
 
 import {Arrowhead} from "./arrowhead";
@@ -12,18 +17,26 @@ const {calculateAngleInDegrees} = angles;
 type Props = {
     tail: vec.Vector2;
     tip: vec.Vector2;
-    color: string;
+    color?: string;
     style?: React.SVGProps<SVGLineElement>["style"];
+    testId?: string;
 };
 
 export function Vector(props: Props) {
-    const {tail, tip, color, style} = props;
+    const {interactiveColor} = useGraphConfig();
+    const {tail, tip, color = interactiveColor, style, testId} = props;
     const [tailPx, tipPx] = useTransformVectorsToPixels(tail, tip);
     const direction = vec.sub(tipPx, tailPx);
     const angle = calculateAngleInDegrees(direction);
 
     return (
-        <g style={{stroke: color, strokeWidth: 2}}>
+        <g
+            style={{
+                stroke: color,
+                strokeWidth: 2,
+            }}
+            data-testid={testId}
+        >
             <SVGLine start={tailPx} end={tipPx} style={style} />
             <Arrowhead angle={angle} tip={tip} color={color} />
         </g>

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
@@ -131,7 +131,6 @@ const LinearSystemGraph = (props: LinearSystemGraphProps) => {
                             ),
                         )
                     }
-                    color="var(--movable-line-stroke-color)"
                 />
             ))}
             {linesAriaInfo.map(

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
@@ -78,7 +78,6 @@ const LinearGraph = (props: LinearGraphProps, key: number) => {
                         actions.linear.movePoint(endpointIndex, destination),
                     )
                 }
-                color="var(--movable-line-stroke-color)"
             />
             {/* Hidden elements to provide the descriptions for the
                 circle and radius point's `aria-describedby` properties. */}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -185,7 +185,7 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
         snapTo = "grid",
         snapStep,
     } = statefulProps.graphState;
-    const {disableKeyboardInteraction} = graphConfig;
+    const {disableKeyboardInteraction, interactiveColor} = graphConfig;
     const {strings, locale} = usePerseusI18n();
     const id = React.useId();
     const pointsOffArray = Array(points.length).fill("off");
@@ -224,7 +224,7 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
         >
             <Polygon
                 points={[...points]}
-                color="var(--movable-line-stroke-color)"
+                color={interactiveColor}
                 svgPolygonProps={{
                     strokeWidth: focusVisible
                         ? "var(--movable-line-stroke-weight-active)"
@@ -420,6 +420,7 @@ const UnlimitedPolygonGraph = (statefulProps: StatefulProps) => {
     const {dispatch, graphConfig, left, top, pointsRef, points} = statefulProps;
     const {coords, closedPolygon} = statefulProps.graphState;
     const {strings, locale} = usePerseusI18n();
+    const {interactiveColor} = useGraphConfig();
 
     const id = React.useId();
     const polygonPointsNumId = id + "-points-num";
@@ -462,7 +463,7 @@ const UnlimitedPolygonGraph = (statefulProps: StatefulProps) => {
         >
             <Polyline
                 points={[...points]}
-                color="var(--movable-line-stroke-color)"
+                color={interactiveColor}
                 svgPolylineProps={{
                     strokeWidth: "var(--movable-line-stroke-weight)",
                     style: {fill: "transparent"},

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -1,10 +1,10 @@
-import {color} from "@khanacademy/wonder-blocks-tokens";
 import {Plot, vec} from "mafs";
 import * as React from "react";
 
 import {usePerseusI18n} from "../../../components/i18n-context";
 import a11y from "../../../util/a11y";
 import {actions} from "../reducer/interactive-graph-action";
+import useGraphConfig from "../reducer/use-graph-config";
 
 import {MovablePoint} from "./components/movable-point";
 import {srFormatNumber} from "./screenreader-text";
@@ -44,6 +44,7 @@ function QuadraticGraph(props: QuadraticGraphProps) {
     const {dispatch, graphState} = props;
 
     const {coords, snapStep} = graphState;
+    const {interactiveColor} = useGraphConfig();
 
     const {strings, locale} = usePerseusI18n();
     const id = React.useId();
@@ -83,7 +84,7 @@ function QuadraticGraph(props: QuadraticGraphProps) {
         >
             <Plot.OfX
                 y={y}
-                color={color.blue}
+                color={interactiveColor}
                 svgPathProps={{
                     // Use aria-hidden to hide the line from screen readers
                     // so it doesn't read as "image" with no context.

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
@@ -1,4 +1,3 @@
-import {color} from "@khanacademy/wonder-blocks-tokens";
 import {Plot, vec} from "mafs";
 import * as React from "react";
 
@@ -8,6 +7,7 @@ import {
 } from "../../../components/i18n-context";
 import {X, Y} from "../math/coordinates";
 import {actions} from "../reducer/interactive-graph-action";
+import useGraphConfig from "../reducer/use-graph-config";
 
 import {MovablePoint} from "./components/movable-point";
 import {srFormatNumber} from "./screenreader-text";
@@ -36,6 +36,7 @@ type SinusoidGraphProps = MafsGraphProps<SinusoidGraphState>;
 
 function SinusoidGraph(props: SinusoidGraphProps) {
     const {dispatch, graphState} = props;
+    const {interactiveColor} = useGraphConfig();
     const i18n = usePerseusI18n();
     const id = React.useId();
     const descriptionId = id + "-description";
@@ -78,7 +79,7 @@ function SinusoidGraph(props: SinusoidGraphProps) {
         >
             <Plot.OfX
                 y={(x) => computeSine(x, coeffRef.current)}
-                color={color.blue}
+                color={interactiveColor}
                 svgPathProps={{
                     // Use aria-hidden to hide the line from screen readers
                     // so it doesn't read as "image" with no context.

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-static.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-static.test.tsx
@@ -1,0 +1,316 @@
+import {screen} from "@testing-library/react";
+
+import {ApiOptions} from "../../perseus-api";
+import {renderQuestion} from "../__testutils__/renderQuestion";
+
+import {interactiveGraphQuestionBuilder} from "./interactive-graph-question-builder";
+
+import type {APIOptions} from "../../types";
+import type {PerseusRenderer} from "@khanacademy/perseus-core";
+
+const blankOptions: APIOptions = Object.freeze(ApiOptions.defaults);
+
+describe.each`
+    type             | staticMode | expectedColor
+    ${"Interactive"} | ${false}   | ${"var(--mafs-blue)"}
+    ${"Static"}      | ${true}    | ${"var(--static-gray)"}
+`("$type", ({staticMode, expectedColor}) => {
+    test("Segment graph", () => {
+        // Arrange
+        const segmentQuestion: PerseusRenderer =
+            interactiveGraphQuestionBuilder()
+                .withStaticMode(staticMode)
+                .withSegments({numSegments: 1})
+                .build();
+        renderQuestion(segmentQuestion, blankOptions);
+
+        // Act
+        // Segment contains two points and the line segment in between.
+        const points = screen.getAllByTestId("movable-point__center");
+        const innerSegment = screen.getByTestId("movable-line__line");
+        const [point1, point2] = points;
+
+        // Assert
+        expect(points).toHaveLength(2);
+        expect(point1).toHaveStyle({fill: expectedColor});
+        expect(point2).toHaveStyle({fill: expectedColor});
+        expect(innerSegment).toHaveStyle({stroke: expectedColor});
+    });
+
+    test("Linear graph", () => {
+        // Arrange
+        const linearQuestion: PerseusRenderer =
+            interactiveGraphQuestionBuilder()
+                .withStaticMode(staticMode)
+                .withLinear()
+                .build();
+        renderQuestion(linearQuestion, blankOptions);
+
+        // Act
+        // Linear graph contains two points, and inner segment,
+        // and two vectors.
+        const points = screen.getAllByTestId("movable-point__center");
+        const innerSegment = screen.getByTestId("movable-line__line");
+        const outerVectors = screen.getAllByTestId("movable-line__vector");
+        const [point1, point2] = points;
+        const [outerVector1, outerVector2] = outerVectors;
+
+        // Assert
+        expect(points).toHaveLength(2);
+        expect(outerVectors).toHaveLength(2);
+        expect(point1).toHaveStyle({fill: expectedColor});
+        expect(point2).toHaveStyle({fill: expectedColor});
+        expect(innerSegment).toHaveStyle({stroke: expectedColor});
+        expect(outerVector1).toHaveStyle({stroke: expectedColor});
+        expect(outerVector2).toHaveStyle({stroke: expectedColor});
+    });
+
+    test("Linear System graph", () => {
+        // Arrange
+        const linearSystemQuestion: PerseusRenderer =
+            interactiveGraphQuestionBuilder()
+                .withStaticMode(staticMode)
+                .withLinearSystem()
+                .build();
+        renderQuestion(linearSystemQuestion, blankOptions);
+
+        // Act
+        // Linear graph contains two lines with two points, and inner segment,
+        // and two vectors each.
+        const points = screen.getAllByTestId("movable-point__center");
+        const innerSegment = screen.getAllByTestId("movable-line__line");
+        const outerVectors = screen.getAllByTestId("movable-line__vector");
+
+        // Assert
+        // Everything is doubled from the Linear test
+        expect(points).toHaveLength(4);
+        expect(innerSegment).toHaveLength(2);
+        expect(outerVectors).toHaveLength(4);
+        for (const point of points) {
+            expect(point).toHaveStyle({fill: expectedColor});
+        }
+        for (const segment of innerSegment) {
+            expect(segment).toHaveStyle({stroke: expectedColor});
+        }
+        for (const vector of outerVectors) {
+            expect(vector).toHaveStyle({stroke: expectedColor});
+        }
+    });
+
+    test("Ray graph", () => {
+        // Arrange
+        const rayQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withStaticMode(staticMode)
+            .withRay()
+            .build();
+        renderQuestion(rayQuestion, blankOptions);
+
+        // Act
+        // Linear graph contains two points, and inner segment,
+        // and one outer vector.
+        const points = screen.getAllByTestId("movable-point__center");
+        const innerSegment = screen.getByTestId("movable-line__line");
+        const outerVector = screen.getByTestId("movable-line__vector");
+        const [point1, point2] = points;
+
+        // Assert
+        expect(points).toHaveLength(2);
+        expect(point1).toHaveStyle({fill: expectedColor});
+        expect(point2).toHaveStyle({fill: expectedColor});
+        expect(innerSegment).toHaveStyle({stroke: expectedColor});
+        expect(outerVector).toHaveStyle({stroke: expectedColor});
+    });
+
+    test("Circle graph", () => {
+        // Arrange
+        const circleQuestion: PerseusRenderer =
+            interactiveGraphQuestionBuilder()
+                .withStaticMode(staticMode)
+                .withCircle()
+                .build();
+        renderQuestion(circleQuestion, blankOptions);
+
+        // Act
+        // Circle graph contains the circle itself, a center drag handle,
+        // and the radius point.
+        const circle = screen.getByTestId("movable-circle__circle");
+        const center = screen.getByTestId("movable-circle__handle");
+        const radiusPoint = screen.getByTestId("movable-point__center");
+
+        // Assert
+        expect(circle).toHaveAttribute("stroke", expectedColor);
+        expect(center).toHaveAttribute("fill", expectedColor);
+        expect(radiusPoint).toHaveStyle({fill: expectedColor});
+    });
+
+    test("Quadratic", () => {
+        // Arrange
+        const quadraticQuestion: PerseusRenderer =
+            interactiveGraphQuestionBuilder()
+                .withStaticMode(staticMode)
+                .withQuadratic()
+                .build();
+        renderQuestion(quadraticQuestion);
+
+        // Act
+        // Quadratic graph contains the parabola itself and three points.
+        const points = screen.getAllByTestId("movable-point__center");
+        // There's no way to get a test ID into the Mafs Plot.ofX, so
+        // we need to use a query selector here.
+        // eslint-disable-next-line testing-library/no-node-access
+        const parabola = document.querySelector("path");
+
+        // Assert
+        expect(points).toHaveLength(3);
+        for (const point of points) {
+            expect(point).toHaveStyle({fill: expectedColor});
+        }
+        expect(parabola).toHaveStyle({color: expectedColor});
+    });
+
+    test("Sinusoid", () => {
+        // Arrange
+        const sinusoidQuestion: PerseusRenderer =
+            interactiveGraphQuestionBuilder()
+                .withStaticMode(staticMode)
+                .withSinusoid()
+                .build();
+        renderQuestion(sinusoidQuestion, blankOptions);
+
+        // Act
+        // Sinusoid graph contains the sinusoid plot itself and two points.
+        const points = screen.getAllByTestId("movable-point__center");
+        // There's no way to get a test ID into the Mafs Plot.ofX, so
+        // we need to use a query selector here.
+        // eslint-disable-next-line testing-library/no-node-access
+        const sinusoid = document.querySelector("path");
+
+        // Assert
+        expect(points).toHaveLength(2);
+        for (const point of points) {
+            expect(point).toHaveStyle({fill: expectedColor});
+        }
+        expect(sinusoid).toHaveStyle({color: expectedColor});
+    });
+
+    test("Point", () => {
+        // Arrange
+        const pointQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withStaticMode(staticMode)
+            .withPoints(1)
+            .build();
+        renderQuestion(pointQuestion, blankOptions);
+
+        // Act
+        // Point graph contains a single point.
+        const point = screen.getByTestId("movable-point__center");
+
+        // Assert
+        expect(point).toHaveStyle({fill: expectedColor});
+    });
+
+    test("Polygon", () => {
+        // Arrange
+        const polygonQuestion: PerseusRenderer =
+            interactiveGraphQuestionBuilder()
+                .withStaticMode(staticMode)
+                // Defaults to 3 sides
+                .withPolygon()
+                .build();
+        renderQuestion(polygonQuestion, blankOptions);
+
+        // Act
+        // Polygon graph contains the polygon and the three points.
+        const points = screen.getAllByTestId("movable-point__center");
+        // There's no way to get a test ID into the Mafs Polyline, so
+        // we need to use a query selector here.
+        // eslint-disable-next-line testing-library/no-node-access
+        const polygon = document.querySelector("polygon");
+
+        // Assert
+        expect(points).toHaveLength(3);
+        for (const point of points) {
+            expect(point).toHaveStyle({fill: expectedColor});
+        }
+        expect(polygon).toHaveStyle({color: expectedColor});
+    });
+
+    test("Angle (angle arc)", () => {
+        // Arrange
+        const angleQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withStaticMode(staticMode)
+            // Defaults to 53 degree angle
+            .withAngle()
+            .build();
+        renderQuestion(angleQuestion, blankOptions);
+
+        // Act
+        // Angle graph contains 3 points, two inner segments,
+        // two outer vectors, and the angle arc.
+        const points = screen.getAllByTestId("movable-point__center");
+        const innerSegments = screen.getAllByTestId("angle-graph__line");
+        const outerVectors = screen.getAllByTestId("angle-graph__vector");
+        const arc = screen.getByTestId("angle-indicators__arc");
+
+        // Assert
+        expect(points).toHaveLength(3);
+        expect(innerSegments).toHaveLength(2);
+        expect(outerVectors).toHaveLength(2);
+        for (const point of points) {
+            expect(point).toHaveStyle({fill: expectedColor});
+        }
+        for (const segment of innerSegments) {
+            expect(segment).toHaveStyle({stroke: expectedColor});
+        }
+        for (const vector of outerVectors) {
+            expect(vector).toHaveStyle({stroke: expectedColor});
+        }
+        expect(arc).toBeInTheDocument();
+    });
+
+    test("Angle (right angle)", () => {
+        // Arrange
+        const angleQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withStaticMode(staticMode)
+            // Defaults to 53 degree angle
+            .withAngle({
+                // Right angle
+                startCoords: [
+                    [0, 5],
+                    [0, 0], // vertex
+                    [5, 0],
+                ],
+                coords: [
+                    [0, 5],
+                    [0, 0], // vertex
+                    [5, 0],
+                ],
+            })
+            .build();
+        renderQuestion(angleQuestion, blankOptions);
+
+        // Act
+        // Angle graph contains 3 points, two inner segments,
+        // two outer vectors, and the right angle square.
+        const points = screen.getAllByTestId("movable-point__center");
+        const innerSegments = screen.getAllByTestId("angle-graph__line");
+        const outerVectors = screen.getAllByTestId("angle-graph__vector");
+
+        const rightAngle = screen.getByTestId("angle-indicators__right-angle");
+
+        // Assert
+        expect(points).toHaveLength(3);
+        expect(innerSegments).toHaveLength(2);
+        expect(outerVectors).toHaveLength(2);
+        for (const point of points) {
+            expect(point).toHaveStyle({fill: expectedColor});
+        }
+        for (const segment of innerSegments) {
+            expect(segment).toHaveStyle({stroke: expectedColor});
+        }
+        for (const vector of outerVectors) {
+            expect(vector).toHaveStyle({stroke: expectedColor});
+        }
+        expect(rightAngle).toBeInTheDocument();
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -165,6 +165,10 @@ export const MafsGraph = (props: MafsGraphProps) => {
                 height,
                 labels,
                 disableKeyboardInteraction: disableInteraction,
+                // If the graph is read-only or static, we want to make it
+                // visually clear that the graph is no longer interactive.
+                // We do this by changing the color of the interactive elements
+                // to a static gray color rather than our standard blue.
                 interactiveColor: disableInteraction
                     ? "var(--static-gray)"
                     : "var(--mafs-blue)",

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -149,6 +149,8 @@ export const MafsGraph = (props: MafsGraphProps) => {
         markings: props.markings,
     });
 
+    const disableInteraction = readOnly || !!props.static;
+
     return (
         <GraphConfigContext.Provider
             value={{
@@ -162,7 +164,10 @@ export const MafsGraph = (props: MafsGraphProps) => {
                 width,
                 height,
                 labels,
-                disableKeyboardInteraction: readOnly || !!props.static,
+                disableKeyboardInteraction: disableInteraction,
+                interactiveColor: disableInteraction
+                    ? "var(--static-gray)"
+                    : "var(--mafs-blue)",
             }}
         >
             <View className="mafs-graph-container">

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -17,6 +17,13 @@
     --mafs-green: #00a60e; /* WB color.green */
     --mafs-violet: #9059ff; /* WB color.purple */
     --mafs-yellow: #ffb100; /* WB color.gold */
+    /* Note: offBlack50 is not the best for contrast. However, this color needs
+    to be distinguishable from our regular interactive blue so it is clear that
+    the element is not interactive, even though the visual elements (e.g.
+    outlines, shadows) may indicate otherwise. When using a darker gray, it
+    looks the same as our WB blue in grayscale. We had to make a call here, and
+    we decided to make it lighter and more distinguishable even if it sacrifices
+    color contrast. (Nisha 2025) */
     --static-gray: #909296 /* WB color.offBlack50 */;
 
     /* overridden on a per-point basis */

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -17,6 +17,7 @@
     --mafs-green: #00a60e; /* WB color.green */
     --mafs-violet: #9059ff; /* WB color.purple */
     --mafs-yellow: #ffb100; /* WB color.gold */
+    --static-gray: #909296 /* WB color.offBlack50 */;
 
     /* overridden on a per-point basis */
     --movable-point-color: var(--mafs-blue);
@@ -166,7 +167,6 @@
 }
 
 .MafsView .movable-circle .circle {
-    stroke: var(--mafs-blue);
     stroke-width: 2px;
     fill: transparent;
 }
@@ -197,7 +197,6 @@
 }
 
 .MafsView .movable-circle .movable-circle-handle {
-    fill: var(--mafs-blue); /* WB fadedOffBlack64 */
     stroke: #fff;
     stroke-width: 2px;
 }
@@ -217,9 +216,13 @@
     stroke: rgba(33, 36, 44, 0.32);
 }
 
-.MafsView .angle-arc,
-.MafsView .arc-right-angle {
+.MafsView .angle-arc-interactive {
     stroke: var(--mafs-blue);
+    stroke-width: 0.1px;
+}
+
+.MafsView .angle-arc-static {
+    stroke: var(--static-gray);
     stroke-width: 0.1px;
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/use-graph-config.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/use-graph-config.ts
@@ -15,6 +15,7 @@ export type GraphConfig = {
     height: number; // in graph units
     labels: readonly string[];
     disableKeyboardInteraction?: boolean;
+    interactiveColor?: string;
 };
 
 const defaultGraphConfig: GraphConfig = {
@@ -32,6 +33,7 @@ const defaultGraphConfig: GraphConfig = {
     height: 0,
     labels: [],
     disableKeyboardInteraction: false,
+    interactiveColor: "var(--mafs-blue)",
 };
 
 export const GraphConfigContext =


### PR DESCRIPTION
## Summary:
Right now, a static graph looks exactly the same as a regular graph that can be interacted with.

To distinguish graphs as disabled visually when in static mode, update the color so that the
graph elements use Wonder Blocks `offBlack50` when in static mode.

I also did some refactoring to make the way we code colors uniform across all the graphs.

NOTE: You may notice that `offBlack50` is not the best for contrast. However, it needs to be distinguishable
from our regular interactive blue so it's clearly disabled. When using a darker gray, it looks the same as
our WB blue in grayscale. We had to make a call here, and we decided to make it lighter and more
distinguishable even if it sacrifices color contrast.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2784

## Test plan:
`yarn jest packages/perseus/src/widgets/interactive-graphs/interactive-graph-static.test.tsx`

Storybook
- Go to http://localhost:6006/?path=/docs/perseuseditor-widgets-interactive-graph--docs
- For all graph types, use the "Static" toggle at the top of the editor to set the
  graph into static mode.
- Confirm that the interactive elements are no longer blue.

| Interactive | Static |
| --- | --- |
| <img width="442" alt="Screenshot 2025-03-06 at 5 54 08 PM" src="https://github.com/user-attachments/assets/abbd2b0d-5a30-47aa-b05b-ce938ca93f06" /> | <img width="441" alt="Screenshot 2025-03-06 at 5 54 14 PM" src="https://github.com/user-attachments/assets/3674a65c-5e1f-40a1-ab9a-6d853f529d3a" /> |
 