### PR TITLE
[Free Response Widget] Add ability to customize placeholder

### DIFF
--- a/.changeset/grumpy-lamps-allow.md
+++ b/.changeset/grumpy-lamps-allow.md
@@ -1,0 +1,8 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-core": minor
+"@khanacademy/perseus-editor": minor
+"@khanacademy/perseus-score": minor
+---
+
+Add ability to customize the placeholder text in a Free Response widget

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1675,10 +1675,10 @@ export type PerseusFreeResponseWidgetScoringCriterion = {
 };
 
 export type PerseusFreeResponseWidgetOptions = {
-    // The question text that will be displayed to the user.
-    question: string;
     // The placeholder text that will be displayed to the user in the text input field.
     placeholder: string;
+    // The question text that will be displayed to the user.
+    question: string;
     // A list of scoring criteria for the free response question. This is a list
     // of things the answer should contain to be considered correct.
     scoringCriteria: ReadonlyArray<PerseusFreeResponseWidgetScoringCriterion>;

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1677,6 +1677,8 @@ export type PerseusFreeResponseWidgetScoringCriterion = {
 export type PerseusFreeResponseWidgetOptions = {
     // The question text that will be displayed to the user.
     question: string;
+    // The placeholder text that will be displayed to the user in the text input field.
+    placeholder: string;
     // A list of scoring criteria for the free response question. This is a list
     // of things the answer should contain to be considered correct.
     scoringCriteria: ReadonlyArray<PerseusFreeResponseWidgetScoringCriterion>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/free-response-widget.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/free-response-widget.test.ts
@@ -13,6 +13,7 @@ describe("freeResponseWidget", () => {
             },
             graded: false,
             options: {
+                placeholder: "test-placeholder",
                 question: "What is your favorite color?",
                 scoringCriteria: [
                     {
@@ -31,6 +32,7 @@ describe("freeResponseWidget", () => {
                 },
                 graded: false,
                 options: {
+                    placeholder: "test-placeholder",
                     question: "What is your favorite color?",
                     scoringCriteria: [
                         {

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/free-response-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/free-response-widget.ts
@@ -8,6 +8,7 @@ import type {Parser} from "../parser-types";
 export const parseFreeResponseWidget: Parser<FreeResponseWidget> = parseWidget(
     constant("free-response"),
     object({
+        placeholder: string,
         question: string,
         scoringCriteria: array(
             object({

--- a/packages/perseus-core/src/widgets/free-response/free-response-util.test.ts
+++ b/packages/perseus-core/src/widgets/free-response/free-response-util.test.ts
@@ -7,6 +7,7 @@ describe("getFreeResponsePublicWidgetOptions", () => {
         // Arrange
         const options: PerseusFreeResponseWidgetOptions = {
             question: "What is the wind speed velocity of an unladen swallow?",
+            placeholder: "Please provide response here",
             scoringCriteria: [
                 {
                     text: "Depends on whether it's an African or European swallow",
@@ -20,6 +21,7 @@ describe("getFreeResponsePublicWidgetOptions", () => {
         // Assert
         expect(publicWidgetOptions).toEqual({
             question: "What is the wind speed velocity of an unladen swallow?",
+            placeholder: "Please provide response here",
         });
     });
 });

--- a/packages/perseus-core/src/widgets/free-response/free-response-util.test.ts
+++ b/packages/perseus-core/src/widgets/free-response/free-response-util.test.ts
@@ -6,8 +6,8 @@ describe("getFreeResponsePublicWidgetOptions", () => {
     it("should return the correct public options without any answer data", () => {
         // Arrange
         const options: PerseusFreeResponseWidgetOptions = {
-            question: "What is the wind speed velocity of an unladen swallow?",
             placeholder: "Please provide response here",
+            question: "What is the wind speed velocity of an unladen swallow?",
             scoringCriteria: [
                 {
                     text: "Depends on whether it's an African or European swallow",
@@ -20,8 +20,8 @@ describe("getFreeResponsePublicWidgetOptions", () => {
 
         // Assert
         expect(publicWidgetOptions).toEqual({
-            question: "What is the wind speed velocity of an unladen swallow?",
             placeholder: "Please provide response here",
+            question: "What is the wind speed velocity of an unladen swallow?",
         });
     });
 });

--- a/packages/perseus-core/src/widgets/free-response/free-response-util.ts
+++ b/packages/perseus-core/src/widgets/free-response/free-response-util.ts
@@ -6,6 +6,7 @@ import type {PerseusFreeResponseWidgetOptions} from "@khanacademy/perseus-core";
  */
 export type FreeResponsePublicWidgetOptions = {
     question: PerseusFreeResponseWidgetOptions["question"];
+    placeholder: PerseusFreeResponseWidgetOptions["placeholder"];
 };
 
 /**
@@ -17,6 +18,7 @@ function getFreeResponsePublicWidgetOptions(
 ): FreeResponsePublicWidgetOptions {
     return {
         question: options.question,
+        placeholder: options.placeholder,
     };
 }
 

--- a/packages/perseus-core/src/widgets/free-response/free-response-util.ts
+++ b/packages/perseus-core/src/widgets/free-response/free-response-util.ts
@@ -5,8 +5,8 @@ import type {PerseusFreeResponseWidgetOptions} from "@khanacademy/perseus-core";
  * {@link PerseusFreeResponseWidgetOptions} type
  */
 export type FreeResponsePublicWidgetOptions = {
-    question: PerseusFreeResponseWidgetOptions["question"];
     placeholder: PerseusFreeResponseWidgetOptions["placeholder"];
+    question: PerseusFreeResponseWidgetOptions["question"];
 };
 
 /**
@@ -17,8 +17,8 @@ function getFreeResponsePublicWidgetOptions(
     options: PerseusFreeResponseWidgetOptions,
 ): FreeResponsePublicWidgetOptions {
     return {
-        question: options.question,
         placeholder: options.placeholder,
+        question: options.question,
     };
 }
 

--- a/packages/perseus-core/src/widgets/free-response/index.ts
+++ b/packages/perseus-core/src/widgets/free-response/index.ts
@@ -5,12 +5,12 @@ import type {WidgetLogic} from "../logic-export.types";
 
 export type FreeResponseDefaultWidgetOptions = Pick<
     PerseusFreeResponseWidgetOptions,
-    "question" | "scoringCriteria" | "placeholder"
+    "placeholder" | "question" | "scoringCriteria"
 >;
 
 const defaultWidgetOptions: FreeResponseDefaultWidgetOptions = {
-    question: "",
     placeholder: "Please provide response here",
+    question: "",
     // Always display one criterion, since the user will always have to input
     // at least one.
     scoringCriteria: [

--- a/packages/perseus-core/src/widgets/free-response/index.ts
+++ b/packages/perseus-core/src/widgets/free-response/index.ts
@@ -5,12 +5,12 @@ import type {WidgetLogic} from "../logic-export.types";
 
 export type FreeResponseDefaultWidgetOptions = Pick<
     PerseusFreeResponseWidgetOptions,
-    "question" | "scoringCriteria"
+    "question" | "scoringCriteria" | "placeholder"
 >;
 
 const defaultWidgetOptions: FreeResponseDefaultWidgetOptions = {
     question: "",
-
+    placeholder: "Please provide response here",
     // Always display one criterion, since the user will always have to input
     // at least one.
     scoringCriteria: [

--- a/packages/perseus-editor/src/widgets/__stories__/free-response-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/free-response-editor.stories.tsx
@@ -49,7 +49,8 @@ type State = Partial<PropsFor<typeof FreeResponseEditor>>;
 
 const WithState = () => {
     const [state, setState] = React.useState<State>({
-        question: "What is the truth?",
+        question: "What is is the truth?",
+        placeholder: "Enter your answer here",
         scoringCriteria: [{text: ""}],
     });
 

--- a/packages/perseus-editor/src/widgets/__stories__/free-response-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/free-response-editor.stories.tsx
@@ -49,8 +49,8 @@ type State = Partial<PropsFor<typeof FreeResponseEditor>>;
 
 const WithState = () => {
     const [state, setState] = React.useState<State>({
-        question: "What is is the truth?",
         placeholder: "Enter your answer here",
+        question: "What is is the truth?",
         scoringCriteria: [{text: ""}],
     });
 

--- a/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
@@ -43,6 +43,24 @@ describe("free-response editor", () => {
         expect(onChangeMock).toBeCalledWith({question: "2"});
     });
 
+    it("calls onChange when the placeholder is changed", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+
+        // Act
+        render(
+            <FreeResponseEditor
+                placeholder="test-placeholder"
+                onChange={onChangeMock}
+            />,
+        );
+
+        await userEvent.type(screen.getByLabelText("Placeholder"), "2");
+
+        // Assert
+        expect(onChangeMock).toBeCalledWith({placeholder: "test-placeholder2"});
+    });
+
     it("calls onChange when a criterion is changed", async () => {
         // Arrange
         const onChangeMock = jest.fn();
@@ -75,6 +93,24 @@ describe("free-response editor", () => {
         expect(ref.current?.getSaveWarnings()).toEqual([
             "The question is empty",
         ]);
+    });
+
+    it("does not return a warning when the placeholder is empty", async () => {
+        // Arrange
+        const ref = React.createRef<FreeResponseEditor>();
+
+        // Act
+        render(
+            <FreeResponseEditor
+                ref={ref}
+                question="test-question"
+                placeholder=""
+                onChange={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(ref.current?.getSaveWarnings()).toEqual([]);
     });
 
     it("serializes the question value", async () => {

--- a/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
@@ -103,8 +103,8 @@ describe("free-response editor", () => {
         render(
             <FreeResponseEditor
                 ref={ref}
-                question="test-question"
                 placeholder=""
+                question="test-question"
                 onChange={() => {}}
             />,
         );

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -26,8 +26,8 @@ class FreeResponseEditor extends React.Component<Props> {
 
     serialize(): PerseusFreeResponseWidgetOptions {
         return {
-            question: this.props.question,
             placeholder: this.props.placeholder,
+            question: this.props.question,
             scoringCriteria: this.props.scoringCriteria,
         };
     }

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -27,6 +27,7 @@ class FreeResponseEditor extends React.Component<Props> {
     serialize(): PerseusFreeResponseWidgetOptions {
         return {
             question: this.props.question,
+            placeholder: this.props.placeholder,
             scoringCriteria: this.props.scoringCriteria,
         };
     }
@@ -89,12 +90,21 @@ class FreeResponseEditor extends React.Component<Props> {
     render(): React.ReactNode {
         return (
             <View>
-                <label className={css(styles.questionContainer)}>
+                <label className={css(styles.textOptionWithLabelContainer)}>
                     <HeadingSmall>Question</HeadingSmall>
                     <textarea
                         value={this.props.question}
                         onChange={(e) =>
                             this.props.onChange({question: e.target.value})
+                        }
+                    />
+                </label>
+                <label className={css(styles.textOptionWithLabelContainer)}>
+                    <HeadingSmall>Placeholder</HeadingSmall>
+                    <textarea
+                        value={this.props.placeholder}
+                        onChange={(e) =>
+                            this.props.onChange({placeholder: e.target.value})
                         }
                     />
                 </label>
@@ -159,12 +169,6 @@ const CriterionEditor = function (props: {
 };
 
 const styles = StyleSheet.create({
-    questionContainer: {
-        display: "flex",
-        flexDirection: "column",
-        gap: spacing.xSmall_8,
-        paddingBottom: spacing.medium_16,
-    },
     criteriaList: {
         gap: spacing.small_12,
     },
@@ -180,6 +184,12 @@ const styles = StyleSheet.create({
         display: "flex",
         flexDirection: "row",
         justifyContent: "flex-end",
+    },
+    textOptionWithLabelContainer: {
+        display: "flex",
+        flexDirection: "column",
+        gap: spacing.xSmall_8,
+        paddingBottom: spacing.medium_16,
     },
 });
 

--- a/packages/perseus/src/widgets/free-response/__snapshots__/free-response.test.tsx.snap
+++ b/packages/perseus/src/widgets/free-response/__snapshots__/free-response.test.tsx.snap
@@ -22,7 +22,9 @@ exports[`free-response widget should snapshot on mobile: first mobile render 1`]
               class="labelAndTextarea_1o27vzy"
             >
               test-question
-              <textarea />
+              <textarea
+                placeholder="test-placeholder"
+              />
             </label>
           </div>
         </div>
@@ -54,7 +56,9 @@ exports[`free-response widget should snapshot: first render 1`] = `
               class="labelAndTextarea_1o27vzy"
             >
               test-question
-              <textarea />
+              <textarea
+                placeholder="test-placeholder"
+              />
             </label>
           </div>
         </div>

--- a/packages/perseus/src/widgets/free-response/free-response.stories.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.stories.tsx
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof FreeResponse>;
 
 export const Primary: Story = {
     args: {
-        question: "What is the theme of the essay?",
         placeholder: "Enter your answer here",
+        question: "What is the theme of the essay?",
     },
 };

--- a/packages/perseus/src/widgets/free-response/free-response.stories.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.stories.tsx
@@ -13,5 +13,6 @@ type Story = StoryObj<typeof FreeResponse>;
 export const Primary: Story = {
     args: {
         question: "What is the theme of the essay?",
+        placeholder: "Enter your answer here",
     },
 };

--- a/packages/perseus/src/widgets/free-response/free-response.test.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.test.tsx
@@ -66,6 +66,17 @@ describe("free-response widget", () => {
         ).toBeVisible();
     });
 
+    it("should render the placeholder text", () => {
+        // Arrange
+        // Act
+        renderQuestion(getFreeResponseItemData(), {});
+
+        // Assert
+        expect(
+            screen.getByRole("textbox", {name: "test-question"}),
+        ).toHaveAttribute("placeholder", "test-placeholder");
+    });
+
     it("should return the correct user input", async () => {
         // Arrange
         const {renderer} = renderQuestion(getFreeResponseItemData());

--- a/packages/perseus/src/widgets/free-response/free-response.testdata.ts
+++ b/packages/perseus/src/widgets/free-response/free-response.testdata.ts
@@ -12,6 +12,7 @@ export function getFreeResponseItemData(): PerseusRenderer {
                 type: "free-response",
                 options: {
                     question: "test-question",
+                    placeholder: "test-placeholder",
                     scoringCriteria: [
                         {
                             text: "test-criterion",

--- a/packages/perseus/src/widgets/free-response/free-response.testdata.ts
+++ b/packages/perseus/src/widgets/free-response/free-response.testdata.ts
@@ -11,8 +11,8 @@ export function getFreeResponseItemData(): PerseusRenderer {
                 static: false,
                 type: "free-response",
                 options: {
-                    question: "test-question",
                     placeholder: "test-placeholder",
+                    question: "test-question",
                     scoringCriteria: [
                         {
                             text: "test-criterion",

--- a/packages/perseus/src/widgets/free-response/free-response.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.tsx
@@ -16,7 +16,7 @@ import type {PerseusFreeResponseUserInput} from "@khanacademy/perseus-score";
 
 type RenderProps = Pick<
     PerseusFreeResponseWidgetOptions,
-    "question" | "placeholder"
+    "placeholder" | "question"
 >;
 type Props = WidgetProps<RenderProps>;
 

--- a/packages/perseus/src/widgets/free-response/free-response.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.tsx
@@ -14,7 +14,10 @@ import type {Widget, WidgetExports, WidgetProps} from "../../types";
 import type {PerseusFreeResponseWidgetOptions} from "@khanacademy/perseus-core";
 import type {PerseusFreeResponseUserInput} from "@khanacademy/perseus-score";
 
-type RenderProps = Pick<PerseusFreeResponseWidgetOptions, "question">;
+type RenderProps = Pick<
+    PerseusFreeResponseWidgetOptions,
+    "question" | "placeholder"
+>;
 type Props = WidgetProps<RenderProps>;
 
 type State = {
@@ -50,6 +53,7 @@ export class FreeResponse
                     <textarea
                         value={this.state.currentValue}
                         onChange={this.handleChange}
+                        placeholder={this.props.placeholder}
                     />
                 </label>
             </View>


### PR DESCRIPTION
## Summary:
This PR adds the ability to set the placeholder text in a Free Response Widget component.

Issue: [LIT-1668](https://khanacademy.atlassian.net/browse/LIT-1668)

## Test plan:
- Open Storybook
- See the placeholder can be changed in the editor
- See the placeholder can be changed in the renderer

<img width="1018" alt="Screenshot 2025-03-12 at 8 47 49 AM" src="https://github.com/user-attachments/assets/f46d66b7-e669-4b63-bc6b-6f1f9a431c6d" />

<img width="1025" alt="Screenshot 2025-03-12 at 8 48 04 AM" src="https://github.com/user-attachments/assets/71e66c84-0af6-492a-9ebf-8abd5a9e1112" />

**NOTE:** The screenshots use something I typed in. The default value is "Please provide response here"

[LIT-1668]: https://khanacademy.atlassian.net/browse/LIT-1668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ