### PR TITLE
Allow widgets in hints to open/close with the Editor toggle

### DIFF
--- a/.changeset/early-planets-try.md
+++ b/.changeset/early-planets-try.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Allow widgets within hints to be collapsed/expanded through editor controls

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -212,12 +212,6 @@ class EditorPage extends React.Component<Props, State> {
         this.props.onChange(newJson);
     };
 
-    toggleWidgetsVisibility = () => {
-        this.setState((prevState) => ({
-            widgetsAreOpen: !prevState.widgetsAreOpen,
-        }));
-    };
-
     render(): React.ReactNode {
         let className = "framework-perseus";
 
@@ -258,20 +252,6 @@ class EditorPage extends React.Component<Props, State> {
                                 this.props.onPreviewDeviceChange
                             }
                         />
-                    )}
-
-                    {this.props.developerMode && (
-                        <span>
-                            <label>
-                                {" "}
-                                Widget Visbility:{" "}
-                                <input
-                                    type="checkbox"
-                                    checked={this.state.widgetsAreOpen}
-                                    onChange={this.toggleWidgetsVisibility}
-                                />
-                            </label>{" "}
-                        </span>
                     )}
 
                     {!this.props.jsonMode && (

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -212,6 +212,12 @@ class EditorPage extends React.Component<Props, State> {
         this.props.onChange(newJson);
     };
 
+    toggleWidgetsVisibility = () => {
+        this.setState((prevState) => ({
+            widgetsAreOpen: !prevState.widgetsAreOpen,
+        }));
+    };
+
     render(): React.ReactNode {
         let className = "framework-perseus";
 
@@ -252,6 +258,20 @@ class EditorPage extends React.Component<Props, State> {
                                 this.props.onPreviewDeviceChange
                             }
                         />
+                    )}
+
+                    {this.props.developerMode && (
+                        <span>
+                            <label>
+                                {" "}
+                                Widget Visbility:{" "}
+                                <input
+                                    type="checkbox"
+                                    checked={this.state.widgetsAreOpen}
+                                    onChange={this.toggleWidgetsVisibility}
+                                />
+                            </label>{" "}
+                        </span>
                     )}
 
                     {!this.props.jsonMode && (
@@ -305,6 +325,7 @@ class EditorPage extends React.Component<Props, State> {
                         apiOptions={deviceBasedApiOptions}
                         previewURL={this.props.previewURL}
                         highlightLint={this.state.highlightLint}
+                        widgetIsOpen={this.state.widgetsAreOpen}
                     />
                 )}
             </div>

--- a/packages/perseus-editor/src/hint-editor.tsx
+++ b/packages/perseus-editor/src/hint-editor.tsx
@@ -46,6 +46,7 @@ type HintEditorProps = {
     onRemove: () => unknown;
     onChange: ChangeHandler;
     __type?: "hint";
+    widgetIsOpen?: boolean;
 };
 
 /* Renders a hint editor box
@@ -112,6 +113,7 @@ class HintEditor extends React.Component<HintEditorProps> {
                     placeholder="Type your hint here..."
                     imageUploader={this.props.imageUploader}
                     onChange={this.props.onChange}
+                    widgetIsOpen={this.props.widgetIsOpen}
                 />
                 <div className="hint-controls-container clearfix">
                     {this.props.showMoveButtons && (
@@ -178,6 +180,7 @@ type CombinedHintEditorProps = {
     onMove: (direction: number) => unknown;
     onRemove: () => unknown;
     onChange: ChangeHandler;
+    widgetIsOpen?: boolean;
 };
 
 /* A single hint-row containing a hint editor and preview */
@@ -254,6 +257,7 @@ class CombinedHintEditor extends React.Component<CombinedHintEditorProps> {
                         onRemove={this.props.onRemove}
                         onMove={this.props.onMove}
                         apiOptions={this.props.apiOptions}
+                        widgetIsOpen={this.props.widgetIsOpen}
                     />
                 </div>
                 <div className="perseus-editor-right-cell">
@@ -287,6 +291,7 @@ type CombinedHintsEditorProps = {
     // The content ID of the AssessmentItem being edited. It may not be set
     // for non-content library exercise questions.
     itemId?: string;
+    widgetIsOpen?: boolean;
 };
 
 /* The entire hints editing/preview area
@@ -432,6 +437,8 @@ class CombinedHintsEditor extends React.Component<CombinedHintsEditorProps> {
                         previewURL={this.props.previewURL}
                         // TODO(CP-4838): what should be passed here?
                         contentPaths={[]}
+                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                        widgetIsOpen={this.props.widgetIsOpen}
                     />
                 );
             },


### PR DESCRIPTION
## Summary:
Allow widgets within hints to expand/collapse with the "Widgets" toggle in the Exercise Editor. This was already working for widgets outside of hints, so this just extends the logic to allow for it to work within hints too.

Note that last time we made a change to these files we caused this: https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/3317891139/widgetIsOpen+breaks+content+pipeline. I _think_ the same thing won't happen this time because of Matthew's fix, but I just wanted to bring it up, just in case!

Demo in Perseus Storybook:


https://github.com/user-attachments/assets/dde66ddb-3379-4fdc-9e32-984df2117c23


Demo in webapp with the npm snapshot:


https://github.com/user-attachments/assets/c987b86a-3c5d-4f97-9c3e-5f32c8152110



Issue: CP-9223

## Test plan:
go to /devadmin/content/exercises/mahtab-test-exercise/xe1821a02aab91969/x640d76ef9134ff98 and verify that toggling "Widgets" opens/closes widgets within hints