### PR TITLE
[SR] Remove instructions for static graphs, mark interactive elements as disabled

### DIFF
--- a/.changeset/shaggy-ladybugs-begin.md
+++ b/.changeset/shaggy-ladybugs-begin.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[SR] Remove instructions for static graphs, mark interactive elements as disabled

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -1243,6 +1243,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                             2
                           </text>
                           <polygon
+                            aria-disabled="false"
                             aria-label="A polygon with 3 points."
                             aria-live="off"
                             class="movable-polygon"
@@ -1257,6 +1258,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                           <g>
                             <g
                               aria-describedby=":r3:-angle-0 :r3:-point-0-side-1 :r3:-point-0-side-2"
+                              aria-disabled="false"
                               aria-label="Point 1 at 3.5 comma 2."
                               aria-live="off"
                               class="movable-point__focusable-handle"
@@ -1327,6 +1329,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                           <g>
                             <g
                               aria-describedby=":r3:-angle-1 :r3:-point-1-side-1 :r3:-point-1-side-2"
+                              aria-disabled="false"
                               aria-label="Point 2 at 2.5 comma 4."
                               aria-live="off"
                               class="movable-point__focusable-handle"
@@ -1397,6 +1400,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                           <g>
                             <g
                               aria-describedby=":r3:-angle-2 :r3:-point-2-side-1 :r3:-point-2-side-2"
+                              aria-disabled="false"
                               aria-label="Point 3 at 1.5 comma 2."
                               aria-live="off"
                               class="movable-point__focusable-handle"
@@ -1674,6 +1678,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                             style="fill: transparent; fill-opacity: 0.15; stroke: var(--mafs-blue); stroke-opacity: 1; vector-effect: non-scaling-stroke; transform: var(--mafs-view-transform);"
                           />
                           <polygon
+                            aria-disabled="false"
                             aria-label="A polygon with 3 points."
                             aria-live="off"
                             class="movable-polygon"
@@ -1688,6 +1693,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                           <g>
                             <g
                               aria-describedby=":rb:-angle-0 :rb:-point-0-side-1 :rb:-point-0-side-2"
+                              aria-disabled="false"
                               aria-label="Point 1 at 3 comma -2."
                               aria-live="off"
                               class="movable-point__focusable-handle"
@@ -1758,6 +1764,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                           <g>
                             <g
                               aria-describedby=":rb:-angle-1 :rb:-point-1-side-1 :rb:-point-1-side-2"
+                              aria-disabled="false"
                               aria-label="Point 2 at 0 comma 3."
                               aria-live="off"
                               class="movable-point__focusable-handle"
@@ -1828,6 +1835,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                           <g>
                             <g
                               aria-describedby=":rb:-angle-2 :rb:-point-2-side-1 :rb:-point-2-side-2"
+                              aria-disabled="false"
                               aria-label="Point 3 at -3 comma -2."
                               aria-live="off"
                               class="movable-point__focusable-handle"
@@ -2627,6 +2635,7 @@ exports[`Interactive Graph question Should render predictably: first render 1`] 
                             2
                           </text>
                           <polygon
+                            aria-disabled="false"
                             aria-label="A polygon with 3 points."
                             aria-live="off"
                             class="movable-polygon"
@@ -2641,6 +2650,7 @@ exports[`Interactive Graph question Should render predictably: first render 1`] 
                           <g>
                             <g
                               aria-describedby=":r3:-angle-0 :r3:-point-0-side-1 :r3:-point-0-side-2"
+                              aria-disabled="false"
                               aria-label="Point 1 at 3.5 comma 2."
                               aria-live="off"
                               class="movable-point__focusable-handle"
@@ -2711,6 +2721,7 @@ exports[`Interactive Graph question Should render predictably: first render 1`] 
                           <g>
                             <g
                               aria-describedby=":r3:-angle-1 :r3:-point-1-side-1 :r3:-point-1-side-2"
+                              aria-disabled="false"
                               aria-label="Point 2 at 2.5 comma 4."
                               aria-live="off"
                               class="movable-point__focusable-handle"
@@ -2781,6 +2792,7 @@ exports[`Interactive Graph question Should render predictably: first render 1`] 
                           <g>
                             <g
                               aria-describedby=":r3:-angle-2 :r3:-point-2-side-1 :r3:-point-2-side-2"
+                              aria-disabled="false"
                               aria-label="Point 3 at 1.5 comma 2."
                               aria-live="off"
                               class="movable-point__focusable-handle"
@@ -3058,6 +3070,7 @@ exports[`Interactive Graph question Should render predictably: first render 2`] 
                             style="fill: transparent; fill-opacity: 0.15; stroke: var(--mafs-blue); stroke-opacity: 1; vector-effect: non-scaling-stroke; transform: var(--mafs-view-transform);"
                           />
                           <polygon
+                            aria-disabled="false"
                             aria-label="A polygon with 3 points."
                             aria-live="off"
                             class="movable-polygon"
@@ -3072,6 +3085,7 @@ exports[`Interactive Graph question Should render predictably: first render 2`] 
                           <g>
                             <g
                               aria-describedby=":rb:-angle-0 :rb:-point-0-side-1 :rb:-point-0-side-2"
+                              aria-disabled="false"
                               aria-label="Point 1 at 3 comma -2."
                               aria-live="off"
                               class="movable-point__focusable-handle"
@@ -3142,6 +3156,7 @@ exports[`Interactive Graph question Should render predictably: first render 2`] 
                           <g>
                             <g
                               aria-describedby=":rb:-angle-1 :rb:-point-1-side-1 :rb:-point-1-side-2"
+                              aria-disabled="false"
                               aria-label="Point 2 at 0 comma 3."
                               aria-live="off"
                               class="movable-point__focusable-handle"
@@ -3212,6 +3227,7 @@ exports[`Interactive Graph question Should render predictably: first render 2`] 
                           <g>
                             <g
                               aria-describedby=":rb:-angle-2 :rb:-point-2-side-1 :rb:-point-2-side-2"
+                              aria-disabled="false"
                               aria-label="Point 3 at -3 comma -2."
                               aria-live="off"
                               class="movable-point__focusable-handle"

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -146,6 +146,7 @@ function MovableCircle(props: {
             aria-label={ariaLabel}
             aria-describedby={ariaDescribedBy}
             aria-live="polite"
+            aria-disabled={disableKeyboardInteraction}
             ref={draggableRef}
             role="button"
             tabIndex={disableKeyboardInteraction ? -1 : 0}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/__snapshots__/movable-line.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/__snapshots__/movable-line.test.tsx.snap
@@ -15,6 +15,7 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
       width="200"
     >
       <g
+        aria-disabled="false"
         aria-label="Point 1 at -1 comma -1."
         aria-live="off"
         class="movable-point__focusable-handle"
@@ -23,6 +24,7 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
         tabindex="0"
       />
       <g
+        aria-disabled="false"
         aria-live="off"
         class="movable-line"
         data-testid="movable-line"
@@ -66,6 +68,7 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
         />
       </g>
       <g
+        aria-disabled="false"
         aria-label="Point 2 at 1 comma 1."
         aria-live="off"
         class="movable-point__focusable-handle"
@@ -163,6 +166,7 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
       width="200"
     >
       <g
+        aria-disabled="false"
         aria-label="Point 1 at -1 comma -1."
         aria-live="off"
         class="movable-point__focusable-handle"
@@ -171,6 +175,7 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
         tabindex="0"
       />
       <g
+        aria-disabled="false"
         aria-live="off"
         class="movable-line"
         data-testid="movable-line"
@@ -214,6 +219,7 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
         />
       </g>
       <g
+        aria-disabled="false"
         aria-label="Point 2 at 1 comma 1."
         aria-live="off"
         class="movable-point__focusable-handle"
@@ -311,6 +317,7 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
       width="200"
     >
       <g
+        aria-disabled="false"
         aria-label="Point 1 at -1 comma -1."
         aria-live="off"
         class="movable-point__focusable-handle"
@@ -319,6 +326,7 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
         tabindex="0"
       />
       <g
+        aria-disabled="false"
         aria-live="off"
         class="movable-line"
         data-testid="movable-line"
@@ -422,6 +430,7 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
         </g>
       </g>
       <g
+        aria-disabled="false"
         aria-label="Point 2 at 1 comma 1."
         aria-live="off"
         class="movable-point__focusable-handle"

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -188,6 +188,7 @@ const Line = (props: LineProps) => {
                 aria-label={ariaLabel}
                 aria-describedby={ariaDescribedBy}
                 aria-live={ariaLive}
+                aria-disabled={disableKeyboardInteraction}
                 className="movable-line"
                 data-testid="movable-line"
                 style={{cursor: dragging ? "grabbing" : "grab"}}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -1,4 +1,3 @@
-import {color as WBColor} from "@khanacademy/wonder-blocks-tokens";
 import Tooltip from "@khanacademy/wonder-blocks-tooltip";
 import * as React from "react";
 import {forwardRef} from "react";
@@ -15,7 +14,6 @@ import type {ForwardedRef} from "react";
 
 type Props = {
     point: vec.Vector2;
-    color?: string | undefined;
     dragging: boolean;
     focused: boolean;
     showFocusRing: boolean;
@@ -32,10 +30,14 @@ const hitboxSizePx = 48;
 // on an interactive graph.
 export const MovablePointView = forwardRef(
     (props: Props, hitboxRef: ForwardedRef<SVGGElement>) => {
-        const {markings, showTooltips, interactiveColor} = useGraphConfig();
+        const {
+            markings,
+            showTooltips,
+            interactiveColor,
+            disableKeyboardInteraction,
+        } = useGraphConfig();
         const {
             point,
-            color = interactiveColor,
             dragging,
             focused,
             cursor,
@@ -43,11 +45,15 @@ export const MovablePointView = forwardRef(
             onClick = () => {},
         } = props;
 
-        // WB Tooltip requires a color name for the background color.
-        // Since the color in props is a hex value, a reverse lookup is needed.
-        const wbColorName = (Object.entries(WBColor).find(
-            ([_, value]) => value === color,
-        )?.[0] ?? "blue") as keyof typeof WBColor;
+        // WB Tooltip requires a WB color name for the background color.
+        // We use the blue color when the points are interactive, and
+        // offBlack64 when they are disabled.
+        // Note: The disabled point color is offBlack50 to contrast with
+        // the interactive blue color, but the tooltip background has to be
+        // darker to contrast with its white text - using offBlack64.
+        const wbColorName = disableKeyboardInteraction
+            ? "fadedOffBlack64" // not see-through
+            : "blue";
 
         const pointClasses = classNames(
             "movable-point",
@@ -68,7 +74,9 @@ export const MovablePointView = forwardRef(
                 aria-hidden={true}
                 ref={hitboxRef}
                 className={pointClasses}
-                style={{"--movable-point-color": color, cursor} as any}
+                style={
+                    {"--movable-point-color": interactiveColor, cursor} as any
+                }
                 data-testid="movable-point"
                 onClick={onClick}
             >
@@ -85,7 +93,7 @@ export const MovablePointView = forwardRef(
                     className="movable-point-center"
                     cx={x}
                     cy={y}
-                    style={{fill: color}}
+                    style={{fill: interactiveColor}}
                     data-testid="movable-point__center"
                 />
             </g>

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.test.tsx
@@ -106,7 +106,7 @@ describe("MovablePoint", () => {
             expect(Tooltip).not.toHaveBeenCalled();
         });
 
-        it("Defaults to a 'blue' background if no color value is provided", () => {
+        it("Defaults to a 'blue' background by default", () => {
             useGraphConfigMock.mockReturnValue(graphConfigContextWithTooltips);
             render(
                 <Mafs width={200} height={200}>
@@ -115,7 +115,6 @@ describe("MovablePoint", () => {
                         sequenceNumber={1}
                         onMove={() => {}}
                     />
-                    ,
                 </Mafs>,
             );
             // @ts-expect-error // TS2339: Property mock does not exist on type typeof Tooltip
@@ -124,27 +123,11 @@ describe("MovablePoint", () => {
             );
         });
 
-        it("Uses the color NAME of the hexadecimal color passed to the point for the background", () => {
-            useGraphConfigMock.mockReturnValue(graphConfigContextWithTooltips);
-            render(
-                <Mafs width={200} height={200}>
-                    <MovablePoint
-                        point={[0, 0]}
-                        sequenceNumber={1}
-                        color="#9059ff"
-                        onMove={() => {}}
-                    />
-                    ,
-                </Mafs>,
-            );
-            // @ts-expect-error // TS2339: Property mock does not exist on type typeof Tooltip
-            expect(Tooltip.mock.calls[0][0]).toEqual(
-                expect.objectContaining({backgroundColor: "purple"}),
-            );
-        });
-
-        it("Defaults to a 'blue' background if the color value provided doesn't match WB colors", () => {
-            useGraphConfigMock.mockReturnValue(graphConfigContextWithTooltips);
+        it("Uses 'fadedOffBlack64' background when the point is disabled", () => {
+            useGraphConfigMock.mockReturnValue({
+                ...graphConfigContextWithTooltips,
+                disableKeyboardInteraction: true,
+            });
             render(
                 <Mafs width={200} height={200}>
                     <MovablePoint
@@ -153,12 +136,11 @@ describe("MovablePoint", () => {
                         color="#f00"
                         onMove={() => {}}
                     />
-                    ,
                 </Mafs>,
             );
             // @ts-expect-error // TS2339: Property mock does not exist on type typeof Tooltip
             expect(Tooltip.mock.calls[0][0]).toEqual(
-                expect.objectContaining({backgroundColor: "blue"}),
+                expect.objectContaining({backgroundColor: "fadedOffBlack64"}),
             );
         });
     });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -53,7 +53,6 @@ export function useControlPoint(params: Params): Return {
         ariaDescribedBy,
         ariaLabel,
         ariaLive = "polite",
-        color,
         constrain = (p) => snap(snapStep, p),
         cursor,
         forwardedRef = noop,
@@ -118,6 +117,7 @@ export function useControlPoint(params: Params): Return {
             aria-describedby={ariaDescribedBy}
             aria-label={pointAriaLabel}
             aria-live={ariaLive}
+            aria-disabled={disableKeyboardInteraction}
             onFocus={(event) => {
                 onFocus(event);
                 setFocused(true);
@@ -138,7 +138,6 @@ export function useControlPoint(params: Params): Return {
             point={point}
             dragging={dragging}
             focused={focused}
-            color={color}
             ref={visiblePointRef}
             showFocusRing={focused}
         />

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -311,6 +311,7 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
                         ? `${srPolygonElementsNum} ${srPolygonGraphPoints}`
                         : srPolygonElementsNum,
                     "aria-live": ariaLives[0],
+                    "aria-disabled": disableKeyboardInteraction,
                 }}
             />
             {points.map((point, i) => {

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -201,7 +201,9 @@ export const MafsGraph = (props: MafsGraphProps) => {
                             interactiveElementsDescriptionId,
                         isUnlimitedGraphState(state) &&
                             unlimitedGraphKeyboardPromptId,
-                        state.type !== "none" && instructionsId,
+                        state.type !== "none" &&
+                            !disableInteraction &&
+                            instructionsId,
                     )}
                     ref={graphRef}
                     tabIndex={0}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -34,7 +34,6 @@
     --movable-point-hover-expansion: 2px;
     --movable-point-focus-ring-offset: 2px;
 
-    --movable-line-stroke-color: var(--mafs-blue);
     --movable-line-stroke-weight: 2px;
     --movable-line-stroke-weight-active: 4px;
     overflow: visible !important;


### PR DESCRIPTION
## Summary:
Right now, when an interactive graph is not interactive (static graphs or after the question has been answered), there is no way for a screen
reader user to know that. The graph instructions are still there, and
the interactive elements sound the same.

Fixing that in this PR
- When a graph is not interactive, remove the interaction instructions
- When a graph is not interactive, give all interactive elements the
  "aria-disabled={true}" property.

| Before | After |
| --- | --- |
| <img width="1130" alt="Screenshot 2025-03-25 at 12 50 14 PM" src="https://github.com/user-attachments/assets/1e8c4148-0040-4101-b521-a492444e0042" /> | <img width="1174" alt="Screenshot 2025-03-25 at 12 49 34 PM" src="https://github.com/user-attachments/assets/1f39b80c-e3d2-4e4c-a069-02fa70996904" /> |


Issue: none

## Test plan:
`yarn jest packages/perseus/src/widgets/interactive-graphs/interactive-graph-static.test.tsx`

Storybook
- https://khan.github.io/perseus/?path=/story/perseuseditor-widgets-interactive-graph--interactive-graph-segment
- For each graph type, go through and make sure everything remains as expected by default
- Set the graph to static
- For each graph type, go through and make sure all interactive elements read as "dimmed"