### PR TITLE
Suppress type errors in numeric-input.class.tsx

### DIFF
--- a/.changeset/gorgeous-emus-type.md
+++ b/.changeset/gorgeous-emus-type.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: suppress intermittent typechecking errors

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.class.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.class.tsx
@@ -99,16 +99,25 @@ export class NumericInput
     }
 
     focus: () => boolean = () => {
-        this.inputRef.current?.focus();
+        // TODO(benchristel): type `inputRef` properly.
+        // Typechecking fails here intermittently, probably because of nondeterminism
+        // in the interpretation of `&` types.
+        (this.inputRef.current as any)?.focus();
         return true;
     };
 
     focusInputPath: () => void = () => {
-        this.inputRef.current?.focus();
+        // TODO(benchristel): type `inputRef` properly
+        // Typechecking fails here intermittently, probably because of nondeterminism
+        // in the interpretation of `&` types.
+        (this.inputRef.current as any)?.focus();
     };
 
     blurInputPath: () => void = () => {
-        this.inputRef.current?.blur();
+        // TODO(benchristel): type `inputRef` properly
+        // Typechecking fails here intermittently, probably because of nondeterminism
+        // in the interpretation of `&` types.
+        (this.inputRef.current as any)?.blur();
     };
 
     getInputPaths: () => ReadonlyArray<ReadonlyArray<string>> = () => {


### PR DESCRIPTION
These type errors appeared intermittently when running `tsc --watch`. I suspect
there's a cleaner way to deal with these refs. In the short term, suppressing the
errors in code is preferable to tolerating them.

Issue: none

## Test plan:

`pnpm tsc -w`