### PR TITLE
Create stories for Assessment's 5 scorable widgets that use answerless data

### DIFF
--- a/.changeset/ninety-wasps-love.md
+++ b/.changeset/ninety-wasps-love.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Update and add stories where Dropdown, Interactive Graph, Numeric Input, Expression, and Radio widgets render using answerless data

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -460,8 +460,6 @@ export class ServerItemRenderer
             />
         );
 
-        console.log("item question sent to renderer", this.props.item.question);
-
         return (
             <DependenciesContext.Provider value={this.props.dependencies}>
                 <div>

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -460,6 +460,8 @@ export class ServerItemRenderer
             />
         );
 
+        console.log("item question sent to renderer", this.props.item.question);
+
         return (
             <DependenciesContext.Provider value={this.props.dependencies}>
                 <div>

--- a/packages/perseus/src/widgets/dropdown/dropdown.stories.tsx
+++ b/packages/perseus/src/widgets/dropdown/dropdown.stories.tsx
@@ -44,5 +44,5 @@ export const DropdownWithEmptyPlaceholder = (
 };
 
 export const DropdownWithNoAnswers = (args: StoryArgs): React.ReactElement => {
-    return <RendererWithDebugUI question={splitPerseusItem(basicDropdown)} />;
+    return <RendererWithDebugUI question={basicDropdown} answerless={true} />;
 };

--- a/packages/perseus/src/widgets/dropdown/dropdown.stories.tsx
+++ b/packages/perseus/src/widgets/dropdown/dropdown.stories.tsx
@@ -1,14 +1,13 @@
-import {splitPerseusItem} from "@khanacademy/perseus-core";
 import * as React from "react";
 
-import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
+import {ServerItemRendererWithDebugUI} from "../../../../../testing/server-item-renderer-with-debug-ui";
 
 import {
-    basicDropdown,
-    dropdownWithEmptyPlaceholder,
-    dropdownWithMath,
-    dropdownWithVisibleLabel,
-    inlineDropdownWithVisibleLabel,
+    basicDropdownItem,
+    dropdownWithEmptyPlaceholderItem,
+    dropdownWithMathItem,
+    dropdownWithVisibleLabelItem,
+    inlineDropdownWithVisibleLabelItem,
 } from "./dropdown.testdata";
 
 export default {
@@ -18,31 +17,92 @@ export default {
 type StoryArgs = Record<any, any>;
 
 export const BasicDropdown = (args: StoryArgs): React.ReactElement => {
-    return <RendererWithDebugUI question={basicDropdown} />;
+    return <ServerItemRendererWithDebugUI item={basicDropdownItem} />;
 };
 
 export const DropdownWithMath = (args: StoryArgs): React.ReactElement => {
-    return <RendererWithDebugUI question={dropdownWithMath} />;
+    return <ServerItemRendererWithDebugUI item={dropdownWithMathItem} />;
 };
 
 export const DropdownWithVisibleLabel = (
     args: StoryArgs,
 ): React.ReactElement => {
-    return <RendererWithDebugUI question={dropdownWithVisibleLabel} />;
+    return (
+        <ServerItemRendererWithDebugUI item={dropdownWithVisibleLabelItem} />
+    );
 };
 
 export const InlineDropdownWithVisibleLabel = (
     args: StoryArgs,
 ): React.ReactElement => {
-    return <RendererWithDebugUI question={inlineDropdownWithVisibleLabel} />;
+    return (
+        <ServerItemRendererWithDebugUI
+            item={inlineDropdownWithVisibleLabelItem}
+        />
+    );
 };
 
 export const DropdownWithEmptyPlaceholder = (
     args: StoryArgs,
 ): React.ReactElement => {
-    return <RendererWithDebugUI question={dropdownWithEmptyPlaceholder} />;
+    return (
+        <ServerItemRendererWithDebugUI
+            item={dropdownWithEmptyPlaceholderItem}
+        />
+    );
 };
 
-export const DropdownWithNoAnswers = (args: StoryArgs): React.ReactElement => {
-    return <RendererWithDebugUI question={basicDropdown} answerless={true} />;
+export const AnswerlessBasicDropdown = (
+    args: StoryArgs,
+): React.ReactElement => {
+    return (
+        <ServerItemRendererWithDebugUI
+            item={basicDropdownItem}
+            startAnswerless={true}
+        />
+    );
+};
+
+export const AnswerlessDropdownWithMath = (
+    args: StoryArgs,
+): React.ReactElement => {
+    return (
+        <ServerItemRendererWithDebugUI
+            item={dropdownWithMathItem}
+            startAnswerless={true}
+        />
+    );
+};
+
+export const AnswerlessDropdownWithVisibleLabel = (
+    args: StoryArgs,
+): React.ReactElement => {
+    return (
+        <ServerItemRendererWithDebugUI
+            item={dropdownWithVisibleLabelItem}
+            startAnswerless={true}
+        />
+    );
+};
+
+export const AnswerlessInlineDropdownWithVisibleLabel = (
+    args: StoryArgs,
+): React.ReactElement => {
+    return (
+        <ServerItemRendererWithDebugUI
+            item={inlineDropdownWithVisibleLabelItem}
+            startAnswerless={true}
+        />
+    );
+};
+
+export const AnswerlessDropdownWithEmptyPlaceholder = (
+    args: StoryArgs,
+): React.ReactElement => {
+    return (
+        <ServerItemRendererWithDebugUI
+            item={dropdownWithEmptyPlaceholderItem}
+            startAnswerless={true}
+        />
+    );
 };

--- a/packages/perseus/src/widgets/dropdown/dropdown.testdata.ts
+++ b/packages/perseus/src/widgets/dropdown/dropdown.testdata.ts
@@ -1,4 +1,27 @@
-import type {PerseusRenderer} from "@khanacademy/perseus-core";
+import type {PerseusItem, PerseusRenderer} from "@khanacademy/perseus-core";
+
+const createDropdownItem = (dropdownQuestion: PerseusRenderer): PerseusItem => {
+    return {
+        question: dropdownQuestion,
+        answer: null,
+        itemDataVersion: {
+            major: 0,
+            minor: 1,
+        },
+        hints: [],
+        answerArea: {
+            calculator: false,
+            chi2Table: false,
+            financialCalculatorMonthlyPayment: false,
+            financialCalculatorTotalAmount: false,
+            financialCalculatorTimeToPayOff: false,
+            periodicTable: false,
+            periodicTableWithKey: false,
+            tTable: false,
+            zTable: false,
+        },
+    };
+};
 
 export const basicDropdown: PerseusRenderer = {
     content:
@@ -32,7 +55,9 @@ export const basicDropdown: PerseusRenderer = {
     },
 };
 
-export const dropdownWithMath: PerseusRenderer = {
+export const basicDropdownItem: PerseusItem = createDropdownItem(basicDropdown);
+
+export const dropdownWithMathItem: PerseusItem = createDropdownItem({
     content: "If x equals 4, then [[☃ dropdown 1]] equals $10$.",
     images: {},
     widgets: {
@@ -61,9 +86,9 @@ export const dropdownWithMath: PerseusRenderer = {
             },
         },
     },
-};
+});
 
-export const dropdownWithVisibleLabel: PerseusRenderer = {
+export const dropdownWithVisibleLabelItem: PerseusItem = createDropdownItem({
     content: "[[☃ dropdown 1]]",
     images: {},
     widgets: {
@@ -120,96 +145,99 @@ export const dropdownWithVisibleLabel: PerseusRenderer = {
             },
         },
     },
-};
+});
 
-export const inlineDropdownWithVisibleLabel: PerseusRenderer = {
-    content:
-        "The dropdown widget is often used inline. This is how it would look in an article with the new visible label:\n\nLorem ipsum odor amet, consectetuer adipiscing elit. Mus curae sollicitudin penatibus, mattis suscipit habitant tincidunt mauris. Vitae curae dolor gravida vehicula adipiscing vulputate penatibus. [[☃ dropdown 1]] Ultricies mollis taciti vel, penatibus dapibus interdum pharetra. Ultricies sollicitudin facilisi vehicula dapibus ligula maecenas libero ligula. Lobortis luctus accumsan rhoncus posuere sapien mi habitant fusce. Per ultrices ac mus ligula habitant pulvinar aliquam dui lacus.\n\nAnother use case is that it can be used in tables:\n\nheader 1 | header 2 \n- | -\ndata 1 | [[☃ dropdown 2]]\ndata 4 | data 5\ndata 7 | data 8",
-    images: {},
-    widgets: {
-        "dropdown 1": {
-            type: "dropdown",
-            alignment: "default",
-            static: false,
-            graded: true,
-            options: {
+export const inlineDropdownWithVisibleLabelItem: PerseusItem =
+    createDropdownItem({
+        content:
+            "The dropdown widget is often used inline. This is how it would look in an article with the new visible label:\n\nLorem ipsum odor amet, consectetuer adipiscing elit. Mus curae sollicitudin penatibus, mattis suscipit habitant tincidunt mauris. Vitae curae dolor gravida vehicula adipiscing vulputate penatibus. [[☃ dropdown 1]] Ultricies mollis taciti vel, penatibus dapibus interdum pharetra. Ultricies sollicitudin facilisi vehicula dapibus ligula maecenas libero ligula. Lobortis luctus accumsan rhoncus posuere sapien mi habitant fusce. Per ultrices ac mus ligula habitant pulvinar aliquam dui lacus.\n\nAnother use case is that it can be used in tables:\n\nheader 1 | header 2 \n- | -\ndata 1 | [[☃ dropdown 2]]\ndata 4 | data 5\ndata 7 | data 8",
+        images: {},
+        widgets: {
+            "dropdown 1": {
+                type: "dropdown",
+                alignment: "default",
                 static: false,
-                placeholder: "Choose an answer",
-                choices: [
-                    {
-                        content: "True",
-                        correct: true,
-                    },
-                    {
-                        content: "False",
-                        correct: false,
-                    },
-                ],
-                visibleLabel: "Test label",
-                ariaLabel: "Test ARIA label",
+                graded: true,
+                options: {
+                    static: false,
+                    placeholder: "Choose an answer",
+                    choices: [
+                        {
+                            content: "True",
+                            correct: true,
+                        },
+                        {
+                            content: "False",
+                            correct: false,
+                        },
+                    ],
+                    visibleLabel: "Test label",
+                    ariaLabel: "Test ARIA label",
+                },
+                version: {
+                    major: 0,
+                    minor: 0,
+                },
             },
-            version: {
-                major: 0,
-                minor: 0,
+            "dropdown 2": {
+                type: "dropdown",
+                alignment: "default",
+                static: false,
+                graded: true,
+                options: {
+                    static: false,
+                    placeholder: "",
+                    choices: [
+                        {
+                            content: "True",
+                            correct: true,
+                        },
+                        {
+                            content: "False",
+                            correct: false,
+                        },
+                    ],
+                    visibleLabel: "Test label",
+                    ariaLabel: "Test ARIA label",
+                },
+                version: {
+                    major: 0,
+                    minor: 0,
+                },
             },
         },
-        "dropdown 2": {
-            type: "dropdown",
-            alignment: "default",
-            static: false,
-            graded: true,
-            options: {
+    });
+
+export const dropdownWithEmptyPlaceholderItem: PerseusItem = createDropdownItem(
+    {
+        content:
+            "The total number of boxes the forklift can carry is [[☃ dropdown 1]] $60$.",
+        images: {},
+        widgets: {
+            "dropdown 1": {
+                type: "dropdown",
+                alignment: "default",
                 static: false,
-                placeholder: "",
-                choices: [
-                    {
-                        content: "True",
-                        correct: true,
-                    },
-                    {
-                        content: "False",
-                        correct: false,
-                    },
-                ],
-                visibleLabel: "Test label",
-                ariaLabel: "Test ARIA label",
-            },
-            version: {
-                major: 0,
-                minor: 0,
+                graded: true,
+                options: {
+                    static: false,
+                    placeholder: "",
+                    choices: [
+                        {
+                            content: "greater than or equal to",
+                            correct: false,
+                        },
+                        {
+                            content: "less than or equal to",
+                            correct: true,
+                        },
+                    ],
+                },
+                version: {
+                    major: 0,
+                    minor: 0,
+                },
             },
         },
     },
-};
-
-export const dropdownWithEmptyPlaceholder: PerseusRenderer = {
-    content:
-        "The total number of boxes the forklift can carry is [[☃ dropdown 1]] $60$.",
-    images: {},
-    widgets: {
-        "dropdown 1": {
-            type: "dropdown",
-            alignment: "default",
-            static: false,
-            graded: true,
-            options: {
-                static: false,
-                placeholder: "",
-                choices: [
-                    {
-                        content: "greater than or equal to",
-                        correct: false,
-                    },
-                    {
-                        content: "less than or equal to",
-                        correct: true,
-                    },
-                ],
-            },
-            version: {
-                major: 0,
-                minor: 0,
-            },
-        },
-    },
-};
+);

--- a/packages/perseus/src/widgets/expression/expression.stories.tsx
+++ b/packages/perseus/src/widgets/expression/expression.stories.tsx
@@ -23,14 +23,14 @@ type WrappedKeypadContextProps = {
     item: PerseusItem;
     customKeypad: boolean;
     isMobile?: boolean;
-    answerless?: boolean;
+    startAnswerless?: boolean;
 };
 
 const WrappedKeypadContext = ({
     item,
     customKeypad,
     isMobile = false,
-    answerless = false,
+    startAnswerless = false,
 }: WrappedKeypadContextProps) => {
     return (
         <TestKeypadContextWrapper>
@@ -39,7 +39,7 @@ const WrappedKeypadContext = ({
                     return (
                         <ServerItemRendererWithDebugUI
                             item={item}
-                            answerless={answerless}
+                            startAnswerless={startAnswerless}
                             keypadElement={keypadElement}
                             // Hardcoding the V2 Keypad to true as the Storybook Args
                             // were not working.
@@ -130,7 +130,7 @@ export const AnswerlessExpression = (args: StoryArgs): React.ReactElement => {
         <WrappedKeypadContext
             item={expressionItem3}
             customKeypad={false}
-            answerless
+            startAnswerless={true}
         />
     );
 };

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.stories.tsx
@@ -1,4 +1,3 @@
-import {splitPerseusItem} from "@khanacademy/perseus-core";
 import * as React from "react";
 
 import {Flipbook} from "../../../../../dev/flipbook";
@@ -28,7 +27,6 @@ import {
     staticGraphQuestionWithAnotherWidget,
     segmentWithLockedLabels,
     unlimitedPolygonQuestion,
-    unlimitedPolygonWithCorrectAnswerQuestion,
     angleItem,
     circleItem,
     linearItem,

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.stories.tsx
@@ -1,3 +1,4 @@
+import {splitPerseusItem} from "@khanacademy/perseus-core";
 import * as React from "react";
 
 import {Flipbook} from "../../../../../dev/flipbook";
@@ -178,3 +179,49 @@ export const StaticGraphWithAnotherWidget = (
 // TODO(jeremy): As of Jan 2022 there are no peresus items in production that
 // use the "quadratic" graph type.
 // "quadratic"
+
+export const AngleWithoutAnswers = (args: StoryArgs): React.ReactElement => (
+    <RendererWithDebugUI question={splitPerseusItem(angleQuestion)} />
+);
+
+export const CircleWithoutAnswers = (args: StoryArgs): React.ReactElement => (
+    <RendererWithDebugUI question={splitPerseusItem(circleQuestion)} />
+);
+
+export const LinearWithoutAnswers = (args: StoryArgs): React.ReactElement => (
+    <RendererWithDebugUI question={splitPerseusItem(linearQuestion)} />
+);
+
+export const LinearSystemWithoutAnswers = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <RendererWithDebugUI question={splitPerseusItem(linearSystemQuestion)} />
+);
+
+export const PointWithoutAnswers = (args: StoryArgs): React.ReactElement => (
+    <RendererWithDebugUI question={splitPerseusItem(pointQuestion)} />
+);
+
+export const PolygonWithoutAnswers = (args: StoryArgs): React.ReactElement => (
+    <RendererWithDebugUI question={splitPerseusItem(polygonQuestion)} />
+);
+
+export const UnlimitedPolygonWithoutAnswers = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <RendererWithDebugUI
+        question={splitPerseusItem(unlimitedPolygonQuestion)}
+    />
+);
+
+export const RayWithoutAnswers = (args: StoryArgs): React.ReactElement => (
+    <RendererWithDebugUI question={splitPerseusItem(rayQuestion)} />
+);
+
+export const SegmentWithoutAnswers = (args: StoryArgs): React.ReactElement => (
+    <RendererWithDebugUI question={splitPerseusItem(segmentQuestion)} />
+);
+
+export const SinusoidWithoutAnswers = (args: StoryArgs): React.ReactElement => (
+    <RendererWithDebugUI question={splitPerseusItem(sinusoidQuestion)} />
+);

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.stories.tsx
@@ -27,6 +27,7 @@ import {
     staticGraphQuestionWithAnotherWidget,
     segmentWithLockedLabels,
     unlimitedPolygonQuestion,
+    unlimitedPolygonWithCorrectAnswerQuestion,
 } from "./interactive-graph.testdata";
 
 const defaultApiOptions = ApiOptions.defaults;
@@ -210,7 +211,7 @@ export const UnlimitedPolygonWithoutAnswers = (
     args: StoryArgs,
 ): React.ReactElement => (
     <RendererWithDebugUI
-        question={unlimitedPolygonQuestion}
+        question={unlimitedPolygonWithCorrectAnswerQuestion}
         answerless={true}
     />
 );

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.stories.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 
 import {Flipbook} from "../../../../../dev/flipbook";
 import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
+import {ServerItemRendererWithDebugUI} from "../../../../../testing/server-item-renderer-with-debug-ui";
 import {ApiOptions} from "../../perseus-api";
 
 import {
@@ -28,6 +29,16 @@ import {
     segmentWithLockedLabels,
     unlimitedPolygonQuestion,
     unlimitedPolygonWithCorrectAnswerQuestion,
+    angleItem,
+    circleItem,
+    linearItem,
+    linearSystemItem,
+    pointItem,
+    polygonItem,
+    unlimitedPolygonWithCorrectAnswerItem,
+    rayItem,
+    segmentItem,
+    sinusoidItem,
 } from "./interactive-graph.testdata";
 
 const defaultApiOptions = ApiOptions.defaults;
@@ -181,49 +192,50 @@ export const StaticGraphWithAnotherWidget = (
 // use the "quadratic" graph type.
 // "quadratic"
 
-export const AngleWithoutAnswers = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI question={angleQuestion} answerless={true} />
+export const AnswerlessAngle = (args: StoryArgs): React.ReactElement => (
+    <ServerItemRendererWithDebugUI item={angleItem} startAnswerless={true} />
 );
 
-export const CircleWithoutAnswers = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI question={circleQuestion} answerless={true} />
+export const AnswerlessCircle = (args: StoryArgs): React.ReactElement => (
+    <ServerItemRendererWithDebugUI item={circleItem} startAnswerless={true} />
 );
 
-export const LinearWithoutAnswers = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI question={linearQuestion} answerless={true} />
+export const AnswerlessLinear = (args: StoryArgs): React.ReactElement => (
+    <ServerItemRendererWithDebugUI item={linearItem} startAnswerless={true} />
 );
 
-export const LinearSystemWithoutAnswers = (
-    args: StoryArgs,
-): React.ReactElement => (
-    <RendererWithDebugUI question={linearSystemQuestion} answerless={true} />
-);
-
-export const PointWithoutAnswers = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI question={pointQuestion} answerless={true} />
-);
-
-export const PolygonWithoutAnswers = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI question={polygonQuestion} answerless={true} />
-);
-
-export const UnlimitedPolygonWithoutAnswers = (
-    args: StoryArgs,
-): React.ReactElement => (
-    <RendererWithDebugUI
-        question={unlimitedPolygonWithCorrectAnswerQuestion}
-        answerless={true}
+export const AnswerlessLinearSystem = (args: StoryArgs): React.ReactElement => (
+    <ServerItemRendererWithDebugUI
+        item={linearSystemItem}
+        startAnswerless={true}
     />
 );
 
-export const RayWithoutAnswers = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI question={rayQuestion} answerless={true} />
+export const AnswerlessPoint = (args: StoryArgs): React.ReactElement => (
+    <ServerItemRendererWithDebugUI item={pointItem} startAnswerless={true} />
 );
 
-export const SegmentWithoutAnswers = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI question={segmentQuestion} answerless={true} />
+export const AnswerlessPolygon = (args: StoryArgs): React.ReactElement => (
+    <ServerItemRendererWithDebugUI item={polygonItem} startAnswerless={true} />
 );
 
-export const SinusoidWithoutAnswers = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI question={sinusoidQuestion} answerless={true} />
+export const AnswerlessUnlimitedPolygon = (
+    args: StoryArgs,
+): React.ReactElement => (
+    <ServerItemRendererWithDebugUI
+        item={unlimitedPolygonWithCorrectAnswerItem}
+        startAnswerless={true}
+    />
+);
+
+export const AnswerlessRay = (args: StoryArgs): React.ReactElement => (
+    <ServerItemRendererWithDebugUI item={rayItem} startAnswerless={true} />
+);
+
+export const AnswerlessSegment = (args: StoryArgs): React.ReactElement => (
+    <ServerItemRendererWithDebugUI item={segmentItem} startAnswerless={true} />
+);
+
+export const AnswerlessSinusoid = (args: StoryArgs): React.ReactElement => (
+    <ServerItemRendererWithDebugUI item={sinusoidItem} startAnswerless={true} />
 );

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.stories.tsx
@@ -181,47 +181,48 @@ export const StaticGraphWithAnotherWidget = (
 // "quadratic"
 
 export const AngleWithoutAnswers = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI question={splitPerseusItem(angleQuestion)} />
+    <RendererWithDebugUI question={angleQuestion} answerless={true} />
 );
 
 export const CircleWithoutAnswers = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI question={splitPerseusItem(circleQuestion)} />
+    <RendererWithDebugUI question={circleQuestion} answerless={true} />
 );
 
 export const LinearWithoutAnswers = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI question={splitPerseusItem(linearQuestion)} />
+    <RendererWithDebugUI question={linearQuestion} answerless={true} />
 );
 
 export const LinearSystemWithoutAnswers = (
     args: StoryArgs,
 ): React.ReactElement => (
-    <RendererWithDebugUI question={splitPerseusItem(linearSystemQuestion)} />
+    <RendererWithDebugUI question={linearSystemQuestion} answerless={true} />
 );
 
 export const PointWithoutAnswers = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI question={splitPerseusItem(pointQuestion)} />
+    <RendererWithDebugUI question={pointQuestion} answerless={true} />
 );
 
 export const PolygonWithoutAnswers = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI question={splitPerseusItem(polygonQuestion)} />
+    <RendererWithDebugUI question={polygonQuestion} answerless={true} />
 );
 
 export const UnlimitedPolygonWithoutAnswers = (
     args: StoryArgs,
 ): React.ReactElement => (
     <RendererWithDebugUI
-        question={splitPerseusItem(unlimitedPolygonQuestion)}
+        question={unlimitedPolygonQuestion}
+        answerless={true}
     />
 );
 
 export const RayWithoutAnswers = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI question={splitPerseusItem(rayQuestion)} />
+    <RendererWithDebugUI question={rayQuestion} answerless={true} />
 );
 
 export const SegmentWithoutAnswers = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI question={splitPerseusItem(segmentQuestion)} />
+    <RendererWithDebugUI question={segmentQuestion} answerless={true} />
 );
 
 export const SinusoidWithoutAnswers = (args: StoryArgs): React.ReactElement => (
-    <RendererWithDebugUI question={splitPerseusItem(sinusoidQuestion)} />
+    <RendererWithDebugUI question={sinusoidQuestion} answerless={true} />
 );

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -2,9 +2,36 @@ import {interactiveGraphQuestionBuilder} from "./interactive-graph-question-buil
 
 import type {LockedFunctionOptions} from "./interactive-graph-question-builder";
 import type {Coord} from "../../interactive2/types";
-import type {PerseusRenderer, RadioWidget} from "@khanacademy/perseus-core";
+import type {
+    PerseusItem,
+    PerseusRenderer,
+    RadioWidget,
+} from "@khanacademy/perseus-core";
 
 // Data for the interactive graph widget
+
+const createInteractiveGraphItem = (question: PerseusRenderer): PerseusItem => {
+    return {
+        question: question,
+        answer: null,
+        itemDataVersion: {
+            major: 0,
+            minor: 1,
+        },
+        hints: [],
+        answerArea: {
+            calculator: false,
+            chi2Table: false,
+            financialCalculatorMonthlyPayment: false,
+            financialCalculatorTotalAmount: false,
+            financialCalculatorTimeToPayOff: false,
+            periodicTable: false,
+            periodicTableWithKey: false,
+            tTable: false,
+            zTable: false,
+        },
+    };
+};
 
 export const angleQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
     .withContent(
@@ -29,6 +56,8 @@ export const angleQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
     })
     .build();
 
+export const angleItem: PerseusItem = createInteractiveGraphItem(angleQuestion);
+
 export const angleQuestionWithDefaultCorrect: PerseusRenderer =
     interactiveGraphQuestionBuilder().withAngle().build();
 
@@ -47,6 +76,9 @@ export const circleQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
     .withCircle({center: [-2, -4], radius: 2})
     .build();
 
+export const circleItem: PerseusItem =
+    createInteractiveGraphItem(circleQuestion);
+
 export const circleQuestionWithDefaultCorrect: PerseusRenderer =
     interactiveGraphQuestionBuilder().withCircle().build();
 
@@ -58,6 +90,9 @@ export const linearQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
         ],
     })
     .build();
+
+export const linearItem: PerseusItem =
+    createInteractiveGraphItem(linearQuestion);
 
 export const linearQuestionWithDefaultCorrect: PerseusRenderer =
     interactiveGraphQuestionBuilder().withLinear().build();
@@ -77,6 +112,9 @@ export const linearSystemQuestion: PerseusRenderer =
             ],
         })
         .build();
+
+export const linearSystemItem: PerseusItem =
+    createInteractiveGraphItem(linearSystemQuestion);
 
 export const linearSystemQuestionWithDefaultCorrect: PerseusRenderer =
     interactiveGraphQuestionBuilder().withLinearSystem().build();
@@ -104,6 +142,8 @@ export const pointQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
         ],
     })
     .build();
+
+export const pointItem: PerseusItem = createInteractiveGraphItem(pointQuestion);
 
 export const pointQuestionWithDefaultCorrect: PerseusRenderer =
     interactiveGraphQuestionBuilder().withPoints(1).build();
@@ -165,6 +205,9 @@ export const polygonQuestion: PerseusRenderer =
         })
         .build();
 
+export const polygonItem: PerseusItem =
+    createInteractiveGraphItem(polygonQuestion);
+
 export const unlimitedPolygonQuestion: PerseusRenderer =
     interactiveGraphQuestionBuilder()
         .withContent(
@@ -208,6 +251,9 @@ export const unlimitedPolygonWithCorrectAnswerQuestion: PerseusRenderer =
             ],
         })
         .build();
+
+export const unlimitedPolygonWithCorrectAnswerItem: PerseusItem =
+    createInteractiveGraphItem(unlimitedPolygonWithCorrectAnswerQuestion);
 
 export const polygonWithAnglesQuestion: PerseusRenderer =
     interactiveGraphQuestionBuilder()
@@ -343,6 +389,8 @@ export const rayQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
     })
     .build();
 
+export const rayItem: PerseusItem = createInteractiveGraphItem(rayQuestion);
+
 export const rayQuestionWithDefaultCorrect: PerseusRenderer =
     interactiveGraphQuestionBuilder().withRay().build();
 
@@ -362,6 +410,9 @@ export const segmentQuestion: PerseusRenderer =
             ],
         })
         .build();
+
+export const segmentItem: PerseusItem =
+    createInteractiveGraphItem(segmentQuestion);
 
 export const segmentQuestionDefaultCorrect: PerseusRenderer =
     interactiveGraphQuestionBuilder()
@@ -533,6 +584,9 @@ export const sinusoidQuestion: PerseusRenderer =
             ],
         })
         .build();
+
+export const sinusoidItem: PerseusItem =
+    createInteractiveGraphItem(sinusoidQuestion);
 
 export const sinusoidMinimalQuestion: PerseusRenderer =
     interactiveGraphQuestionBuilder().withSinusoid().build();

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.stories.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import {RendererWithDebugUI} from "../../../../../testing/renderer-with-debug-ui";
+import {ServerItemRendererWithDebugUI} from "../../../../../testing/server-item-renderer-with-debug-ui";
 
 import {NumericInput} from "./numeric-input.class";
 import {
@@ -15,6 +16,7 @@ import {
 } from "./numeric-input.testdata";
 
 import type {
+    PerseusItem,
     PerseusNumericInputWidgetOptions,
     PerseusRenderer,
 } from "@khanacademy/perseus-core";
@@ -180,6 +182,29 @@ const updateWidgetOptions = (
     };
 };
 
+const createNumericInputItem = (question: PerseusRenderer): PerseusItem => {
+    return {
+        question,
+        answer: null,
+        itemDataVersion: {
+            major: 0,
+            minor: 1,
+        },
+        hints: [],
+        answerArea: {
+            calculator: false,
+            chi2Table: false,
+            financialCalculatorMonthlyPayment: false,
+            financialCalculatorTotalAmount: false,
+            financialCalculatorTimeToPayOff: false,
+            periodicTable: false,
+            periodicTableWithKey: false,
+            tTable: false,
+            zTable: false,
+        },
+    };
+};
+
 export const Default = (
     args: PerseusNumericInputWidgetOptions,
 ): React.ReactElement => {
@@ -332,7 +357,12 @@ export const Answerless = (
         "numeric-input 1",
         args,
     );
-    return <RendererWithDebugUI question={question} answerless={true} />;
+    return (
+        <ServerItemRendererWithDebugUI
+            item={createNumericInputItem(question)}
+            startAnswerless={true}
+        />
+    );
 };
 Answerless.args = defaultQuestion.widgets["numeric-input 1"].options;
 Answerless.parameters = {

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.stories.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.stories.tsx
@@ -323,3 +323,22 @@ CoefficientExample.parameters = {
         },
     },
 };
+
+export const Answerless = (
+    args: PerseusNumericInputWidgetOptions,
+): React.ReactElement => {
+    const question = updateWidgetOptions(
+        defaultQuestion,
+        "numeric-input 1",
+        args,
+    );
+    return <RendererWithDebugUI question={question} answerless={true} />;
+};
+Answerless.args = defaultQuestion.widgets["numeric-input 1"].options;
+Answerless.parameters = {
+    docs: {
+        description: {
+            story: "The answerless Numeric Input widget.",
+        },
+    },
+};

--- a/packages/perseus/src/widgets/radio/__stories__/radio.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__stories__/radio.stories.tsx
@@ -1,24 +1,28 @@
 import * as React from "react";
 
-import {RendererWithDebugUI} from "../../../../../../testing/renderer-with-debug-ui";
+import {ServerItemRendererWithDebugUI} from "../../../../../../testing/server-item-renderer-with-debug-ui";
 import {
-    questionWithPassage,
-    choicesWithImages,
-    multiChoiceQuestion,
-    multiChoiceQuestionSimple,
+    itemWithQuestionAndPassage,
+    itemWithChoicesAndImages,
+    itemWithMultiChoiceQuestion,
+    itemWithMultiChoiceQuestionSimple,
+    radioItem,
 } from "../__tests__/radio.testdata";
 
-import type {APIOptions} from "../../../types";
-import type {PerseusRenderer} from "@khanacademy/perseus-core";
+import type {RendererWithDebugUI} from "../../../../../../testing/renderer-with-debug-ui";
+import type {APIOptions} from "@khanacademy/perseus";
+import type {PerseusItem} from "@khanacademy/perseus-core";
 import type {Meta} from "@storybook/react";
 
 type StoryArgs = {
     // Story Option
-    question: PerseusRenderer;
+    item: PerseusItem;
     // Radio Options
     static: boolean;
     // API Options
     crossOutEnabled: boolean;
+    // Renderer Options
+    startAnswerless: boolean;
 } & Pick<
     React.ComponentProps<typeof RendererWithDebugUI>,
     "reviewMode" | "showSolutions"
@@ -31,7 +35,8 @@ export default {
         crossOutEnabled: false,
         reviewMode: false,
         showSolutions: "none",
-        question: questionWithPassage,
+        item: itemWithQuestionAndPassage,
+        startAnswerless: false,
     } satisfies StoryArgs,
     argTypes: {
         showSolutions: {
@@ -42,26 +47,28 @@ export default {
         },
     },
     render: (args: StoryArgs) => (
-        <RendererWithDebugUI
-            question={applyStoryArgs(args)}
+        <ServerItemRendererWithDebugUI
+            item={applyStoryArgs(args)}
             apiOptions={buildApiOptions(args)}
-            reviewMode={args.reviewMode}
-            showSolutions={args.showSolutions}
         />
     ),
 } satisfies Meta<StoryArgs>;
 
-const applyStoryArgs = (args: StoryArgs): PerseusRenderer => {
-    const q = {
-        ...args.question,
-        widgets: {},
-    } as const;
-
-    for (const [widgetId, widget] of Object.entries(args.question.widgets)) {
-        q.widgets[widgetId] = {...widget, static: args.static};
+const applyStoryArgs = (args: StoryArgs): PerseusItem => {
+    const storyItem = {
+        ...args.item,
+        question: {
+            ...args.item.question,
+            widgets: {},
+        },
+    };
+    for (const [widgetId, widget] of Object.entries(
+        args.item.question.widgets,
+    )) {
+        storyItem.question.widgets[widgetId] = {...widget, static: args.static};
     }
 
-    return q;
+    return storyItem;
 };
 
 const buildApiOptions = (args: StoryArgs): APIOptions => ({
@@ -70,24 +77,45 @@ const buildApiOptions = (args: StoryArgs): APIOptions => ({
 
 export const SingleSelect = {
     args: {
-        question: questionWithPassage,
+        item: itemWithQuestionAndPassage,
     },
 };
 
 export const SelectWithImages = {
     args: {
-        question: choicesWithImages,
+        item: itemWithChoicesAndImages,
     },
 };
 
 export const MultiSelectSimple = {
     args: {
-        question: multiChoiceQuestionSimple,
+        item: itemWithMultiChoiceQuestionSimple,
     },
 };
 
 export const MultiSelect = {
     args: {
-        question: multiChoiceQuestion,
+        item: itemWithMultiChoiceQuestion,
+    },
+};
+
+export const SingleSelectWithoutAnswers = {
+    args: {
+        item: radioItem,
+        startAnswerless: true,
+    },
+};
+
+export const MultiSelectSimpleWithoutAnswers = {
+    args: {
+        item: itemWithMultiChoiceQuestionSimple,
+        startAnswerless: true,
+    },
+};
+
+export const MultiSelectWithoutAnswers = {
+    args: {
+        item: itemWithMultiChoiceQuestion,
+        startAnswerless: true,
     },
 };

--- a/packages/perseus/src/widgets/radio/__stories__/radio.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__stories__/radio.stories.tsx
@@ -50,6 +50,7 @@ export default {
         <ServerItemRendererWithDebugUI
             item={applyStoryArgs(args)}
             apiOptions={buildApiOptions(args)}
+            startAnswerless={args.startAnswerless}
         />
     ),
 } satisfies Meta<StoryArgs>;
@@ -99,21 +100,21 @@ export const MultiSelect = {
     },
 };
 
-export const SingleSelectWithoutAnswers = {
+export const AnswerlessSingleSelect = {
     args: {
         item: radioItem,
         startAnswerless: true,
     },
 };
 
-export const MultiSelectSimpleWithoutAnswers = {
+export const AnswerlessMultiSelectSimple = {
     args: {
         item: itemWithMultiChoiceQuestionSimple,
         startAnswerless: true,
     },
 };
 
-export const MultiSelectWithoutAnswers = {
+export const AnswerlessMultiSelect = {
     args: {
         item: itemWithMultiChoiceQuestion,
         startAnswerless: true,

--- a/packages/perseus/src/widgets/radio/__stories__/radio.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__stories__/radio.stories.tsx
@@ -100,6 +100,11 @@ export const MultiSelect = {
     },
 };
 
+// NOTE(Tamara): The answerless radio stories currently lose the user's input
+// upon switching to answerless data initially. It will remember the user's
+// input after clicking the Check button a second time.
+// TODO(LEMS-2948): After investigating a solution, confirm this issue is fixed
+
 export const AnswerlessSingleSelect = {
     args: {
         item: radioItem,

--- a/packages/perseus/src/widgets/radio/__tests__/__snapshots__/radio.test.ts.snap
+++ b/packages/perseus/src/widgets/radio/__tests__/__snapshots__/radio.test.ts.snap
@@ -509,12 +509,8 @@ exports[`Radio Widget multi-choice question should snapshot the same when invali
       >
          
         <div
-          class="fixed-to-responsive svg-image"
-          style="max-width: 428px; max-height: 428px;"
+          class="unresponsive-svg-image"
         >
-          <div
-            style="padding-bottom: 100%;"
-          />
           <span
             style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
           >

--- a/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
@@ -1,7 +1,12 @@
+import {ItemExtras, radioLogic} from "@khanacademy/perseus-core";
+
 import type {
     PerseusRenderer,
     RadioWidget,
     PassageWidget,
+    PerseusItem,
+    PerseusRadioWidgetOptions,
+    PerseusAnswerArea,
 } from "@khanacademy/perseus-core";
 
 export const question: PerseusRenderer = {
@@ -61,252 +66,290 @@ export const questionAndAnswer: [
     ReadonlyArray<number>,
 ] = [question, 2, [0, 1, 3]];
 
-export const questionWithPassage: PerseusRenderer = {
-    content:
-        "Read the following passage:\n\n[[\u2603 passage 1]]\n\nWhich of the following values of $x$ satisfies the equation $\\sqrt{64}=x$ ?\n\n[[\u2603 radio 1]]\n\n",
-    images: {},
-    widgets: {
-        "radio 1": {
-            graded: true,
-            version: {
-                major: 1,
-                minor: 0,
-            },
-            static: false,
-            type: "radio",
-            options: {
-                displayCount: null,
-                choices: [
-                    {
-                        content: "$-8$ and $8$",
-                        correct: false,
-                        clue: "The square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number, so $x$ is equal to *only* $8$.",
-                    },
-                    {
-                        content: "$-8$",
-                        correct: false,
-                        clue: "While $(-8)^2=64$, the square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number.",
-                    },
-                    {
-                        content: "$8$ {{passage-ref 1 1}}\n\n",
-                        correct: true,
-                        isNoneOfTheAbove: false,
-                        clue: "$8$ is the positive square root of $64$.",
-                    },
-                    {
-                        content: "No value of $x$ satisfies the equation.",
-                        correct: false,
-                        isNoneOfTheAbove: false,
-                        clue: "$8$ satisfies the equation.",
-                    },
-                ],
-                countChoices: false,
-                hasNoneOfTheAbove: false,
-                multipleSelect: false,
-                randomize: false,
-                deselectEnabled: false,
-            },
-            alignment: "default",
-        } as RadioWidget,
-        "passage 1": {
-            alignment: "default",
-            graded: true,
-            options: {
-                footnotes: "",
-                passageText:
-                    "Here's a passage about the positive square root. It contains a {{reference to something}}.",
-                passageTitle: "",
-                showLineNumbers: true,
+export const itemWithQuestionAndPassage: PerseusItem = {
+    question: {
+        content:
+            "Read the following passage:\n\n[[\u2603 passage 1]]\n\nWhich of the following values of $x$ satisfies the equation $\\sqrt{64}=x$ ?\n\n[[\u2603 radio 1]]\n\n",
+        images: {},
+        widgets: {
+            "radio 1": {
+                graded: true,
+                version: {
+                    major: 1,
+                    minor: 0,
+                },
                 static: false,
-            },
-            static: false,
-            type: "passage",
-            version: {major: 0, minor: 0},
-        } as PassageWidget,
-    },
-};
-
-export const choicesWithImages: PerseusRenderer = {
-    content:
-        "The following options have images. All but one of them should be on their own line. [[☃ radio 1]]",
-    images: {},
-    widgets: {
-        "radio 1": {
-            graded: true,
-            version: {
-                major: 1,
-                minor: 0,
-            },
-            static: false,
-            type: "radio",
-            options: {
-                displayCount: null,
-                choices: [
-                    {
-                        content:
-                            "Same \nLine\n![2 micron diameter cell](https://ka-perseus-images.s3.amazonaws.com/b17cfb6a3270c6f41f66099462e495c841cf6ca9.png)\nSame\nLine",
-                        correct: false,
-                        clue: "The markdown only has single lines between each item, so they should be treated as one complete line.",
-                    },
-                    {
-                        content:
-                            "Text \n\nBefore\n\n![2 micron diameter cell](https://ka-perseus-images.s3.amazonaws.com/b17cfb6a3270c6f41f66099462e495c841cf6ca9.png)",
-                        correct: false,
-                        clue: "There are two 'new line' characters between the preceding text and the image. Therefore, the image should be on its own line.",
-                    },
-                    {
-                        content:
-                            "![2 micron diameter cell](https://ka-perseus-images.s3.amazonaws.com/b17cfb6a3270c6f41f66099462e495c841cf6ca9.png)\n\nText \n\nAfter",
-                        correct: false,
-                        clue: "There are two 'new line' characters between the image and the text that follows. Therefore, the image should be on its own line.",
-                    },
-                    {
-                        content:
-                            "Text \n\nBefore\n\n![2 micron diameter cell](https://ka-perseus-images.s3.amazonaws.com/b17cfb6a3270c6f41f66099462e495c841cf6ca9.png)\n\nText \n\nAfter",
-                        correct: false,
-                        clue: "There are two 'new line' characters between the image and the text that surrounds it. Therefore, the image should be on its own line.",
-                    },
-                    {
-                        content:
-                            "![2 micron diameter cell](https://ka-perseus-images.s3.amazonaws.com/b17cfb6a3270c6f41f66099462e495c841cf6ca9.png)",
-                        correct: false,
-                        clue: "The markdown only has an image (no text), so nothing should be adjusted.",
-                    },
-                    {
-                        content:
-                            "![2 micron diameter cell](https://ka-perseus-images.s3.amazonaws.com/b17cfb6a3270c6f41f66099462e495c841cf6ca9.png)\n\n![2 micron diameter cell](https://ka-perseus-images.s3.amazonaws.com/b17cfb6a3270c6f41f66099462e495c841cf6ca9.png)",
-                        correct: false,
-                        clue: "The markdown has two images (no text) with two 'new line' characters between them, so they should be on their own lines.",
-                    },
-                ],
-                countChoices: false,
-                hasNoneOfTheAbove: false,
-                multipleSelect: false,
-                randomize: false,
-                deselectEnabled: false,
-            },
-            alignment: "default",
-        } as RadioWidget,
-        "passage 1": {
-            alignment: "default",
-            graded: true,
-            options: {
-                footnotes: "",
-                passageText:
-                    "Here's a passage about the positive square root. It contains a {{reference to something}}.",
-                passageTitle: "",
-                showLineNumbers: true,
+                type: "radio",
+                options: {
+                    displayCount: null,
+                    choices: [
+                        {
+                            content: "$-8$ and $8$",
+                            correct: false,
+                            clue: "The square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number, so $x$ is equal to *only* $8$.",
+                        },
+                        {
+                            content: "$-8$",
+                            correct: false,
+                            clue: "While $(-8)^2=64$, the square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number.",
+                        },
+                        {
+                            content: "$8$ {{passage-ref 1 1}}\n\n",
+                            correct: true,
+                            isNoneOfTheAbove: false,
+                            clue: "$8$ is the positive square root of $64$.",
+                        },
+                        {
+                            content: "No value of $x$ satisfies the equation.",
+                            correct: false,
+                            isNoneOfTheAbove: false,
+                            clue: "$8$ satisfies the equation.",
+                        },
+                    ],
+                    countChoices: false,
+                    hasNoneOfTheAbove: false,
+                    multipleSelect: false,
+                    randomize: false,
+                    deselectEnabled: false,
+                },
+                alignment: "default",
+            } as RadioWidget,
+            "passage 1": {
+                alignment: "default",
+                graded: true,
+                options: {
+                    footnotes: "",
+                    passageText:
+                        "Here's a passage about the positive square root. It contains a {{reference to something}}.",
+                    passageTitle: "",
+                    showLineNumbers: true,
+                    static: false,
+                },
                 static: false,
-            },
-            static: false,
-            type: "passage",
-            version: {major: 0, minor: 0},
-        } as PassageWidget,
+                type: "passage",
+                version: {major: 0, minor: 0},
+            } as PassageWidget,
+        },
     },
+    answer: null,
+    answerArea: Object.fromEntries(
+        ItemExtras.map((extra) => [extra, false]),
+    ) as PerseusAnswerArea,
+    itemDataVersion: {
+        major: 0,
+        minor: 1,
+    },
+    hints: [],
 };
 
-export const multiChoiceQuestion: PerseusRenderer = {
-    content:
-        "**Select all input values for which $g(x)=2$.**\n\n[[\u2603 radio 1]]\n\n ![](web+graphie://ka-perseus-graphie.s3.amazonaws.com/4613e0d9c906b3053fb5523eed83d4f779fdf6bb)",
-    images: {
-        "web+graphie://ka-perseus-graphie.s3.amazonaws.com/4613e0d9c906b3053fb5523eed83d4f779fdf6bb":
-            {
-                width: 428,
-                height: 428,
-            },
+export const itemWithChoicesAndImages: PerseusItem = {
+    question: {
+        content:
+            "The following options have images. All but one of them should be on their own line. [[☃ radio 1]]",
+        images: {},
+        widgets: {
+            "radio 1": {
+                graded: true,
+                version: {
+                    major: 1,
+                    minor: 0,
+                },
+                static: false,
+                type: "radio",
+                options: {
+                    displayCount: null,
+                    choices: [
+                        {
+                            content:
+                                "Same \nLine\n![2 micron diameter cell](https://ka-perseus-images.s3.amazonaws.com/b17cfb6a3270c6f41f66099462e495c841cf6ca9.png)\nSame\nLine",
+                            correct: false,
+                            clue: "The markdown only has single lines between each item, so they should be treated as one complete line.",
+                        },
+                        {
+                            content:
+                                "Text \n\nBefore\n\n![2 micron diameter cell](https://ka-perseus-images.s3.amazonaws.com/b17cfb6a3270c6f41f66099462e495c841cf6ca9.png)",
+                            correct: false,
+                            clue: "There are two 'new line' characters between the preceding text and the image. Therefore, the image should be on its own line.",
+                        },
+                        {
+                            content:
+                                "![2 micron diameter cell](https://ka-perseus-images.s3.amazonaws.com/b17cfb6a3270c6f41f66099462e495c841cf6ca9.png)\n\nText \n\nAfter",
+                            correct: false,
+                            clue: "There are two 'new line' characters between the image and the text that follows. Therefore, the image should be on its own line.",
+                        },
+                        {
+                            content:
+                                "Text \n\nBefore\n\n![2 micron diameter cell](https://ka-perseus-images.s3.amazonaws.com/b17cfb6a3270c6f41f66099462e495c841cf6ca9.png)\n\nText \n\nAfter",
+                            correct: false,
+                            clue: "There are two 'new line' characters between the image and the text that surrounds it. Therefore, the image should be on its own line.",
+                        },
+                        {
+                            content:
+                                "![2 micron diameter cell](https://ka-perseus-images.s3.amazonaws.com/b17cfb6a3270c6f41f66099462e495c841cf6ca9.png)",
+                            correct: false,
+                            clue: "The markdown only has an image (no text), so nothing should be adjusted.",
+                        },
+                        {
+                            content:
+                                "![2 micron diameter cell](https://ka-perseus-images.s3.amazonaws.com/b17cfb6a3270c6f41f66099462e495c841cf6ca9.png)\n\n![2 micron diameter cell](https://ka-perseus-images.s3.amazonaws.com/b17cfb6a3270c6f41f66099462e495c841cf6ca9.png)",
+                            correct: false,
+                            clue: "The markdown has two images (no text) with two 'new line' characters between them, so they should be on their own lines.",
+                        },
+                    ],
+                    countChoices: false,
+                    hasNoneOfTheAbove: false,
+                    multipleSelect: false,
+                    randomize: false,
+                    deselectEnabled: false,
+                },
+                alignment: "default",
+            } as RadioWidget,
+            "passage 1": {
+                alignment: "default",
+                graded: true,
+                options: {
+                    footnotes: "",
+                    passageText:
+                        "Here's a passage about the positive square root. It contains a {{reference to something}}.",
+                    passageTitle: "",
+                    showLineNumbers: true,
+                    static: false,
+                },
+                static: false,
+                type: "passage",
+                version: {major: 0, minor: 0},
+            } as PassageWidget,
+        },
     },
-    widgets: {
-        "radio 1": {
-            graded: true,
-            version: {
-                major: 1,
-                minor: 0,
-            },
-            static: false,
-            type: "radio",
-            options: {
-                onePerLine: true,
-                displayCount: null,
-                choices: [
-                    {
-                        content: "$x=-6$",
-                        correct: false,
-                    },
-                    {
-                        content: "$x=4$",
-                        correct: false,
-                    },
-                    {
-                        content: "$x=7$",
-                        isNoneOfTheAbove: false,
-                        correct: false,
-                    },
-                    {
-                        content: "There is no such input value.",
-                        isNoneOfTheAbove: true,
-                        correct: true,
-                    },
-                ],
-                hasNoneOfTheAbove: true,
-                multipleSelect: true,
-                randomize: false,
-                deselectEnabled: false,
-            },
-            alignment: "default",
-        } as RadioWidget,
+    answer: null,
+    answerArea: Object.fromEntries(
+        ItemExtras.map((extra) => [extra, false]),
+    ) as PerseusAnswerArea,
+    itemDataVersion: {
+        major: 0,
+        minor: 1,
     },
+    hints: [],
 };
 
-export const multiChoiceQuestionSimple: PerseusRenderer = {
-    content: "What are some ways to say hello?\n\n[[\u2603 radio 1]]",
-    images: {},
-    widgets: {
-        "radio 1": {
-            graded: true,
-            version: {
-                major: 1,
-                minor: 0,
-            },
-            static: false,
-            type: "radio",
-            options: {
-                onePerLine: true,
-                displayCount: null,
-                choices: [
-                    {
-                        content: "Hola",
-                        isNoneOfTheAbove: false,
-                        correct: true,
-                    },
-                    {
-                        content: "Hey",
-                        isNoneOfTheAbove: false,
-                        correct: true,
-                    },
-                    {
-                        content: "Hi",
-                        isNoneOfTheAbove: false,
-                        correct: true,
-                    },
-                    {
-                        content: "Goodbye",
-                        isNoneOfTheAbove: false,
-                        correct: false,
-                    },
-                    {
-                        content: "None of these",
-                        isNoneOfTheAbove: true,
-                        correct: false,
-                    },
-                ],
-                hasNoneOfTheAbove: true,
-                multipleSelect: true,
-                randomize: false,
-                deselectEnabled: false,
-            },
-            alignment: "default",
-        } as RadioWidget,
+export const itemWithMultiChoiceQuestion: PerseusItem = {
+    question: {
+        content:
+            "**Select all input values for which $g(x)=2$.**\n\n[[\u2603 radio 1]]\n\n ![](web+graphie://ka-perseus-graphie.s3.amazonaws.com/4613e0d9c906b3053fb5523eed83d4f779fdf6bb)",
+        images: {},
+        widgets: {
+            "radio 1": {
+                graded: true,
+                version: {
+                    major: 1,
+                    minor: 0,
+                },
+                static: false,
+                type: "radio",
+                options: {
+                    onePerLine: true,
+                    displayCount: null,
+                    choices: [
+                        {
+                            content: "$x=-6$",
+                            correct: false,
+                        },
+                        {
+                            content: "$x=4$",
+                            correct: false,
+                        },
+                        {
+                            content: "$x=7$",
+                            isNoneOfTheAbove: false,
+                            correct: false,
+                        },
+                        {
+                            content: "There is no such input value.",
+                            isNoneOfTheAbove: true,
+                            correct: true,
+                        },
+                    ],
+                    hasNoneOfTheAbove: true,
+                    multipleSelect: true,
+                    randomize: false,
+                    deselectEnabled: false,
+                },
+                alignment: "default",
+            } as RadioWidget,
+        },
     },
+    answer: null,
+    answerArea: Object.fromEntries(
+        ItemExtras.map((extra) => [extra, false]),
+    ) as PerseusAnswerArea,
+    itemDataVersion: {
+        major: 0,
+        minor: 1,
+    },
+    hints: [],
+};
+
+export const itemWithMultiChoiceQuestionSimple: PerseusItem = {
+    question: {
+        content: "What are some ways to say hello?\n\n[[\u2603 radio 1]]",
+        images: {},
+        widgets: {
+            "radio 1": {
+                graded: true,
+                version: {
+                    major: 1,
+                    minor: 0,
+                },
+                static: false,
+                type: "radio",
+                options: {
+                    onePerLine: true,
+                    displayCount: null,
+                    choices: [
+                        {
+                            content: "Hola",
+                            isNoneOfTheAbove: false,
+                            correct: true,
+                        },
+                        {
+                            content: "Hey",
+                            isNoneOfTheAbove: false,
+                            correct: true,
+                        },
+                        {
+                            content: "Hi",
+                            isNoneOfTheAbove: false,
+                            correct: true,
+                        },
+                        {
+                            content: "Goodbye",
+                            isNoneOfTheAbove: false,
+                            correct: false,
+                        },
+                        {
+                            content: "None of these",
+                            isNoneOfTheAbove: true,
+                            correct: false,
+                        },
+                    ],
+                    hasNoneOfTheAbove: true,
+                    multipleSelect: true,
+                    randomize: false,
+                    deselectEnabled: false,
+                },
+                alignment: "default",
+            } as RadioWidget,
+        },
+    },
+    answer: null,
+    answerArea: Object.fromEntries(
+        ItemExtras.map((extra) => [extra, false]),
+    ) as PerseusAnswerArea,
+    itemDataVersion: {
+        major: 0,
+        minor: 1,
+    },
+    hints: [],
 };
 
 export const multiChoiceQuestionAndAnswer: [
@@ -315,7 +358,7 @@ export const multiChoiceQuestionAndAnswer: [
     ReadonlyArray<ReadonlyArray<number>>,
     ReadonlyArray<ReadonlyArray<number>>,
 ] = [
-    multiChoiceQuestion,
+    itemWithMultiChoiceQuestion.question,
     [3],
     [[0], [1], [2], [0, 1], [0, 2], [0, 1, 2], [1, 2]],
     [
@@ -415,4 +458,46 @@ export const shuffledNoneQuestion: PerseusRenderer = {
             alignment: "default",
         } as RadioWidget,
     },
+};
+
+export const radioItem: PerseusItem = {
+    question: {
+        content: "[[☃ radio 1]]",
+        images: {},
+        widgets: {
+            "radio 1": {
+                type: "radio",
+                graded: true,
+                options: {
+                    choices: [
+                        {
+                            content: "Incorrect",
+                            correct: false,
+                            clue: "Rationale for incorrect",
+                        },
+                        {
+                            content: "Correct",
+                            correct: true,
+                            clue: "Rationale for correct",
+                        },
+                        {
+                            content: "Also incorrect",
+                            correct: false,
+                            clue: "Rationale for second incorrect",
+                        },
+                    ],
+                },
+                version: radioLogic.version,
+            },
+        },
+    },
+    answer: null,
+    answerArea: Object.fromEntries(
+        ItemExtras.map((extra) => [extra, false]),
+    ) as PerseusAnswerArea,
+    itemDataVersion: {
+        major: 0,
+        minor: 1,
+    },
+    hints: [],
 };

--- a/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
@@ -5,7 +5,6 @@ import type {
     RadioWidget,
     PassageWidget,
     PerseusItem,
-    PerseusRadioWidgetOptions,
     PerseusAnswerArea,
 } from "@khanacademy/perseus-core";
 

--- a/testing/renderer-with-debug-ui.tsx
+++ b/testing/renderer-with-debug-ui.tsx
@@ -9,6 +9,7 @@ import deviceMobile from "@phosphor-icons/core/regular/device-mobile.svg";
 import * as React from "react";
 import ReactJson from "react-json-view";
 
+import {splitPerseusItem} from "@khanacademy/perseus-core";
 import {scorePerseusItem} from "@khanacademy/perseus-score";
 
 import {Renderer, usePerseusI18n} from "../packages/perseus/src/index";
@@ -21,6 +22,7 @@ import type {ComponentProps} from "react";
 
 type Props = {
     question: PerseusRenderer;
+    answerless?: boolean;
 } & Partial<
     Omit<
         ComponentProps<typeof Renderer>,
@@ -32,6 +34,7 @@ export const RendererWithDebugUI = ({
     question,
     apiOptions,
     reviewMode = false,
+    answerless = false,
     ...rest
 }: Props): React.ReactElement => {
     registerAllWidgetsForTesting();
@@ -45,6 +48,12 @@ export const RendererWithDebugUI = ({
         isMobile,
         customKeypad: isMobile, // Use the mobile keypad for mobile
     };
+
+    const renderedQuestion: PerseusRenderer = answerless
+        ? splitPerseusItem(question)
+        : question;
+
+    console.log("renderedQuestion", renderedQuestion);
 
     return (
         <SplitView
@@ -72,13 +81,14 @@ export const RendererWithDebugUI = ({
                         <Renderer
                             // @ts-expect-error - TS2322 - Type 'MutableRefObject<Renderer | null | undefined>' is not assignable to type 'LegacyRef<Renderer> | undefined'.
                             ref={ref}
-                            content={question.content}
+                            content={renderedQuestion.content}
                             images={question.images}
                             widgets={question.widgets}
                             problemNum={0}
                             apiOptions={controlledAPIOptions}
                             reviewMode={reviewMode}
                             strings={strings}
+                            answerless={answerless}
                             {...rest}
                         />
                     </View>

--- a/testing/renderer-with-debug-ui.tsx
+++ b/testing/renderer-with-debug-ui.tsx
@@ -81,9 +81,9 @@ export const RendererWithDebugUI = ({
                         <Renderer
                             // @ts-expect-error - TS2322 - Type 'MutableRefObject<Renderer | null | undefined>' is not assignable to type 'LegacyRef<Renderer> | undefined'.
                             ref={ref}
-                            content={renderedQuestion.content}
+                            content={question.content}
                             images={question.images}
-                            widgets={question.widgets}
+                            widgets={renderedQuestion.widgets}
                             problemNum={0}
                             apiOptions={controlledAPIOptions}
                             reviewMode={reviewMode}

--- a/testing/server-item-renderer-with-debug-ui.tsx
+++ b/testing/server-item-renderer-with-debug-ui.tsx
@@ -15,7 +15,7 @@ import * as Perseus from "../packages/perseus/src/index";
 import {keScoreFromPerseusScore} from "../packages/perseus/src/util/scoring";
 
 import KEScoreUI from "./ke-score-ui";
-import SideBySide from "./split-view";
+import SplitView from "./split-view";
 import {storybookDependenciesV2} from "./test-dependencies";
 
 import type {APIOptions} from "../packages/perseus/src/types";
@@ -25,17 +25,21 @@ type Props = {
     item: PerseusItem;
     apiOptions?: APIOptions;
     keypadElement?: KeypadAPI | null | undefined;
-    answerless?: boolean;
+    // Temporary measure testing rendering with answerless data;
+    // only exists until all widgets are renderable with answerless data
+    startAnswerless?: boolean;
 };
 
 export const ServerItemRendererWithDebugUI = ({
     item,
     apiOptions,
     keypadElement,
-    answerless = false,
+    startAnswerless = false,
 }: Props): React.ReactElement => {
     const ref = React.useRef<Perseus.ServerItemRendererComponent>(null);
     const [state, setState] = React.useState<KEScore | null | undefined>(null);
+    const [useAnswerless, setUseAnswerless] =
+        React.useState<boolean>(startAnswerless);
     const options = apiOptions || Object.freeze({});
 
     const getKeScore = () => {
@@ -58,7 +62,7 @@ export const ServerItemRendererWithDebugUI = ({
         );
     };
 
-    const renderedQuestion: PerseusRenderer = answerless
+    const renderedQuestion: PerseusRenderer = useAnswerless
         ? splitPerseusItem(item.question)
         : item.question;
 
@@ -68,7 +72,7 @@ export const ServerItemRendererWithDebugUI = ({
     };
 
     return (
-        <SideBySide
+        <SplitView
             rendererTitle="Renderer"
             renderer={
                 <>
@@ -83,6 +87,7 @@ export const ServerItemRendererWithDebugUI = ({
                     <View style={{flexDirection: "row", alignItems: "center"}}>
                         <Button
                             onClick={() => {
+                                setUseAnswerless(false);
                                 if (!ref.current) {
                                     return;
                                 }
@@ -94,6 +99,7 @@ export const ServerItemRendererWithDebugUI = ({
                         <Strut size={8} />
                         <Button
                             onClick={() => {
+                                setUseAnswerless(false);
                                 ref.current?.showRationalesForCurrentlySelectedChoices();
                             }}
                         >


### PR DESCRIPTION
## Summary:
In order to confirm Assessment's main widgets can render with answerless data and then still score after that, we are adding stories for each of the widgets that render with answer less data.

Issue: LEMS-2869

## Test plan:
- Confirm all answerless stories start out with answerless data and then switch to answerful data in order to score. 
- Confirm the widgets in the stories score correctly.
- Confirm behavior has no regressios and is as expected.
- Confirm all checks pass.