### PR TITLE
Add tests to ensure Perseus JSON parsers are idempotent

### DIFF
--- a/.changeset/silly-crabs-pump.md
+++ b/.changeset/silly-crabs-pump.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+Internal: add tests to ensure Perseus JSON parsers are idempotent

--- a/packages/perseus-core/src/parse-perseus-json/general-purpose-parsers/defaulted.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/general-purpose-parsers/defaulted.test.ts
@@ -1,6 +1,7 @@
 import {success} from "../result";
 
 import {defaulted} from "./defaulted";
+import {nullable} from "./nullable";
 import {number} from "./number";
 import {ctx, parseFailureWith} from "./test-helpers";
 
@@ -24,7 +25,7 @@ describe("defaulted()", () => {
     it("allows the fallback function to distinguish between null and undefined", () => {
         // Maybe null is actually a valid value, but we want to default
         // undefined to 0. We can do it!
-        const numberOrNull = defaulted(number, (v): null | number =>
+        const numberOrNull = defaulted(nullable(number), (v) =>
             v === null ? null : 0,
         );
         numberOrNull satisfies Parser<number | null>;

--- a/packages/perseus-core/src/parse-perseus-json/general-purpose-parsers/defaulted.ts
+++ b/packages/perseus-core/src/parse-perseus-json/general-purpose-parsers/defaulted.ts
@@ -2,10 +2,10 @@ import {success} from "../result";
 
 import type {Parser} from "../parser-types";
 
-export function defaulted<T, Default>(
+export function defaulted<T>(
     parser: Parser<T>,
-    fallback: (missingValue: null | undefined) => Default,
-): Parser<T | Default> {
+    fallback: (missingValue: null | undefined) => NoInfer<T>,
+): Parser<T> {
     return (rawValue, ctx) => {
         if (rawValue == null) {
             return success(fallback(rawValue));

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/hint.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/hint.ts
@@ -1,11 +1,17 @@
-import {any, boolean, object, string} from "../general-purpose-parsers";
+import {
+    any,
+    boolean,
+    object,
+    optional,
+    string,
+} from "../general-purpose-parsers";
 import {defaulted} from "../general-purpose-parsers/defaulted";
 
 import {parseImages} from "./images-map";
 import {parseWidgetsMap} from "./widgets-map";
 
 export const parseHint = object({
-    replace: defaulted(boolean, () => undefined),
+    replace: defaulted(optional(boolean), () => undefined),
     content: string,
     widgets: defaulted(parseWidgetsMap, () => ({})),
     images: parseImages,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/legacy-button-sets.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/legacy-button-sets.ts
@@ -1,8 +1,6 @@
 import {array, enumeration} from "../general-purpose-parsers";
 import {defaulted} from "../general-purpose-parsers/defaulted";
 
-import type {ParsedValue} from "../parser-types";
-
 const parseLegacyButtonSet = enumeration(
     "basic",
     "basic+div",
@@ -19,10 +17,10 @@ export const parseLegacyButtonSets = defaulted(
     // NOTE(benchristel): I copied the default buttonSets from
     // expression.tsx. See the parse-perseus-json/README.md for
     // an explanation of why we want to duplicate the default here.
-    (): Array<ParsedValue<typeof parseLegacyButtonSet>> => [
-        "basic",
-        "trig",
-        "prealgebra",
-        "logarithms",
+    () => [
+        "basic" as const,
+        "trig" as const,
+        "prealgebra" as const,
+        "logarithms" as const,
     ],
 );

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/measurer-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/measurer-widget.ts
@@ -11,22 +11,17 @@ import {defaulted} from "../general-purpose-parsers/defaulted";
 import {parsePerseusImageBackground} from "./perseus-image-background";
 import {parseWidget} from "./widget";
 
-import type {ParsedValue} from "../parser-types";
-
 export const parseMeasurerWidget = parseWidget(
     constant("measurer"),
     object({
         // The default value for image comes from measurer.tsx.
         // See parse-perseus-json/README.md for why we want to duplicate the
         // defaults here.
-        image: defaulted(
-            parsePerseusImageBackground,
-            (): ParsedValue<typeof parsePerseusImageBackground> => ({
-                url: null,
-                top: 0,
-                left: 0,
-            }),
-        ),
+        image: defaulted(parsePerseusImageBackground, () => ({
+            url: null,
+            top: 0,
+            left: 0,
+        })),
         showProtractor: boolean,
         showRuler: boolean,
         rulerLabel: string,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/numeric-input-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/numeric-input-widget.ts
@@ -73,7 +73,10 @@ export const parseNumericInputWidget = parseWidget(
                 // the data, simplify this.
                 value: optional(nullable(number)),
                 status: string,
-                answerForms: defaulted(array(parseMathFormat), () => undefined),
+                answerForms: defaulted(
+                    optional(array(parseMathFormat)),
+                    () => undefined,
+                ),
                 strict: boolean,
                 maxError: optional(nullable(number)),
                 // TODO(benchristel): simplify should never be a boolean, but we

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-image-background.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-image-background.ts
@@ -22,7 +22,10 @@ const imageDimensionToNumber = pipeParsers(union(number).or(string).parser)
     .then(convert(emptyToZero))
     .then(stringToNumber).parser;
 
-const dimensionOrUndefined = defaulted(imageDimensionToNumber, () => undefined);
+const dimensionOrUndefined = defaulted(
+    optional(imageDimensionToNumber),
+    () => undefined,
+);
 
 export const parsePerseusImageBackground = object({
     url: optional(nullable(string)),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.ts
@@ -21,7 +21,7 @@ const parseWidgetsMapOrUndefined = defaulted(
     // There is an import cycle between radio-widget.ts and
     // widgets-map.ts. The anonymous function below ensures that we
     // don't refer to parseWidgetsMap before it's defined.
-    (rawVal, ctx) => parseWidgetsMap(rawVal, ctx),
+    optional((rawVal, ctx) => parseWidgetsMap(rawVal, ctx)),
     () => undefined,
 );
 

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/parse-perseus-json-regression.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/parse-perseus-json-regression.test.ts
@@ -6,6 +6,9 @@ import {
     parseAndMigratePerseusArticle,
     parseAndMigratePerseusItem,
 } from "../index";
+import {parse} from "../parse";
+import {parsePerseusArticle} from "../perseus-parsers/perseus-article";
+import {parsePerseusItem} from "../perseus-parsers/perseus-item";
 import {assertSuccess, mapFailure} from "../result";
 
 const itemDataDir = join(__dirname, "item-data");
@@ -34,6 +37,23 @@ describe("parseAndMigratePerseusItem", () => {
             assertSuccess(result);
             expect(result.value).toMatchSnapshot();
         });
+
+        it("is not changed by a second pass through the parser", () => {
+            // This test ensures that the parser is idempotent, i.e. running it
+            // once is the same as running it many times. Idempotency is
+            // valuable because it means e.g. that if we run the parser on data
+            // before saving it to datastore, it won't be changed by being
+            // parsed again on read.
+            assertSuccess(result);
+
+            const result2 = parse(result.value, parsePerseusItem);
+
+            expect(result2).toEqual(anySuccess);
+            // Narrow the type. This assertion should always pass due to the
+            // expectation above.
+            assertSuccess(result2);
+            expect(result2.value).toEqual(result.value);
+        });
     });
 });
 
@@ -56,6 +76,23 @@ describe("parseAndMigratePerseusArticle", () => {
         it("returns the same result as before", () => {
             assertSuccess(result);
             expect(result.value).toMatchSnapshot();
+        });
+
+        it("is not changed by a second pass through the parser", () => {
+            // This test ensures that the parser is idempotent, i.e. running it
+            // once is the same as running it many times. Idempotency is
+            // valuable because it means e.g. that if we run the parser on data
+            // before saving it to datastore, it won't be changed by being
+            // parsed again on read.
+            assertSuccess(result);
+
+            const result2 = parse(result.value, parsePerseusArticle);
+
+            expect(result2).toEqual(anySuccess);
+            // Narrow the type. This assertion should always pass due to the
+            // expectation above.
+            assertSuccess(result2);
+            expect(result2.value).toEqual(result.value);
         });
     });
 });


### PR DESCRIPTION
## Summary:
I realized that the type of the `defaulted` parser encouraged non-idempotent
parsing. Essentially, a default value could be supplied that would cause a parse
error on a second pass through the parser. Example:

```ts
const parseMyObject = object({
  myField: defaulted(number, () => "bork"),
})
```

The inferred type `ParsedValue<typeof parseMyObject>` would be:

```ts
type MyObject = {myField: number | string}
```

However, the parser doesn't consider a myField value of type `string` to be valid!
This contradicts the types! You will get an error if you try to parse

```ts
parseMyObject({myField: "bork"}, ctx)
```

because the parser for `myField` only accepts a number, null, or undefined as
input.

This is clearly not how we want parsers to behave. Parsing should be idempotent.

This PR fixes the types of `defaulted` so we don't encourage non-idempotent
parsing. It also adds tests to verify that our existing parsers are idempotent
when run on example data.

Issue: LEMS-3055

## Test plan:

`pnpm test`