### PR TITLE
Allow `itemDataVersion` to be null when parsing Perseus assessment item JSON

### DIFF
--- a/.changeset/twenty-rivers-cry.md
+++ b/.changeset/twenty-rivers-cry.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+Allow `itemDataVersion` to be null when parsing Perseus assessment item JSON

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-item.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-item.ts
@@ -1,4 +1,11 @@
-import {any, array, number, object, optional} from "../general-purpose-parsers";
+import {
+    any,
+    array,
+    nullable,
+    number,
+    object,
+    optional,
+} from "../general-purpose-parsers";
 import {defaulted} from "../general-purpose-parsers/defaulted";
 
 import {parseHint} from "./hint";
@@ -13,10 +20,12 @@ export const parsePerseusItem: Parser<PerseusItem> = object({
     hints: defaulted(array(parseHint), () => []),
     answerArea: parsePerseusAnswerArea,
     itemDataVersion: optional(
-        object({
-            major: number,
-            minor: number,
-        }),
+        nullable(
+            object({
+                major: number,
+                minor: number,
+            }),
+        ),
     ),
     // Deprecated field
     answer: any,

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -5605,6 +5605,178 @@ exports[`parseAndMigratePerseusItem given interactive-graph-with-string-backgrou
 }
 `;
 
+exports[`parseAndMigratePerseusItem given item-with-null-itemDataVersion.json returns the same result as before 1`] = `
+{
+  "_multi": null,
+  "answer": null,
+  "answerArea": {
+    "calculator": false,
+    "chi2Table": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTimeToPayOff": false,
+    "financialCalculatorTotalAmount": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+    "tTable": false,
+    "zTable": false,
+  },
+  "hints": [],
+  "itemDataVersion": null,
+  "question": {
+    "content": "
+ [[☃ image 1]]
+
+##A shot after all
+
+*By Heather M. Meston*
+
+___
+
+1. I peered through the neglected bushes crowning the hill overlooking the field, a vicious debate raging in my mind.
+
+2. *To go or not to go?*
+
+3. *To try or not to try?*
+
+4. I winced as Marcus Fitzwilliam barreled into a blocking sled, 300 pounds of foam padding and metal. The sled flew back six feet.
+
+5. *I can’t compete with that,* I thought. I barely weighed a hundred pounds in snow boots. It would take a miracle for me to move that thing an inch.
+
+6. *Stop it, Jamila,* commanded my braver side. *You don’t need to be big to be a quarterback, just fast and smart. Marcus may be big, but his bad knee makes him slow.* My eyes drifted to a sleek form running sprints across the field. *Now, Hiro, on the other hand…he’s fast. Gotta watch out for him.*
+
+7. Before I could stop myself, I shoved through the bushes, my head held high even as my heart trembled.
+
+8. Donny, who’d lost two teeth playing last year, was the first to spy me. He completely missed the left-handed pass Raj sent his way, drawing Coach Franklin’s irritation. But before Coach could begin lecturing, Raj interrupted him to point out the intruder on the field.
+
+9. Me.
+
+10. Coach looked startled for a moment, then came to his senses. “Jamila! You looking for cheerleading tryouts? In the gym.”
+
+11. I thought of all the hours my brother Malik had spent practicing with me. I couldn’t disappoint him. “No, I’m here to try out. Er…that is…for football, I mean. For quarterback.” Smooth. So smooth.
+
+12. Raj laughed, Marcus grinned, and Coach’s mouth twisted like I'd just force-fed him a lemon 
+
+13. “Well, you see,” he started, “It’s just that girls aren’t allowed on the football team. Too dangerous, you know.”
+
+14. *But it's not too dangerous for boys? What’s wrong with people?*
+
+15. “Actually, sir, that’s not true. There’s nothing saying we can’t play.” I pulled out my copy of the school handbook. “See?” I said. “The only qualifications are that a player must have at least a C average and that the coach and a doctor must declare the player physically fit. I have straight As, and here’s my doctor’s note.”
+
+16. He grimaced, and then his face lit up. “Well, I don’t declare you physically fit. So that’s that.” He folded his arms across his chest with a satisfied grin.
+
+17. “Why?” I asked.
+
+18. “Girls are too delicate for football. I don't care how good your brother was. You'll snap like a twig out there. Sorry.”
+
+19. I’d come prepared with a second printout. Silently, I handed the paper to Coach. It contained only 37 words.
+
+20. “What in the name of the [[☃ definition 1]] is this?” he asked.
+
+21. “A copy of Title 9, sir. It’s a policy stating that any school that receives money from the government–which ours does–can’t discriminate on the basis of gender. So, I think your reasoning might be invalid. Can we get on with tryouts now?”
+
+22. His face contorted with rage, then confusion, and finally resignation as he pointed towards the center line. “You wanna be quarterback? Show me you can get past these three–” he pointed to Marcus, Raj, and Hiro, “and get the ball to the end zone.” He tossed me a ball.
+
+23. I gulped. I’d expected we’d start slow, maybe with some sprints. 
+
+24. *You’ve got this,* I coached myself as I walked toward the center line. *You’re ready. Even Malik said so.* 
+
+25. When I arrived at the center line and saw the three boys between me and the end zone, a sense of calm settled over me. Strategy flooded my mind as I thought of everything I’d observed from the bushes. Marcus, on the right, was big but slow. Raj, in the center, had a tendency to cover the left side of his area. Hiro, on the left, was the biggest threat–he was fast and clever, and, as he smirked at me, I knew immediately what my best play would be.
+
+26. As Coach blew his whistle, I raced hard towards the left, ignoring the obvious opening on the right side of the field. No one who knew him ever tried to get past Hiro, so that’s exactly what I would do. I barely saw Hiro’s smirk change into a look of surprise as I approached him, sliding under his outstretched arms. I leapt into the end zone with a whoop of delight. 
+
+27. Coach looked reluctantly impressed when I trotted back to him. “Well, that wasn’t half-bad. I think we might give you a shot after all.”
+
+[[☃ explanation 1]]
+
+
+=====",
+    "images": {},
+    "metadata": null,
+    "replace": null,
+    "widgets": {
+      "definition 1": {
+        "alignment": "default",
+        "graded": true,
+        "id": null,
+        "key": null,
+        "options": {
+          "definition": "A trophy awarded each year to the top college football player in the United States",
+          "static": false,
+          "togglePrompt": "Heisman Trophy",
+        },
+        "static": false,
+        "type": "definition",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+      "explanation 1": {
+        "alignment": "default",
+        "graded": true,
+        "id": null,
+        "key": null,
+        "options": {
+          "explanation": "Image source: Image provided by Chidi Young under a [Canva license](https://www.canva.com/policies/content-license-agreement/).",
+          "hidePrompt": "Hide attribution",
+          "showPrompt": "Attribution",
+          "static": false,
+          "widgets": {},
+        },
+        "static": false,
+        "type": "explanation",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+      "image 1": {
+        "alignment": "block",
+        "graded": true,
+        "id": null,
+        "key": null,
+        "options": {
+          "alt": "",
+          "backgroundImage": {
+            "bottom": undefined,
+            "height": 600,
+            "left": undefined,
+            "scale": undefined,
+            "top": 0,
+            "url": "https://cdn.kastatic.org/ka-content-images/339d80b3e1b39872e391c232a0edacdff0b0b66d.png",
+            "width": 380,
+          },
+          "box": [
+            380,
+            600,
+          ],
+          "caption": "",
+          "labels": [],
+          "range": [
+            [
+              0,
+              10,
+            ],
+            [
+              0,
+              10,
+            ],
+          ],
+          "static": false,
+          "title": "",
+        },
+        "static": false,
+        "type": "image",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`parseAndMigratePerseusItem given label-image-missing-static.json returns the same result as before 1`] = `
 {
   "answerArea": {

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/item-with-null-itemDataVersion.json
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/item-with-null-itemDataVersion.json
@@ -1,0 +1,111 @@
+{
+    "question": {
+        "content": "\n [[☃ image 1]]\n\n##A shot after all\n\n*By Heather M. Meston*\n\n___\n\n1. I peered through the neglected bushes crowning the hill overlooking the field, a vicious debate raging in my mind.\n\n2. *To go or not to go?*\n\n3. *To try or not to try?*\n\n4. I winced as Marcus Fitzwilliam barreled into a blocking sled, 300 pounds of foam padding and metal. The sled flew back six feet.\n\n5. *I can’t compete with that,* I thought. I barely weighed a hundred pounds in snow boots. It would take a miracle for me to move that thing an inch.\n\n6. *Stop it, Jamila,* commanded my braver side. *You don’t need to be big to be a quarterback, just fast and smart. Marcus may be big, but his bad knee makes him slow.* My eyes drifted to a sleek form running sprints across the field. *Now, Hiro, on the other hand…he’s fast. Gotta watch out for him.*\n\n7. Before I could stop myself, I shoved through the bushes, my head held high even as my heart trembled.\n\n8. Donny, who’d lost two teeth playing last year, was the first to spy me. He completely missed the left-handed pass Raj sent his way, drawing Coach Franklin’s irritation. But before Coach could begin lecturing, Raj interrupted him to point out the intruder on the field.\n\n9. Me.\n\n10. Coach looked startled for a moment, then came to his senses. “Jamila! You looking for cheerleading tryouts? In the gym.”\n\n11. I thought of all the hours my brother Malik had spent practicing with me. I couldn’t disappoint him. “No, I’m here to try out. Er…that is…for football, I mean. For quarterback.” Smooth. So smooth.\n\n12. Raj laughed, Marcus grinned, and Coach’s mouth twisted like I'd just force-fed him a lemon \n\n13. “Well, you see,” he started, “It’s just that girls aren’t allowed on the football team. Too dangerous, you know.”\n\n14. *But it's not too dangerous for boys? What’s wrong with people?*\n\n15. “Actually, sir, that’s not true. There’s nothing saying we can’t play.” I pulled out my copy of the school handbook. “See?” I said. “The only qualifications are that a player must have at least a C average and that the coach and a doctor must declare the player physically fit. I have straight As, and here’s my doctor’s note.”\n\n16. He grimaced, and then his face lit up. “Well, I don’t declare you physically fit. So that’s that.” He folded his arms across his chest with a satisfied grin.\n\n17. “Why?” I asked.\n\n18. “Girls are too delicate for football. I don't care how good your brother was. You'll snap like a twig out there. Sorry.”\n\n19. I’d come prepared with a second printout. Silently, I handed the paper to Coach. It contained only 37 words.\n\n20. “What in the name of the [[☃ definition 1]] is this?” he asked.\n\n21. “A copy of Title 9, sir. It’s a policy stating that any school that receives money from the government–which ours does–can’t discriminate on the basis of gender. So, I think your reasoning might be invalid. Can we get on with tryouts now?”\n\n22. His face contorted with rage, then confusion, and finally resignation as he pointed towards the center line. “You wanna be quarterback? Show me you can get past these three–” he pointed to Marcus, Raj, and Hiro, “and get the ball to the end zone.” He tossed me a ball.\n\n23. I gulped. I’d expected we’d start slow, maybe with some sprints. \n\n24. *You’ve got this,* I coached myself as I walked toward the center line. *You’re ready. Even Malik said so.* \n\n25. When I arrived at the center line and saw the three boys between me and the end zone, a sense of calm settled over me. Strategy flooded my mind as I thought of everything I’d observed from the bushes. Marcus, on the right, was big but slow. Raj, in the center, had a tendency to cover the left side of his area. Hiro, on the left, was the biggest threat–he was fast and clever, and, as he smirked at me, I knew immediately what my best play would be.\n\n26. As Coach blew his whistle, I raced hard towards the left, ignoring the obvious opening on the right side of the field. No one who knew him ever tried to get past Hiro, so that’s exactly what I would do. I barely saw Hiro’s smirk change into a look of surprise as I approached him, sliding under his outstretched arms. I leapt into the end zone with a whoop of delight. \n\n27. Coach looked reluctantly impressed when I trotted back to him. “Well, that wasn’t half-bad. I think we might give you a shot after all.”\n\n[[☃ explanation 1]]\n\n\n=====",
+        "widgets": {
+        "definition 1": {
+            "type": "definition",
+            "static": false,
+            "graded": true,
+            "alignment": "default",
+            "id": null,
+            "key": null,
+            "version": {
+            "major": 0,
+            "minor": 0
+            },
+            "options": {
+            "togglePrompt": "Heisman Trophy",
+            "definition": "A trophy awarded each year to the top college football player in the United States",
+            "static": false
+            }
+        },
+        "explanation 1": {
+            "type": "explanation",
+            "static": false,
+            "graded": true,
+            "alignment": "default",
+            "id": null,
+            "key": null,
+            "version": {
+            "major": 0,
+            "minor": 0
+            },
+            "options": {
+            "showPrompt": "Attribution",
+            "hidePrompt": "Hide attribution",
+            "explanation": "Image source: Image provided by Chidi Young under a [Canva license](https://www.canva.com/policies/content-license-agreement/).",
+            "widgets": {},
+            "static": false
+            }
+        },
+        "image 1": {
+            "type": "image",
+            "static": false,
+            "graded": true,
+            "alignment": "block",
+            "id": null,
+            "key": null,
+            "version": {
+            "major": 0,
+            "minor": 0
+            },
+            "options": {
+            "title": "",
+            "labels": [],
+            "caption": "",
+            "alt": "",
+            "backgroundImage": {
+                "url": "https://cdn.kastatic.org/ka-content-images/339d80b3e1b39872e391c232a0edacdff0b0b66d.png",
+                "width": 380,
+                "height": 600,
+                "top": 0,
+                "scale": null,
+                "bottom": null,
+                "left": null
+            },
+            "static": false,
+            "range": [
+                [
+                0,
+                10
+                ],
+                [
+                0,
+                10
+                ]
+            ],
+            "box": [
+                380,
+                600
+            ]
+            }
+        }
+        },
+        "replace": null,
+        "metadata": null,
+        "images": {}
+    },
+    "hints": [],
+    "answerArea": {
+        "type": "",
+        "static": false,
+        "graded": false,
+        "alignment": "",
+        "id": null,
+        "key": null,
+        "version": null,
+        "zTable": false,
+        "chi2Table": false,
+        "tTable": false,
+        "calculator": false,
+        "periodicTable": false,
+        "periodicTableWithKey": false,
+        "financialCalculatorMonthlyPayment": false,
+        "financialCalculatorTotalAmount": false,
+        "financialCalculatorTimeToPayOff": false,
+        "options": null
+    },
+    "_multi": null,
+    "itemDataVersion": null,
+    "answer": null
+}


### PR DESCRIPTION
## Summary:
There are a few content items that have `itemDataVersion: null`, and these are
causing parser errors in production because the parser doesn't like `null`.
This PR updates the parser to accept `null` values for `itemDataVersion`.
`itemDataVersion` is already marked deprecated, and can be `undefined`, so it
seems harmless to allow `null` as well.

Issue: none

## Test plan:

`pnpm test`