### PR TITLE
Add logic to allow the PhET Widget to go full screen on older browsers/devices.

### DIFF
--- a/.changeset/thirty-coins-move.md
+++ b/.changeset/thirty-coins-move.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Add logic to allow the PhET Widget to go full screen on older browsers/devices.

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -200,7 +200,9 @@ export class PhetSimulation
                     <IconButton
                         icon={cornersOutIcon}
                         onClick={() => {
-                            this.iframeRef.current?.requestFullscreen();
+                            if (this.iframeRef.current) {
+                                openFullscreen(this.iframeRef.current);
+                            }
                         }}
                         kind={"secondary"}
                         aria-label={"Fullscreen"}
@@ -215,6 +217,28 @@ export class PhetSimulation
         );
     }
 }
+
+// Unfortunately, the fullscreen API is not standardized across browsers, and
+// Safari continually changes their implementation across versions. This extension
+// and function are necessary to ensure that the fullscreen button works on all
+// browsers.
+interface HTMLElement {
+    webkitRequestFullscreen?: () => Promise<void>;
+    webkitEnterFullscreen?: () => void;
+    msRequestFullscreen?: () => Promise<void>;
+    requestFullscreen?: () => Promise<void>;
+}
+const openFullscreen = (element: HTMLElement) => {
+    if (element.requestFullscreen) {
+        element.requestFullscreen(); // Most browsers
+    } else if (element.webkitEnterFullscreen) {
+        element.webkitEnterFullscreen(); // Newer versions of Safari
+    } else if (element.webkitRequestFullscreen) {
+        element.webkitRequestFullscreen(); // Older versions of Safari
+    } else if (element.msRequestFullscreen) {
+        element.msRequestFullscreen(); // IE 11
+    }
+};
 
 // Setting URL to null will display an error message in the iframe
 export const makeSafeUrl = (urlString: string, locale: string): URL | null => {


### PR DESCRIPTION
## Summary:
[TEST] Ensure the PhET Widget can be opened full screen on older browsers/Safari webkits. 

TBD

Issue: LEMS-2922

## Test plan:
- Manual testing the storybook on devices (TBD) 