### PR TITLE
New labeLocation property for Interactive Graph with Bug Fixes 

### DIFF
--- a/.changeset/beige-stingrays-cry.md
+++ b/.changeset/beige-stingrays-cry.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-core": minor
+"@khanacademy/perseus-editor": minor
+---
+
+Add new labelLocation value for Interactive Graphs

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -431,6 +431,7 @@ export type PerseusImageBackground = {
  * - none: shows no markings
  */
 export type MarkingsType = "axes" | "graph" | "grid" | "none";
+export type AxisLabelLocation = "onAxis" | "alongEdge";
 
 export type PerseusCategorizerWidgetOptions = {
     // Translatable text; a list of items to categorize. e.g. ["banana", "yellow", "apple", "purple", "shirt"]
@@ -734,6 +735,13 @@ export type PerseusInteractiveGraphWidgetOptions = {
     markings: MarkingsType;
     // How to label the X and Y axis.  default: ["x", "y"]
     labels?: ReadonlyArray<string>;
+    /**
+     * Specifies the location of the labels on the graph.  default: "onAxis".
+     * - "onAxis": Labels are positioned on the axis at the right (x) and top (y) of the graph.
+     * - "alongEdge": Labels are centered along the bottom (x) and left (y) edges of the graph.
+     *    The y label is rotated. Typically used when the range min is near 0 with longer labels.
+     */
+    labelLocation?: AxisLabelLocation;
     // Whether to show the Protractor tool overlayed on top of the graph
     showProtractor: boolean;
     /**

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-settings.tsx
@@ -20,6 +20,7 @@ import Heading from "../../../components/heading";
 import LabeledRow from "../locked-figures/labeled-row";
 
 import type {
+    AxisLabelLocation,
     MarkingsType,
     PerseusImageBackground,
 } from "@khanacademy/perseus-core";
@@ -49,6 +50,13 @@ type Props = {
      * The labels for the x and y axes.
      */
     labels: ReadonlyArray<string>;
+    /**
+     * Specifies the location of the labels on the graph.  default: "onAxis".
+     * - "onAxis": Labels are positioned on the axis at the right (x) and top (y) of the graph.
+     * - "alongEdge": Labels are centered along the bottom (x) and left (y) edges of the graph.
+     *    The y label is rotated. Typically used when the range min is near 0 with longer labels.
+     */
+    labelLocation: AxisLabelLocation;
     /**
      * The range of the graph.
      */
@@ -99,6 +107,7 @@ type Props = {
 type State = {
     isExpanded: boolean;
     labelsTextbox: ReadonlyArray<string>;
+    labelLocation: AxisLabelLocation;
     gridStepTextbox: [x: number, y: number];
     snapStepTextbox: [x: number, y: number];
     stepTextbox: [x: number, y: number];
@@ -116,6 +125,7 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
     static stateFromProps(props: Props) {
         return {
             labelsTextbox: props.labels,
+            labelLocation: props.labelLocation,
             gridStepTextbox: props.gridStep,
             snapStepTextbox: props.snapStep,
             stepTextbox: props.step,
@@ -140,6 +150,7 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
             interactiveSizes.defaultBoxSizeSmall,
         ],
         labels: ["$x$", "$y$"],
+        labelLocation: "onAxis",
         range: [
             [-10, 10],
             [-10, 10],
@@ -165,6 +176,7 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
     UNSAFE_componentWillReceiveProps(nextProps) {
         if (
             !_.isEqual(this.props.labels, nextProps.labels) ||
+            !_.isEqual(this.props.labelLocation, nextProps.labelLocation) ||
             !_.isEqual(this.props.gridStep, nextProps.gridStep) ||
             !_.isEqual(this.props.snapStep, nextProps.snapStep) ||
             !_.isEqual(this.props.step, nextProps.step) ||
@@ -399,6 +411,7 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
 
     changeGraph = () => {
         const labels = this.state.labelsTextbox;
+        const labelLocation = this.state.labelLocation;
         const range = _.map(this.state.rangeTextbox, function (range) {
             return _.map(range, Number);
         });
@@ -425,6 +438,7 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
             this.change({
                 valid: true,
                 labels: labels,
+                labelLocation: labelLocation,
                 range: range,
                 step: step,
                 gridStep: gridStep,
@@ -452,6 +466,26 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
                 {this.state.isExpanded && (
                     <View>
                         <div className="graph-settings">
+                            <div className="perseus-widget-row">
+                                <LabeledRow label="Label Location">
+                                    <ButtonGroup
+                                        value={this.props.labelLocation}
+                                        allowEmpty={false}
+                                        buttons={[
+                                            {
+                                                value: "onAxis",
+                                                content: "On Axis",
+                                            },
+                                            {
+                                                value: "alongEdge",
+                                                content: "Along Graph Edge",
+                                            },
+                                        ]}
+                                        onChange={this.change("labelLocation")}
+                                    />
+                                </LabeledRow>
+                            </div>
+
                             <div className="perseus-widget-row">
                                 <div className="perseus-widget-left-col">
                                     <LabeledRow label="x Label">

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -14,6 +14,7 @@ import {
     type PerseusGraphType,
     type MarkingsType,
     type InteractiveGraphDefaultWidgetOptions,
+    type AxisLabelLocation,
     interactiveGraphLogic,
 } from "@khanacademy/perseus-core";
 import {Id, View} from "@khanacademy/wonder-blocks-core";
@@ -70,6 +71,13 @@ export type Props = {
      * The labels for the x and y axes.
      */
     labels: ReadonlyArray<string>;
+    /**
+     * Specifies the location of the labels on the graph.  default: "onAxis".
+     * - "onAxis": Labels are positioned on the axis at the right (x) and top (y) of the graph.
+     * - "alongEdge": Labels are centered along the bottom (x) and left (y) edges of the graph.
+     *    The y label is rotated. Typically used when the range min is near 0 with longer labels.
+     */
+    labelLocation?: AxisLabelLocation;
     /**
      * The range of the graph in the x and y directions.
      */
@@ -194,6 +202,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
             "backgroundImage",
             "markings",
             "labels",
+            "labelLocation",
             "showProtractor",
             "showTooltips",
             "range",
@@ -291,6 +300,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
                 box: this.props.box,
                 range: this.props.range,
                 labels: this.props.labels,
+                labelLocation: this.props.labelLocation,
                 step: this.props.step,
                 gridStep: gridStep,
                 snapStep: snapStep,
@@ -741,6 +751,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
                             box={getInteractiveBoxFromSizeClass(sizeClass)}
                             range={this.props.range}
                             labels={this.props.labels}
+                            labelLocation={this.props.labelLocation}
                             step={this.props.step}
                             gridStep={gridStep}
                             snapStep={snapStep}

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`Interactive Graph A none-type graph renders predictably: first render 1
                 </span>
                 <span
                   aria-label="Y-axis"
-                  style="position: absolute; left: 200px; top: -24px; font-size: 14px; transform: translate(-50%, 0px);"
+                  style="position: absolute; left: 200px; top: -28px; font-size: 14px; transform: translate(-50%, 0px);"
                 >
                   <span
                     class="mock-TeX"

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.test.ts
@@ -1,4 +1,4 @@
-import {getLabelPosition, fontSize} from "./axis-labels";
+import {getLabelPosition, fontSize, getLabelTransform} from "./axis-labels";
 
 import type {GraphDimensions} from "../types";
 
@@ -19,6 +19,24 @@ describe("getLabelPosition", () => {
         ];
 
         expect(getLabelPosition(graphInfo, labelLocation)).toEqual(expected);
+    });
+
+    it("should return the correct position for the default graph without a labelLocation", () => {
+        const graphInfo: GraphDimensions = {
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            width: 400,
+            height: 400,
+        };
+
+        const expected = [
+            [400, 200], // X Label at [Right edge of the graph, vertical center of the graph]
+            [200, -2 * fontSize], // Y Label at [Horizontal center of the graph, 2x fontSize above the top edge]
+        ];
+
+        expect(getLabelPosition(graphInfo, undefined)).toEqual(expected);
     });
 
     it("should return the correct position for labels set to alongEdge", () => {
@@ -92,5 +110,35 @@ describe("getLabelPosition", () => {
         ];
 
         expect(getLabelPosition(graphInfo, labelLocation)).toEqual(expected);
+    });
+});
+describe("getLabelTransform", () => {
+    it("should return the correct transform for the default graph", () => {
+        const expected = {
+            xLabelTransform: "translate(7px, -50%)",
+            yLabelTransform: "translate(-50%, 0px)",
+        };
+
+        expect(getLabelTransform(undefined)).toEqual(expected);
+    });
+
+    it("should return the correct transform for an onAxis graph", () => {
+        const labelLocation = "onAxis";
+        const expected = {
+            xLabelTransform: "translate(7px, -50%)",
+            yLabelTransform: "translate(-50%, 0px)",
+        };
+
+        expect(getLabelTransform(labelLocation)).toEqual(expected);
+    });
+
+    it("should return the correct transform for labels set to alongEdge", () => {
+        const labelLocation = "alongEdge";
+        const expected = {
+            xLabelTransform: "translate(-50%, -50%)",
+            yLabelTransform: "translate(-50%, 0px) rotate(-90deg)",
+        };
+
+        expect(getLabelTransform(labelLocation)).toEqual(expected);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.test.ts
@@ -1,0 +1,96 @@
+import {getLabelPosition, fontSize} from "./axis-labels";
+
+import type {GraphDimensions} from "../types";
+
+describe("getLabelPosition", () => {
+    it("should return the correct position for the default graph", () => {
+        const graphInfo: GraphDimensions = {
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            width: 400,
+            height: 400,
+        };
+        const labelLocation = "onAxis";
+        const expected = [
+            [400, 200], // X Label at [Right edge of the graph, vertical center of the graph]
+            [200, -2 * fontSize], // Y Label at [Horizontal center of the graph, 2x fontSize above the top edge]
+        ];
+
+        expect(getLabelPosition(graphInfo, labelLocation)).toEqual(expected);
+    });
+
+    it("should return the correct position for labels set to alongEdge", () => {
+        const graphInfo: GraphDimensions = {
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            width: 400,
+            height: 400,
+        };
+        const labelLocation = "alongEdge";
+        const expected = [
+            [200, 400 + fontSize], // X Label at [Horizontal center of the graph, 1x fontSize below the bottom edge]
+            [-fontSize, 200 - fontSize], // Y label at [1x fontSize to the left of the left edge, vertical center of the graph]
+        ];
+
+        expect(getLabelPosition(graphInfo, labelLocation)).toEqual(expected);
+    });
+
+    it("should return the correct position for labels set to alongEdge with wholly negative ranges", () => {
+        const graphInfo: GraphDimensions = {
+            range: [
+                [-10, -5],
+                [-10, -5],
+            ],
+            width: 400,
+            height: 400,
+        };
+        const labelLocation = "alongEdge";
+        const expected = [
+            [200, 400 + fontSize], // X Label at [Horizontal center of the graph, 1x fontSize below the bottom edge]
+            [-fontSize, 200 - fontSize], // Y label at [1x fontSize to the left of the left edge, vertical center of the graph]
+        ];
+
+        expect(getLabelPosition(graphInfo, labelLocation)).toEqual(expected);
+    });
+
+    it("should return the correct position for labels set to alongEdge with wholly positive ranges", () => {
+        const graphInfo: GraphDimensions = {
+            range: [
+                [5, 10],
+                [5, 10],
+            ],
+            width: 400,
+            height: 400,
+        };
+        const labelLocation = "alongEdge";
+        const expected = [
+            [200, 400 + 3 * fontSize], // X Label at [Horizontal center of the graph, 3x fontSize below the bottom edge]
+            [-3 * fontSize, 200 - fontSize], // Y label at [3x fontSize to the left of the left edge, vertical center of the graph]
+        ];
+
+        expect(getLabelPosition(graphInfo, labelLocation)).toEqual(expected);
+    });
+
+    it("should return the correct position for labels set to alongEdge with min ranges at 0", () => {
+        // Should result in same position as the wholly positive range test
+        const graphInfo: GraphDimensions = {
+            range: [
+                [0, 10],
+                [0, 10],
+            ],
+            width: 400,
+            height: 400,
+        };
+        const labelLocation = "alongEdge";
+        const expected = [
+            [200, 400 + 3 * fontSize], // X Label at [Horizontal center of the graph, 3x fontSize below the bottom edge]
+            [-3 * fontSize, 200 - fontSize], // Y label at [3x fontSize to the left of the left edge, vertical center of the graph]
+        ];
+
+        expect(getLabelPosition(graphInfo, labelLocation)).toEqual(expected);
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
@@ -3,34 +3,46 @@ import React from "react";
 
 import {getDependencies} from "../../../dependencies";
 import {pointToPixel} from "../graphs/use-transform";
-import {MAX, X, Y} from "../math";
+import {MAX, MIN, X, Y} from "../math";
 import useGraphConfig from "../reducer/use-graph-config";
 import {replaceOutsideTeX} from "../utils";
 
 import type {I18nContextType} from "../../../components/i18n-context";
+import type {GraphConfig} from "../reducer/use-graph-config";
 import type {GraphDimensions} from "../types";
 
+// Exported for testing purposes
+export const fontSize = 14;
+
 export default function AxisLabels({i18n}: {i18n: I18nContextType}) {
-    const {range, labels, width, height} = useGraphConfig();
+    const {range, labels, width, height, labelLocation} = useGraphConfig();
     const {strings} = i18n;
 
-    const yAxisLabelLocation: vec.Vector2 = [0, range[Y][MAX]];
-    const xAxisLabelLocation: vec.Vector2 = [range[X][MAX], 0];
-
-    const [xAxisLabelText, yAxisLabelText] = labels;
     const graphInfo: GraphDimensions = {
         range,
         width,
         height,
     };
-    const [x1, y1] = pointToPixel(xAxisLabelLocation, graphInfo);
-    // The default location for the y-axis-label is at the maximum y point
-    // This is just underneath the tick line for that point. The -24 moves the
-    // label up one grid square, so it sits on top of the graph
-    const [x2, y2] = vec.add(
-        pointToPixel(yAxisLabelLocation, graphInfo),
-        [0, -24],
+
+    // Get the position of the main axis labels
+    const [xAxisLabelLocation, yAxisLabelLocation] = getLabelPosition(
+        graphInfo,
+        labelLocation,
     );
+
+    const [xAxisLabelText, yAxisLabelText] = labels;
+
+    // If the labels are rotated, we need to center the
+    // x-axis label along the bottom of the graph.
+    const xLabelTransform =
+        labelLocation === "onAxis"
+            ? "translate(7px, -50%)"
+            : "translate(-50%, -50%)";
+
+    const yLabelTransform =
+        labelLocation === "onAxis"
+            ? "translate(-50%, 0px)"
+            : "translate(-50%, 0px) rotate(-90deg)";
 
     const {TeX} = getDependencies();
 
@@ -40,10 +52,10 @@ export default function AxisLabels({i18n}: {i18n: I18nContextType}) {
                 aria-label={strings.xAxis}
                 style={{
                     position: "absolute",
-                    left: x1,
-                    top: y1,
-                    fontSize: "14px",
-                    transform: "translate(7px, -50%)",
+                    left: xAxisLabelLocation[X],
+                    top: xAxisLabelLocation[Y],
+                    fontSize: fontSize + "px",
+                    transform: xLabelTransform,
                 }}
             >
                 <TeX>{replaceOutsideTeX(xAxisLabelText)}</TeX>
@@ -52,10 +64,10 @@ export default function AxisLabels({i18n}: {i18n: I18nContextType}) {
                 aria-label={strings.yAxis}
                 style={{
                     position: "absolute",
-                    left: x2,
-                    top: y2,
-                    fontSize: "14px",
-                    transform: "translate(-50%, 0px)",
+                    left: yAxisLabelLocation[X],
+                    top: yAxisLabelLocation[Y],
+                    fontSize: fontSize + "px",
+                    transform: yLabelTransform,
                 }}
             >
                 <TeX>{replaceOutsideTeX(yAxisLabelText)}</TeX>
@@ -63,3 +75,58 @@ export default function AxisLabels({i18n}: {i18n: I18nContextType}) {
         </>
     );
 }
+
+export const getLabelPosition = (
+    graphInfo: GraphDimensions,
+    labelLocation: GraphConfig["labelLocation"],
+): vec.Vector2[] => {
+    // If the labels are placed along the edge of the graph, we need to place them at the
+    // center of the graph, which is the average of the min and max values of the axes.
+    if (labelLocation === "alongEdge") {
+        // Offset the labels by a certain amount based on the range of the graph, to ensure that
+        // the labels do not overlap with the axis tick if they are out of the graph bounds.
+        const xAxisLabelOffset: [number, number] =
+            graphInfo.range[Y][MIN] >= 0
+                ? [0, fontSize * 3] // Move the label down by 3 font sizes if the y-axis min is positive
+                : [0, fontSize]; // Move the label down by 1 font size if the y-axis min is negative
+        const yAxisLabelOffset: [number, number] =
+            graphInfo.range[X][MIN] >= 0
+                ? [-fontSize * 3, -fontSize] // Move the label left by 3 font sizes if the x-axis min is positive
+                : [-fontSize, -fontSize]; // Move the label left by 1 font size if the x-axis min is negative
+
+        // Calculate the location of the labels to be halfway between the min and max values of the axes
+        const xAxisLabelLocation: vec.Vector2 = [
+            (graphInfo.range[X][MIN] + graphInfo.range[X][MAX]) / 2,
+            graphInfo.range[Y][MIN],
+        ];
+        const yAxisLabelLocation: vec.Vector2 = [
+            graphInfo.range[X][MIN],
+            (graphInfo.range[Y][MIN] + graphInfo.range[Y][MAX]) / 2,
+        ];
+
+        // Convert the Vector2 coordinates to pixel coordinates and add the offsets
+        const xLabel = vec.add(
+            pointToPixel(xAxisLabelLocation, graphInfo),
+            xAxisLabelOffset,
+        );
+        const yLabel = vec.add(
+            pointToPixel(yAxisLabelLocation, graphInfo),
+            yAxisLabelOffset,
+        );
+
+        return [xLabel, yLabel];
+    }
+
+    // Otherwise, the labels are placed on the axes (default), and we need to
+    // place them at the end of the axis, which is the maximum value of the axis.
+    const xLabelInitial: vec.Vector2 = [graphInfo.range[X][MAX], 0];
+    const yLabelInitial: vec.Vector2 = [0, graphInfo.range[Y][MAX]];
+    const yLabelOffset: vec.Vector2 = [0, -fontSize * 2]; // Move the y-axis label up by 2 font sizes
+
+    const xLabel = pointToPixel(xLabelInitial, graphInfo);
+    const yLabel = vec.add(
+        pointToPixel(yLabelInitial, graphInfo),
+        yLabelOffset,
+    );
+    return [xLabel, yLabel];
+};

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
@@ -67,6 +67,9 @@ export default function AxisLabels({i18n}: {i18n: I18nContextType}) {
     );
 }
 
+/* Get the transform for the labels based on the labelLocation
+ *  Exported for testing purposes.
+ */
 export const getLabelTransform = (
     labelLocation: GraphConfig["labelLocation"],
 ): {xLabelTransform: string; yLabelTransform: string} => {
@@ -84,6 +87,9 @@ export const getLabelTransform = (
     return {xLabelTransform, yLabelTransform};
 };
 
+/* Calculate the position of the main axis labels based on the labelLocation
+ * and the ranges of the graph. Exported for testing purposes.
+ */
 export const getLabelPosition = (
     graphInfo: GraphDimensions,
     labelLocation: GraphConfig["labelLocation"],

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
@@ -32,17 +32,8 @@ export default function AxisLabels({i18n}: {i18n: I18nContextType}) {
 
     const [xAxisLabelText, yAxisLabelText] = labels;
 
-    // If the labels are rotated, we need to center the
-    // x-axis label along the bottom of the graph.
-    const xLabelTransform =
-        labelLocation === "onAxis"
-            ? "translate(7px, -50%)"
-            : "translate(-50%, -50%)";
-
-    const yLabelTransform =
-        labelLocation === "onAxis"
-            ? "translate(-50%, 0px)"
-            : "translate(-50%, 0px) rotate(-90deg)";
+    // Get the transform for the labels
+    const {xLabelTransform, yLabelTransform} = getLabelTransform(labelLocation);
 
     const {TeX} = getDependencies();
 
@@ -75,6 +66,23 @@ export default function AxisLabels({i18n}: {i18n: I18nContextType}) {
         </>
     );
 }
+
+export const getLabelTransform = (
+    labelLocation: GraphConfig["labelLocation"],
+): {xLabelTransform: string; yLabelTransform: string} => {
+    // onAxis is the default label location
+    const isOnAxis = labelLocation === undefined || labelLocation === "onAxis";
+
+    const xLabelTransform = isOnAxis
+        ? "translate(7px, -50%)"
+        : "translate(-50%, -50%)";
+
+    const yLabelTransform = isOnAxis
+        ? "translate(-50%, 0px)"
+        : "translate(-50%, 0px) rotate(-90deg)";
+
+    return {xLabelTransform, yLabelTransform};
+};
 
 export const getLabelPosition = (
     graphInfo: GraphDimensions,

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
@@ -82,6 +82,16 @@ describe("InteractiveGraphQuestionBuilder", () => {
         expect(graph.options.labels).toEqual(["the x label", "the y label"]);
     });
 
+    it("sets the axis labelLocation", () => {
+        const question: PerseusRenderer = interactiveGraphQuestionBuilder()
+            .withAxisLabels("the x label", "the y label")
+            .withLabelLocation("alongEdge")
+            .build();
+        const graph = question.widgets["interactive-graph 1"];
+
+        expect(graph.options.labelLocation).toEqual("alongEdge");
+    });
+
     it("sets the background markings", () => {
         const question: PerseusRenderer = interactiveGraphQuestionBuilder()
             .withMarkings("grid")

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -3,6 +3,7 @@ import {vec} from "mafs";
 import type {SnapTo} from "./types";
 import type {Coord} from "../../interactive2/types";
 import type {
+    AxisLabelLocation,
     CollinearTuple,
     LockedEllipseType,
     LockedFigure,
@@ -56,6 +57,7 @@ class InteractiveGraphQuestionBuilder {
     };
     private gridStep: vec.Vector2 = [1, 1];
     private labels: [string, string] = ["$x$", "$y$"];
+    private labelLocation: AxisLabelLocation = "onAxis";
     private markings: MarkingsType = "graph";
     private xRange: Interval = [-10, 10];
     private yRange: Interval = [-10, 10];
@@ -84,6 +86,7 @@ class InteractiveGraphQuestionBuilder {
                         graph: this.interactiveFigureConfig.graph(),
                         gridStep: this.gridStep,
                         labels: this.labels,
+                        labelLocation: this.labelLocation,
                         markings: this.markings,
                         range: [this.xRange, this.yRange],
                         showProtractor: this.showProtractor,
@@ -147,6 +150,13 @@ class InteractiveGraphQuestionBuilder {
 
     withAxisLabels(x: string, y: string): InteractiveGraphQuestionBuilder {
         this.labels = [x, y];
+        return this;
+    }
+
+    withLabelLocation(
+        labelLocation: AxisLabelLocation,
+    ): InteractiveGraphQuestionBuilder {
+        this.labelLocation = labelLocation;
         return this;
     }
 

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -57,7 +57,7 @@ class InteractiveGraphQuestionBuilder {
     };
     private gridStep: vec.Vector2 = [1, 1];
     private labels: [string, string] = ["$x$", "$y$"];
-    private labelLocation: AxisLabelLocation = "onAxis";
+    private labelLocation: AxisLabelLocation | undefined = undefined;
     private markings: MarkingsType = "graph";
     private xRange: Interval = [-10, 10];
     private yRange: Interval = [-10, 10];

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-regression.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-regression.stories.tsx
@@ -1,4 +1,5 @@
 import {splitPerseusItem} from "@khanacademy/perseus-core";
+import {View} from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
 
 import {ApiOptions} from "../../perseus-api";
@@ -19,6 +20,13 @@ const meta: Meta<typeof MafsQuestionRenderer> = {
     parameters: {
         chromatic: {disableSnapshot: false},
     },
+    decorators: (Story) => (
+        // Add margin so we can look at individual story canvases for
+        // graphs that have axis ticks off the graph.
+        <View style={{marginInlineStart: 32}}>
+            <Story />
+        </View>
+    ),
 };
 export default meta;
 
@@ -186,6 +194,50 @@ export const MafsWithXAxisAtTop: Story = {
 export const MafsWithXAxisOffTop: Story = {
     args: {
         question: interactiveGraphQuestionBuilder().withYRange(-20, -1).build(),
+    },
+};
+
+export const MafsWithLabelsAlongEdge: Story = {
+    args: {
+        question: interactiveGraphQuestionBuilder()
+            .withXRange(0, 10)
+            .withYRange(0, 10)
+            .withAxisLabels(
+                "Video Game Hours per Week",
+                "Reaction Time (milliseconds)",
+            )
+            .withLabelLocation("alongEdge")
+            .build(),
+    },
+};
+
+export const MafsWithLabelsAlongEdgeJustOverLeft: Story = {
+    args: {
+        question: interactiveGraphQuestionBuilder()
+            .withXRange(-1, 10)
+            .withYRange(-1, 10)
+            .withAxisLabels(
+                "Video Game Hours per Week",
+                "Reaction Time (milliseconds)",
+            )
+            .withLabelLocation("alongEdge")
+            .build(),
+    },
+};
+
+export const MafsWithLabelsAlongEdgeZoomed: Story = {
+    args: {
+        question: interactiveGraphQuestionBuilder()
+            .withXRange(0, 0.5)
+            .withYRange(0, 0.5)
+            .withTickStep(0.1, 0.1)
+            .withGridStep(0.1, 0.1)
+            .withAxisLabels(
+                "Video Game Hours per Week",
+                "Reaction Time (milliseconds)",
+            )
+            .withLabelLocation("alongEdge")
+            .build(),
     },
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -70,6 +70,7 @@ export type MafsGraphProps = {
     showTooltips: Required<InteractiveGraphProps["showTooltips"]>;
     showProtractor: boolean;
     labels: ReadonlyArray<string>;
+    labelLocation?: InteractiveGraphProps["labelLocation"];
     fullGraphAriaLabel?: InteractiveGraphProps["fullGraphAriaLabel"];
     fullGraphAriaDescription?: InteractiveGraphProps["fullGraphAriaDescription"];
     state: InteractiveGraphState;
@@ -83,6 +84,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
         state,
         dispatch,
         labels,
+        labelLocation,
         readOnly,
         fullGraphAriaLabel,
         fullGraphAriaDescription,
@@ -164,6 +166,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                 width,
                 height,
                 labels,
+                labelLocation,
                 disableKeyboardInteraction: disableInteraction,
                 // If the graph is read-only or static, we want to make it
                 // visually clear that the graph is no longer interactive.

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/use-graph-config.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/use-graph-config.ts
@@ -1,6 +1,6 @@
 import React, {createContext} from "react";
 
-import type {MarkingsType} from "@khanacademy/perseus-core";
+import type {AxisLabelLocation, MarkingsType} from "@khanacademy/perseus-core";
 import type {Interval, vec} from "mafs";
 
 export type GraphConfig = {
@@ -14,6 +14,7 @@ export type GraphConfig = {
     width: number; // in graph units
     height: number; // in graph units
     labels: readonly string[];
+    labelLocation?: AxisLabelLocation;
     disableKeyboardInteraction?: boolean;
     interactiveColor?: string;
 };
@@ -32,6 +33,7 @@ const defaultGraphConfig: GraphConfig = {
     width: 0,
     height: 0,
     labels: [],
+    labelLocation: "onAxis",
     disableKeyboardInteraction: false,
     interactiveColor: "var(--mafs-blue)",
 };

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -39,6 +39,7 @@ export type StatefulMafsGraphProps = {
     showTooltips: Required<InteractiveGraphProps["showTooltips"]>;
     showProtractor: boolean;
     labels: ReadonlyArray<string>;
+    labelLocation?: InteractiveGraphProps["labelLocation"];
     fullGraphAriaLabel?: InteractiveGraphProps["fullGraphAriaLabel"];
     fullGraphAriaDescription?: InteractiveGraphProps["fullGraphAriaDescription"];
     readOnly: boolean;


### PR DESCRIPTION
## Summary:
This PR redeploys [the labelLocation work](https://github.com/Khan/perseus/pull/2284) with several fixes:

1. A fix was applied to the InteractiveGraphBuilder to ensure that `labelLocation` will default to `undefined` for manual testing purposes. 
2. A fix was applied to th transform logic to account for `labelLocation` being undefined.
3. The transform logic was extracted out into a separate function for testing purposes. 

## Test plan:
- manual testing 
- new tests 