### PR TITLE
[Polygon] Show right angle markers when showAngles is on

### DIFF
--- a/.changeset/small-gifts-float.md
+++ b/.changeset/small-gifts-float.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Polygon] Show right angle markers when showAngles is on

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.tsx
@@ -122,7 +122,7 @@ export const PolygonAngle = ({
                 </filter>
             </defs>
 
-            {!isOutside && isRightAngle(angle) ? (
+            {!isOutside && isRightPolygonAngle(angle) ? (
                 <RightAngleSquare
                     start={[x1, y1]}
                     vertex={[x2, y2]}


### PR DESCRIPTION
## Summary:
There was a small bug where the 90 degree angles had the arc instead of the square marker
in the Polygon interactive graph, but only when `showAngles` was on.

Fixed it so that it uses the correct function and shows it appropriately.

Issue: none

## Test plan:
- Start up `yarn dev`
- Look at the polygon question with the square and the angle labels showing
- Confirm that it shows the square indicators now

| Before | After |
| --- | --- |
| <img width="531" alt="Screenshot 2025-03-10 at 4 01 30 PM" src="https://github.com/user-attachments/assets/0b7a84d5-f19d-46b7-99f8-fc80bfc39195" /> | <img width="522" alt="Screenshot 2025-03-10 at 4 01 41 PM" src="https://github.com/user-attachments/assets/780b34b9-e783-4be0-a909-8cfe2a7ef2f6" /> |
