### PR TITLE
Update Radio Widget docs to include rationales in the test data

### DIFF
--- a/.changeset/metal-ties-remain.md
+++ b/.changeset/metal-ties-remain.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Update Radio Widget docs to include rationales in the test data

--- a/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
@@ -289,7 +289,7 @@ export const multiChoiceQuestionSimple: PerseusRenderer = {
                         content: "Goodbye",
                         isNoneOfTheAbove: false,
                         correct: false,
-                        clue: "Some people likes to say Goodbye.",
+                        clue: "Some people like to say Goodbye.",
                     },
                     {
                         content: "None of these",

--- a/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
@@ -271,21 +271,25 @@ export const multiChoiceQuestionSimple: PerseusRenderer = {
                         content: "Hola",
                         isNoneOfTheAbove: false,
                         correct: true,
+                        clue: "The Spanish-speaking countries typically say Hola.",
                     },
                     {
                         content: "Hey",
                         isNoneOfTheAbove: false,
                         correct: true,
+                        clue: "This used to attract someone's attention.",
                     },
                     {
                         content: "Hi",
                         isNoneOfTheAbove: false,
                         correct: true,
+                        clue: "This used as friendly greeting.",
                     },
                     {
                         content: "Goodbye",
                         isNoneOfTheAbove: false,
                         correct: false,
+                        clue: "Some people likes to say Goodbye.",
                     },
                     {
                         content: "None of these",

--- a/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
@@ -277,13 +277,13 @@ export const multiChoiceQuestionSimple: PerseusRenderer = {
                         content: "Hey",
                         isNoneOfTheAbove: false,
                         correct: true,
-                        clue: "This used to attract someone's attention.",
+                        clue: "This is used to attract someone's attention.",
                     },
                     {
                         content: "Hi",
                         isNoneOfTheAbove: false,
                         correct: true,
-                        clue: "This used as friendly greeting.",
+                        clue: "This is used as friendly greeting.",
                     },
                     {
                         content: "Goodbye",


### PR DESCRIPTION
## Summary:
Update Radio Widget docs to include rationales in the test data

Issue: LEMS-3027

## Test plan:
1. Navigate to the Radio Widget docs
2. Select Multi Select Simple
3. Click "Show Rationales" button

| Before | After |
| ------- | ----- |
| <img width="500" alt="image" src="https://github.com/user-attachments/assets/ec996daa-36f1-402f-9b67-ba7a59c0b4ad" /> | <img width="500" alt="image" src="https://github.com/user-attachments/assets/a56e23ee-f865-41a6-9d06-9eb0aa2c7fa6" /> |
