### PR TITLE
Fix for ensure that numCorrect is calculated properly when editing new Radio Widgets

### DIFF
--- a/.changeset/quiet-clouds-design.md
+++ b/.changeset/quiet-clouds-design.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Bugfix to ensure numCorrect is calculated correctly while in Radio Editor

--- a/packages/perseus-editor/src/widgets/radio/editor.tsx
+++ b/packages/perseus-editor/src/widgets/radio/editor.tsx
@@ -174,6 +174,9 @@ class RadioEditor extends React.Component<RadioEditorProps> {
             numCorrect: deriveNumCorrect({
                 ...this.props,
                 choices,
+                // When deriving numCorrect, we don't want to pass the current value,
+                // as it has changed.
+                numCorrect: undefined,
             }),
         });
     };
@@ -279,7 +282,12 @@ class RadioEditor extends React.Component<RadioEditorProps> {
             displayCount,
             hasNoneOfTheAbove,
             deselectEnabled,
-            numCorrect: deriveNumCorrect(this.props),
+            numCorrect: deriveNumCorrect({
+                ...this.props,
+                // When deriving numCorrect, we don't want to pass the current value,
+                // as it has changed.
+                numCorrect: undefined,
+            }),
         };
     }
 


### PR DESCRIPTION
## Summary:
Radio questions set to Multiple Select and "Specify Number Correct" set to true were not actually having the text update accordingly in the Editor. This PR fixes the numCorrect calculation so that new widgets with these values will have numCorrect calculated properly.

Issue: LEMS-2921

## Test plan:
- manual testing