### PR TITLE
Fix parsing of `widgets` field in `PerseusRadioChoice`

### DIFF
--- a/.changeset/calm-avocados-retire.md
+++ b/.changeset/calm-avocados-retire.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+Fix parser for Radio widget options to accept `null` for `PerseusRadioChoice.widgets` and convert it to `undefined`.

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.test.ts
@@ -1,3 +1,4 @@
+import {anySuccess} from "../general-purpose-parsers/test-helpers";
 import {parse} from "../parse";
 import {failure, success} from "../result";
 
@@ -94,5 +95,53 @@ describe("parseRadioWidget", () => {
         };
 
         expect(parse(widget, parseRadioWidget)).toEqual(success(widget));
+    });
+
+    it("accepts `null` for a choice's widgets map in version 0", () => {
+        const widget = {
+            type: "radio",
+            version: {major: 0, minor: 0},
+            options: {
+                choices: [
+                    {
+                        widgets: null,
+                    },
+                ],
+            },
+        };
+
+        expect(parse(widget, parseRadioWidget)).toEqual(anySuccess);
+    });
+
+    it("accepts `null` for a choice's widgets map in version 1", () => {
+        const widget = {
+            type: "radio",
+            version: {major: 1, minor: 0},
+            options: {
+                choices: [
+                    {
+                        widgets: null,
+                    },
+                ],
+            },
+        };
+
+        expect(parse(widget, parseRadioWidget)).toEqual(anySuccess);
+    });
+
+    it("accepts `null` for a choice's widgets map in version 2", () => {
+        const widget = {
+            type: "radio",
+            version: {major: 2, minor: 0},
+            options: {
+                choices: [
+                    {
+                        widgets: null,
+                    },
+                ],
+            },
+        };
+
+        expect(parse(widget, parseRadioWidget)).toEqual(anySuccess);
     });
 });

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.ts
@@ -18,6 +18,14 @@ import {parseWidgetsMap} from "./widgets-map";
 import type {RadioWidget} from "../../data-schema";
 import type {ParsedValue, Parser} from "../parser-types";
 
+const parseWidgetsMapOrUndefined = defaulted(
+    // There is an import cycle between radio-widget.ts and
+    // widgets-map.ts. The anonymous function below ensures that we
+    // don't refer to parseWidgetsMap before it's defined.
+    (rawVal, ctx) => parseWidgetsMap(rawVal, ctx),
+    () => undefined,
+);
+
 const version2 = optional(object({major: constant(2), minor: number}));
 const parseRadioWidgetV2: Parser<RadioWidget> = parseWidgetWithVersion(
     version2,
@@ -31,12 +39,7 @@ const parseRadioWidgetV2: Parser<RadioWidget> = parseWidgetWithVersion(
                 correct: optional(boolean),
                 isNoneOfTheAbove: optional(boolean),
                 // deprecated
-                // There is an import cycle between radio-widget.ts and
-                // widgets-map.ts. The anonymous function below ensures that we
-                // don't refer to parseWidgetsMap before it's defined.
-                widgets: optional((rawVal, ctx) =>
-                    parseWidgetsMap(rawVal, ctx),
-                ),
+                widgets: parseWidgetsMapOrUndefined,
             }),
         ),
         hasNoneOfTheAbove: optional(boolean),
@@ -66,13 +69,7 @@ const parseRadioWidgetV1: Parser<RadioWidget> = parseWidgetWithVersion(
                 correct: optional(boolean),
                 isNoneOfTheAbove: optional(boolean),
                 // deprecated
-                // There is an import cycle between radio-widget.ts and
-                // widgets-map.ts. The anonymous function below ensures that we
-                // don't refer to parseWidgetsMap before it's defined.
-                widgets: defaulted(
-                    (rawVal, ctx) => parseWidgetsMap(rawVal, ctx),
-                    () => undefined,
-                ),
+                widgets: parseWidgetsMapOrUndefined,
             }),
         ),
         hasNoneOfTheAbove: optional(boolean),
@@ -116,12 +113,7 @@ const parseRadioWidgetV0: Parser<RadioWidget> = parseWidgetWithVersion(
                 correct: optional(boolean),
                 isNoneOfTheAbove: optional(boolean),
                 // deprecated
-                // There is an import cycle between radio-widget.ts and
-                // widgets-map.ts. The anonymous function below ensures that we
-                // don't refer to parseWidgetsMap before it's defined.
-                widgets: optional((rawVal, ctx) =>
-                    parseWidgetsMap(rawVal, ctx),
-                ),
+                widgets: parseWidgetsMapOrUndefined,
             }),
         ),
         hasNoneOfTheAbove: optional(boolean),


### PR DESCRIPTION
I noticed Sentry errors related to this. We weren't parsing the `widgets` field
of `PerseusRadioChoice` consistently. The logic was different depending on the
version of the widget options. This PR makes it consistent.

Issue: none

## Test plan:

Sentry errors related to this field should diminish after deploying.