### PR TITLE
When parsing Perseus JSON, optionalize object properties that can be undefined

### DIFF
--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -213,11 +213,11 @@ export type PerseusItem = {
      * The version of the item.
      * @deprecated Not used.
      */
-    itemDataVersion: any;
+    itemDataVersion?: any;
     /**
      * @deprecated Superseded by per-widget answers.
      */
-    answer: any;
+    answer?: any;
 };
 
 /**
@@ -401,7 +401,7 @@ export type DeprecatedStandinWidget = WidgetOptions<'deprecated-standin', object
  */
 export type PerseusImageBackground = {
     // The URL of the image
-    url: string | null | undefined;
+    url?: string | null;
     // The width of the image
     width?: number;
     // The height of the image
@@ -1252,7 +1252,7 @@ export type PerseusNumericInputAnswer = {
     strict: boolean;
     // A range of error +/- the value
     // NOTE: perseus_data.go says this is non-nullable even though we handle null values.
-    maxError: number | null | undefined;
+    maxError?: number | null;
     // Unsimplified answers are Ungraded, Accepted, or Wrong.
     simplify: PerseusNumericInputSimplify;
 };
@@ -1267,21 +1267,21 @@ export type PerseusNumberLineWidgetOptions = {
     // Show label ticks
     labelTicks: boolean;
     // Show tick controller
-    isTickCtrl?: boolean | null | undefined;
+    isTickCtrl?: boolean | null;
     // The range of divisions within the line
     divisionRange: ReadonlyArray<number>;
     // This controls the number (and position) of the tick marks. The number of divisions is constrained to the division range. Note:  The user will be able to specify the number of divisions in a number input.
-    numDivisions: number | null | undefined;
+    numDivisions?: number | null;
     // This determines the number of different places the point will snap between two adjacent tick marks. Note: Ensure the required number of snap increments is provided to answer the question.
     snapDivisions: number;
     // This controls the number (and position) of the tick marks; you can either set the number of divisions (2 divisions would split the entire range in two halves), or the tick step (the distance between ticks) and the other value will be updated accordingly. Note:  There is no check to see if labels coordinate with the tick marks, which may be confusing for users if the blue labels and black ticks are off-step.
-    tickStep: number | null | undefined;
+    tickStep?: number | null;
     // The correct relative value. default: "eq". options: "eq", "lt", "gt", "le", "ge"
-    correctRel: string | null | undefined;
+    correctRel?: string | null;
     // This is the correct answer. The answer is validated (as right or wrong) by using only the end position of the point and the relation (=, &lt;, &gt;, ≤, ≥).
     correctX: number | null;
     // This controls the initial position of the point along the number line
-    initialX: number | null | undefined;
+    initialX?: number | null;
     // Show tooltips
     showTooltips?: boolean;
     // When true, the answer is displayed and is immutable
@@ -1344,7 +1344,7 @@ export type PerseusPlotterWidgetOptions = {
     // The scale of the Y Axis
     scaleY: number;
     // Which ticks to display the labels for. For instance, setting this to "4" will only show every 4th label (plus the last one)
-    labelInterval: number | null | undefined;
+    labelInterval?: number | null;
     // Creates the specified number of divisions between the horizontal lines. Fewer snaps between lines makes the graph easier for the student to create correctly.
     snapsPerLine: number;
     // The Y values the graph should start with
@@ -1352,11 +1352,11 @@ export type PerseusPlotterWidgetOptions = {
     // The Y values that represent the correct answer expected
     correct: ReadonlyArray<number>;
     // A picture to represent items in a graph.
-    picUrl: string | null | undefined;
+    picUrl?: string | null;
     // deprecated
-    picSize: number | null | undefined;
+    picSize?: number | null;
     // deprecated
-    picBoxHeight: number | null | undefined;
+    picBoxHeight?: number | null;
     // deprecated
     plotDimensions: ReadonlyArray<number>;
 };

--- a/packages/perseus-core/src/parse-perseus-json/general-purpose-parsers/object-types.ts
+++ b/packages/perseus-core/src/parse-perseus-json/general-purpose-parsers/object-types.ts
@@ -1,0 +1,17 @@
+/**
+ * These types were inspired by:
+ * - https://stackoverflow.com/questions/56863875/typescript-how-do-you-filter-a-types-properties-to-those-of-a-certain-type
+ *   (public domain)
+ * - https://github.com/ianstormtaylor/superstruct/blob/e414c8afd3b69f6bc0173b8ee25f71d8e5694f01/src/utils.ts
+ *   (MIT license)
+ */
+
+export type OptionalizeProperties<T extends object> = Omit<
+    T,
+    OptionalKeysOf<T>
+> &
+    Partial<Pick<T, OptionalKeysOf<T>>>;
+
+export type OptionalKeysOf<T extends object> = {
+    [K in keyof T]-?: undefined extends T[K] ? K : never;
+}[keyof T];

--- a/packages/perseus-core/src/parse-perseus-json/general-purpose-parsers/object-types.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/general-purpose-parsers/object-types.typetest.ts
@@ -1,0 +1,78 @@
+import {summon} from "./test-helpers";
+
+import type {OptionalizeProperties, OptionalKeysOf} from "./object-types";
+
+/**
+ * Test: `ObjectWithOptionalProperties` optionalizes properties that can be
+ * undefined
+ */
+
+type obj = {
+    opt1?: string;
+    opt2: number | undefined;
+    req1: string;
+    req2: number;
+};
+
+type expected = {
+    opt1?: string;
+    opt2?: number;
+    req1: string;
+    req2: number;
+};
+
+summon<OptionalizeProperties<obj>>() satisfies expected;
+summon<expected>() satisfies OptionalizeProperties<obj>;
+
+/**
+ * Test: `OptionalKeysOf` returns no keys given an empty object type.
+ */
+
+type noKeys = object;
+
+summon<OptionalKeysOf<noKeys>>() satisfies never;
+
+/**
+ * Test: `OptionalKeysOf` returns all keys when none are required
+ */
+
+type abc = {a?: 1; b?: 1; c?: 1};
+
+summon<OptionalKeysOf<abc>>() satisfies "a" | "b" | "c";
+summon<"a" | "b" | "c">() satisfies OptionalKeysOf<abc>;
+
+/**
+ * Test: `OptionalKeysOf` returns no keys when all are required.
+ */
+
+type allRequired = {a: 1; b: 1; c: 1};
+
+summon<OptionalKeysOf<allRequired>>() satisfies never;
+
+/**
+ * Test: `OptionalKeysOf` treats keys as optional if they can be `undefined`
+ */
+
+type aMayBeUndefined = {a: 1 | undefined};
+
+summon<OptionalKeysOf<aMayBeUndefined>>() satisfies "a";
+summon<"a">() satisfies OptionalKeysOf<aMayBeUndefined>;
+
+/**
+ * Test: `OptionalKeysOf` does NOT treat keys as optional if they can be `null`
+ * but not `undefined`.
+ */
+
+type aMayBeNull = {a: 1 | null};
+
+summon<OptionalKeysOf<aMayBeNull>>() satisfies never;
+
+/**
+ * Test: `OptionalKeysOf` gets the right set of keys when an object contains
+ * both required and optional properties.
+ */
+
+type aAndBOptional = {a?: 1; b?: 1; c: 1};
+
+summon<OptionalKeysOf<aAndBOptional>>() satisfies "a" | "b";
+summon<"a" | "b">() satisfies OptionalKeysOf<aAndBOptional>;

--- a/packages/perseus-core/src/parse-perseus-json/general-purpose-parsers/object.ts
+++ b/packages/perseus-core/src/parse-perseus-json/general-purpose-parsers/object.ts
@@ -2,13 +2,20 @@ import {failure, isSuccess} from "../result";
 
 import {isObject} from "./is-object";
 
+import type {OptionalizeProperties} from "./object-types";
 import type {Mismatch, ParsedValue, Parser} from "../parser-types";
 
 type ObjectSchema = Record<keyof any, Parser<any>>;
 
-export function object<S extends ObjectSchema>(
+export function objectWithAllPropertiesRequired<S extends ObjectSchema>(
     schema: S,
 ): Parser<{[K in keyof S]: ParsedValue<S[K]>}> {
+    return object(schema) as any;
+}
+
+export function object<S extends ObjectSchema>(
+    schema: S,
+): Parser<OptionalizeProperties<{[K in keyof S]: ParsedValue<S[K]>}>> {
     return (rawValue, ctx) => {
         if (!isObject(rawValue)) {
             return ctx.failure("object", rawValue);

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.ts
@@ -3,6 +3,7 @@ import {
     nullable,
     number,
     object,
+    objectWithAllPropertiesRequired,
     optional,
     string,
 } from "../general-purpose-parsers";
@@ -10,11 +11,11 @@ import {
 import type {WidgetOptions} from "../../data-schema";
 import type {Parser} from "../parser-types";
 
-export function parseWidget<Type extends string, Options>(
+export function parseWidget<Type extends string, Options extends object>(
     parseType: Parser<Type>,
     parseOptions: Parser<Options>,
 ): Parser<WidgetOptions<Type, Options>> {
-    return object({
+    return objectWithAllPropertiesRequired({
         type: parseType,
         static: optional(boolean),
         graded: optional(boolean),
@@ -33,13 +34,13 @@ export function parseWidget<Type extends string, Options>(
 export function parseWidgetWithVersion<
     Version extends {major: number; minor: number} | undefined,
     Type extends string,
-    Options,
+    Options extends object,
 >(
     parseVersion: Parser<Version>,
     parseType: Parser<Type>,
     parseOptions: Parser<Options>,
 ): Parser<WidgetOptions<Type, Options>> {
-    return object({
+    return objectWithAllPropertiesRequired({
         type: parseType,
         static: optional(boolean),
         graded: optional(boolean),


### PR DESCRIPTION
## Summary:
Previously, it was not possible for the return types of our parsers to have
optional properties, like `{foo?: string}`. This meant that the data-schema types
that used that syntax were not mutually assignable with the types inferred from their parser.

E.g. if you have a parser like this:

```ts
const foo = object({foo: optional(string)});
```

The type `ParsedValue<typeof foo>` is equivalent to `{foo: string |
undefined}`. It is assignable to `{foo?: string}`, but `{foo?: string}`
is not assignable to `ParsedValue<typeof foo>`.

This lack of mutual assignability made it hard to write robust typetests for
the parsers, which in turn made it hard to ensure that parsers would be kept
up to date when changes were made to data-schema.

For example, consider the case of adding a variant to a union type in data-schema.

```ts
type MyUnion = "a" | "b" | "new-variant";
```

Suppose the parser for this type looks like this:

```ts
const parseMyUnion = enumeration("a", "b");
```

You won't get any type errors after adding `"new-variant"` to the type, because
`"a" | "b"` is assignable to `"a" | "b" | "new-variant"`. Yet the parser will
reject `"new-variant"`, which is certainly not what you want. In order to catch
this bug statically, you need typetests that ensure the data-schema types can
be assigned to the parser return types.

This PR takes a first step toward making that possible, by standardizing on the
syntax `{foo?: T}` for optional properties, rather than `{foo: T | undefined}`.

Issue: LEMS-3048

## Test plan:

`pnpm tsc`