### PR TITLE
Fix self-imports and eslint rule for type imports

### DIFF
--- a/.changeset/late-trains-fold.md
+++ b/.changeset/late-trains-fold.md
@@ -1,0 +1,8 @@
+---
+"@khanacademy/kmath": patch
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus-score": patch
+---
+
+Fix import of internal items to use relative paths instead of the package name

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -197,7 +197,6 @@ module.exports = {
         "max-lines": "off",
         "new-cap": "off",
         "no-invalid-this": "off",
-        "@typescript-eslint/no-this-alias": "off",
         "no-unused-expressions": "off",
         "no-restricted-imports": [
             "error",
@@ -388,6 +387,10 @@ module.exports = {
          * typescript
          */
         "@typescript-eslint/no-empty-function": "off",
-        "@typescript-eslint/consistent-type-imports": "error",
+        "@typescript-eslint/no-this-alias": "off",
+        "@typescript-eslint/consistent-type-imports": [
+            "error",
+            {prefer: "type-imports"},
+        ],
     },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -390,7 +390,10 @@ module.exports = {
         "@typescript-eslint/no-this-alias": "off",
         "@typescript-eslint/consistent-type-imports": [
             "error",
-            {prefer: "type-imports"},
+            {
+                prefer: "type-imports",
+                fixStyle: "separate-type-imports",
+            },
         ],
     },
 };

--- a/packages/kmath/src/geometry.ts
+++ b/packages/kmath/src/geometry.ts
@@ -9,7 +9,9 @@ import {
 } from "@khanacademy/perseus-core";
 import _ from "underscore";
 
-import {number as knumber, point as kpoint, sum} from "@khanacademy/kmath";
+import {sum} from "./math";
+import * as knumber from "./number";
+import * as kpoint from "./point";
 
 type Line = [Coord, Coord];
 

--- a/packages/kmath/src/math.ts
+++ b/packages/kmath/src/math.ts
@@ -1,7 +1,7 @@
 import $ from "jquery";
 import _ from "underscore";
 
-import {number as knumber} from "@khanacademy/kmath";
+import * as knumber from "./number";
 
 import type {MathFormat} from "@khanacademy/perseus-core";
 

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-answer-area.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-answer-area.test.ts
@@ -3,7 +3,7 @@ import {success} from "../result";
 
 import {parsePerseusAnswerArea} from "./perseus-answer-area";
 
-import type {PerseusAnswerArea} from "@khanacademy/perseus-core";
+import type {PerseusAnswerArea} from "../../data-schema";
 
 describe("parsePerseusAnswerArea", () => {
     const allFalse: PerseusAnswerArea = {

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-answer-area.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-answer-area.ts
@@ -2,7 +2,7 @@ import {object, pipeParsers} from "../general-purpose-parsers";
 import {convert} from "../general-purpose-parsers/convert";
 import {defaulted} from "../general-purpose-parsers/defaulted";
 
-import type {PerseusAnswerArea} from "@khanacademy/perseus-core";
+import type {PerseusAnswerArea} from "../../data-schema";
 
 export const parsePerseusAnswerArea = pipeParsers(
     defaulted(object({}), () => ({})),

--- a/packages/perseus-core/src/widgets/categorizer/categorizer-util.ts
+++ b/packages/perseus-core/src/widgets/categorizer/categorizer-util.ts
@@ -1,4 +1,4 @@
-import type {PerseusCategorizerWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusCategorizerWidgetOptions} from "../../data-schema";
 
 /**
  * For details on the individual options, see the

--- a/packages/perseus-core/src/widgets/dropdown/dropdown-util.ts
+++ b/packages/perseus-core/src/widgets/dropdown/dropdown-util.ts
@@ -1,4 +1,4 @@
-import type {PerseusDropdownWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusDropdownWidgetOptions} from "../../data-schema";
 
 /**
  * For details on the individual options, see the

--- a/packages/perseus-core/src/widgets/expression/expression-util.ts
+++ b/packages/perseus-core/src/widgets/expression/expression-util.ts
@@ -1,4 +1,4 @@
-import type {PerseusExpressionWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusExpressionWidgetOptions} from "../../data-schema";
 
 /**
  * For details on the individual options, see the

--- a/packages/perseus-core/src/widgets/interactive-graph/interactive-graph-util.test.ts
+++ b/packages/perseus-core/src/widgets/interactive-graph/interactive-graph-util.test.ts
@@ -1,6 +1,6 @@
 import getInteractiveGraphPublicWidgetOptions from "./interactive-graph-util";
 
-import type {PerseusInteractiveGraphWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusInteractiveGraphWidgetOptions} from "../../data-schema";
 
 describe("getInteractiveGraphPublicWidgetOptions", () => {
     it("removes the `correct` field", () => {

--- a/packages/perseus-core/src/widgets/interactive-graph/interactive-graph-util.ts
+++ b/packages/perseus-core/src/widgets/interactive-graph/interactive-graph-util.ts
@@ -1,4 +1,4 @@
-import type {PerseusInteractiveGraphWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusInteractiveGraphWidgetOptions} from "../../data-schema";
 
 export type InteractiveGraphPublicWidgetOptions = Pick<
     PerseusInteractiveGraphWidgetOptions,

--- a/packages/perseus-core/src/widgets/label-image/label-image-util.test.ts
+++ b/packages/perseus-core/src/widgets/label-image/label-image-util.test.ts
@@ -1,6 +1,6 @@
 import getLabelImagePublicWidgetOptions from "./label-image-util";
 
-import type {PerseusLabelImageWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusLabelImageWidgetOptions} from "../../data-schema";
 
 describe("getLabelImagePublicWidgetOptions", () => {
     it("removes private fields", () => {

--- a/packages/perseus-core/src/widgets/label-image/label-image-util.ts
+++ b/packages/perseus-core/src/widgets/label-image/label-image-util.ts
@@ -1,7 +1,7 @@
 import type {
     PerseusLabelImageMarker,
     PerseusLabelImageWidgetOptions,
-} from "@khanacademy/perseus-core";
+} from "../../data-schema";
 
 /**
  * For details on the individual options, see the

--- a/packages/perseus-core/src/widgets/matcher/matcher-util.ts
+++ b/packages/perseus-core/src/widgets/matcher/matcher-util.ts
@@ -1,6 +1,6 @@
-import {seededRNG, shuffle} from "@khanacademy/perseus-core";
+import {seededRNG, shuffle} from "../../utils/random-util";
 
-import type {PerseusMatcherWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusMatcherWidgetOptions} from "../../data-schema";
 
 // TODO(LEMS-2841): Should be able to remove once getPublicWidgetOptions is hooked up
 type MatcherInfo = {

--- a/packages/perseus-core/src/widgets/matrix/matrix-util.ts
+++ b/packages/perseus-core/src/widgets/matrix/matrix-util.ts
@@ -1,4 +1,4 @@
-import type {PerseusMatrixWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusMatrixWidgetOptions} from "../../data-schema";
 
 type MatrixPublicWidgetOptions = Pick<
     PerseusMatrixWidgetOptions,

--- a/packages/perseus-core/src/widgets/numeric-input/numeric-input-util.ts
+++ b/packages/perseus-core/src/widgets/numeric-input/numeric-input-util.ts
@@ -1,7 +1,7 @@
 import type {
     PerseusNumericInputAnswer,
     PerseusNumericInputWidgetOptions,
-} from "@khanacademy/perseus-core";
+} from "../../data-schema";
 
 type NumericInputAnswerPublicData = Pick<
     PerseusNumericInputAnswer,

--- a/packages/perseus-core/src/widgets/orderer/orderer-util.ts
+++ b/packages/perseus-core/src/widgets/orderer/orderer-util.ts
@@ -1,4 +1,4 @@
-import type {PerseusOrdererWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusOrdererWidgetOptions} from "../../data-schema";
 
 /**
  * For details on the individual options, see the

--- a/packages/perseus-core/src/widgets/plotter/plotter-util.ts
+++ b/packages/perseus-core/src/widgets/plotter/plotter-util.ts
@@ -1,4 +1,4 @@
-import type {PerseusPlotterWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusPlotterWidgetOptions} from "../../data-schema";
 
 /**
  * For details on the individual options, see the

--- a/packages/perseus-core/src/widgets/radio/radio-util.test.ts
+++ b/packages/perseus-core/src/widgets/radio/radio-util.test.ts
@@ -1,4 +1,4 @@
-import {getRadioPublicWidgetOptions} from "@khanacademy/perseus-core";
+import getRadioPublicWidgetOptions from "./radio-util";
 
 import type {PerseusRadioWidgetOptions} from "../../data-schema";
 

--- a/packages/perseus-core/src/widgets/radio/radio-util.ts
+++ b/packages/perseus-core/src/widgets/radio/radio-util.ts
@@ -1,7 +1,7 @@
 import type {
     PerseusRadioChoice,
     PerseusRadioWidgetOptions,
-} from "@khanacademy/perseus-core";
+} from "../../data-schema";
 
 /**
  * For details on the individual options, see the

--- a/packages/perseus-core/src/widgets/sorter/sorter-util.ts
+++ b/packages/perseus-core/src/widgets/sorter/sorter-util.ts
@@ -1,6 +1,6 @@
-import {shuffle} from "@khanacademy/perseus-core";
+import {shuffle} from "../../utils/random-util";
 
-import type {PerseusSorterWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusSorterWidgetOptions} from "../../data-schema";
 
 /**
  * For details on the individual options, see the

--- a/packages/perseus-core/src/widgets/table/table-util.test.ts
+++ b/packages/perseus-core/src/widgets/table/table-util.test.ts
@@ -1,6 +1,6 @@
 import getTablePublicWidgetOptions from "./table-util";
 
-import type {PerseusTableWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusTableWidgetOptions} from "../../data-schema";
 
 describe("getTablePublicWidgetOptions", () => {
     it("removes the answers", () => {

--- a/packages/perseus-core/src/widgets/table/table-util.ts
+++ b/packages/perseus-core/src/widgets/table/table-util.ts
@@ -1,4 +1,4 @@
-import type {PerseusTableWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusTableWidgetOptions} from "../../data-schema";
 
 type TablePublicWidgetOptions = Pick<
     PerseusTableWidgetOptions,

--- a/packages/perseus-score/src/widgets/categorizer/validate-categorizer.test.ts
+++ b/packages/perseus-score/src/widgets/categorizer/validate-categorizer.test.ts
@@ -1,6 +1,6 @@
 import validateCategorizer from "./validate-categorizer";
 
-import type {PerseusCategorizerValidationData} from "@khanacademy/perseus-score";
+import type {PerseusCategorizerValidationData} from "../../validation.types";
 
 describe("validateCategorizer", () => {
     it("tells the learner its not complete if not selected", () => {

--- a/packages/perseus-score/src/widgets/categorizer/validate-categorizer.ts
+++ b/packages/perseus-score/src/widgets/categorizer/validate-categorizer.ts
@@ -1,10 +1,10 @@
-import {ErrorCodes} from "@khanacademy/perseus-score";
+import ErrorCodes from "../../error-codes";
 
 import type {
-    ValidationResult,
     PerseusCategorizerUserInput,
     PerseusCategorizerValidationData,
-} from "@khanacademy/perseus-score";
+    ValidationResult,
+} from "../../validation.types";
 
 /**
  * Checks userInput from the categorizer widget to see if the user has selected

--- a/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.ts
@@ -11,12 +11,12 @@ import {
 } from "@khanacademy/perseus-core";
 import _ from "underscore";
 
-import type {Coord} from "@khanacademy/perseus-core";
 import type {
+    PerseusInteractiveGraphUserInput,
     PerseusInteractiveGraphRubric,
     PerseusScore,
-    PerseusInteractiveGraphUserInput,
-} from "@khanacademy/perseus-score";
+} from "../../validation.types";
+import type {Coord} from "@khanacademy/perseus-core";
 
 const {collinear, canonicalSineCoefficients, similar, clockwise} = geometry;
 const {getClockwiseAngle} = angles;

--- a/packages/perseus/src/widgets/group/group.test.tsx
+++ b/packages/perseus/src/widgets/group/group.test.tsx
@@ -5,10 +5,9 @@ import {act, cleanup, render, screen, waitFor} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
-import * as Perseus from "@khanacademy/perseus";
-
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
+import Renderer from "../../renderer";
 import {mockStrings} from "../../strings";
 import {traverse} from "../../traversal";
 import {renderQuestion} from "../__testutils__/renderQuestion";
@@ -148,7 +147,7 @@ describe("group widget", () => {
 
         render(
             <RenderStateRoot>
-                <Perseus.Renderer
+                <Renderer
                     content={question1.content}
                     images={question1.images}
                     widgets={question1.widgets}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/angle.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/angle.test.tsx
@@ -1,9 +1,8 @@
 import {render, screen} from "@testing-library/react";
 import * as React from "react";
 
-import {Dependencies} from "@khanacademy/perseus";
-
 import {testDependencies} from "../../../../../../testing/test-dependencies";
+import * as Dependencies from "../../../dependencies";
 import {MafsGraph} from "../mafs-graph";
 import {getBaseMafsGraphPropsForTests} from "../utils";
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.test.tsx
@@ -3,10 +3,9 @@ import {userEvent as userEventLib} from "@testing-library/user-event";
 import {Mafs} from "mafs";
 import * as React from "react";
 
-import {Dependencies} from "@khanacademy/perseus";
-
 import {testDependencies} from "../../../../../../testing/test-dependencies";
 import {mockPerseusI18nContext} from "../../../components/i18n-context";
+import * as Dependencies from "../../../dependencies";
 import {MafsGraph} from "../mafs-graph";
 import * as ReducerGraphConfig from "../reducer/use-graph-config";
 import {getBaseMafsGraphPropsForTests} from "../utils";

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.test.ts
@@ -2,8 +2,7 @@ import {angles} from "@khanacademy/kmath";
 
 import {shouldDrawArcOutside} from "./angle-indicators";
 
-import type {Coord} from "@khanacademy/perseus";
-import type {CollinearTuple} from "@khanacademy/perseus-core";
+import type {Coord, CollinearTuple} from "@khanacademy/perseus-core";
 import type {vec, Interval} from "mafs";
 
 const {getClockwiseAngle} = angles;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.test.tsx
@@ -2,10 +2,9 @@ import {render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
-import {Dependencies} from "@khanacademy/perseus";
-
 import {testDependencies} from "../../../../../../testing/test-dependencies";
 import {mockPerseusI18nContext} from "../../../components/i18n-context";
+import * as Dependencies from "../../../dependencies";
 import {MafsGraph} from "../mafs-graph";
 import {getBaseMafsGraphPropsForTests} from "../utils";
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.test.tsx
@@ -2,10 +2,9 @@ import {render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
-import {Dependencies} from "@khanacademy/perseus";
-
 import {testDependencies} from "../../../../../../testing/test-dependencies";
 import {mockPerseusI18nContext} from "../../../components/i18n-context";
+import * as Dependencies from "../../../dependencies";
 import {MafsGraph} from "../mafs-graph";
 import {getBaseMafsGraphPropsForTests} from "../utils";
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.test.tsx
@@ -3,9 +3,8 @@ import {userEvent as userEventLib} from "@testing-library/user-event";
 import {Mafs, Polygon} from "mafs";
 import React from "react";
 
-import {Dependencies} from "@khanacademy/perseus";
-
 import {testDependencies} from "../../../../../../testing/test-dependencies";
+import * as Dependencies from "../../../dependencies";
 import {MafsGraph} from "../mafs-graph";
 import {getBaseMafsGraphPropsForTests} from "../utils";
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.test.tsx
@@ -1,10 +1,9 @@
 import {render, screen} from "@testing-library/react";
 import * as React from "react";
 
-import {Dependencies} from "@khanacademy/perseus";
-
 import {testDependencies} from "../../../../../../testing/test-dependencies";
 import {mockPerseusI18nContext} from "../../../components/i18n-context";
+import * as Dependencies from "../../../dependencies";
 import {MafsGraph} from "../mafs-graph";
 import {getBaseMafsGraphPropsForTests} from "../utils";
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/ray.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/ray.test.tsx
@@ -2,10 +2,9 @@ import {render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
-import {Dependencies} from "@khanacademy/perseus";
-
 import {testDependencies} from "../../../../../../testing/test-dependencies";
 import {mockPerseusI18nContext} from "../../../components/i18n-context";
+import * as Dependencies from "../../../dependencies";
 import {MafsGraph} from "../mafs-graph";
 import {getBaseMafsGraphPropsForTests} from "../utils";
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.test.tsx
@@ -2,10 +2,9 @@ import {render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
-import {Dependencies} from "@khanacademy/perseus";
-
 import {testDependencies} from "../../../../../../testing/test-dependencies";
 import {mockPerseusI18nContext} from "../../../components/i18n-context";
+import * as Dependencies from "../../../dependencies";
 import {MafsGraph} from "../mafs-graph";
 import {getBaseMafsGraphPropsForTests} from "../utils";
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.test.tsx
@@ -1,9 +1,8 @@
 import {render, screen} from "@testing-library/react";
 import * as React from "react";
 
-import {Dependencies} from "@khanacademy/perseus";
-
 import {testDependencies} from "../../../../../../testing/test-dependencies";
+import * as Dependencies from "../../../dependencies";
 import {MafsGraph} from "../mafs-graph";
 import {getBaseMafsGraphPropsForTests} from "../utils";
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.test.ts
@@ -7,7 +7,7 @@ import {
     getSideLengthsFromPoints,
 } from "./utils";
 
-import type {Coord} from "@khanacademy/perseus";
+import type {Coord} from "@khanacademy/perseus-core";
 import type {Interval, vec} from "mafs";
 
 const {convertRadiansToDegrees} = angles;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -4,7 +4,7 @@ import {srFormatNumber} from "./screenreader-text";
 
 import type {PerseusStrings} from "../../../strings";
 import type {PairOfPoints} from "../types";
-import type {Coord} from "@khanacademy/perseus";
+import type {Coord} from "@khanacademy/perseus-core";
 import type {Interval} from "mafs";
 
 /**

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.test.tsx
@@ -1,9 +1,8 @@
 import {render} from "@testing-library/react";
 import * as React from "react";
 
-import {Dependencies} from "@khanacademy/perseus";
-
 import {testDependencies} from "../../../../../../testing/test-dependencies";
+import * as Dependencies from "../../../dependencies";
 import {MafsGraph} from "../mafs-graph";
 import {getBaseMafsGraphPropsForTests} from "../utils";
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -17,7 +17,7 @@ import {getBaseMafsGraphPropsForTests} from "./utils";
 
 import type {MafsGraphProps} from "./mafs-graph";
 import type {InteractiveGraphState} from "./types";
-import type {PerseusDependenciesV2} from "@khanacademy/perseus";
+import type {PerseusDependenciesV2} from "../../types";
 import type {GraphRange} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
 


### PR DESCRIPTION
## Summary:

I noticed that we have quite a few files that are importing symbols from the package their in using the package name instead of a relative import. This is confusing when looking at the source and will also cause issues in future versions of Rollup (our build tool).

Issue: "none"

## Test plan:

`yarn lint`
`yarn build`
`yarn typecheck`