### PR TITLE
Fix `each` vs `forEach` bug

### DIFF
--- a/.changeset/big-buttons-crash.md
+++ b/.changeset/big-buttons-crash.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus-score": patch
+---
+
+Bugfix: each vs forEach in answer-types causing issues with fractions in the editor

--- a/packages/perseus-editor/src/widgets/__tests__/numeric-input-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/numeric-input-editor.test.tsx
@@ -2,6 +2,7 @@ import {Dependencies} from "@khanacademy/perseus";
 import {render, screen, waitFor, within} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
+import {useState} from "react";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import NumericInputEditor from "../numeric-input-editor";
@@ -136,6 +137,31 @@ describe("numeric-input-editor", () => {
             expect.objectContaining({labelText: "a"}),
             undefined,
         );
+    });
+
+    it("regression LEMS-2962: should be possible to have a fraction answer", async () => {
+        function StatefulNumericInputEditor() {
+            const [props, setProps] = useState({});
+
+            function mergeProps(newProps) {
+                setProps({
+                    ...props,
+                    ...newProps,
+                });
+            }
+
+            return <NumericInputEditor onChange={mergeProps} {...props} />;
+        }
+
+        render(<StatefulNumericInputEditor />);
+
+        const input = screen.getByRole("textbox", {
+            name: "User input:",
+        });
+
+        await userEvent.type(input, "6/8");
+
+        expect(screen.getByText("Correct answer: 3/4")).toBeInTheDocument();
     });
 
     it("should be possible to set unsimplified answers to ungraded", async () => {

--- a/packages/perseus-editor/src/widgets/input-number-editor.tsx
+++ b/packages/perseus-editor/src/widgets/input-number-editor.tsx
@@ -1,4 +1,4 @@
-import {components, PerseusI18nContext, Util} from "@khanacademy/perseus";
+import {components, Util} from "@khanacademy/perseus";
 import {inputNumberLogic} from "@khanacademy/perseus-core";
 import {inputNumberAnswerTypes} from "@khanacademy/perseus-score";
 import * as React from "react";
@@ -34,9 +34,6 @@ type Props = {
 };
 
 class InputNumberEditor extends React.Component<Props> {
-    static contextType = PerseusI18nContext;
-    declare context: React.ContextType<typeof PerseusI18nContext>;
-
     static widgetName = "input-number" as const;
 
     static defaultProps: InputNumberDefaultWidgetOptions =
@@ -45,7 +42,7 @@ class InputNumberEditor extends React.Component<Props> {
     input = React.createRef<BlurInput>();
 
     handleAnswerChange: (arg1: string) => void = (str) => {
-        const value = Util.firstNumericalParse(str, this.context.strings) || 0;
+        const value = Util.firstNumericalParse(str) || 0;
         this.props.onChange({value: value});
     };
 
@@ -166,10 +163,8 @@ class InputNumberEditor extends React.Component<Props> {
                             onBlur={(e) => {
                                 const ans =
                                     "" +
-                                    (Util.firstNumericalParse(
-                                        e.target.value,
-                                        this.context.strings,
-                                    ) || 0);
+                                    (Util.firstNumericalParse(e.target.value) ||
+                                        0);
                                 e.target.value = ans;
                                 this.props.onChange({maxError: ans});
                             }}

--- a/packages/perseus-editor/src/widgets/numeric-input-editor.tsx
+++ b/packages/perseus-editor/src/widgets/numeric-input-editor.tsx
@@ -586,53 +586,56 @@ class NumericInputEditor extends React.Component<Props, State> {
                                     (answer.maxError ? " with-max-error" : "")
                                 }
                             >
-                                {/* eslint-disable-next-line jsx-a11y/label-has-associated-control -- TODO(LEMS-2871): Address a11y error */}
-                                <label>User input:</label>
-                                <NumberInput
-                                    value={answer.value}
-                                    className="numeric-input-value"
-                                    placeholder="answer"
-                                    format={_.last(answer.answerForms || [])}
-                                    onFormatChange={(newValue, format) => {
-                                        // NOTE(charlie): The mobile web expression
-                                        // editor relies on this automatic answer
-                                        // form resolution for determining when to
-                                        // show the Pi symbol. If we get rid of it,
-                                        // we should also disable Pi for
-                                        // NumericInput and require problems that
-                                        // use Pi to build on Expression.
-                                        // Alternatively, we could store answers
-                                        // as plaintext and parse them to determine
-                                        // whether or not to reveal Pi on the
-                                        // keypad (right now, answers are stored as
-                                        // resolved values, like '0.125' rather
-                                        // than '1/8').
-                                        let forms;
-                                        if (format === "pi") {
-                                            forms = ["pi"];
-                                        } else if (format === "mixed") {
-                                            forms = ["proper", "mixed"];
-                                        } else if (
-                                            format === "proper" ||
-                                            format === "improper"
-                                        ) {
-                                            forms = ["proper", "improper"];
-                                        }
-                                        this.updateAnswer(i, {
-                                            value: firstNumericalParse(
-                                                newValue,
-                                            ),
-                                            answerForms: forms,
-                                        });
-                                    }}
-                                    onChange={(newValue) => {
-                                        this.updateAnswer(i, {
-                                            value: firstNumericalParse(
-                                                newValue,
-                                            ),
-                                        });
-                                    }}
-                                />
+                                <label>
+                                    User input:
+                                    <NumberInput
+                                        value={answer.value}
+                                        className="numeric-input-value"
+                                        placeholder="answer"
+                                        format={_.last(
+                                            answer.answerForms || [],
+                                        )}
+                                        onFormatChange={(newValue, format) => {
+                                            // NOTE(charlie): The mobile web expression
+                                            // editor relies on this automatic answer
+                                            // form resolution for determining when to
+                                            // show the Pi symbol. If we get rid of it,
+                                            // we should also disable Pi for
+                                            // NumericInput and require problems that
+                                            // use Pi to build on Expression.
+                                            // Alternatively, we could store answers
+                                            // as plaintext and parse them to determine
+                                            // whether or not to reveal Pi on the
+                                            // keypad (right now, answers are stored as
+                                            // resolved values, like '0.125' rather
+                                            // than '1/8').
+                                            let forms;
+                                            if (format === "pi") {
+                                                forms = ["pi"];
+                                            } else if (format === "mixed") {
+                                                forms = ["proper", "mixed"];
+                                            } else if (
+                                                format === "proper" ||
+                                                format === "improper"
+                                            ) {
+                                                forms = ["proper", "improper"];
+                                            }
+                                            this.updateAnswer(i, {
+                                                value: firstNumericalParse(
+                                                    newValue,
+                                                ),
+                                                answerForms: forms,
+                                            });
+                                        }}
+                                        onChange={(newValue) => {
+                                            this.updateAnswer(i, {
+                                                value: firstNumericalParse(
+                                                    newValue,
+                                                ),
+                                            });
+                                        }}
+                                    />
+                                </label>
                                 <span className="max-error-plusmn">
                                     &plusmn;
                                 </span>

--- a/packages/perseus-editor/src/widgets/numeric-input-editor.tsx
+++ b/packages/perseus-editor/src/widgets/numeric-input-editor.tsx
@@ -5,7 +5,6 @@ import {
     Changeable,
     EditorJsonify,
     Util,
-    PerseusI18nContext,
 } from "@khanacademy/perseus";
 import {
     numericInputLogic,
@@ -76,9 +75,6 @@ type State = {
 };
 
 class NumericInputEditor extends React.Component<Props, State> {
-    static contextType = PerseusI18nContext;
-    declare context: React.ContextType<typeof PerseusI18nContext>;
-
     static widgetName = "numeric-input";
     static displayName = "NumericInputEditor";
 
@@ -625,7 +621,6 @@ class NumericInputEditor extends React.Component<Props, State> {
                                         this.updateAnswer(i, {
                                             value: firstNumericalParse(
                                                 newValue,
-                                                this.context.strings,
                                             ),
                                             answerForms: forms,
                                         });
@@ -634,7 +629,6 @@ class NumericInputEditor extends React.Component<Props, State> {
                                         this.updateAnswer(i, {
                                             value: firstNumericalParse(
                                                 newValue,
-                                                this.context.strings,
                                             ),
                                         });
                                     }}

--- a/packages/perseus-score/src/util/answer-types.ts
+++ b/packages/perseus-score/src/util/answer-types.ts
@@ -563,50 +563,63 @@ const KhanAnswerTypes = {
                     guess: guess,
                 };
 
-                // iterate over all the acceptable forms, and if one of the
-                // answers is correct, return true
-                acceptableForms.forEach((form) => {
-                    const transformed = forms[form](guess);
-                    for (let j = 0, l = transformed.length; j < l; j++) {
-                        const val = transformed[j].value;
-                        const exact = transformed[j].exact;
-                        const piApprox = transformed[j].piApprox;
-                        // If a string was returned, and it exactly matches,
-                        // return true
-                        if (predicate(val, options.maxError)) {
-                            // If the exact correct number was returned,
+                // Iterate over all the acceptable forms
+                // and exit if one of the answers is correct.
+                //
+                // HACK: The anonomous function is a bug fix from LEMS-2962;
+                // after a transition from jQuery's `each` to JS's `forEach`
+                // we realized this code was banking on the ability to exit early
+                // from nested loops which is tricky to do outside of a function.
+                (function () {
+                    // WARNING: Don't use `forEach` without additional refactoring
+                    // code needs to be able to exit early
+                    for (const form of acceptableForms) {
+                        const transformed = forms[form](guess);
+                        for (let j = 0, l = transformed.length; j < l; j++) {
+                            const val = transformed[j].value;
+                            const exact = transformed[j].exact;
+                            const piApprox = transformed[j].piApprox;
+                            // If a string was returned, and it exactly matches,
                             // return true
-                            if (exact || options.simplify === "optional") {
-                                score.correct = true;
-                                score.message = options.message || null;
-                                // If the answer is correct, don't say it's
-                                // empty. This happens, for example, with the
-                                // coefficient type where guess === "" but is
-                                // interpreted as "1" which is correct.
-                                score.empty = false;
-                            } else if (form === "percent") {
-                                // Otherwise, an error was returned
+                            if (predicate(val, options.maxError)) {
+                                // If the exact correct number was returned,
+                                // return true
+                                if (exact || options.simplify === "optional") {
+                                    score.correct = true;
+                                    score.message = options.message || null;
+                                    // If the answer is correct, don't say it's
+                                    // empty. This happens, for example, with the
+                                    // coefficient type where guess === "" but is
+                                    // interpreted as "1" which is correct.
+                                    score.empty = false;
+                                } else if (form === "percent") {
+                                    // Otherwise, an error was returned
+                                    score.empty = true;
+                                    score.message =
+                                        ErrorCodes.MISSING_PERCENT_ERROR;
+                                } else {
+                                    if (options.simplify !== "enforced") {
+                                        score.empty = true;
+                                    }
+                                    score.message =
+                                        ErrorCodes.NEEDS_TO_BE_SIMPLIFIED_ERROR;
+                                }
+                                // HACK: The return false below stops the looping of the
+                                // callback since predicate check succeeded.
+                                // No more forms to look to verify the user guess.
+                                return false;
+                            }
+                            if (
+                                piApprox &&
+                                predicate(val, Math.abs(val * 0.001))
+                            ) {
                                 score.empty = true;
                                 score.message =
-                                    ErrorCodes.MISSING_PERCENT_ERROR;
-                            } else {
-                                if (options.simplify !== "enforced") {
-                                    score.empty = true;
-                                }
-                                score.message =
-                                    ErrorCodes.NEEDS_TO_BE_SIMPLIFIED_ERROR;
+                                    ErrorCodes.APPROXIMATED_PI_ERROR;
                             }
-                            // The return false below stops the looping of the
-                            // callback since predicate check  succeeded.
-                            // No more forms to look to verify the user guess.
-                            return false;
-                        }
-                        if (piApprox && predicate(val, Math.abs(val * 0.001))) {
-                            score.empty = true;
-                            score.message = ErrorCodes.APPROXIMATED_PI_ERROR;
                         }
                     }
-                });
+                })();
 
                 if (score.correct === false) {
                     let interpretedGuess = false;

--- a/packages/perseus-score/src/util/answer-types.ts
+++ b/packages/perseus-score/src/util/answer-types.ts
@@ -566,13 +566,16 @@ const KhanAnswerTypes = {
                 // Iterate over all the acceptable forms
                 // and exit if one of the answers is correct.
                 //
-                // HACK: The anonomous function is a bug fix from LEMS-2962;
+                // HACK: This function is a bug fix from LEMS-2962;
                 // after a transition from jQuery's `each` to JS's `forEach`
-                // we realized this code was banking on the ability to exit early
-                // from nested loops which is tricky to do outside of a function.
-                (function () {
+                // we realized this code was banking on the ability to:
+                //   1. exit early from nested loops (can be tricky outside of functions)
+                //   2. mutate external variables (score)
+                // Could probably be refactored to be a pure function that
+                // returns a score, but this code is poorly tested and prone to break.
+                const findCorrectAnswer = () => {
                     // WARNING: Don't use `forEach` without additional refactoring
-                    // code needs to be able to exit early
+                    // because code needs to be able to exit early
                     for (const form of acceptableForms) {
                         const transformed = forms[form](guess);
                         for (let j = 0, l = transformed.length; j < l; j++) {
@@ -619,7 +622,10 @@ const KhanAnswerTypes = {
                             }
                         }
                     }
-                })();
+                };
+
+                // mutates `score`
+                findCorrectAnswer();
 
                 if (score.correct === false) {
                     let interpretedGuess = false;

--- a/packages/perseus/src/components/number-input.tsx
+++ b/packages/perseus/src/components/number-input.tsx
@@ -8,8 +8,6 @@ import _ from "underscore";
 import Util from "../util";
 import {isPiMultiple} from "../util/math-utils";
 
-import {PerseusI18nContext} from "./i18n-context";
-
 import type {MathFormat} from "@khanacademy/perseus-core";
 
 const {firstNumericalParse, captureScratchpadTouchStart} = Util;
@@ -36,8 +34,6 @@ const getNumericFormat = KhanMath.getNumericFormat;
  * Optionally takes a `size` (`"mini"`, `"small"`,` `"normal"`)
  */
 class NumberInput extends React.Component<any, any> {
-    static contextType = PerseusI18nContext;
-    declare context: React.ContextType<typeof PerseusI18nContext>;
     inputRef = React.createRef<HTMLInputElement>();
 
     static propTypes = {
@@ -111,7 +107,7 @@ class NumberInput extends React.Component<any, any> {
             const placeholder = this.props.placeholder;
             return _.isFinite(placeholder) ? +placeholder : null;
         }
-        const result = firstNumericalParse(value, this.context.strings);
+        const result = firstNumericalParse(value);
         return _.isFinite(result) ? result : this.props.value;
     };
 
@@ -146,7 +142,7 @@ class NumberInput extends React.Component<any, any> {
             return true;
         }
 
-        const val = firstNumericalParse(value, this.context.strings);
+        const val = firstNumericalParse(value);
         const checkValidity = this.props.checkValidity;
 
         return _.isFinite(val) && checkValidity(val);

--- a/packages/perseus/src/util.test.ts
+++ b/packages/perseus/src/util.test.ts
@@ -1,0 +1,7 @@
+import Util from "./util";
+
+describe("firstNumericalParse", () => {
+    it("regression LEMS-2962: handles fractions properly", () => {
+        expect(Util.firstNumericalParse("6/8")).toBe(0.75);
+    });
+});

--- a/packages/perseus/src/util.ts
+++ b/packages/perseus/src/util.ts
@@ -3,7 +3,6 @@ import _ from "underscore";
 
 import * as GraphieUtil from "./util.graphie";
 
-import type {PerseusStrings} from "./strings";
 import type {Range} from "@khanacademy/perseus-core";
 import type * as React from "react";
 
@@ -127,10 +126,7 @@ const split: (str: string, r: RegExp) => ReadonlyArray<string> = "x".split(
  * Return the first valid interpretation of 'text' as a number, in the form
  * {value: 2.3, exact: true}.
  */
-function firstNumericalParse(
-    text: string,
-    strings: PerseusStrings,
-): ParsedValue | null | undefined {
+function firstNumericalParse(text: string): ParsedValue | null | undefined {
     // TODO(alpert): This is sort of hacky...
     let first;
     const val = KhanAnswerTypes.predicate.createValidatorFunctional(


### PR DESCRIPTION
## Summary:
In https://github.com/Khan/perseus/pull/2278 I removed jQuery from code we needed to run on the server. Unfortunately there are some subtle nuances between jQuery and native JS functions.

One of the differences is that `each` can exit the loop early while `forEach` cannot. I happened to trip on some untested code that was banking on that jQuery feature.

Issue: LEMS-2962

## Test plan:
- Go to the [EditorPage in Storybook](https://khan.github.io/perseus/?path=/story/perseuseditor-editorpage--demo)
- Add a NumericInput widget
- In the input labelled "User input:" under "Answers" type "6/8"
- Note the title of the card "Correct answer:"
    - BROKEN: It will say "Correct answer: 6"
    - FIXED: It will say "Correct answer 3/4"