### PR TITLE
Adding button roles to the Image Widget to help improve A11Y.

### DIFF
--- a/.changeset/silly-houses-dress.md
+++ b/.changeset/silly-houses-dress.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Adding roles to the Image Widget to help improve A11Y.

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -409,7 +409,9 @@ describe("renderer", () => {
             markImagesAsLoaded();
 
             // Assert
-            const imageNodes = screen.queryAllByRole("img");
+            const imageNodes = screen.queryAllByAltText(
+                "This image has dimensions",
+            );
             expect(imageNodes).toHaveLength(1);
 
             // eslint-disable-next-line testing-library/no-node-access
@@ -433,7 +435,9 @@ describe("renderer", () => {
             markImagesAsLoaded();
 
             // Assert
-            const imageNodes = screen.queryAllByRole("img");
+            const imageNodes = screen.queryAllByAltText(
+                "This image doesn't have dimensions",
+            );
             expect(imageNodes).toHaveLength(1);
 
             // image didn't have dimensions provided so it is not rendered as
@@ -462,7 +466,9 @@ describe("renderer", () => {
             markImagesAsLoaded();
 
             // Assert
-            expect(screen.queryAllByRole("img")).toHaveLength(1);
+            expect(
+                screen.queryAllByAltText("This image has dimensions"),
+            ).toHaveLength(1);
 
             const wrapperStyle = getComputedStyle(
                 // @ts-expect-error - TS2345 - Argument of type 'HTMLElement | null' is not assignable to parameter of type 'Element'.
@@ -487,7 +493,9 @@ describe("renderer", () => {
             markImagesAsLoaded();
 
             // Assert
-            expect(screen.queryAllByRole("img")).toHaveLength(1);
+            expect(screen.queryAllByAltText("This image doesn't")).toHaveLength(
+                1,
+            );
 
             const wrapperStyle = getComputedStyle(
                 // @ts-expect-error - TS2345 - Argument of type 'HTMLElement | null' is not assignable to parameter of type 'Element'.
@@ -519,7 +527,9 @@ describe("renderer", () => {
             markImagesAsLoaded();
 
             // Assert
-            const imageNodes = screen.queryAllByRole("img");
+            const imageNodes = screen.queryAllByAltText(
+                "This image has dimensions",
+            );
             expect(imageNodes).toHaveLength(1);
             expect(getComputedStyle(imageNodes[0]).width).toBe("420px");
             expect(getComputedStyle(imageNodes[0]).height).toBe("410px");

--- a/packages/perseus/src/components/__tests__/__snapshots__/svg-image.test.tsx.snap
+++ b/packages/perseus/src/components/__tests__/__snapshots__/svg-image.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`SvgImage should load and render a localized graphie svg 1`] = `
   >
     <img
       alt="svg image"
+      role="button"
       src="mockStaticUrl(https://ka-perseus-graphie.s3.amazonaws.com/ccefe63aa1bd05f1d11123f72790a49378d2e42b.svg)"
       tabindex="0"
     />
@@ -21,6 +22,7 @@ exports[`SvgImage should load and render a normal graphie svg 1`] = `
   >
     <img
       alt="svg image"
+      role="button"
       src="mockStaticUrl(https://ka-perseus-graphie.s3.amazonaws.com/ccefe63aa1bd05f1d11123f72790a49378d2e42b.svg)"
       tabindex="0"
     />
@@ -32,6 +34,7 @@ exports[`SvgImage should load and render a png 1`] = `
 <div>
   <img
     alt="png image"
+    role="button"
     src="mockStaticUrl(http://localhost/sample.png)"
     tabindex="0"
   />

--- a/packages/perseus/src/components/image-loader.tsx
+++ b/packages/perseus/src/components/image-loader.tsx
@@ -142,11 +142,18 @@ class ImageLoader extends React.Component<Props, State> {
         }
         const staticUrl = getDependencies().staticUrl;
 
+        // If the image is interactive, it should have a role of "button"
+        // to indicate that it is interactive.
+        const imageRole = imgProps.onClick !== null ? "button" : "img";
+
         return (
-            // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions -- TODO(LEMS-2871): Address a11y error
+            // (LEMS-2871) NOTE: This image IS interactive if it requires zooming, and LevelAccess specifically requested
+            // that the role and tabIndex be set here. When users interact with the image on mobile, it will zoom in.
+            // eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
             <img
                 // eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex -- TODO(LEMS-2871): Address a11y error
                 tabIndex={0}
+                role={imageRole}
                 src={staticUrl(src)}
                 onKeyUp={onKeyUp}
                 onKeyDown={onKeyDown}

--- a/packages/perseus/src/widgets/image/image.stories.tsx
+++ b/packages/perseus/src/widgets/image/image.stories.tsx
@@ -99,10 +99,12 @@ export const ImageWithZoom = (args: StoryArgs): React.ReactElement => {
         },
     } as const;
     return (
-        <RendererWithDebugUI
-            question={questionWithCaptionAndArgs}
-            apiOptions={apiOptions}
-        />
+        <div style={{width: "50%", margin: "0 auto"}}>
+            <RendererWithDebugUI
+                question={questionWithCaptionAndArgs}
+                apiOptions={apiOptions}
+            />
+        </div>
     );
 };
 

--- a/packages/perseus/src/zoom.ts
+++ b/packages/perseus/src/zoom.ts
@@ -370,6 +370,7 @@ Zoom.prototype.zoomImage = function () {
     img.src = this._targetImage.src;
     img.alt = this._targetImage.alt;
     img.tabIndex = 0;
+    img.role = "button";
 
     this.$zoomedImage = $zoomedImage;
 };


### PR DESCRIPTION
## Summary:
Our A11Y Partner has requested that the button role be added to our Image Widget, as images within it may be interactive if they require a zoom. 

This PR adds the role, fixes a related story for testing purposes, and updates several related tests. 

Issue: LEMS-2697

## Test plan:
- Manual testing on Desktop/Mobile 
- Tests Pass 