### PR TITLE
Expression Editor: UI update to clarify how things work

### DIFF
--- a/.changeset/new-tips-provide.md
+++ b/.changeset/new-tips-provide.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+UI updates to Expression editor

--- a/.changeset/pretty-buses-listen.md
+++ b/.changeset/pretty-buses-listen.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Add option to ButtonGroup component to allow selected button to be styled

--- a/packages/perseus-editor/src/widgets/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor.tsx
@@ -358,75 +358,94 @@ class ExpressionEditor extends React.Component<Props, State> {
 
                 <div className={css(styles.paddedY)}>
                     <LabeledTextField
-                        label="Visible label"
+                        label={
+                            <>
+                                Visible label
+                                <InfoTip>
+                                    <p>
+                                        Optional visible text; strongly
+                                        encouraged to help learners using
+                                        dictation software, but can be omitted
+                                        if the surrounding content provides
+                                        enough context.
+                                    </p>
+                                </InfoTip>
+                            </>
+                        }
                         value={this.props.visibleLabel || ""}
                         onChange={this.handleVisibleLabel}
                     />
-                    <InfoTip>
-                        <p>
-                            Optional visible text; strongly encouraged to help
-                            learners using dictation software, but can be
-                            omitted if the surrounding content provides enough
-                            context.
-                        </p>
-                    </InfoTip>
                 </div>
 
                 <div className={css(styles.paddedY)}>
                     <LabeledTextField
-                        label="Aria label"
-                        value={this.props.ariaLabel || ""}
-                        onChange={this.handleAriaLabel}
-                    />
-                    <InfoTip>
-                        <p>
-                            Label text that&apos;s read by screen readers.
-                            Highly recommend adding a label here to ensure your
-                            exercise is accessible. For more information on
-                            writting accessible labels, please see{" "}
-                            <a
-                                href="https://www.w3.org/WAI/tips/designing/#ensure-that-form-elements-include-clearly-associated-labels"
+                        label={
+                            <>
+                                Aria label
+                                <InfoTip>
+                                    <p>
+                                        Label text that&apos;s read by screen
+                                        readers. Highly recommend adding a label
+                                        here to ensure your exercise is
+                                        accessible. For more information on
+                                        writting accessible labels, please see{" "}
+                                        <a
+                                            href="https://www.w3.org/WAI/tips/designing/#ensure-that-form-elements-include-clearly-associated-labels"
                                 target="_blank"
                                 rel="noreferrer"
                             >
                                 this article.
                             </a>
                         </p>
-                    </InfoTip>
+                                </InfoTip>
+                            </>
+                        }
+                        value={this.props.ariaLabel || ""}
+                        onChange={this.handleAriaLabel}
+                    />
                 </div>
 
                 <div className={css(styles.paddedY)}>
                     <LabeledTextField
-                        label="Function variables"
+                        label={
+                            <>
+                                Function variables
+                                <InfoTip>
+                                    <p>
+                                        Single-letter variables listed here will
+                                        be interpreted as functions. This let us
+                                        know that f(x) means &quot;f of x&quot;
+                                        and not &quot;f times x&quot;.
+                                    </p>
+                                </InfoTip>
+                            </>
+                        }
                         value={this.state.functionsInternal}
                         onChange={this.handleFunctions}
                     />
-                    <InfoTip>
-                        <p>
-                            Single-letter variables listed here will be
-                            interpreted as functions. This let us know that f(x)
-                            means &quot;f of x&quot; and not &quot;f times
-                            x&quot;.
-                        </p>
-                    </InfoTip>
                 </div>
 
                 <div className={css(styles.paddedY)}>
                     <Checkbox
-                        label="Use × instead of ⋅ for multiplication"
+                        label={
+                            <>
+                                Use × instead of ⋅ for multiplication
+                                <InfoTip>
+                                    <p>
+                                        For pre-algebra problems this option
+                                        displays multiplication as \times
+                                        instead of \cdot in both the rendered
+                                        output and the acceptable formats
+                                        examples.
+                                    </p>
+                                </InfoTip>
+                            </>
+                        }
                         checked={this.props.times}
                         onChange={(newCheckedState) => {
                             this.changeTimes(newCheckedState);
                         }}
                     />
-                    <InfoTip>
-                        <p>
-                            For pre-algebra problems this option displays
-                            multiplication as \times instead of \cdot in both
-                            the rendered output and the acceptable formats
-                            examples.
-                        </p>
-                    </InfoTip>
                 </div>
 
                 <div className={css(styles.paddedY)}>
@@ -562,37 +581,47 @@ class AnswerOption extends React.Component<
                         </div>
                     </div>
 
-                    <div className={css(styles.paddedY, styles.paddedX)}>
-                        <Checkbox
-                            label="Answer expression must have the same form."
-                            checked={this.props.form}
-                            onChange={this.props.onChangeForm}
-                        />
-                        <InfoTip>
-                            <p>
-                                The student&apos;s answer must be in the same
-                                form. Commutativity and excess negative signs
-                                are ignored.
-                            </p>
-                        </InfoTip>
-                    </div>
+                <div className={css(styles.paddedY, styles.paddedX)}>
+                    <Checkbox
+                        label={
+                            <>
+                                Answer expression must have the same form.
+                                <InfoTip>
+                                    <p>
+                                        The student&apos;s answer must be in the
+                                        same form. Commutativity and excess
+                                        negative signs are ignored.
+                                    </p>
+                                </InfoTip>
+                            </>
+                        }
+                        checked={this.props.form}
+                        onChange={this.props.onChangeForm}
+                    />
+                </div>
 
-                    <div className={css(styles.paddedY, styles.paddedX)}>
-                        <Checkbox
-                            label="Answer expression must be fully expanded and simplified."
-                            checked={this.props.simplify}
-                            onChange={this.props.onChangeSimplify}
-                        />
-                        <InfoTip>
-                            <p>
-                                The student&apos;s answer must be fully expanded
-                                and simplified. Answering this equation
-                                (x^2+2x+1) with this factored equation (x+1)^2
-                                will render this response &quot;Your answer is
-                                not fully expanded and simplified.&quot;
-                            </p>
-                        </InfoTip>
-                    </div>
+                <div className={css(styles.paddedY, styles.paddedX)}>
+                    <Checkbox
+                        label={
+                            <>
+                                Answer expression must be fully expanded and
+                                simplified.
+                                <InfoTip>
+                                    <p>
+                                        The student&apos;s answer must be fully
+                                        expanded and simplified. Answering this
+                                        equation (x^2+2x+1) with this factored
+                                        equation (x+1)^2 will render this
+                                        response &quot;Your answer is not fully
+                                        expanded and simplified.&quot;
+                                    </p>
+                                </InfoTip>
+                            </>
+                        }
+                        checked={this.props.simplify}
+                        onChange={this.props.onChangeSimplify}
+                    />
+                </div>
 
                     <div className={css(styles.buttonRow, styles.paddedY)}>
                         {removeButton}

--- a/packages/perseus-editor/src/widgets/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor.tsx
@@ -12,9 +12,10 @@ import {color, sizing, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {
     HeadingSmall,
     HeadingXSmall,
+    Caption,
 } from "@khanacademy/wonder-blocks-typography";
 import {isTruthy} from "@khanacademy/wonder-stuff-core";
-import {css, StyleSheet} from "aphrodite";
+import {css, CSSProperties, StyleSheet} from "aphrodite";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import * as React from "react";
 import _ from "underscore";
@@ -25,8 +26,9 @@ import type {
     ExpressionDefaultWidgetOptions,
     PerseusExpressionAnswerForm,
 } from "@khanacademy/perseus-core";
+import {View} from "@khanacademy/wonder-blocks-core";
 
-const {InfoTip} = components;
+const {ButtonGroup, InfoTip} = components;
 
 type Props = {
     widgetId?: string;
@@ -353,7 +355,7 @@ class ExpressionEditor extends React.Component<Props, State> {
         );
 
         return (
-            <div>
+            <View>
                 <HeadingSmall>Global Options</HeadingSmall>
 
                 <div className={css(styles.paddedY)}>
@@ -362,13 +364,10 @@ class ExpressionEditor extends React.Component<Props, State> {
                             <>
                                 Visible label
                                 <InfoTip>
-                                    <p>
-                                        Optional visible text; strongly
-                                        encouraged to help learners using
-                                        dictation software, but can be omitted
-                                        if the surrounding content provides
-                                        enough context.
-                                    </p>
+                                    Optional visible text; strongly encouraged
+                                    to help learners using dictation software,
+                                    but can be omitted if the surrounding
+                                    content provides enough context.
                                 </InfoTip>
                             </>
                         }
@@ -383,20 +382,18 @@ class ExpressionEditor extends React.Component<Props, State> {
                             <>
                                 Aria label
                                 <InfoTip>
-                                    <p>
-                                        Label text that&apos;s read by screen
-                                        readers. Highly recommend adding a label
-                                        here to ensure your exercise is
-                                        accessible. For more information on
-                                        writting accessible labels, please see{" "}
-                                        <a
-                                            href="https://www.w3.org/WAI/tips/designing/#ensure-that-form-elements-include-clearly-associated-labels"
-                                target="_blank"
-                                rel="noreferrer"
-                            >
-                                this article.
-                            </a>
-                        </p>
+                                    Label text that&apos;s read by screen
+                                    readers. Highly recommend adding a label
+                                    here to ensure your exercise is accessible.
+                                    For more information on writting accessible
+                                    labels, please see{" "}
+                                    <a
+                                        href="https://www.w3.org/WAI/tips/designing/#ensure-that-form-elements-include-clearly-associated-labels"
+                                        target="_blank"
+                                        rel="noreferrer"
+                                    >
+                                        this article.
+                                    </a>
                                 </InfoTip>
                             </>
                         }
@@ -411,12 +408,10 @@ class ExpressionEditor extends React.Component<Props, State> {
                             <>
                                 Function variables
                                 <InfoTip>
-                                    <p>
-                                        Single-letter variables listed here will
-                                        be interpreted as functions. This let us
-                                        know that f(x) means &quot;f of x&quot;
-                                        and not &quot;f times x&quot;.
-                                    </p>
+                                    Single-letter variables listed here will be
+                                    interpreted as functions. This let us know
+                                    that f(x) means &quot;f of x&quot; and not
+                                    &quot;f times x&quot;.
                                 </InfoTip>
                             </>
                         }
@@ -431,13 +426,10 @@ class ExpressionEditor extends React.Component<Props, State> {
                             <>
                                 Use × instead of ⋅ for multiplication
                                 <InfoTip>
-                                    <p>
-                                        For pre-algebra problems this option
-                                        displays multiplication as \times
-                                        instead of \cdot in both the rendered
-                                        output and the acceptable formats
-                                        examples.
-                                    </p>
+                                    For pre-algebra problems this option
+                                    displays multiplication as \times instead of
+                                    \cdot in both the rendered output and the
+                                    acceptable formats examples.
                                 </InfoTip>
                             </>
                         }
@@ -455,19 +447,18 @@ class ExpressionEditor extends React.Component<Props, State> {
 
                 <HeadingSmall>Answers</HeadingSmall>
 
-                <p style={{margin: "4px 0"}}>
+                <Caption style={{fontStyle: "italic"}}>
                     student responses area matched against these from top to
                     bottom
-                </p>
+                </Caption>
 
-                {answerOptions}
+                <View style={{gap: spacing.xSmall_8}}>{answerOptions}</View>
 
-                <div>
-                    <Button size="small" onClick={this.newAnswer}>
-                        Add new answer
-                    </Button>
-                </div>
-            </div>
+                <Strut size={spacing.small_12} />
+                <Button size="small" onClick={this.newAnswer}>
+                    Add new answer
+                </Button>
+            </View>
         );
     }
 }
@@ -558,28 +549,23 @@ class AnswerOption extends React.Component<
             </Button>
         );
 
-        const answerStatusCss = css(
-            styles.answerStatus,
-            this.props.considered === "wrong" && styles.answerStatusWrong,
-            this.props.considered === "correct" && styles.answerStatusCorrect,
-            this.props.considered === "ungraded" && styles.answerStatusUngraded,
-        );
-
         return (
             <div className={css(styles.answerOption)}>
-                <div className={css(styles.answerBody)}>
-                    <div>
-                        <button
-                            onClick={this.toggleConsidered}
-                            className={answerStatusCss}
-                        >
-                            {this.props.considered}
-                        </button>
+                <ButtonGroup
+                    onChange={this.toggleConsidered}
+                    allowEmpty={false}
+                    value={this.props.considered}
+                    selectedButtonStyle={
+                        consideredButtonStyles[this.props.considered]
+                    }
+                    buttons={PerseusExpressionAnswerFormConsidered.map((c) => ({
+                        value: c,
+                        content: c,
+                        title: `This answer will be considered ${c}`,
+                    }))}
+                />
 
-                        <div>
-                            <Expression {...this.props.expressionProps} />
-                        </div>
-                    </div>
+                <Expression {...this.props.expressionProps} />
 
                 <div className={css(styles.paddedY, styles.paddedX)}>
                     <Checkbox
@@ -587,11 +573,9 @@ class AnswerOption extends React.Component<
                             <>
                                 Answer expression must have the same form.
                                 <InfoTip>
-                                    <p>
-                                        The student&apos;s answer must be in the
-                                        same form. Commutativity and excess
-                                        negative signs are ignored.
-                                    </p>
+                                    The student&apos;s answer must be in the
+                                    same form. Commutativity and excess negative
+                                    signs are ignored.
                                 </InfoTip>
                             </>
                         }
@@ -607,14 +591,12 @@ class AnswerOption extends React.Component<
                                 Answer expression must be fully expanded and
                                 simplified.
                                 <InfoTip>
-                                    <p>
-                                        The student&apos;s answer must be fully
-                                        expanded and simplified. Answering this
-                                        equation (x^2+2x+1) with this factored
-                                        equation (x+1)^2 will render this
-                                        response &quot;Your answer is not fully
-                                        expanded and simplified.&quot;
-                                    </p>
+                                    The student&apos;s answer must be fully
+                                    expanded and simplified. Answering this
+                                    equation (x^2+2x+1) with this factored
+                                    equation (x+1)^2 will render this response
+                                    &quot;Your answer is not fully expanded and
+                                    simplified.&quot;
                                 </InfoTip>
                             </>
                         }
@@ -623,9 +605,8 @@ class AnswerOption extends React.Component<
                     />
                 </div>
 
-                    <div className={css(styles.buttonRow, styles.paddedY)}>
-                        {removeButton}
-                    </div>
+                <div className={css(styles.buttonRow, styles.paddedY)}>
+                    {removeButton}
                 </div>
             </div>
         );
@@ -647,6 +628,7 @@ const styles = StyleSheet.create({
         border: "1px solid #ddd",
         borderRadius: "3px",
         display: "flex",
+        flexDirection: "column",
     },
     answerStatus: {
         border: "none",
@@ -664,7 +646,6 @@ const styles = StyleSheet.create({
     answerStatusUngraded: {
         backgroundColor: color.fadedBlue16,
     },
-    answerBody: {},
     buttonRow: {
         display: "flex",
     },
@@ -672,3 +653,12 @@ const styles = StyleSheet.create({
         paddingInline: sizing.size_160,
     },
 });
+
+const consideredButtonStyles: Record<
+    (typeof PerseusExpressionAnswerFormConsidered)[number],
+    CSSProperties
+> = {
+    wrong: styles.answerStatusWrong,
+    correct: styles.answerStatusCorrect,
+    ungraded: styles.answerStatusUngraded,
+};

--- a/packages/perseus-editor/src/widgets/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor.tsx
@@ -447,7 +447,7 @@ class ExpressionEditor extends React.Component<Props, State> {
 
                 <HeadingSmall>Answers</HeadingSmall>
 
-                <Caption style={{fontStyle: "italic"}}>
+                <Caption style={styles.answersSubtitle}>
                     student responses area matched against these from top to
                     bottom
                 </Caption>
@@ -624,6 +624,7 @@ const styles = StyleSheet.create({
         paddingTop: spacing.xxSmall_6,
         paddingBottom: spacing.xxSmall_6,
     },
+    answersSubtitle: {fontStyle: "italic"},
     answerOption: {
         border: "1px solid #ddd",
         borderRadius: "3px",

--- a/packages/perseus-editor/src/widgets/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor.tsx
@@ -6,6 +6,7 @@ import {
     expressionLogic,
 } from "@khanacademy/perseus-core";
 import Button from "@khanacademy/wonder-blocks-button";
+import {View} from "@khanacademy/wonder-blocks-core";
 import {Checkbox, LabeledTextField} from "@khanacademy/wonder-blocks-form";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {color, sizing, spacing} from "@khanacademy/wonder-blocks-tokens";
@@ -16,18 +17,16 @@ import {
 } from "@khanacademy/wonder-blocks-typography";
 import {isTruthy} from "@khanacademy/wonder-stuff-core";
 import {css, StyleSheet} from "aphrodite";
-// eslint-disable-next-line import/no-extraneous-dependencies
 import * as React from "react";
 import _ from "underscore";
 
-import type {CSSProperties} from "aphrodite";
 import type {
     PerseusExpressionWidgetOptions,
     LegacyButtonSets,
     ExpressionDefaultWidgetOptions,
     PerseusExpressionAnswerForm,
 } from "@khanacademy/perseus-core";
-import {View} from "@khanacademy/wonder-blocks-core";
+import type {CSSProperties} from "aphrodite";
 
 const {ButtonGroup, InfoTip} = components;
 
@@ -630,13 +629,6 @@ const styles = StyleSheet.create({
         borderRadius: "3px",
         display: "flex",
         flexDirection: "column",
-    },
-    answerStatus: {
-        border: "none",
-        userSelect: "none",
-        width: "100px",
-        paddingTop: spacing.small_12,
-        paddingBottom: spacing.small_12,
     },
     answerStatusWrong: {
         backgroundColor: color.fadedRed16,

--- a/packages/perseus-editor/src/widgets/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor.tsx
@@ -15,11 +15,12 @@ import {
     Caption,
 } from "@khanacademy/wonder-blocks-typography";
 import {isTruthy} from "@khanacademy/wonder-stuff-core";
-import {css, CSSProperties, StyleSheet} from "aphrodite";
+import {css, StyleSheet} from "aphrodite";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import * as React from "react";
 import _ from "underscore";
 
+import type {CSSProperties} from "aphrodite";
 import type {
     PerseusExpressionWidgetOptions,
     LegacyButtonSets,

--- a/packages/perseus/src/components/button-group.tsx
+++ b/packages/perseus/src/components/button-group.tsx
@@ -19,6 +19,11 @@ type Props = {
     // if false, exactly one button _must_ be selected;
     // defaults to true and _at most_ one button (0 or 1) may be selected.
     allowEmpty: boolean;
+
+    /**
+     * Customizes the selected button's styling.
+     */
+    selectedButtonStyle?: CSSProperties;
 };
 
 type DefaultProps = {
@@ -66,12 +71,13 @@ class ButtonGroup extends React.Component<Props> {
                 <button
                     title={button.title}
                     type="button"
-                    id={"" + i}
                     ref={"button" + i}
                     key={"" + i}
                     className={css(
                         styles.buttonStyle,
                         button.value === value && styles.selectedStyle,
+                        button.value === value &&
+                            this.props.selectedButtonStyle,
                     )}
                     onClick={() => this.toggleSelect(button.value)}
                 >

--- a/packages/perseus/src/components/button-group.tsx
+++ b/packages/perseus/src/components/button-group.tsx
@@ -1,6 +1,8 @@
 import {css, StyleSheet} from "aphrodite";
 import * as React from "react";
 
+import type {CSSProperties} from "aphrodite";
+
 type Props = {
     // the initial value of the button selected, defaults to null
     value: any;

--- a/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
+++ b/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
@@ -2610,7 +2610,6 @@ exports[`grapher widget should snapshot question with multiple graph types: init
               >
                 <button
                   class="buttonStyle_1xlhe29-o_O-selectedStyle_1ewmj59"
-                  id="0"
                   title="Linear"
                   type="button"
                 >
@@ -2621,7 +2620,6 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                 </button>
                 <button
                   class="buttonStyle_1xlhe29"
-                  id="1"
                   title="Absolute_value"
                   type="button"
                 >
@@ -2632,7 +2630,6 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                 </button>
                 <button
                   class="buttonStyle_1xlhe29"
-                  id="2"
                   title="Quadratic"
                   type="button"
                 >
@@ -2643,7 +2640,6 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                 </button>
                 <button
                   class="buttonStyle_1xlhe29"
-                  id="3"
                   title="Exponential"
                   type="button"
                 >
@@ -2654,7 +2650,6 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                 </button>
                 <button
                   class="buttonStyle_1xlhe29"
-                  id="4"
                   title="Logarithm"
                   type="button"
                 >


### PR DESCRIPTION
## Summary:

I spent an hour cleaning up a bunch of UI stuff in the `expression` editor. Namely: 

  * Change the 'considered' (`correct`, `incorrect`, `ungraded`) options to be a button group so it's more obvious that you can actually change it
  * Moved tooltip `?` to be at end of field label instead of trailing input
  * Added a gap between answers
  * Stretch "Add new answer" to full width so it looks nicer


| Before | After | 
| --- | --- | 
| <img width="346" alt="image" src="https://github.com/user-attachments/assets/8731ac92-cb82-481a-91ed-fdcde14e6c05" />  |  <img width="345" alt="image" src="https://github.com/user-attachments/assets/149667a4-0242-42a3-9012-5425f916a7b9" /> |

Issue: "none" 

## Test plan:

Review UI changes and code