### PR TITLE
[SR] Update graph elements so their aria-describedby is read in non-Chrome browsers

### DIFF
--- a/.changeset/early-dodos-wink.md
+++ b/.changeset/early-dodos-wink.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[SR] Update graph elements so their aria-describedby is read in non-Chrome browsers

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -1299,21 +1299,30 @@ exports[`Interactive Graph question Should render predictably: after interaction
                                 style="fill: var(--mafs-blue);"
                               />
                             </g>
-                            <g
-                              id=":r3:-angle-0"
-                            >
-                              Angle approximately equal to 63.4 degrees.
-                            </g>
-                            <g
-                              id=":r3:-point-0-side-1"
-                            >
-                              A line segment, length equal to 2 units, connects to point 3.
-                            </g>
-                            <g
-                              id=":r3:-point-0-side-2"
-                            >
-                              A line segment, length approximately equal to 2.2 units, connects to point 2.
-                            </g>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":r3:-angle-0"
+                              >
+                                Angle approximately equal to 63.4 degrees.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":r3:-point-0-side-1"
+                              >
+                                A line segment, length equal to 2 units, connects to point 3.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":r3:-point-0-side-2"
+                              >
+                                A line segment, length approximately equal to 2.2 units, connects to point 2.
+                              </span>
+                            </foreignobject>
                           </g>
                           <g>
                             <g
@@ -1360,21 +1369,30 @@ exports[`Interactive Graph question Should render predictably: after interaction
                                 style="fill: var(--mafs-blue);"
                               />
                             </g>
-                            <g
-                              id=":r3:-angle-1"
-                            >
-                              Angle approximately equal to 53.1 degrees.
-                            </g>
-                            <g
-                              id=":r3:-point-1-side-1"
-                            >
-                              A line segment, length approximately equal to 2.2 units, connects to point 1.
-                            </g>
-                            <g
-                              id=":r3:-point-1-side-2"
-                            >
-                              A line segment, length approximately equal to 2.2 units, connects to point 3.
-                            </g>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":r3:-angle-1"
+                              >
+                                Angle approximately equal to 53.1 degrees.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":r3:-point-1-side-1"
+                              >
+                                A line segment, length approximately equal to 2.2 units, connects to point 1.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":r3:-point-1-side-2"
+                              >
+                                A line segment, length approximately equal to 2.2 units, connects to point 3.
+                              </span>
+                            </foreignobject>
                           </g>
                           <g>
                             <g
@@ -1421,27 +1439,39 @@ exports[`Interactive Graph question Should render predictably: after interaction
                                 style="fill: var(--mafs-blue);"
                               />
                             </g>
-                            <g
-                              id=":r3:-angle-2"
-                            >
-                              Angle approximately equal to 63.4 degrees.
-                            </g>
-                            <g
-                              id=":r3:-point-2-side-1"
-                            >
-                              A line segment, length approximately equal to 2.2 units, connects to point 2.
-                            </g>
-                            <g
-                              id=":r3:-point-2-side-2"
-                            >
-                              A line segment, length equal to 2 units, connects to point 1.
-                            </g>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":r3:-angle-2"
+                              >
+                                Angle approximately equal to 63.4 degrees.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":r3:-point-2-side-1"
+                              >
+                                A line segment, length approximately equal to 2.2 units, connects to point 2.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":r3:-point-2-side-2"
+                              >
+                                A line segment, length equal to 2 units, connects to point 1.
+                              </span>
+                            </foreignobject>
                           </g>
-                          <g
-                            id=":r3:-points-num"
-                          >
-                            The polygon has 3 points.
-                          </g>
+                          <foreignobject>
+                            <span
+                              aria-hidden="true"
+                              id=":r3:-points-num"
+                            >
+                              The polygon has 3 points.
+                            </span>
+                          </foreignobject>
                         </g>
                       </svg>
                     </svg>
@@ -1700,21 +1730,30 @@ exports[`Interactive Graph question Should render predictably: after interaction
                                 style="fill: var(--mafs-blue);"
                               />
                             </g>
-                            <g
-                              id=":rb:-angle-0"
-                            >
-                              Angle approximately equal to 59 degrees.
-                            </g>
-                            <g
-                              id=":rb:-point-0-side-1"
-                            >
-                              A line segment, length equal to 6 units, connects to point 3.
-                            </g>
-                            <g
-                              id=":rb:-point-0-side-2"
-                            >
-                              A line segment, length approximately equal to 5.8 units, connects to point 2.
-                            </g>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":rb:-angle-0"
+                              >
+                                Angle approximately equal to 59 degrees.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":rb:-point-0-side-1"
+                              >
+                                A line segment, length equal to 6 units, connects to point 3.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":rb:-point-0-side-2"
+                              >
+                                A line segment, length approximately equal to 5.8 units, connects to point 2.
+                              </span>
+                            </foreignobject>
                           </g>
                           <g>
                             <g
@@ -1761,21 +1800,30 @@ exports[`Interactive Graph question Should render predictably: after interaction
                                 style="fill: var(--mafs-blue);"
                               />
                             </g>
-                            <g
-                              id=":rb:-angle-1"
-                            >
-                              Angle approximately equal to 61.9 degrees.
-                            </g>
-                            <g
-                              id=":rb:-point-1-side-1"
-                            >
-                              A line segment, length approximately equal to 5.8 units, connects to point 1.
-                            </g>
-                            <g
-                              id=":rb:-point-1-side-2"
-                            >
-                              A line segment, length approximately equal to 5.8 units, connects to point 3.
-                            </g>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":rb:-angle-1"
+                              >
+                                Angle approximately equal to 61.9 degrees.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":rb:-point-1-side-1"
+                              >
+                                A line segment, length approximately equal to 5.8 units, connects to point 1.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":rb:-point-1-side-2"
+                              >
+                                A line segment, length approximately equal to 5.8 units, connects to point 3.
+                              </span>
+                            </foreignobject>
                           </g>
                           <g>
                             <g
@@ -1822,27 +1870,39 @@ exports[`Interactive Graph question Should render predictably: after interaction
                                 style="fill: var(--mafs-blue);"
                               />
                             </g>
-                            <g
-                              id=":rb:-angle-2"
-                            >
-                              Angle approximately equal to 59 degrees.
-                            </g>
-                            <g
-                              id=":rb:-point-2-side-1"
-                            >
-                              A line segment, length approximately equal to 5.8 units, connects to point 2.
-                            </g>
-                            <g
-                              id=":rb:-point-2-side-2"
-                            >
-                              A line segment, length equal to 6 units, connects to point 1.
-                            </g>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":rb:-angle-2"
+                              >
+                                Angle approximately equal to 59 degrees.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":rb:-point-2-side-1"
+                              >
+                                A line segment, length approximately equal to 5.8 units, connects to point 2.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":rb:-point-2-side-2"
+                              >
+                                A line segment, length equal to 6 units, connects to point 1.
+                              </span>
+                            </foreignobject>
                           </g>
-                          <g
-                            id=":rb:-points-num"
-                          >
-                            The polygon has 3 points.
-                          </g>
+                          <foreignobject>
+                            <span
+                              aria-hidden="true"
+                              id=":rb:-points-num"
+                            >
+                              The polygon has 3 points.
+                            </span>
+                          </foreignobject>
                         </g>
                       </svg>
                     </svg>
@@ -2623,21 +2683,30 @@ exports[`Interactive Graph question Should render predictably: first render 1`] 
                                 style="fill: var(--mafs-blue);"
                               />
                             </g>
-                            <g
-                              id=":r3:-angle-0"
-                            >
-                              Angle approximately equal to 63.4 degrees.
-                            </g>
-                            <g
-                              id=":r3:-point-0-side-1"
-                            >
-                              A line segment, length equal to 2 units, connects to point 3.
-                            </g>
-                            <g
-                              id=":r3:-point-0-side-2"
-                            >
-                              A line segment, length approximately equal to 2.2 units, connects to point 2.
-                            </g>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":r3:-angle-0"
+                              >
+                                Angle approximately equal to 63.4 degrees.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":r3:-point-0-side-1"
+                              >
+                                A line segment, length equal to 2 units, connects to point 3.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":r3:-point-0-side-2"
+                              >
+                                A line segment, length approximately equal to 2.2 units, connects to point 2.
+                              </span>
+                            </foreignobject>
                           </g>
                           <g>
                             <g
@@ -2684,21 +2753,30 @@ exports[`Interactive Graph question Should render predictably: first render 1`] 
                                 style="fill: var(--mafs-blue);"
                               />
                             </g>
-                            <g
-                              id=":r3:-angle-1"
-                            >
-                              Angle approximately equal to 53.1 degrees.
-                            </g>
-                            <g
-                              id=":r3:-point-1-side-1"
-                            >
-                              A line segment, length approximately equal to 2.2 units, connects to point 1.
-                            </g>
-                            <g
-                              id=":r3:-point-1-side-2"
-                            >
-                              A line segment, length approximately equal to 2.2 units, connects to point 3.
-                            </g>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":r3:-angle-1"
+                              >
+                                Angle approximately equal to 53.1 degrees.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":r3:-point-1-side-1"
+                              >
+                                A line segment, length approximately equal to 2.2 units, connects to point 1.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":r3:-point-1-side-2"
+                              >
+                                A line segment, length approximately equal to 2.2 units, connects to point 3.
+                              </span>
+                            </foreignobject>
                           </g>
                           <g>
                             <g
@@ -2745,27 +2823,39 @@ exports[`Interactive Graph question Should render predictably: first render 1`] 
                                 style="fill: var(--mafs-blue);"
                               />
                             </g>
-                            <g
-                              id=":r3:-angle-2"
-                            >
-                              Angle approximately equal to 63.4 degrees.
-                            </g>
-                            <g
-                              id=":r3:-point-2-side-1"
-                            >
-                              A line segment, length approximately equal to 2.2 units, connects to point 2.
-                            </g>
-                            <g
-                              id=":r3:-point-2-side-2"
-                            >
-                              A line segment, length equal to 2 units, connects to point 1.
-                            </g>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":r3:-angle-2"
+                              >
+                                Angle approximately equal to 63.4 degrees.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":r3:-point-2-side-1"
+                              >
+                                A line segment, length approximately equal to 2.2 units, connects to point 2.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":r3:-point-2-side-2"
+                              >
+                                A line segment, length equal to 2 units, connects to point 1.
+                              </span>
+                            </foreignobject>
                           </g>
-                          <g
-                            id=":r3:-points-num"
-                          >
-                            The polygon has 3 points.
-                          </g>
+                          <foreignobject>
+                            <span
+                              aria-hidden="true"
+                              id=":r3:-points-num"
+                            >
+                              The polygon has 3 points.
+                            </span>
+                          </foreignobject>
                         </g>
                       </svg>
                     </svg>
@@ -3024,21 +3114,30 @@ exports[`Interactive Graph question Should render predictably: first render 2`] 
                                 style="fill: var(--mafs-blue);"
                               />
                             </g>
-                            <g
-                              id=":rb:-angle-0"
-                            >
-                              Angle approximately equal to 59 degrees.
-                            </g>
-                            <g
-                              id=":rb:-point-0-side-1"
-                            >
-                              A line segment, length equal to 6 units, connects to point 3.
-                            </g>
-                            <g
-                              id=":rb:-point-0-side-2"
-                            >
-                              A line segment, length approximately equal to 5.8 units, connects to point 2.
-                            </g>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":rb:-angle-0"
+                              >
+                                Angle approximately equal to 59 degrees.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":rb:-point-0-side-1"
+                              >
+                                A line segment, length equal to 6 units, connects to point 3.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":rb:-point-0-side-2"
+                              >
+                                A line segment, length approximately equal to 5.8 units, connects to point 2.
+                              </span>
+                            </foreignobject>
                           </g>
                           <g>
                             <g
@@ -3085,21 +3184,30 @@ exports[`Interactive Graph question Should render predictably: first render 2`] 
                                 style="fill: var(--mafs-blue);"
                               />
                             </g>
-                            <g
-                              id=":rb:-angle-1"
-                            >
-                              Angle approximately equal to 61.9 degrees.
-                            </g>
-                            <g
-                              id=":rb:-point-1-side-1"
-                            >
-                              A line segment, length approximately equal to 5.8 units, connects to point 1.
-                            </g>
-                            <g
-                              id=":rb:-point-1-side-2"
-                            >
-                              A line segment, length approximately equal to 5.8 units, connects to point 3.
-                            </g>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":rb:-angle-1"
+                              >
+                                Angle approximately equal to 61.9 degrees.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":rb:-point-1-side-1"
+                              >
+                                A line segment, length approximately equal to 5.8 units, connects to point 1.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":rb:-point-1-side-2"
+                              >
+                                A line segment, length approximately equal to 5.8 units, connects to point 3.
+                              </span>
+                            </foreignobject>
                           </g>
                           <g>
                             <g
@@ -3146,27 +3254,39 @@ exports[`Interactive Graph question Should render predictably: first render 2`] 
                                 style="fill: var(--mafs-blue);"
                               />
                             </g>
-                            <g
-                              id=":rb:-angle-2"
-                            >
-                              Angle approximately equal to 59 degrees.
-                            </g>
-                            <g
-                              id=":rb:-point-2-side-1"
-                            >
-                              A line segment, length approximately equal to 5.8 units, connects to point 2.
-                            </g>
-                            <g
-                              id=":rb:-point-2-side-2"
-                            >
-                              A line segment, length equal to 6 units, connects to point 1.
-                            </g>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":rb:-angle-2"
+                              >
+                                Angle approximately equal to 59 degrees.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":rb:-point-2-side-1"
+                              >
+                                A line segment, length approximately equal to 5.8 units, connects to point 2.
+                              </span>
+                            </foreignobject>
+                            <foreignobject>
+                              <span
+                                aria-hidden="true"
+                                id=":rb:-point-2-side-2"
+                              >
+                                A line segment, length equal to 6 units, connects to point 1.
+                              </span>
+                            </foreignobject>
                           </g>
-                          <g
-                            id=":rb:-points-num"
-                          >
-                            The polygon has 3 points.
-                          </g>
+                          <foreignobject>
+                            <span
+                              aria-hidden="true"
+                              id=":rb:-points-num"
+                            >
+                              The polygon has 3 points.
+                            </span>
+                          </foreignobject>
                         </g>
                       </svg>
                     </svg>

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/angle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/angle.tsx
@@ -3,7 +3,6 @@ import {vec} from "mafs";
 import * as React from "react";
 
 import {usePerseusI18n} from "../../../components/i18n-context";
-import a11y from "../../../util/a11y";
 import {X, Y} from "../math";
 import {findIntersectionOfRays} from "../math/geometry";
 import {actions} from "../reducer/interactive-graph-action";
@@ -12,6 +11,7 @@ import useGraphConfig from "../reducer/use-graph-config";
 import {Angle} from "./components/angle-indicators";
 import {trimRange} from "./components/movable-line";
 import {MovablePoint} from "./components/movable-point";
+import SRDescInSVG from "./components/sr-description-within-svg";
 import {SVGLine} from "./components/svg-line";
 import {Vector} from "./components/vector";
 import {srFormatNumber} from "./screenreader-text";
@@ -159,9 +159,9 @@ function AngleGraph(props: AngleGraphProps) {
                 }
                 ariaLabel={srAngleStartingSide}
             />
-            <g id={descriptionId} style={a11y.srOnly}>
+            <SRDescInSVG id={descriptionId}>
                 {srAngleGraphAriaDescription}
-            </g>
+            </SRDescInSVG>
         </g>
     );
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -3,7 +3,6 @@ import * as React from "react";
 import {useRef} from "react";
 
 import {usePerseusI18n} from "../../../components/i18n-context";
-import a11y from "../../../util/a11y";
 import {snap, X, Y} from "../math";
 import {actions} from "../reducer/interactive-graph-action";
 import {getRadius} from "../reducer/interactive-graph-state";
@@ -11,6 +10,7 @@ import useGraphConfig from "../reducer/use-graph-config";
 
 import Hairlines from "./components/hairlines";
 import {MovablePoint} from "./components/movable-point";
+import SRDescInSVG from "./components/sr-description-within-svg";
 import {srFormatNumber} from "./screenreader-text";
 import {useDraggable} from "./use-draggable";
 import {
@@ -110,12 +110,8 @@ export function CircleGraph(props: CircleGraphProps) {
             />
             {/* Hidden elements to provide the descriptions for the
                 circle and radius point's `aria-describedby` properties. */}
-            <g id={radiusId} style={a11y.srOnly}>
-                {srCircleRadius}
-            </g>
-            <g id={outerPointsId} style={a11y.srOnly}>
-                {srCircleOuterPoints}
-            </g>
+            <SRDescInSVG id={radiusId}>{srCircleRadius}</SRDescInSVG>
+            <SRDescInSVG id={outerPointsId}>{srCircleOuterPoints}</SRDescInSVG>
         </g>
     );
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/sr-description-within-svg.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/sr-description-within-svg.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+
+import a11y from "../../../../util/a11y";
+
+type Props = {
+    id: string;
+    children: React.ReactNode | string;
+};
+
+/**
+ * If an element has an `aria-describedby` attribute, it needs to point to
+ * a separate description element that contains the description for that
+ * element.
+ *
+ * If the element is within an SVG, the description element must be a
+ * `<span>` within a `<foreignObject>` in order for some browser/SR
+ * combos to be able to access it.
+ *
+ * Use this SRDescInSVG component to create the <foreignObject>
+ * and styling for this description element.
+ */
+function SRDescInSVG(props: Props) {
+    const {id, children} = props;
+
+    return (
+        <foreignObject>
+            <span
+                id={id}
+                // Hidden visually
+                style={a11y.srOnly}
+                // Hidden from screen readers so they don't read this
+                // again outside of the element that it describes.
+                aria-hidden={true}
+            >
+                {children}
+            </span>
+        </foreignObject>
+    );
+}
+
+export default SRDescInSVG;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
@@ -2,10 +2,10 @@ import {geometry} from "@khanacademy/kmath";
 import * as React from "react";
 
 import {usePerseusI18n} from "../../../components/i18n-context";
-import a11y from "../../../util/a11y";
 import {actions} from "../reducer/interactive-graph-action";
 
 import {MovableLine} from "./components/movable-line";
+import SRDescInSVG from "./components/sr-description-within-svg";
 import {srFormatNumber} from "./screenreader-text";
 import {getInterceptStringForLine, getSlopeStringForLine} from "./utils";
 
@@ -134,42 +134,33 @@ const LinearSystemGraph = (props: LinearSystemGraphProps) => {
                 />
             ))}
             {linesAriaInfo.map(
-                ({
-                    pointsDescriptionId,
-                    interceptDescriptionId,
-                    slopeDescriptionId,
-                    pointsDescription,
-                    interceptDescription,
-                    slopeDescription,
-                }) => (
-                    <>
-                        <g
-                            key={pointsDescriptionId}
-                            id={pointsDescriptionId}
-                            style={a11y.srOnly}
-                        >
+                (
+                    {
+                        pointsDescriptionId,
+                        interceptDescriptionId,
+                        slopeDescriptionId,
+                        pointsDescription,
+                        interceptDescription,
+                        slopeDescription,
+                    },
+                    i,
+                ) => (
+                    <span key={`line-descriptions-${i}`}>
+                        <SRDescInSVG id={pointsDescriptionId}>
                             {pointsDescription}
-                        </g>
-                        <g
-                            key={interceptDescriptionId}
-                            id={interceptDescriptionId}
-                            style={a11y.srOnly}
-                        >
+                        </SRDescInSVG>
+                        <SRDescInSVG id={interceptDescriptionId}>
                             {interceptDescription}
-                        </g>
-                        <g
-                            key={slopeDescriptionId}
-                            id={slopeDescriptionId}
-                            style={a11y.srOnly}
-                        >
+                        </SRDescInSVG>
+                        <SRDescInSVG id={slopeDescriptionId}>
                             {slopeDescription}
-                        </g>
-                    </>
+                        </SRDescInSVG>
+                    </span>
                 ),
             )}
-            <g id={intersectionId} style={a11y.srOnly}>
+            <SRDescInSVG id={intersectionId}>
                 {intersectionDescription}
-            </g>
+            </SRDescInSVG>
         </g>
     );
 };

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 
 import {usePerseusI18n} from "../../../components/i18n-context";
-import a11y from "../../../util/a11y";
 import {actions} from "../reducer/interactive-graph-action";
 
 import {MovableLine} from "./components/movable-line";
+import SRDescInSVG from "./components/sr-description-within-svg";
 import {srFormatNumber} from "./screenreader-text";
 import {getInterceptStringForLine, getSlopeStringForLine} from "./utils";
 
@@ -81,15 +81,13 @@ const LinearGraph = (props: LinearGraphProps, key: number) => {
             />
             {/* Hidden elements to provide the descriptions for the
                 circle and radius point's `aria-describedby` properties. */}
-            <g id={pointsDescriptionId} style={a11y.srOnly}>
+            <SRDescInSVG id={pointsDescriptionId}>
                 {srLinearGraphPoints}
-            </g>
-            <g id={interceptDescriptionId} style={a11y.srOnly}>
+            </SRDescInSVG>
+            <SRDescInSVG id={interceptDescriptionId}>
                 {interceptString}
-            </g>
-            <g id={slopeDescriptionId} style={a11y.srOnly}>
-                {slopeString}
-            </g>
+            </SRDescInSVG>
+            <SRDescInSVG id={slopeDescriptionId}>{slopeString}</SRDescInSVG>
         </g>
     );
 };

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -7,7 +7,6 @@ import {
     usePerseusI18n,
     type I18nContextType,
 } from "../../../components/i18n-context";
-import a11y from "../../../util/a11y";
 import {snap} from "../math";
 import {isInBound} from "../math/box";
 import {actions} from "../reducer/interactive-graph-action";
@@ -20,6 +19,7 @@ import {bound, TARGET_SIZE} from "../utils";
 
 import {PolygonAngle} from "./components/angle-indicators";
 import {MovablePoint} from "./components/movable-point";
+import SRDescInSVG from "./components/sr-description-within-svg";
 import {TextLabel} from "./components/text-label";
 import {srFormatNumber} from "./screenreader-text";
 import {useDraggable} from "./use-draggable";
@@ -372,7 +372,7 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
                             }}
                         />
                         {angleDegree && (
-                            <g id={angleId}>
+                            <SRDescInSVG id={angleId}>
                                 {Number.isInteger(angleDegree)
                                     ? strings.srPolygonPointAngle({
                                           angle: angleDegree,
@@ -384,36 +384,36 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
                                               1,
                                           ),
                                       })}
-                            </g>
+                            </SRDescInSVG>
                         )}
-                        <g id={side1Id}>
+                        <SRDescInSVG id={side1Id}>
                             {getPolygonSideString(
                                 side1Length,
                                 point1Index,
                                 strings,
                                 locale,
                             )}
-                        </g>
-                        <g id={side2Id}>
+                        </SRDescInSVG>
+                        <SRDescInSVG id={side2Id}>
                             {getPolygonSideString(
                                 side2Length,
                                 point2Index,
                                 strings,
                                 locale,
                             )}
-                        </g>
+                        </SRDescInSVG>
                     </g>
                 );
             })}
             {/* Hidden elements to provide the descriptions for the
                 `aria-describedby` properties */}
-            <g id={polygonPointsNumId} style={a11y.srOnly}>
+            <SRDescInSVG id={polygonPointsNumId}>
                 {srPolygonGraphPointsNum}
-            </g>
+            </SRDescInSVG>
             {srPolygonGraphPoints && (
-                <g id={polygonPointsId} style={a11y.srOnly}>
+                <SRDescInSVG id={polygonPointsId}>
                     {srPolygonGraphPoints}
-                </g>
+                </SRDescInSVG>
             )}
         </g>
     );
@@ -566,7 +566,7 @@ const UnlimitedPolygonGraph = (statefulProps: StatefulProps) => {
                             }}
                         />
                         {angleDegree && (
-                            <g id={angleId}>
+                            <SRDescInSVG id={angleId}>
                                 {Number.isInteger(angleDegree)
                                     ? strings.srPolygonPointAngle({
                                           angle: angleDegree,
@@ -578,10 +578,10 @@ const UnlimitedPolygonGraph = (statefulProps: StatefulProps) => {
                                               1,
                                           ),
                                       })}
-                            </g>
+                            </SRDescInSVG>
                         )}
                         {sidesArray.map(({pointIndex, sideLength}, j) => (
-                            <g
+                            <SRDescInSVG
                                 key={`${id}-point-${i}-side-${j}`}
                                 id={`${id}-point-${i}-side-${j}`}
                             >
@@ -591,7 +591,7 @@ const UnlimitedPolygonGraph = (statefulProps: StatefulProps) => {
                                     strings,
                                     locale,
                                 )}
-                            </g>
+                            </SRDescInSVG>
                         ))}
                     </g>
                 );
@@ -599,14 +599,14 @@ const UnlimitedPolygonGraph = (statefulProps: StatefulProps) => {
             {/* Hidden elements to provide the descriptions for the
                 `aria-describedby` properties */}
             {coords.length > 0 && (
-                <g id={polygonPointsNumId} style={a11y.srOnly}>
+                <SRDescInSVG id={polygonPointsNumId}>
                     {srPolygonGraphPointsNum}
-                </g>
+                </SRDescInSVG>
             )}
             {srPolygonGraphPoints && (
-                <g id={polygonPointsId} style={a11y.srOnly}>
+                <SRDescInSVG id={polygonPointsId}>
                     {srPolygonGraphPoints}
-                </g>
+                </SRDescInSVG>
             )}
         </g>
     );

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -2,11 +2,11 @@ import {Plot, vec} from "mafs";
 import * as React from "react";
 
 import {usePerseusI18n} from "../../../components/i18n-context";
-import a11y from "../../../util/a11y";
 import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 
 import {MovablePoint} from "./components/movable-point";
+import SRDescInSVG from "./components/sr-description-within-svg";
 import {srFormatNumber} from "./screenreader-text";
 import {
     getQuadraticPointString,
@@ -126,20 +126,20 @@ function QuadraticGraph(props: QuadraticGraphProps) {
             {/* Hidden elements to provide the descriptions for the
                 `aria-describedby` properties */}
             {srQuadraticDirection && (
-                <g id={quadraticDirectionId} style={a11y.srOnly}>
+                <SRDescInSVG id={quadraticDirectionId}>
                     {srQuadraticDirection}
-                </g>
+                </SRDescInSVG>
             )}
             {srQuadraticVertex && (
-                <g id={quadraticVertexId} style={a11y.srOnly}>
+                <SRDescInSVG id={quadraticVertexId}>
                     {srQuadraticVertex}
-                </g>
+                </SRDescInSVG>
             )}
-            <g id={quadraticInterceptsId} style={a11y.srOnly}>
+            <SRDescInSVG id={quadraticInterceptsId}>
                 {srQuadraticXIntercepts
                     ? `${srQuadraticXIntercepts} ${srQuadraticYIntercept}`
                     : `${srQuadraticYIntercept}`}
-            </g>
+            </SRDescInSVG>
         </g>
     );
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
@@ -1,10 +1,10 @@
 import * as React from "react";
 
 import {usePerseusI18n} from "../../../components/i18n-context";
-import a11y from "../../../util/a11y";
 import {actions} from "../reducer/interactive-graph-action";
 
 import {MovableLine} from "./components/movable-line";
+import SRDescInSVG from "./components/sr-description-within-svg";
 import {srFormatNumber} from "./screenreader-text";
 
 import type {I18nContextType} from "../../../components/i18n-context";
@@ -74,9 +74,7 @@ const RayGraph = (props: Props) => {
             />
             {/* Hidden elements to provide the descriptions for the
                 `aria-describedby` properties. */}
-            <g id={pointsDescriptionId} style={a11y.srOnly}>
-                {srRayPoints}
-            </g>
+            <SRDescInSVG id={pointsDescriptionId}>{srRayPoints}</SRDescInSVG>
         </g>
     );
 };

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -2,11 +2,11 @@ import {point as kpoint} from "@khanacademy/kmath";
 import * as React from "react";
 
 import {usePerseusI18n} from "../../../components/i18n-context";
-import a11y from "../../../util/a11y";
 import {X, Y} from "../math";
 import {actions} from "../reducer/interactive-graph-action";
 
 import {MovableLine} from "./components/movable-line";
+import SRDescInSVG from "./components/sr-description-within-svg";
 import {srFormatNumber} from "./screenreader-text";
 
 import type {I18nContextType} from "../../../components/i18n-context";
@@ -155,19 +155,19 @@ const SegmentGraph = ({dispatch, graphState}: SegmentProps) => {
                             }),
                         }}
                     />
-                    <g id={lengthDescriptionId} style={a11y.srOnly}>
+                    <SRDescInSVG id={lengthDescriptionId}>
                         {strings.srSegmentLength({
                             length: srFormatNumber(
                                 getLengthOfSegment(segment),
                                 locale,
                             ),
                         })}
-                    </g>
+                    </SRDescInSVG>
                 </g>
             ))}
-            <g style={a11y.srOnly} id={wholeGraphDescriptionId}>
+            <SRDescInSVG id={wholeGraphDescriptionId}>
                 {getWholeSegmentGraphAriaDescription()}
-            </g>
+            </SRDescInSVG>
         </g>
     );
 };

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
@@ -10,6 +10,7 @@ import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 
 import {MovablePoint} from "./components/movable-point";
+import SRDescInSVG from "./components/sr-description-within-svg";
 import {srFormatNumber} from "./screenreader-text";
 
 import type {
@@ -105,7 +106,9 @@ function SinusoidGraph(props: SinusoidGraphProps) {
                     }
                 />
             ))}
-            <g id={descriptionId}>{srSinusoidDescription}</g>
+            <SRDescInSVG id={descriptionId}>
+                {srSinusoidDescription}
+            </SRDescInSVG>
         </g>
     );
 }


### PR DESCRIPTION
## Summary:
Descriptions are not working in Safari or Firefox.

After a number of Slack discussions, it was determined that this was caused by the description blocks being defined within SVGs.

With a small amount of refactoring, we can make is so that the screen reader reads as expected across browsers.

Note: This does not include any changes for the outer graph descriptions, just the interactive elements and their surrounding container inside the graph SVG.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2914

## Test plan:
`yarn jest`

Storybook
- http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--interactive-graph-segment
- Go through every graph type in Storybook
- Confirm that the screen reader experience matches what's in the SR tree