### PR TITLE
Don't export mediaQueries - not used (and shouldn't be) outside of Perseus

### DIFF
--- a/.changeset/new-trains-swim.md
+++ b/.changeset/new-trains-swim.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": major
+---
+
+No longer export 'mediaQueries' object (it is internal-only)

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -69,7 +69,6 @@ export * as Dependencies from "./dependencies";
 export {Log} from "./logging/log";
 export {default as JiptParagraphs} from "./jipt-paragraphs";
 export {default as LoadingContext} from "./loading-context";
-export {default as mediaQueries} from "./styles/media-queries";
 export {default as PerseusMarkdown} from "./perseus-markdown";
 export {traverse} from "./traversal";
 export {isItemRenderableByVersion} from "./renderability";


### PR DESCRIPTION
## Summary:

I noticed in webapp that the Perseus `mediaQueries` object is being used. It was unrelated to Perseus and so I fixed it. But it pointed to the fact that there's no reason for this object to be exported. 

I checked other packages in this repo and none of them use `mediaQueries`, so I'm changing things so that we don't export it anymore; it's an internal thing.

Issue: "none"

## Test plan:

`pnpm typecheck`
Check consuming apps and ensure none use `mediaQueries`