### PR TITLE
[Free Response Widget] Add optional character limit support

### DIFF
--- a/.changeset/four-cougars-work.md
+++ b/.changeset/four-cougars-work.md
@@ -1,0 +1,8 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-core": minor
+"@khanacademy/perseus-editor": minor
+"@khanacademy/perseus-score": minor
+---
+
+Add optional character limit support

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1675,6 +1675,10 @@ export type PerseusFreeResponseWidgetScoringCriterion = {
 };
 
 export type PerseusFreeResponseWidgetOptions = {
+    // Whether to allow the user to enter an unlimited number of characters.
+    allowUnlimitedCharacters: boolean;
+    // The maximum number of characters that the user can enter.
+    characterLimit: number;
     // The placeholder text that will be displayed to the user in the text input field.
     placeholder: string;
     // The question text that will be displayed to the user.

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/free-response-widget.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/free-response-widget.test.ts
@@ -34,6 +34,7 @@ describe("freeResponseWidget", () => {
                 },
                 graded: false,
                 options: {
+                    allowUnlimitedCharacters: false,
                     characterLimit: 500,
                     placeholder: "test-placeholder",
                     question: "What is your favorite color?",

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/free-response-widget.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/free-response-widget.test.ts
@@ -13,6 +13,8 @@ describe("freeResponseWidget", () => {
             },
             graded: false,
             options: {
+                allowUnlimitedCharacters: false,
+                characterLimit: 500,
                 placeholder: "test-placeholder",
                 question: "What is your favorite color?",
                 scoringCriteria: [
@@ -32,6 +34,7 @@ describe("freeResponseWidget", () => {
                 },
                 graded: false,
                 options: {
+                    characterLimit: 500,
                     placeholder: "test-placeholder",
                     question: "What is your favorite color?",
                     scoringCriteria: [

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/free-response-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/free-response-widget.ts
@@ -1,4 +1,11 @@
-import {array, constant, object, string} from "../general-purpose-parsers";
+import {
+    array,
+    boolean,
+    constant,
+    number,
+    object,
+    string,
+} from "../general-purpose-parsers";
 
 import {parseWidget} from "./widget";
 
@@ -8,6 +15,8 @@ import type {Parser} from "../parser-types";
 export const parseFreeResponseWidget: Parser<FreeResponseWidget> = parseWidget(
     constant("free-response"),
     object({
+        allowUnlimitedCharacters: boolean,
+        characterLimit: number,
         placeholder: string,
         question: string,
         scoringCriteria: array(

--- a/packages/perseus-core/src/widgets/free-response/free-response-util.test.ts
+++ b/packages/perseus-core/src/widgets/free-response/free-response-util.test.ts
@@ -6,6 +6,8 @@ describe("getFreeResponsePublicWidgetOptions", () => {
     it("should return the correct public options without any answer data", () => {
         // Arrange
         const options: PerseusFreeResponseWidgetOptions = {
+            allowUnlimitedCharacters: false,
+            characterLimit: 500,
             placeholder: "Please provide response here",
             question: "What is the wind speed velocity of an unladen swallow?",
             scoringCriteria: [
@@ -20,6 +22,8 @@ describe("getFreeResponsePublicWidgetOptions", () => {
 
         // Assert
         expect(publicWidgetOptions).toEqual({
+            allowUnlimitedCharacters: false,
+            characterLimit: 500,
             placeholder: "Please provide response here",
             question: "What is the wind speed velocity of an unladen swallow?",
         });

--- a/packages/perseus-core/src/widgets/free-response/free-response-util.ts
+++ b/packages/perseus-core/src/widgets/free-response/free-response-util.ts
@@ -5,6 +5,8 @@ import type {PerseusFreeResponseWidgetOptions} from "@khanacademy/perseus-core";
  * {@link PerseusFreeResponseWidgetOptions} type
  */
 export type FreeResponsePublicWidgetOptions = {
+    allowUnlimitedCharacters: PerseusFreeResponseWidgetOptions["allowUnlimitedCharacters"];
+    characterLimit: PerseusFreeResponseWidgetOptions["characterLimit"];
     placeholder: PerseusFreeResponseWidgetOptions["placeholder"];
     question: PerseusFreeResponseWidgetOptions["question"];
 };
@@ -17,6 +19,8 @@ function getFreeResponsePublicWidgetOptions(
     options: PerseusFreeResponseWidgetOptions,
 ): FreeResponsePublicWidgetOptions {
     return {
+        allowUnlimitedCharacters: options.allowUnlimitedCharacters,
+        characterLimit: options.characterLimit,
         placeholder: options.placeholder,
         question: options.question,
     };

--- a/packages/perseus-core/src/widgets/free-response/index.ts
+++ b/packages/perseus-core/src/widgets/free-response/index.ts
@@ -5,10 +5,16 @@ import type {WidgetLogic} from "../logic-export.types";
 
 export type FreeResponseDefaultWidgetOptions = Pick<
     PerseusFreeResponseWidgetOptions,
-    "placeholder" | "question" | "scoringCriteria"
+    | "allowUnlimitedCharacters"
+    | "characterLimit"
+    | "placeholder"
+    | "question"
+    | "scoringCriteria"
 >;
 
 const defaultWidgetOptions: FreeResponseDefaultWidgetOptions = {
+    allowUnlimitedCharacters: false,
+    characterLimit: 500,
     placeholder: "Please provide response here",
     question: "",
     // Always display one criterion, since the user will always have to input

--- a/packages/perseus-editor/src/widgets/__stories__/free-response-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/free-response-editor.stories.tsx
@@ -49,6 +49,8 @@ type State = Partial<PropsFor<typeof FreeResponseEditor>>;
 
 const WithState = () => {
     const [state, setState] = React.useState<State>({
+        allowUnlimitedCharacters: false,
+        characterLimit: 500,
         placeholder: "Enter your answer here",
         question: "What is is the truth?",
         scoringCriteria: [{text: ""}],

--- a/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
@@ -31,6 +31,41 @@ describe("free-response editor", () => {
         expect(screen.getByDisplayValue("test-question")).toBeInTheDocument();
     });
 
+    it("calls onChange when the allow unlimited characters is changed", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+
+        // Act
+        render(
+            <FreeResponseEditor
+                allowUnlimitedCharacters={false}
+                onChange={onChangeMock}
+            />,
+        );
+
+        await userEvent.click(
+            screen.getByRole("checkbox", {name: /Allow unlimited characters/i}),
+        );
+
+        // Assert
+        expect(onChangeMock).toBeCalledWith({allowUnlimitedCharacters: true});
+    });
+
+    it("calls onChange when the character limit is changed", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+
+        // Act
+        render(
+            <FreeResponseEditor characterLimit={0} onChange={onChangeMock} />,
+        );
+
+        await userEvent.type(screen.getByLabelText(/Character limit/), "1");
+
+        // Assert
+        expect(onChangeMock).toBeCalledWith({characterLimit: 1});
+    });
+
     it("calls onChange when the question is changed", async () => {
         // Arrange
         const onChangeMock = jest.fn();

--- a/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
@@ -51,7 +51,7 @@ describe("free-response editor", () => {
         expect(onChangeMock).toBeCalledWith({allowUnlimitedCharacters: true});
     });
 
-    it("calls onChange when the character limit is changed", async () => {
+    it("calls onChange when the character limit is changed to a number", async () => {
         // Arrange
         const onChangeMock = jest.fn();
 
@@ -64,6 +64,21 @@ describe("free-response editor", () => {
 
         // Assert
         expect(onChangeMock).toBeCalledWith({characterLimit: 1});
+    });
+
+    it("does not call onChange when the character limit is changed to a non-number", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+
+        // Act
+        render(
+            <FreeResponseEditor characterLimit={5} onChange={onChangeMock} />,
+        );
+
+        await userEvent.type(screen.getByLabelText(/Character limit/), "e");
+
+        // Assert
+        expect(onChangeMock).not.toBeCalled();
     });
 
     it("calls onChange when the question is changed", async () => {

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -121,14 +121,11 @@ class FreeResponseEditor extends React.Component<Props> {
                         }
                     />
                 </label>
-                <label
-                    className={css(styles.textOptionWithLabelContainer)}
-                    htmlFor="allow-unlimited-characters"
-                >
+                {/* eslint-disable-next-line jsx-a11y/label-has-associated-control -- TODO(LEMS-2871): Address a11y error */}
+                <label className={css(styles.textOptionWithLabelContainer)}>
                     <HeadingSmall>Allow unlimited characters</HeadingSmall>
                     <Checkbox
                         checked={this.props.allowUnlimitedCharacters}
-                        id="allow-unlimited-characters"
                         onChange={(val) =>
                             this.props.onChange({
                                 allowUnlimitedCharacters: val,

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -14,6 +14,7 @@ import type {
     FreeResponseDefaultWidgetOptions,
     PerseusFreeResponseWidgetScoringCriterion,
 } from "@khanacademy/perseus-core";
+import type {ChangeEventHandler} from "react";
 
 type Props = PerseusFreeResponseWidgetOptions & {
     onChange: (options: Partial<PerseusFreeResponseWidgetOptions>) => void;
@@ -42,6 +43,15 @@ class FreeResponseEditor extends React.Component<Props> {
         }
         return warnings;
     }
+
+    handleUpdateCharacterLimit: ChangeEventHandler<HTMLInputElement> = (e) => {
+        const val = parseInt(e.target.value);
+        if (isNaN(val)) {
+            return;
+        }
+
+        this.props.onChange({characterLimit: Math.max(1, val)});
+    };
 
     handleUpdateCriterion = (
         index: number,
@@ -133,12 +143,7 @@ class FreeResponseEditor extends React.Component<Props> {
                             type="number"
                             min={1}
                             value={this.props.characterLimit}
-                            onChange={(e) => {
-                                const val = parseInt(e.target.value);
-                                this.props.onChange({
-                                    characterLimit: Math.max(1, val),
-                                });
-                            }}
+                            onChange={this.handleUpdateCharacterLimit}
                         />
                     </label>
                 )}

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -1,6 +1,7 @@
 import {freeResponseLogic} from "@khanacademy/perseus-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
+import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {spacing, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {HeadingSmall} from "@khanacademy/wonder-blocks-typography";
 import plusCircleIcon from "@phosphor-icons/core/regular/plus-circle.svg";
@@ -26,6 +27,8 @@ class FreeResponseEditor extends React.Component<Props> {
 
     serialize(): PerseusFreeResponseWidgetOptions {
         return {
+            allowUnlimitedCharacters: this.props.allowUnlimitedCharacters,
+            characterLimit: this.props.characterLimit,
             placeholder: this.props.placeholder,
             question: this.props.question,
             scoringCriteria: this.props.scoringCriteria,
@@ -108,6 +111,36 @@ class FreeResponseEditor extends React.Component<Props> {
                         }
                     />
                 </label>
+                <label
+                    className={css(styles.textOptionWithLabelContainer)}
+                    htmlFor="allow-unlimited-characters"
+                >
+                    <HeadingSmall>Allow unlimited characters</HeadingSmall>
+                    <Checkbox
+                        checked={this.props.allowUnlimitedCharacters}
+                        id="allow-unlimited-characters"
+                        onChange={(val) =>
+                            this.props.onChange({
+                                allowUnlimitedCharacters: val,
+                            })
+                        }
+                    />
+                </label>
+                {!this.props.allowUnlimitedCharacters && (
+                    <label className={css(styles.textOptionWithLabelContainer)}>
+                        <HeadingSmall>Character limit</HeadingSmall>
+                        <input
+                            type="number"
+                            min={1}
+                            value={this.props.characterLimit}
+                            onChange={(e) =>
+                                this.props.onChange({
+                                    characterLimit: parseInt(e.target.value),
+                                })
+                            }
+                        />
+                    </label>
+                )}
                 <View>
                     <HeadingSmall>Scoring criteria</HeadingSmall>
                     <View style={styles.criteriaList}>

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -133,11 +133,12 @@ class FreeResponseEditor extends React.Component<Props> {
                             type="number"
                             min={1}
                             value={this.props.characterLimit}
-                            onChange={(e) =>
+                            onChange={(e) => {
+                                const val = parseInt(e.target.value);
                                 this.props.onChange({
-                                    characterLimit: parseInt(e.target.value),
-                                })
-                            }
+                                    characterLimit: Math.max(1, val),
+                                });
+                            }}
                         />
                     </label>
                 )}

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -4,6 +4,8 @@ import type {ErrorCodes} from "@khanacademy/perseus-score";
  * The translated strings that are used to render Perseus.
  */
 export type PerseusStrings = {
+    // `num` is a special variable name that is used to determine the plurality
+    // of the translated string.
     characterCount: ({used, num}: {used: number; num: number}) => string;
     closeKeypad: string;
     openKeypad: string;
@@ -517,6 +519,8 @@ export type PerseusStrings = {
  * !! Note: Ensure that all escape sequences are double-escaped. (e.g. `\\text` -> `\\\\text`)
  */
 export const strings = {
+    // `num` is a special variable name that is used to determine the plurality
+    // of the translated string.
     characterCount: {
         one: "%(used)s / %(num)s Character",
         other: "%(used)s / %(num)s Characters",

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -4,6 +4,7 @@ import type {ErrorCodes} from "@khanacademy/perseus-score";
  * The translated strings that are used to render Perseus.
  */
 export type PerseusStrings = {
+    characterCount: ({used, num}: {used: number; num: number}) => string;
     closeKeypad: string;
     openKeypad: string;
     mathInputBox: string;
@@ -516,6 +517,10 @@ export type PerseusStrings = {
  * !! Note: Ensure that all escape sequences are double-escaped. (e.g. `\\text` -> `\\\\text`)
  */
 export const strings = {
+    characterCount: {
+        one: "%(used)s / %(num)s Character",
+        other: "%(used)s / %(num)s Characters",
+    },
     closeKeypad: "close math keypad",
     openKeypad: "open math keypad",
     mathInputBox: "Math input box",
@@ -818,6 +823,10 @@ export const strings = {
  * Mock strings for the Perseus package, to be used for tests and Storybook.
  */
 export const mockStrings: PerseusStrings = {
+    characterCount: ({used, num}) =>
+        num === 1
+            ? `${used} / ${num} Character`
+            : `${used} / ${num} Characters`,
     closeKeypad: "close math keypad",
     openKeypad: "open math keypad",
     mathInputBox: "Math input box",

--- a/packages/perseus/src/widgets/free-response/__snapshots__/free-response.test.tsx.snap
+++ b/packages/perseus/src/widgets/free-response/__snapshots__/free-response.test.tsx.snap
@@ -16,16 +16,37 @@ exports[`free-response widget should snapshot on mobile: first mobile render 1`]
           class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="default_xu2jcg"
+            class="default_xu2jcg-o_O-container_lci7r"
           >
             <label
-              class="labelAndTextarea_1o27vzy"
+              class="labelAndTextarea_b4ep1"
             >
-              test-question
-              <textarea
-                placeholder="test-placeholder"
-              />
+              <span
+                class="text_f1191h-o_O-LabelLarge_5s82ln"
+              >
+                test-question
+              </span>
+              <div
+                class="default_xu2jcg-o_O-inlineStyles_zdxht7"
+              >
+                <textarea
+                  aria-invalid="false"
+                  aria-required="false"
+                  class="textarea_o89kg2-o_O-LabelMedium_1rew30o-o_O-default_1tc7wjm-o_O-defaultFocus_lrnqlz-o_O-textarea_1x0fg6n"
+                  id=":r1:"
+                  placeholder="test-placeholder"
+                />
+              </div>
             </label>
+            <div
+              class="default_xu2jcg"
+            >
+              <span
+                class="text_f1191h"
+              >
+                0 / 500 Characters
+              </span>
+            </div>
           </div>
         </div>
       </div>
@@ -50,16 +71,37 @@ exports[`free-response widget should snapshot: first render 1`] = `
           class="perseus-widget-container widget-nohighlight widget-block"
         >
           <div
-            class="default_xu2jcg"
+            class="default_xu2jcg-o_O-container_lci7r"
           >
             <label
-              class="labelAndTextarea_1o27vzy"
+              class="labelAndTextarea_b4ep1"
             >
-              test-question
-              <textarea
-                placeholder="test-placeholder"
-              />
+              <span
+                class="text_f1191h-o_O-LabelLarge_5s82ln"
+              >
+                test-question
+              </span>
+              <div
+                class="default_xu2jcg-o_O-inlineStyles_zdxht7"
+              >
+                <textarea
+                  aria-invalid="false"
+                  aria-required="false"
+                  class="textarea_o89kg2-o_O-LabelMedium_1rew30o-o_O-default_1tc7wjm-o_O-defaultFocus_lrnqlz-o_O-textarea_1x0fg6n"
+                  id=":r0:"
+                  placeholder="test-placeholder"
+                />
+              </div>
             </label>
+            <div
+              class="default_xu2jcg"
+            >
+              <span
+                class="text_f1191h"
+              >
+                0 / 500 Characters
+              </span>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/perseus/src/widgets/free-response/free-response.stories.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.stories.tsx
@@ -12,6 +12,26 @@ type Story = StoryObj<typeof FreeResponse>;
 
 export const Primary: Story = {
     args: {
+        allowUnlimitedCharacters: false,
+        characterLimit: 500,
+        placeholder: "Enter your answer here",
+        question: "What is the theme of the essay?",
+    },
+};
+
+export const CharacterLimit: Story = {
+    args: {
+        allowUnlimitedCharacters: false,
+        characterLimit: 500,
+        placeholder: "Enter your answer here",
+        question: "What is the theme of the essay?",
+    },
+};
+
+export const UnlimitedCharacters: Story = {
+    args: {
+        allowUnlimitedCharacters: true,
+        characterLimit: 500,
         placeholder: "Enter your answer here",
         question: "What is the theme of the essay?",
     },

--- a/packages/perseus/src/widgets/free-response/free-response.test.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.test.tsx
@@ -55,6 +55,60 @@ describe("free-response widget", () => {
         expect(container).toMatchSnapshot("first mobile render");
     });
 
+    it("should render the character limit when not allowing unlimited characters", () => {
+        // Arrange
+        const data = getFreeResponseItemData();
+        data.widgets["free-response 1"].options.allowUnlimitedCharacters =
+            false;
+
+        // Act
+        renderQuestion(data, {});
+
+        // Assert
+        expect(screen.queryByText(/Character/)).toBeVisible();
+    });
+
+    it("should not render the character limit when allowing unlimited characters", () => {
+        // Arrange
+        const data = getFreeResponseItemData();
+        data.widgets["free-response 1"].options.allowUnlimitedCharacters = true;
+
+        // Act
+        renderQuestion(data, {});
+
+        // Assert
+        expect(screen.queryByText(/Character/)).not.toBeInTheDocument();
+    });
+
+    it("should ignore newline characters when rendering the character limit", async () => {
+        // Arrange
+        const data = getFreeResponseItemData();
+        data.widgets["free-response 1"].options.characterLimit = 10;
+
+        // Act
+        renderQuestion(data, {});
+
+        await userEvent.type(
+            screen.getByRole("textbox", {name: "test-question"}),
+            "a\nb",
+        );
+
+        // Assert
+        expect(screen.queryByText(/2 \/ 10 Character/)).toBeVisible();
+    });
+
+    it("should not render the character limit when it is not set", () => {
+        // Arrange
+        const data = getFreeResponseItemData();
+        data.widgets["free-response 1"].options.characterLimit = 0;
+
+        // Act
+        renderQuestion(data, {});
+
+        // Assert
+        expect(screen.queryByText(/Characters/)).not.toBeInTheDocument();
+    });
+
     it("should render the question text", () => {
         // Arrange
         // Act

--- a/packages/perseus/src/widgets/free-response/free-response.test.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.test.tsx
@@ -97,18 +97,6 @@ describe("free-response widget", () => {
         expect(screen.queryByText(/2 \/ 10 Character/)).toBeVisible();
     });
 
-    it("should not render the character limit when it is not set", () => {
-        // Arrange
-        const data = getFreeResponseItemData();
-        data.widgets["free-response 1"].options.characterLimit = 0;
-
-        // Act
-        renderQuestion(data, {});
-
-        // Assert
-        expect(screen.queryByText(/Characters/)).not.toBeInTheDocument();
-    });
-
     it("should render the question text", () => {
         // Arrange
         // Act

--- a/packages/perseus/src/widgets/free-response/free-response.testdata.ts
+++ b/packages/perseus/src/widgets/free-response/free-response.testdata.ts
@@ -11,6 +11,8 @@ export function getFreeResponseItemData(): PerseusRenderer {
                 static: false,
                 type: "free-response",
                 options: {
+                    allowUnlimitedCharacters: false,
+                    characterLimit: 500,
                     placeholder: "test-placeholder",
                     question: "test-question",
                     scoringCriteria: [

--- a/packages/perseus/src/widgets/free-response/free-response.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.tsx
@@ -58,12 +58,12 @@ export class FreeResponse
         this.setState({currentValue: newValue});
     };
 
-    isOverLimit = () => {
+    isOverLimit() {
         return (
             !this.props.allowUnlimitedCharacters &&
             this.characterCount() > this.props.characterLimit
         );
-    };
+    }
 
     renderCharacterCount(): React.ReactNode {
         if (this.props.allowUnlimitedCharacters) {

--- a/packages/perseus/src/widgets/free-response/free-response.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.tsx
@@ -70,11 +70,10 @@ export class FreeResponse
             return null;
         }
 
-        const counts = {
+        const characterCountText = this.context.strings.characterCount({
             used: this.characterCount(),
             num: this.props.characterLimit,
-        };
-        const characterLimitText = this.context.strings.characterCount(counts);
+        });
 
         return (
             <View>
@@ -93,7 +92,7 @@ export class FreeResponse
                         />
                     )}
 
-                    {characterLimitText}
+                    {characterCountText}
                 </Text>
             </View>
         );

--- a/packages/perseus/src/widgets/free-response/free-response.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.tsx
@@ -5,10 +5,16 @@
  * is "short answer" type questions.
  */
 
-import {View} from "@khanacademy/wonder-blocks-core";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {Text, View} from "@khanacademy/wonder-blocks-core";
+import {TextArea} from "@khanacademy/wonder-blocks-form";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {LabelLarge} from "@khanacademy/wonder-blocks-typography";
+import warningCircleIcon from "@phosphor-icons/core/regular/warning-circle.svg";
 import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
+
+import {PerseusI18nContext} from "../../components/i18n-context";
 
 import type {Widget, WidgetExports, WidgetProps} from "../../types";
 import type {PerseusFreeResponseWidgetOptions} from "@khanacademy/perseus-core";
@@ -16,7 +22,7 @@ import type {PerseusFreeResponseUserInput} from "@khanacademy/perseus-score";
 
 type RenderProps = Pick<
     PerseusFreeResponseWidgetOptions,
-    "placeholder" | "question"
+    "allowUnlimitedCharacters" | "characterLimit" | "placeholder" | "question"
 >;
 type Props = WidgetProps<RenderProps>;
 
@@ -31,12 +37,15 @@ export class FreeResponse
     extends React.Component<Props, State>
     implements Widget
 {
+    static contextType = PerseusI18nContext;
+    declare context: React.ContextType<typeof PerseusI18nContext>;
+
     state: State = {
         currentValue: "",
     };
 
-    handleChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-        this.setState({currentValue: event.target.value});
+    characterCount = () => {
+        return this.state.currentValue.replace(/\n/g, "").length;
     };
 
     getUserInput(): PerseusFreeResponseUserInput {
@@ -45,17 +54,65 @@ export class FreeResponse
         };
     }
 
-    render(): React.ReactNode {
+    handleChange = (newValue: string) => {
+        this.setState({currentValue: newValue});
+    };
+
+    isOverLimit = () => {
+        return (
+            !this.props.allowUnlimitedCharacters &&
+            this.characterCount() > this.props.characterLimit
+        );
+    };
+
+    renderCharacterCount(): React.ReactNode {
+        if (this.props.allowUnlimitedCharacters) {
+            return null;
+        }
+
+        const counts = {
+            used: this.characterCount(),
+            num: this.props.characterLimit,
+        };
+        const characterLimitText = this.context.strings.characterCount(counts);
+
         return (
             <View>
+                <Text
+                    style={
+                        this.isOverLimit()
+                            ? styles.overCharacterLimit
+                            : undefined
+                    }
+                >
+                    {this.isOverLimit() && (
+                        <PhosphorIcon
+                            icon={warningCircleIcon}
+                            size="small"
+                            style={styles.warningCircleIcon}
+                        />
+                    )}
+
+                    {characterLimitText}
+                </Text>
+            </View>
+        );
+    }
+
+    render(): React.ReactNode {
+        return (
+            <View style={styles.container}>
                 <label className={css(styles.labelAndTextarea)}>
-                    {this.props.question}
-                    <textarea
-                        value={this.state.currentValue}
+                    <LabelLarge>{this.props.question}</LabelLarge>
+                    <TextArea
+                        error={this.isOverLimit()}
                         onChange={this.handleChange}
                         placeholder={this.props.placeholder}
+                        style={styles.textarea}
+                        value={this.state.currentValue}
                     />
                 </label>
+                {this.renderCharacterCount()}
             </View>
         );
     }
@@ -71,9 +128,21 @@ export default {
 } as WidgetExports<typeof FreeResponse>;
 
 const styles = StyleSheet.create({
+    container: {
+        gap: spacing.xSmall_8,
+    },
     labelAndTextarea: {
         display: "flex",
         flexDirection: "column",
-        gap: spacing.xSmall_8,
+        gap: spacing.small_12,
+    },
+    overCharacterLimit: {
+        color: color.red,
+    },
+    textarea: {
+        padding: spacing.medium_16,
+    },
+    warningCircleIcon: {
+        marginInlineEnd: spacing.xSmall_8,
     },
 });


### PR DESCRIPTION
## Summary:
This PR adds the ability for content creators to set a character limit for the answers. If the user goes over that limit, then the field visually shows it as invalid.

The creator can choose to allow for unlimited characters if they would prefer.

Issue: LIT-1666

## Test plan:

- Open Storybook
- In the editor
  - modify the character limit
  - toggle unlimited characters
- In the renderer
  - type some characters to see the count update
  - type enough to go over the limit, see the error state
  - type a lot into the unlimited, see no error state