### PR TITLE
Remove readonly types from data-schema.ts

### DIFF
--- a/.changeset/bright-guests-march.md
+++ b/.changeset/bright-guests-march.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": major
+---
+
+Remove ReadonlyArray types from `@khanacademy/perseus-core` in favor of mutable arrays. Users should define separate readonly types if desired.

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -56,8 +56,8 @@ export type ShowSolutions = "all" | "selected" | "none";
  *
  * ```
  * interface DummyRegistry {
- *     categorizer: { categories: ReadonlyArray<string> };
- *     dropdown: { choices: ReadonlyArray<string> }:
+ *     categorizer: { categories: string[] };
+ *     dropdown: { choices: string[] }:
  * }
  * ```
  *
@@ -71,8 +71,8 @@ export type ShowSolutions = "all" | "selected" | "none";
  *
  * ```
  * type DummyMap = {
- *     `categorizer ${number}`: { categories: ReadonlyArray<string> };
- *     `dropdown ${number}`: { choices: ReadonlyArray<string> };
+ *     `categorizer ${number}`: { categories: string[] };
+ *     `dropdown ${number}`: { choices: string[] };
  * }
  * ```
  *
@@ -206,7 +206,7 @@ export type PerseusItem = {
     // The details of the question being asked to the user.
     question: PerseusRenderer;
     // A collection of hints to be offered to the user that support answering the question.
-    hints: ReadonlyArray<Hint>;
+    hints: Hint[];
     // Details about the tools the user might need to answer the question
     answerArea: PerseusAnswerArea | null | undefined;
 };
@@ -215,7 +215,7 @@ export type PerseusItem = {
  * A "PerseusArticle" is an item that is meant to be rendered as an article.
  * This item is never scored and is rendered by the `ArticleRenderer`.
  */
-export type PerseusArticle = PerseusRenderer | ReadonlyArray<PerseusRenderer>;
+export type PerseusArticle = PerseusRenderer | PerseusRenderer[];
 
 export type Version = {
     // The major part of the version
@@ -427,15 +427,15 @@ export type AxisLabelLocation = "onAxis" | "alongEdge";
 
 export type PerseusCategorizerWidgetOptions = {
     // Translatable text; a list of items to categorize. e.g. ["banana", "yellow", "apple", "purple", "shirt"]
-    items: ReadonlyArray<string>;
+    items: string[];
     // Translatable text; a list of categories. e.g. ["fruits", "colors", "clothing"]
-    categories: ReadonlyArray<string>;
+    categories: string[];
     // Whether the items should be randemized
     randomizeItems: boolean;
     // Whether this widget is displayed with the results and immutable
     static: boolean;
     // The correct answers where index relates to the items and value relates to the category.  e.g. [0, 1, 0, 1, 2]
-    values: ReadonlyArray<number>;
+    values: number[];
     // Whether we should highlight i18n linter errors found on this widget
     highlightLint?: boolean;
     // Internal editor configuration. Can be ignored by consumers.
@@ -444,8 +444,8 @@ export type PerseusCategorizerWidgetOptions = {
 
 export type PerseusLinterContext = {
     contentType: string;
-    paths: ReadonlyArray<string>;
-    stack: ReadonlyArray<string>;
+    paths: string[];
+    stack: string[];
 };
 
 export type PerseusDefinitionWidgetOptions = {
@@ -459,7 +459,7 @@ export type PerseusDefinitionWidgetOptions = {
 
 export type PerseusDropdownWidgetOptions = {
     // A list of choices for the dropdown
-    choices: ReadonlyArray<PerseusDropdownChoice>;
+    choices: PerseusDropdownChoice[];
     // Translatable Text; placeholder text for a dropdown. e.g. "Please select a fruit"
     placeholder: string;
     // Always false.  Not used for this widget
@@ -490,7 +490,7 @@ export type PerseusExplanationWidgetOptions = {
     static: boolean;
 };
 
-export type LegacyButtonSets = ReadonlyArray<
+export type LegacyButtonSets = Array<
     | "basic"
     | "basic+div"
     | "trig"
@@ -503,16 +503,16 @@ export type LegacyButtonSets = ReadonlyArray<
 
 export type PerseusExpressionWidgetOptions = {
     // The expression forms the answer may come in
-    answerForms: ReadonlyArray<PerseusExpressionAnswerForm>;
+    answerForms: PerseusExpressionAnswerForm[];
     buttonSets: LegacyButtonSets;
     // Variables that can be used as functions.  Default: ["f", "g", "h"]
-    functions: ReadonlyArray<string>;
+    functions: string[];
     // Use x for rendering multiplication instead of a center dot.
     times: boolean;
     // What extra keys need to be displayed on the keypad so that the
     // question can be answerable without a keyboard (ie mobile)
-    // TODO: this is really ReadonlyArray<Key>
-    extraKeys?: ReadonlyArray<KeypadKey>;
+    // TODO: this is really Key[]
+    extraKeys?: KeypadKey[];
     // visible label associated with the MathQuill field
     visibleLabel?: string;
     // aria label for screen readers attached to MathQuill field
@@ -567,7 +567,7 @@ export type PerseusGradedGroupWidgetOptions = {
 
 export type PerseusGradedGroupSetWidgetOptions = {
     // A list of Widget Groups
-    gradedGroups: ReadonlyArray<PerseusGradedGroupWidgetOptions>;
+    gradedGroups: PerseusGradedGroupWidgetOptions[];
 };
 
 // 2D range: xMin, xMax, yMin, yMax
@@ -633,7 +633,7 @@ export type GrapherAnswerTypes =
       };
 
 export type PerseusGrapherWidgetOptions = {
-    availableTypes: ReadonlyArray<
+    availableTypes: Array<
         | "absolute_value"
         | "exponential"
         | "linear"
@@ -653,9 +653,7 @@ export type PerseusGrapherWidgetOptions = {
             width?: number;
         };
         box?: [number, number];
-        editableSettings?: ReadonlyArray<
-            "graph" | "snap" | "image" | "measure"
-        >;
+        editableSettings?: Array<"graph" | "snap" | "image" | "measure">;
         gridStep?: [number, number];
         labels: [string, string];
         markings: MarkingsType;
@@ -690,7 +688,7 @@ export type PerseusImageWidgetOptions = {
     static?: boolean;
     // A list of labels to display on the image
     // NOTE: perseus_data.go says this is required even though it isn't necessary.
-    labels?: ReadonlyArray<PerseusImageLabel>;
+    labels?: Array<PerseusImageLabel>;
     // The range on the image render for labels
     // NOTE: perseus_data.go says this is required even though it isn't necessary.
     range?: [Interval, Interval];
@@ -705,7 +703,7 @@ export type PerseusImageLabel = {
     // The visual alignment of the label. default: "center"
     alignment: string;
     // The point on the image to display the label
-    coordinates: ReadonlyArray<number>;
+    coordinates: number[];
 };
 
 export type PerseusInteractiveGraphWidgetOptions = {
@@ -726,7 +724,7 @@ export type PerseusInteractiveGraphWidgetOptions = {
      */
     markings: MarkingsType;
     // How to label the X and Y axis.  default: ["x", "y"]
-    labels?: ReadonlyArray<string>;
+    labels?: string[];
     /**
      * Specifies the location of the labels on the graph.  default: "onAxis".
      * - "onAxis": Labels are positioned on the axis at the right (x) and top (y) of the graph.
@@ -773,7 +771,7 @@ export type PerseusInteractiveGraphWidgetOptions = {
     correct: PerseusGraphType;
     // Shapes (points, chords, etc) displayed on the graph that cannot
     // be moved by the user.
-    lockedFigures?: ReadonlyArray<LockedFigure>;
+    lockedFigures?: LockedFigure[];
     // Aria label that applies to the entire graph.
     fullGraphAriaLabel?: string;
     // Aria description that applies to the entire graph.
@@ -865,7 +863,7 @@ export type LockedEllipseType = {
 
 export type LockedPolygonType = {
     type: "polygon";
-    points: ReadonlyArray<Coord>;
+    points: Coord[];
     color: LockedFigureColor;
     showVertices: boolean;
     fillStyle: LockedFigureFillType;
@@ -978,9 +976,9 @@ export type PerseusGraphTypePoint = {
     type: "point";
     // The number of points if a "point" type.  default: 1.  "unlimited" if no limit
     numPoints?: number | "unlimited";
-    coords?: ReadonlyArray<Coord> | null;
+    coords?: Coord[] | null;
     // The initial coordinates the graph renders with.
-    startCoords?: ReadonlyArray<Coord>;
+    startCoords?: Coord[];
 } & PerseusGraphTypeCommon;
 
 export type PerseusGraphTypePolygon = {
@@ -995,9 +993,9 @@ export type PerseusGraphTypePolygon = {
     snapTo?: "grid" | "angles" | "sides";
     // How to match the answer. If missing, defaults to exact matching.
     match?: "similar" | "congruent" | "approx" | "exact";
-    coords?: ReadonlyArray<Coord> | null;
+    coords?: Coord[] | null;
     // The initial coordinates the graph renders with.
-    startCoords?: ReadonlyArray<Coord>;
+    startCoords?: Coord[];
 } & PerseusGraphTypeCommon;
 
 export type PerseusGraphTypeQuadratic = {
@@ -1021,9 +1019,9 @@ export type PerseusGraphTypeSegment = {
 export type PerseusGraphTypeSinusoid = {
     type: "sinusoid";
     // Expects a list of 2 Coords
-    coords?: ReadonlyArray<Coord> | null;
+    coords?: Coord[] | null;
     // The initial coordinates the graph renders with.
-    startCoords?: ReadonlyArray<Coord>;
+    startCoords?: Coord[];
 } & PerseusGraphTypeCommon;
 
 export type PerseusGraphTypeRay = {
@@ -1063,13 +1061,13 @@ type NoneGraphCorrect = {
 
 type PointGraphCorrect = {
     type: "point";
-    coords: ReadonlyArray<Coord>;
+    coords: Coord[];
 };
 
 type PolygonGraphCorrect = {
     type: "polygon";
     match: "similar" | "congruent" | "approx";
-    coords: ReadonlyArray<Coord>;
+    coords: Coord[];
 };
 
 type QuadraticGraphCorrect = {
@@ -1107,7 +1105,7 @@ export type PerseusGraphCorrectType =
 
 export type PerseusLabelImageWidgetOptions = {
     // Translatable Text; Tex representation of choices
-    choices: ReadonlyArray<string>;
+    choices: string[];
     // The URL of the image
     imageUrl: string;
     // Translatable Text; To show up in the img.alt attribute
@@ -1117,7 +1115,7 @@ export type PerseusLabelImageWidgetOptions = {
     // The width of the image
     imageWidth: number;
     // A list of markers to display on the image
-    markers: ReadonlyArray<PerseusLabelImageMarker>;
+    markers: PerseusLabelImageMarker[];
     // Do not display answer choices in instructions
     hideChoicesFromInstructions: boolean;
     // Allow multiple answers per marker
@@ -1128,7 +1126,7 @@ export type PerseusLabelImageWidgetOptions = {
 
 export type PerseusLabelImageMarker = {
     // A list of correct answers for this marker.  Often only one but can have multiple
-    answers: ReadonlyArray<string>;
+    answers: string[];
     // Translatable Text; The text to show for the marker. Not displayed directly to the user
     label: string;
     // X Coordiate location of the marker on the image
@@ -1139,18 +1137,18 @@ export type PerseusLabelImageMarker = {
 
 export type PerseusMatcherWidgetOptions = {
     // Translatable Text; Labels to adorn the headings for the columns.  Only 2 values [left, right]. e.g. ["Concepts", "Things"]
-    labels: ReadonlyArray<string>;
+    labels: string[];
     // Translatable Text; Static concepts to show in the left column. e.g. ["Fruit", "Color", "Clothes"]
-    left: ReadonlyArray<string>;
+    left: string[];
     // Translatable Markup; Values that represent the concepts to be correlated with the concepts.  e.g. ["Red", "Shirt", "Banana"]
-    right: ReadonlyArray<string>;
+    right: string[];
     // Order of the matched pairs matters. With this option enabled, only the order provided above will be treated as correct. This is useful when ordering is significant, such as in the context of a proof. If disabled, pairwise matching is sufficient. To make this clear, the left column becomes fixed in the provided order and only the cards in the right column can be moved.
     orderMatters: boolean;
     // Adds padding to the rows.  Padding is good for text, but not needed for images.
     padding: boolean;
 };
 
-export type PerseusMatrixWidgetAnswers = ReadonlyArray<ReadonlyArray<number>>;
+export type PerseusMatrixWidgetAnswers = number[][];
 export type PerseusMatrixWidgetOptions = {
     // Translatable Text; Shown before the matrix
     prefix?: string | undefined;
@@ -1159,9 +1157,9 @@ export type PerseusMatrixWidgetOptions = {
     // A data matrix representing the "correct" answers to be entered into the matrix
     answers: PerseusMatrixWidgetAnswers;
     // The coordinate location of the cursor position at start. default: [0, 0]
-    cursorPosition?: ReadonlyArray<number> | undefined;
+    cursorPosition?: number[] | undefined;
     // The coordinate size of the matrix.  Only supports 2-dimensional matrix.  default: [3, 3]
-    matrixBoardSize: ReadonlyArray<number>;
+    matrixBoardSize: number[];
     // Whether this is meant to statically display the answers (true) or be used as an input field, graded against the answers
     static?: boolean | undefined;
 };
@@ -1214,7 +1212,7 @@ export type PerseusNumericInputSimplify = "required" | "enforced" | "optional";
 
 export type PerseusNumericInputWidgetOptions = {
     // A list of all the possible correct and incorrect answers
-    answers: ReadonlyArray<PerseusNumericInputAnswer>;
+    answers: PerseusNumericInputAnswer[];
     // Translatable Text; Text to describe this input. This will be shown to users using screenreaders.
     labelText?: string | undefined;
     // Use size "Normal" for all text boxes, unless there are multiple text boxes in one line and the answer area is too narrow to fit them. Options: "normal" or "small"
@@ -1237,7 +1235,7 @@ export type PerseusNumericInputAnswer = {
     status: string;
     // The forms available for this answer.  Options: "integer, ""decimal", "proper", "improper", "mixed", or "pi"
     // NOTE: perseus_data.go says this is required even though it isn't necessary.
-    answerForms?: ReadonlyArray<MathFormat>;
+    answerForms?: MathFormat[];
     // Whether we should check the answer strictly against the the configured answerForms (strict = true)
     // or include the set of default answerForms (strict = false).
     strict: boolean;
@@ -1250,9 +1248,9 @@ export type PerseusNumericInputAnswer = {
 
 export type PerseusNumberLineWidgetOptions = {
     // The position of the endpoints of the number line. Setting the range constrains the position of the answer and the labels.
-    range: ReadonlyArray<number>;
+    range: number[];
     // This controls the position of the left / right labels. By default, the labels are set by the range.  Note:  Ensure that the labels line up with the tick marks, or it may be confusing for users.
-    labelRange: ReadonlyArray<number | null>;
+    labelRange: Array<number | null>;
     // This controls the styling of the labels for the two main labels as well as all the tick mark labels, if applicable. Options: "decimal", "improper", "mixed", "non-reduced"
     labelStyle: string;
     // Show label ticks
@@ -1260,7 +1258,7 @@ export type PerseusNumberLineWidgetOptions = {
     // Show tick controller
     isTickCtrl?: boolean | null;
     // The range of divisions within the line
-    divisionRange: ReadonlyArray<number>;
+    divisionRange: number[];
     // This controls the number (and position) of the tick marks. The number of divisions is constrained to the division range. Note:  The user will be able to specify the number of divisions in a number input.
     numDivisions?: number | null;
     // This determines the number of different places the point will snap between two adjacent tick marks. Note: Ensure the required number of snap increments is provided to answer the question.
@@ -1281,11 +1279,11 @@ export type PerseusNumberLineWidgetOptions = {
 
 export type PerseusOrdererWidgetOptions = {
     // All of the options available to the user. Place the cards in the correct order. The same card can be used more than once in the answer but will only be displayed once at the top of a stack of identical cards.
-    options: ReadonlyArray<PerseusRenderer>;
+    options: PerseusRenderer[];
     // The correct order of the options
-    correctOptions: ReadonlyArray<PerseusRenderer>;
+    correctOptions: PerseusRenderer[];
     // Cards that are not part of the answer
-    otherOptions: ReadonlyArray<PerseusRenderer>;
+    otherOptions: PerseusRenderer[];
     // "normal" for text options.  "auto" for image options.
     height: "normal" | "auto";
     // Use the "horizontal" layout for short text and small images. The "vertical" layout is best for longer text (e.g. proofs).
@@ -1325,9 +1323,9 @@ export type PlotType = (typeof plotterPlotTypes)[number];
 
 export type PerseusPlotterWidgetOptions = {
     // Translatable Text; The Axis labels. e.g. ["X Label", "Y Label"]
-    labels: ReadonlyArray<string>;
+    labels: string[];
     // Translatable Text; Categories to display along the X access.  e.g. [">0", ">6", ">12", ">18"]
-    categories: ReadonlyArray<string>;
+    categories: string[];
     // The type of the graph. options "bar", "line", "pic", "histogram", "dotplot"
     type: PlotType;
     // The maximimum Y tick to display in the graph
@@ -1339,9 +1337,9 @@ export type PerseusPlotterWidgetOptions = {
     // Creates the specified number of divisions between the horizontal lines. Fewer snaps between lines makes the graph easier for the student to create correctly.
     snapsPerLine: number;
     // The Y values the graph should start with
-    starting: ReadonlyArray<number>;
+    starting: number[];
     // The Y values that represent the correct answer expected
-    correct: ReadonlyArray<number>;
+    correct: number[];
     // A picture to represent items in a graph.
     picUrl?: string | null;
     // deprecated
@@ -1349,12 +1347,12 @@ export type PerseusPlotterWidgetOptions = {
     // deprecated
     picBoxHeight?: number | null;
     // deprecated
-    plotDimensions: ReadonlyArray<number>;
+    plotDimensions: number[];
 };
 
 export type PerseusRadioWidgetOptions = {
     // The choices provided to the user.
-    choices: ReadonlyArray<PerseusRadioChoice>;
+    choices: PerseusRadioChoice[];
     // Does this have a "none of the above" option?
     // NOTE: perseus_data.go says this is required even though it isn't necessary.
     hasNoneOfTheAbove?: boolean;
@@ -1403,7 +1401,7 @@ export type PerseusRadioChoice = {
 
 export type PerseusSorterWidgetOptions = {
     // Translatable Text; The correct answer (in the correct order). The user will see the cards in a randomized order.
-    correct: ReadonlyArray<string>;
+    correct: string[];
     // Adds padding to the options.  Padding is good for text but not needed for images
     padding: boolean;
     // Use the "horizontal" layout for short text and small images. The "vertical" layout is best for longer text and larger images.
@@ -1412,31 +1410,31 @@ export type PerseusSorterWidgetOptions = {
 
 export type PerseusTableWidgetOptions = {
     // Translatable Text; A list of column headers
-    headers: ReadonlyArray<string>;
+    headers: string[];
     // The number of rows to display
     rows: number;
     // The number of columns to display
     columns: number;
     // Translatable Text; A 2-dimensional array of text to populate the table with
-    answers: ReadonlyArray<ReadonlyArray<string>>;
+    answers: string[][];
 };
 
 export type PerseusInteractionWidgetOptions = {
     // The definition of the graph
     graph: PerseusInteractionGraph;
     // The elements of the graph
-    elements: ReadonlyArray<PerseusInteractionElement>;
+    elements: PerseusInteractionElement[];
     // Always false.  Not used for this widget
     static: boolean;
 };
 
 export type PerseusInteractionGraph = {
     // "canvas", "graph"
-    editableSettings?: ReadonlyArray<"canvas" | "graph">;
+    editableSettings?: Array<"canvas" | "graph">;
     // The Grid Canvas size. e.g. [400, 140]
     box: Size;
     // The Axis labels.  e.g. ["x", "y"]
-    labels: ReadonlyArray<string>;
+    labels: string[];
     // The Axis ranges. e.g. [[-10, 10], [-10, 10]]
     range: [Interval, Interval];
     // The steps in the grid. default [1, 1]
@@ -1661,7 +1659,7 @@ export type PerseusCSProgramWidgetOptions = {
     // Deprecated.  Always null and sometimes omitted entirely.
     programType?: any;
     // Settings that you add here are available to the program as an object returned by Program.settings()
-    settings: ReadonlyArray<PerseusCSProgramSetting>;
+    settings: PerseusCSProgramSetting[];
     // If you show the editor, you should use the "full-width" alignment to make room for the width of the editor.
     showEditor: boolean;
     // Whether to show the execute buttons
@@ -1691,7 +1689,7 @@ export type PerseusIFrameWidgetOptions = {
     // A URL to display OR a CS Program ID
     url: string;
     // Settings that you add here are available to the program as an object returned by Program.settings()
-    settings?: ReadonlyArray<PerseusCSProgramSetting>;
+    settings?: PerseusCSProgramSetting[];
     // The width of the widget
     width: number | string;
     // The height of the widget

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -6,6 +6,7 @@ export type {
     InteractiveMarkerType,
     Relationship,
     Alignment,
+    RecursiveReadonly,
 } from "./types";
 export type {
     KeypadKey,

--- a/packages/perseus-core/src/keypad.ts
+++ b/packages/perseus-core/src/keypad.ts
@@ -115,7 +115,7 @@ export type KeypadType = "FRACTION" | "EXPRESSION";
 
 export type KeypadConfiguration = {
     keypadType: KeypadType;
-    extraKeys?: ReadonlyArray<KeypadKey>;
+    extraKeys?: KeypadKey[];
     times?: boolean;
     scientific?: boolean;
 };

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/legacy-button-sets.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/legacy-button-sets.ts
@@ -1,6 +1,8 @@
 import {array, enumeration} from "../general-purpose-parsers";
 import {defaulted} from "../general-purpose-parsers/defaulted";
 
+import type {LegacyButtonSets} from "../../data-schema";
+
 export const parseLegacyButtonSet = enumeration(
     "basic",
     "basic+div",
@@ -17,5 +19,5 @@ export const parseLegacyButtonSets = defaulted(
     // NOTE(benchristel): I copied the default buttonSets from
     // expression.tsx. See the parse-perseus-json/README.md for
     // an explanation of why we want to duplicate the default here.
-    () => ["basic", "trig", "prealgebra", "logarithms"] as const,
+    (): LegacyButtonSets => ["basic", "trig", "prealgebra", "logarithms"],
 );

--- a/packages/perseus-core/src/types.ts
+++ b/packages/perseus-core/src/types.ts
@@ -26,7 +26,7 @@ export type KEScore = {
 // Base marker, with the props that are set by the editor.
 export type MarkerType = {
     // The list of correct answers expected for the marker.
-    answers: ReadonlyArray<string>;
+    answers: string[];
     // The marker title or description.
     label: string;
     // The marker coordinates on the question image as percent of image size.
@@ -37,7 +37,7 @@ export type MarkerType = {
 // Additional props that are set when user interacts with the marker.
 export type InteractiveMarkerType = MarkerType & {
     // The user selected list of answers, used to grade the question.
-    selected?: ReadonlyArray<string>;
+    selected?: string[];
     // Reveal the correctness state of the user selected answers for the marker.
     showCorrectness?: "correct" | "incorrect";
     focused?: boolean;

--- a/packages/perseus-core/src/types.ts
+++ b/packages/perseus-core/src/types.ts
@@ -55,3 +55,7 @@ export type Alignment =
     | "float-left"
     | "float-right"
     | "full-width";
+
+export type RecursiveReadonly<T> = {
+    readonly [K in keyof T]: RecursiveReadonly<T[K]>;
+};

--- a/packages/perseus-core/src/utils/random-util.ts
+++ b/packages/perseus-core/src/utils/random-util.ts
@@ -29,9 +29,9 @@ export function shuffle<T>(
     array: ReadonlyArray<T>,
     randomSeed: number | RNG,
     ensurePermuted = false,
-): ReadonlyArray<T> {
+): T[] {
     // Always return a copy of the input array
-    const shuffled = _.clone(array);
+    const shuffled = [...array];
 
     // Handle edge cases (input array is empty or uniform)
     if (
@@ -57,9 +57,7 @@ export function shuffle<T>(
             const newEnd = Math.floor(random() * top);
             const temp = shuffled[newEnd];
 
-            // @ts-expect-error - TS2542 - Index signature in type 'readonly T[]' only permits reading.
             shuffled[newEnd] = shuffled[top - 1];
-            // @ts-expect-error - TS2542 - Index signature in type 'readonly T[]' only permits reading.
             shuffled[top - 1] = temp;
         }
     } while (ensurePermuted && _.isEqual(array, shuffled));

--- a/packages/perseus-core/src/validation.types.ts
+++ b/packages/perseus-core/src/validation.types.ts
@@ -82,7 +82,7 @@ export type UserInputStatus = "correct" | "incorrect" | "incomplete";
 export type PerseusCategorizerRubric = {
     // The correct answers where index relates to the items and value relates
     // to the category.  e.g. [0, 1, 0, 1, 2]
-    values: ReadonlyArray<number>;
+    values: number[];
 } & PerseusCategorizerValidationData;
 
 export type PerseusCategorizerUserInput = {
@@ -91,7 +91,7 @@ export type PerseusCategorizerUserInput = {
 
 export type PerseusCategorizerValidationData = {
     // Translatable text; a list of items to categorize. e.g. ["banana", "yellow", "apple", "purple", "shirt"]
-    items: ReadonlyArray<string>;
+    items: string[];
 };
 
 export type PerseusCSProgramUserInput = {
@@ -100,7 +100,7 @@ export type PerseusCSProgramUserInput = {
 };
 
 export type PerseusDropdownRubric = {
-    choices: ReadonlyArray<PerseusDropdownChoice>;
+    choices: Array<PerseusDropdownChoice>;
 };
 
 export type PerseusDropdownUserInput = {
@@ -108,8 +108,8 @@ export type PerseusDropdownUserInput = {
 };
 
 export type PerseusExpressionRubric = {
-    answerForms: ReadonlyArray<PerseusExpressionAnswerForm>;
-    functions: ReadonlyArray<string>;
+    answerForms: Array<PerseusExpressionAnswerForm>;
+    functions: string[];
 };
 
 export type PerseusExpressionUserInput = string;
@@ -162,29 +162,29 @@ export type PerseusInteractiveGraphRubric = {
 export type PerseusInteractiveGraphUserInput = PerseusGraphType;
 
 export type PerseusLabelImageRubric = {
-    markers: ReadonlyArray<{
-        answers: ReadonlyArray<string>;
+    markers: Array<{
+        answers: string[];
         label: string;
     }>;
 };
 
 export type PerseusLabelImageUserInput = {
-    markers: ReadonlyArray<{
-        selected?: ReadonlyArray<string>;
+    markers: Array<{
+        selected?: string[];
         label: string;
     }>;
 };
 
 export type PerseusMatcherRubric = {
     // Translatable Text; Static concepts to show in the left column. e.g. ["Fruit", "Color", "Clothes"]
-    left: ReadonlyArray<string>;
+    left: string[];
     // Translatable Markup; Values that represent the concepts to be correlated with the concepts.  e.g. ["Red", "Shirt", "Banana"]
-    right: ReadonlyArray<string>;
+    right: string[];
 };
 
 export type PerseusMatcherUserInput = {
-    left: ReadonlyArray<string>;
-    right: ReadonlyArray<string>;
+    left: string[];
+    right: string[];
 };
 
 export type PerseusMatrixRubric = {
@@ -201,7 +201,7 @@ export type PerseusMatrixUserInput = {
 export type PerseusNumberLineRubric = {
     correctRel: string | null | undefined;
     correctX: number;
-    range: ReadonlyArray<number>;
+    range: number[];
     initialX: number | null | undefined;
     isInequality: boolean;
 };
@@ -211,12 +211,12 @@ export type PerseusNumberLineUserInput = {
     numLinePosition: number;
     rel: Relationship | "eq";
     numDivisions: number;
-    divisionRange: ReadonlyArray<number>;
+    divisionRange: number[];
 };
 
 export type PerseusNumericInputRubric = {
     // A list of all the possible correct and incorrect answers
-    answers: ReadonlyArray<PerseusNumericInputAnswer>;
+    answers: PerseusNumericInputAnswer[];
     // A coefficient style number allows the student to use - for -1 and an empty string to mean 1.
     coefficient: boolean;
 };
@@ -228,46 +228,46 @@ export type PerseusNumericInputUserInput = {
 export type PerseusOrdererRubric = PerseusOrdererWidgetOptions;
 
 export type PerseusOrdererUserInput = {
-    current: ReadonlyArray<string>;
+    current: string[];
 };
 
 export type PerseusPlotterRubric = {
     // The Y values that represent the correct answer expected
-    correct: ReadonlyArray<number>;
+    correct: number[];
 } & PerseusPlotterValidationData;
 
 export type PerseusPlotterValidationData = {
     // The Y values the graph should start with
-    starting: ReadonlyArray<number>;
+    starting: number[];
 };
 
-export type PerseusPlotterUserInput = ReadonlyArray<number>;
+export type PerseusPlotterUserInput = number[];
 
 export type PerseusRadioRubric = {
     // The choices provided to the user.
-    choices: ReadonlyArray<PerseusRadioChoice>;
+    choices: PerseusRadioChoice[];
 };
 
 export type PerseusRadioUserInput = {
-    choicesSelected: ReadonlyArray<boolean>;
+    choicesSelected: boolean[];
 };
 
 export type PerseusSorterRubric = {
     // Translatable Text; The correct answer (in the correct order). The user will see the cards in a randomized order.
-    correct: ReadonlyArray<string>;
+    correct: string[];
 };
 
 export type PerseusSorterUserInput = {
-    options: ReadonlyArray<string>;
+    options: string[];
     changed: boolean;
 };
 
 export type PerseusTableRubric = {
     // Translatable Text; A 2-dimensional array of text to populate the table with
-    answers: ReadonlyArray<ReadonlyArray<string>>;
+    answers: string[][];
 };
 
-export type PerseusTableUserInput = ReadonlyArray<ReadonlyArray<string>>;
+export type PerseusTableUserInput = string[][];
 
 export interface RubricRegistry {
     categorizer: PerseusCategorizerRubric;
@@ -352,7 +352,7 @@ export type UserInputMap = MakeWidgetMap<UserInputRegistry>;
 /**
  * deprecated prefer using UserInputMap
  */
-export type UserInputArray = ReadonlyArray<
+export type UserInputArray = Array<
     UserInputArray | UserInput | null | undefined
 >;
 

--- a/packages/perseus-core/src/widgets/expression/derive-extra-keys.ts
+++ b/packages/perseus-core/src/widgets/expression/derive-extra-keys.ts
@@ -16,12 +16,12 @@ function deriveExtraKeys(
     widgetOptions: PerseusExpressionWidgetOptions,
 ): KeypadConfiguration["extraKeys"] {
     if (widgetOptions.extraKeys) {
-        return widgetOptions.extraKeys as ReadonlyArray<KeypadKey>;
+        return widgetOptions.extraKeys;
     }
 
     // If there are no extra symbols available, we include Pi anyway, so
     // that the "extra symbols" button doesn't appear empty.
-    const defaultKeys: ReadonlyArray<KeypadKey> = ["PI"];
+    const defaultKeys: KeypadKey[] = ["PI"];
 
     if (widgetOptions.answerForms == null) {
         return defaultKeys;

--- a/packages/perseus-core/src/widgets/matcher/matcher-util.ts
+++ b/packages/perseus-core/src/widgets/matcher/matcher-util.ts
@@ -38,8 +38,8 @@ export const shuffleMatcher = (
 
 // TODO(LEMS-2841): Can shorten to shuffleMatcher after above function removed
 function shuffleMatcherWithRandom(data: MatcherShuffleInfo): {
-    left: ReadonlyArray<string>;
-    right: ReadonlyArray<string>;
+    left: string[];
+    right: string[];
 } {
     // Use the same random() function to shuffle both columns sequentially
     let left;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-point.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-point.tsx
@@ -10,8 +10,8 @@ import CoordinatePairInput from "../../../components/coordinate-pair-input";
 import type {Coord} from "@khanacademy/perseus";
 
 type Props = {
-    startCoords: ReadonlyArray<Coord>;
-    onChange: (startCoords: ReadonlyArray<Coord>) => void;
+    startCoords: Coord[];
+    onChange: (startCoords: Coord[]) => void;
 };
 
 const StartCoordsPoint = (props: Props) => {

--- a/packages/perseus-editor/src/widgets/label-image-editor.tsx
+++ b/packages/perseus-editor/src/widgets/label-image-editor.tsx
@@ -25,7 +25,7 @@ import type {
 
 type Props = {
     // List of answer choices to label question image with.
-    choices: ReadonlyArray<string>;
+    choices: string[];
     // The question image properties.
     imageAlt: string;
     imageUrl: string;

--- a/packages/perseus-editor/src/widgets/label-image/marker.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/marker.tsx
@@ -162,8 +162,6 @@ export default class Marker extends React.Component<Props, State> {
 
                             <OptionGroup
                                 onSelected={this.handleSelectAnswer}
-                                // TODO(WB-1096): make selectedValues immutable in wonder-blocks
-                                // @ts-expect-error - TS2769 - No overload matches this call.
                                 selectedValues={answers}
                             >
                                 {choices.map((choice) => (

--- a/packages/perseus-editor/src/widgets/label-image/question-markers.tsx
+++ b/packages/perseus-editor/src/widgets/label-image/question-markers.tsx
@@ -15,7 +15,7 @@ import type {PerseusLabelImageWidgetOptions} from "@khanacademy/perseus-core";
 
 type Props = {
     // The list of possible answers in a specific order.
-    choices: ReadonlyArray<string>;
+    choices: string[];
     // The question image properties.
     imageUrl: string;
     imageWidth: number;

--- a/packages/perseus-editor/src/widgets/radio/editor.tsx
+++ b/packages/perseus-editor/src/widgets/radio/editor.tsx
@@ -101,7 +101,7 @@ class ChoiceEditor extends React.Component<ChoiceEditorProps> {
 type RadioEditorProps = {
     apiOptions: APIOptions;
     countChoices: boolean;
-    choices: ReadonlyArray<PerseusRadioChoice>;
+    choices: PerseusRadioChoice[];
     displayCount: number;
     randomize: boolean;
     hasNoneOfTheAbove: boolean;

--- a/packages/perseus-score/src/widgets/categorizer/score-categorizer.test.ts
+++ b/packages/perseus-score/src/widgets/categorizer/score-categorizer.test.ts
@@ -11,7 +11,7 @@ describe("scoreCategorizer", () => {
 
         const userInput = {
             values: [1, 3],
-        } as const;
+        };
         const score = scoreCategorizer(userInput, rubric);
 
         expect(score).toHaveBeenAnsweredCorrectly();
@@ -25,7 +25,7 @@ describe("scoreCategorizer", () => {
 
         const userInput = {
             values: [2, 3],
-        } as const;
+        };
         const score = scoreCategorizer(userInput, rubric);
 
         expect(score).toHaveBeenAnsweredIncorrectly();

--- a/packages/perseus-score/src/widgets/categorizer/validate-categorizer.test.ts
+++ b/packages/perseus-score/src/widgets/categorizer/validate-categorizer.test.ts
@@ -10,7 +10,7 @@ describe("validateCategorizer", () => {
 
         const userInput = {
             values: [2],
-        } as const;
+        };
         const score = validateCategorizer(userInput, validationData);
 
         expect(score).toHaveInvalidInput("INVALID_SELECTION_ERROR");
@@ -23,7 +23,7 @@ describe("validateCategorizer", () => {
 
         const userInput = {
             values: [2, 4],
-        } as const;
+        };
         const score = validateCategorizer(userInput, validationData);
 
         expect(score).toBeNull();

--- a/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.ts
@@ -168,8 +168,9 @@ function scoreInteractiveGraph(
             // eq() comparison but _.isEqual(0, -0) is false, so we'll use
             // eq() anyway. The sort should be fine because it'll stringify
             // it and -0 converted to a string is "0"
+            // TODO(benchristel): once we drop support for Safari 15, use
+            // toSorted here to avoid mutating the input arrays!
             guess?.sort();
-            // @ts-expect-error - TS2339 - Property 'sort' does not exist on type 'readonly Coord[]'.
             correct.sort();
             if (approximateDeepEqual(guess, correct)) {
                 return {

--- a/packages/perseus-score/src/widgets/label-image/score-label-image.test.ts
+++ b/packages/perseus-score/src/widgets/label-image/score-label-image.test.ts
@@ -73,7 +73,7 @@ describe("scoreLabelImage", function () {
                     selected: ["Ferrari"],
                 },
             ],
-        } as const;
+        };
 
         const rubric = {
             markers: [
@@ -90,7 +90,7 @@ describe("scoreLabelImage", function () {
                     answers: [],
                 },
             ],
-        } as const;
+        };
 
         const score = scoreLabelImage(userInput, rubric);
 
@@ -113,7 +113,7 @@ describe("scoreLabelImage", function () {
                     selected: ["Ferrari"],
                 },
             ],
-        } as const;
+        };
 
         const rubric = {
             markers: [
@@ -130,7 +130,7 @@ describe("scoreLabelImage", function () {
                     answers: ["Lamborghini", "Fiat", "Ferrari"],
                 },
             ],
-        } as const;
+        };
 
         const score = scoreLabelImage(userInput, rubric);
 
@@ -153,7 +153,7 @@ describe("scoreLabelImage", function () {
                     selected: ["Lamborghini", "Fiat", "Ferrari"],
                 },
             ],
-        } as const;
+        };
 
         const rubric = {
             markers: [
@@ -170,7 +170,7 @@ describe("scoreLabelImage", function () {
                     answers: ["Lamborghini", "Fiat", "Ferrari"],
                 },
             ],
-        } as const;
+        };
 
         const score = scoreLabelImage(userInput, rubric);
 

--- a/packages/perseus-score/src/widgets/label-image/validate-label-image.test.ts
+++ b/packages/perseus-score/src/widgets/label-image/validate-label-image.test.ts
@@ -6,7 +6,7 @@ describe("scoreLabelImage", () => {
     it("should not grade non-interacted widget", function () {
         const userInput: PerseusLabelImageUserInput = {
             markers: [{label: "England"}, {label: "Germany"}, {label: "Italy"}],
-        } as const;
+        };
 
         const validationError = validateLabelImage(userInput);
 
@@ -14,13 +14,13 @@ describe("scoreLabelImage", () => {
     });
 
     it("should not grade widget with not all markers answered", function () {
-        const userInput = {
+        const userInput: PerseusLabelImageUserInput = {
             markers: [
                 {label: "England", selected: ["Fiat"]},
                 {label: "Germany", selected: ["Lamborghini"]},
                 {label: "Italy"},
             ],
-        } as const;
+        };
 
         const validationError = validateLabelImage(userInput);
 

--- a/packages/perseus-score/src/widgets/radio/score-radio.ts
+++ b/packages/perseus-score/src/widgets/radio/score-radio.ts
@@ -4,6 +4,7 @@ import type {
     PerseusRadioRubric,
     PerseusRadioUserInput,
     PerseusScore,
+    RecursiveReadonly,
 } from "@khanacademy/perseus-core";
 
 function scoreRadio(

--- a/packages/perseus-score/src/widgets/radio/score-radio.ts
+++ b/packages/perseus-score/src/widgets/radio/score-radio.ts
@@ -7,8 +7,8 @@ import type {
 } from "@khanacademy/perseus-core";
 
 function scoreRadio(
-    userInput: PerseusRadioUserInput,
-    rubric: PerseusRadioRubric,
+    userInput: RecursiveReadonly<PerseusRadioUserInput>,
+    rubric: RecursiveReadonly<PerseusRadioRubric>,
 ): PerseusScore {
     const numSelected = userInput.choicesSelected.reduce((sum, selected) => {
         return sum + (selected ? 1 : 0);

--- a/packages/perseus/src/__testdata__/article-renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/article-renderer.testdata.ts
@@ -87,7 +87,7 @@ export const articleSectionWithExpression: PerseusRenderer = {
     },
 };
 
-export const multiSectionArticle: ReadonlyArray<PerseusRenderer> = [
+export const multiSectionArticle: PerseusRenderer[] = [
     {
         content:
             "## What is a matrix?\n\nA matrix is a rectangular array of numbers arranged in rows and columns.\n\nMatrices can be useful for organizing and manipulating data. They can also be used as a tool to help solve systems of equations.",
@@ -126,90 +126,89 @@ export const multiSectionArticle: ReadonlyArray<PerseusRenderer> = [
     },
 ];
 
-export const multiSectionArticleWithExpression: ReadonlyArray<PerseusRenderer> =
-    [
-        {
-            content:
-                "### Practice Problem\n\n$8\\cdot(11i+2)=$ [[☃ expression 1]]  \n*Your answer should be a complex number in the form $a+bi$ where $a$ and $b$ are real numbers.*",
-            images: {},
-            widgets: {
-                "expression 1": {
-                    alignment: "default",
-                    graded: true,
-                    options: {
-                        answerForms: [
-                            {
-                                considered: "correct",
-                                form: true,
-                                simplify: false,
-                                value: "16+88i",
-                            },
-                        ],
-                        buttonSets: ["basic"],
-                        functions: ["f", "g", "h"],
-                        times: false,
-                    },
-                    static: false,
-                    type: "expression",
-                    version: {major: 1, minor: 0},
+export const multiSectionArticleWithExpression: PerseusRenderer[] = [
+    {
+        content:
+            "### Practice Problem\n\n$8\\cdot(11i+2)=$ [[☃ expression 1]]  \n*Your answer should be a complex number in the form $a+bi$ where $a$ and $b$ are real numbers.*",
+        images: {},
+        widgets: {
+            "expression 1": {
+                alignment: "default",
+                graded: true,
+                options: {
+                    answerForms: [
+                        {
+                            considered: "correct",
+                            form: true,
+                            simplify: false,
+                            value: "16+88i",
+                        },
+                    ],
+                    buttonSets: ["basic"],
+                    functions: ["f", "g", "h"],
+                    times: false,
                 },
+                static: false,
+                type: "expression",
+                version: {major: 1, minor: 0},
             },
         },
-        {
-            content:
-                "### Practice Problem\n\n$8\\cdot(11i+2)=$ [[☃ expression 2]]  \n*Your answer should be a complex number in the form $a+bi$ where $a$ and $b$ are real numbers.*",
-            images: {},
-            widgets: {
-                "expression 2": {
-                    alignment: "default",
-                    graded: true,
-                    options: {
-                        answerForms: [
-                            {
-                                considered: "correct",
-                                form: true,
-                                simplify: false,
-                                value: "16+88i",
-                            },
-                        ],
-                        buttonSets: ["basic"],
-                        functions: ["f", "g", "h"],
-                        times: false,
-                    },
-                    static: false,
-                    type: "expression",
-                    version: {major: 1, minor: 0},
+    },
+    {
+        content:
+            "### Practice Problem\n\n$8\\cdot(11i+2)=$ [[☃ expression 2]]  \n*Your answer should be a complex number in the form $a+bi$ where $a$ and $b$ are real numbers.*",
+        images: {},
+        widgets: {
+            "expression 2": {
+                alignment: "default",
+                graded: true,
+                options: {
+                    answerForms: [
+                        {
+                            considered: "correct",
+                            form: true,
+                            simplify: false,
+                            value: "16+88i",
+                        },
+                    ],
+                    buttonSets: ["basic"],
+                    functions: ["f", "g", "h"],
+                    times: false,
                 },
+                static: false,
+                type: "expression",
+                version: {major: 1, minor: 0},
             },
         },
-        {
-            content:
-                "### Practice Problem\n\n$8\\cdot(11i+2)=$ [[☃ expression 3]]  \n*Your answer should be a complex number in the form $a+bi$ where $a$ and $b$ are real numbers.*",
-            images: {},
-            widgets: {
-                "expression 3": {
-                    alignment: "default",
-                    graded: true,
-                    options: {
-                        answerForms: [
-                            {
-                                considered: "correct",
-                                form: true,
-                                simplify: false,
-                                value: "16+88i",
-                            },
-                        ],
-                        buttonSets: ["basic"],
-                        functions: ["f", "g", "h"],
-                        times: false,
-                    },
-                    static: false,
-                    type: "expression",
-                    version: {major: 1, minor: 0},
+    },
+    {
+        content:
+            "### Practice Problem\n\n$8\\cdot(11i+2)=$ [[☃ expression 3]]  \n*Your answer should be a complex number in the form $a+bi$ where $a$ and $b$ are real numbers.*",
+        images: {},
+        widgets: {
+            "expression 3": {
+                alignment: "default",
+                graded: true,
+                options: {
+                    answerForms: [
+                        {
+                            considered: "correct",
+                            form: true,
+                            simplify: false,
+                            value: "16+88i",
+                        },
+                    ],
+                    buttonSets: ["basic"],
+                    functions: ["f", "g", "h"],
+                    times: false,
                 },
+                static: false,
+                type: "expression",
+                version: {major: 1, minor: 0},
             },
         },
-    ];
+    },
+];
 
 export const articleWithImages: PerseusRenderer = {
     content:

--- a/packages/perseus/src/__tests__/article-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/article-renderer.test.tsx
@@ -17,7 +17,7 @@ import * as Dependencies from "../dependencies";
 import {ApiOptions} from "../perseus-api";
 
 import type {APIOptions} from "../types";
-import type {PerseusRenderer} from "@khanacademy/perseus-core";
+import type {PerseusArticle} from "@khanacademy/perseus-core";
 
 function KeypadWithContext() {
     return (
@@ -38,9 +38,7 @@ function KeypadWithContext() {
 // the ArticleRenderer instead of Renderer
 export const RenderArticle = (
     apiOptions: APIOptions = Object.freeze({}),
-    json:
-        | PerseusRenderer
-        | ReadonlyArray<PerseusRenderer> = articleSectionWithExpression,
+    json: PerseusArticle = articleSectionWithExpression,
 ): {
     container: HTMLElement;
     renderer: ArticleRenderer;

--- a/packages/perseus/src/__tests__/extract-perseus-data.test.ts
+++ b/packages/perseus/src/__tests__/extract-perseus-data.test.ts
@@ -28,7 +28,23 @@ beforeEach(() => {
     stub.mockClear();
 });
 
-import type {RadioWidget, PerseusWidgetsMap} from "@khanacademy/perseus-core";
+import type {
+    RadioWidget,
+    PerseusWidgetsMap,
+    PerseusRenderer,
+    MatcherWidget,
+    MatrixWidget,
+    NumberLineWidget,
+    LabelImageWidget,
+    DropdownWidget,
+    GrapherWidget,
+    SorterWidget,
+    PlotterWidget,
+    GroupWidget,
+    NumericInputWidget,
+    ExpressionWidget,
+    CategorizerWidget,
+} from "@khanacademy/perseus-core";
 
 describe("ExtractPerseusData", () => {
     describe("getAnswersFromWidgets", () => {
@@ -53,7 +69,7 @@ describe("ExtractPerseusData", () => {
         });
 
         it("should get the answers from a radio widget with multiple correct answers", () => {
-            const widget = {
+            const widget: RadioWidget = {
                 type: "radio",
                 options: {
                     choices: [
@@ -71,13 +87,13 @@ describe("ExtractPerseusData", () => {
                         },
                     ],
                 },
-            } as const;
+            };
             const answer = getAnswersFromWidgets({"radio 1": widget});
             expect(answer).toEqual(["choice 1", "choice 2"]);
         });
 
         it("should get the answer from a categorizer widget", () => {
-            const widget = {
+            const widget: CategorizerWidget = {
                 type: "categorizer",
                 options: {
                     static: false,
@@ -86,7 +102,7 @@ describe("ExtractPerseusData", () => {
                     values: [0, 1, 0, 0],
                     randomizeItems: false,
                 },
-            } as const;
+            };
 
             const answer = getAnswersFromWidgets({"categorizer 1": widget});
             expect(answer).toMatchInlineSnapshot(`
@@ -113,7 +129,7 @@ describe("ExtractPerseusData", () => {
         });
 
         it("should get the answer from an expression widget", () => {
-            const widget = {
+            const widget: ExpressionWidget = {
                 type: "expression",
                 options: {
                     answerForms: [
@@ -136,7 +152,7 @@ describe("ExtractPerseusData", () => {
                     functions: ["f", "g", "h"],
                     times: false,
                 },
-            } as const;
+            };
 
             const answer = getAnswersFromWidgets({"expression 1": widget});
             expect(answer).toMatchInlineSnapshot(`
@@ -148,7 +164,7 @@ describe("ExtractPerseusData", () => {
         });
 
         it("should get the answer from a numeric-input widget", () => {
-            const widget = {
+            const widget: NumericInputWidget = {
                 type: "numeric-input",
                 options: {
                     answers: [
@@ -166,13 +182,13 @@ describe("ExtractPerseusData", () => {
                     coefficient: false,
                     static: false,
                 },
-            } as const;
+            };
             const answer = getAnswersFromWidgets({"numeric-input 1": widget});
             expect(answer).toEqual(["42"]);
         });
 
         it("should get the answers from a group widget", () => {
-            const widget = {
+            const widget: GroupWidget = {
                 type: "group",
                 options: {
                     content: "Answer the questions in the following widgets",
@@ -203,13 +219,13 @@ describe("ExtractPerseusData", () => {
                         },
                     },
                 },
-            } as const;
+            };
             const answer = getAnswersFromWidgets({"group 1": widget});
             expect(answer).toEqual(["choice 1", "42"]);
         });
 
         it("should get the answers from a plotter widget", () => {
-            const widget = {
+            const widget: PlotterWidget = {
                 type: "plotter",
                 graded: true,
                 options: {
@@ -234,7 +250,7 @@ describe("ExtractPerseusData", () => {
                     picBoxHeight: null,
                     plotDimensions: [],
                 },
-            } as const;
+            };
 
             const answer = getAnswersFromWidgets({"plotter 1": widget});
             expect(answer).toMatchInlineSnapshot(`
@@ -245,7 +261,7 @@ describe("ExtractPerseusData", () => {
         });
 
         it("should get the answers from a grapher widget", () => {
-            const widget = {
+            const widget: GrapherWidget = {
                 type: "grapher",
                 options: {
                     correct: {
@@ -276,9 +292,8 @@ describe("ExtractPerseusData", () => {
                         showRuler: false,
                     },
                 },
-            } as const;
+            };
 
-            // @ts-expect-error - TS2322 - Type '{ readonly type: "grapher"; readonly options: { readonly correct: { readonly type: "quadratic"; readonly coords: readonly [readonly [-4, -1], readonly [-3, 0]]; }; readonly availableTypes: readonly ["quadratic"]; readonly graph: { readonly editableSettings: readonly [...]; ... 12 more ...; readonly showRuler: false;...' is not assignable to type 'PerseusWidget'.
             const answer = getAnswersFromWidgets({"grapher 1": widget});
             expect(answer).toMatchInlineSnapshot(`
                             [
@@ -288,7 +303,7 @@ describe("ExtractPerseusData", () => {
         });
 
         it("should get the answers from a dropdown widget", () => {
-            const widget = {
+            const widget: DropdownWidget = {
                 type: "dropdown",
                 options: {
                     placeholder: "Select an option",
@@ -305,7 +320,7 @@ describe("ExtractPerseusData", () => {
                         },
                     ],
                 },
-            } as const;
+            };
             const answer = getAnswersFromWidgets({"dropdown 1": widget});
             expect(answer).toEqual(["choice 1"]);
         });
@@ -345,14 +360,14 @@ describe("ExtractPerseusData", () => {
         });
 
         it("should get the answers from an sorter widget", () => {
-            const widget = {
+            const widget: SorterWidget = {
                 type: "sorter",
                 options: {
                     correct: ["$4^2+2$", "$5^2$", "$6^2-6$"],
                     layout: "horizontal",
                     padding: true,
                 },
-            } as const;
+            };
 
             const answer = getAnswersFromWidgets({"sorter 1": widget});
             expect(answer).toMatchInlineSnapshot(`
@@ -363,7 +378,7 @@ describe("ExtractPerseusData", () => {
         });
 
         it("should get the answers from the label-image widget", () => {
-            const widget = {
+            const widget: LabelImageWidget = {
                 type: "label-image",
                 options: {
                     choices: ["answer 1", "answer 2"],
@@ -389,7 +404,7 @@ describe("ExtractPerseusData", () => {
                     multipleAnswers: false,
                     static: false,
                 },
-            } as const;
+            };
 
             const answer = getAnswersFromWidgets({"label-image 1": widget});
             expect(answer).toEqual([
@@ -399,7 +414,7 @@ describe("ExtractPerseusData", () => {
         });
 
         it("should get the answers from the number-line widget", () => {
-            const widget = {
+            const widget: NumberLineWidget = {
                 type: "number-line",
                 options: {
                     correctRel: "eq",
@@ -415,14 +430,14 @@ describe("ExtractPerseusData", () => {
                     static: false,
                     tickStep: 0.5,
                 },
-            } as const;
+            };
 
             const answer = getAnswersFromWidgets({"number-line 1": widget});
             expect(answer).toEqual(["-1.5"]);
         });
 
         it("should get the answers from the matrix widget", () => {
-            const widget = {
+            const widget: MatrixWidget = {
                 type: "matrix",
                 options: {
                     answers: [
@@ -436,14 +451,14 @@ describe("ExtractPerseusData", () => {
                     static: false,
                     suffix: "",
                 },
-            } as const;
+            };
 
             const answer = getAnswersFromWidgets({"matrix 1": widget});
             expect(answer).toEqual(["[-2,22,-29,-16], [1,-4,7,5], [3,4,6,1]"]);
         });
 
         it("should get the answers from the matcher widget", () => {
-            const widget = {
+            const widget: MatcherWidget = {
                 type: "matcher",
                 options: {
                     labels: ["Left", "Right"],
@@ -452,7 +467,7 @@ describe("ExtractPerseusData", () => {
                     padding: true,
                     right: ["1", "2", "3", "4"],
                 },
-            } as const;
+            };
 
             const answer = getAnswersFromWidgets({"matcher 1": widget});
             expect(answer).toEqual([
@@ -522,7 +537,7 @@ describe("ExtractPerseusData", () => {
         });
 
         it("should inject radio widget into the content", () => {
-            const widgets = {
+            const widgets: PerseusWidgetsMap = {
                 "radio 1": {
                     type: "radio",
                     options: {
@@ -538,7 +553,7 @@ describe("ExtractPerseusData", () => {
                         ],
                     },
                 },
-            } as const;
+            };
             const content = injectWidgets(
                 "Content with a radio\n[[☃ radio 1]]",
                 widgets,
@@ -796,7 +811,7 @@ describe("ExtractPerseusData", () => {
         });
 
         it("should inject categorizer widget into the content", () => {
-            const widgets = {
+            const widgets: PerseusWidgetsMap = {
                 "categorizer 1": {
                     type: "categorizer",
                     alignment: "default",
@@ -811,7 +826,7 @@ describe("ExtractPerseusData", () => {
                     },
                     version: {major: 0, minor: 0},
                 },
-            } as const;
+            };
 
             const content = injectWidgets("[[☃ categorizer 1]]", widgets);
             expect(content).toMatchInlineSnapshot(`
@@ -826,31 +841,35 @@ describe("ExtractPerseusData", () => {
         });
 
         it("should inject orderer widget into the content", () => {
-            const widgets = {
+            const blankOption: PerseusRenderer = {
+                content: "",
+                images: {},
+                widgets: {},
+            };
+            const widgets: PerseusWidgetsMap = {
                 "orderer 1": {
                     type: "orderer",
                     options: {
                         height: "normal",
                         layout: "horizontal",
                         correctOptions: [
-                            {content: "$\\sqrt{145}$"},
-                            {content: "$12.1$"},
-                            {content: "$12.2$"},
+                            {...blankOption, content: "$\\sqrt{145}$"},
+                            {...blankOption, content: "$12.1$"},
+                            {...blankOption, content: "$12.2$"},
                         ],
                         options: [
-                            {content: "$12.1$"},
-                            {content: "$12.2$"},
-                            {content: "$\\sqrt{145}$"},
+                            {...blankOption, content: "$12.1$"},
+                            {...blankOption, content: "$12.2$"},
+                            {...blankOption, content: "$\\sqrt{145}$"},
                         ],
                         otherOptions: [],
                     },
                 },
-            } as const;
+            };
 
             // Perseus types think `widgets` and `images` are required on
             // options.options objects, but we have data in production that omits
             // these keys.
-            // @ts-expect-error - TS2345 - Argument of type '{ readonly "orderer 1": { readonly type: "orderer"; readonly options: { readonly height: "normal"; readonly layout: "horizontal"; readonly correctOptions: readonly [{ readonly content: "$\\sqrt{145}$"; }, { readonly content: "$12.1$"; }, { ...; }]; readonly options: readonly [...]; readonly otherOptions: readonly []...' is not assignable to parameter of type '{ [key: string]: PerseusWidget; }'.
             const content = injectWidgets("[[☃ orderer 1]]", widgets);
             expect(content).toMatchInlineSnapshot(`
                 "$12.1$
@@ -860,7 +879,7 @@ describe("ExtractPerseusData", () => {
         });
 
         it("should inject sorter widget into the content", () => {
-            const widgets = {
+            const widgets: PerseusWidgetsMap = {
                 "sorter 1": {
                     type: "sorter",
                     options: {
@@ -869,7 +888,7 @@ describe("ExtractPerseusData", () => {
                         padding: true,
                     },
                 },
-            } as const;
+            };
 
             const content = injectWidgets("[[☃ sorter 1]]", widgets);
             expect(content).toMatchInlineSnapshot(
@@ -878,7 +897,7 @@ describe("ExtractPerseusData", () => {
         });
 
         it("should inject interactive-graph widget into the content", () => {
-            const widgets = {
+            const widgets: PerseusWidgetsMap = {
                 "interactive-graph 1": {
                     type: "interactive-graph",
                     options: {
@@ -914,11 +933,10 @@ describe("ExtractPerseusData", () => {
                         step: [1, 1],
                     },
                 },
-            } as const;
+            };
 
             const content = injectWidgets(
                 "[[☃ interactive-graph 1]]",
-                // @ts-expect-error - TS2345 - Argument of type '{ readonly "interactive-graph 1": { readonly type: "interactive-graph"; readonly options: { readonly correct: { readonly coords: readonly [readonly [7, -7], readonly [5, 4], readonly [-3, 4], readonly [-3, -4]]; readonly numSides: "unlimited"; readonly snapTo: "grid"; readonly type: "polygon"; }; ... 11 more ...; re...' is not assignable to parameter of type '{ [key: string]: PerseusWidget; }'.
                 widgets,
             );
             expect(content).toMatchInlineSnapshot(
@@ -927,7 +945,7 @@ describe("ExtractPerseusData", () => {
         });
 
         it("should inject number-line widget into the content", () => {
-            const widgets = {
+            const widgets: PerseusWidgetsMap = {
                 "number-line 1": {
                     type: "number-line",
                     options: {
@@ -945,7 +963,7 @@ describe("ExtractPerseusData", () => {
                         tickStep: 0.5,
                     },
                 },
-            } as const;
+            };
 
             const content = injectWidgets("[[☃ number-line 1]]", widgets);
             expect(content).toMatchInlineSnapshot(
@@ -954,7 +972,7 @@ describe("ExtractPerseusData", () => {
         });
 
         it("should inject matcher widget into the content", () => {
-            const widgets = {
+            const widgets: PerseusWidgetsMap = {
                 "matcher 1": {
                     type: "matcher",
                     options: {
@@ -965,7 +983,7 @@ describe("ExtractPerseusData", () => {
                         right: ["1", "2", "3", "4"],
                     },
                 },
-            } as const;
+            };
 
             const content = injectWidgets("[[☃ matcher 1]]", widgets);
             expect(content).toMatchInlineSnapshot(`
@@ -980,7 +998,7 @@ describe("ExtractPerseusData", () => {
         });
 
         it("should inject ? placeholder string for input widgets", () => {
-            const widgets = {
+            const widgets: PerseusWidgetsMap = {
                 "numeric-input 1": {
                     type: "numeric-input",
                     options: {
@@ -1025,7 +1043,7 @@ describe("ExtractPerseusData", () => {
                         times: false,
                     },
                 },
-            } as const;
+            };
             const content = injectWidgets(
                 "Enter your numeric-input [[☃ numeric-input 1]], Enter your input-number [[☃ input-number 1]], Enter your expression [[☃ expression 1]]",
                 widgets,

--- a/packages/perseus/src/__tests__/test-items/mock-widget-1-item.ts
+++ b/packages/perseus/src/__tests__/test-items/mock-widget-1-item.ts
@@ -15,5 +15,5 @@ export default {
         },
     },
     answerArea: null,
-    hints: [] as ReadonlyArray<any>,
+    hints: [],
 } satisfies PerseusItem;

--- a/packages/perseus/src/__tests__/test-items/mock-widget-2-item.ts
+++ b/packages/perseus/src/__tests__/test-items/mock-widget-2-item.ts
@@ -22,5 +22,5 @@ export default {
         },
     },
     answerArea: null,
-    hints: [] as ReadonlyArray<any>,
+    hints: [],
 } satisfies PerseusItem;

--- a/packages/perseus/src/util.ts
+++ b/packages/perseus/src/util.ts
@@ -149,10 +149,7 @@ function stringArrayOfSize(size: number): string[] {
     return Array(size).fill("");
 }
 
-function stringArrayOfSize2D(opt: {
-    rows: number;
-    columns: number;
-}): string[][] {
+function stringArrayOfSize2D(opt: {rows: number; columns: number}): string[][] {
     const {rows, columns} = opt;
     const rowArr = stringArrayOfSize(rows);
     return rowArr.map(() => stringArrayOfSize(columns));

--- a/packages/perseus/src/util.ts
+++ b/packages/perseus/src/util.ts
@@ -145,14 +145,14 @@ function firstNumericalParse(text: string): ParsedValue | null | undefined {
     return first;
 }
 
-function stringArrayOfSize(size: number): ReadonlyArray<string> {
+function stringArrayOfSize(size: number): string[] {
     return Array(size).fill("");
 }
 
 function stringArrayOfSize2D(opt: {
     rows: number;
     columns: number;
-}): ReadonlyArray<ReadonlyArray<string>> {
+}): string[][] {
     const {rows, columns} = opt;
     const rowArr = stringArrayOfSize(rows);
     return rowArr.map(() => stringArrayOfSize(columns));

--- a/packages/perseus/src/widget-ai-utils/radio/radio-ai-utils.ts
+++ b/packages/perseus/src/widget-ai-utils/radio/radio-ai-utils.ts
@@ -1,6 +1,8 @@
 import type radio from "../../widgets/radio/radio";
-import type {PerseusRadioUserInput} from "@khanacademy/perseus-core";
-import { render } from "@testing-library/react";
+import type {
+    PerseusRadioUserInput,
+    RecursiveReadonly,
+} from "@khanacademy/perseus-core";
 import type React from "react";
 
 type BasicOption = {

--- a/packages/perseus/src/widget-ai-utils/radio/radio-ai-utils.ts
+++ b/packages/perseus/src/widget-ai-utils/radio/radio-ai-utils.ts
@@ -1,5 +1,6 @@
 import type radio from "../../widgets/radio/radio";
 import type {PerseusRadioUserInput} from "@khanacademy/perseus-core";
+import { render } from "@testing-library/react";
 import type React from "react";
 
 type BasicOption = {
@@ -16,8 +17,8 @@ export type RadioPromptJSON = {
 };
 
 export const getPromptJSON = (
-    renderProps: React.ComponentProps<typeof radio.widget>,
-    userInput: PerseusRadioUserInput,
+    renderProps: RecursiveReadonly<React.ComponentProps<typeof radio.widget>>,
+    userInput: RecursiveReadonly<PerseusRadioUserInput>,
 ): RadioPromptJSON => {
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     const choices = renderProps.choices || [];

--- a/packages/perseus/src/widgets/expression/expression.test.tsx
+++ b/packages/perseus/src/widgets/expression/expression.test.tsx
@@ -1,5 +1,8 @@
 import {it, describe, beforeEach} from "@jest/globals";
-import {splitPerseusItem, generateTestPerseusItem} from "@khanacademy/perseus-core";
+import {
+    splitPerseusItem,
+    generateTestPerseusItem,
+} from "@khanacademy/perseus-core";
 import {scorePerseusItem} from "@khanacademy/perseus-score";
 import {act, screen, waitFor} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";

--- a/packages/perseus/src/widgets/expression/expression.test.tsx
+++ b/packages/perseus/src/widgets/expression/expression.test.tsx
@@ -1,11 +1,5 @@
 import {it, describe, beforeEach} from "@jest/globals";
-import {
-    type PerseusItem,
-    type PerseusExpressionWidgetOptions,
-    type PerseusRenderer,
-    splitPerseusItem,
-    generateTestPerseusItem,
-} from "@khanacademy/perseus-core";
+import {splitPerseusItem, generateTestPerseusItem} from "@khanacademy/perseus-core";
 import {scorePerseusItem} from "@khanacademy/perseus-score";
 import {act, screen, waitFor} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
@@ -27,6 +21,12 @@ import {
     expressionItemWithLabels,
 } from "./expression.testdata";
 
+import type {
+    PerseusItem,
+    PerseusExpressionWidgetOptions,
+    PerseusRenderer,
+    PerseusExpressionRubric,
+} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
 
 const renderAndAnswer = async (
@@ -278,12 +278,10 @@ describe("Expression Widget", function () {
 
         it("should return undefined if rubric.value is null/undefined", () => {
             // Arrange
-            const rubric = {
+            const rubric: PerseusExpressionRubric = {
                 answerForms: [],
-                buttonSets: [],
                 functions: [],
-                times: true,
-            } as const;
+            };
 
             // Act
             const result =
@@ -295,7 +293,7 @@ describe("Expression Widget", function () {
 
         it("returns a correct answer when there is one correct answer", () => {
             // Arrange
-            const rubric = {
+            const rubric: PerseusExpressionRubric = {
                 answerForms: [
                     {
                         value: "123",
@@ -304,10 +302,8 @@ describe("Expression Widget", function () {
                         considered: "correct",
                     },
                 ],
-                buttonSets: [],
                 functions: [],
-                times: true,
-            } as const;
+            };
 
             // Act
             const result =
@@ -319,7 +315,7 @@ describe("Expression Widget", function () {
 
         it("returns the first correct answer when there are multiple correct answers", () => {
             // Arrange
-            const rubric = {
+            const rubric: PerseusExpressionRubric = {
                 answerForms: [
                     {
                         value: "123",
@@ -334,10 +330,8 @@ describe("Expression Widget", function () {
                         considered: "correct",
                     },
                 ],
-                buttonSets: [],
                 functions: [],
-                times: true,
-            } as const;
+            };
 
             // Act
             const result =

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -453,7 +453,7 @@ export default {
         return {
             keypadConfiguration: {
                 keypadType: "EXPRESSION",
-                extraKeys: extraKeys as ReadonlyArray<KeypadKey>,
+                extraKeys,
                 times,
             },
             times,

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.test.ts
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.test.ts
@@ -7,6 +7,7 @@ import {renderQuestion} from "../__testutils__/renderQuestion";
 
 import {article1} from "./graded-group-set.testdata";
 
+import type {PerseusRenderer} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
 
 describe("graded group widget", () => {
@@ -39,7 +40,7 @@ describe("graded group widget", () => {
 
     it("should render error message when no current group", () => {
         // Arrange
-        const articleWithNoGradedGroups = {
+        const articleWithNoGradedGroups: PerseusRenderer = {
             ...article1,
             widgets: {
                 "graded-group-set 1": {
@@ -50,7 +51,7 @@ describe("graded group widget", () => {
                     },
                 },
             },
-        } as const;
+        };
 
         // Act
         renderQuestion(articleWithNoGradedGroups);

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -106,7 +106,7 @@ type RenderProps = {
     /**
      * How to label the X and Y axis.  default: ["x", "y"]
      */
-    labels: ReadonlyArray<string>;
+    labels: string[];
     /**
      * Whether to show the Protractor tool overlaid on top of the graph
      */
@@ -161,7 +161,7 @@ type RenderProps = {
      * Shapes (points, chords, etc) displayed on the graph that cannot be moved
      * by the user.
      */
-    lockedFigures?: ReadonlyArray<LockedFigure>;
+    lockedFigures?: LockedFigure[];
     /**
      * Aria label that applies to the entire graph.
      */
@@ -174,7 +174,7 @@ type RenderProps = {
 type Props = WidgetProps<RenderProps>;
 type State = any;
 type DefaultProps = {
-    labels: ReadonlyArray<string>;
+    labels: string[];
     range: Props["range"];
     step: Props["step"];
     backgroundImage: Props["backgroundImage"];
@@ -202,9 +202,7 @@ type DefaultProps = {
 
 // TODO: there's another, very similar getSinusoidCoefficients function
 // they should probably be merged
-function getSinusoidCoefficients(
-    coords: ReadonlyArray<Coord>,
-): SineCoefficient {
+function getSinusoidCoefficients(coords: Coord[]): SineCoefficient {
     // It's assumed that p1 is the root and p2 is the first peak
     const p1 = coords[0];
     const p2 = coords[1];
@@ -220,9 +218,7 @@ function getSinusoidCoefficients(
 
 // TODO: there's another, very similar getQuadraticCoefficients function
 // they should probably be merged
-function getQuadraticCoefficients(
-    coords: ReadonlyArray<Coord>,
-): QuadraticCoefficient {
+function getQuadraticCoefficients(coords: Coord[]): QuadraticCoefficient {
     const p1 = coords[0];
     const p2 = coords[1];
     const p3 = coords[2];
@@ -311,10 +307,7 @@ class InteractiveGraph extends React.Component<Props, State> {
      * @param {object} graph Like props.graph or props.correct
      * @param {object} props of an InteractiveGraph instance
      */
-    static getLineCoords(
-        graph: PerseusGraphType,
-        props: Props,
-    ): ReadonlyArray<Coord> {
+    static getLineCoords(graph: PerseusGraphType, props: Props): Coord[] {
         return (
             // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'.
             graph.coords ||
@@ -329,10 +322,7 @@ class InteractiveGraph extends React.Component<Props, State> {
      * @param {object} graph Like props.graph or props.correct
      * @param {object} props of an InteractiveGraph instance
      */
-    static getPointCoords(
-        graph: PerseusGraphTypePoint,
-        props: Props,
-    ): ReadonlyArray<Coord> {
+    static getPointCoords(graph: PerseusGraphTypePoint, props: Props): Coord[] {
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         const numPoints = graph.numPoints || 1;
         let coords = graph.coords;
@@ -408,7 +398,7 @@ class InteractiveGraph extends React.Component<Props, State> {
     static getLinearSystemCoords(
         graph: PerseusGraphType,
         props: Props,
-    ): ReadonlyArray<ReadonlyArray<Coord>> {
+    ): Coord[][] {
         return (
             // The callers assume that we're return an array of points
             // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'.
@@ -423,9 +413,8 @@ class InteractiveGraph extends React.Component<Props, State> {
                         [0.25, 0.25],
                         [0.75, 0.25],
                     ],
-                ],
+                ] as Coord[][],
                 (coords) => {
-                    // @ts-expect-error - TS2345 - Argument of type 'number[][]' is not assignable to parameter of type 'readonly Coord[]'.
                     return InteractiveGraph.pointsFromNormalized(props, coords);
                 },
             )
@@ -436,10 +425,7 @@ class InteractiveGraph extends React.Component<Props, State> {
      * @param {object} graph Like props.graph or props.correct
      * @param {object} props of an InteractiveGraph instance
      */
-    static getPolygonCoords(
-        graph: PerseusGraphType,
-        props: Props,
-    ): ReadonlyArray<Coord> {
+    static getPolygonCoords(graph: PerseusGraphType, props: Props): Coord[] {
         if (graph.type !== "polygon") {
             throw makeInvalidTypeError("toggleShowSides", "polygon");
         }
@@ -495,15 +481,15 @@ class InteractiveGraph extends React.Component<Props, State> {
     static getSegmentCoords(
         graph: PerseusGraphTypeSegment,
         props: Props,
-    ): ReadonlyArray<ReadonlyArray<Coord>> {
+    ): Coord[][] {
         const coords = graph.coords;
         if (coords) {
             return coords;
         }
 
         const n = graph.numSegments || 1;
-        // @ts-expect-error - TS2322 - Type 'number[] | undefined' is not assignable to type 'readonly number[]'.
-        const ys: ReadonlyArray<number> = {
+        // @ts-expect-error - TS2322 - Type 'number[] | undefined' is not assignable to type 'number[]'.
+        const ys: number[] = {
             1: [5],
             2: [5, -5],
             3: [5, 0, -5],
@@ -575,9 +561,9 @@ class InteractiveGraph extends React.Component<Props, State> {
     }
 
     static normalizeCoords(
-        coordsList: ReadonlyArray<Coord>,
+        coordsList: Coord[],
         ranges: [Range, Range],
-    ): ReadonlyArray<Coord> {
+    ): Coord[] {
         // @ts-expect-error - TS2322 - Type 'number[][]' is not assignable to type 'readonly Coord[]'.
         return _.map(coordsList, function (coords) {
             return _.map(coords, function (coord, i) {
@@ -619,9 +605,9 @@ class InteractiveGraph extends React.Component<Props, State> {
 
     static pointsFromNormalized(
         props: Props,
-        coordsList: ReadonlyArray<Coord>,
+        coordsList: Coord[],
         noSnap?: boolean,
-    ): ReadonlyArray<Coord> {
+    ): Coord[] {
         // @ts-expect-error - TS2322 - Type 'number[][]' is not assignable to type 'readonly Coord[]'.
         return _.map(coordsList, function (coords) {
             return _.map(coords, function (coord, i) {
@@ -692,7 +678,7 @@ class InteractiveGraph extends React.Component<Props, State> {
         return getSinusoidCoefficients(coords);
     }
 
-    static defaultSinusoidCoords(props: Props): ReadonlyArray<Coord> {
+    static defaultSinusoidCoords(props: Props): Coord[] {
         const coords = [
             [0.5, 0.5],
             [0.65, 0.6],

--- a/packages/perseus/src/widgets/label-image/__tests__/label-image.test.ts
+++ b/packages/perseus/src/widgets/label-image/__tests__/label-image.test.ts
@@ -24,7 +24,7 @@ const emptyMarker = {
     selected: [],
     x: 0,
     y: 0,
-} as const;
+};
 
 describe("LabelImage", function () {
     let userEvent: UserEvent;

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -193,10 +193,10 @@ const TickMarks: any = Graphie.createSimpleClass((graphie, props) => {
 // should this one?
 type Props = ChangeableProps & {
     range: [number, number];
-    labelRange: ReadonlyArray<number | null>;
+    labelRange: Array<number | null>;
     labelStyle: string;
     labelTicks: boolean;
-    divisionRange: ReadonlyArray<number>;
+    divisionRange: number[];
     numDivisions: number;
     snapDivisions: number;
     isTickCtrl: boolean;

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
@@ -237,7 +237,7 @@ describe("static function getOneCorrectAnswerFromRubric", () => {
         const widget = multipleAnswersWithDecimals.widgets["numeric-input 1"];
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         const widgetOptions = widget && widget.options;
-        const answers: ReadonlyArray<any> =
+        const answers =
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             (widgetOptions && widgetOptions.answers) || [];
 
@@ -253,7 +253,7 @@ describe("static function getOneCorrectAnswerFromRubric", () => {
         const widget = question1.widgets["numeric-input 1"];
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         const widgetOptions = widget && widget.options;
-        const answers: ReadonlyArray<any> =
+        const answers =
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             (widgetOptions && widgetOptions.answers) || [];
         const singleAnswer =

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -41,7 +41,7 @@ type DefaultProps = {
 };
 
 type State = {
-    values: ReadonlyArray<number>;
+    values: number[];
     categoryHeights: Record<string, number>;
 };
 

--- a/packages/perseus/src/widgets/radio/radio-component.new.tsx
+++ b/packages/perseus/src/widgets/radio/radio-component.new.tsx
@@ -275,7 +275,7 @@ class Radio extends React.Component<Props> implements Widget {
      * @deprecated Internal only. Use `showSolutions` prop instead.
      */
     showRationalesForCurrentlySelectedChoices: (
-        arg1: PerseusRadioWidgetOptions,
+        arg1: RecursiveReadonly<PerseusRadioRubric>,
     ) => void = (rubric) => {
         const {choiceStates} = this.props;
         if (choiceStates) {

--- a/packages/perseus/src/widgets/radio/radio-component.new.tsx
+++ b/packages/perseus/src/widgets/radio/radio-component.new.tsx
@@ -15,10 +15,10 @@ import type {WidgetProps, ChoiceState, Widget} from "../../types";
 import type {RadioPromptJSON} from "../../widget-ai-utils/radio/radio-ai-utils";
 import type {
     PerseusRadioChoice,
-    PerseusRadioWidgetOptions,
     ShowSolutions,
     PerseusRadioRubric,
     PerseusRadioUserInput,
+    RecursiveReadonly,
 } from "@khanacademy/perseus-core";
 
 // RenderProps is the return type for radio.jsx#transform

--- a/packages/perseus/src/widgets/radio/radio-component.tsx
+++ b/packages/perseus/src/widgets/radio/radio-component.tsx
@@ -28,13 +28,13 @@ export type RenderProps = {
     multipleSelect?: boolean;
     countChoices?: boolean;
     deselectEnabled?: boolean;
-    choices: ReadonlyArray<RadioChoiceWithMetadata>;
-    selectedChoices: ReadonlyArray<PerseusRadioChoice["correct"]>;
+    choices: RadioChoiceWithMetadata[];
+    selectedChoices: PerseusRadioChoice["correct"][];
     showSolutions?: ShowSolutions;
-    choiceStates?: ReadonlyArray<ChoiceState>;
+    choiceStates?: ChoiceState[];
     // Depreciated; support for legacy way of handling changes
     // Adds proptype for prop that is used but was lacking type
-    values?: ReadonlyArray<boolean>;
+    values?: boolean[];
 };
 
 type Props = WidgetProps<RenderProps, PerseusRadioRubric>;

--- a/packages/perseus/src/widgets/table/table.tsx
+++ b/packages/perseus/src/widgets/table/table.tsx
@@ -118,7 +118,6 @@ class Table extends React.Component<Props> implements Widget {
 
         // If this is coming from an "input", the last argument will be an
         // event. If it's coming from a SimpleKeypadInput, it'll be the value.
-        // @ts-expect-error - TS2571 - Object is of type 'unknown'.
         answers[row][column] = eventOrValue.target
             ? eventOrValue.target.value
             : eventOrValue;
@@ -180,7 +179,7 @@ class Table extends React.Component<Props> implements Widget {
         return ReactDOM.findDOMNode(inputRef);
     }
 
-    getInputPaths(): ReadonlyArray<ReadonlyArray<string>> {
+    getInputPaths(): string[][] {
         const rows = this._getRows();
         const columns = this._getColumns();
         const inputPaths: Array<Array<string>> = [];
@@ -200,7 +199,6 @@ class Table extends React.Component<Props> implements Widget {
         const column = getColumnFromPath(typedPath);
 
         const answers = this._getAnswersClone();
-        // @ts-expect-error - TS2571 - Object is of type 'unknown'.
         answers[row][column] = newValue;
         this.props.onChange(
             {

--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -4,5 +4,3 @@
 declare type SpreadType<A, B> = Omit<A, keyof B> & B;
 
 declare type Empty = Record<never, never>;
-
-declare type RecursiveReadonly<T> = {readonly [K in keyof T]: RecursiveReadonly<T[K]>}

--- a/types/utility.d.ts
+++ b/types/utility.d.ts
@@ -4,3 +4,5 @@
 declare type SpreadType<A, B> = Omit<A, keyof B> & B;
 
 declare type Empty = Record<never, never>;
+
+declare type RecursiveReadonly<T> = {readonly [K in keyof T]: RecursiveReadonly<T[K]>}


### PR DESCRIPTION
## Summary:
See the [slack discussion] for more details. TL;DR:

- The `readonly` modifier in TypeScript simply removes mutating operations like
  `Array.push` and `obj.foo = 1` property assignment from a type.
- As such, it's best to think of it as an application of the [Interface
  Segregation Principle].
- That implies that `readonly` types are most appropriate in function parameters.
  There, they act as a promise that the function won't mutate its arguments.
- They may also be appropriate in return types **if** the function returns a
  frozen object or array, because frozen objects actually disallow mutation at
  runtime.
- In general, readonly types are **not** appropriate in the return types of
  functions, because they unnecessarily restrict the caller from mutating an
  object to which no one else holds a reference.
- That means readonly types are probably **not** appropriate for shared data types
  which may be used in _either_ parameters or return values.
- We weren't using readonly types consistently in `data-schema.ts` to begin with.
  We used them for arrays, but not for tuples or objects.
- For the sake of consistency, and to allow our `data-schema` types to be reused
  easily in different contexts, this PR replaces `ReadonlyArray` with `Array` in
  `data-schema.ts` and fixes the type errors that cascade out of that.

[slack discussion]: https://khanacademy.slack.com/archives/C01AZ9H8TTQ/p1744325813358959
[Interface Segregation Principle]: https://en.wikipedia.org/wiki/Interface_segregation_principle

Issue: LEMS-XXXX

## Test plan:

`pnpm tsc`