### PR TITLE
Allow the 'key' field of Radio widgets to be null

### DIFF
--- a/.changeset/early-swans-brush.md
+++ b/.changeset/early-swans-brush.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+Bugfix: allow the 'key' field of Radio widgets to be null when parsing Perseus JSON"

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.test.ts
@@ -78,4 +78,21 @@ describe("parseRadioWidget", () => {
             ),
         );
     });
+
+    it("allows a null key", () => {
+        const widget = {
+            type: "radio",
+            key: null,
+            graded: true,
+            version: {
+                major: 2,
+                minor: 0,
+            },
+            options: {
+                choices: [],
+            },
+        };
+
+        expect(parse(widget, parseRadioWidget)).toEqual(success(widget));
+    });
 });

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.ts
@@ -45,7 +45,7 @@ export function parseWidgetWithVersion<
         graded: optional(boolean),
         alignment: optional(string),
         options: parseOptions,
-        key: optional(number),
+        key: optional(nullable(number)),
         version: parseVersion,
     });
 }


### PR DESCRIPTION
This fixes a bug in the parser that caused it to incorrectly reject some production data.

Issue: none

## Test plan:

`yarn test`

After deployment, the number of errors on Sentry mentioning `At
(root).question.widgets["radio 1"].key -- expected number, but got null`
should decrease sharply.