### PR TITLE
More test cleanup

### DIFF
--- a/.changeset/poor-lamps-leave.md
+++ b/.changeset/poor-lamps-leave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Give a name to the InputWithExamples functional component so that it is named in React stack traces

--- a/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
@@ -154,9 +154,8 @@ describe("expression-editor", () => {
         });
     });
 
-        const onChangeMock = jest.fn();
     it("should toggle logarithms checkbox", async () => {
-
+        const onChangeMock = jest.fn();
         render(<ExpressionEditor onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
@@ -171,9 +170,8 @@ describe("expression-editor", () => {
         });
     });
 
-        const onChangeMock = jest.fn();
     it("should toggle basic relations checkbox", async () => {
-
+        const onChangeMock = jest.fn();
         render(<ExpressionEditor onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
@@ -188,8 +186,8 @@ describe("expression-editor", () => {
         });
     });
 
-        const onChangeMock = jest.fn();
     it("should toggle advanced relations checkbox", async () => {
+        const onChangeMock = jest.fn();
 
         render(<ExpressionEditor onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());

--- a/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
@@ -154,8 +154,8 @@ describe("expression-editor", () => {
         });
     });
 
-    it("should toggle prealgebra checkbox", async () => {
         const onChangeMock = jest.fn();
+    it("should toggle logarithms checkbox", async () => {
 
         render(<ExpressionEditor onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
@@ -171,8 +171,8 @@ describe("expression-editor", () => {
         });
     });
 
-    it("should toggle prealgebra checkbox", async () => {
         const onChangeMock = jest.fn();
+    it("should toggle basic relations checkbox", async () => {
 
         render(<ExpressionEditor onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
@@ -188,8 +188,8 @@ describe("expression-editor", () => {
         });
     });
 
-    it("should toggle prealgebra checkbox", async () => {
         const onChangeMock = jest.fn();
+    it("should toggle advanced relations checkbox", async () => {
 
         render(<ExpressionEditor onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());

--- a/packages/perseus/src/widgets/__testutils__/renderQuestion.tsx
+++ b/packages/perseus/src/widgets/__testutils__/renderQuestion.tsx
@@ -92,7 +92,7 @@ const RendererWrapper = React.forwardRef<
         apiOptions: APIOptions;
         extraProps?: PropsFor<typeof Perseus.Renderer>;
     }
->((props, ref) => {
+>(function RendererWithDependencies(props, ref) {
     const dependencies = useDependencies();
     return (
         <UserInputManager widgets={props.question.widgets} problemNum={0}>

--- a/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
@@ -125,7 +125,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                       <div
                                         class="paragraph"
                                       >
-                                         Some bacteria conduct photosynthesis and produce oxygen, much like plants.
+                                        Some bacteria conduct photosynthesis and produce oxygen, much like plants.
                                       </div>
                                     </div>
                                   </div>
@@ -557,7 +557,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                       <div
                                         class="paragraph"
                                       >
-                                         Some bacteria conduct photosynthesis and produce oxygen, much like plants.
+                                        Some bacteria conduct photosynthesis and produce oxygen, much like plants.
                                       </div>
                                     </div>
                                   </div>

--- a/packages/perseus/src/widgets/graded-group/graded-group.test.ts
+++ b/packages/perseus/src/widgets/graded-group/graded-group.test.ts
@@ -21,7 +21,7 @@ const checkAnswer = async (
 ) => {
     // NOTE(jeremy): The only route to check the answer
     // is to use the "Check" button that is embedded _inside_ the widget.
-    await userEvent.click(screen.getByRole("button", {name: "Check"}));
+    await userEvent.click(await screen.findByRole("button", {name: "Check"}));
 };
 
 describe("graded-group", () => {
@@ -272,7 +272,7 @@ describe("graded-group", () => {
             expect(screen.getByText("Keep trying")).toBeVisible();
         });
 
-        it("should let the user retry when checked if not fully answered", async () => {
+        it("should let the user try again when checked if not fully answered", async () => {
             // Arrange
             renderQuestion(question1, apiOptions);
 

--- a/packages/perseus/src/widgets/graded-group/graded-group.testdata.ts
+++ b/packages/perseus/src/widgets/graded-group/graded-group.testdata.ts
@@ -23,7 +23,7 @@ export const question1: PerseusRenderer = {
                         options: {
                             static: false,
                             items: [
-                                " Some bacteria conduct photosynthesis and produce oxygen, much like plants.",
+                                "Some bacteria conduct photosynthesis and produce oxygen, much like plants.",
                                 "Bacteria are always autotrophic but they may get energy from either light or chemical sources.",
                                 "Some chemosynthetic bacteria introduce energy and fixed carbon into communities where photosynthesis is not possible (e.g., deep-sea vents).",
                                 "Some bacteria live symbiotically inside of host organisms and provide the host with nutrients.",
@@ -48,7 +48,7 @@ export const question1: PerseusRenderer = {
                             options: {
                                 static: false,
                                 items: [
-                                    " Some bacteria conduct photosynthesis and produce oxygen, much like plants.",
+                                    "Some bacteria conduct photosynthesis and produce oxygen, much like plants.",
                                     "Bacteria are always autotrophic but they may get energy from either light or chemical sources.",
                                     "Some chemosynthetic bacteria introduce energy and fixed carbon into communities where photosynthesis is not possible (e.g., deep-sea vents).",
                                     "Some bacteria live symbiotically inside of host organisms and provide the host with nutrients.",

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -112,10 +112,10 @@ export const MovablePointView = forwardRef(
         return (
             <>
                 {showHairlines && <Hairlines point={point} />}
-
                 {showTooltips ? (
                     <Tooltip
                         autoUpdate={true}
+                        opened={true}
                         backgroundColor={wbColorName}
                         content={pointTooltipContent}
                         contentStyle={{color: "white"}}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.test.tsx
@@ -28,8 +28,9 @@ jest.mock("@khanacademy/wonder-blocks-tooltip", () => {
                   in the document (usually the bottom of the <body>), and only
                   when the user interacts with the element. This makes checking
                   for the Tooltip element difficult to manage in a test.
-                  Therefore, these tests mock the Tooltip component and check
-                  if/how it is called.
+                  Therefore, these tests mock the Tooltip component and just
+                  have it render the tooltip content inline, making it very
+                  easy to verify.
             */
             return (
                 <div {...props} data-testid="tooltip-content-for-test">

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.test.tsx
@@ -1,4 +1,4 @@
-import {logRoles, render, screen} from "@testing-library/react";
+import {render, screen} from "@testing-library/react";
 import {
     type UserEvent,
     userEvent as userEventLib,

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from "@testing-library/react";
+import {logRoles, render, screen} from "@testing-library/react";
 import {
     type UserEvent,
     userEvent as userEventLib,
@@ -71,7 +71,11 @@ describe("MovablePoint", () => {
             );
 
             // Act
-            await userEvent.hover(await screen.findByTestId("movable-point"));
+            await userEvent.hover(
+                await screen.findByRole("button", {
+                    name: /Point 1 at 0 comma 0/,
+                }),
+            );
 
             // Assert
             expect(await screen.findByRole("tooltip")).toHaveTextContent(
@@ -93,7 +97,11 @@ describe("MovablePoint", () => {
             );
 
             // Act
-            await userEvent.hover(await screen.findByTestId("movable-point"));
+            await userEvent.hover(
+                await screen.findByRole("button", {
+                    name: /Point 1 at 0 comma 0/,
+                }),
+            );
 
             // Assert
             expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
@@ -117,7 +125,11 @@ describe("MovablePoint", () => {
             );
 
             // Act
-            await userEvent.hover(await screen.findByTestId("movable-point"));
+            await userEvent.hover(
+                await screen.findByRole("button", {
+                    name: /Point 1 at 0 comma 0/,
+                }),
+            );
 
             // Background color check borrowed from WB tooltip tests.
             // https://github.com/Khan/wonder-blocks/blob/aca4fd7bfab8275987f1aaf1dccf8b8bcb751928/packages/wonder-blocks-tooltip/src/components/__tests__/tooltip.test.tsx#L114

--- a/packages/perseus/src/widgets/numeric-input/input-with-examples.tsx
+++ b/packages/perseus/src/widgets/numeric-input/input-with-examples.tsx
@@ -45,7 +45,7 @@ type Props = {
  * examples of how to input the selected answer forms.
  */
 const InputWithExamples = forwardRef<Focusable, Props>(
-    (
+    function InputWithExamples(
         {
             shouldShowExamples = true,
             onFocus = () => {},
@@ -56,7 +56,7 @@ const InputWithExamples = forwardRef<Focusable, Props>(
             ...props
         },
         ref,
-    ) => {
+    ) {
         const context = React.useContext(PerseusI18nContext);
         const inputRef = React.useRef<TextInput>(null);
         const [inputFocused, setInputFocused] = React.useState<boolean>(false);


### PR DESCRIPTION
## Summary:

This PR forms another small set of unit test cleanup/fixes. It includes: 

  * Mock WB ToolTip differently so that it's a bit more dependable (avoids needing shared variables)
  * Fix test names for expression-editor
  * Add component names so they show up in React stack traces properly
  * Fix graded-group tests to be a bit more accurate

Issue: "none"

## Test plan:

`pnpm test`