### PR TITLE
Ensure Orderer Editor updates Options property in change callback

### DIFF
--- a/.changeset/fluffy-onions-camp.md
+++ b/.changeset/fluffy-onions-camp.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Fixing OrdererEditor so that it properly returns fully updated options onOptionsChange.

--- a/packages/perseus-editor/src/editor-page.test.tsx
+++ b/packages/perseus-editor/src/editor-page.test.tsx
@@ -1,0 +1,100 @@
+import {Dependencies} from "@khanacademy/perseus";
+import {
+    type PerseusOrdererWidgetOptions,
+    type PerseusRenderer,
+} from "@khanacademy/perseus-core";
+import {render, screen} from "@testing-library/react";
+import {userEvent as userEventLib} from "@testing-library/user-event";
+import * as React from "react";
+
+import {testDependencies} from "../../../testing/test-dependencies";
+
+import EditorPage from "./editor-page";
+import {registerAllWidgetsAndEditorsForTesting} from "./util/register-all-widgets-and-editors-for-testing";
+
+import type {UserEvent} from "@testing-library/user-event";
+
+describe("EditorPage", () => {
+    beforeAll(() => {
+        registerAllWidgetsAndEditorsForTesting();
+    });
+
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("updates Orderer state correctly", async () => {
+        const onChangeMock = jest.fn();
+
+        const imageUrl =
+            "https://ka-perseus-graphie.s3.amazonaws.com/6e68574abb61d2b4a12644d777006fcfa8a73cff.png";
+        const noAltImage = `![](${imageUrl})`;
+        const altImage = `![a fox](${imageUrl})`;
+        // "[" is a special char in UserEvent, so I need to do it twice when typing
+        const altImageTyped = `![[a fox](${imageUrl})`;
+
+        const startWidgetOptions: PerseusOrdererWidgetOptions = {
+            options: [
+                {
+                    content: noAltImage,
+                    widgets: {},
+                    images: {},
+                },
+            ],
+            correctOptions: [
+                {
+                    content: noAltImage,
+                    widgets: {},
+                    images: {},
+                },
+            ],
+            otherOptions: [],
+            height: "normal",
+            layout: "horizontal",
+        };
+
+        const startRenderer: PerseusRenderer = {
+            content: "[[☃ orderer 1]]",
+            widgets: {
+                "orderer 1": {
+                    type: "orderer",
+                    options: startWidgetOptions,
+                },
+            },
+            images: {},
+        };
+
+        render(
+            <EditorPage
+                question={startRenderer}
+                onChange={onChangeMock}
+                onPreviewDeviceChange={() => {}}
+                previewDevice="desktop"
+                previewURL=""
+                frameSource=""
+                itemId="itemId"
+                developerMode={false}
+                jsonMode={false}
+                widgetsAreOpen={true}
+            />,
+        );
+
+        const input = screen.getByDisplayValue(noAltImage);
+        await userEvent.clear(input);
+        await userEvent.type(input, altImageTyped);
+
+        expect(onChangeMock).toHaveBeenLastCalledWith(
+            {
+                correctOptions: [{content: altImage}],
+            },
+            undefined,
+        );
+    });
+});

--- a/packages/perseus-editor/src/editor-page.test.tsx
+++ b/packages/perseus-editor/src/editor-page.test.tsx
@@ -90,11 +90,27 @@ describe("EditorPage", () => {
         await userEvent.clear(input);
         await userEvent.type(input, altImageTyped);
 
-        expect(onChangeMock).toHaveBeenLastCalledWith(
-            {
-                correctOptions: [{content: altImage}],
-            },
-            undefined,
+        // Verify the mock was called
+        expect(onChangeMock).toHaveBeenCalled();
+
+        // Get the widget options directly to avoid having to mock the entire PerseusItem
+        const widgetOptions =
+            onChangeMock.mock.lastCall[0].question.widgets["orderer 1"].options;
+
+        // Verify the options were updated correctly
+        expect(widgetOptions).toEqual(
+            expect.objectContaining({
+                correctOptions: [
+                    {
+                        content: altImage,
+                    },
+                ],
+                options: [
+                    {
+                        content: altImage,
+                    },
+                ],
+            }),
         );
     });
 });

--- a/packages/perseus-editor/src/widgets/__tests__/orderer-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/orderer-editor.test.tsx
@@ -81,4 +81,67 @@ describe("OrdererEditor", () => {
             undefined,
         );
     });
+
+    it.only("sorts options correctly", async () => {
+        const onChangeMock = jest.fn();
+        const editorRef = React.createRef<OrdererEditor>();
+
+        const startWidgetOptions: PerseusOrdererWidgetOptions = {
+            correctOptions: [
+                {
+                    content: "3",
+                    widgets: {},
+                    images: {},
+                },
+                {
+                    content: "$b$",
+                    widgets: {},
+                    images: {},
+                },
+            ],
+            otherOptions: [
+                {
+                    content: "2",
+                    widgets: {},
+                    images: {},
+                },
+                {
+                    content: "1",
+                    widgets: {},
+                    images: {},
+                },
+            ],
+            height: "normal",
+            layout: "horizontal",
+            options: [],
+        };
+
+        render(
+            <OrdererEditor
+                ref={editorRef}
+                onChange={onChangeMock}
+                {...startWidgetOptions}
+            />,
+        );
+
+        const input = screen.getByDisplayValue("1");
+        await userEvent.clear(input);
+        await userEvent.type(input, "a");
+
+        // We should be sorted alphabetically, and then by category:
+        // 1. Numbers
+        // 2. $tex$ (but $tex$ without an initial number)
+        // 3. Everything else
+        expect(onChangeMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                options: [
+                    {content: "2"},
+                    {content: "3"},
+                    {content: "$b$"},
+                    {content: "a"},
+                ],
+            }),
+            undefined,
+        );
+    });
 });

--- a/packages/perseus-editor/src/widgets/__tests__/orderer-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/orderer-editor.test.tsx
@@ -82,7 +82,7 @@ describe("OrdererEditor", () => {
         );
     });
 
-    it.only("sorts options correctly", async () => {
+    it("sorts options correctly", async () => {
         const onChangeMock = jest.fn();
         const editorRef = React.createRef<OrdererEditor>();
 

--- a/packages/perseus-editor/src/widgets/__tests__/orderer-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/orderer-editor.test.tsx
@@ -1,0 +1,93 @@
+import {Dependencies} from "@khanacademy/perseus";
+import {render, screen} from "@testing-library/react";
+import {userEvent as userEventLib} from "@testing-library/user-event";
+import * as React from "react";
+
+import {testDependencies} from "../../../../../testing/test-dependencies";
+import OrdererEditor from "../orderer-editor";
+
+import type {PerseusOrdererWidgetOptions} from "@khanacademy/perseus-core";
+import type {UserEvent} from "@testing-library/user-event";
+
+describe("OrdererEditor", () => {
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("updates state correctly", async () => {
+        const onChangeMock = jest.fn();
+        const editorRef = React.createRef<OrdererEditor>();
+
+        const imageUrl =
+            "https://ka-perseus-graphie.s3.amazonaws.com/6e68574abb61d2b4a12644d777006fcfa8a73cff.png";
+        const noAltImage = `![](${imageUrl})`;
+        const altImage = `![a fox](${imageUrl})`;
+        // "[" is a special char in UserEvent, so I need to do it twice when typing
+        const altImageTyped = `![[a fox](${imageUrl})`;
+        const startWidgetOptions: PerseusOrdererWidgetOptions = {
+            options: [
+                {
+                    content: noAltImage,
+                    widgets: {},
+                    images: {},
+                },
+            ],
+            correctOptions: [
+                {
+                    content: noAltImage,
+                    widgets: {},
+                    images: {},
+                },
+            ],
+            otherOptions: [],
+            height: "normal",
+            layout: "horizontal",
+        };
+
+        render(
+            <OrdererEditor
+                ref={editorRef}
+                onChange={onChangeMock}
+                {...startWidgetOptions}
+            />,
+        );
+
+        const input = screen.getByDisplayValue(noAltImage);
+        await userEvent.clear(input);
+        await userEvent.type(input, altImageTyped);
+
+        expect(editorRef.current?.serialize()).toBe({
+            options: [
+                {
+                    content: altImage,
+                    widgets: {},
+                    images: {},
+                },
+            ],
+            correctOptions: [
+                {
+                    content: altImage,
+                    widgets: {},
+                    images: {},
+                },
+            ],
+            otherOptions: [],
+            height: "normal",
+            layout: "horizontal",
+        });
+
+        expect(onChangeMock).toHaveBeenLastCalledWith(
+            {
+                correctOptions: [{content: altImage}],
+            },
+            undefined,
+        );
+    });
+});

--- a/packages/perseus-editor/src/widgets/__tests__/orderer-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/orderer-editor.test.tsx
@@ -63,30 +63,21 @@ describe("OrdererEditor", () => {
         await userEvent.clear(input);
         await userEvent.type(input, altImageTyped);
 
-        expect(editorRef.current?.serialize()).toBe({
-            options: [
-                {
-                    content: altImage,
-                    widgets: {},
-                    images: {},
-                },
-            ],
-            correctOptions: [
-                {
-                    content: altImage,
-                    widgets: {},
-                    images: {},
-                },
-            ],
-            otherOptions: [],
-            height: "normal",
-            layout: "horizontal",
-        });
-
-        expect(onChangeMock).toHaveBeenLastCalledWith(
-            {
-                correctOptions: [{content: altImage}],
-            },
+        expect(onChangeMock).toHaveBeenCalled();
+        // Verify the options were updated correctly
+        expect(onChangeMock).toHaveBeenCalledWith(
+            expect.objectContaining({
+                correctOptions: [
+                    {
+                        content: altImage,
+                    },
+                ],
+                options: [
+                    {
+                        content: altImage,
+                    },
+                ],
+            }),
             undefined,
         );
     });

--- a/packages/perseus-editor/src/widgets/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor.tsx
@@ -61,11 +61,8 @@ class OrdererEditor extends React.Component<Props> {
         const updatedOptions = [
             ...new Set(allOptions.map((item) => item.content)),
         ]
-            // filter out empty strings
             .filter((content) => content !== "")
-            // Alphabetical sort
             .sort()
-            // Category sort
             .sort((a, b) => {
                 const getCategoryScore = (content) => {
                     // 1. Any content that contains numbers

--- a/packages/perseus-editor/src/widgets/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor.tsx
@@ -58,20 +58,14 @@ class OrdererEditor extends React.Component<Props> {
         const allOptions = [...correctOptionsToUse, ...otherOptionsToUse];
 
         // Get unique content items
-        const contentArray = [
+        const updatedOptions = [
             ...new Set(allOptions.map((item) => item.content)),
-        ];
-
-        // filter out empty strings
-        const filteredContentArray = [...contentArray].filter(
-            (content) => content !== "",
-        );
-
-        // Alphabetical sort
-        const alphaSorted = [...filteredContentArray].sort();
-
-        // Category sort
-        const newOptions = [...alphaSorted]
+        ]
+            // filter out empty strings
+            .filter((content) => content !== "")
+            // Alphabetical sort
+            .sort()
+            // Category sort
             .sort((a, b) => {
                 const getCategoryScore = (content) => {
                     // 1. Any content that contains numbers
@@ -90,7 +84,7 @@ class OrdererEditor extends React.Component<Props> {
             .map((content) => ({content}));
 
         // Update the options with the new options whenever the correct or other options change
-        props["options"] = newOptions;
+        props["options"] = updatedOptions;
         this.props.onChange(props, cb);
     };
 

--- a/packages/perseus-editor/src/widgets/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor.tsx
@@ -42,15 +42,20 @@ class OrdererEditor extends React.Component<Props> {
             return {content: option};
         });
 
-        // Get all content items (from both current and updated collections)
-        const allOptions = [
-            ...(whichOptions === "correctOptions"
+        // Get content from correctOptions (either updated or existing)
+        const correctOptionsToUse =
+            whichOptions === "correctOptions"
                 ? props.correctOptions
-                : this.props.correctOptions || []),
-            ...(whichOptions === "otherOptions"
+                : this.props.correctOptions || [];
+
+        // Get content from otherOptions (either updated or existing)
+        const otherOptionsToUse =
+            whichOptions === "otherOptions"
                 ? props.otherOptions
-                : this.props.otherOptions || []),
-        ];
+                : this.props.otherOptions || [];
+
+        // Combine all content items
+        const allOptions = [...correctOptionsToUse, ...otherOptionsToUse];
 
         // Get unique content items
         const contentArray = [

--- a/packages/perseus-editor/src/widgets/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor.tsx
@@ -61,8 +61,11 @@ class OrdererEditor extends React.Component<Props> {
         const updatedOptions = [
             ...new Set(allOptions.map((item) => item.content)),
         ]
+            // filter out empty strings
             .filter((content) => content !== "")
+            // Alphabetical sort
             .sort()
+            // Category sort
             .sort((a, b) => {
                 const getCategoryScore = (content) => {
                     // 1. Any content that contains numbers

--- a/packages/perseus-editor/src/widgets/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor.tsx
@@ -42,29 +42,29 @@ class OrdererEditor extends React.Component<Props> {
             return {content: option};
         });
 
-        // We combine the correct answer and the other cards by merging them,
-        // removing duplicates and empty cards, and sorting them into
-        // categories based on their content
-        const newOptions = _.chain(_.pluck(props.correctOptions, "content"))
-            .union(_.pluck(props.otherOptions, "content"))
-            .uniq()
-            .reject(function (content) {
-                return content === "";
-            })
+        // Get all content items (from both current and updated collections)
+        const allOptions = [
+            ...(whichOptions === "correctOptions"
+                ? props.correctOptions
+                : this.props.correctOptions || []),
+            ...(whichOptions === "otherOptions"
+                ? props.otherOptions
+                : this.props.otherOptions || []),
+        ];
+
+        // Create a unique merged array, filter empty strings, and sort by category
+        const newOptions = [...new Set(allOptions.map((item) => item.content))]
+            .filter((content) => content !== "")
             .sort()
-            .sortBy(function (content) {
-                if (/\d/.test(content)) {
-                    return 0;
-                }
-                if (/^\$?[a-zA-Z]+\$?$/.test(content)) {
-                    return 2;
-                }
-                return 1;
+            .sort((a, b) => {
+                const getCategoryScore = (content) => {
+                    if (/\d/.test(content)) return 0; // Numbers first
+                    if (/^\$?[a-zA-Z]+\$?$/.test(content)) return 2; // $tex$ next
+                    return 1; // Everything else last
+                };
+                return getCategoryScore(a) - getCategoryScore(b);
             })
-            .map(function (content) {
-                return {content: content};
-            })
-            .value();
+            .map((content) => ({content}));
 
         // Update the options with the new options whenever the correct or other options change
         props["options"] = newOptions;

--- a/packages/perseus-editor/src/widgets/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor.tsx
@@ -24,31 +24,30 @@ const getUpdatedOptions = (
     whichOptions?: string,
     options?: string[],
 ): Record<string, any> => {
-    const props: Record<string, any> = {};
-
     // Update the changed options by mapping the options to an array of objects with a content property
-    if (whichOptions && options) {
-        props[whichOptions] = _.map(options, function (option) {
-            return {content: option};
-        });
+    const props: Record<string, any> = {};
+    if (whichOptions && options !== undefined) {
+        // eslint-disable-next-line functional/immutable-data
+        props[whichOptions] = options.map((option) => ({
+            content: option,
+        }));
     }
 
     // Get content from correctOptions (either updated or existing)
     const correctOptionsToUse =
         whichOptions === "correctOptions"
             ? props.correctOptions
-            : correctOptions || [];
+            : correctOptions;
 
     // Get content from otherOptions (either updated or existing)
     const otherOptionsToUse =
-        whichOptions === "otherOptions"
-            ? props.otherOptions
-            : otherOptions || [];
+        whichOptions === "otherOptions" ? props.otherOptions : otherOptions;
 
     // Combine all content items
     const allOptions = [...correctOptionsToUse, ...otherOptionsToUse];
 
     // Get unique content items
+    // eslint-disable-next-line functional/immutable-data
     const updatedOptions = [...new Set(allOptions.map((item) => item.content))]
         // filter out empty strings
         .filter((content) => content !== "")
@@ -72,10 +71,10 @@ const getUpdatedOptions = (
         })
         .map((content) => ({content}));
 
-    // Update the options with the new options
-    props["options"] = updatedOptions;
-
-    return props;
+    return {
+        ...props,
+        options: updatedOptions,
+    };
 };
 
 class OrdererEditor extends React.Component<Props> {

--- a/packages/perseus-editor/src/widgets/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor.tsx
@@ -41,6 +41,33 @@ class OrdererEditor extends React.Component<Props> {
         props[whichOptions] = _.map(options, function (option) {
             return {content: option};
         });
+
+        // We combine the correct answer and the other cards by merging them,
+        // removing duplicates and empty cards, and sorting them into
+        // categories based on their content
+        const newOptions = _.chain(_.pluck(props.correctOptions, "content"))
+            .union(_.pluck(props.otherOptions, "content"))
+            .uniq()
+            .reject(function (content) {
+                return content === "";
+            })
+            .sort()
+            .sortBy(function (content) {
+                if (/\d/.test(content)) {
+                    return 0;
+                }
+                if (/^\$?[a-zA-Z]+\$?$/.test(content)) {
+                    return 2;
+                }
+                return 1;
+            })
+            .map(function (content) {
+                return {content: content};
+            })
+            .value();
+
+        // Update the options with the new options whenever the correct or other options change
+        props["options"] = newOptions;
         this.props.onChange(props, cb);
     };
 

--- a/packages/perseus-editor/src/widgets/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor.tsx
@@ -69,11 +69,11 @@ class OrdererEditor extends React.Component<Props> {
         const newOptions = [...alphaSorted]
             .sort((a, b) => {
                 const getCategoryScore = (content) => {
-                    // 1. Numbers
+                    // 1. Any content that contains numbers
                     if (/\d/.test(content)) {
                         return 0;
                     }
-                    // 2. $tex$ (but $tex$ without an initial number)
+                    // 2. $tex$ or variables without any numbers
                     if (/^\$?[a-zA-Z]+\$?$/.test(content)) {
                         return 2;
                     }

--- a/packages/perseus-editor/src/widgets/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor.tsx
@@ -52,13 +52,18 @@ class OrdererEditor extends React.Component<Props> {
                 : this.props.otherOptions || []),
         ];
 
-        // Get unique content items and filter out empty strings
+        // Get unique content items
         const contentArray = [
             ...new Set(allOptions.map((item) => item.content)),
-        ].filter((content) => content !== "");
+        ];
+
+        // filter out empty strings
+        const filteredContentArray = [...contentArray].filter(
+            (content) => content !== "",
+        );
 
         // Alphabetical sort
-        const alphaSorted = [...contentArray].sort();
+        const alphaSorted = [...filteredContentArray].sort();
 
         // Category sort
         const newOptions = [...alphaSorted]

--- a/packages/perseus-editor/src/widgets/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor.tsx
@@ -52,15 +52,23 @@ class OrdererEditor extends React.Component<Props> {
                 : this.props.otherOptions || []),
         ];
 
-        // Create a unique merged array, filter empty strings, and sort by category
+        // Create a unique merged array, filter empty strings, sort alphabetically,
+        // and then finally sort by category: Numbers, $tex$, and everything else
         const newOptions = [...new Set(allOptions.map((item) => item.content))]
             .filter((content) => content !== "")
             .sort()
             .sort((a, b) => {
                 const getCategoryScore = (content) => {
-                    if (/\d/.test(content)) return 0; // Numbers first
-                    if (/^\$?[a-zA-Z]+\$?$/.test(content)) return 2; // $tex$ next
-                    return 1; // Everything else last
+                    // 1. Numbers
+                    if (/\d/.test(content)) {
+                        return 0;
+                    }
+                    // 2. $tex$ (but $tex$ without an initial number)
+                    if (/^\$?[a-zA-Z]+\$?$/.test(content)) {
+                        return 2;
+                    }
+                    // 3. Everything else
+                    return 1;
                 };
                 return getCategoryScore(a) - getCategoryScore(b);
             })

--- a/packages/perseus-editor/src/widgets/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor.tsx
@@ -18,7 +18,7 @@ const VERTICAL = "vertical";
 
 type Props = any;
 
-const getUpdatedOptions = (
+export const getUpdatedOptions = (
     correctOptions: Array<{content: string}>,
     otherOptions: Array<{content: string}>,
     whichOptions?: string,
@@ -219,5 +219,3 @@ class OrdererEditor extends React.Component<Props> {
 }
 
 export default OrdererEditor;
-
-export {getUpdatedOptions};

--- a/packages/perseus-editor/src/widgets/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor.tsx
@@ -52,11 +52,16 @@ class OrdererEditor extends React.Component<Props> {
                 : this.props.otherOptions || []),
         ];
 
-        // Create a unique merged array, filter empty strings, sort alphabetically,
-        // and then finally sort by category: Numbers, $tex$, and everything else
-        const newOptions = [...new Set(allOptions.map((item) => item.content))]
-            .filter((content) => content !== "")
-            .sort()
+        // Get unique content items and filter out empty strings
+        const contentArray = [
+            ...new Set(allOptions.map((item) => item.content)),
+        ].filter((content) => content !== "");
+
+        // Alphabetical sort
+        const alphaSorted = [...contentArray].sort();
+
+        // Category sort
+        const newOptions = [...alphaSorted]
             .sort((a, b) => {
                 const getCategoryScore = (content) => {
                     // 1. Numbers


### PR DESCRIPTION
## Summary:
We were facing a bug with the Orderer Editor where the state was always a step out-of-date. Thanks to @handeyeco 's insights, it sounds like we've deprecated `serialize`, and we're now handling everything in the onChange events. Unfortunately, the logic for `onOptionsChange` did not handle the updating of the dynamic options property, thus resulting in it being out of sync while editing pre-existing content. 

This PR adds the missing logic to `onOptionsChange`, while also modernizing it to remove underscore. 

Issue: LEMS-3082

## Test plan:
- New tests for onChange response AND sort order 
- Confirmed fixes work upstream via snapshot testing 