### PR TITLE
Revert PR 2331: Moving to ESM-only packages

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,26 +1,20 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 /* eslint-disable import/no-commonjs */
-const path = require("node:path");
+const fs = require("fs");
+const path = require("path");
 
-const fg = require("fast-glob");
+const pkgNames = fs
+    .readdirSync(path.join(__dirname, "packages"))
+    .filter((name) => name !== ".DS_Store");
 
-const pkgAliases = fg
-    .globSync(path.join(__dirname, "packages/*/package.json"))
-    .map((pkgJsonPath) => {
-        const pkgJson = require(pkgJsonPath);
-        const packageDirName = path.basename(path.dirname(pkgJsonPath));
-        return [
-            pkgJson.name,
-            `./packages/${packageDirName}/${pkgJson.exports["."].source.slice(2)}`,
-        ];
-    });
+const pkgAliases = pkgNames.map((pkgName) => {
+    return [`@khanacademy/${pkgName}`, `./packages/${pkgName}/src/index.js`];
+});
 
-const vendorAliases = fg
-    .globSync(path.join(__dirname, "vendor/*/package.json"))
-    .map((pkgJsonPath) => {
-        const pkgJson = require(pkgJsonPath);
-        const packageDirName = path.basename(path.dirname(pkgJsonPath));
-        return [pkgJson.name, `./vendor/${packageDirName}/${pkgJson.main}`];
+const vendorAliases = fs
+    .readdirSync(path.join(__dirname, "vendor"))
+    .map((name) => {
+        return [name, `./vendor/${name}`];
     });
 
 const allAliases = [...pkgAliases, ...vendorAliases];

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -132,10 +132,7 @@ jobs:
               name: Files that would trigger a full jest run
               with:
                   changed-files: ${{ steps.changed.outputs.files }}
-                  files: >-
-                      jest.config.js, test.config.js, config/test/,
-                      package.json, pnpm-lock.yaml,
-                      babel.config.js, config/build/babel.config.js
+                  files: "jest.config.js,package.json,pnpm-lock.yaml,test.config.js,test.transform.js"
 
             - name: Jest
               uses: Khan/actions@full-or-limited-v0
@@ -218,7 +215,8 @@ jobs:
             - name: Check Builds
               uses: preactjs/compressed-size-action@v2
               with:
-                  pattern: "**/dist/*.js"
+                  # We only care about the ES module size, really:
+                  pattern: "**/dist/es/*.js"
                   # Always ignore SourceMaps and node_modules:
                   exclude: "{**/*.map,**/node_modules/**}"
                   # Clean up before a build

--- a/config/build/babel.config.js
+++ b/config/build/babel.config.js
@@ -1,38 +1,19 @@
 /* eslint-disable import/no-commonjs */
+const createBabelPlugins = require("./create-babel-plugins");
+const createBabelPresets = require("./create-babel-presets");
+
+// This config is used for Jest and Cypress here in this repository, only.
 module.exports = {
     assumptions: {
         constantReexports: true,
     },
-    presets: [
-        [
-            "@babel/preset-typescript",
-            {
-                // NOTE(john): We need this so that we can handle the declare
-                // fields inside React classes.
-                allowDeclareFields: true,
-            },
-        ],
-        [
-            "@babel/preset-env",
-            {
-                targets: {esmodules: true},
-                bugfixes: true,
-                loose: true,
-            },
-        ],
-        "@babel/preset-react",
-    ],
-    plugins: [
-        // NOTE(john): We need this so that we can handle the declare fields
-        // inside React classes.
-        ["@babel/plugin-transform-typescript", {allowDeclareFields: true}],
-        [
-            "@babel/plugin-transform-runtime",
-            {
-                corejs: false,
-                helpers: true,
-                regenerator: false,
-            },
-        ],
-    ],
+    presets: createBabelPresets({
+        platform: "browser",
+        format: "cjs",
+    }),
+    plugins: createBabelPlugins({
+        platform: "browser",
+        format: "cjs",
+        coverage: process.env["BABEL_COVERAGE"],
+    }),
 };

--- a/config/build/create-babel-plugins.js
+++ b/config/build/create-babel-plugins.js
@@ -1,0 +1,20 @@
+/* eslint-disable import/no-commonjs */
+module.exports = function createBabelPlugins({platform, format, coverage}) {
+    const plugins = [
+        // NOTE(john): We need this so that we can handle the declare fields
+        // inside React classes.
+        ["@babel/plugin-transform-typescript", {allowDeclareFields: true}],
+    ];
+    if (coverage) {
+        plugins.push("istanbul");
+    }
+    plugins.push([
+        "@babel/plugin-transform-runtime",
+        {
+            corejs: false,
+            helpers: true,
+            regenerator: false,
+        },
+    ]);
+    return plugins;
+};

--- a/config/build/create-babel-presets.js
+++ b/config/build/create-babel-presets.js
@@ -1,0 +1,36 @@
+/* eslint-disable import/no-commonjs */
+module.exports = function createBabelPresets({platform, format}) {
+    const targets = {};
+    const options = {targets};
+
+    if (platform === "node") {
+        targets.node = true;
+    }
+
+    switch (format) {
+        case "cjs":
+            if (platform === "browser") {
+                targets.browsers = ["defaults", "not IE 11"];
+            }
+            break;
+
+        case "esm":
+            targets.esmodules = true;
+            options.bugfixes = true;
+            options.loose = true;
+            break;
+    }
+
+    return [
+        [
+            "@babel/preset-typescript",
+            {
+                // NOTE(john): We need this so that we can handle the declare
+                // fields inside React classes.
+                allowDeclareFields: true,
+            },
+        ],
+        ["@babel/preset-env", options],
+        "@babel/preset-react",
+    ];
+};

--- a/config/build/rollup.config.js
+++ b/config/build/rollup.config.js
@@ -12,9 +12,25 @@ import autoExternal from "rollup-plugin-auto-external";
 import filesize from "rollup-plugin-filesize";
 import styles from "rollup-plugin-styles";
 
-const babelConfig = require("./babel.config");
+const createBabelPlugins = require("./create-babel-plugins");
+const createBabelPresets = require("./create-babel-presets");
 
 const rootDir = ancesdir(__dirname);
+
+/**
+ * We support the following config args with this rollup configuration:
+ *
+ * --configFormats
+ *      A comma-delimited list of formats to build.
+ *      Valid options are "cjs" and "esm".
+ *      Default: cjs, esm
+ *
+ * --configEnvironment
+ *      A string to use as the NODE_ENV environment variable.
+ *      Valid options are "development" and "production".
+ *      Default: We do not target an environment so that consumers can benefit
+ *               from the default behavior.
+ */
 
 /**
  * Make path to a package relative path.
@@ -28,20 +44,62 @@ const makePackageBasedPath = (pkgName, pkgRelPath) => {
         path.join(rootDir, "packages", pkgName, "package.json"),
     );
     const pkgJson = require(pkgPath);
-    return path.normalize(
-        path.join("packages", pkgName, pkgJson.exports["."].source),
-    );
+    return path.normalize(path.join("packages", pkgName, pkgJson.source));
 };
+
+/**
+ * Generate the rollup output configuration for a given package
+ */
+const createOutputConfig = (pkgName, format, targetFile) => ({
+    file: makePackageBasedPath(pkgName, targetFile),
+    sourcemap: true,
+    format,
+
+    // These two settings are to keep the builds as similar to pre-Rollup v4 as
+    // possible until we get rid of CJS builds.
+    // See: https://rollupjs.org/migration/#changed-defaults
+    esModule: true,
+    interop: "compat",
+
+    // Governs names of CSS files (for assets from CSS use `hash` option for
+    // url handler).
+    // Note: using value below will put `.css` files near js,
+    // but make sure to adjust `hash`, `assetDir` and `publicPath`
+    // options for url handler accordingly.
+    assetFileNames: "[name][extname]",
+});
+
+/**
+ * Get a set of strings from a given string, returning the defaults
+ *
+ * This assumes comma-delimited strings.
+ */
+const getSetFromDelimitedString = (arg, defaults) => {
+    const values =
+        arg != null && arg.length > 0
+            ? arg
+                  .split(",")
+                  .map((p) => p.trim())
+                  .filter(Boolean)
+            : [];
+    return new Set(values.length ? values : defaults);
+};
+
+/**
+ * Determine what formats we are targetting.
+ */
+const getFormats = ({configFormats}) =>
+    getSetFromDelimitedString(configFormats, ["cjs", "esm"]);
 
 /**
  * Generate a rollup configuration.
  */
 const createConfig = (
     commandLineArgs,
-    {name, fullName, version, inputFile, file},
+    {name, fullName, version, format, platform, inputFile, file, plugins},
 ) => {
     const valueReplacementMappings = {
-        __IS_BROWSER__: true,
+        __IS_BROWSER__: platform === "browser",
     };
 
     // We don't normally target a specific environment, leaving that for
@@ -61,18 +119,7 @@ const createConfig = (
     const extensions = [".js", ".jsx", ".ts", ".tsx"];
 
     const config = {
-        output: {
-            file: makePackageBasedPath(name, file),
-            sourcemap: true,
-            format: "esm",
-
-            // Governs names of CSS files (for assets from CSS use `hash` option for
-            // url handler).
-            // Note: using value below will put `.css` files near js,
-            // but make sure to adjust `hash`, `assetDir` and `publicPath`
-            // options for url handler accordingly.
-            assetFileNames: "[name][extname]",
-        },
+        output: createOutputConfig(name, format, file),
         input: makePackageBasedPath(name, inputFile),
         external: [/@phosphor-icons\/core\/.*/],
         plugins: [
@@ -117,9 +164,8 @@ const createConfig = (
             }),
             babel({
                 babelHelpers: "runtime",
-                comments: false,
-                presets: babelConfig.presets,
-                plugins: babelConfig.plugins,
+                presets: createBabelPresets({platform, format}),
+                plugins: createBabelPlugins({platform, format}),
                 exclude: "node_modules/**",
                 extensions,
             }),
@@ -127,13 +173,18 @@ const createConfig = (
             // to deal with TypeScript types.
             commonjs(),
             resolve({
-                browser: true,
+                browser: platform === "browser",
                 extensions,
             }),
             autoExternal({
                 packagePath: makePackageBasedPath(name, "./package.json"),
             }),
-            filesize(),
+            // TODO(FEI-4557): Figure out how to make this plugin work so that
+            // @khanacademy/perseus-editor works in webapp.  If we enable this
+            // plugin right now, the content editor pages in webapp will fail
+            // with the following error: `TypeError: Object(...) is not a function`
+            // terser(),
+            ...plugins,
         ],
     };
 
@@ -149,32 +200,77 @@ const createConfig = (
  * each package. If the package has a `browser` field, then we generate
  * browser and node assets. If not, we just generate the node assets.
  * Note that we also get the output paths from the package.json.
+ *
+ * We also can filter the outputs based on command line options:
+ * `--configPlatforms` - Comma-separated list. Valid values are "browser"
+ *                       and "node".
+ * `--configFormats`   - Comma-separated list. Valid values are "cjs" and
+ *                       "esm". If not specified, then we generate both.
  */
-const getPackageInfo = (pkgName) => {
+const getPackageInfo = (commandLineArgs, pkgName) => {
     const pkgJsonPath = makePackageBasedPath(pkgName, "./package.json");
     if (!fs.existsSync(pkgJsonPath)) {
         return [];
     }
     const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath));
 
+    // Determine what formats and platforms we are building.
+    const formats = getFormats(commandLineArgs);
+
     const configs = [];
 
-    if (!pkgJson.exports) {
-        throw new Error(
-            `${pkgName} does not define the required 'exports' field.`,
-        );
-    }
+    if (pkgJson.exports) {
+        for (const exportConfig of Object.values(pkgJson.exports)) {
+            if (exportConfig.require && formats.has("cjs")) {
+                configs.push({
+                    name: pkgName,
+                    fullName: pkgJson.name,
+                    version: pkgJson.version,
+                    format: "cjs",
+                    platform: "browser",
+                    inputFile: exportConfig.source,
+                    file: exportConfig.require,
+                    plugins: [],
+                });
+            }
 
-    for (const exportConfig of Object.values(pkgJson.exports)) {
-        if (exportConfig.default) {
+            if (exportConfig.import && formats.has("esm")) {
+                configs.push({
+                    name: pkgName,
+                    fullName: pkgJson.name,
+                    version: pkgJson.version,
+                    format: "esm",
+                    platform: "browser",
+                    inputFile: exportConfig.source,
+                    file: exportConfig.import,
+                    plugins: [filesize()],
+                });
+            }
+        }
+    } else {
+        if (formats.has("cjs")) {
+            configs.push({
+                name: pkgName,
+                fullName: pkgJson.name,
+                version: pkgJson.version,
+                format: "cjs",
+                platform: "browser",
+                inputFile: pkgJson.source,
+                file: pkgJson.main,
+                plugins: [],
+            });
+        }
+        if (formats.has("esm")) {
             configs.push({
                 name: pkgName,
                 fullName: pkgJson.name,
                 version: pkgJson.version,
                 format: "esm",
                 platform: "browser",
-                inputFile: exportConfig.source,
-                file: exportConfig.default,
+                inputFile: pkgJson.source,
+                file: pkgJson.module,
+                // We care about the file size of this one.
+                plugins: [filesize()],
             });
         }
     }
@@ -190,9 +286,8 @@ const createRollupConfig = async (commandLineArgs) => {
     // about them and generate configurations.
     const results = fs
         .readdirSync("packages")
-        .flatMap((p) => getPackageInfo(p))
+        .flatMap((p) => getPackageInfo(commandLineArgs, p))
         .map((c) => createConfig(commandLineArgs, c));
-
     return results;
 };
 

--- a/config/cypress/cypress.config.ts
+++ b/config/cypress/cypress.config.ts
@@ -2,24 +2,28 @@ import fs from "fs";
 import path from "path";
 import {mergeConfig} from "vite";
 import istanbul from "vite-plugin-istanbul";
-import fg from "fast-glob";
 
 import {defineConfig} from "cypress";
 import viteConfig from "../../vite.config";
 
 const aliases = {};
-
-fg.globSync(path.join(__dirname, "../../packages/*/package.json")).forEach(
-    (pkgPath) => {
-        const pkgJson = require(pkgPath);
-        const packageDirName = pkgJson.name.replace(/^@khanacademy\//, "");
-        aliases[pkgJson.name] = path.join(
-            path.dirname(pkgPath),
-            packageDirName,
-            pkgJson.exports["."].source,
-        );
-    },
-);
+fs.readdirSync(path.join(__dirname, "../../packages")).forEach((name) => {
+    if (name.startsWith(".")) {
+        return;
+    }
+    const stat = fs.statSync(path.join(__dirname, "../../packages", name));
+    if (stat.isFile()) {
+        return;
+    }
+    const pkgPath = path.join("../../packages", name, "package.json");
+    const pkgJson = require(pkgPath);
+    aliases["@khanacademy/" + name] = path.join(
+        __dirname,
+        "../../packages",
+        name,
+        pkgJson.source,
+    );
+});
 fs.readdirSync(path.join(__dirname, "../../vendor")).forEach((name) => {
     aliases[name] = path.join(__dirname, "../../vendor", name);
 });

--- a/packages/kas/package.json
+++ b/packages/kas/package.json
@@ -15,16 +15,9 @@
     "bugs": {
         "url": "https://github.com/Khan/perseus/issues"
     },
-    "engines": {
-        "node": ">=18"
-    },
-    "exports": {
-        ".": {
-            "source": "./src/index.ts",
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        }
-    },
+    "module": "dist/es/index.js",
+    "main": "dist/index.js",
+    "source": "src/index.ts",
     "files": [
         "dist"
     ],

--- a/packages/keypad-context/package.json
+++ b/packages/keypad-context/package.json
@@ -15,16 +15,9 @@
     "bugs": {
         "url": "https://github.com/Khan/perseus/issues"
     },
-    "engines": {
-        "node": ">=18"
-    },
-    "exports": {
-        ".": {
-            "source": "./src/index.ts",
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        }
-    },
+    "module": "dist/es/index.js",
+    "main": "dist/index.js",
+    "source": "src/index.ts",
     "files": [
         "dist"
     ],

--- a/packages/kmath/package.json
+++ b/packages/kmath/package.json
@@ -15,16 +15,9 @@
     "bugs": {
         "url": "https://github.com/Khan/perseus/issues"
     },
-    "engines": {
-        "node": ">=18"
-    },
-    "exports": {
-        ".": {
-            "source": "./src/index.ts",
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        }
-    },
+    "module": "dist/es/index.js",
+    "main": "dist/index.js",
+    "source": "src/index.ts",
     "files": [
         "dist"
     ],

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -15,19 +15,21 @@
     "bugs": {
         "url": "https://github.com/Khan/perseus/issues"
     },
-    "engines": {
-        "node": ">=18"
-    },
+    "module": "dist/es/index.js",
+    "main": "dist/index.js",
+    "source": "src/index.ts",
     "exports": {
         ".": {
-            "source": "./src/index.ts",
+            "import": "./dist/es/index.js",
+            "require": "./dist/index.js",
             "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
+            "source": "./src/index.ts"
         },
         "./strings": {
-            "source": "./src/strings.ts",
+            "import": "./dist/es/strings.js",
+            "require": "./dist/strings.js",
             "types": "./dist/strings.d.ts",
-            "default": "./dist/strings.js"
+            "source": "./src/strings.ts"
         },
         "./styles.css": "./dist/index.css"
     },

--- a/packages/perseus-core/package.json
+++ b/packages/perseus-core/package.json
@@ -15,16 +15,9 @@
     "bugs": {
         "url": "https://github.com/Khan/perseus/issues"
     },
-    "engines": {
-        "node": ">=18"
-    },
-    "exports": {
-        ".": {
-            "source": "./src/index.ts",
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        }
-    },
+    "module": "dist/es/index.js",
+    "main": "dist/index.js",
+    "source": "src/index.ts",
     "files": [
         "dist"
     ],

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -15,14 +15,15 @@
     "bugs": {
         "url": "https://github.com/Khan/perseus/issues"
     },
-    "engines": {
-        "node": ">=18"
-    },
+    "module": "dist/es/index.js",
+    "main": "dist/index.js",
+    "source": "src/index.ts",
     "exports": {
         ".": {
-            "source": "./src/index.ts",
+            "import": "./dist/es/index.js",
+            "require": "./dist/index.js",
             "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
+            "source": "./src/index.ts"
         },
         "./styles.css": "./dist/index.css"
     },

--- a/packages/perseus-linter/package.json
+++ b/packages/perseus-linter/package.json
@@ -15,16 +15,9 @@
     "bugs": {
         "url": "https://github.com/Khan/perseus/issues"
     },
-    "engines": {
-        "node": ">=18"
-    },
-    "exports": {
-        ".": {
-            "source": "./src/index.ts",
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        }
-    },
+    "module": "dist/es/index.js",
+    "main": "dist/index.js",
+    "source": "src/index.ts",
     "files": [
         "dist"
     ],

--- a/packages/perseus-score/package.json
+++ b/packages/perseus-score/package.json
@@ -15,16 +15,9 @@
     "bugs": {
         "url": "https://github.com/Khan/perseus/issues"
     },
-    "engines": {
-        "node": ">=18"
-    },
-    "exports": {
-        ".": {
-            "source": "./src/index.ts",
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        }
-    },
+    "module": "dist/es/index.js",
+    "main": "dist/index.js",
+    "source": "src/index.ts",
     "files": [
         "dist"
     ],

--- a/packages/perseus-utils/package.json
+++ b/packages/perseus-utils/package.json
@@ -15,16 +15,10 @@
     "bugs": {
         "url": "https://github.com/Khan/perseus/issues"
     },
-    "engines": {
-        "node": ">=18"
-    },
-    "exports": {
-        ".": {
-            "source": "./src/index.ts",
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        }
-    },
+    "module": "dist/es/index.js",
+    "main": "dist/index.js",
+    "source": "src/index.ts",
+    "types": "dist/index.d.ts",
     "files": [
         "dist"
     ],

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -15,19 +15,21 @@
     "bugs": {
         "url": "https://github.com/Khan/perseus/issues"
     },
-    "engines": {
-        "node": ">=18"
-    },
+    "module": "dist/es/index.js",
+    "main": "dist/index.js",
+    "source": "src/index.ts",
     "exports": {
         ".": {
-            "source": "./src/index.ts",
+            "import": "./dist/es/index.js",
+            "require": "./dist/index.js",
             "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
+            "source": "./src/index.ts"
         },
         "./strings": {
-            "source": "./src/strings.ts",
+            "import": "./dist/es/strings.js",
+            "require": "./dist/strings.js",
             "types": "./dist/strings.d.ts",
-            "default": "./dist/strings.js"
+            "source": "./src/strings.ts"
         },
         "./styles.css": "./dist/index.css"
     },

--- a/packages/pure-markdown/package.json
+++ b/packages/pure-markdown/package.json
@@ -15,16 +15,9 @@
     "bugs": {
         "url": "https://github.com/Khan/perseus/issues"
     },
-    "engines": {
-        "node": ">=18"
-    },
-    "exports": {
-        ".": {
-            "source": "./src/index.ts",
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        }
-    },
+    "module": "dist/es/index.js",
+    "main": "dist/index.js",
+    "source": "src/index.ts",
     "files": [
         "dist"
     ],

--- a/packages/simple-markdown/package.json
+++ b/packages/simple-markdown/package.json
@@ -15,16 +15,9 @@
     "bugs": {
         "url": "https://github.com/Khan/perseus/issues"
     },
-    "engines": {
-        "node": ">=18"
-    },
-    "exports": {
-        ".": {
-            "source": "./src/index.ts",
-            "types": "./dist/index.d.ts",
-            "default": "./dist/index.js"
-        }
-    },
+    "module": "dist/es/index.js",
+    "main": "dist/index.js",
+    "source": "src/index.ts",
     "files": [
         "dist"
     ],

--- a/utils/pre-publish-check-ci.ts
+++ b/utils/pre-publish-check-ci.ts
@@ -8,27 +8,33 @@ import fg from "fast-glob";
 
 import {
     checkPrivate,
-    checkExports,
+    checkEntrypoints,
+    checkSource,
     checkPublishConfig,
-    isFalsey,
 } from "./internal/pre-publish-utils";
 
-const pkgPaths = fg.globSync(
-    path.join(__dirname, "..", "packages", "*", "package.json"),
+// eslint-disable-next-line promise/catch-or-return
+fg(path.join(__dirname, "..", "packages", "*", "package.json")).then(
+    (pkgPaths) => {
+        let allPassed = true;
+        // eslint-disable-next-line promise/always-return
+        for (const pkgPath of pkgPaths) {
+            // eslint-disable-next-line @typescript-eslint/no-require-imports
+            const pkgJson = require(path.relative(__dirname, pkgPath));
+
+            if (
+                !checkPrivate(pkgJson) &&
+                !checkPublishConfig(pkgJson) &&
+                !checkEntrypoints(pkgJson) &&
+                !checkSource(pkgJson)
+            ) {
+                allPassed = false;
+            }
+        }
+
+        // Exit only after we've processed all the packages.
+        if (!allPassed) {
+            process.exit(1);
+        }
+    },
 );
-
-const results = pkgPaths.flatMap((pkgPath) => {
-    const pkgJson = require(path.relative(__dirname, pkgPath));
-
-    // allPassed is at the end of the chain because of short-circuiting
-    return [
-        checkPrivate(pkgJson),
-        checkPublishConfig(pkgJson),
-        checkExports(pkgJson),
-    ];
-});
-
-// Exit only after we've processed all the packages.
-if (results.some(isFalsey)) {
-    process.exit(1);
-}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,10 +10,7 @@ const packageAliases = {};
 glob.sync(join(__dirname, "/packages/*/package.json")).forEach(
     (packageJsonPath) => {
         const pkg = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-        packageAliases[pkg.name] = join(
-            dirname(packageJsonPath),
-            pkg.exports["."].source,
-        );
+        packageAliases[pkg.name] = join(dirname(packageJsonPath), pkg.source);
     },
 );
 


### PR DESCRIPTION
## Summary:

In PR #2331 I moved the Perseus packages to be ESM-only. I thought I had it all working, but missed doing the actual thing that definitively marks a package as ESM: adding `"type": "module"` to each package's `package.json`. 

Today when I add that, but `kas` build has issues and JohnR mentioned issues with Jest mocking and snapshots. I haven't seen that so I feel there's indication that I missed something else. 

Out of abundance of caution I'm reverting these changes so I can dig further without blocking Perseus releases.

Issue: LEMS-2954

## Test plan:

`pnpm test`
`pnpm clean; pnpm install; pnpm build;`