### PR TITLE
Ensure that keypad backspaces don't delete entire parentheses nodes at once.

### DIFF
--- a/.changeset/spotty-pans-yell.md
+++ b/.changeset/spotty-pans-yell.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Ensure that keypad backspaces don't delete entire parentheses nodes at once.

--- a/packages/math-input/src/components/input/__tests__/mathquill.test.ts
+++ b/packages/math-input/src/components/input/__tests__/mathquill.test.ts
@@ -302,64 +302,6 @@ describe("MathQuill", () => {
             expect(mathField.getContent()).toEqual("\\left(\\right)");
         });
 
-        it("should select an expression when deleting from outside (1)", () => {
-            const expr = "\\left(35x+5\\right)";
-            mathField.setContent(expr);
-            mathField.pressKey("BACKSPACE");
-            expect(mathField.isSelected()).toBeTruthy();
-            expect(mathField.getContent()).toEqual(expr);
-        });
-
-        it("should select an expression when deleting from outside (2)", () => {
-            const expr = "1+\\left(35x+5\\right)";
-            mathField.setContent(expr);
-            mathField.pressKey("BACKSPACE");
-            const selection = mathField.getSelection();
-            const left = selection.ends[MQ.L][MQ.L];
-            const right = selection.ends[MQ.R][MQ.R];
-
-            expect(left.ctrlSeq).toEqual("+");
-            expect(right).toEqual(END_OF_EXPR);
-            expect(mathField.getContent()).toEqual(expr);
-        });
-
-        it("should select an expression when deleting from outside (3)", () => {
-            const expr = "1+\\left(35x+5\\right)-1";
-            mathField.setContent(expr);
-            mathField.pressKey("LEFT");
-            mathField.pressKey("LEFT");
-            mathField.pressKey("BACKSPACE");
-            const selection = mathField.getSelection();
-            const left = selection.ends[MQ.L][MQ.L];
-            const right = selection.ends[MQ.R][MQ.R];
-
-            expect(left.ctrlSeq).toEqual("+");
-            expect(right.ctrlSeq).toEqual("-");
-            expect(mathField.getContent()).toEqual(expr);
-        });
-
-        it("should select an expression when deleting from outside (4)", () => {
-            const expr = "\\left(35x+5\\right)-1";
-            mathField.setContent(expr);
-            mathField.pressKey("LEFT");
-            mathField.pressKey("LEFT");
-            mathField.pressKey("BACKSPACE");
-            const selection = mathField.getSelection();
-            const left = selection.ends[MQ.L][MQ.L];
-            const right = selection.ends[MQ.R][MQ.R];
-
-            expect(left).toEqual(END_OF_EXPR);
-            expect(right.ctrlSeq).toEqual("-");
-            expect(mathField.getContent()).toEqual(expr);
-        });
-
-        it("should select an expression when deleting from outside", () => {
-            mathField.setContent("\\left(35x+5\\right)");
-            mathField.pressKey("BACKSPACE");
-            expect(mathField.isSelected()).toBeTruthy();
-            expect(mathField.getContent()).toEqual("\\left(35x+5\\right)");
-        });
-
         // TODO(kevinb) fix this behavior so that we delete the exponent too
         it.skip("should not delete squared exponents", () => {
             mathField.setContent("35x^{2}");
@@ -506,57 +448,6 @@ describe("MathQuill", () => {
             mathField.pressKey("RIGHT");
             mathField.pressKey("BACKSPACE");
             expect(mathField.isSelected()).toBeTruthy();
-            expect(mathField.getContent()).toEqual(expr);
-        });
-
-        it("should select log when outside full log at tail (1)", () => {
-            const expr = "\\log\\left(35x\\right)";
-            mathField.setContent(expr);
-            mathField.pressKey("BACKSPACE");
-            expect(mathField.isSelected()).toBeTruthy();
-            expect(mathField.getContent()).toEqual(expr);
-        });
-
-        it("should select log when outside full log at tail (2)", () => {
-            const expr = "1+\\log\\left(35x\\right)";
-            mathField.setContent(expr);
-            mathField.pressKey("BACKSPACE");
-            const selection = mathField.getSelection();
-            const left = selection.ends[MQ.L][MQ.L];
-            const right = selection.ends[MQ.R][MQ.R];
-
-            expect(left.ctrlSeq).toEqual("+");
-            expect(right).toEqual(END_OF_EXPR);
-            expect(mathField.getContent()).toEqual(expr);
-        });
-
-        it("should select log when outside full log at tail (3)", () => {
-            const expr = "1+\\log\\left(35x\\right)-1";
-            mathField.setContent(expr);
-            mathField.pressKey("LEFT");
-            mathField.pressKey("LEFT");
-            mathField.pressKey("BACKSPACE");
-            const selection = mathField.getSelection();
-            const left = selection.ends[MQ.L][MQ.L];
-            const right = selection.ends[MQ.R][MQ.R];
-
-            expect(left.ctrlSeq).toEqual("+");
-            expect(right.ctrlSeq).toEqual("-");
-            expect(mathField.getContent()).toEqual(expr);
-        });
-
-        it("should select log when outside full log at tail (4)", () => {
-            const expr = "\\log\\left(35x\\right)-1";
-            mathField.setContent(expr);
-            mathField.pressKey("LEFT");
-            mathField.pressKey("LEFT");
-            mathField.pressKey("BACKSPACE");
-            const selection = mathField.getSelection();
-            const left = selection.ends[MQ.L][MQ.L];
-            const right = selection.ends[MQ.R][MQ.R];
-
-            expect(left).toEqual(END_OF_EXPR);
-            expect(right.ctrlSeq).toEqual("-");
             expect(mathField.getContent()).toEqual(expr);
         });
 

--- a/packages/math-input/src/components/input/__tests__/mathquill.test.ts
+++ b/packages/math-input/src/components/input/__tests__/mathquill.test.ts
@@ -302,6 +302,18 @@ describe("MathQuill", () => {
             expect(mathField.getContent()).toEqual("\\left(\\right)");
         });
 
+        it("should not select or delete the entire expression on backspace from outside (MOB-5576)", () => {
+            const expr = "\\left(35x+5\\right)";
+            mathField.setContent(expr);
+            // "Delete" the right parens (it still exists until the parens are fully empty)
+            mathField.pressKey("BACKSPACE");
+            expect(mathField.isSelected()).toBeFalsy();
+
+            // Delete the first element within the parens
+            mathField.pressKey("BACKSPACE");
+            expect(mathField.getContent()).toEqual("\\left(35x+\\right)");
+        });
+
         // TODO(kevinb) fix this behavior so that we delete the exponent too
         it.skip("should not delete squared exponents", () => {
             mathField.setContent("35x^{2}");

--- a/packages/math-input/src/components/key-handlers/handle-backspace.ts
+++ b/packages/math-input/src/components/key-handlers/handle-backspace.ts
@@ -118,39 +118,6 @@ function handleBackspaceInLogIndex(
     }
 }
 
-function handleBackspaceOutsideParens(cursor: MathQuill.Cursor) {
-    // In this case the node with '\\left(' for its ctrlSeq
-    // is the parent of the expression contained within the
-    // parentheses.
-    //
-    // Handle selecting an expression before deleting:
-    // (x+1)| => |(x+1)|
-    // \log(x+1)| => |\log(x+1)|
-
-    const leftNode = cursor[mathQuillInstance.L];
-    const rightNode = cursor[mathQuillInstance.R];
-    const command = maybeFindCommandBeforeParens(leftNode);
-
-    if (command && command.startNode) {
-        // There's a command before the parens so we select it as well as
-        // the parens.
-        cursor.insLeftOf(command.startNode);
-        cursor.startSelection();
-        if (rightNode === MathFieldActionType.MQ_END) {
-            cursor.insAtRightEnd(cursor.parent);
-        } else {
-            cursor.insLeftOf(rightNode);
-        }
-        cursor.select();
-        cursor.endSelection();
-    } else {
-        cursor.startSelection();
-        cursor.insLeftOf(leftNode); // left of \\left(
-        cursor.select();
-        cursor.endSelection();
-    }
-}
-
 function handleBackspaceInsideParens(
     mathField: MathFieldInterface,
     cursor: MathQuill.Cursor,
@@ -248,8 +215,6 @@ function handleBackspace(mathField: MathFieldInterface) {
             selectNode(leftNode, cursor);
         } else if (isNthRootIndex(parent)) {
             handleBackspaceInRootIndex(mathField, cursor);
-        } else if (leftNode.ctrlSeq === "\\left(") {
-            handleBackspaceOutsideParens(cursor);
         } else if (grandparent.ctrlSeq === "\\left(") {
             handleBackspaceInsideParens(mathField, cursor);
         } else if (isInsideLogIndex(cursor)) {


### PR DESCRIPTION
## Summary:
When performing a backspace, our Math Input keypad appears to be deleting the entire contents of a parentheses node, which has been frustrating for our users. This functionality also occurs for logarithmic or trigonometric functions. 

For example: hitting backspace on `x+(9*9)` would result in only `x+` remaining.

When reviewing the code it appears that this functionality was set up deliberately, but I have been unable to find the justification or history why.

Given there's no clear reason for this feature, this PR is removing this special logic so that backspaces are handled with the default logic.

For example: hitting backspace on `x+(9*9)` would result in `x+(9*9`

Issue: MOB-5576

## Test plan:
Manual testing