### PR TITLE
docs(changeset): New feature for PhET Widget to provide an option for full screen on mobile devices.

### DIFF
--- a/.changeset/friendly-years-share.md
+++ b/.changeset/friendly-years-share.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+New feature for PhET Widget to provide an option for full screen on mobile devices.

--- a/packages/perseus/src/perseus-api.tsx
+++ b/packages/perseus/src/perseus-api.tsx
@@ -97,6 +97,9 @@ export const ApiOptions = {
         // Indicates whether or not to use mobile styling.
         isMobile: PropTypes.bool,
 
+        // Indicates whether or not to use mobile app styling.
+        isMobileApp: PropTypes.bool,
+
         // A function, called with a bool indicating whether use of the
         // drawing area (scratchpad) should be allowed/disallowed.
         // Previously handled by `Khan.scratchpad.enable/disable`
@@ -136,6 +139,7 @@ export const ApiOptions = {
     defaults: {
         isArticle: false,
         isMobile: false,
+        isMobileApp: false,
         onFocusChange: function () {},
         GroupMetadataEditor: StubTagEditor,
         showAlignmentOptions: false,

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -256,6 +256,8 @@ export type APIOptions = Readonly<{
     nativeKeypadProxy?: (blur: () => void) => KeypadAPI;
     /** Indicates whether or not to use mobile styling. */
     isMobile?: boolean;
+    /** Indicates whether or not to use mobile app styling. */
+    isMobileApp?: boolean;
     /** A function, called with a bool indicating whether use of the
      * drawing area (scratchpad) should be allowed/disallowed.
      *
@@ -438,6 +440,7 @@ export type APIOptionsWithDefaults = Readonly<
         groupAnnotator: NonNullable<APIOptions["groupAnnotator"]>;
         isArticle: NonNullable<APIOptions["isArticle"]>;
         isMobile: NonNullable<APIOptions["isMobile"]>;
+        isMobileApp: NonNullable<APIOptions["isMobileApp"]>;
         onFocusChange: NonNullable<APIOptions["onFocusChange"]>;
         readOnly: NonNullable<APIOptions["readOnly"]>;
         setDrawingAreaAvailable: NonNullable<

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.stories.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.stories.tsx
@@ -1,6 +1,14 @@
+import {
+    generateTestPerseusItem,
+    type PerseusRenderer,
+} from "@khanacademy/perseus-core";
+import * as React from "react";
+
+import {ServerItemRendererWithDebugUI} from "../../../../../testing/server-item-renderer-with-debug-ui";
+
 import {PhetSimulation} from "./phet-simulation";
 
-import type {Meta, StoryObj} from "@storybook/react";
+import type {Meta} from "@storybook/react";
 
 const meta: Meta<typeof PhetSimulation> = {
     component: PhetSimulation,
@@ -8,11 +16,43 @@ const meta: Meta<typeof PhetSimulation> = {
 };
 
 export default meta;
-type Story = StoryObj<typeof PhetSimulation>;
 
-export const Primary: Story = {
-    args: {
-        url: "https://phet.colorado.edu/sims/html/projectile-data-lab/latest/projectile-data-lab_all.html",
-        description: "Projectile Data Lab",
-    },
+// Create a simple renderer with a PhET simulation widget
+const createPhETSimulation = (
+    url: string,
+    description: string,
+): PerseusRenderer => {
+    return {
+        content: "[[☃ phet-simulation 1]]",
+        images: {},
+        widgets: {
+            "phet-simulation 1": {
+                type: "phet-simulation",
+                graded: true,
+                static: false,
+                options: {
+                    url,
+                    description,
+                },
+                version: {
+                    major: 0,
+                    minor: 0,
+                },
+            },
+        },
+    };
+};
+
+export const Primary = (args: any): React.ReactElement => {
+    const question = createPhETSimulation(
+        "https://phet.colorado.edu/sims/html/projectile-data-lab/latest/projectile-data-lab_all.html",
+        "Projectile Data Lab",
+    );
+
+    return (
+        <ServerItemRendererWithDebugUI
+            item={generateTestPerseusItem({question})}
+            title="PhET Simulation"
+        />
+    );
 };

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.stories.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.stories.tsx
@@ -7,8 +7,6 @@ import type {Meta, StoryObj} from "@storybook/react";
 const meta: Meta<typeof PhetSimulation> = {
     title: "Perseus/Widgets/PhET Simulation",
     component: PhetSimulation,
-    // Using parameters to avoid component-level type checking issues since PhetSimulation
-    // expects WidgetProps that we can't fully satisfy in the story
     parameters: {
         docs: {
             description: {

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.stories.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.stories.tsx
@@ -1,58 +1,36 @@
-import {
-    generateTestPerseusItem,
-    type PerseusRenderer,
-} from "@khanacademy/perseus-core";
-import * as React from "react";
-
-import {ServerItemRendererWithDebugUI} from "../../../../../testing/server-item-renderer-with-debug-ui";
+import {ApiOptions} from "../../perseus-api";
 
 import {PhetSimulation} from "./phet-simulation";
 
-import type {Meta} from "@storybook/react";
+import type {Meta, StoryObj} from "@storybook/react";
 
 const meta: Meta<typeof PhetSimulation> = {
-    component: PhetSimulation,
     title: "Perseus/Widgets/PhET Simulation",
+    component: PhetSimulation,
+    // Using parameters to avoid component-level type checking issues since PhetSimulation
+    // expects WidgetProps that we can't fully satisfy in the story
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    "PhET Simulation widget for embedding interactive simulations from PhET Colorado",
+            },
+        },
+    },
 };
 
 export default meta;
 
-// Create a simple renderer with a PhET simulation widget
-const createPhETSimulation = (
-    url: string,
-    description: string,
-): PerseusRenderer => {
-    return {
-        content: "[[☃ phet-simulation 1]]",
-        images: {},
-        widgets: {
-            "phet-simulation 1": {
-                type: "phet-simulation",
-                graded: true,
-                static: false,
-                options: {
-                    url,
-                    description,
-                },
-                version: {
-                    major: 0,
-                    minor: 0,
-                },
-            },
+type Story = StoryObj<typeof PhetSimulation>;
+
+// Story showing the PhetSimulation component directly
+export const Default: Story = {
+    args: {
+        url: "https://phet.colorado.edu/sims/html/projectile-data-lab/latest/projectile-data-lab_all.html",
+        description: "Projectile Data Lab",
+        apiOptions: {
+            ...ApiOptions.defaults,
+            isMobileApp: false,
         },
-    };
-};
-
-export const Primary = (args: any): React.ReactElement => {
-    const question = createPhETSimulation(
-        "https://phet.colorado.edu/sims/html/projectile-data-lab/latest/projectile-data-lab_all.html",
-        "Projectile Data Lab",
-    );
-
-    return (
-        <ServerItemRendererWithDebugUI
-            item={generateTestPerseusItem({question})}
-            title="PhET Simulation"
-        />
-    );
+    },
 };

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -15,6 +15,7 @@ import * as React from "react";
 import {PerseusI18nContext} from "../../components/i18n-context";
 import {getDependencies} from "../../dependencies";
 import {phoneMargin} from "../../styles/constants";
+import {isFileProtocol} from "../../util/mobile-native-utils";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/phet-simulation/phet-simulation-ai-utils";
 
 import type {WidgetExports, WidgetProps, Widget} from "../../types";
@@ -180,9 +181,10 @@ export class PhetSimulation
         // We handle mobile fullscreen differently, as many mobile browsers
         // and apps don't support the fullscreen API. Instead, we use our own
         // fake fullscreen implementation to take up the full webview.
-        const isMobile = apiOptions?.isMobile || false;
+        const isMobile = apiOptions?.isMobile || true;
         const {isFullScreen} = this.state;
-
+        const {InitialRequestUrl} = getDependencies();
+        const isMobileNative = isFileProtocol(InitialRequestUrl.protocol);
         // We sandbox the iframe so that we allowlist only the functionality
         // that we need. This makes it safer to present third-party content
         // from the PhET website.
@@ -229,7 +231,7 @@ export class PhetSimulation
                 </View>
                 {this.state.url !== null && (
                     <View style={styles.buttonContainer}>
-                        {isFullScreen && isMobile ? (
+                        {isFullScreen && isMobileNative ? (
                             <IconButton
                                 icon={xIcon}
                                 onClick={this.toggleFullScreen}
@@ -242,7 +244,7 @@ export class PhetSimulation
                             <IconButton
                                 icon={cornersOutIcon}
                                 onClick={
-                                    isMobile
+                                    isMobileNative
                                         ? this.toggleFullScreen
                                         : () => {
                                               this.iframeRef.current?.requestFullscreen();
@@ -292,8 +294,7 @@ const styles = StyleSheet.create({
         height: "100%",
         zIndex: 1000,
         backgroundColor: "white",
-        padding: "0 0 120px 0",
-        margin: 0,
+        margin: "0 0 120px 0",
         display: "flex",
         flexDirection: "column",
     },

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -178,30 +178,31 @@ export class PhetSimulation
 
     render(): React.ReactNode {
         const {apiOptions} = this.props;
+
         // We handle mobile fullscreen differently, as many mobile browsers
         // and apps don't support the fullscreen API. Instead, we use our own
         // fake fullscreen implementation to take up the full webview.
-        const isMobile = apiOptions?.isMobile || true;
         const {isFullScreen} = this.state;
         const {InitialRequestUrl} = getDependencies();
         const isMobileNative = isFileProtocol(InitialRequestUrl.protocol);
-        // We sandbox the iframe so that we allowlist only the functionality
-        // that we need. This makes it safer to present third-party content
-        // from the PhET website.
-        // http://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/
-        const sandboxProperties = "allow-same-origin allow-scripts";
 
         // Determine which container style to use based on fullscreen state
         const containerStyle =
-            isFullScreen && isMobile
+            isFullScreen && isMobileNative
                 ? styles.fullScreenWidgetContainer
                 : styles.widgetContainer;
 
         // Determine iframe container style based on fullscreen state
         const iframeContainerStyle =
-            isFullScreen && isMobile
+            isFullScreen && isMobileNative
                 ? styles.fullScreenIframeContainer
                 : styles.iframeContainer;
+
+        // We sandbox the iframe so that we allowlist only the functionality
+        // that we need. This makes it safer to present third-party content
+        // from the PhET website.
+        // http://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/
+        const sandboxProperties = "allow-same-origin allow-scripts";
 
         return (
             <View style={containerStyle}>

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -292,7 +292,7 @@ const styles = StyleSheet.create({
         height: "100%",
         zIndex: 1000,
         backgroundColor: "white",
-        padding: 0,
+        padding: "0 0 120px 0",
         margin: 0,
         display: "flex",
         flexDirection: "column",

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -181,18 +181,17 @@ export class PhetSimulation
         // and apps don't support the fullscreen API. Instead, we use our own
         // fake fullscreen implementation to take up the full webview.
         const {isFullScreen} = this.state;
-        const {InitialRequestUrl} = getDependencies();
-        const isMobileNative = isFileProtocol(InitialRequestUrl.protocol);
+        const {isMobileApp} = this.props.apiOptions;
 
         // Determine which container style to use based on fullscreen state
         const containerStyle =
-            isFullScreen && isMobileNative
+            isFullScreen && isMobileApp
                 ? styles.fullScreenWidgetContainer
                 : styles.widgetContainer;
 
         // Determine iframe container style based on fullscreen state
         const iframeContainerStyle =
-            isFullScreen && isMobileNative
+            isFullScreen && isMobileApp
                 ? styles.fullScreenIframeContainer
                 : styles.iframeContainer;
 
@@ -230,7 +229,7 @@ export class PhetSimulation
                 </View>
                 {this.state.url !== null && (
                     <View style={styles.buttonContainer}>
-                        {isFullScreen && isMobileNative ? (
+                        {isFullScreen && isMobileApp ? (
                             <IconButton
                                 icon={xIcon}
                                 onClick={this.toggleFullScreen}
@@ -243,7 +242,7 @@ export class PhetSimulation
                             <IconButton
                                 icon={cornersOutIcon}
                                 onClick={
-                                    isMobileNative
+                                    isMobileApp
                                         ? this.toggleFullScreen
                                         : () => {
                                               this.iframeRef.current?.requestFullscreen();

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -177,8 +177,6 @@ export class PhetSimulation
     };
 
     render(): React.ReactNode {
-        const {apiOptions} = this.props;
-
         // We handle mobile fullscreen differently, as many mobile browsers
         // and apps don't support the fullscreen API. Instead, we use our own
         // fake fullscreen implementation to take up the full webview.

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -15,7 +15,6 @@ import * as React from "react";
 import {PerseusI18nContext} from "../../components/i18n-context";
 import {getDependencies} from "../../dependencies";
 import {phoneMargin} from "../../styles/constants";
-import {isFileProtocol} from "../../util/mobile-native-utils";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/phet-simulation/phet-simulation-ai-utils";
 
 import type {WidgetExports, WidgetProps, Widget} from "../../types";
@@ -217,6 +216,7 @@ export class PhetSimulation
                         />
                     </View>
                 )}
+                We are in the mobile app: {isMobileApp ? "true" : "false"}
                 <View style={iframeContainerStyle}>
                     <iframe
                         ref={this.iframeRef}

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -170,9 +170,29 @@ export class PhetSimulation
 
     toggleFullScreen = () => {
         // Toggle the fullscreen state
-        this.setState((prevState) => ({
-            isFullScreen: !prevState.isFullScreen,
-        }));
+        this.setState(
+            (prevState) => ({
+                isFullScreen: !prevState.isFullScreen,
+            }),
+            () => {
+                // If exiting fullscreen, send a message to reset viewport
+                if (!this.state.isFullScreen && this.iframeRef.current) {
+                    try {
+                        this.iframeRef.current.contentWindow?.postMessage(
+                            {
+                                type: "reset-viewport",
+                                initialScale: 1.0,
+                            },
+                            "https://phet.colorado.edu",
+                        );
+                    } catch (e) {
+                        // Welp didn't work too bad.
+                        // eslint-disable-next-line no-console
+                        console.log("Failed to send reset message:", e);
+                    }
+                }
+            },
+        );
     };
 
     render(): React.ReactNode {

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -177,9 +177,9 @@ export class PhetSimulation
     };
 
     render(): React.ReactNode {
-        // We handle mobile fullscreen differently, as many mobile browsers
-        // and apps don't support the fullscreen API. Instead, we use our own
-        // fake fullscreen implementation to take up the full webview.
+        // We handle fullscreen differently in the mobile app, as it doesn't
+        // support the fullscreen API. Instead, we use our own fake fullscreen
+        // implementation to take up the full webview.
         const {isFullScreen} = this.state;
         const {isMobileApp} = this.props.apiOptions;
 

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -169,7 +169,7 @@ export class PhetSimulation
     }
 
     toggleFullScreen = () => {
-        // Use our fake fullscreen implementation for mobile
+        // Toggle the fullscreen state
         this.setState((prevState) => ({
             isFullScreen: !prevState.isFullScreen,
         }));
@@ -180,7 +180,7 @@ export class PhetSimulation
         // We handle mobile fullscreen differently, as many mobile browsers
         // and apps don't support the fullscreen API. Instead, we use our own
         // fake fullscreen implementation to take up the full webview.
-        const isMobile = apiOptions?.isMobile || false;
+        const isMobile = apiOptions?.isMobile || true;
         const {isFullScreen} = this.state;
 
         // We sandbox the iframe so that we allowlist only the functionality
@@ -203,6 +203,18 @@ export class PhetSimulation
 
         return (
             <View style={containerStyle}>
+                {isFullScreen && isMobile && (
+                    <View style={styles.closeButtonContainer}>
+                        <IconButton
+                            icon={xIcon}
+                            onClick={this.toggleFullScreen}
+                            kind="tertiary"
+                            actionType="neutral"
+                            aria-label={"Exit fullscreen"}
+                            style={styles.closeButton}
+                        />
+                    </View>
+                )}
                 {this.state.banner !== null && (
                     // TODO(anna): Make this banner focusable
                     <View
@@ -227,34 +239,25 @@ export class PhetSimulation
                         allow="fullscreen"
                     />
                 </View>
-                {this.state.url !== null && (
-                    <View style={styles.buttonContainer}>
-                        {isFullScreen && isMobile ? (
-                            <IconButton
-                                icon={xIcon}
-                                onClick={this.toggleFullScreen}
-                                kind="tertiary"
-                                actionType="neutral"
-                                aria-label={"Exit fullscreen"}
-                                style={styles.fullScreenButton}
-                            />
-                        ) : (
-                            <IconButton
-                                icon={cornersOutIcon}
-                                onClick={
-                                    isMobile
-                                        ? this.toggleFullScreen
-                                        : () => {
-                                              this.iframeRef.current?.requestFullscreen();
-                                          }
-                                }
-                                kind="tertiary"
-                                actionType="neutral"
-                                aria-label={"Fullscreen"}
-                                style={styles.fullScreenButton}
-                            />
-                        )}
-                    </View>
+                {this.state.url !== null && !isFullScreen && (
+                    <IconButton
+                        icon={cornersOutIcon}
+                        onClick={
+                            isMobile
+                                ? this.toggleFullScreen
+                                : () => {
+                                      this.iframeRef.current?.requestFullscreen();
+                                  }
+                        }
+                        kind="tertiary"
+                        actionType="neutral"
+                        aria-label={"Fullscreen"}
+                        style={{
+                            marginTop: 5,
+                            marginBottom: 5,
+                            alignSelf: "flex-end",
+                        }}
+                    />
                 )}
             </View>
         );
@@ -320,14 +323,15 @@ const styles = StyleSheet.create({
         width: "100%",
         height: "100%",
     },
-    buttonContainer: {
-        display: "flex",
-        justifyContent: "flex-end",
-        marginTop: 5,
-        marginBottom: 5,
+    closeButtonContainer: {
+        position: "absolute",
+        top: 8,
+        right: 8,
+        zIndex: 1001,
     },
-    fullScreenButton: {
-        alignSelf: "flex-end",
+    closeButton: {
+        backgroundColor: "rgba(255, 255, 255, 0.8)",
+        borderRadius: "50%",
     },
 });
 


### PR DESCRIPTION
## Summary:
This PR creates a fake fullscreen view in the mobile application for the PhET Widget, as we're currently unable to use the fullscreen API. It also adds a new apiOption for isMobileApp, which will allow Perseus to know when we're being served in one of the mobile applications. 

This PR will require updates in webapp in order to pass down the new isMobileApp variable as part of the apiOptions.

Additional support for the fullscreen API could _**possibly**_ be added to the Mobile application in the future, but there is currently no set release date or work for the next Mobile release. Given that, we've opted for a bit of a "hacky" temporary solution that will allow us to get the widget a little larger to improve usability. 

Unfortunately, full screen will not be supported in iOS web at this time. 

This direction was chosen due to several restrictions:

1. We're locked into a z-index in an upstream container that we cannot change. 
2. We have many variable headers, banners, and footers in the mobile web version that interfere with allowing this fix to also be served to mobile web. 
3. We can't inject the widget at the document root to work around the z-index issue as it would result in the loss of any actions that had been performed in the PhET iframe. 
4. This is a low usage widget. If we were to see increased usage and partnership, we could discuss improving the communication of state with PhET so that alternative solutions could be used in the future. 

Issue: LEMS-2922

## Test plan:
- Manual testing in mobile application 
- New test that confirms isMobileApp logic is being used. 