### PR TITLE
Add mutual assignability tests for parsed types <-> data-schema types

### DIFF
--- a/.changeset/clean-pianos-greet.md
+++ b/.changeset/clean-pianos-greet.md
@@ -1,0 +1,9 @@
+---
+"@khanacademy/perseus-core": major
+"@khanacademy/perseus-editor": patch
+---
+
+Add typetests to ensure that the data format accepted by
+`parseAndMigratePerseusItem` stays in sync with the types in `data-schema.ts`,
+exported from `@khanacademy/perseus-core`. Breaking change:
+`PerseusGraphTypeAngle.coords` can no longer be `null`; use `undefined` instead.

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -936,7 +936,7 @@ export type PerseusGraphTypeAngle = {
     // How to match the answer. If missing, defaults to exact matching.
     match?: "congruent";
     // must have 3 coords - ie [Coord, Coord, Coord]
-    coords?: [Coord, Coord, Coord] | null;
+    coords?: [Coord, Coord, Coord];
     // The initial coordinates the graph renders with.
     startCoords?: [Coord, Coord, Coord];
 };

--- a/packages/perseus-core/src/parse-perseus-json/general-purpose-parsers/test-helpers.ts
+++ b/packages/perseus-core/src/parse-perseus-json/general-purpose-parsers/test-helpers.ts
@@ -31,3 +31,10 @@ export function summonParsedValue<P extends Parser<any>>(): ParsedValue<P> {
 export function summon<T>(): T {
     return "fake summoned value" as any;
 }
+
+export type RecursiveRequired<T> =
+    T extends object
+    ? RecursiveRequiredObject<T>
+    : T
+
+type RecursiveRequiredObject<T extends object> = {[K in keyof T]-?: RecursiveRequired<T[K]>}

--- a/packages/perseus-core/src/parse-perseus-json/general-purpose-parsers/test-helpers.ts
+++ b/packages/perseus-core/src/parse-perseus-json/general-purpose-parsers/test-helpers.ts
@@ -32,9 +32,10 @@ export function summon<T>(): T {
     return "fake summoned value" as any;
 }
 
-export type RecursiveRequired<T> =
-    T extends object
+export type RecursiveRequired<T> = T extends object
     ? RecursiveRequiredObject<T>
-    : T
+    : T;
 
-type RecursiveRequiredObject<T extends object> = {[K in keyof T]-?: RecursiveRequired<T[K]>}
+type RecursiveRequiredObject<T extends object> = {
+    [K in keyof T]-?: RecursiveRequired<T[K]>;
+};

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/categorizer-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/categorizer-widget.ts
@@ -11,10 +11,7 @@ import {defaulted} from "../general-purpose-parsers/defaulted";
 
 import {parseWidget} from "./widget";
 
-import type {CategorizerWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parseCategorizerWidget: Parser<CategorizerWidget> = parseWidget(
+export const parseCategorizerWidget = parseWidget(
     constant("categorizer"),
     object({
         items: array(string),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/categorizer-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/categorizer-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { CategorizerWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseCategorizerWidget } from "./categorizer-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseCategorizerWidget} from "./categorizer-widget";
+import type {CategorizerWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseCategorizerWidget>;
 
@@ -10,4 +12,6 @@ summon<CategorizerWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<CategorizerWidget>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<CategorizerWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/categorizer-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/categorizer-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { CategorizerWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseCategorizerWidget } from "./categorizer-widget";
+
+type Parsed = ParsedValue<typeof parseCategorizerWidget>;
+
+summon<Parsed>() satisfies CategorizerWidget;
+summon<CategorizerWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<CategorizerWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/cs-program-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/cs-program-widget.ts
@@ -11,10 +11,7 @@ import {defaulted} from "../general-purpose-parsers/defaulted";
 
 import {parseWidget} from "./widget";
 
-import type {CSProgramWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parseCSProgramWidget: Parser<CSProgramWidget> = parseWidget(
+export const parseCSProgramWidget = parseWidget(
     constant("cs-program"),
     object({
         programID: string,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/cs-program-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/cs-program-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { CSProgramWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseCSProgramWidget } from "./cs-program-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseCSProgramWidget} from "./cs-program-widget";
+import type {CSProgramWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseCSProgramWidget>;
 
@@ -10,4 +12,6 @@ summon<CSProgramWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<CSProgramWidget>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<CSProgramWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/cs-program-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/cs-program-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { CSProgramWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseCSProgramWidget } from "./cs-program-widget";
+
+type Parsed = ParsedValue<typeof parseCSProgramWidget>;
+
+summon<Parsed>() satisfies CSProgramWidget;
+summon<CSProgramWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<CSProgramWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/definition-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/definition-widget.ts
@@ -3,10 +3,7 @@ import {defaulted} from "../general-purpose-parsers/defaulted";
 
 import {parseWidget} from "./widget";
 
-import type {DefinitionWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parseDefinitionWidget: Parser<DefinitionWidget> = parseWidget(
+export const parseDefinitionWidget = parseWidget(
     constant("definition"),
     object({
         togglePrompt: string,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/definition-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/definition-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { DefinitionWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseDefinitionWidget } from "./definition-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseDefinitionWidget} from "./definition-widget";
+import type {DefinitionWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseDefinitionWidget>;
 
@@ -10,4 +12,6 @@ summon<DefinitionWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<DefinitionWidget>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<DefinitionWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/definition-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/definition-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { DefinitionWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseDefinitionWidget } from "./definition-widget";
+
+type Parsed = ParsedValue<typeof parseDefinitionWidget>;
+
+summon<Parsed>() satisfies DefinitionWidget;
+summon<DefinitionWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<DefinitionWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/dropdown-user-input.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/dropdown-user-input.typetest.ts
@@ -1,7 +1,8 @@
-import {RecursiveRequired, summon} from "../general-purpose-parsers/test-helpers";
+import {summon} from "../general-purpose-parsers/test-helpers";
 
 import type {parseDropdownUserInput} from "./dropdown-user-input";
 import type {PerseusDropdownUserInput} from "../../validation.types";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
 import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseDropdownUserInput>;
@@ -11,4 +12,6 @@ summon<PerseusDropdownUserInput>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PerseusDropdownUserInput>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<PerseusDropdownUserInput>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/dropdown-user-input.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/dropdown-user-input.typetest.ts
@@ -1,9 +1,14 @@
-import {summon} from "../general-purpose-parsers/test-helpers";
+import {RecursiveRequired, summon} from "../general-purpose-parsers/test-helpers";
 
 import type {parseDropdownUserInput} from "./dropdown-user-input";
 import type {PerseusDropdownUserInput} from "../../validation.types";
 import type {ParsedValue} from "../parser-types";
 
-summon<
-    ParsedValue<typeof parseDropdownUserInput>
->() satisfies PerseusDropdownUserInput;
+type Parsed = ParsedValue<typeof parseDropdownUserInput>;
+
+summon<Parsed>() satisfies PerseusDropdownUserInput;
+summon<PerseusDropdownUserInput>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PerseusDropdownUserInput>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/dropdown-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/dropdown-widget.ts
@@ -10,10 +10,7 @@ import {defaulted} from "../general-purpose-parsers/defaulted";
 
 import {parseWidget} from "./widget";
 
-import type {DropdownWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parseDropdownWidget: Parser<DropdownWidget> = parseWidget(
+export const parseDropdownWidget = parseWidget(
     constant("dropdown"),
     object({
         placeholder: defaulted(string, () => ""),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/dropdown-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/dropdown-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { DropdownWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseDropdownWidget } from "./dropdown-widget";
+
+type Parsed = ParsedValue<typeof parseDropdownWidget>;
+
+summon<Parsed>() satisfies DropdownWidget;
+summon<DropdownWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<DropdownWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/dropdown-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/dropdown-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { DropdownWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseDropdownWidget } from "./dropdown-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseDropdownWidget} from "./dropdown-widget";
+import type {DropdownWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseDropdownWidget>;
 

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/explanation-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/explanation-widget.ts
@@ -4,10 +4,7 @@ import {defaulted} from "../general-purpose-parsers/defaulted";
 import {parseWidget} from "./widget";
 import {parseWidgetsMap} from "./widgets-map";
 
-import type {ExplanationWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parseExplanationWidget: Parser<ExplanationWidget> = parseWidget(
+export const parseExplanationWidget = parseWidget(
     constant("explanation"),
     object({
         showPrompt: string,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/explanation-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/explanation-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { ExplanationWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseExplanationWidget } from "./explanation-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseExplanationWidget} from "./explanation-widget";
+import type {ExplanationWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseExplanationWidget>;
 
@@ -10,4 +12,6 @@ summon<ExplanationWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<ExplanationWidget>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<ExplanationWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/explanation-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/explanation-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { ExplanationWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseExplanationWidget } from "./explanation-widget";
+
+type Parsed = ParsedValue<typeof parseExplanationWidget>;
+
+summon<Parsed>() satisfies ExplanationWidget;
+summon<ExplanationWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<ExplanationWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/expression-user-input.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/expression-user-input.typetest.ts
@@ -1,9 +1,14 @@
-import {summon} from "../general-purpose-parsers/test-helpers";
+import {RecursiveRequired, summon} from "../general-purpose-parsers/test-helpers";
 
 import type {parseExpressionUserInput} from "./expression-user-input";
 import type {PerseusExpressionUserInput} from "../../validation.types";
 import type {ParsedValue} from "../parser-types";
 
-summon<
-    ParsedValue<typeof parseExpressionUserInput>
->() satisfies PerseusExpressionUserInput;
+type Parsed = ParsedValue<typeof parseExpressionUserInput>;
+
+summon<Parsed>() satisfies PerseusExpressionUserInput;
+summon<PerseusExpressionUserInput>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PerseusExpressionUserInput>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/expression-user-input.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/expression-user-input.typetest.ts
@@ -1,7 +1,8 @@
-import {RecursiveRequired, summon} from "../general-purpose-parsers/test-helpers";
+import {summon} from "../general-purpose-parsers/test-helpers";
 
 import type {parseExpressionUserInput} from "./expression-user-input";
 import type {PerseusExpressionUserInput} from "../../validation.types";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
 import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseExpressionUserInput>;
@@ -11,4 +12,6 @@ summon<PerseusExpressionUserInput>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PerseusExpressionUserInput>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<PerseusExpressionUserInput>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/expression-widget.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/expression-widget.test.ts
@@ -20,6 +20,7 @@ describe("parseExpressionWidget", () => {
                     {
                         considered: "correct",
                         form: true,
+                        key: "undefined",
                         simplify: false,
                         value: "88x",
                     },

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/expression-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/expression-widget.typetest.ts
@@ -1,7 +1,8 @@
-import {RecursiveRequired, summon} from "../general-purpose-parsers/test-helpers";
+import {summon} from "../general-purpose-parsers/test-helpers";
 
 import type {parseExpressionWidget} from "./expression-widget";
 import type {ExpressionWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
 import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseExpressionWidget>;
@@ -11,4 +12,6 @@ summon<ExpressionWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<ExpressionWidget>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<ExpressionWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/expression-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/expression-widget.typetest.ts
@@ -1,0 +1,14 @@
+import {RecursiveRequired, summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseExpressionWidget} from "./expression-widget";
+import type {ExpressionWidget} from "../../data-schema";
+import type {ParsedValue} from "../parser-types";
+
+type Parsed = ParsedValue<typeof parseExpressionWidget>;
+
+summon<Parsed>() satisfies ExpressionWidget;
+summon<ExpressionWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<ExpressionWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/graded-group-set-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/graded-group-set-widget.ts
@@ -3,8 +3,7 @@ import {array, constant, object} from "../general-purpose-parsers";
 import {parseGradedGroupWidgetOptions} from "./graded-group-widget";
 import {parseWidget} from "./widget";
 
-export const parseGradedGroupSetWidget =
-    parseWidget(
-        constant("graded-group-set"),
-        object({gradedGroups: array(parseGradedGroupWidgetOptions)}),
-    );
+export const parseGradedGroupSetWidget = parseWidget(
+    constant("graded-group-set"),
+    object({gradedGroups: array(parseGradedGroupWidgetOptions)}),
+);

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/graded-group-set-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/graded-group-set-widget.ts
@@ -3,10 +3,7 @@ import {array, constant, object} from "../general-purpose-parsers";
 import {parseGradedGroupWidgetOptions} from "./graded-group-widget";
 import {parseWidget} from "./widget";
 
-import type {GradedGroupSetWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parseGradedGroupSetWidget: Parser<GradedGroupSetWidget> =
+export const parseGradedGroupSetWidget =
     parseWidget(
         constant("graded-group-set"),
         object({gradedGroups: array(parseGradedGroupWidgetOptions)}),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/graded-group-set-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/graded-group-set-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { GradedGroupSetWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseGradedGroupSetWidget } from "./graded-group-set-widget";
+
+type Parsed = ParsedValue<typeof parseGradedGroupSetWidget>;
+
+summon<Parsed>() satisfies GradedGroupSetWidget;
+summon<GradedGroupSetWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<GradedGroupSetWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/graded-group-set-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/graded-group-set-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { GradedGroupSetWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseGradedGroupSetWidget } from "./graded-group-set-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseGradedGroupSetWidget} from "./graded-group-set-widget";
+import type {GradedGroupSetWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseGradedGroupSetWidget>;
 
@@ -10,4 +12,6 @@ summon<GradedGroupSetWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<GradedGroupSetWidget>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<GradedGroupSetWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/graded-group-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/graded-group-widget.ts
@@ -17,9 +17,6 @@ import {parsePerseusRenderer} from "./perseus-renderer";
 import {parseWidget} from "./widget";
 import {parseWidgetsMap} from "./widgets-map";
 
-import type {GradedGroupWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
 const falseToNull = pipeParsers(constant(false)).then(
     convert(() => null),
 ).parser;
@@ -49,7 +46,7 @@ export const parseGradedGroupWidgetOptions = object({
     ),
 });
 
-export const parseGradedGroupWidget: Parser<GradedGroupWidget> = parseWidget(
+export const parseGradedGroupWidget = parseWidget(
     constant("graded-group"),
     parseGradedGroupWidgetOptions,
 );

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/graded-group-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/graded-group-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { GradedGroupWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseGradedGroupWidget } from "./graded-group-widget";
+
+type Parsed = ParsedValue<typeof parseGradedGroupWidget>;
+
+summon<Parsed>() satisfies GradedGroupWidget;
+summon<GradedGroupWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<GradedGroupWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/graded-group-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/graded-group-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { GradedGroupWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseGradedGroupWidget } from "./graded-group-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseGradedGroupWidget} from "./graded-group-widget";
+import type {GradedGroupWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseGradedGroupWidget>;
 
@@ -10,4 +12,6 @@ summon<GradedGroupWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<GradedGroupWidget>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<GradedGroupWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/grapher-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/grapher-widget.ts
@@ -15,14 +15,11 @@ import {discriminatedUnionOn} from "../general-purpose-parsers/discriminated-uni
 
 import {parseWidget} from "./widget";
 
-import type {GrapherWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
 const pairOfNumbers = pair(number, number);
 
 const pairOfPoints = pair(pairOfNumbers, pairOfNumbers);
 
-export const parseGrapherWidget: Parser<GrapherWidget> = parseWidget(
+export const parseGrapherWidget = parseWidget(
     constant("grapher"),
     object({
         availableTypes: array(
@@ -103,7 +100,7 @@ export const parseGrapherWidget: Parser<GrapherWidget> = parseWidget(
             ),
             gridStep: optional(pairOfNumbers),
             labels: pair(string, string),
-            markings: enumeration("graph", "none", "grid"),
+            markings: enumeration("graph", "none", "grid", "axes"),
             range: pair(pairOfNumbers, pairOfNumbers),
             rulerLabel: constant(""),
             rulerTicks: number,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/grapher-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/grapher-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { GrapherWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseGrapherWidget } from "./grapher-widget";
+
+type Parsed = ParsedValue<typeof parseGrapherWidget>;
+
+summon<Parsed>() satisfies GrapherWidget;
+summon<GrapherWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<GrapherWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/grapher-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/grapher-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { GrapherWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseGrapherWidget } from "./grapher-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseGrapherWidget} from "./grapher-widget";
+import type {GrapherWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseGrapherWidget>;
 

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/group-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/group-widget.ts
@@ -3,10 +3,7 @@ import {constant} from "../general-purpose-parsers";
 import {parsePerseusRenderer} from "./perseus-renderer";
 import {parseWidget} from "./widget";
 
-import type {GroupWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parseGroupWidget: Parser<GroupWidget> = parseWidget(
+export const parseGroupWidget = parseWidget(
     constant("group"),
     // This module has an import cycle with parsePerseusRenderer.
     // The anonymous function below ensures that we don't try to access

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/group-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/group-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { GroupWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseGroupWidget } from "./group-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseGroupWidget} from "./group-widget";
+import type {GroupWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseGroupWidget>;
 

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/group-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/group-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { GroupWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseGroupWidget } from "./group-widget";
+
+type Parsed = ParsedValue<typeof parseGroupWidget>;
+
+summon<Parsed>() satisfies GroupWidget;
+summon<GroupWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<GroupWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/hint.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/hint.ts
@@ -4,10 +4,7 @@ import {defaulted} from "../general-purpose-parsers/defaulted";
 import {parseImages} from "./images-map";
 import {parseWidgetsMap} from "./widgets-map";
 
-import type {Hint} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parseHint: Parser<Hint> = object({
+export const parseHint = object({
     replace: defaulted(boolean, () => undefined),
     content: string,
     widgets: defaulted(parseWidgetsMap, () => ({})),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/hint.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/hint.typetest.ts
@@ -1,0 +1,13 @@
+import { Hint } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseHint } from "./hint";
+
+type Parsed = ParsedValue<typeof parseHint>;
+
+summon<Parsed>() satisfies Hint;
+summon<Hint>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<Hint>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/hint.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/hint.typetest.ts
@@ -1,7 +1,9 @@
-import { Hint } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseHint } from "./hint";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseHint} from "./hint";
+import type {Hint} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseHint>;
 

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/iframe-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/iframe-widget.ts
@@ -12,10 +12,7 @@ import {defaulted} from "../general-purpose-parsers/defaulted";
 
 import {parseWidget} from "./widget";
 
-import type {IFrameWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parseIframeWidget: Parser<IFrameWidget> = parseWidget(
+export const parseIframeWidget = parseWidget(
     constant("iframe"),
     object({
         url: string,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/iframe-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/iframe-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { IFrameWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseIframeWidget } from "./iframe-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseIframeWidget} from "./iframe-widget";
+import type {IFrameWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseIframeWidget>;
 

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/iframe-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/iframe-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { IFrameWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseIframeWidget } from "./iframe-widget";
+
+type Parsed = ParsedValue<typeof parseIframeWidget>;
+
+summon<Parsed>() satisfies IFrameWidget;
+summon<IFrameWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<IFrameWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/image-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/image-widget.ts
@@ -12,12 +12,9 @@ import {
 import {parsePerseusImageBackground} from "./perseus-image-background";
 import {parseWidget} from "./widget";
 
-import type {ImageWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
 const pairOfNumbers = pair(number, number);
 
-export const parseImageWidget: Parser<ImageWidget> = parseWidget(
+export const parseImageWidget = parseWidget(
     constant("image"),
     object({
         title: optional(string),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/image-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/image-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { ImageWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseImageWidget } from "./image-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseImageWidget} from "./image-widget";
+import type {ImageWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseImageWidget>;
 

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/image-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/image-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { ImageWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseImageWidget } from "./image-widget";
+
+type Parsed = ParsedValue<typeof parseImageWidget>;
+
+summon<Parsed>() satisfies ImageWidget;
+summon<ImageWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<ImageWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/images-map.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/images-map.ts
@@ -1,17 +1,15 @@
-import {number, object, record, string} from "../general-purpose-parsers";
+import {record, string} from "../general-purpose-parsers";
 import {defaulted} from "../general-purpose-parsers/defaulted";
 
 import type {PerseusImageDetail} from "../../data-schema";
 import type {Parser} from "../parser-types";
+import { parsePerseusImageDetail } from "./perseus-image-detail";
 
 export const parseImages: Parser<{[key: string]: PerseusImageDetail}> =
     defaulted(
         record(
             string,
-            object({
-                width: number,
-                height: number,
-            }),
+            parsePerseusImageDetail,
         ),
         () => ({}),
     );

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/images-map.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/images-map.ts
@@ -1,15 +1,10 @@
 import {record, string} from "../general-purpose-parsers";
 import {defaulted} from "../general-purpose-parsers/defaulted";
 
+import {parsePerseusImageDetail} from "./perseus-image-detail";
+
 import type {PerseusImageDetail} from "../../data-schema";
 import type {Parser} from "../parser-types";
-import { parsePerseusImageDetail } from "./perseus-image-detail";
 
 export const parseImages: Parser<{[key: string]: PerseusImageDetail}> =
-    defaulted(
-        record(
-            string,
-            parsePerseusImageDetail,
-        ),
-        () => ({}),
-    );
+    defaulted(record(string, parsePerseusImageDetail), () => ({}));

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/input-number-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/input-number-widget.ts
@@ -11,7 +11,6 @@ import {
 
 import {parseWidget} from "./widget";
 
-import type {InputNumberWidget} from "../../data-schema";
 import type {Parser} from "../parser-types";
 
 const booleanToString: Parser<string> = (rawValue, ctx) => {
@@ -21,7 +20,7 @@ const booleanToString: Parser<string> = (rawValue, ctx) => {
     return ctx.failure("boolean", rawValue);
 };
 
-export const parseInputNumberWidget: Parser<InputNumberWidget> = parseWidget(
+export const parseInputNumberWidget = parseWidget(
     constant("input-number"),
     object({
         answerType: optional(

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/input-number-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/input-number-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { InputNumberWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseInputNumberWidget } from "./input-number-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseInputNumberWidget} from "./input-number-widget";
+import type {InputNumberWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseInputNumberWidget>;
 
@@ -10,4 +12,6 @@ summon<InputNumberWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<InputNumberWidget>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<InputNumberWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/input-number-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/input-number-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { InputNumberWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseInputNumberWidget } from "./input-number-widget";
+
+type Parsed = ParsedValue<typeof parseInputNumberWidget>;
+
+summon<Parsed>() satisfies InputNumberWidget;
+summon<InputNumberWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<InputNumberWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interaction-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interaction-widget.ts
@@ -18,19 +18,12 @@ import {discriminatedUnionOn} from "../general-purpose-parsers/discriminated-uni
 import {parsePerseusImageBackground} from "./perseus-image-background";
 import {parseWidget} from "./widget";
 
-import type {
-    InteractionWidget,
-    PerseusInteractionElement,
-} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
 const pairOfNumbers = pair(number, number);
 const stringOrEmpty = defaulted(string, () => "");
 
 const parseKey = pipeParsers(optional(string)).then(convert(String)).parser;
 
-type FunctionElement = Extract<PerseusInteractionElement, {type: "function"}>;
-const parseFunctionElement: Parser<FunctionElement> = object({
+const parseFunctionElement = object({
     type: constant("function"),
     key: parseKey,
     options: object({
@@ -44,8 +37,7 @@ const parseFunctionElement: Parser<FunctionElement> = object({
     }),
 });
 
-type LabelElement = Extract<PerseusInteractionElement, {type: "label"}>;
-const parseLabelElement: Parser<LabelElement> = object({
+const parseLabelElement = object({
     type: constant("label"),
     key: parseKey,
     options: object({
@@ -56,8 +48,7 @@ const parseLabelElement: Parser<LabelElement> = object({
     }),
 });
 
-type LineElement = Extract<PerseusInteractionElement, {type: "line"}>;
-const parseLineElement: Parser<LineElement> = object({
+const parseLineElement = object({
     type: constant("line"),
     key: parseKey,
     options: object({
@@ -72,11 +63,7 @@ const parseLineElement: Parser<LineElement> = object({
     }),
 });
 
-type MovableLineElement = Extract<
-    PerseusInteractionElement,
-    {type: "movable-line"}
->;
-const parseMovableLineElement: Parser<MovableLineElement> = object({
+const parseMovableLineElement = object({
     type: constant("movable-line"),
     key: parseKey,
     options: object({
@@ -96,11 +83,7 @@ const parseMovableLineElement: Parser<MovableLineElement> = object({
     }),
 });
 
-type MovablePointElement = Extract<
-    PerseusInteractionElement,
-    {type: "movable-point"}
->;
-const parseMovablePointElement: Parser<MovablePointElement> = object({
+const parseMovablePointElement = object({
     type: constant("movable-point"),
     key: parseKey,
     options: object({
@@ -117,11 +100,7 @@ const parseMovablePointElement: Parser<MovablePointElement> = object({
     }),
 });
 
-type ParametricElement = Extract<
-    PerseusInteractionElement,
-    {type: "parametric"}
->;
-const parseParametricElement: Parser<ParametricElement> = object({
+const parseParametricElement = object({
     type: constant("parametric"),
     key: parseKey,
     options: object({
@@ -135,8 +114,7 @@ const parseParametricElement: Parser<ParametricElement> = object({
     }),
 });
 
-type PointElement = Extract<PerseusInteractionElement, {type: "point"}>;
-const parsePointElement: Parser<PointElement> = object({
+const parsePointElement = object({
     type: constant("point"),
     key: parseKey,
     options: object({
@@ -146,8 +124,7 @@ const parsePointElement: Parser<PointElement> = object({
     }),
 });
 
-type RectangleElement = Extract<PerseusInteractionElement, {type: "rectangle"}>;
-const parseRectangleElement: Parser<RectangleElement> = object({
+const parseRectangleElement = object({
     type: constant("rectangle"),
     key: parseKey,
     options: object({
@@ -159,7 +136,7 @@ const parseRectangleElement: Parser<RectangleElement> = object({
     }),
 });
 
-export const parseInteractionWidget: Parser<InteractionWidget> = parseWidget(
+export const parseInteractionWidget = parseWidget(
     constant("interaction"),
     object({
         static: defaulted(boolean, () => false),
@@ -169,7 +146,7 @@ export const parseInteractionWidget: Parser<InteractionWidget> = parseWidget(
             labels: array(string),
             range: pair(pairOfNumbers, pairOfNumbers),
             gridStep: pairOfNumbers,
-            markings: enumeration("graph", "grid", "none"),
+            markings: enumeration("graph", "grid", "none", "axes"),
             snapStep: optional(pairOfNumbers),
             valid: optional(union(boolean).or(string).parser),
             backgroundImage: optional(parsePerseusImageBackground),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interaction-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interaction-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { InteractionWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseInteractionWidget } from "./interaction-widget";
+
+type Parsed = ParsedValue<typeof parseInteractionWidget>;
+
+summon<Parsed>() satisfies InteractionWidget;
+summon<InteractionWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<InteractionWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interaction-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interaction-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { InteractionWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseInteractionWidget } from "./interaction-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseInteractionWidget} from "./interaction-widget";
+import type {InteractionWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseInteractionWidget>;
 
@@ -10,4 +12,6 @@ summon<InteractionWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<InteractionWidget>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<InteractionWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-user-input.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-user-input.typetest.ts
@@ -1,9 +1,13 @@
-import {summon} from "../general-purpose-parsers/test-helpers";
+import { PerseusInteractiveGraphUserInput } from "../../validation.types";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseInteractiveGraphUserInput } from "./interactive-graph-user-input";
 
-import type {parseInteractiveGraphUserInput} from "./interactive-graph-user-input";
-import type {PerseusInteractiveGraphUserInput} from "../../validation.types";
-import type {ParsedValue} from "../parser-types";
+type Parsed = ParsedValue<typeof parseInteractiveGraphUserInput>;
 
-summon<
-    ParsedValue<typeof parseInteractiveGraphUserInput>
->() satisfies PerseusInteractiveGraphUserInput;
+summon<Parsed>() satisfies PerseusInteractiveGraphUserInput;
+summon<PerseusInteractiveGraphUserInput>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PerseusInteractiveGraphUserInput>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-user-input.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-user-input.typetest.ts
@@ -1,7 +1,9 @@
-import { PerseusInteractiveGraphUserInput } from "../../validation.types";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseInteractiveGraphUserInput } from "./interactive-graph-user-input";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseInteractiveGraphUserInput} from "./interactive-graph-user-input";
+import type {PerseusInteractiveGraphUserInput} from "../../validation.types";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseInteractiveGraphUserInput>;
 
@@ -10,4 +12,6 @@ summon<PerseusInteractiveGraphUserInput>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PerseusInteractiveGraphUserInput>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<PerseusInteractiveGraphUserInput>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -1,4 +1,4 @@
-import {lockedFigureColorNames, PerseusGraphTypeLinear} from "../../data-schema";
+import {lockedFigureColorNames} from "../../data-schema";
 import {
     array,
     boolean,
@@ -18,6 +18,8 @@ import {discriminatedUnionOn} from "../general-purpose-parsers/discriminated-uni
 
 import {parsePerseusImageBackground} from "./perseus-image-background";
 import {parseWidget} from "./widget";
+
+import type {PerseusGraphTypeLinear} from "../../data-schema";
 
 // Used to represent 2-D points and ranges
 const pairOfNumbers = pair(number, number);
@@ -55,15 +57,14 @@ const parsePerseusGraphTypeLinear = object({
     coord: optional(pairOfNumbers),
 });
 
-const parsePerseusGraphTypeLinearSystem =
-    object({
-        type: constant("linear-system"),
-        // TODO(benchristel): default coords to empty array?
-        coords: optional(nullable(array(pair(pairOfNumbers, pairOfNumbers)))),
-        startCoords: optional(array(pair(pairOfNumbers, pairOfNumbers))),
-        // TODO: remove coord? it's legacy.
-        coord: optional(pairOfNumbers),
-    });
+const parsePerseusGraphTypeLinearSystem = object({
+    type: constant("linear-system"),
+    // TODO(benchristel): default coords to empty array?
+    coords: optional(nullable(array(pair(pairOfNumbers, pairOfNumbers)))),
+    startCoords: optional(array(pair(pairOfNumbers, pairOfNumbers))),
+    // TODO: remove coord? it's legacy.
+    coord: optional(pairOfNumbers),
+});
 
 const parsePerseusGraphTypeNone = object({
     type: constant("none"),
@@ -91,18 +92,15 @@ const parsePerseusGraphTypePolygon = object({
     coord: optional(pairOfNumbers),
 });
 
-const parsePerseusGraphTypeQuadratic =
-    object({
-        type: constant("quadratic"),
-        coords: optional(
-            nullable(trio(pairOfNumbers, pairOfNumbers, pairOfNumbers)),
-        ),
-        startCoords: optional(
-            trio(pairOfNumbers, pairOfNumbers, pairOfNumbers),
-        ),
-        // TODO: remove coord? it's legacy.
-        coord: optional(pairOfNumbers),
-    });
+const parsePerseusGraphTypeQuadratic = object({
+    type: constant("quadratic"),
+    coords: optional(
+        nullable(trio(pairOfNumbers, pairOfNumbers, pairOfNumbers)),
+    ),
+    startCoords: optional(trio(pairOfNumbers, pairOfNumbers, pairOfNumbers)),
+    // TODO: remove coord? it's legacy.
+    coord: optional(pairOfNumbers),
+});
 
 const parsePerseusGraphTypeRay = object({
     type: constant("ray"),
@@ -143,9 +141,7 @@ export const parsePerseusGraphType = discriminatedUnionOn("type")
     .withBranch("segment", parsePerseusGraphTypeSegment)
     .withBranch("sinusoid", parsePerseusGraphTypeSinusoid).parser;
 
-const parseLockedFigureColor = enumeration(
-    ...lockedFigureColorNames,
-);
+const parseLockedFigureColor = enumeration(...lockedFigureColorNames);
 
 const parseLockedFigureFillType = enumeration(
     "none",
@@ -154,10 +150,7 @@ const parseLockedFigureFillType = enumeration(
     "solid",
 );
 
-const parseLockedLineStyle = enumeration(
-    "solid",
-    "dashed",
-);
+const parseLockedLineStyle = enumeration("solid", "dashed");
 
 const parseLockedLabelType = object({
     type: constant("label"),
@@ -254,37 +247,39 @@ const parseLockedFigure = discriminatedUnionOn("type")
     .withBranch("function", parseLockedFunctionType)
     .withBranch("label", parseLockedLabelType).parser;
 
-export const parseInteractiveGraphWidget =
-    parseWidget(
-        constant("interactive-graph"),
-        object({
-            step: pairOfNumbers,
-            // TODO(benchristel): rather than making gridStep and snapStep
-            // optional, we should duplicate the defaulting logic from the
-            // InteractiveGraph component. See parse-perseus-json/README.md for
-            // why.
-            gridStep: optional(pairOfNumbers),
-            snapStep: optional(pairOfNumbers),
-            backgroundImage: optional(parsePerseusImageBackground),
-            markings: enumeration("graph", "grid", "none", "axes"),
-            labels: optional(array(string)),
-            labelLocation: optional(enumeration("onAxis", "alongEdge")),
-            showProtractor: boolean,
-            showRuler: optional(boolean),
-            showTooltips: optional(boolean),
-            rulerLabel: optional(string),
-            rulerTicks: optional(number),
-            range: pair(pairOfNumbers, pairOfNumbers),
-            // NOTE(benchristel): I copied the default graph from
-            // interactive-graph.tsx. See the parse-perseus-json/README.md for
-            // an explanation of why we want to duplicate the default here.
-            graph: defaulted(parsePerseusGraphType, (): PerseusGraphTypeLinear => ({
+export const parseInteractiveGraphWidget = parseWidget(
+    constant("interactive-graph"),
+    object({
+        step: pairOfNumbers,
+        // TODO(benchristel): rather than making gridStep and snapStep
+        // optional, we should duplicate the defaulting logic from the
+        // InteractiveGraph component. See parse-perseus-json/README.md for
+        // why.
+        gridStep: optional(pairOfNumbers),
+        snapStep: optional(pairOfNumbers),
+        backgroundImage: optional(parsePerseusImageBackground),
+        markings: enumeration("graph", "grid", "none", "axes"),
+        labels: optional(array(string)),
+        labelLocation: optional(enumeration("onAxis", "alongEdge")),
+        showProtractor: boolean,
+        showRuler: optional(boolean),
+        showTooltips: optional(boolean),
+        rulerLabel: optional(string),
+        rulerTicks: optional(number),
+        range: pair(pairOfNumbers, pairOfNumbers),
+        // NOTE(benchristel): I copied the default graph from
+        // interactive-graph.tsx. See the parse-perseus-json/README.md for
+        // an explanation of why we want to duplicate the default here.
+        graph: defaulted(
+            parsePerseusGraphType,
+            (): PerseusGraphTypeLinear => ({
                 type: "linear" as const,
-            })),
-            correct: parsePerseusGraphType,
-            // TODO(benchristel): default lockedFigures to empty array
-            lockedFigures: optional(array(parseLockedFigure)),
-            fullGraphAriaLabel: optional(string),
-            fullGraphAriaDescription: optional(string),
-        }),
-    );
+            }),
+        ),
+        correct: parsePerseusGraphType,
+        // TODO(benchristel): default lockedFigures to empty array
+        lockedFigures: optional(array(parseLockedFigure)),
+        fullGraphAriaLabel: optional(string),
+        fullGraphAriaDescription: optional(string),
+    }),
+);

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -1,4 +1,4 @@
-import {lockedFigureColorNames} from "../../data-schema";
+import {lockedFigureColorNames, PerseusGraphTypeLinear} from "../../data-schema";
 import {
     array,
     boolean,
@@ -19,37 +19,10 @@ import {discriminatedUnionOn} from "../general-purpose-parsers/discriminated-uni
 import {parsePerseusImageBackground} from "./perseus-image-background";
 import {parseWidget} from "./widget";
 
-import type {
-    InteractiveGraphWidget,
-    LockedEllipseType,
-    LockedFigure,
-    LockedFigureColor,
-    LockedFigureFillType,
-    LockedFunctionType,
-    LockedLabelType,
-    LockedLineStyle,
-    LockedLineType,
-    LockedPointType,
-    LockedPolygonType,
-    LockedVectorType,
-    PerseusGraphTypeAngle,
-    PerseusGraphTypeCircle,
-    PerseusGraphTypeLinear,
-    PerseusGraphTypeLinearSystem,
-    PerseusGraphTypeNone,
-    PerseusGraphTypePoint,
-    PerseusGraphTypePolygon,
-    PerseusGraphTypeQuadratic,
-    PerseusGraphTypeRay,
-    PerseusGraphTypeSegment,
-    PerseusGraphTypeSinusoid,
-} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
 // Used to represent 2-D points and ranges
 const pairOfNumbers = pair(number, number);
 
-const parsePerseusGraphTypeAngle: Parser<PerseusGraphTypeAngle> = object({
+const parsePerseusGraphTypeAngle = object({
     type: constant("angle"),
     showAngles: optional(boolean),
     allowReflexAngles: optional(boolean),
@@ -60,7 +33,7 @@ const parsePerseusGraphTypeAngle: Parser<PerseusGraphTypeAngle> = object({
     startCoords: optional(trio(pairOfNumbers, pairOfNumbers, pairOfNumbers)),
 });
 
-const parsePerseusGraphTypeCircle: Parser<PerseusGraphTypeCircle> = object({
+const parsePerseusGraphTypeCircle = object({
     type: constant("circle"),
     center: optional(pairOfNumbers),
     radius: optional(number),
@@ -74,7 +47,7 @@ const parsePerseusGraphTypeCircle: Parser<PerseusGraphTypeCircle> = object({
     coord: optional(pairOfNumbers),
 });
 
-const parsePerseusGraphTypeLinear: Parser<PerseusGraphTypeLinear> = object({
+const parsePerseusGraphTypeLinear = object({
     type: constant("linear"),
     coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
     startCoords: optional(pair(pairOfNumbers, pairOfNumbers)),
@@ -82,7 +55,7 @@ const parsePerseusGraphTypeLinear: Parser<PerseusGraphTypeLinear> = object({
     coord: optional(pairOfNumbers),
 });
 
-const parsePerseusGraphTypeLinearSystem: Parser<PerseusGraphTypeLinearSystem> =
+const parsePerseusGraphTypeLinearSystem =
     object({
         type: constant("linear-system"),
         // TODO(benchristel): default coords to empty array?
@@ -92,11 +65,11 @@ const parsePerseusGraphTypeLinearSystem: Parser<PerseusGraphTypeLinearSystem> =
         coord: optional(pairOfNumbers),
     });
 
-const parsePerseusGraphTypeNone: Parser<PerseusGraphTypeNone> = object({
+const parsePerseusGraphTypeNone = object({
     type: constant("none"),
 });
 
-const parsePerseusGraphTypePoint: Parser<PerseusGraphTypePoint> = object({
+const parsePerseusGraphTypePoint = object({
     type: constant("point"),
     numPoints: optional(union(number).or(constant("unlimited")).parser),
     coords: optional(nullable(array(pairOfNumbers))),
@@ -105,7 +78,7 @@ const parsePerseusGraphTypePoint: Parser<PerseusGraphTypePoint> = object({
     coord: optional(pairOfNumbers),
 });
 
-const parsePerseusGraphTypePolygon: Parser<PerseusGraphTypePolygon> = object({
+const parsePerseusGraphTypePolygon = object({
     type: constant("polygon"),
     numSides: optional(union(number).or(constant("unlimited")).parser),
     showAngles: optional(boolean),
@@ -113,11 +86,12 @@ const parsePerseusGraphTypePolygon: Parser<PerseusGraphTypePolygon> = object({
     snapTo: optional(enumeration("grid", "angles", "sides")),
     match: optional(enumeration("similar", "congruent", "approx", "exact")),
     startCoords: optional(array(pairOfNumbers)),
+    coords: optional(nullable(array(pairOfNumbers))),
     // TODO: remove coord? it's legacy.
     coord: optional(pairOfNumbers),
 });
 
-const parsePerseusGraphTypeQuadratic: Parser<PerseusGraphTypeQuadratic> =
+const parsePerseusGraphTypeQuadratic =
     object({
         type: constant("quadratic"),
         coords: optional(
@@ -130,7 +104,7 @@ const parsePerseusGraphTypeQuadratic: Parser<PerseusGraphTypeQuadratic> =
         coord: optional(pairOfNumbers),
     });
 
-const parsePerseusGraphTypeRay: Parser<PerseusGraphTypeRay> = object({
+const parsePerseusGraphTypeRay = object({
     type: constant("ray"),
     coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
     startCoords: optional(pair(pairOfNumbers, pairOfNumbers)),
@@ -138,7 +112,7 @@ const parsePerseusGraphTypeRay: Parser<PerseusGraphTypeRay> = object({
     coord: optional(pairOfNumbers),
 });
 
-const parsePerseusGraphTypeSegment: Parser<PerseusGraphTypeSegment> = object({
+const parsePerseusGraphTypeSegment = object({
     type: constant("segment"),
     // TODO(benchristel): default numSegments?
     numSegments: optional(number),
@@ -148,7 +122,7 @@ const parsePerseusGraphTypeSegment: Parser<PerseusGraphTypeSegment> = object({
     coord: optional(pairOfNumbers),
 });
 
-const parsePerseusGraphTypeSinusoid: Parser<PerseusGraphTypeSinusoid> = object({
+const parsePerseusGraphTypeSinusoid = object({
     type: constant("sinusoid"),
     coords: optional(nullable(array(pairOfNumbers))),
     startCoords: optional(array(pairOfNumbers)),
@@ -169,23 +143,23 @@ export const parsePerseusGraphType = discriminatedUnionOn("type")
     .withBranch("segment", parsePerseusGraphTypeSegment)
     .withBranch("sinusoid", parsePerseusGraphTypeSinusoid).parser;
 
-const parseLockedFigureColor: Parser<LockedFigureColor> = enumeration(
+const parseLockedFigureColor = enumeration(
     ...lockedFigureColorNames,
 );
 
-const parseLockedFigureFillType: Parser<LockedFigureFillType> = enumeration(
+const parseLockedFigureFillType = enumeration(
     "none",
     "white",
     "translucent",
     "solid",
 );
 
-const parseLockedLineStyle: Parser<LockedLineStyle> = enumeration(
+const parseLockedLineStyle = enumeration(
     "solid",
     "dashed",
 );
 
-const parseLockedLabelType: Parser<LockedLabelType> = object({
+const parseLockedLabelType = object({
     type: constant("label"),
     coord: pairOfNumbers,
     text: string,
@@ -193,7 +167,7 @@ const parseLockedLabelType: Parser<LockedLabelType> = object({
     size: enumeration("small", "medium", "large"),
 });
 
-const parseLockedPointType: Parser<LockedPointType> = object({
+const parseLockedPointType = object({
     type: constant("point"),
     coord: pairOfNumbers,
     color: parseLockedFigureColor,
@@ -203,7 +177,7 @@ const parseLockedPointType: Parser<LockedPointType> = object({
     ariaLabel: optional(string),
 });
 
-const parseLockedLineType: Parser<LockedLineType> = object({
+const parseLockedLineType = object({
     type: constant("line"),
     kind: enumeration("line", "ray", "segment"),
     points: pair(parseLockedPointType, parseLockedPointType),
@@ -216,7 +190,7 @@ const parseLockedLineType: Parser<LockedLineType> = object({
     ariaLabel: optional(string),
 });
 
-const parseLockedVectorType: Parser<LockedVectorType> = object({
+const parseLockedVectorType = object({
     type: constant("vector"),
     points: pair(pairOfNumbers, pairOfNumbers),
     color: parseLockedFigureColor,
@@ -225,7 +199,7 @@ const parseLockedVectorType: Parser<LockedVectorType> = object({
     ariaLabel: optional(string),
 });
 
-const parseLockedEllipseType: Parser<LockedEllipseType> = object({
+const parseLockedEllipseType = object({
     type: constant("ellipse"),
     center: pairOfNumbers,
     radius: pairOfNumbers,
@@ -238,7 +212,7 @@ const parseLockedEllipseType: Parser<LockedEllipseType> = object({
     ariaLabel: optional(string),
 });
 
-const parseLockedPolygonType: Parser<LockedPolygonType> = object({
+const parseLockedPolygonType = object({
     type: constant("polygon"),
     points: array(pairOfNumbers),
     color: parseLockedFigureColor,
@@ -259,7 +233,7 @@ export const parseLockedFunctionDomain = defaulted(
     (): [number, number] => [-Infinity, Infinity],
 );
 
-const parseLockedFunctionType: Parser<LockedFunctionType> = object({
+const parseLockedFunctionType = object({
     type: constant("function"),
     color: parseLockedFigureColor,
     strokeStyle: parseLockedLineStyle,
@@ -271,7 +245,7 @@ const parseLockedFunctionType: Parser<LockedFunctionType> = object({
     ariaLabel: optional(string),
 });
 
-const parseLockedFigure: Parser<LockedFigure> = discriminatedUnionOn("type")
+const parseLockedFigure = discriminatedUnionOn("type")
     .withBranch("point", parseLockedPointType)
     .withBranch("line", parseLockedLineType)
     .withBranch("vector", parseLockedVectorType)
@@ -280,7 +254,7 @@ const parseLockedFigure: Parser<LockedFigure> = discriminatedUnionOn("type")
     .withBranch("function", parseLockedFunctionType)
     .withBranch("label", parseLockedLabelType).parser;
 
-export const parseInteractiveGraphWidget: Parser<InteractiveGraphWidget> =
+export const parseInteractiveGraphWidget =
     parseWidget(
         constant("interactive-graph"),
         object({
@@ -292,7 +266,7 @@ export const parseInteractiveGraphWidget: Parser<InteractiveGraphWidget> =
             gridStep: optional(pairOfNumbers),
             snapStep: optional(pairOfNumbers),
             backgroundImage: optional(parsePerseusImageBackground),
-            markings: enumeration("graph", "grid", "none"),
+            markings: enumeration("graph", "grid", "none", "axes"),
             labels: optional(array(string)),
             labelLocation: optional(enumeration("onAxis", "alongEdge")),
             showProtractor: boolean,
@@ -304,13 +278,13 @@ export const parseInteractiveGraphWidget: Parser<InteractiveGraphWidget> =
             // NOTE(benchristel): I copied the default graph from
             // interactive-graph.tsx. See the parse-perseus-json/README.md for
             // an explanation of why we want to duplicate the default here.
-            graph: defaulted(parsePerseusGraphType, () => ({
+            graph: defaulted(parsePerseusGraphType, (): PerseusGraphTypeLinear => ({
                 type: "linear" as const,
             })),
             correct: parsePerseusGraphType,
             // TODO(benchristel): default lockedFigures to empty array
             lockedFigures: optional(array(parseLockedFigure)),
-            fullGraphLabel: optional(string),
+            fullGraphAriaLabel: optional(string),
             fullGraphAriaDescription: optional(string),
         }),
     );

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { InteractiveGraphWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseInteractiveGraphWidget } from "./interactive-graph-widget";
+
+type Parsed = ParsedValue<typeof parseInteractiveGraphWidget>;
+
+summon<Parsed>() satisfies InteractiveGraphWidget;
+summon<InteractiveGraphWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<InteractiveGraphWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { InteractiveGraphWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseInteractiveGraphWidget } from "./interactive-graph-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseInteractiveGraphWidget} from "./interactive-graph-widget";
+import type {InteractiveGraphWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseInteractiveGraphWidget>;
 
@@ -10,4 +12,6 @@ summon<InteractiveGraphWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<InteractiveGraphWidget>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<InteractiveGraphWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/label-image-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/label-image-widget.ts
@@ -10,10 +10,7 @@ import {defaulted} from "../general-purpose-parsers/defaulted";
 
 import {parseWidget} from "./widget";
 
-import type {LabelImageWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parseLabelImageWidget: Parser<LabelImageWidget> = parseWidget(
+export const parseLabelImageWidget = parseWidget(
     constant("label-image"),
     object({
         choices: array(string),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/label-image-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/label-image-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { LabelImageWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseLabelImageWidget } from "./label-image-widget";
+
+type Parsed = ParsedValue<typeof parseLabelImageWidget>;
+
+summon<Parsed>() satisfies LabelImageWidget;
+summon<LabelImageWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<LabelImageWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/label-image-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/label-image-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { LabelImageWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseLabelImageWidget } from "./label-image-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseLabelImageWidget} from "./label-image-widget";
+import type {LabelImageWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseLabelImageWidget>;
 
@@ -10,4 +12,6 @@ summon<LabelImageWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<LabelImageWidget>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<LabelImageWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/legacy-button-sets.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/legacy-button-sets.ts
@@ -1,9 +1,9 @@
 import {array, enumeration} from "../general-purpose-parsers";
 import {defaulted} from "../general-purpose-parsers/defaulted";
 
-import type {LegacyButtonSets} from "../../data-schema";
+import { ParsedValue } from "../parser-types";
 
-export const parseLegacyButtonSet = enumeration(
+const parseLegacyButtonSet = enumeration(
     "basic",
     "basic+div",
     "trig",
@@ -19,5 +19,5 @@ export const parseLegacyButtonSets = defaulted(
     // NOTE(benchristel): I copied the default buttonSets from
     // expression.tsx. See the parse-perseus-json/README.md for
     // an explanation of why we want to duplicate the default here.
-    (): LegacyButtonSets => ["basic", "trig", "prealgebra", "logarithms"],
+    (): Array<ParsedValue<typeof parseLegacyButtonSet>> => ["basic", "trig", "prealgebra", "logarithms"],
 );

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/legacy-button-sets.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/legacy-button-sets.ts
@@ -1,7 +1,7 @@
 import {array, enumeration} from "../general-purpose-parsers";
 import {defaulted} from "../general-purpose-parsers/defaulted";
 
-import { ParsedValue } from "../parser-types";
+import type {ParsedValue} from "../parser-types";
 
 const parseLegacyButtonSet = enumeration(
     "basic",
@@ -19,5 +19,10 @@ export const parseLegacyButtonSets = defaulted(
     // NOTE(benchristel): I copied the default buttonSets from
     // expression.tsx. See the parse-perseus-json/README.md for
     // an explanation of why we want to duplicate the default here.
-    (): Array<ParsedValue<typeof parseLegacyButtonSet>> => ["basic", "trig", "prealgebra", "logarithms"],
+    (): Array<ParsedValue<typeof parseLegacyButtonSet>> => [
+        "basic",
+        "trig",
+        "prealgebra",
+        "logarithms",
+    ],
 );

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/legacy-button-sets.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/legacy-button-sets.typetest.ts
@@ -1,7 +1,9 @@
-import { LegacyButtonSets } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseLegacyButtonSets } from "./legacy-button-sets";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseLegacyButtonSets} from "./legacy-button-sets";
+import type {LegacyButtonSets} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseLegacyButtonSets>;
 
@@ -10,4 +12,6 @@ summon<LegacyButtonSets>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<LegacyButtonSets>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<LegacyButtonSets>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/legacy-button-sets.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/legacy-button-sets.typetest.ts
@@ -1,13 +1,13 @@
-import {summon} from "../general-purpose-parsers/test-helpers";
+import { LegacyButtonSets } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseLegacyButtonSets } from "./legacy-button-sets";
 
-import type {parseLegacyButtonSet} from "./legacy-button-sets";
-import type {LegacyButtonSets} from "../../data-schema";
-import type {ParsedValue} from "../parser-types";
+type Parsed = ParsedValue<typeof parseLegacyButtonSets>;
 
-type ParsedButtonSet = ParsedValue<typeof parseLegacyButtonSet>;
+summon<Parsed>() satisfies LegacyButtonSets;
+summon<LegacyButtonSets>() satisfies Parsed;
 
-// Test: LegacyButtonSets is mutually assignable with the result type of
-// parseButtonSets(). This ensures that we keep the parser up to date with any
-// new enum values added to the data schema.
-summon<ParsedButtonSet>() satisfies LegacyButtonSets[number];
-summon<LegacyButtonSets[number]>() satisfies ParsedButtonSet;
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<LegacyButtonSets>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matcher-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matcher-widget.ts
@@ -8,10 +8,7 @@ import {
 
 import {parseWidget} from "./widget";
 
-import type {MatcherWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parseMatcherWidget: Parser<MatcherWidget> = parseWidget(
+export const parseMatcherWidget = parseWidget(
     constant("matcher"),
     object({
         labels: array(string),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matcher-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matcher-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { MatcherWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseMatcherWidget } from "./matcher-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseMatcherWidget} from "./matcher-widget";
+import type {MatcherWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseMatcherWidget>;
 

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matcher-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matcher-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { MatcherWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseMatcherWidget } from "./matcher-widget";
+
+type Parsed = ParsedValue<typeof parseMatcherWidget>;
+
+summon<Parsed>() satisfies MatcherWidget;
+summon<MatcherWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<MatcherWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matrix-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matrix-widget.ts
@@ -14,15 +14,12 @@ import {stringToNumber} from "../general-purpose-parsers/string-to-number";
 
 import {parseWidget} from "./widget";
 
-import type {MatrixWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
 const numberOrString = union(number).or(string).parser;
 const numeric = pipeParsers(defaulted(numberOrString, () => NaN)).then(
     stringToNumber,
 ).parser;
 
-export const parseMatrixWidget: Parser<MatrixWidget> = parseWidget(
+export const parseMatrixWidget = parseWidget(
     defaulted(constant("matrix"), () => "matrix"),
     object({
         prefix: optional(string),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matrix-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matrix-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { MatrixWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseMatrixWidget } from "./matrix-widget";
+
+type Parsed = ParsedValue<typeof parseMatrixWidget>;
+
+summon<Parsed>() satisfies MatrixWidget;
+summon<MatrixWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<MatrixWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matrix-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matrix-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { MatrixWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseMatrixWidget } from "./matrix-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseMatrixWidget} from "./matrix-widget";
+import type {MatrixWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseMatrixWidget>;
 

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/measurer-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/measurer-widget.ts
@@ -7,20 +7,18 @@ import {
     string,
 } from "../general-purpose-parsers";
 import {defaulted} from "../general-purpose-parsers/defaulted";
+import { ParsedValue } from "../parser-types";
 
 import {parsePerseusImageBackground} from "./perseus-image-background";
 import {parseWidget} from "./widget";
 
-import type {MeasurerWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parseMeasurerWidget: Parser<MeasurerWidget> = parseWidget(
+export const parseMeasurerWidget = parseWidget(
     constant("measurer"),
     object({
         // The default value for image comes from measurer.tsx.
         // See parse-perseus-json/README.md for why we want to duplicate the
         // defaults here.
-        image: defaulted(parsePerseusImageBackground, () => ({
+        image: defaulted(parsePerseusImageBackground, (): ParsedValue<typeof parsePerseusImageBackground> => ({
             url: null,
             top: 0,
             left: 0,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/measurer-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/measurer-widget.ts
@@ -7,10 +7,11 @@ import {
     string,
 } from "../general-purpose-parsers";
 import {defaulted} from "../general-purpose-parsers/defaulted";
-import { ParsedValue } from "../parser-types";
 
 import {parsePerseusImageBackground} from "./perseus-image-background";
 import {parseWidget} from "./widget";
+
+import type {ParsedValue} from "../parser-types";
 
 export const parseMeasurerWidget = parseWidget(
     constant("measurer"),
@@ -18,11 +19,14 @@ export const parseMeasurerWidget = parseWidget(
         // The default value for image comes from measurer.tsx.
         // See parse-perseus-json/README.md for why we want to duplicate the
         // defaults here.
-        image: defaulted(parsePerseusImageBackground, (): ParsedValue<typeof parsePerseusImageBackground> => ({
-            url: null,
-            top: 0,
-            left: 0,
-        })),
+        image: defaulted(
+            parsePerseusImageBackground,
+            (): ParsedValue<typeof parsePerseusImageBackground> => ({
+                url: null,
+                top: 0,
+                left: 0,
+            }),
+        ),
         showProtractor: boolean,
         showRuler: boolean,
         rulerLabel: string,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/measurer-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/measurer-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { MeasurerWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseMeasurerWidget } from "./measurer-widget";
+
+type Parsed = ParsedValue<typeof parseMeasurerWidget>;
+
+summon<Parsed>() satisfies MeasurerWidget;
+summon<MeasurerWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<MeasurerWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/measurer-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/measurer-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { MeasurerWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseMeasurerWidget } from "./measurer-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseMeasurerWidget} from "./measurer-widget";
+import type {MeasurerWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseMeasurerWidget>;
 

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/molecule-renderer-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/molecule-renderer-widget.ts
@@ -8,10 +8,7 @@ import {
 
 import {parseWidget} from "./widget";
 
-import type {MoleculeRendererWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parseMoleculeRendererWidget: Parser<MoleculeRendererWidget> =
+export const parseMoleculeRendererWidget =
     parseWidget(
         constant("molecule-renderer"),
         object({

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/molecule-renderer-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/molecule-renderer-widget.ts
@@ -8,12 +8,11 @@ import {
 
 import {parseWidget} from "./widget";
 
-export const parseMoleculeRendererWidget =
-    parseWidget(
-        constant("molecule-renderer"),
-        object({
-            widgetId: string,
-            rotationAngle: optional(number),
-            smiles: optional(string),
-        }),
-    );
+export const parseMoleculeRendererWidget = parseWidget(
+    constant("molecule-renderer"),
+    object({
+        widgetId: string,
+        rotationAngle: optional(number),
+        smiles: optional(string),
+    }),
+);

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/molecule-renderer-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/molecule-renderer-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { MoleculeRendererWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseMoleculeRendererWidget } from "./molecule-renderer-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseMoleculeRendererWidget} from "./molecule-renderer-widget";
+import type {MoleculeRendererWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseMoleculeRendererWidget>;
 
@@ -10,4 +12,6 @@ summon<MoleculeRendererWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<MoleculeRendererWidget>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<MoleculeRendererWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/molecule-renderer-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/molecule-renderer-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { MoleculeRendererWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseMoleculeRendererWidget } from "./molecule-renderer-widget";
+
+type Parsed = ParsedValue<typeof parseMoleculeRendererWidget>;
+
+summon<Parsed>() satisfies MoleculeRendererWidget;
+summon<MoleculeRendererWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<MoleculeRendererWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/number-line-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/number-line-widget.ts
@@ -15,14 +15,11 @@ import {defaulted} from "../general-purpose-parsers/defaulted";
 
 import {parseWidget} from "./widget";
 
-import type {NumberLineWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
 const emptyStringToNull = pipeParsers(constant("")).then(
     convert(() => null),
 ).parser;
 
-export const parseNumberLineWidget: Parser<NumberLineWidget> = parseWidget(
+export const parseNumberLineWidget = parseWidget(
     constant("number-line"),
     object({
         range: array(number),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/number-line-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/number-line-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { NumberLineWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseNumberLineWidget } from "./number-line-widget";
+
+type Parsed = ParsedValue<typeof parseNumberLineWidget>;
+
+summon<Parsed>() satisfies NumberLineWidget;
+summon<NumberLineWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<NumberLineWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/number-line-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/number-line-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { NumberLineWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseNumberLineWidget } from "./number-line-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseNumberLineWidget} from "./number-line-widget";
+import type {NumberLineWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseNumberLineWidget>;
 
@@ -10,4 +12,6 @@ summon<NumberLineWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<NumberLineWidget>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<NumberLineWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/numeric-input-user-input.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/numeric-input-user-input.typetest.ts
@@ -1,9 +1,13 @@
-import {summon} from "../general-purpose-parsers/test-helpers";
+import { PerseusNumericInputUserInput } from "../../validation.types";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseNumericInputUserInput } from "./numeric-input-user-input";
 
-import type {parseNumericInputUserInput} from "./numeric-input-user-input";
-import type {PerseusNumericInputUserInput} from "../../validation.types";
-import type {ParsedValue} from "../parser-types";
+type Parsed = ParsedValue<typeof parseNumericInputUserInput>;
 
-summon<
-    ParsedValue<typeof parseNumericInputUserInput>
->() satisfies PerseusNumericInputUserInput;
+summon<Parsed>() satisfies PerseusNumericInputUserInput;
+summon<PerseusNumericInputUserInput>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PerseusNumericInputUserInput>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/numeric-input-user-input.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/numeric-input-user-input.typetest.ts
@@ -1,7 +1,9 @@
-import { PerseusNumericInputUserInput } from "../../validation.types";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseNumericInputUserInput } from "./numeric-input-user-input";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseNumericInputUserInput} from "./numeric-input-user-input";
+import type {PerseusNumericInputUserInput} from "../../validation.types";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseNumericInputUserInput>;
 
@@ -10,4 +12,6 @@ summon<PerseusNumericInputUserInput>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PerseusNumericInputUserInput>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<PerseusNumericInputUserInput>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/numeric-input-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/numeric-input-widget.ts
@@ -16,12 +16,6 @@ import {defaulted} from "../general-purpose-parsers/defaulted";
 
 import {parseWidget} from "./widget";
 
-import type {
-    NumericInputWidget,
-    PerseusNumericInputSimplify,
-} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
 const parseMathFormat = enumeration(
     "integer",
     "mixed",
@@ -53,7 +47,7 @@ function deprecatedSimplifyValuesToRequired(
         | null
         | undefined
         | boolean,
-): PerseusNumericInputSimplify {
+): "enforced" | "required" | "optional" {
     switch (simplify) {
         case "enforced":
         case "required":
@@ -68,7 +62,7 @@ function deprecatedSimplifyValuesToRequired(
     }
 }
 
-export const parseNumericInputWidget: Parser<NumericInputWidget> = parseWidget(
+export const parseNumericInputWidget = parseWidget(
     constant("numeric-input"),
     object({
         answers: array(

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/numeric-input-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/numeric-input-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { NumericInputWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseNumericInputWidget } from "./numeric-input-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseNumericInputWidget} from "./numeric-input-widget";
+import type {NumericInputWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseNumericInputWidget>;
 
@@ -10,4 +12,6 @@ summon<NumericInputWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<NumericInputWidget>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<NumericInputWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/numeric-input-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/numeric-input-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { NumericInputWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseNumericInputWidget } from "./numeric-input-widget";
+
+type Parsed = ParsedValue<typeof parseNumericInputWidget>;
+
+summon<Parsed>() satisfies NumericInputWidget;
+summon<NumericInputWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<NumericInputWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/orderer-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/orderer-widget.ts
@@ -10,8 +10,7 @@ import {defaulted} from "../general-purpose-parsers/defaulted";
 import {parsePerseusRenderer} from "./perseus-renderer";
 import {parseWidget} from "./widget";
 
-import type {OrdererWidget} from "../../data-schema";
-import type {Parser, PartialParser} from "../parser-types";
+import type {PartialParser} from "../parser-types";
 
 // There is an import cycle between orderer-widget.ts and perseus-renderer.ts.
 // This wrapper ensures that we don't refer to parsePerseusRenderer before
@@ -30,7 +29,7 @@ const largeToAuto: PartialParser<
     return ctx.success(height);
 };
 
-export const parseOrdererWidget: Parser<OrdererWidget> = parseWidget(
+export const parseOrdererWidget = parseWidget(
     constant("orderer"),
     object({
         options: defaulted(array(parseRenderer), () => []),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/orderer-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/orderer-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { OrdererWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parseOrdererWidget } from "./orderer-widget";
+
+type Parsed = ParsedValue<typeof parseOrdererWidget>;
+
+summon<Parsed>() satisfies OrdererWidget;
+summon<OrdererWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<OrdererWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/orderer-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/orderer-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { OrdererWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parseOrdererWidget } from "./orderer-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseOrdererWidget} from "./orderer-widget";
+import type {OrdererWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseOrdererWidget>;
 

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/passage-ref-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/passage-ref-widget.ts
@@ -8,10 +8,7 @@ import {
 
 import {parseWidget} from "./widget";
 
-import type {PassageRefWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parsePassageRefWidget: Parser<PassageRefWidget> = parseWidget(
+export const parsePassageRefWidget = parseWidget(
     constant("passage-ref"),
     object({
         passageNumber: number,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/passage-ref-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/passage-ref-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { PassageRefWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parsePassageRefWidget } from "./passage-ref-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parsePassageRefWidget} from "./passage-ref-widget";
+import type {PassageRefWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parsePassageRefWidget>;
 
@@ -10,4 +12,6 @@ summon<PassageRefWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PassageRefWidget>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<PassageRefWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/passage-ref-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/passage-ref-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { PassageRefWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parsePassageRefWidget } from "./passage-ref-widget";
+
+type Parsed = ParsedValue<typeof parsePassageRefWidget>;
+
+summon<Parsed>() satisfies PassageRefWidget;
+summon<PassageRefWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PassageRefWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/passage-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/passage-widget.ts
@@ -3,10 +3,7 @@ import {defaulted} from "../general-purpose-parsers/defaulted";
 
 import {parseWidget} from "./widget";
 
-import type {PassageWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parsePassageWidget: Parser<PassageWidget> = parseWidget(
+export const parsePassageWidget = parseWidget(
     constant("passage"),
     object({
         footnotes: defaulted(string, () => ""),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/passage-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/passage-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { PassageWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parsePassageWidget } from "./passage-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parsePassageWidget} from "./passage-widget";
+import type {PassageWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parsePassageWidget>;
 

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/passage-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/passage-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { PassageWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parsePassageWidget } from "./passage-widget";
+
+type Parsed = ParsedValue<typeof parsePassageWidget>;
+
+summon<Parsed>() satisfies PassageWidget;
+summon<PassageWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PassageWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-answer-area.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-answer-area.ts
@@ -2,8 +2,6 @@ import {object, pipeParsers} from "../general-purpose-parsers";
 import {convert} from "../general-purpose-parsers/convert";
 import {defaulted} from "../general-purpose-parsers/defaulted";
 
-import type {PerseusAnswerArea} from "../../data-schema";
-
 export const parsePerseusAnswerArea = pipeParsers(
     defaulted(object({}), () => ({})),
 ).then(convert(toAnswerArea)).parser;
@@ -21,7 +19,7 @@ export const parsePerseusAnswerArea = pipeParsers(
 //
 // This function filters the fields of an answerArea object, keeping only the
 // known ones, and converts `undefined` and `null` values to `false`.
-function toAnswerArea(raw: Record<string, unknown>): PerseusAnswerArea {
+function toAnswerArea(raw: Record<string, unknown>) {
     return {
         zTable: !!raw.zTable,
         calculator: !!raw.calculator,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-answer-area.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-answer-area.typetest.ts
@@ -1,0 +1,13 @@
+import { PerseusAnswerArea } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parsePerseusAnswerArea } from "./perseus-answer-area";
+
+type Parsed = ParsedValue<typeof parsePerseusAnswerArea>;
+
+summon<Parsed>() satisfies PerseusAnswerArea;
+summon<PerseusAnswerArea>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PerseusAnswerArea>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-answer-area.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-answer-area.typetest.ts
@@ -1,7 +1,9 @@
-import { PerseusAnswerArea } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parsePerseusAnswerArea } from "./perseus-answer-area";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parsePerseusAnswerArea} from "./perseus-answer-area";
+import type {PerseusAnswerArea} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parsePerseusAnswerArea>;
 
@@ -10,4 +12,6 @@ summon<PerseusAnswerArea>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PerseusAnswerArea>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<PerseusAnswerArea>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-image-background.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-image-background.ts
@@ -11,9 +11,6 @@ import {convert} from "../general-purpose-parsers/convert";
 import {defaulted} from "../general-purpose-parsers/defaulted";
 import {stringToNumber} from "../general-purpose-parsers/string-to-number";
 
-import type {PerseusImageBackground} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
 function emptyToZero(x: string | number): string | number {
     return x === "" ? 0 : x;
 }
@@ -27,7 +24,7 @@ const imageDimensionToNumber = pipeParsers(union(number).or(string).parser)
 
 const dimensionOrUndefined = defaulted(imageDimensionToNumber, () => undefined);
 
-export const parsePerseusImageBackground: Parser<PerseusImageBackground> =
+export const parsePerseusImageBackground =
     object({
         url: optional(nullable(string)),
         width: dimensionOrUndefined,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-image-background.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-image-background.ts
@@ -24,13 +24,12 @@ const imageDimensionToNumber = pipeParsers(union(number).or(string).parser)
 
 const dimensionOrUndefined = defaulted(imageDimensionToNumber, () => undefined);
 
-export const parsePerseusImageBackground =
-    object({
-        url: optional(nullable(string)),
-        width: dimensionOrUndefined,
-        height: dimensionOrUndefined,
-        top: dimensionOrUndefined,
-        left: dimensionOrUndefined,
-        bottom: dimensionOrUndefined,
-        scale: dimensionOrUndefined,
-    });
+export const parsePerseusImageBackground = object({
+    url: optional(nullable(string)),
+    width: dimensionOrUndefined,
+    height: dimensionOrUndefined,
+    top: dimensionOrUndefined,
+    left: dimensionOrUndefined,
+    bottom: dimensionOrUndefined,
+    scale: dimensionOrUndefined,
+});

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-image-background.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-image-background.typetest.ts
@@ -1,0 +1,13 @@
+import { PerseusImageBackground } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parsePerseusImageBackground } from "./perseus-image-background";
+
+type Parsed = ParsedValue<typeof parsePerseusImageBackground>;
+
+summon<Parsed>() satisfies PerseusImageBackground;
+summon<PerseusImageBackground>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PerseusImageBackground>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-image-background.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-image-background.typetest.ts
@@ -1,7 +1,9 @@
-import { PerseusImageBackground } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parsePerseusImageBackground } from "./perseus-image-background";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parsePerseusImageBackground} from "./perseus-image-background";
+import type {PerseusImageBackground} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parsePerseusImageBackground>;
 
@@ -10,4 +12,6 @@ summon<PerseusImageBackground>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PerseusImageBackground>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<PerseusImageBackground>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-image-detail.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-image-detail.ts
@@ -1,0 +1,6 @@
+import { number, object } from "../general-purpose-parsers";
+
+export const parsePerseusImageDetail = object({
+    width: number,
+    height: number,
+});

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-image-detail.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-image-detail.ts
@@ -1,4 +1,4 @@
-import { number, object } from "../general-purpose-parsers";
+import {number, object} from "../general-purpose-parsers";
 
 export const parsePerseusImageDetail = object({
     width: number,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-image-detail.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-image-detail.typetest.ts
@@ -1,7 +1,9 @@
-import { PerseusImageDetail } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parsePerseusImageDetail } from "./perseus-image-detail";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parsePerseusImageDetail} from "./perseus-image-detail";
+import type {PerseusImageDetail} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parsePerseusImageDetail>;
 
@@ -10,4 +12,6 @@ summon<PerseusImageDetail>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PerseusImageDetail>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<PerseusImageDetail>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-image-detail.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-image-detail.typetest.ts
@@ -1,0 +1,13 @@
+import { PerseusImageDetail } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parsePerseusImageDetail } from "./perseus-image-detail";
+
+type Parsed = ParsedValue<typeof parsePerseusImageDetail>;
+
+summon<Parsed>() satisfies PerseusImageDetail;
+summon<PerseusImageDetail>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PerseusImageDetail>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/phet-simulation-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/phet-simulation-widget.ts
@@ -2,10 +2,7 @@ import {constant, object, string} from "../general-purpose-parsers";
 
 import {parseWidget} from "./widget";
 
-import type {PhetSimulationWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parsePhetSimulationWidget: Parser<PhetSimulationWidget> =
+export const parsePhetSimulationWidget =
     parseWidget(
         constant("phet-simulation"),
         object({

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/phet-simulation-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/phet-simulation-widget.ts
@@ -2,11 +2,10 @@ import {constant, object, string} from "../general-purpose-parsers";
 
 import {parseWidget} from "./widget";
 
-export const parsePhetSimulationWidget =
-    parseWidget(
-        constant("phet-simulation"),
-        object({
-            url: string,
-            description: string,
-        }),
-    );
+export const parsePhetSimulationWidget = parseWidget(
+    constant("phet-simulation"),
+    object({
+        url: string,
+        description: string,
+    }),
+);

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/phet-simulation-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/phet-simulation-widget.typetest.ts
@@ -1,0 +1,13 @@
+import { PhetSimulationWidget } from "../../data-schema";
+import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
+import { ParsedValue } from "../parser-types";
+import { parsePhetSimulationWidget } from "./phet-simulation-widget";
+
+type Parsed = ParsedValue<typeof parsePhetSimulationWidget>;
+
+summon<Parsed>() satisfies PhetSimulationWidget;
+summon<PhetSimulationWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PhetSimulationWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/phet-simulation-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/phet-simulation-widget.typetest.ts
@@ -1,7 +1,9 @@
-import { PhetSimulationWidget } from "../../data-schema";
-import { RecursiveRequired, summon } from "../general-purpose-parsers/test-helpers";
-import { ParsedValue } from "../parser-types";
-import { parsePhetSimulationWidget } from "./phet-simulation-widget";
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parsePhetSimulationWidget} from "./phet-simulation-widget";
+import type {PhetSimulationWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parsePhetSimulationWidget>;
 
@@ -10,4 +12,6 @@ summon<PhetSimulationWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PhetSimulationWidget>;
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<PhetSimulationWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/plotter-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/plotter-widget.ts
@@ -13,10 +13,7 @@ import {defaulted} from "../general-purpose-parsers/defaulted";
 
 import {parseWidget} from "./widget";
 
-import type {PlotterWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parsePlotterWidget: Parser<PlotterWidget> = parseWidget(
+export const parsePlotterWidget = parseWidget(
     constant("plotter"),
     object({
         labels: array(string),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/plotter-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/plotter-widget.typetest.ts
@@ -12,6 +12,4 @@ summon<PlotterWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<
-    RecursiveRequired<Parsed>
->() satisfies RecursiveRequired<PlotterWidget>;
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<PlotterWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/plotter-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/plotter-widget.typetest.ts
@@ -1,17 +1,17 @@
 import {summon} from "../general-purpose-parsers/test-helpers";
 
-import type {parseRadioUserInput} from "./radio-user-input";
-import type {PerseusRadioUserInput} from "../../validation.types";
+import type {parsePlotterWidget} from "./plotter-widget";
+import type {PlotterWidget} from "../../data-schema";
 import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
 import type {ParsedValue} from "../parser-types";
 
-type Parsed = ParsedValue<typeof parseRadioUserInput>;
+type Parsed = ParsedValue<typeof parsePlotterWidget>;
 
-summon<Parsed>() satisfies PerseusRadioUserInput;
-summon<PerseusRadioUserInput>() satisfies Parsed;
+summon<Parsed>() satisfies PlotterWidget;
+summon<PlotterWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
 summon<
     RecursiveRequired<Parsed>
->() satisfies RecursiveRequired<PerseusRadioUserInput>;
+>() satisfies RecursiveRequired<PlotterWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/python-program-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/python-program-widget.ts
@@ -2,10 +2,7 @@ import {constant, object, string, number} from "../general-purpose-parsers";
 
 import {parseWidget} from "./widget";
 
-import type {PythonProgramWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parsePythonProgramWidget: Parser<PythonProgramWidget> =
+export const parsePythonProgramWidget =
     parseWidget(
         constant("python-program"),
         object({

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/python-program-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/python-program-widget.ts
@@ -2,11 +2,10 @@ import {constant, object, string, number} from "../general-purpose-parsers";
 
 import {parseWidget} from "./widget";
 
-export const parsePythonProgramWidget =
-    parseWidget(
-        constant("python-program"),
-        object({
-            programID: string,
-            height: number,
-        }),
-    );
+export const parsePythonProgramWidget = parseWidget(
+    constant("python-program"),
+    object({
+        programID: string,
+        height: number,
+    }),
+);

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/python-program-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/python-program-widget.typetest.ts
@@ -1,17 +1,17 @@
 import {summon} from "../general-purpose-parsers/test-helpers";
 
-import type {parseRadioUserInput} from "./radio-user-input";
-import type {PerseusRadioUserInput} from "../../validation.types";
+import type {parsePythonProgramWidget} from "./python-program-widget";
+import type {PythonProgramWidget} from "../../data-schema";
 import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
 import type {ParsedValue} from "../parser-types";
 
-type Parsed = ParsedValue<typeof parseRadioUserInput>;
+type Parsed = ParsedValue<typeof parsePythonProgramWidget>;
 
-summon<Parsed>() satisfies PerseusRadioUserInput;
-summon<PerseusRadioUserInput>() satisfies Parsed;
+summon<Parsed>() satisfies PythonProgramWidget;
+summon<PythonProgramWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
 summon<
     RecursiveRequired<Parsed>
->() satisfies RecursiveRequired<PerseusRadioUserInput>;
+>() satisfies RecursiveRequired<PythonProgramWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.typetest.ts
@@ -12,6 +12,4 @@ summon<RadioWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<
-    RecursiveRequired<Parsed>
->() satisfies RecursiveRequired<RadioWidget>;
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<RadioWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.typetest.ts
@@ -2,7 +2,16 @@ import {summon} from "../general-purpose-parsers/test-helpers";
 
 import type {parseRadioWidget} from "./radio-widget";
 import type {RadioWidget} from "../../data-schema";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
 import type {ParsedValue} from "../parser-types";
 
 type Parsed = ParsedValue<typeof parseRadioWidget>;
+
 summon<Parsed>() satisfies RadioWidget;
+summon<RadioWidget>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<RadioWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/sorter-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/sorter-widget.ts
@@ -9,10 +9,7 @@ import {
 
 import {parseWidget} from "./widget";
 
-import type {SorterWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parseSorterWidget: Parser<SorterWidget> = parseWidget(
+export const parseSorterWidget = parseWidget(
     constant("sorter"),
     object({
         correct: array(string),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/sorter-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/sorter-widget.typetest.ts
@@ -12,6 +12,4 @@ summon<SorterWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<
-    RecursiveRequired<Parsed>
->() satisfies RecursiveRequired<SorterWidget>;
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<SorterWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/sorter-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/sorter-widget.typetest.ts
@@ -1,17 +1,17 @@
 import {summon} from "../general-purpose-parsers/test-helpers";
 
-import type {parseRadioUserInput} from "./radio-user-input";
-import type {PerseusRadioUserInput} from "../../validation.types";
+import type {parseSorterWidget} from "./sorter-widget";
+import type {SorterWidget} from "../../data-schema";
 import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
 import type {ParsedValue} from "../parser-types";
 
-type Parsed = ParsedValue<typeof parseRadioUserInput>;
+type Parsed = ParsedValue<typeof parseSorterWidget>;
 
-summon<Parsed>() satisfies PerseusRadioUserInput;
-summon<PerseusRadioUserInput>() satisfies Parsed;
+summon<Parsed>() satisfies SorterWidget;
+summon<SorterWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
 summon<
     RecursiveRequired<Parsed>
->() satisfies RecursiveRequired<PerseusRadioUserInput>;
+>() satisfies RecursiveRequired<SorterWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/table-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/table-widget.ts
@@ -8,10 +8,7 @@ import {
 
 import {parseWidget} from "./widget";
 
-import type {TableWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parseTableWidget: Parser<TableWidget> = parseWidget(
+export const parseTableWidget = parseWidget(
     constant("table"),
     object({
         headers: array(string),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/table-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/table-widget.typetest.ts
@@ -12,6 +12,4 @@ summon<TableWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<
-    RecursiveRequired<Parsed>
->() satisfies RecursiveRequired<TableWidget>;
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<TableWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/table-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/table-widget.typetest.ts
@@ -1,17 +1,17 @@
 import {summon} from "../general-purpose-parsers/test-helpers";
 
-import type {parseRadioUserInput} from "./radio-user-input";
-import type {PerseusRadioUserInput} from "../../validation.types";
+import type {parseTableWidget} from "./table-widget";
+import type {TableWidget} from "../../data-schema";
 import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
 import type {ParsedValue} from "../parser-types";
 
-type Parsed = ParsedValue<typeof parseRadioUserInput>;
+type Parsed = ParsedValue<typeof parseTableWidget>;
 
-summon<Parsed>() satisfies PerseusRadioUserInput;
-summon<PerseusRadioUserInput>() satisfies Parsed;
+summon<Parsed>() satisfies TableWidget;
+summon<TableWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
 summon<
     RecursiveRequired<Parsed>
->() satisfies RecursiveRequired<PerseusRadioUserInput>;
+>() satisfies RecursiveRequired<TableWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/video-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/video-widget.ts
@@ -8,10 +8,7 @@ import {
 
 import {parseWidget} from "./widget";
 
-import type {VideoWidget} from "../../data-schema";
-import type {Parser} from "../parser-types";
-
-export const parseVideoWidget: Parser<VideoWidget> = parseWidget(
+export const parseVideoWidget = parseWidget(
     constant("video"),
     object({
         location: string,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/video-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/video-widget.typetest.ts
@@ -1,17 +1,17 @@
 import {summon} from "../general-purpose-parsers/test-helpers";
 
-import type {parseRadioUserInput} from "./radio-user-input";
-import type {PerseusRadioUserInput} from "../../validation.types";
+import type {parseVideoWidget} from "./video-widget";
+import type {VideoWidget} from "../../data-schema";
 import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
 import type {ParsedValue} from "../parser-types";
 
-type Parsed = ParsedValue<typeof parseRadioUserInput>;
+type Parsed = ParsedValue<typeof parseVideoWidget>;
 
-summon<Parsed>() satisfies PerseusRadioUserInput;
-summon<PerseusRadioUserInput>() satisfies Parsed;
+summon<Parsed>() satisfies VideoWidget;
+summon<VideoWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
 summon<
     RecursiveRequired<Parsed>
->() satisfies RecursiveRequired<PerseusRadioUserInput>;
+>() satisfies RecursiveRequired<VideoWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/video-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/video-widget.typetest.ts
@@ -12,6 +12,4 @@ summon<VideoWidget>() satisfies Parsed;
 
 // The `RecursiveRequired` test ensures that any new optional properties added
 // to the types in data-schema.ts are also added to the parser.
-summon<
-    RecursiveRequired<Parsed>
->() satisfies RecursiveRequired<VideoWidget>;
+summon<RecursiveRequired<Parsed>>() satisfies RecursiveRequired<VideoWidget>;

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -1347,7 +1347,6 @@ $\\qquad$![](https://ka-perseus-graphie.s3.amazonaws.com/bee05e004428ab4fb0d8af9
             {
               "considered": "correct",
               "form": false,
-              "key": "undefined",
               "simplify": false,
               "value": "sqrt(3)*3",
             },
@@ -1382,7 +1381,6 @@ $\\qquad$![](https://ka-perseus-graphie.s3.amazonaws.com/bee05e004428ab4fb0d8af9
             {
               "considered": "correct",
               "form": false,
-              "key": "undefined",
               "simplify": false,
               "value": "3",
             },
@@ -1417,7 +1415,6 @@ $\\qquad$![](https://ka-perseus-graphie.s3.amazonaws.com/bee05e004428ab4fb0d8af9
             {
               "considered": "correct",
               "form": false,
-              "key": "undefined",
               "simplify": false,
               "value": "pi/6",
             },
@@ -6743,7 +6740,6 @@ The graph of the solution of the inequality, $c ≥ 8.75$, looks like this:
             {
               "considered": "correct",
               "form": false,
-              "key": "undefined",
               "simplify": false,
               "value": "1.2c+3\\ge13.5",
             },

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor.test.tsx
@@ -290,13 +290,13 @@ describe("InteractiveGraphEditor", () => {
                 correct: {
                     type: "polygon",
                     numSides: 5,
-                    coords: null,
+                    coords: undefined,
                     snapTo: "grid",
                 },
                 graph: {
                     type: "polygon",
                     numSides: 5,
-                    coords: null,
+                    coords: undefined,
                     snapTo: "grid",
                 },
             }),

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -524,7 +524,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                             const updates = {
                                                 numSides:
                                                     parsePointCount(newValue),
-                                                coords: null,
+                                                coords: undefined,
                                                 startCoords: undefined,
                                                 // reset the snap for UNLIMITED, which
                                                 // only supports "grid"


### PR DESCRIPTION
These typetests ensure that our parsers stay in sync with the data-schema types.

- If you add a new property (even an optional one) to any type used in widget options,
  but don't update the parser, you will get a type error.
- If you add a variant to a union type used in widget options without updating the parser,
  you will get a type error.

While adding these typetests, I found some discrepancies in our existing types, which are
fixed in this PR.

## Test plan:

`pnpm tsc`