### PR TITLE
[SR][Pi ticks] Add a coefficient before pi-based values that start with negative pi

### DIFF
--- a/.changeset/nervous-gifts-relax.md
+++ b/.changeset/nervous-gifts-relax.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[SR][pi ticks] Add a coefficient before pi-based values that start with negative pi

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.test.ts
@@ -30,7 +30,7 @@ describe("srFormatNumber", () => {
     });
 
     it("uses pi format when the number is a multiple of pi", () => {
-        expect(srFormatNumber(Math.PI, "en")).toBe("π");
+        expect(srFormatNumber(Math.PI, "en")).toBe("1π");
     });
 });
 
@@ -59,20 +59,20 @@ describe("getPiMultiple", () => {
 
     test.each`
         num                   | expectedString
-        ${Math.PI}            | ${"π"}
-        ${-Math.PI}           | ${"-π"}
+        ${Math.PI}            | ${"1π"}
+        ${-Math.PI}           | ${"-1π"}
         ${2 * Math.PI}        | ${"2π"}
         ${-2 * Math.PI}       | ${"-2π"}
         ${10 * Math.PI}       | ${"10π"}
         ${-10 * Math.PI}      | ${"-10π"}
-        ${Math.PI / 2}        | ${"π/2"}
-        ${Math.PI / 3}        | ${"π/3"}
-        ${Math.PI / 4}        | ${"π/4"}
-        ${Math.PI / 6}        | ${"π/6"}
-        ${Math.PI / -2}       | ${"-π/2"}
-        ${Math.PI / -3}       | ${"-π/3"}
-        ${Math.PI / -4}       | ${"-π/4"}
-        ${Math.PI / -6}       | ${"-π/6"}
+        ${Math.PI / 2}        | ${"1π/2"}
+        ${Math.PI / 3}        | ${"1π/3"}
+        ${Math.PI / 4}        | ${"1π/4"}
+        ${Math.PI / 6}        | ${"1π/6"}
+        ${Math.PI / -2}       | ${"-1π/2"}
+        ${Math.PI / -3}       | ${"-1π/3"}
+        ${Math.PI / -4}       | ${"-1π/4"}
+        ${Math.PI / -6}       | ${"-1π/6"}
         ${(7 * Math.PI) / 2}  | ${"7π/2"}
         ${3.5 * Math.PI}      | ${"7π/2"}
         ${(2 * Math.PI) / 3}  | ${"2π/3"}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.ts
@@ -38,16 +38,11 @@ export function getPiMultiple(a: number): string | null {
     // is a multiple of π. Return it here.
     // Example: If a = 2π, then truncatedCoefficient = 2, so return "2π"
     if (Number.isInteger(truncatedCoefficient)) {
-        // Return "π" rather than "1π".
-        if (truncatedCoefficient === 1) {
-            return "π";
-        }
-
-        // Return "-π" rather than "-1π".
-        if (truncatedCoefficient === -1) {
-            return "-π";
-        }
-
+        // NOTE: We are NOT doing a custom check to return -π and π here
+        // instead of -1π and 1π, because screen readers may not read the
+        // negative sign at all if it's directly before the π. This could
+        // completely mess up the understanding of the graph for visually
+        // impaired users.
         return truncatedCoefficient + "π";
     }
 
@@ -72,18 +67,11 @@ export function getPiMultiple(a: number): string | null {
         );
 
         if (Number.isInteger(coefficientNumerator)) {
-            // Handle the case where the coefficient numberator is just 1.
-            // We don't want to write "π/6" as "1π/6"
-            if (coefficientNumerator === 1) {
-                return "π/" + divisor;
-            }
-
-            // Handle the case where the coefficient numberator is just -1.
-            // We don't want to write "π/6" as "-1π/6"
-            if (coefficientNumerator === -1) {
-                return "-π/" + divisor;
-            }
-
+            // NOTE: We are NOT doing a custom check to return -π and π here
+            // instead of -1π and 1π, because screen readers may not read the
+            // negative sign at all if it's directly before the π. This could
+            // completely mess up the understanding of the graph for visually
+            // impaired users.
             return coefficientNumerator + "π/" + divisor;
         }
     }


### PR DESCRIPTION
## Summary:
We need to add `1` coefficient before pi-based values that start with negative pi,
because screen readers may not read the `-` sign, implying the value is positive
even when it's not.

By adding the `1`, it will read "minus one pi" which is at least correct in terms
of meaning, even if it doesn't totally match the spoken vocabulary.

In the [Slack conversation about this](https://khanacademy.slack.com/archives/C067UM1QAR4/p1744829758895619), I received confirmation from Charlie that
this is an acceptable approach.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3041

## Test plan:
`pnpm jest packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.test.ts`

Storybook
- Go to http://localhost:6006/iframe.html?globals=&args=&id=perseuseditor-widgets-interactive-graph--interactive-graph-sinusoid-with-pi-ticks&viewMode=story
- Move a point to an x value of -pi
- Turn on a screen reader and navigate to the point
- Confirm that it reads as "minus one pi" and NOT "pi"