### PR TITLE
Ensure Interactive Graph Axis Labels are clamped by graph dimensions

### DIFF
--- a/.changeset/angry-toes-crash.md
+++ b/.changeset/angry-toes-crash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Ensure Interactive Graph Axis Labels are clamped by graph dimensions

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.test.ts
@@ -1,6 +1,12 @@
-import {getLabelPosition, fontSize, getLabelTransform} from "./axis-labels";
+import {
+    getLabelPosition,
+    fontSize,
+    clampLabelPosition,
+    getLabelTransform,
+} from "./axis-labels";
 
 import type {GraphDimensions} from "../types";
+import type {vec} from "mafs";
 
 describe("getLabelPosition", () => {
     it("should return the correct position for the default graph", () => {
@@ -20,7 +26,6 @@ describe("getLabelPosition", () => {
 
         expect(getLabelPosition(graphInfo, labelLocation)).toEqual(expected);
     });
-
     it("should return the correct position for the default graph without a labelLocation", () => {
         const graphInfo: GraphDimensions = {
             range: [
@@ -37,6 +42,42 @@ describe("getLabelPosition", () => {
         ];
 
         expect(getLabelPosition(graphInfo, undefined)).toEqual(expected);
+    });
+
+    it("should return the correct position for a graph with high positive min-ranges", () => {
+        const graphInfo: GraphDimensions = {
+            range: [
+                [6, 15],
+                [6, 15],
+            ],
+            width: 400,
+            height: 400,
+        };
+        const labelLocation = "onAxis";
+        const expected = [
+            [400, 400 + 1.25 * fontSize], // X Label at [Right edge of the graph, vertical center of the graph]
+            [-1.5 * fontSize, -2 * fontSize], // Y Label at [Horizontal center of the graph, 2x fontSize above the top edge]
+        ];
+
+        expect(getLabelPosition(graphInfo, labelLocation)).toEqual(expected);
+    });
+
+    it("should return the correct position for a graph with low negative max-ranges", () => {
+        const graphInfo: GraphDimensions = {
+            range: [
+                [-15, -6],
+                [-15, -6],
+            ],
+            width: 400,
+            height: 400,
+        };
+        const labelLocation = "onAxis";
+        const expected = [
+            [400, -2 * fontSize], // X Label at [Right edge of the graph, vertical center of the graph]
+            [400 + 1.25 * fontSize, -2 * fontSize], // Y Label at [Horizontal center of the graph, 2x fontSize above the top edge]
+        ];
+
+        expect(getLabelPosition(graphInfo, labelLocation)).toEqual(expected);
     });
 
     it("should return the correct position for labels set to alongEdge", () => {
@@ -140,5 +181,36 @@ describe("getLabelTransform", () => {
         };
 
         expect(getLabelTransform(labelLocation)).toEqual(expected);
+    });
+});
+
+describe("clampLabelPosition", () => {
+    it("should clamp the label position down to the max values", () => {
+        const graphInfo: GraphDimensions = {
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            width: 400,
+            height: 400,
+        };
+        const labelPosition: vec.Vector2 = [500, 500];
+        const expected = [400 + fontSize * 1.25, 400 + fontSize * 1.25];
+
+        expect(clampLabelPosition(labelPosition, graphInfo)).toEqual(expected);
+    });
+    it("should clamp the label position up to the min values", () => {
+        const graphInfo: GraphDimensions = {
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            width: 400,
+            height: 400,
+        };
+        const labelPosition: vec.Vector2 = [-500, -500];
+        const expected = [-fontSize * 1.5, -fontSize * 2];
+
+        expect(clampLabelPosition(labelPosition, graphInfo)).toEqual(expected);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
@@ -97,6 +97,22 @@ export const getLabelTransform = (
 /* Calculate the position of the main axis labels based on the labelLocation
  * and the ranges of the graph. Exported for testing purposes.
  */
+// This function clamps the label position to ensure that the labels do not go too far
+// outside the graph bounds. This is only required when the labelLocations are set to "onAxis".
+export const clampLabelPosition = (
+    labelPosition: vec.Vector2,
+    graphInfo: GraphDimensions,
+): vec.Vector2 => {
+    const x = Math.max(
+        Math.min(labelPosition[X], graphInfo.width + fontSize * 1.25), // The maximum x value is the width of the graph + 2 font sizes
+        -fontSize * 1.5, // The minimum x value is -1.5 font sizes
+    );
+    const y = Math.max(
+        Math.min(labelPosition[Y], graphInfo.height + fontSize * 1.25), // The maximum y value is the height of the graph + 1.25 font sizes
+        -fontSize * 2, // The minimum y value is -2 font sizes
+    );
+    return [x, y];
+};
 export const getLabelPosition = (
     graphInfo: GraphDimensions,
     labelLocation: GraphConfig["labelLocation"],
@@ -144,10 +160,11 @@ export const getLabelPosition = (
     const yLabelInitial: vec.Vector2 = [0, graphInfo.range[Y][MAX]];
     const yLabelOffset: vec.Vector2 = [0, -fontSize * 2]; // Move the y-axis label up by 2 font sizes
 
-    const xLabel = pointToPixel(xLabelInitial, graphInfo);
-    const yLabel = vec.add(
-        pointToPixel(yLabelInitial, graphInfo),
-        yLabelOffset,
-    );
+    let xLabel = pointToPixel(xLabelInitial, graphInfo);
+    let yLabel = vec.add(pointToPixel(yLabelInitial, graphInfo), yLabelOffset);
+
+    // Clamp the label positions to ensure that the labels do not go too far outside of the graph bounds.
+    xLabel = clampLabelPosition(xLabel, graphInfo);
+    yLabel = clampLabelPosition(yLabel, graphInfo);
     return [xLabel, yLabel];
 };

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
@@ -103,13 +103,24 @@ export const clampLabelPosition = (
     labelPosition: vec.Vector2,
     graphInfo: GraphDimensions,
 ): vec.Vector2 => {
+    // Clamp the label position to ensure that the labels do not go too far outside of the graph bounds.
+    // Unfortuantely, this logic is a little complex as we have to account for both the positive and negative
+    // ranges of the graph, and the variable position of the axis tick labels.
     const x = Math.max(
-        Math.min(labelPosition[X], graphInfo.width + fontSize * 1.25), // The maximum x value is the width of the graph + 2 font sizes
-        -fontSize * 1.5, // The minimum x value is -1.5 font sizes
+        // The maximum x value is the width of the graph + 1.25 font sizes, which aligns the label with the axis ticks
+        // when the x-axis is out of bounds to the right of the graph.
+        Math.min(labelPosition[X], graphInfo.width + fontSize * 1.25),
+        // The minimum x value is -1.5 font sizes, as this aligns the label with the axis ticks
+        // when the y-axis is out of bounds to the left of the graph.
+        -fontSize * 1.5,
     );
     const y = Math.max(
-        Math.min(labelPosition[Y], graphInfo.height + fontSize * 1.25), // The maximum y value is the height of the graph + 1.25 font sizes
-        -fontSize * 2, // The minimum y value is -2 font sizes
+        // The maximum y value is the height of the graph + 1.25 font sizes, which aligns the label with the axis ticks
+        // when the y-axis is out of bounds below the graph.
+        Math.min(labelPosition[Y], graphInfo.height + fontSize * 1.25),
+        // The minimum y value is -2 font sizes, which aligns the label with the axis ticks
+        // when the y-axis is out of bounds above the graph.
+        -fontSize * 2,
     );
     return [x, y];
 };
@@ -166,5 +177,6 @@ export const getLabelPosition = (
     // Clamp the label positions to ensure that the labels do not go too far outside of the graph bounds.
     xLabel = clampLabelPosition(xLabel, graphInfo);
     yLabel = clampLabelPosition(yLabel, graphInfo);
+
     return [xLabel, yLabel];
 };

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-regression.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-regression.stories.tsx
@@ -158,6 +158,12 @@ export const MafsWithYAxisOffRight: Story = {
     },
 };
 
+export const MafsWithYAxisOffFarRight: Story = {
+    args: {
+        question: interactiveGraphQuestionBuilder().withXRange(-20, -6).build(),
+    },
+};
+
 export const MafsWithXAxisAtBottom: Story = {
     args: {
         question: interactiveGraphQuestionBuilder().withYRange(0, 20).build(),


### PR DESCRIPTION
## Summary:
This ticket is part of the Interactive Graph Project.

While working on LEMS-2718, it was discovered that the axis labels could "shoot off into space" as min-ranges climbed, or max-ranges plummeted. This PR makes sure to clamp these values so that the axis labels still roughly align with the tick labels. 

## Video:
https://github.com/user-attachments/assets/dd5bb3b0-0976-4fcb-a3f1-1ad6897700f8

Issue: LEMS-2912

## Test plan:
- New tests
- Manual Testing