### PR TITLE
[LX] Stop locked functions from memory leaking

### DIFF
--- a/.changeset/thirty-pumpkins-smash.md
+++ b/.changeset/thirty-pumpkins-smash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[LX] Stop locked functions from memory leaking

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.test.ts
@@ -1,0 +1,25 @@
+import {clampedDomain} from "./locked-function";
+
+describe("clampedDomain", () => {
+    test.each`
+        domain                   | graphXBounds | expected
+        ${[-Infinity, Infinity]} | ${[-10, 10]} | ${[-10, 10]}
+        ${[-20, Infinity]}       | ${[-10, 10]} | ${[-10, 10]}
+        ${[-10, Infinity]}       | ${[-10, 10]} | ${[-10, 10]}
+        ${[-5, Infinity]}        | ${[-10, 10]} | ${[-5, 10]}
+        ${[-Infinity, 20]}       | ${[-10, 10]} | ${[-10, 10]}
+        ${[-Infinity, 10]}       | ${[-10, 10]} | ${[-10, 10]}
+        ${[-Infinity, 5]}        | ${[-10, 10]} | ${[-10, 5]}
+        ${[-Infinity, -5]}       | ${[-10, 10]} | ${[-10, -5]}
+        ${[-Infinity, -10]}      | ${[-10, 10]} | ${[-10, -10]}
+        ${[10, -10]}             | ${[-10, 10]} | ${[-10, 10]}
+        ${[-10, -20]}            | ${[-10, 10]} | ${[-10, 10]}
+        ${[10, 10]}              | ${[-10, 10]} | ${[10, 10]}
+        ${[-10, 10]}             | ${[-10, 10]} | ${[-10, 10]}
+    `(
+        "clampedDomain($domain, $graphXBounds) = $expected",
+        ({domain, graphXBounds, expected}) => {
+            expect(clampedDomain(domain, graphXBounds)).toEqual(expected);
+        },
+    );
+});

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.tsx
@@ -4,9 +4,12 @@ import {Plot} from "mafs";
 import * as React from "react";
 import {useState, useEffect} from "react";
 
+import useGraphConfig from "../reducer/use-graph-config";
+
 import type {LockedFunctionType} from "@khanacademy/perseus-core";
 
 const LockedFunction = (props: LockedFunctionType) => {
+    const {range} = useGraphConfig();
     type Equation = {
         [k: string]: any;
         eval: (number) => number;
@@ -19,7 +22,7 @@ const LockedFunction = (props: LockedFunctionType) => {
     const plotProps = {
         color: lockedFigureColors[color],
         style: strokeStyle,
-        domain,
+        domain: clampedDomain(domain, range[0]),
     };
 
     const hasAria = !!props.ariaLabel;
@@ -50,5 +53,23 @@ const LockedFunction = (props: LockedFunctionType) => {
         </g>
     );
 };
+
+// Exported for testing
+export function clampedDomain(
+    domain: [number, number],
+    graphXBounds: [number, number],
+): [number, number] {
+    // If the domain is invalid, return the graph bounds
+    if (domain[0] > domain[1]) {
+        return graphXBounds;
+    }
+
+    // Clamp the function to the bounds of the graph to prevent memory
+    // leaks when the domain is set to something like [-Infinity, Infinity].
+    const min = Math.max(domain[0], graphXBounds[0]);
+    const max = Math.min(domain[1], graphXBounds[1]);
+
+    return [min, max];
+}
 
 export default LockedFunction;


### PR DESCRIPTION
## Summary:
It looks like locked functions - specifically locked exponential functions (y = e^x) - cause a memory leak and completely brick the webpage.

One solution is to add bounds behind the scenes. Instead of -Infinity to Infinity, we can clamp the bounds to the range of the graph.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2899

## Test plan:
`yarn jest packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.test.ts`

Storybook
- All locked function stories: http://localhost:6006/?path=/docs/perseus-widgets-interactive-graph-locked-functions--docs
- Story that was causing storybook to freeze: http://localhost:6006/?path=/story/perseus-widgets-interactive-graph-locked-functions--exponent