### PR TITLE
Numeric Input: Treat unrecognized `simplify` values as "required"

### DIFF
--- a/.changeset/fair-ravens-guess.md
+++ b/.changeset/fair-ravens-guess.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+Fix a bug in numeric input scoring where `simplify` value of `false` led to incorrect scoring logic being applied

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1206,15 +1206,19 @@ export type MathFormat =
     | "pi";
 
 export type PerseusNumericInputAnswerForm = {
-    simplify: PerseusNumericInputSimplify | null | undefined;
+    simplify: PerseusNumericInputSimplify;
     name: MathFormat;
 };
 
-export type PerseusNumericInputSimplify =
-    | "required"
-    | "correct"
-    | "enforced"
-    | "optional";
+/**
+ * Determines how unsimplified fractions are scored.
+ *
+ * - "required" means unsimplified fractions are considered invalid input, and
+ *   the learner can try again.
+ * - "enforced" means unsimplified fractions are marked incorrect.
+ * - "optional" means unsimplified fractions are accepted.
+ */
+export type PerseusNumericInputSimplify = "required" | "enforced" | "optional";
 
 export type PerseusNumericInputWidgetOptions = {
     // A list of all the possible correct and incorrect answers
@@ -1249,7 +1253,7 @@ export type PerseusNumericInputAnswer = {
     // NOTE: perseus_data.go says this is non-nullable even though we handle null values.
     maxError: number | null | undefined;
     // Unsimplified answers are Ungraded, Accepted, or Wrong. Options: "required", "correct", or "enforced"
-    simplify: PerseusNumericInputSimplify | null | undefined;
+    simplify: PerseusNumericInputSimplify;
 };
 
 export type PerseusNumberLineWidgetOptions = {

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/numeric-input-widget.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/numeric-input-widget.test.ts
@@ -1,0 +1,47 @@
+import {anyFailure} from "../general-purpose-parsers/test-helpers";
+import {parse} from "../parse";
+import {success} from "../result";
+
+import {parseSimplify} from "./numeric-input-widget";
+
+describe("parseSimplify", () => {
+    it(`preserves "required"`, () => {
+        expect(parse("required", parseSimplify)).toEqual(success("required"));
+    });
+
+    it(`preserves "enforced"`, () => {
+        expect(parse("enforced", parseSimplify)).toEqual(success("enforced"));
+    });
+
+    it(`preserves "optional"`, () => {
+        expect(parse("optional", parseSimplify)).toEqual(success("optional"));
+    });
+
+    it(`converts null to "required"`, () => {
+        expect(parse(null, parseSimplify)).toEqual(success("required"));
+    });
+
+    it(`converts undefined to "required"`, () => {
+        expect(parse(undefined, parseSimplify)).toEqual(success("required"));
+    });
+
+    it(`converts true to "required"`, () => {
+        expect(parse(true, parseSimplify)).toEqual(success("required"));
+    });
+
+    it(`converts false to "required"`, () => {
+        expect(parse(false, parseSimplify)).toEqual(success("required"));
+    });
+
+    it(`converts "accepted" to "required"`, () => {
+        expect(parse("accepted", parseSimplify)).toEqual(success("required"));
+    });
+
+    it(`converts "correct" to "required"`, () => {
+        expect(parse("correct", parseSimplify)).toEqual(success("required"));
+    });
+
+    it(`rejects an arbitrary string`, () => {
+        expect(parse("foobar", parseSimplify)).toEqual(anyFailure);
+    });
+});

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/numeric-input-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/numeric-input-widget.ts
@@ -32,7 +32,7 @@ const parseMathFormat = enumeration(
     "pi",
 );
 
-const parseSimplify = pipeParsers(
+export const parseSimplify = pipeParsers(
     union(constant(null))
         .or(constant(undefined))
         .or(boolean)

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/numeric-input-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/numeric-input-widget.ts
@@ -16,7 +16,10 @@ import {defaulted} from "../general-purpose-parsers/defaulted";
 
 import {parseWidget} from "./widget";
 
-import type {NumericInputWidget} from "../../data-schema";
+import type {
+    NumericInputWidget,
+    PerseusNumericInputSimplify,
+} from "../../data-schema";
 import type {Parser} from "../parser-types";
 
 const parseMathFormat = enumeration(
@@ -29,12 +32,41 @@ const parseMathFormat = enumeration(
     "pi",
 );
 
-const parseSimplify = enumeration(
-    "required",
-    "correct",
-    "enforced",
-    "optional",
-);
+const parseSimplify = pipeParsers(
+    union(constant(null))
+        .or(constant(undefined))
+        .or(boolean)
+        .or(constant("required"))
+        .or(constant("correct"))
+        .or(constant("enforced"))
+        .or(constant("optional"))
+        .or(constant("accepted")).parser,
+).then(convert(deprecatedSimplifyValuesToRequired)).parser;
+
+function deprecatedSimplifyValuesToRequired(
+    simplify:
+        | "required"
+        | "correct"
+        | "enforced"
+        | "optional"
+        | "accepted"
+        | null
+        | undefined
+        | boolean,
+): PerseusNumericInputSimplify {
+    switch (simplify) {
+        case "enforced":
+        case "required":
+        case "optional":
+            return simplify;
+        // NOTE(benchristel): "accepted", "correct", true, false, undefined, and
+        // null are all treated the same as "required" during scoring, so we
+        // convert them to "required" here to preserve behavior. See the tests
+        // in score-numeric-input.test.ts
+        default:
+            return "required";
+    }
+}
 
 export const parseNumericInputWidget: Parser<NumericInputWidget> = parseWidget(
     constant("numeric-input"),
@@ -53,20 +85,7 @@ export const parseNumericInputWidget: Parser<NumericInputWidget> = parseWidget(
                 // TODO(benchristel): simplify should never be a boolean, but we
                 // have some content where it is anyway. If we ever backfill
                 // the data, we should simplify `simplify`.
-                simplify: optional(
-                    nullable(
-                        union(parseSimplify).or(
-                            pipeParsers(boolean).then(
-                                convert((value) => {
-                                    if (typeof value === "boolean") {
-                                        return value ? "required" : "optional";
-                                    }
-                                    return value;
-                                }),
-                            ).parser,
-                        ).parser,
-                    ),
-                ),
+                simplify: parseSimplify,
             }),
         ),
         labelText: optional(string),
@@ -78,16 +97,7 @@ export const parseNumericInputWidget: Parser<NumericInputWidget> = parseWidget(
             array(
                 object({
                     name: parseMathFormat,
-                    simplify: optional(
-                        nullable(
-                            enumeration(
-                                "required",
-                                "correct",
-                                "enforced",
-                                "optional",
-                            ),
-                        ),
-                    ),
+                    simplify: parseSimplify,
                 }),
             ),
         ),

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -7917,6 +7917,221 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-null-answerForms.js
 }
 `;
 
+exports[`parseAndMigratePerseusItem given numeric-input-with-simplify-accepted.json returns the same result as before 1`] = `
+{
+  "answerArea": {
+    "calculator": true,
+    "chi2Table": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTimeToPayOff": false,
+    "financialCalculatorTotalAmount": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+    "tTable": false,
+    "zTable": false,
+  },
+  "hints": [
+    {
+      "content": "### The strategy
+
+- Model the situation as a right triangle.
+
+- Determine the appropriate trigonometric ratio in order to find the missing side.
+
+- Form an equation and solve for the missing side.
+
+- Calculate the final result and round.",
+      "images": {},
+      "replace": false,
+      "widgets": {},
+    },
+    {
+      "content": "### Modeling as a right triangle
+
+This situation can be modeled by the following right triangle. The hypotenuse is $2.1\\text{ km}$ and the angle on the right is $37^\\circ$. We are asked to find the distance between the skydiving center and Stella's landing point, which is the base of the triangle.
+
+
+
+[[☃ image 1]]
+
+### Determining the appropriate trigonometric ratio
+
+We are given the measure of an angle and the length of the $\\purpleC{\\text{hypotenuse}}$. We are asked to find the side $\\maroonC{\\text{adjacent}}$ to the given angle. The appropriate trigonometric ratio is therefore the $\\Large\\text{cosine}$.
+",
+      "images": {},
+      "replace": false,
+      "widgets": {
+        "image 1": {
+          "alignment": "block",
+          "graded": true,
+          "options": {
+            "alt": "A right triangle where the base is unknown. The angle on the right side of the base is thirty-seven degrees. The angle on the left side of the base is the right angle. The hypotenuse is two point one.",
+            "backgroundImage": {
+              "height": 252,
+              "url": "web+graphie://cdn.kastatic.org/ka-perseus-graphie/5b2b177fc0ba3ba56c75d2e21329191582aeb5bc",
+              "width": 300,
+            },
+            "box": [
+              300,
+              252,
+            ],
+            "caption": "",
+            "labels": [],
+            "range": [
+              [
+                0,
+                10,
+              ],
+              [
+                0,
+                10,
+              ],
+            ],
+            "static": false,
+            "title": "",
+          },
+          "static": false,
+          "type": "image",
+          "version": {
+            "major": 0,
+            "minor": 0,
+          },
+        },
+      },
+    },
+    {
+      "content": "### Forming an equation and solving
+
+Denoting the missing side by $x$, we obtain the equation $\\cos(37^\\circ)=\\dfrac{x}{2.1}$.
+
+Solving the equation, we get $x=2.1\\cdot\\cos(37^\\circ)$.
+
+Evaluating this result in the calculator and rounding to the nearest hundredth, we get $x=1.68\\text{ km}$.",
+      "images": {},
+      "replace": false,
+      "widgets": {},
+    },
+    {
+      "content": "### Summary
+
+Stella landed $1.68$ kilometers from the skydiving center.",
+      "images": {},
+      "replace": false,
+      "widgets": {},
+    },
+  ],
+  "itemDataVersion": {
+    "major": 0,
+    "minor": 1,
+  },
+  "question": {
+    "content": "Stella's friends got her a skydiving lesson for her birthday. Her helicopter took off from the skydiving center, ascending in an angle of $37^\\circ$, and traveled a distance of $2.1$ kilometers before she fell in a straight line perpendicular to the ground.
+ 
+**How far from the skydiving center did Stella land?** 
+*Round your final answer to the nearest hundredth.*
+
+[[☃ numeric-input 1]] kilometers
+ 
+
+
+[[☃ image 1]]
+
+",
+    "images": {},
+    "widgets": {
+      "image 1": {
+        "alignment": "block",
+        "graded": true,
+        "options": {
+          "alt": "A rectangle that represents the ground. A point is on the top of the rectangle. A helicopter is above the ground with a person parachuting beneath it. The distance from the helicopter to the point is two point one kilometers and is the hypotenuse. The inside angle from the point to the helicopter is thirty-seven degrees.",
+          "backgroundImage": {
+            "height": 270,
+            "url": "https://cdn.kastatic.org/ka-perseus-graphie/532e339d4d95f9cf6423e66bdc70dd06f1143a97.png",
+            "width": 300,
+          },
+          "box": [
+            300,
+            270,
+          ],
+          "caption": "",
+          "labels": [],
+          "range": [
+            [
+              0,
+              10,
+            ],
+            [
+              0,
+              10,
+            ],
+          ],
+          "static": false,
+          "title": "",
+        },
+        "static": false,
+        "type": "image",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+      "numeric-input 1": {
+        "alignment": "default",
+        "graded": true,
+        "options": {
+          "answers": [
+            {
+              "maxError": 0.01,
+              "message": "",
+              "simplify": "required",
+              "status": "correct",
+              "strict": false,
+              "value": 1.68,
+            },
+            {
+              "maxError": 0.2,
+              "message": "You probably solved correctly but your answer is not precise enough. Try rounding only at the last step of your solution.",
+              "simplify": "required",
+              "status": "ungraded",
+              "strict": false,
+              "value": 1.68,
+            },
+            {
+              "maxError": 0.5,
+              "message": "You probably used radians instead of degrees. Make sure your calculator is set to degrees.",
+              "simplify": "required",
+              "status": "ungraded",
+              "strict": false,
+              "value": 1.61,
+            },
+            {
+              "maxError": 0.1,
+              "message": "This is the height of Stella's fall. We asked for the distance from her landing point to the skydiving center.",
+              "simplify": "required",
+              "status": "wrong",
+              "strict": false,
+              "value": 1.2,
+            },
+          ],
+          "coefficient": false,
+          "labelText": "",
+          "multipleNumberInput": false,
+          "rightAlign": false,
+          "size": "normal",
+          "static": false,
+        },
+        "static": false,
+        "type": "numeric-input",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`parseAndMigratePerseusItem given numeric-input-with-simplify-false.json returns the same result as before 1`] = `
 {
   "answerArea": {
@@ -7957,7 +8172,7 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-simplify-false.json
             {
               "maxError": 0,
               "message": "",
-              "simplify": "optional",
+              "simplify": "required",
               "status": "correct",
               "strict": false,
               "value": 2.6,

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/numeric-input-with-simplify-accepted.json
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/numeric-input-with-simplify-accepted.json
@@ -1,0 +1,170 @@
+{
+  "answerArea": {
+    "calculator": true,
+    "chi2Table": false,
+    "periodicTable": false,
+    "tTable": false,
+    "zTable": false
+  },
+  "hints": [
+    {
+      "content": "### The strategy\n\n- Model the situation as a right triangle.\n\n- Determine the appropriate trigonometric ratio in order to find the missing side.\n\n- Form an equation and solve for the missing side.\n\n- Calculate the final result and round.",
+      "images": {},
+      "replace": false,
+      "widgets": {}
+    },
+    {
+      "content": "### Modeling as a right triangle\n\nThis situation can be modeled by the following right triangle. The hypotenuse is $2.1\\text{ km}$ and the angle on the right is $37^\\circ$. We are asked to find the distance between the skydiving center and Stella's landing point, which is the base of the triangle.\n\n\n\n[[☃ image 1]]\n\n### Determining the appropriate trigonometric ratio\n\nWe are given the measure of an angle and the length of the $\\purpleC{\\text{hypotenuse}}$. We are asked to find the side $\\maroonC{\\text{adjacent}}$ to the given angle. The appropriate trigonometric ratio is therefore the $\\Large\\text{cosine}$.\n",
+      "images": {},
+      "replace": false,
+      "widgets": {
+        "image 1": {
+          "alignment": "block",
+          "graded": true,
+          "options": {
+            "alt": "A right triangle where the base is unknown. The angle on the right side of the base is thirty-seven degrees. The angle on the left side of the base is the right angle. The hypotenuse is two point one.",
+            "backgroundImage": {
+              "height": 252,
+              "url": "web+graphie://cdn.kastatic.org/ka-perseus-graphie/5b2b177fc0ba3ba56c75d2e21329191582aeb5bc",
+              "width": 300
+            },
+            "box": [
+              300,
+              252
+            ],
+            "caption": "",
+            "labels": [],
+            "range": [
+              [
+                0,
+                10
+              ],
+              [
+                0,
+                10
+              ]
+            ],
+            "static": false,
+            "title": ""
+          },
+          "static": false,
+          "type": "image",
+          "version": {
+            "major": 0,
+            "minor": 0
+          }
+        }
+      }
+    },
+    {
+      "content": "### Forming an equation and solving\n\nDenoting the missing side by $x$, we obtain the equation $\\cos(37^\\circ)=\\dfrac{x}{2.1}$.\n\nSolving the equation, we get $x=2.1\\cdot\\cos(37^\\circ)$.\n\nEvaluating this result in the calculator and rounding to the nearest hundredth, we get $x=1.68\\text{ km}$.",
+      "images": {},
+      "replace": false,
+      "widgets": {}
+    },
+    {
+      "content": "### Summary\n\nStella landed $1.68$ kilometers from the skydiving center.",
+      "images": {},
+      "replace": false,
+      "widgets": {}
+    }
+  ],
+  "itemDataVersion": {
+    "major": 0,
+    "minor": 1
+  },
+  "question": {
+    "content": "Stella's friends got her a skydiving lesson for her birthday. Her helicopter took off from the skydiving center, ascending in an angle of $37^\\circ$, and traveled a distance of $2.1$ kilometers before she fell in a straight line perpendicular to the ground.\n \n**How far from the skydiving center did Stella land?** \n*Round your final answer to the nearest hundredth.*\n\n[[☃ numeric-input 1]] kilometers\n \n\n\n[[☃ image 1]]\n\n",
+    "images": {},
+    "widgets": {
+      "image 1": {
+        "alignment": "block",
+        "graded": true,
+        "options": {
+          "alt": "A rectangle that represents the ground. A point is on the top of the rectangle. A helicopter is above the ground with a person parachuting beneath it. The distance from the helicopter to the point is two point one kilometers and is the hypotenuse. The inside angle from the point to the helicopter is thirty-seven degrees.",
+          "backgroundImage": {
+            "height": 270,
+            "url": "https://cdn.kastatic.org/ka-perseus-graphie/532e339d4d95f9cf6423e66bdc70dd06f1143a97.png",
+            "width": 300
+          },
+          "box": [
+            300,
+            270
+          ],
+          "caption": "",
+          "labels": [],
+          "range": [
+            [
+              0,
+              10
+            ],
+            [
+              0,
+              10
+            ]
+          ],
+          "static": false,
+          "title": ""
+        },
+        "static": false,
+        "type": "image",
+        "version": {
+          "major": 0,
+          "minor": 0
+        }
+      },
+      "numeric-input 1": {
+        "alignment": "default",
+        "graded": true,
+        "options": {
+          "answers": [
+            {
+              "maxError": 0.01,
+              "message": "",
+              "simplify": "required",
+              "status": "correct",
+              "strict": false,
+              "value": 1.68
+            },
+            {
+              "maxError": 0.2,
+              "message": "You probably solved correctly but your answer is not precise enough. Try rounding only at the last step of your solution.",
+              "simplify": "accepted",
+              "status": "ungraded",
+              "strict": false,
+              "value": 1.68
+            },
+            {
+              "maxError": 0.5,
+              "message": "You probably used radians instead of degrees. Make sure your calculator is set to degrees.",
+              "simplify": "accepted",
+              "status": "ungraded",
+              "strict": false,
+              "value": 1.61
+            },
+            {
+              "maxError": 0.1,
+              "message": "This is the height of Stella's fall. We asked for the distance from her landing point to the skydiving center.",
+              "simplify": "required",
+              "status": "wrong",
+              "strict": false,
+              "value": 1.2
+            }
+          ],
+          "coefficient": false,
+          "labelText": "",
+          "multipleNumberInput": false,
+          "rightAlign": false,
+          "size": "normal",
+          "static": false
+        },
+        "static": false,
+        "type": "numeric-input",
+        "version": {
+          "major": 0,
+          "minor": 0
+        }
+      }
+    }
+  }
+}

--- a/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
+++ b/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
@@ -528,6 +528,249 @@ describe("scoreNumericInput", () => {
 
         expect(score).toHaveBeenAnsweredIncorrectly();
     });
+
+    it("marks unsimplified fractions incorrect when 'simplify' is 'enforced'", () => {
+        // Arrange
+        const rubric: PerseusNumericInputRubric = {
+            coefficient: false,
+            answers: [
+                {
+                    value: 0.5,
+                    status: "correct",
+                    maxError: 0,
+                    simplify: "enforced",
+                    strict: false,
+                    message: "",
+                },
+            ],
+        };
+
+        const userInput = {
+            currentValue: "2/4",
+        };
+
+        // Act
+        const score = scoreNumericInput(userInput, rubric);
+
+        // Assert
+        expect(score).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("marks simplified fractions correct when 'simplify' is 'enforced'", () => {
+        // Arrange
+        const rubric: PerseusNumericInputRubric = {
+            coefficient: false,
+            answers: [
+                {
+                    value: 0.5,
+                    status: "correct",
+                    maxError: 0,
+                    simplify: "enforced",
+                    strict: false,
+                    message: "",
+                },
+            ],
+        };
+
+        const userInput = {
+            currentValue: "1/2",
+        };
+
+        // Act
+        const score = scoreNumericInput(userInput, rubric);
+
+        // Assert
+        expect(score).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("marks wrong fractions incorrect when 'simplify' is 'enforced'", () => {
+        // Arrange
+        const rubric: PerseusNumericInputRubric = {
+            coefficient: false,
+            answers: [
+                {
+                    value: 0.5,
+                    status: "correct",
+                    maxError: 0,
+                    simplify: "enforced",
+                    strict: false,
+                    message: "",
+                },
+            ],
+        };
+
+        const userInput = {
+            currentValue: "1/3",
+        };
+
+        // Act
+        const score = scoreNumericInput(userInput, rubric);
+
+        // Assert
+        expect(score).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("marks unsimplified fractions correct when 'simplify' is 'optional'", () => {
+        // Arrange
+        const rubric: PerseusNumericInputRubric = {
+            coefficient: false,
+            answers: [
+                {
+                    value: 0.5,
+                    status: "correct",
+                    maxError: 0,
+                    simplify: "optional",
+                    strict: false,
+                    message: "",
+                },
+            ],
+        };
+
+        const userInput = {
+            currentValue: "2/4",
+        };
+
+        // Act
+        const score = scoreNumericInput(userInput, rubric);
+
+        // Assert
+        expect(score).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("marks simplified fractions correct when 'simplify' is 'optional'", () => {
+        // Arrange
+        const rubric: PerseusNumericInputRubric = {
+            coefficient: false,
+            answers: [
+                {
+                    value: 0.5,
+                    status: "correct",
+                    maxError: 0,
+                    simplify: "optional",
+                    strict: false,
+                    message: "",
+                },
+            ],
+        };
+
+        const userInput = {
+            currentValue: "1/2",
+        };
+
+        // Act
+        const score = scoreNumericInput(userInput, rubric);
+
+        // Assert
+        expect(score).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("marks wrong fractions incorrect when 'simplify' is 'optional'", () => {
+        // Arrange
+        const rubric: PerseusNumericInputRubric = {
+            coefficient: false,
+            answers: [
+                {
+                    value: 0.5,
+                    status: "correct",
+                    maxError: 0,
+                    simplify: "optional",
+                    strict: false,
+                    message: "",
+                },
+            ],
+        };
+
+        const userInput = {
+            currentValue: "1/3",
+        };
+
+        // Act
+        const score = scoreNumericInput(userInput, rubric);
+
+        // Assert
+        expect(score).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("rejects unsimplified fractions as invalid when 'simplify' is 'required'", () => {
+        // Arrange
+        const rubric: PerseusNumericInputRubric = {
+            coefficient: false,
+            answers: [
+                {
+                    value: 0.5,
+                    status: "correct",
+                    maxError: 0,
+                    simplify: "required",
+                    strict: false,
+                    message: "",
+                },
+            ],
+        };
+
+        const userInput = {
+            currentValue: "2/4",
+        };
+
+        // Act
+        const score = scoreNumericInput(userInput, rubric);
+
+        // Assert
+        expect(score).toHaveInvalidInput();
+    });
+
+    it("marks simplified fractions correct when 'simplify' is 'required'", () => {
+        // Arrange
+        const rubric: PerseusNumericInputRubric = {
+            coefficient: false,
+            answers: [
+                {
+                    value: 0.5,
+                    status: "correct",
+                    maxError: 0,
+                    simplify: "required",
+                    strict: false,
+                    message: "",
+                },
+            ],
+        };
+
+        const userInput = {
+            currentValue: "1/2",
+        };
+
+        // Act
+        const score = scoreNumericInput(userInput, rubric);
+
+        // Assert
+        expect(score).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("marks wrong fractions incorrect when 'simplify' is 'required'", () => {
+        // Arrange
+        const rubric: PerseusNumericInputRubric = {
+            coefficient: false,
+            answers: [
+                {
+                    value: 0.5,
+                    status: "correct",
+                    maxError: 0,
+                    simplify: "required",
+                    strict: false,
+                    message: "",
+                },
+            ],
+        };
+
+        const userInput = {
+            currentValue: "1/3",
+        };
+
+        // Act
+        const score = scoreNumericInput(userInput, rubric);
+
+        // Assert
+        expect(score).toHaveBeenAnsweredIncorrectly();
+    });
 });
 
 describe("maybeParsePercentInput utility function", () => {

--- a/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
+++ b/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
@@ -529,248 +529,58 @@ describe("scoreNumericInput", () => {
         expect(score).toHaveBeenAnsweredIncorrectly();
     });
 
-    it("marks unsimplified fractions incorrect when 'simplify' is 'enforced'", () => {
-        // Arrange
-        const rubric: PerseusNumericInputRubric = {
-            coefficient: false,
-            answers: [
-                {
-                    value: 0.5,
-                    status: "correct",
-                    maxError: 0,
-                    simplify: "enforced",
-                    strict: false,
-                    message: "",
-                },
-            ],
-        };
+    const answerMatchers = {
+        incorrect: expect.objectContaining({
+            type: "points",
+            earned: 0,
+        }),
 
-        const userInput = {
-            currentValue: "2/4",
-        };
+        correct: expect.objectContaining({
+            type: "points",
+            earned: 1,
+        }),
 
-        // Act
-        const score = scoreNumericInput(userInput, rubric);
+        invalid: expect.objectContaining({
+            type: "invalid",
+        }),
+    };
 
-        // Assert
-        expect(score).toHaveBeenAnsweredIncorrectly();
-    });
+    it.each`
+        simplify      | answer | userInput | expected
+        ${"enforced"} | ${0.5} | ${"2/4"}  | ${"incorrect"}
+        ${"enforced"} | ${0.5} | ${"1/2"}  | ${"correct"}
+        ${"enforced"} | ${0.5} | ${"2/3"}  | ${"incorrect"}
+        ${"optional"} | ${0.5} | ${"2/4"}  | ${"correct"}
+        ${"optional"} | ${0.5} | ${"1/2"}  | ${"correct"}
+        ${"optional"} | ${0.5} | ${"2/3"}  | ${"incorrect"}
+        ${"required"} | ${0.5} | ${"2/4"}  | ${"invalid"}
+        ${"required"} | ${0.5} | ${"1/2"}  | ${"correct"}
+        ${"required"} | ${0.5} | ${"2/3"}  | ${"incorrect"}
+    `(
+        "with simplify: $simplify, marks $userInput $expected for $answer",
+        ({simplify, answer, userInput, expected}) => {
+            // Arrange
+            const rubric: PerseusNumericInputRubric = {
+                coefficient: false,
+                answers: [
+                    {
+                        value: answer,
+                        status: "correct",
+                        maxError: 0,
+                        simplify,
+                        strict: false,
+                        message: "",
+                    },
+                ],
+            };
 
-    it("marks simplified fractions correct when 'simplify' is 'enforced'", () => {
-        // Arrange
-        const rubric: PerseusNumericInputRubric = {
-            coefficient: false,
-            answers: [
-                {
-                    value: 0.5,
-                    status: "correct",
-                    maxError: 0,
-                    simplify: "enforced",
-                    strict: false,
-                    message: "",
-                },
-            ],
-        };
+            // Act
+            const score = scoreNumericInput({currentValue: userInput}, rubric);
 
-        const userInput = {
-            currentValue: "1/2",
-        };
-
-        // Act
-        const score = scoreNumericInput(userInput, rubric);
-
-        // Assert
-        expect(score).toHaveBeenAnsweredCorrectly();
-    });
-
-    it("marks wrong fractions incorrect when 'simplify' is 'enforced'", () => {
-        // Arrange
-        const rubric: PerseusNumericInputRubric = {
-            coefficient: false,
-            answers: [
-                {
-                    value: 0.5,
-                    status: "correct",
-                    maxError: 0,
-                    simplify: "enforced",
-                    strict: false,
-                    message: "",
-                },
-            ],
-        };
-
-        const userInput = {
-            currentValue: "1/3",
-        };
-
-        // Act
-        const score = scoreNumericInput(userInput, rubric);
-
-        // Assert
-        expect(score).toHaveBeenAnsweredIncorrectly();
-    });
-
-    it("marks unsimplified fractions correct when 'simplify' is 'optional'", () => {
-        // Arrange
-        const rubric: PerseusNumericInputRubric = {
-            coefficient: false,
-            answers: [
-                {
-                    value: 0.5,
-                    status: "correct",
-                    maxError: 0,
-                    simplify: "optional",
-                    strict: false,
-                    message: "",
-                },
-            ],
-        };
-
-        const userInput = {
-            currentValue: "2/4",
-        };
-
-        // Act
-        const score = scoreNumericInput(userInput, rubric);
-
-        // Assert
-        expect(score).toHaveBeenAnsweredCorrectly();
-    });
-
-    it("marks simplified fractions correct when 'simplify' is 'optional'", () => {
-        // Arrange
-        const rubric: PerseusNumericInputRubric = {
-            coefficient: false,
-            answers: [
-                {
-                    value: 0.5,
-                    status: "correct",
-                    maxError: 0,
-                    simplify: "optional",
-                    strict: false,
-                    message: "",
-                },
-            ],
-        };
-
-        const userInput = {
-            currentValue: "1/2",
-        };
-
-        // Act
-        const score = scoreNumericInput(userInput, rubric);
-
-        // Assert
-        expect(score).toHaveBeenAnsweredCorrectly();
-    });
-
-    it("marks wrong fractions incorrect when 'simplify' is 'optional'", () => {
-        // Arrange
-        const rubric: PerseusNumericInputRubric = {
-            coefficient: false,
-            answers: [
-                {
-                    value: 0.5,
-                    status: "correct",
-                    maxError: 0,
-                    simplify: "optional",
-                    strict: false,
-                    message: "",
-                },
-            ],
-        };
-
-        const userInput = {
-            currentValue: "1/3",
-        };
-
-        // Act
-        const score = scoreNumericInput(userInput, rubric);
-
-        // Assert
-        expect(score).toHaveBeenAnsweredIncorrectly();
-    });
-
-    it("rejects unsimplified fractions as invalid when 'simplify' is 'required'", () => {
-        // Arrange
-        const rubric: PerseusNumericInputRubric = {
-            coefficient: false,
-            answers: [
-                {
-                    value: 0.5,
-                    status: "correct",
-                    maxError: 0,
-                    simplify: "required",
-                    strict: false,
-                    message: "",
-                },
-            ],
-        };
-
-        const userInput = {
-            currentValue: "2/4",
-        };
-
-        // Act
-        const score = scoreNumericInput(userInput, rubric);
-
-        // Assert
-        expect(score).toHaveInvalidInput();
-    });
-
-    it("marks simplified fractions correct when 'simplify' is 'required'", () => {
-        // Arrange
-        const rubric: PerseusNumericInputRubric = {
-            coefficient: false,
-            answers: [
-                {
-                    value: 0.5,
-                    status: "correct",
-                    maxError: 0,
-                    simplify: "required",
-                    strict: false,
-                    message: "",
-                },
-            ],
-        };
-
-        const userInput = {
-            currentValue: "1/2",
-        };
-
-        // Act
-        const score = scoreNumericInput(userInput, rubric);
-
-        // Assert
-        expect(score).toHaveBeenAnsweredCorrectly();
-    });
-
-    it("marks wrong fractions incorrect when 'simplify' is 'required'", () => {
-        // Arrange
-        const rubric: PerseusNumericInputRubric = {
-            coefficient: false,
-            answers: [
-                {
-                    value: 0.5,
-                    status: "correct",
-                    maxError: 0,
-                    simplify: "required",
-                    strict: false,
-                    message: "",
-                },
-            ],
-        };
-
-        const userInput = {
-            currentValue: "1/3",
-        };
-
-        // Act
-        const score = scoreNumericInput(userInput, rubric);
-
-        // Assert
-        expect(score).toHaveBeenAnsweredIncorrectly();
-    });
+            // Assert
+            expect(score).toEqual(answerMatchers[expected]);
+        },
+    );
 });
 
 describe("maybeParsePercentInput utility function", () => {

--- a/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
+++ b/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
@@ -545,6 +545,10 @@ describe("scoreNumericInput", () => {
         }),
     };
 
+    // NOTE(benchristel): "accepted" is not a valid value for `simplify`
+    // according to our types, but it appears in production data. The tests
+    // for "accepted" characterize the current behavior as of 2025-03-13.
+    // Note that "accepted" is treated the same as "required".
     it.each`
         simplify      | answer | userInput | expected
         ${"enforced"} | ${0.5} | ${"2/4"}  | ${"incorrect"}
@@ -556,6 +560,9 @@ describe("scoreNumericInput", () => {
         ${"required"} | ${0.5} | ${"2/4"}  | ${"invalid"}
         ${"required"} | ${0.5} | ${"1/2"}  | ${"correct"}
         ${"required"} | ${0.5} | ${"2/3"}  | ${"incorrect"}
+        ${"accepted"} | ${0.5} | ${"2/4"}  | ${"invalid"}
+        ${"accepted"} | ${0.5} | ${"1/2"}  | ${"correct"}
+        ${"accepted"} | ${0.5} | ${"2/3"}  | ${"incorrect"}
     `(
         "with simplify: $simplify, marks $userInput $expected for $answer",
         ({simplify, answer, userInput, expected}) => {

--- a/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
+++ b/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
@@ -545,10 +545,20 @@ describe("scoreNumericInput", () => {
         }),
     };
 
-    // NOTE(benchristel): "accepted" is not a valid value for `simplify`
-    // according to our types, but it appears in production data. The tests
-    // for "accepted" characterize the current behavior as of 2025-03-13.
-    // Note that "accepted" is treated the same as "required".
+    // Tests for the "simplify" widget option:
+    //
+    // - simplify: "enforced" means unsimplified fractions are marked incorrect.
+    // - simplify: "required" means unsimplified fractions are returned as
+    //   invalid, and the learner can try again.
+    // - simplify: "optional" means unsimplified fractions are accepted as
+    //   correct.
+    //
+    // NOTE(benchristel): "accepted", "correct", booleans, undefined, and null
+    // are treated the same as "required". They are not valid values for
+    // `simplify` according to our types, but they appear in production data.
+    // The tests for these values characterize the current behavior as of
+    // 2025-03-18. Note that "accepted", "correct", booleans, undefined, and
+    // null are treated the same as "required".
     it.each`
         simplify      | answer | userInput | expected
         ${"enforced"} | ${0.5} | ${"2/4"}  | ${"incorrect"}
@@ -563,6 +573,21 @@ describe("scoreNumericInput", () => {
         ${"accepted"} | ${0.5} | ${"2/4"}  | ${"invalid"}
         ${"accepted"} | ${0.5} | ${"1/2"}  | ${"correct"}
         ${"accepted"} | ${0.5} | ${"2/3"}  | ${"incorrect"}
+        ${"correct"}  | ${0.5} | ${"2/4"}  | ${"invalid"}
+        ${"correct"}  | ${0.5} | ${"1/2"}  | ${"correct"}
+        ${"correct"}  | ${0.5} | ${"2/3"}  | ${"incorrect"}
+        ${undefined}  | ${0.5} | ${"2/4"}  | ${"invalid"}
+        ${undefined}  | ${0.5} | ${"1/2"}  | ${"correct"}
+        ${undefined}  | ${0.5} | ${"2/3"}  | ${"incorrect"}
+        ${null}       | ${0.5} | ${"2/4"}  | ${"invalid"}
+        ${null}       | ${0.5} | ${"1/2"}  | ${"correct"}
+        ${null}       | ${0.5} | ${"2/3"}  | ${"incorrect"}
+        ${false}      | ${0.5} | ${"2/4"}  | ${"invalid"}
+        ${false}      | ${0.5} | ${"1/2"}  | ${"correct"}
+        ${false}      | ${0.5} | ${"2/3"}  | ${"incorrect"}
+        ${true}       | ${0.5} | ${"2/4"}  | ${"invalid"}
+        ${true}       | ${0.5} | ${"1/2"}  | ${"correct"}
+        ${true}       | ${0.5} | ${"2/3"}  | ${"incorrect"}
     `(
         "with simplify: $simplify, marks $userInput $expected for $answer",
         ({simplify, answer, userInput, expected}) => {


### PR DESCRIPTION
Context: I'm seeing errors in Sentry because the perseus JSON parser doesn't
understand some of the values of `simplify` that exist in production data. This
PR ensures we accept and handle those values.

## Summary:
- I added tests to characterize the behavior of numeric input scoring for all
  the values of `simplify` that are in production.
- I updated the perseus JSON parser to convert nonstandard `simplify` values
  to equivalent ones.

Issue: none

## Test plan:

`yarn test`