### PR TITLE
[TUT-1590] Add itemHasHints & itemHasRationales utilities

### DIFF
--- a/.changeset/soft-years-brush.md
+++ b/.changeset/soft-years-brush.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": minor
+---
+
+Introduce `itemHasHints` & `itemHasRationales` methods to detect when a parsed PerseusItem contains widgets with hints or rationales, respectively.

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -32,6 +32,8 @@ export {
     generateTestPerseusItem,
     generateTestPerseusRenderer,
 } from "./utils/test-utils";
+export {itemHasRationales} from "./utils/item-has-rationales";
+export {itemHasHints} from "./utils/item-has-hints";
 
 export {
     parsePerseusItem,

--- a/packages/perseus-core/src/utils/item-has-hints.test.ts
+++ b/packages/perseus-core/src/utils/item-has-hints.test.ts
@@ -1,0 +1,36 @@
+import {itemHasHints} from "./item-has-hints";
+import {generateTestPerseusItem} from "./test-utils";
+
+describe("itemHasHints", () => {
+    it("returns true when item has hints", () => {
+        // Arrange
+        const item = generateTestPerseusItem({
+            hints: [
+                {
+                    content: "This is a hint",
+                    widgets: {},
+                    images: {},
+                },
+            ],
+        });
+
+        // Act
+        const result = itemHasHints(item);
+
+        // Assert
+        expect(result).toBe(true);
+    });
+
+    it("returns false when item has no hints", () => {
+        // Arrange
+        const item = generateTestPerseusItem({
+            hints: [],
+        });
+
+        // Act
+        const result = itemHasHints(item);
+
+        // Assert
+        expect(result).toBe(false);
+    });
+});

--- a/packages/perseus-core/src/utils/item-has-hints.ts
+++ b/packages/perseus-core/src/utils/item-has-hints.ts
@@ -1,0 +1,8 @@
+import type {PerseusItem} from "../data-schema";
+
+/**
+ * Returns true if the item has hints
+ */
+export const itemHasHints = (item: PerseusItem): boolean => {
+    return item.hints.length > 0;
+};

--- a/packages/perseus-core/src/utils/item-has-rationales.test.ts
+++ b/packages/perseus-core/src/utils/item-has-rationales.test.ts
@@ -1,0 +1,206 @@
+import {itemHasRationales} from "./item-has-rationales";
+import {generateTestPerseusItem} from "./test-utils";
+
+describe("itemHasRationales", () => {
+    it("returns true when item has radio widget with clues", () => {
+        // Arrange
+        const item = generateTestPerseusItem({
+            question: {
+                content: "[[☃ radio 1]]",
+                widgets: {
+                    "radio 1": {
+                        type: "radio",
+                        options: {
+                            choices: [
+                                {
+                                    content: "Choice 1",
+                                    correct: false,
+                                },
+                                {
+                                    content: "Choice 2",
+                                    correct: false,
+                                    clue: "This is a clue",
+                                },
+                            ],
+                        },
+                    },
+                },
+                images: {},
+            },
+        });
+
+        // Act
+        const result = itemHasRationales(item);
+
+        // Assert
+        expect(result).toBe(true);
+    });
+
+    it("returns true when item has label-image widget with answers", () => {
+        // Arrange
+        const item = generateTestPerseusItem({
+            question: {
+                content: "[[☃ label-image 1]]",
+                widgets: {
+                    "label-image 1": {
+                        type: "label-image",
+                        options: {
+                            markers: [
+                                {
+                                    answers: ["answer1", "answer2"],
+                                    label: "A",
+                                    x: 0,
+                                    y: 0,
+                                },
+                            ],
+                            choices: [],
+                            imageUrl: "https://example.com/image.png",
+                            imageAlt: "Test image",
+                            imageHeight: 400,
+                            imageWidth: 600,
+                            static: false,
+                            hideChoicesFromInstructions: false,
+                            multipleAnswers: true,
+                        },
+                    },
+                },
+                images: {},
+            },
+        });
+
+        // Act
+        const result = itemHasRationales(item);
+
+        // Assert
+        expect(result).toBe(true);
+    });
+
+    it("returns true when item has graded-group widget with rationales", () => {
+        // Arrange
+        const item = generateTestPerseusItem({
+            question: {
+                content: "[[☃ graded-group 1]]",
+                widgets: {
+                    "graded-group 1": {
+                        type: "graded-group",
+                        options: {
+                            widgets: {
+                                "radio 1": {
+                                    type: "radio",
+                                    options: {
+                                        choices: [
+                                            {
+                                                content: "Choice 1",
+                                                correct: false,
+                                                clue: "This is a clue",
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                            title: "Test group",
+                            content: "Test content",
+                            images: {},
+                        },
+                    },
+                },
+                images: {},
+            },
+        });
+
+        // Act
+        const result = itemHasRationales(item);
+
+        // Assert
+        expect(result).toBe(true);
+    });
+
+    it("returns true when item has group widget with rationales", () => {
+        // Arrange
+        const item = generateTestPerseusItem({
+            question: {
+                content: "[[☃ group 1]]",
+                widgets: {
+                    "group 1": {
+                        type: "group",
+                        options: {
+                            widgets: {
+                                "radio 1": {
+                                    type: "radio",
+                                    options: {
+                                        choices: [
+                                            {
+                                                content: "Choice 1",
+                                                correct: false,
+                                                clue: "This is a clue",
+                                            },
+                                        ],
+                                    },
+                                },
+                            },
+                            content: "Test content",
+                            images: {},
+                        },
+                    },
+                },
+                images: {},
+            },
+        });
+
+        // Act
+        const result = itemHasRationales(item);
+
+        // Assert
+        expect(result).toBe(true);
+    });
+
+    it("returns false when item has no widgets with rationales", () => {
+        // Arrange
+        const item = generateTestPerseusItem({
+            question: {
+                content: "[[☃ radio 1]]",
+                widgets: {
+                    "radio 1": {
+                        type: "radio",
+                        options: {
+                            choices: [
+                                {
+                                    content: "Choice 1",
+                                    correct: false,
+                                },
+                                {
+                                    content: "Choice 2",
+                                    correct: true,
+                                },
+                            ],
+                        },
+                    },
+                },
+                images: {},
+            },
+        });
+
+        // Act
+        const result = itemHasRationales(item);
+
+        // Assert
+        expect(result).toBe(false);
+    });
+
+    it("returns false when item has no widgets", () => {
+        // Arrange
+        const item = generateTestPerseusItem({
+            question: {
+                content: "",
+                widgets: {},
+                images: {},
+            },
+        });
+
+        // Act
+        const result = itemHasRationales(item);
+
+        // Assert
+        expect(result).toBe(false);
+    });
+});

--- a/packages/perseus-core/src/utils/item-has-rationales.ts
+++ b/packages/perseus-core/src/utils/item-has-rationales.ts
@@ -1,0 +1,45 @@
+import type {
+    GradedGroupWidget,
+    GroupWidget,
+    LabelImageWidget,
+    PerseusItem,
+    PerseusWidget,
+    RadioWidget,
+} from "../data-schema";
+
+/**
+ * Returns true if a Perseus item contains any widget with rationales.
+ */
+export const itemHasRationales = (item: PerseusItem) =>
+    Object.values(item.question.widgets).some(widgetHasRationales);
+
+const widgetHasRationales = (widget: PerseusWidget) => {
+    switch (widget.type) {
+        case "radio":
+            return radioWidgetHasRationales(widget);
+        case "label-image":
+            return labelImageWidgetHasRationales(widget);
+        case "graded-group":
+            return gradedGroupWidgetHasRationales(widget);
+        case "group":
+            return groupWidgetHasRationales(widget);
+        default:
+            return false;
+    }
+};
+
+const radioWidgetHasRationales = (widget: RadioWidget): boolean => {
+    return widget.options.choices.some((choice) => !!choice.clue);
+};
+
+const labelImageWidgetHasRationales = (widget: LabelImageWidget): boolean => {
+    return widget.options.markers.some((marker) => marker.answers.length > 0);
+};
+
+const gradedGroupWidgetHasRationales = (widget: GradedGroupWidget): boolean => {
+    return Object.values(widget.options.widgets).some(widgetHasRationales);
+};
+
+const groupWidgetHasRationales = (widget: GroupWidget): boolean => {
+    return Object.values(widget.options.widgets).some(widgetHasRationales);
+};

--- a/packages/perseus-core/src/utils/item-has-rationales.ts
+++ b/packages/perseus-core/src/utils/item-has-rationales.ts
@@ -1,9 +1,8 @@
 import type {
-    GradedGroupWidget,
-    GroupWidget,
     LabelImageWidget,
     PerseusItem,
     PerseusWidget,
+    PerseusWidgetsMap,
     RadioWidget,
 } from "../data-schema";
 
@@ -11,18 +10,20 @@ import type {
  * Returns true if a Perseus item contains any widget with rationales.
  */
 export const itemHasRationales = (item: PerseusItem) =>
-    Object.values(item.question.widgets).some(widgetHasRationales);
+    widgetsHaveRationales(item.question.widgets);
 
-const widgetHasRationales = (widget: PerseusWidget) => {
+const widgetsHaveRationales = (widgets: PerseusWidgetsMap) =>
+    Object.values(widgets).some(widgetHasRationales);
+
+const widgetHasRationales = (widget: PerseusWidget): boolean => {
     switch (widget.type) {
         case "radio":
             return radioWidgetHasRationales(widget);
         case "label-image":
             return labelImageWidgetHasRationales(widget);
         case "graded-group":
-            return gradedGroupWidgetHasRationales(widget);
         case "group":
-            return groupWidgetHasRationales(widget);
+            return widgetsHaveRationales(widget.options.widgets);
         default:
             return false;
     }
@@ -34,12 +35,4 @@ const radioWidgetHasRationales = (widget: RadioWidget): boolean => {
 
 const labelImageWidgetHasRationales = (widget: LabelImageWidget): boolean => {
     return widget.options.markers.some((marker) => marker.answers.length > 0);
-};
-
-const gradedGroupWidgetHasRationales = (widget: GradedGroupWidget): boolean => {
-    return Object.values(widget.options.widgets).some(widgetHasRationales);
-};
-
-const groupWidgetHasRationales = (widget: GroupWidget): boolean => {
-    return Object.values(widget.options.widgets).some(widgetHasRationales);
 };


### PR DESCRIPTION
## Summary:
In this PR, I introduce two new utilities to the perseus-core package for detecting whether a given parsed PerseusItem has hints (itemHasHints) and whether it has rationales (itemHasRationales).

Issue: https://khanacademy.atlassian.net/browse/TUT-1590

Test plan:

- pnpm test packages/perseus-core/src/utils