### PR TITLE
Mark interactive graph widget as accessible!

### DIFF
--- a/.changeset/calm-socks-cheer.md
+++ b/.changeset/calm-socks-cheer.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Mark Interactive Graph Widget as accessible. (Content authors are no longer blocked from checking/unchecking the "Requires screen or mouse?" checkbox.)

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -832,7 +832,8 @@ const staticTransform = _.identity;
 
 export default {
     name: "interactive-graph",
-    displayName: "Interactive graph (Assessments only)",
+    displayName: "Interactive graph",
+    accessible: true,
     widget: InteractiveGraph,
     staticTransform: staticTransform,
 } satisfies WidgetExports<typeof InteractiveGraph>;


### PR DESCRIPTION
## Summary:
Now that the Interactive Graph updates phase 1 is coming to a close,
we can mark the Interactive Graph widget as accessible.

And since the new mobile version is released, it also means that
Interactive Graph is no longer reserved for assessments only.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2522

## Test plan:
- Bump the Perseus version in webapp using this PR version
- Check in local devserver that the interactive graph
  "Requires screen or mouse?" checkbox is no longer
  auto-checked and disabled.

| Before | After |
| --- | --- |
| <img width="269" alt="Screenshot 2025-03-06 at 6 21 40 PM" src="https://github.com/user-attachments/assets/8241c597-36ce-465a-ba69-c00855410341" /> | <img width="268" alt="Screenshot 2025-03-06 at 6 21 25 PM" src="https://github.com/user-attachments/assets/9423594c-e363-4fc2-8b57-f41e7bdf1951" /> |
