### PR TITLE
idocs(changeset): Modified the 'Aligned equations' template content to change the current format as requested in the ticket. Added // eslint-disable-next-line prettier/prettier to preserve the formatting.

### DIFF
--- a/.changeset/twelve-pumpkins-play.md
+++ b/.changeset/twelve-pumpkins-play.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Modified the 'Aligned equations' template content to change the current format as requested in the ticket. Added // eslint-disable-next-line prettier/prettier to preserve the formatting.

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -771,10 +771,11 @@ class Editor extends React.Component<Props, State> {
                 "data 4 | data 5 | data 6\n" +
                 "data 7 | data 8 | data 9";
         } else if (templateType === "alignment") {
+            // eslint-disable-next-line prettier/prettier
             template =
-                "$\\begin{align} x+5 &= 30 \\\\\n" +
-                "x+5-5 &= 30-5 \\\\\n" +
-                "x &= 25 \\end{align}$";
+                "$\\begin{align} \n" +
+                "\\\\\\\\\n" +
+                "\\end{align}$";
         } else if (templateType === "piecewise") {
             template =
                 "$f(x) = \\begin{cases}\n" +


### PR DESCRIPTION
## Summary:
[update-aligned-equations-template] [LEMS-1822] Modified the 'Aligned equations' template content to change the current format as requested in the ticket. Added // eslint-disable-next-line prettier/prettier to preserve the formatting.

Issue: LEMS-1822