### PR TITLE
[SR] Move axis labels' screen reader text

### DIFF
--- a/.changeset/pretty-toys-help.md
+++ b/.changeset/pretty-toys-help.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[SR] Hide axis labels from screen readers

--- a/.changeset/quick-mice-turn.md
+++ b/.changeset/quick-mice-turn.md
@@ -1,5 +1,0 @@
----
-"@khanacademy/perseus": patch
----
-
-[SR] Move axis labels' screen reader text

--- a/.changeset/quick-mice-turn.md
+++ b/.changeset/quick-mice-turn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[SR] Move axis labels' screen reader text

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -136,8 +136,6 @@ export type PerseusStrings = {
     // The following strings are used for interactive graph SR descriptions.
     srGraphInstructions: string;
     srUnlimitedGraphInstructions: string;
-    xAxis: string;
-    yAxis: string;
     addPoint: string;
     removePoint: string;
     graphKeyboardPrompt: string;
@@ -693,8 +691,6 @@ export const strings = {
         "Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it.",
     srUnlimitedGraphInstructions:
         "Press Shift + Enter to interact with the graph. Use the Tab key to move through the interactive elements in the graph and access the graph Action Bar. When an interactive element has focus, use Control + Shift + Arrows to move it or use the Delete key to remove it from the graph. Use the buttons in the Action Bar to add or adjust elements within the graph.",
-    xAxis: "X-axis",
-    yAxis: "Y-axis",
     srPointAtCoordinates: "Point %(num)s at %(x)s comma %(y)s.",
     srCircleGraph: "A circle on a coordinate plane.",
     srCircleShape:
@@ -973,8 +969,6 @@ export const mockStrings: PerseusStrings = {
         "Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it.",
     srUnlimitedGraphInstructions:
         "Press Shift + Enter to interact with the graph. Use the Tab key to move through the interactive elements in the graph and access the graph Action Bar. When an interactive element has focus, use Control + Shift + Arrows to move it or use the Delete key to remove it from the graph. Use the buttons in the Action Bar to add or adjust elements within the graph.",
-    xAxis: "X-axis",
-    yAxis: "Y-axis",
     graphKeyboardPrompt: "Press Shift + Enter to interact with the graph",
     addPoint: "Add Point",
     removePoint: "Remove Point",

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -26,9 +26,13 @@ exports[`Interactive Graph A none-type graph renders predictably: first render 1
                 class="default_xu2jcg-o_O-inlineStyles_16155wj"
               >
                 <span
-                  aria-label="X-axis"
                   style="position: absolute; left: 400px; top: 200px; font-size: 14px; transform: translate(7px, -50%);"
                 >
+                  <span
+                    class="srOnly_19bpjuy"
+                  >
+                    X-axis
+                  </span>
                   <span
                     class="mock-TeX"
                   >
@@ -36,9 +40,13 @@ exports[`Interactive Graph A none-type graph renders predictably: first render 1
                   </span>
                 </span>
                 <span
-                  aria-label="Y-axis"
                   style="position: absolute; left: 200px; top: -28px; font-size: 14px; transform: translate(-50%, 0px);"
                 >
+                  <span
+                    class="srOnly_19bpjuy"
+                  >
+                    Y-axis
+                  </span>
                   <span
                     class="mock-TeX"
                   >

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -26,13 +26,9 @@ exports[`Interactive Graph A none-type graph renders predictably: first render 1
                 class="default_xu2jcg-o_O-inlineStyles_16155wj"
               >
                 <span
+                  aria-hidden="true"
                   style="position: absolute; left: 400px; top: 200px; font-size: 14px; transform: translate(7px, -50%);"
                 >
-                  <span
-                    class="srOnly_19bpjuy"
-                  >
-                    X-axis
-                  </span>
                   <span
                     class="mock-TeX"
                   >
@@ -40,13 +36,9 @@ exports[`Interactive Graph A none-type graph renders predictably: first render 1
                   </span>
                 </span>
                 <span
+                  aria-hidden="true"
                   style="position: absolute; left: 200px; top: -28px; font-size: 14px; transform: translate(-50%, 0px);"
                 >
-                  <span
-                    class="srOnly_19bpjuy"
-                  >
-                    Y-axis
-                  </span>
                   <span
                     class="mock-TeX"
                   >

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
@@ -1,7 +1,9 @@
+import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {vec} from "mafs";
 import React from "react";
 
 import {getDependencies} from "../../../dependencies";
+import a11y from "../../../util/a11y";
 import {pointToPixel} from "../graphs/use-transform";
 import {MAX, MIN, X, Y} from "../math";
 import useGraphConfig from "../reducer/use-graph-config";
@@ -13,6 +15,8 @@ import type {GraphDimensions} from "../types";
 
 // Exported for testing purposes
 export const fontSize = 14;
+
+const StyledSpan = addStyle("span");
 
 export default function AxisLabels({i18n}: {i18n: I18nContextType}) {
     const {range, labels, width, height, labelLocation} = useGraphConfig();
@@ -40,7 +44,6 @@ export default function AxisLabels({i18n}: {i18n: I18nContextType}) {
     return (
         <>
             <span
-                aria-label={strings.xAxis}
                 style={{
                     position: "absolute",
                     left: xAxisLabelLocation[X],
@@ -49,10 +52,10 @@ export default function AxisLabels({i18n}: {i18n: I18nContextType}) {
                     transform: xLabelTransform,
                 }}
             >
+                <StyledSpan style={a11y.srOnly}>{strings.xAxis}</StyledSpan>
                 <TeX>{replaceOutsideTeX(xAxisLabelText)}</TeX>
             </span>
             <span
-                aria-label={strings.yAxis}
                 style={{
                     position: "absolute",
                     left: yAxisLabelLocation[X],
@@ -61,6 +64,7 @@ export default function AxisLabels({i18n}: {i18n: I18nContextType}) {
                     transform: yLabelTransform,
                 }}
             >
+                <StyledSpan style={a11y.srOnly}>{strings.yAxis}</StyledSpan>
                 <TeX>{replaceOutsideTeX(yAxisLabelText)}</TeX>
             </span>
         </>

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
@@ -1,9 +1,7 @@
-import {addStyle} from "@khanacademy/wonder-blocks-core";
 import {vec} from "mafs";
 import React from "react";
 
 import {getDependencies} from "../../../dependencies";
-import a11y from "../../../util/a11y";
 import {pointToPixel} from "../graphs/use-transform";
 import {MAX, MIN, X, Y} from "../math";
 import useGraphConfig from "../reducer/use-graph-config";
@@ -16,11 +14,8 @@ import type {GraphDimensions} from "../types";
 // Exported for testing purposes
 export const fontSize = 14;
 
-const StyledSpan = addStyle("span");
-
 export default function AxisLabels({i18n}: {i18n: I18nContextType}) {
     const {range, labels, width, height, labelLocation} = useGraphConfig();
-    const {strings} = i18n;
 
     const graphInfo: GraphDimensions = {
         range,
@@ -44,6 +39,11 @@ export default function AxisLabels({i18n}: {i18n: I18nContextType}) {
     return (
         <>
             <span
+                // Reading the axis labels by themselves is mostly unhelpful
+                // for screen reader users, so we should hide them to avoid
+                // confusion. Instead, the axis labels should be included as
+                // part of the graph description by content authors.
+                aria-hidden={true}
                 style={{
                     position: "absolute",
                     left: xAxisLabelLocation[X],
@@ -52,10 +52,14 @@ export default function AxisLabels({i18n}: {i18n: I18nContextType}) {
                     transform: xLabelTransform,
                 }}
             >
-                <StyledSpan style={a11y.srOnly}>{strings.xAxis}</StyledSpan>
                 <TeX>{replaceOutsideTeX(xAxisLabelText)}</TeX>
             </span>
             <span
+                // Reading the axis labels by themselves is mostly unhelpful
+                // for screen reader users, so we should hide them to avoid
+                // confusion. Instead, the axis labels should be included as
+                // part of the graph description by content authors.
+                aria-hidden={true}
                 style={{
                     position: "absolute",
                     left: yAxisLabelLocation[X],
@@ -64,7 +68,6 @@ export default function AxisLabels({i18n}: {i18n: I18nContextType}) {
                     transform: yLabelTransform,
                 }}
             >
-                <StyledSpan style={a11y.srOnly}>{strings.yAxis}</StyledSpan>
                 <TeX>{replaceOutsideTeX(yAxisLabelText)}</TeX>
             </span>
         </>

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -190,18 +190,6 @@ describe("MafsGraph", () => {
         expect(screen.getByText("\\text{5/6}")).toBeInTheDocument();
     });
 
-    it("includes aria-labels for the axes labels", () => {
-        const basePropsWithTexLabels = {...baseMafsProps};
-
-        render(<MafsGraph {...basePropsWithTexLabels} />);
-
-        const xAxisLabel = screen.getByText("X-axis");
-        const yAxisLabel = screen.getByText("Y-axis");
-
-        expect(xAxisLabel).toBeInTheDocument();
-        expect(yAxisLabel).toBeInTheDocument();
-    });
-
     it("renders ARIA labels for each point (segment)", () => {
         const state: InteractiveGraphState = {
             type: "segment",

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -195,8 +195,8 @@ describe("MafsGraph", () => {
 
         render(<MafsGraph {...basePropsWithTexLabels} />);
 
-        const xAxisLabel = screen.getByLabelText("X-axis");
-        const yAxisLabel = screen.getByLabelText("Y-axis");
+        const xAxisLabel = screen.getByText("X-axis");
+        const yAxisLabel = screen.getByText("Y-axis");
 
         expect(xAxisLabel).toBeInTheDocument();
         expect(yAxisLabel).toBeInTheDocument();


### PR DESCRIPTION
## Summary:
We found out from the UXR that having the axis labels just there didn't really help. Instead, it would be better for them to be part of the overall graph description, which is specified by content authors.

Hiding axis labels from screen readers here.

Issue: none

## Test plan:
- Go to http://localhost:6006/iframe.html?globals=&args=&id=perseuseditor-widgets-interactive-graph--interactive-graph-segment&viewMode=story
- Use a screen read to go through the graph
- Confirm that the axis labels are no longer read.