### PR TITLE
Answerless Table

### DIFF
--- a/.changeset/khaki-bikes-care.md
+++ b/.changeset/khaki-bikes-care.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Update the Table widget to allow for rendering answerless data

--- a/packages/perseus/src/util.test.ts
+++ b/packages/perseus/src/util.test.ts
@@ -14,7 +14,7 @@ describe("stringArrayOfSize", () => {
 
 describe("stringArrayOfSize2D", () => {
     it("makes a 2D array of strings", () => {
-        expect(Util.stringArrayOfSize2D(2, 4)).toEqual([
+        expect(Util.stringArrayOfSize2D({rows: 2, columns: 4})).toEqual([
             ["", "", "", ""],
             ["", "", "", ""],
         ]);

--- a/packages/perseus/src/util.test.ts
+++ b/packages/perseus/src/util.test.ts
@@ -5,3 +5,18 @@ describe("firstNumericalParse", () => {
         expect(Util.firstNumericalParse("6/8")).toBe(0.75);
     });
 });
+
+describe("stringArrayOfSize", () => {
+    it("makes an array of strings", () => {
+        expect(Util.stringArrayOfSize(2)).toEqual(["", ""]);
+    });
+});
+
+describe("stringArrayOfSize2D", () => {
+    it("makes a 2D array of strings", () => {
+        expect(Util.stringArrayOfSize2D(2, 4)).toEqual([
+            ["", "", "", ""],
+            ["", "", "", ""],
+        ]);
+    });
+});

--- a/packages/perseus/src/util.ts
+++ b/packages/perseus/src/util.ts
@@ -146,9 +146,15 @@ function firstNumericalParse(text: string): ParsedValue | null | undefined {
 }
 
 function stringArrayOfSize(size: number): ReadonlyArray<string> {
-    return _(size).times(function () {
-        return "";
-    });
+    return Array(size).fill("");
+}
+
+function stringArrayOfSize2D(
+    rows: number,
+    columns: number,
+): ReadonlyArray<ReadonlyArray<string>> {
+    const rowArr = stringArrayOfSize(rows);
+    return rowArr.map(() => stringArrayOfSize(columns));
 }
 
 /**
@@ -593,6 +599,7 @@ const Util = {
     split,
     firstNumericalParse,
     stringArrayOfSize,
+    stringArrayOfSize2D,
     gridDimensionConfig,
     getGridStep,
     snapStepFromGridStep,

--- a/packages/perseus/src/util.ts
+++ b/packages/perseus/src/util.ts
@@ -149,10 +149,11 @@ function stringArrayOfSize(size: number): ReadonlyArray<string> {
     return Array(size).fill("");
 }
 
-function stringArrayOfSize2D(
-    rows: number,
-    columns: number,
-): ReadonlyArray<ReadonlyArray<string>> {
+function stringArrayOfSize2D(opt: {
+    rows: number;
+    columns: number;
+}): ReadonlyArray<ReadonlyArray<string>> {
+    const {rows, columns} = opt;
     const rowArr = stringArrayOfSize(rows);
     return rowArr.map(() => stringArrayOfSize(columns));
 }

--- a/packages/perseus/src/widgets/table/__snapshots__/table.test.tsx.snap
+++ b/packages/perseus/src/widgets/table/__snapshots__/table.test.tsx.snap
@@ -1,0 +1,189 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`table answerful: snapshots 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <table
+            class="perseus-widget-table-of-values non-markdown"
+          >
+            <thead>
+              <tr>
+                <th>
+                  <div
+                    class="perseus-renderer perseus-renderer-responsive"
+                  >
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
+                    >
+                      <div
+                        class="paragraph"
+                      >
+                        Column 1
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th>
+                  <div
+                    class="perseus-renderer perseus-renderer-responsive"
+                  >
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
+                    >
+                      <div
+                        class="paragraph"
+                      >
+                        Column 2
+                      </div>
+                    </div>
+                  </div>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <input
+                    type="text"
+                    value=""
+                  />
+                </td>
+                <td>
+                  <input
+                    type="text"
+                    value=""
+                  />
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <input
+                    type="text"
+                    value=""
+                  />
+                </td>
+                <td>
+                  <input
+                    type="text"
+                    value=""
+                  />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`table answerless: snapshots 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="paragraph"
+      >
+        <div
+          class="perseus-widget-container widget-nohighlight widget-block"
+        >
+          <table
+            class="perseus-widget-table-of-values non-markdown"
+          >
+            <thead>
+              <tr>
+                <th>
+                  <div
+                    class="perseus-renderer perseus-renderer-responsive"
+                  >
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
+                    >
+                      <div
+                        class="paragraph"
+                      >
+                        Column 1
+                      </div>
+                    </div>
+                  </div>
+                </th>
+                <th>
+                  <div
+                    class="perseus-renderer perseus-renderer-responsive"
+                  >
+                    <div
+                      class="paragraph"
+                      data-perseus-paragraph-index="0"
+                    >
+                      <div
+                        class="paragraph"
+                      >
+                        Column 2
+                      </div>
+                    </div>
+                  </div>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <input
+                    type="text"
+                    value=""
+                  />
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <input
+                    type="text"
+                    value=""
+                  />
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <input
+                    type="text"
+                    value=""
+                  />
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <input
+                    type="text"
+                    value=""
+                  />
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/perseus/src/widgets/table/__snapshots__/table.test.tsx.snap
+++ b/packages/perseus/src/widgets/table/__snapshots__/table.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`table answerful: snapshots 1`] = `
+exports[`table answerful vs answerless answerful: snapshots 1`] = `
 <div>
   <div
     class="perseus-renderer perseus-renderer-responsive"
@@ -94,7 +94,7 @@ exports[`table answerful: snapshots 1`] = `
 </div>
 `;
 
-exports[`table answerless: snapshots 1`] = `
+exports[`table answerful vs answerless answerless: snapshots 1`] = `
 <div>
   <div
     class="perseus-renderer perseus-renderer-responsive"

--- a/packages/perseus/src/widgets/table/__snapshots__/table.test.tsx.snap
+++ b/packages/perseus/src/widgets/table/__snapshots__/table.test.tsx.snap
@@ -154,8 +154,6 @@ exports[`table answerless: snapshots 1`] = `
                     value=""
                   />
                 </td>
-              </tr>
-              <tr>
                 <td>
                   <input
                     type="text"
@@ -170,8 +168,6 @@ exports[`table answerless: snapshots 1`] = `
                     value=""
                   />
                 </td>
-              </tr>
-              <tr>
                 <td>
                   <input
                     type="text"

--- a/packages/perseus/src/widgets/table/__snapshots__/table.test.tsx.snap
+++ b/packages/perseus/src/widgets/table/__snapshots__/table.test.tsx.snap
@@ -12,6 +12,8 @@ exports[`table answerful: snapshots 1`] = `
       <div
         class="paragraph"
       >
+        The answer is 42
+
         <div
           class="perseus-widget-container widget-nohighlight widget-block"
         >
@@ -104,6 +106,8 @@ exports[`table answerless: snapshots 1`] = `
       <div
         class="paragraph"
       >
+        The answer is 42
+
         <div
           class="perseus-widget-container widget-nohighlight widget-block"
         >

--- a/packages/perseus/src/widgets/table/table.stories.tsx
+++ b/packages/perseus/src/widgets/table/table.stories.tsx
@@ -1,0 +1,32 @@
+import {ServerItemRendererWithDebugUI} from "../../../../../testing/server-item-renderer-with-debug-ui";
+import {generateTestPerseusItem} from "../../util/test-utils";
+
+import {generateTableRenderer} from "./test-util";
+
+import type {PerseusItem} from "@khanacademy/perseus-core";
+import type {Meta, StoryObj} from "@storybook/react";
+
+const meta: Meta = {
+    title: "Perseus/Widgets/Table",
+    component: ServerItemRendererWithDebugUI,
+};
+export default meta;
+
+type Story = StoryObj<typeof ServerItemRendererWithDebugUI>;
+
+const tableItem: PerseusItem = generateTestPerseusItem({
+    question: generateTableRenderer(),
+});
+
+export const AnswerfulTable: Story = {
+    args: {
+        item: tableItem,
+    },
+};
+
+export const AnswerlessTable: Story = {
+    args: {
+        item: tableItem,
+        startAnswerless: true,
+    },
+};

--- a/packages/perseus/src/widgets/table/table.test.tsx
+++ b/packages/perseus/src/widgets/table/table.test.tsx
@@ -102,5 +102,22 @@ describe("table", () => {
 
             expect(score).toHaveBeenAnsweredCorrectly();
         });
+
+        it(`${optionsMode}: returns user input in correct order`, async () => {
+            const {renderer} = renderQuestion(renderItem.question);
+
+            const inputs = screen.getAllByRole("textbox");
+            for (let i = 0; i < 4; i++) {
+                await userEvent.type(inputs[i], `${i}`);
+            }
+
+            const userInput = renderer.getUserInputMap();
+            expect(userInput).toEqual({
+                "table 1": [
+                    ["0", "1"],
+                    ["2", "3"],
+                ],
+            });
+        });
     });
 });

--- a/packages/perseus/src/widgets/table/table.test.tsx
+++ b/packages/perseus/src/widgets/table/table.test.tsx
@@ -28,10 +28,10 @@ describe("table", () => {
         });
     });
 
-    [
+    describe.each([
         {optionsMode: "answerful", renderItem: getFullItem()},
         {optionsMode: "answerless", renderItem: getSplitItem()},
-    ].forEach(({optionsMode, renderItem}) => {
+    ])("answerful vs answerless", ({optionsMode, renderItem}) => {
         it(`${optionsMode}: renders`, () => {
             renderQuestion(renderItem.question);
 

--- a/packages/perseus/src/widgets/table/table.test.tsx
+++ b/packages/perseus/src/widgets/table/table.test.tsx
@@ -1,8 +1,4 @@
-import {
-    splitPerseusItem,
-    type PerseusItem,
-    type PerseusRenderer,
-} from "@khanacademy/perseus-core";
+import {splitPerseusItem, type PerseusItem} from "@khanacademy/perseus-core";
 import {scorePerseusItem} from "@khanacademy/perseus-score";
 import {screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
@@ -10,32 +6,9 @@ import {userEvent as userEventLib} from "@testing-library/user-event";
 import {generateTestPerseusItem} from "../../util/test-utils";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
+import {generateTableRenderer} from "./test-util";
+
 import type {UserEvent} from "@testing-library/user-event";
-
-function generateTableRenderer(
-    extend: Partial<PerseusRenderer> = {},
-): PerseusRenderer {
-    const base: PerseusRenderer = {
-        content: "[[☃ table 1]]",
-        widgets: {
-            "table 1": {
-                type: "table",
-                options: {
-                    headers: ["Column 1", "Column 2"],
-                    rows: 2,
-                    columns: 2,
-                    answers: [
-                        ["42", "42"],
-                        ["42", "42"],
-                    ],
-                },
-            },
-        },
-        images: {},
-    };
-
-    return {...base, ...extend};
-}
 
 function getFullItem(): PerseusItem {
     return generateTestPerseusItem({question: generateTableRenderer()});

--- a/packages/perseus/src/widgets/table/table.tsx
+++ b/packages/perseus/src/widgets/table/table.tsx
@@ -74,6 +74,8 @@ function getRefForPath(path: Path): string {
 class Table extends React.Component<Props> implements Widget {
     static contextType = PerseusI18nContext;
     declare context: React.ContextType<typeof PerseusI18nContext>;
+    headerRefs: Record<string, any> = {};
+    answerRefs: Record<string, any> = {};
 
     static defaultProps: DefaultProps = (function () {
         const defaultRows = 4;
@@ -108,8 +110,7 @@ class Table extends React.Component<Props> implements Widget {
     }
 
     getUserInput(): PerseusTableUserInput {
-        const cloned = this._getAnswersClone();
-        return cloned as PerseusTableUserInput;
+        return this._getAnswersClone();
     }
 
     onValueChange(row: number, column: number, eventOrValue: any): void {
@@ -151,10 +152,8 @@ class Table extends React.Component<Props> implements Widget {
 
     focusInputPath(path: FocusPath): void {
         const inputID = getRefForPath(path as Path);
-        // eslint-disable-next-line react/no-string-refs
-        const inputComponent = this.refs[inputID];
+        const inputComponent = this.answerRefs[inputID];
         if (this.props.apiOptions.customKeypad) {
-            // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'ReactInstance'.
             inputComponent.focus();
         } else {
             // @ts-expect-error - TS2531 - Object is possibly 'null'. | TS2339 - Property 'focus' does not exist on type 'Element | Text'.
@@ -164,10 +163,8 @@ class Table extends React.Component<Props> implements Widget {
 
     blurInputPath(path: FocusPath): void {
         const inputID = getRefForPath(path as Path);
-        // eslint-disable-next-line react/no-string-refs
-        const inputComponent = this.refs[inputID];
+        const inputComponent = this.answerRefs[inputID];
         if (this.props.apiOptions.customKeypad) {
-            // @ts-expect-error - TS2339 - Property 'blur' does not exist on type 'ReactInstance'.
             inputComponent.blur();
         } else {
             // @ts-expect-error - TS2531 - Object is possibly 'null'. | TS2339 - Property 'blur' does not exist on type 'Element | Text'.
@@ -179,8 +176,8 @@ class Table extends React.Component<Props> implements Widget {
         path: FocusPath,
     ): ReturnType<typeof ReactDOM.findDOMNode> {
         const inputID = getRefForPath(path as Path);
-        // eslint-disable-next-line react/no-string-refs
-        return ReactDOM.findDOMNode(this.refs[inputID]);
+        const inputRef = this.answerRefs[inputID];
+        return ReactDOM.findDOMNode(inputRef);
     }
 
     getInputPaths(): ReadonlyArray<ReadonlyArray<string>> {
@@ -239,7 +236,11 @@ class Table extends React.Component<Props> implements Widget {
                                 return (
                                     <th key={i}>
                                         <this.props.Editor
-                                            ref={"columnHeader" + i}
+                                            ref={(ref) => {
+                                                this.headerRefs[
+                                                    "columnHeader" + i
+                                                ] = ref;
+                                            }}
                                             apiOptions={this.props.apiOptions}
                                             content={header}
                                             widgetEnabled={false}
@@ -270,9 +271,13 @@ class Table extends React.Component<Props> implements Widget {
                                     return (
                                         <td key={c}>
                                             <InputComponent
-                                                ref={getRefForPath(
-                                                    getInputPath(r, c),
-                                                )}
+                                                ref={(ref) => {
+                                                    this.answerRefs[
+                                                        getRefForPath(
+                                                            getInputPath(r, c),
+                                                        )
+                                                    ] = ref;
+                                                }}
                                                 type="text"
                                                 value={answer}
                                                 disabled={

--- a/packages/perseus/src/widgets/table/table.tsx
+++ b/packages/perseus/src/widgets/table/table.tsx
@@ -304,8 +304,8 @@ class Table extends React.Component<Props> implements Widget {
 
 const propTransform: (arg1: any) => any = (editorProps) => {
     // Remove answers before passing to widget
-    const rows = editorProps.answers.length;
-    const columns = editorProps.answers[0].length;
+    const rows = editorProps.rows;
+    const columns = editorProps.columns;
     const blankAnswers = _(rows).times(function () {
         return Util.stringArrayOfSize(columns);
     });

--- a/packages/perseus/src/widgets/table/table.tsx
+++ b/packages/perseus/src/widgets/table/table.tsx
@@ -80,10 +80,10 @@ class Table extends React.Component<Props> implements Widget {
     static defaultProps: DefaultProps = (function () {
         const defaultRows = 4;
         const defaultColumns = 1;
-        const blankAnswers = Util.stringArrayOfSize2D(
-            defaultRows,
-            defaultColumns,
-        );
+        const blankAnswers = Util.stringArrayOfSize2D({
+            rows: defaultRows,
+            columns: defaultColumns,
+        });
         return {
             apiOptions: ApiOptions.defaults,
             headers: [""],
@@ -316,7 +316,7 @@ function propTransform(options: Props): RenderProps {
     // Remove answers before passing to widget
     const rows = options.rows;
     const columns = options.columns;
-    const blankAnswers = Util.stringArrayOfSize2D(rows, columns);
+    const blankAnswers = Util.stringArrayOfSize2D({rows, columns});
     return {
         ...options,
         answers: blankAnswers,

--- a/packages/perseus/src/widgets/table/test-util.ts
+++ b/packages/perseus/src/widgets/table/test-util.ts
@@ -1,0 +1,26 @@
+import type {PerseusRenderer} from "@khanacademy/perseus-core";
+
+export function generateTableRenderer(
+    extend: Partial<PerseusRenderer> = {},
+): PerseusRenderer {
+    const base: PerseusRenderer = {
+        content: "The answer is 42\n[[☃ table 1]]",
+        widgets: {
+            "table 1": {
+                type: "table",
+                options: {
+                    headers: ["Column 1", "Column 2"],
+                    rows: 2,
+                    columns: 2,
+                    answers: [
+                        ["42", "42"],
+                        ["42", "42"],
+                    ],
+                },
+            },
+        },
+        images: {},
+    };
+
+    return {...base, ...extend};
+}


### PR DESCRIPTION
## Summary:
I probably could have kept cleaning this widget up, but...
- Table is `hidden`
- This display name for Table is: "Table (deprecated - use markdown table instead)"
- I did more than what I needed for SSS

The only thing it was really using `PerseusTableWidgetOptions.answers` for was to determine the number of rows/columns, but `PerseusTableWidgetOptions` has `rows: number` and `columns: number` so I just used those. Before switching things over however, I wrote some unit tests for current behavior and then made sure those tests passed with answerless data.

Issue: LEMS-2982