### PR TITLE
Use interface for shared ref type

### DIFF
--- a/.changeset/good-trains-dream.md
+++ b/.changeset/good-trains-dream.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix types used for forwardref in `expression` widget

--- a/packages/perseus/src/components/simple-keypad-input.tsx
+++ b/packages/perseus/src/components/simple-keypad-input.tsx
@@ -34,10 +34,6 @@ export default class SimpleKeypadInput
         this._isMounted = false;
     }
 
-    get current() {
-        return this.inputRef.current;
-    }
-
     focus() {
         // The inputRef is a ref to a MathInput, which
         // also controls the keypad state during focus events.

--- a/packages/perseus/src/components/simple-keypad-input.tsx
+++ b/packages/perseus/src/components/simple-keypad-input.tsx
@@ -12,7 +12,8 @@ import {KeypadContext} from "@khanacademy/keypad-context";
 import {KeypadInput, keypadElementPropType} from "@khanacademy/math-input";
 import PropTypes from "prop-types";
 import * as React from "react";
-import {NumericInputHandle} from "../types";
+
+import type {NumericInputHandle} from "../types";
 
 export default class SimpleKeypadInput
     extends React.Component<any>
@@ -23,10 +24,6 @@ export default class SimpleKeypadInput
     _isMounted = false;
     inputRef = React.createRef<KeypadInput>();
 
-    get current() {
-        return this.inputRef.current;
-    }
-
     componentDidMount() {
         // TODO(scottgrant): This is a hack to remove the deprecated call to
         // this.isMounted() but is still considered an anti-pattern.
@@ -35,6 +32,10 @@ export default class SimpleKeypadInput
 
     componentWillUnmount() {
         this._isMounted = false;
+    }
+
+    get current() {
+        return this.inputRef.current;
     }
 
     focus() {

--- a/packages/perseus/src/components/simple-keypad-input.tsx
+++ b/packages/perseus/src/components/simple-keypad-input.tsx
@@ -12,12 +12,20 @@ import {KeypadContext} from "@khanacademy/keypad-context";
 import {KeypadInput, keypadElementPropType} from "@khanacademy/math-input";
 import PropTypes from "prop-types";
 import * as React from "react";
+import {NumericInputHandle} from "../types";
 
-export default class SimpleKeypadInput extends React.Component<any> {
+export default class SimpleKeypadInput
+    extends React.Component<any>
+    implements NumericInputHandle
+{
     static contextType = KeypadContext;
     declare context: React.ContextType<typeof KeypadContext>;
     _isMounted = false;
     inputRef = React.createRef<KeypadInput>();
+
+    get current() {
+        return this.inputRef.current;
+    }
 
     componentDidMount() {
         // TODO(scottgrant): This is a hack to remove the deprecated call to

--- a/packages/perseus/src/components/simple-keypad-input.tsx
+++ b/packages/perseus/src/components/simple-keypad-input.tsx
@@ -13,11 +13,11 @@ import {KeypadInput, keypadElementPropType} from "@khanacademy/math-input";
 import PropTypes from "prop-types";
 import * as React from "react";
 
-import type {NumericInputHandle} from "../types";
+import type {Focusable} from "../types";
 
 export default class SimpleKeypadInput
     extends React.Component<any>
-    implements NumericInputHandle
+    implements Focusable
 {
     static contextType = KeypadContext;
     declare context: React.ContextType<typeof KeypadContext>;

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -609,7 +609,6 @@ export type SharedRendererProps = {
 };
 
 export interface NumericInputHandle {
-    current: any;
     focus: () => void;
     blur: () => void;
 }

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -608,7 +608,7 @@ export type SharedRendererProps = {
     linterContext: LinterContextProps;
 };
 
-export interface NumericInputHandle {
+export interface Focusable {
     focus: () => void;
     blur: () => void;
 }

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -607,3 +607,9 @@ export type SharedRendererProps = {
     apiOptions: APIOptions;
     linterContext: LinterContextProps;
 };
+
+export interface NumericInputHandle {
+    current: any;
+    focus: () => void;
+    blur: () => void;
+}

--- a/packages/perseus/src/widgets/numeric-input/input-with-examples.tsx
+++ b/packages/perseus/src/widgets/numeric-input/input-with-examples.tsx
@@ -10,9 +10,9 @@ import {ClassNames as ApiClassNames} from "../../perseus-api";
 import Renderer from "../../renderer";
 import Util from "../../util";
 
+import type {NumericInputHandle} from "../../types";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
-import {NumericInputHandle} from "../../types";
 
 const {captureScratchpadTouchStart} = Util;
 

--- a/packages/perseus/src/widgets/numeric-input/input-with-examples.tsx
+++ b/packages/perseus/src/widgets/numeric-input/input-with-examples.tsx
@@ -10,7 +10,7 @@ import {ClassNames as ApiClassNames} from "../../perseus-api";
 import Renderer from "../../renderer";
 import Util from "../../util";
 
-import type {NumericInputHandle} from "../../types";
+import type {Focusable} from "../../types";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
@@ -44,7 +44,7 @@ type Props = {
  * for the desktop versions of these widgets, and displays a tooltip with
  * examples of how to input the selected answer forms.
  */
-const InputWithExamples = forwardRef<NumericInputHandle, Props>(
+const InputWithExamples = forwardRef<Focusable, Props>(
     (
         {
             shouldShowExamples = true,

--- a/packages/perseus/src/widgets/numeric-input/input-with-examples.tsx
+++ b/packages/perseus/src/widgets/numeric-input/input-with-examples.tsx
@@ -100,7 +100,7 @@ const InputWithExamples = forwardRef<NumericInputHandle, Props>(
 
         const renderInput = () => {
             // Generate the provided examples in simple language for screen readers.
-            const examplesAria = props.shouldShowExamples
+            const examplesAria = shouldShowExamples
                 ? `${props.examples[0]}
                    ${props.examples.slice(1).join(", or\n")}`
                       // @ts-expect-error TS2550: Property replaceAll does not exist on type string.
@@ -113,9 +113,7 @@ const InputWithExamples = forwardRef<NumericInputHandle, Props>(
             const inputProps = {
                 id: id,
                 // If we have examples, we want to provide the aria-describedby attribute
-                "aria-describedby": props.shouldShowExamples
-                    ? ariaId
-                    : undefined,
+                "aria-describedby": shouldShowExamples ? ariaId : undefined,
                 ref: inputRef,
                 className: getInputClassName(),
                 labelText: props.labelText,

--- a/packages/perseus/src/widgets/numeric-input/input-with-examples.tsx
+++ b/packages/perseus/src/widgets/numeric-input/input-with-examples.tsx
@@ -12,25 +12,26 @@ import Util from "../../util";
 
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
+import {NumericInputHandle} from "../../types";
 
 const {captureScratchpadTouchStart} = Util;
 
 type Props = {
     value: string;
     onChange: any;
-    className: string;
+    className?: string;
     examples: ReadonlyArray<string>;
     shouldShowExamples: boolean;
     convertDotToTimes?: boolean;
     buttonSet?: string;
     buttonsVisible?: "always" | "never" | "focused";
     labelText?: string;
-    onFocus: () => void;
-    onBlur: () => void;
-    disabled: boolean;
+    onFocus?: () => void;
+    onBlur?: () => void;
+    disabled?: boolean;
     style?: StyleType;
     id: string;
-    linterContext: LinterContextProps;
+    linterContext?: LinterContextProps;
 };
 
 // [LEMS-2411](Jan 2025) Third: This component has been moved to the NumericInput
@@ -43,143 +44,145 @@ type Props = {
  * for the desktop versions of these widgets, and displays a tooltip with
  * examples of how to input the selected answer forms.
  */
-const InputWithExamples = forwardRef<
-    React.RefObject<typeof InputWithExamples>,
-    Props
->((props, ref) => {
-    // Desctructure the props to set default values
-    const {
-        shouldShowExamples = true,
-        onFocus = () => {},
-        onBlur = () => {},
-        disabled = false,
-        linterContext = PerseusLinter.linterContextDefault,
-        className = "",
-    } = props;
-
-    const context = React.useContext(PerseusI18nContext);
-    const inputRef = React.useRef<TextInput>(null);
-    const [inputFocused, setInputFocused] = React.useState<boolean>(false);
-    const id = useId();
-    const ariaId = `aria-for-${id}`;
-
-    useImperativeHandle(ref, () => ({
-        current: inputRef.current,
-        focus: () => {
-            if (inputRef.current) {
-                inputRef.current.focus();
-            }
+const InputWithExamples = forwardRef<NumericInputHandle, Props>(
+    (
+        {
+            shouldShowExamples = true,
+            onFocus = () => {},
+            onBlur = () => {},
+            disabled = false,
+            linterContext = PerseusLinter.linterContextDefault,
+            className = "",
+            ...props
         },
-        blur: () => {
-            if (inputRef.current) {
-                inputRef.current.blur();
+        ref,
+    ) => {
+        const context = React.useContext(PerseusI18nContext);
+        const inputRef = React.useRef<TextInput>(null);
+        const [inputFocused, setInputFocused] = React.useState<boolean>(false);
+        const id = useId();
+        const ariaId = `aria-for-${id}`;
+
+        useImperativeHandle(ref, () => ({
+            current: inputRef.current,
+            focus: () => {
+                if (inputRef.current) {
+                    inputRef.current.focus();
+                }
+            },
+            blur: () => {
+                if (inputRef.current) {
+                    inputRef.current.blur();
+                }
+            },
+        }));
+
+        const getInputClassName = () => {
+            let inputClassName = ApiClassNames.INPUT;
+            if (inputFocused) {
+                inputClassName += " " + ApiClassNames.FOCUSED;
             }
-        },
-    }));
-
-    const getInputClassName = () => {
-        let inputClassName = ApiClassNames.INPUT;
-        if (inputFocused) {
-            inputClassName += " " + ApiClassNames.FOCUSED;
-        }
-        if (className) {
-            inputClassName += " " + className;
-        }
-        return inputClassName;
-    };
-
-    const handleFocus = () => {
-        onFocus();
-        setInputFocused(true);
-    };
-
-    const handleBlur = () => {
-        onBlur();
-        setInputFocused(false);
-    };
-
-    const renderInput = () => {
-        // Generate the provided examples in simple language for screen readers.
-        const examplesAria = props.shouldShowExamples
-            ? `${props.examples[0]}
-                   ${props.examples.slice(1).join(", or\n")}`
-                  // @ts-expect-error TS2550: Property replaceAll does not exist on type string.
-                  .replaceAll("*", "")
-                  .replaceAll("$", "")
-                  .replaceAll("\\ \\text{pi}", " pi")
-                  .replaceAll("\\ ", " and ")
-            : "";
-
-        const inputProps = {
-            id: id,
-            // If we have examples, we want to provide the aria-describedby attribute
-            "aria-describedby": props.shouldShowExamples ? ariaId : undefined,
-            ref: inputRef,
-            className: getInputClassName(),
-            labelText: props.labelText,
-            value: props.value,
-            onFocus: handleFocus,
-            onBlur: handleBlur,
-            disabled: disabled,
-            style: props.style,
-            onChange: props.onChange,
-            onTouchStart: captureScratchpadTouchStart,
-            autoCapitalize: "off",
-            autoComplete: "off",
-            autoCorrect: "off",
-            spellCheck: "false",
+            if (className) {
+                inputClassName += " " + className;
+            }
+            return inputClassName;
         };
+
+        const handleFocus = () => {
+            onFocus();
+            setInputFocused(true);
+        };
+
+        const handleBlur = () => {
+            onBlur();
+            setInputFocused(false);
+        };
+
+        const renderInput = () => {
+            // Generate the provided examples in simple language for screen readers.
+            const examplesAria = props.shouldShowExamples
+                ? `${props.examples[0]}
+                   ${props.examples.slice(1).join(", or\n")}`
+                      // @ts-expect-error TS2550: Property replaceAll does not exist on type string.
+                      .replaceAll("*", "")
+                      .replaceAll("$", "")
+                      .replaceAll("\\ \\text{pi}", " pi")
+                      .replaceAll("\\ ", " and ")
+                : "";
+
+            const inputProps = {
+                id: id,
+                // If we have examples, we want to provide the aria-describedby attribute
+                "aria-describedby": props.shouldShowExamples
+                    ? ariaId
+                    : undefined,
+                ref: inputRef,
+                className: getInputClassName(),
+                labelText: props.labelText,
+                value: props.value,
+                onFocus: handleFocus,
+                onBlur: handleBlur,
+                disabled: disabled,
+                style: props.style,
+                onChange: props.onChange,
+                onTouchStart: captureScratchpadTouchStart,
+                autoCapitalize: "off",
+                autoComplete: "off",
+                autoCorrect: "off",
+                spellCheck: "false",
+            };
+            return (
+                <>
+                    <TextInput {...inputProps} />
+                    <span id={ariaId} style={{display: "none"}}>
+                        {examplesAria}
+                    </span>
+                </>
+            );
+        };
+
+        const renderTooltipContent = () => {
+            return (
+                <TooltipContent>
+                    <div id={id} className="input-with-examples-tooltip">
+                        <Renderer
+                            content={examplesContent}
+                            linterContext={PerseusLinter.pushContextStack(
+                                linterContext,
+                                "input-with-examples",
+                            )}
+                            strings={context.strings}
+                        />
+                    </div>
+                </TooltipContent>
+            );
+        };
+        // Display the examples as a string when there are less than or equal to 2 examples.
+        // Otherwise, display the examples as a list.
+        const examplesContent =
+            props.examples.length <= 2
+                ? props.examples.join(" ")
+                : props.examples
+                      .map((example, index) => {
+                          return index === 0 && example.startsWith("**")
+                              ? `${example}\n`
+                              : `- ${example}`;
+                      })
+                      .join("\n");
+
+        // Display the examples when they are enabled (shouldShowExamples) and the input is focused.
+        const showExamplesTooltip = shouldShowExamples && inputFocused;
+
         return (
-            <>
-                <TextInput {...inputProps} />
-                <span id={ariaId} style={{display: "none"}}>
-                    {examplesAria}
-                </span>
-            </>
+            <Tooltip
+                content={renderTooltipContent()}
+                opened={showExamplesTooltip}
+                placement="bottom"
+            >
+                {renderInput()}
+            </Tooltip>
         );
-    };
-
-    const renderTooltipContent = () => {
-        return (
-            <TooltipContent>
-                <div id={id} className="input-with-examples-tooltip">
-                    <Renderer
-                        content={examplesContent}
-                        linterContext={PerseusLinter.pushContextStack(
-                            linterContext,
-                            "input-with-examples",
-                        )}
-                        strings={context.strings}
-                    />
-                </div>
-            </TooltipContent>
-        );
-    };
-    // Display the examples as a string when there are less than or equal to 2 examples.
-    // Otherwise, display the examples as a list.
-    const examplesContent =
-        props.examples.length <= 2
-            ? props.examples.join(" ")
-            : props.examples
-                  .map((example, index) => {
-                      return index === 0 && example.startsWith("**")
-                          ? `${example}\n`
-                          : `- ${example}`;
-                  })
-                  .join("\n");
-
-    // Display the examples when they are enabled (shouldShowExamples) and the input is focused.
-    const showExamplesTooltip = shouldShowExamples && inputFocused;
-
-    return (
-        <Tooltip
-            content={renderTooltipContent()}
-            opened={showExamplesTooltip}
-            placement="bottom"
-        >
-            {renderInput()}
-        </Tooltip>
-    );
-});
+    },
+);
 
 export default InputWithExamples;

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.class.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.class.tsx
@@ -8,9 +8,13 @@ import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/numeric-inp
 import {NumericInputComponent} from "./numeric-input";
 import {unionAnswerForms} from "./utils";
 
-import type InputWithExamples from "./input-with-examples";
-import type SimpleKeypadInput from "../../components/simple-keypad-input";
-import type {FocusPath, Widget, WidgetExports, WidgetProps} from "../../types";
+import type {
+    FocusPath,
+    NumericInputHandle,
+    Widget,
+    WidgetExports,
+    WidgetProps,
+} from "../../types";
 import type {NumericInputPromptJSON} from "../../widget-ai-utils/numeric-input/prompt-utils";
 import type {
     PerseusNumericInputWidgetOptions,
@@ -77,7 +81,7 @@ export class NumericInput
     extends React.Component<NumericInputProps>
     implements Widget
 {
-    inputRef = React.createRef<SimpleKeypadInput | typeof InputWithExamples>();
+    inputRef = React.createRef<NumericInputHandle>();
 
     static defaultProps: DefaultProps = {
         currentValue: "",

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.class.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.class.tsx
@@ -10,7 +10,7 @@ import {unionAnswerForms} from "./utils";
 
 import type {
     FocusPath,
-    NumericInputHandle,
+    Focusable,
     Widget,
     WidgetExports,
     WidgetProps,
@@ -81,7 +81,7 @@ export class NumericInput
     extends React.Component<NumericInputProps>
     implements Widget
 {
-    inputRef = React.createRef<NumericInputHandle>();
+    inputRef = React.createRef<Focusable>();
 
     static defaultProps: DefaultProps = {
         currentValue: "",

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
@@ -22,96 +22,97 @@ import type {NumericInputHandle} from "../../types";
  * component. It is responsible for rendering the UI elements of the Numeric
  * Input widget.
  */
-export const NumericInputComponent = forwardRef<NumericInputHandle, NumericInputProps>(
-    (props: NumericInputProps, ref) => {
-        const context = useContext(PerseusI18nContext);
-        const inputRef = useRef<NumericInputHandle>(null);
-        const [isFocused, setIsFocused] = useState<boolean>(false);
+export const NumericInputComponent = forwardRef<
+    NumericInputHandle,
+    NumericInputProps
+>((props, ref) => {
+    const context = useContext(PerseusI18nContext);
+    const inputRef = useRef<NumericInputHandle>(null);
+    const [isFocused, setIsFocused] = useState<boolean>(false);
 
-        // Pass the focus and blur methods to the Numeric Input Class component
-        useImperativeHandle(ref, () => ({
-            current: inputRef.current,
-            focus: () => {
-                if (inputRef.current) {
-                    inputRef.current?.focus();
-                    setIsFocused(true);
-                }
-            },
-            blur: () => {
-                if (inputRef.current) {
-                    inputRef.current?.blur();
-                    setIsFocused(false);
-                }
-            },
-        }));
+    // Pass the focus and blur methods to the Numeric Input Class component
+    useImperativeHandle(ref, () => ({
+        current: inputRef.current,
+        focus: () => {
+            if (inputRef.current) {
+                inputRef.current?.focus();
+                setIsFocused(true);
+            }
+        },
+        blur: () => {
+            if (inputRef.current) {
+                inputRef.current?.blur();
+                setIsFocused(false);
+            }
+        },
+    }));
 
-        const handleChange = (
-            newValue: string,
-            cb?: () => unknown | null | undefined,
-        ): void => {
-            props.onChange({currentValue: newValue}, cb);
-            props.trackInteraction();
-        };
+    const handleChange = (
+        newValue: string,
+        cb?: () => unknown | null | undefined,
+    ): void => {
+        props.onChange({currentValue: newValue}, cb);
+        props.trackInteraction();
+    };
 
-        const handleFocus = (): void => {
-            props.onFocus([]);
-            setIsFocused(true);
-        };
+    const handleFocus = (): void => {
+        props.onFocus([]);
+        setIsFocused(true);
+    };
 
-        const handleBlur = (): void => {
-            props.onBlur([]);
-            setIsFocused(false);
-        };
+    const handleBlur = (): void => {
+        props.onBlur([]);
+        setIsFocused(false);
+    };
 
-        // Styles for the InputWithExamples
-        const styles = StyleSheet.create({
-            inputWithExamples: {
-                borderRadius: "3px",
-                borderWidth: isFocused ? "2px" : "1px",
-                display: "inline-block",
-                fontFamily: `Symbola, "Times New Roman", serif`,
-                fontSize: "18px",
-                height: "32px",
-                lineHeight: "18px",
-                padding: isFocused ? "4px" : "4px 5px",
-                textAlign: props.rightAlign ? "right" : "left",
-                width: props.size === "small" ? 40 : 80,
-            },
-        });
+    // Styles for the InputWithExamples
+    const styles = StyleSheet.create({
+        inputWithExamples: {
+            borderRadius: "3px",
+            borderWidth: isFocused ? "2px" : "1px",
+            display: "inline-block",
+            fontFamily: `Symbola, "Times New Roman", serif`,
+            fontSize: "18px",
+            height: "32px",
+            lineHeight: "18px",
+            padding: isFocused ? "4px" : "4px 5px",
+            textAlign: props.rightAlign ? "right" : "left",
+            width: props.size === "small" ? 40 : 80,
+        },
+    });
 
-        // (mobile-only) If the custom keypad is enabled, use the SimpleKeypadInput component
-        if (props.apiOptions.customKeypad) {
-            const alignmentClass = props.rightAlign
-                ? "perseus-input-right-align"
-                : undefined;
-            return (
-                <div className={alignmentClass}>
-                    <SimpleKeypadInput
-                        ref={inputRef as React.RefObject<SimpleKeypadInput>}
-                        value={props.currentValue}
-                        keypadElement={props.keypadElement}
-                        onChange={handleChange}
-                        onFocus={handleFocus}
-                        onBlur={handleBlur}
-                    />
-                </div>
-            );
-        }
-        // (desktop-only) Otherwise, use the InputWithExamples component
+    // (mobile-only) If the custom keypad is enabled, use the SimpleKeypadInput component
+    if (props.apiOptions.customKeypad) {
+        const alignmentClass = props.rightAlign
+            ? "perseus-input-right-align"
+            : undefined;
         return (
-            <InputWithExamples
-                ref={inputRef}
-                value={props.currentValue}
-                onChange={handleChange}
-                labelText={props.labelText}
-                examples={generateExamples(props.answerForms, context.strings)}
-                shouldShowExamples={shouldShowExamples(props.answerForms)}
-                onFocus={handleFocus}
-                onBlur={handleBlur}
-                id={props.widgetId}
-                disabled={props.apiOptions.readOnly}
-                style={styles.inputWithExamples}
-            />
+            <div className={alignmentClass}>
+                <SimpleKeypadInput
+                    ref={inputRef as React.RefObject<SimpleKeypadInput>}
+                    value={props.currentValue}
+                    keypadElement={props.keypadElement}
+                    onChange={handleChange}
+                    onFocus={handleFocus}
+                    onBlur={handleBlur}
+                />
+            </div>
         );
-    },
-);
+    }
+    // (desktop-only) Otherwise, use the InputWithExamples component
+    return (
+        <InputWithExamples
+            ref={inputRef}
+            value={props.currentValue}
+            onChange={handleChange}
+            labelText={props.labelText}
+            examples={generateExamples(props.answerForms, context.strings)}
+            shouldShowExamples={shouldShowExamples(props.answerForms)}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+            id={props.widgetId}
+            disabled={props.apiOptions.readOnly}
+            style={styles.inputWithExamples}
+        />
+    );
+});

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
@@ -15,7 +15,7 @@ import InputWithExamples from "./input-with-examples";
 import {type NumericInputProps} from "./numeric-input.class";
 import {generateExamples, shouldShowExamples} from "./utils";
 
-type InputRefType = SimpleKeypadInput | typeof InputWithExamples | null;
+import type {NumericInputHandle} from "../../types";
 
 /**
  * The NumericInputComponent is a child component of the NumericInput class
@@ -25,7 +25,7 @@ type InputRefType = SimpleKeypadInput | typeof InputWithExamples | null;
 export const NumericInputComponent = forwardRef(
     (props: NumericInputProps, ref) => {
         const context = useContext(PerseusI18nContext);
-        const inputRef = useRef<InputRefType>(null);
+        const inputRef = useRef<NumericInputHandle>(null);
         const [isFocused, setIsFocused] = useState<boolean>(false);
 
         // Pass the focus and blur methods to the Numeric Input Class component
@@ -100,7 +100,7 @@ export const NumericInputComponent = forwardRef(
         // (desktop-only) Otherwise, use the InputWithExamples component
         return (
             <InputWithExamples
-                ref={inputRef as React.RefObject<typeof InputWithExamples>}
+                ref={inputRef}
                 value={props.currentValue}
                 onChange={handleChange}
                 labelText={props.labelText}

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
@@ -22,7 +22,7 @@ import type {NumericInputHandle} from "../../types";
  * component. It is responsible for rendering the UI elements of the Numeric
  * Input widget.
  */
-export const NumericInputComponent = forwardRef(
+export const NumericInputComponent = forwardRef<NumericInputHandle, NumericInputProps>(
     (props: NumericInputProps, ref) => {
         const context = useContext(PerseusI18nContext);
         const inputRef = useRef<NumericInputHandle>(null);

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
@@ -15,104 +15,103 @@ import InputWithExamples from "./input-with-examples";
 import {type NumericInputProps} from "./numeric-input.class";
 import {generateExamples, shouldShowExamples} from "./utils";
 
-import type {NumericInputHandle} from "../../types";
+import type {Focusable} from "../../types";
 
 /**
  * The NumericInputComponent is a child component of the NumericInput class
  * component. It is responsible for rendering the UI elements of the Numeric
  * Input widget.
  */
-export const NumericInputComponent = forwardRef<
-    NumericInputHandle,
-    NumericInputProps
->((props, ref) => {
-    const context = useContext(PerseusI18nContext);
-    const inputRef = useRef<NumericInputHandle>(null);
-    const [isFocused, setIsFocused] = useState<boolean>(false);
+export const NumericInputComponent = forwardRef<Focusable, NumericInputProps>(
+    (props, ref) => {
+        const context = useContext(PerseusI18nContext);
+        const inputRef = useRef<Focusable>(null);
+        const [isFocused, setIsFocused] = useState<boolean>(false);
 
-    // Pass the focus and blur methods to the Numeric Input Class component
-    useImperativeHandle(ref, () => ({
-        current: inputRef.current,
-        focus: () => {
-            if (inputRef.current) {
-                inputRef.current?.focus();
-                setIsFocused(true);
-            }
-        },
-        blur: () => {
-            if (inputRef.current) {
-                inputRef.current?.blur();
-                setIsFocused(false);
-            }
-        },
-    }));
+        // Pass the focus and blur methods to the Numeric Input Class component
+        useImperativeHandle(ref, () => ({
+            current: inputRef.current,
+            focus: () => {
+                if (inputRef.current) {
+                    inputRef.current?.focus();
+                    setIsFocused(true);
+                }
+            },
+            blur: () => {
+                if (inputRef.current) {
+                    inputRef.current?.blur();
+                    setIsFocused(false);
+                }
+            },
+        }));
 
-    const handleChange = (
-        newValue: string,
-        cb?: () => unknown | null | undefined,
-    ): void => {
-        props.onChange({currentValue: newValue}, cb);
-        props.trackInteraction();
-    };
+        const handleChange = (
+            newValue: string,
+            cb?: () => unknown | null | undefined,
+        ): void => {
+            props.onChange({currentValue: newValue}, cb);
+            props.trackInteraction();
+        };
 
-    const handleFocus = (): void => {
-        props.onFocus([]);
-        setIsFocused(true);
-    };
+        const handleFocus = (): void => {
+            props.onFocus([]);
+            setIsFocused(true);
+        };
 
-    const handleBlur = (): void => {
-        props.onBlur([]);
-        setIsFocused(false);
-    };
+        const handleBlur = (): void => {
+            props.onBlur([]);
+            setIsFocused(false);
+        };
 
-    // Styles for the InputWithExamples
-    const styles = StyleSheet.create({
-        inputWithExamples: {
-            borderRadius: "3px",
-            borderWidth: isFocused ? "2px" : "1px",
-            display: "inline-block",
-            fontFamily: `Symbola, "Times New Roman", serif`,
-            fontSize: "18px",
-            height: "32px",
-            lineHeight: "18px",
-            padding: isFocused ? "4px" : "4px 5px",
-            textAlign: props.rightAlign ? "right" : "left",
-            width: props.size === "small" ? 40 : 80,
-        },
-    });
+        // Styles for the InputWithExamples
+        const styles = StyleSheet.create({
+            inputWithExamples: {
+                borderRadius: "3px",
+                borderWidth: isFocused ? "2px" : "1px",
+                display: "inline-block",
+                fontFamily: `Symbola, "Times New Roman", serif`,
+                fontSize: "18px",
+                height: "32px",
+                lineHeight: "18px",
+                padding: isFocused ? "4px" : "4px 5px",
+                textAlign: props.rightAlign ? "right" : "left",
+                width: props.size === "small" ? 40 : 80,
+            },
+        });
 
-    // (mobile-only) If the custom keypad is enabled, use the SimpleKeypadInput component
-    if (props.apiOptions.customKeypad) {
-        const alignmentClass = props.rightAlign
-            ? "perseus-input-right-align"
-            : undefined;
+        // (mobile-only) If the custom keypad is enabled, use the SimpleKeypadInput component
+        if (props.apiOptions.customKeypad) {
+            const alignmentClass = props.rightAlign
+                ? "perseus-input-right-align"
+                : undefined;
+            return (
+                <div className={alignmentClass}>
+                    <SimpleKeypadInput
+                        ref={inputRef as React.RefObject<SimpleKeypadInput>}
+                        value={props.currentValue}
+                        keypadElement={props.keypadElement}
+                        onChange={handleChange}
+                        onFocus={handleFocus}
+                        onBlur={handleBlur}
+                    />
+                </div>
+            );
+        }
+        // (desktop-only) Otherwise, use the InputWithExamples component
         return (
-            <div className={alignmentClass}>
-                <SimpleKeypadInput
-                    ref={inputRef as React.RefObject<SimpleKeypadInput>}
-                    value={props.currentValue}
-                    keypadElement={props.keypadElement}
-                    onChange={handleChange}
-                    onFocus={handleFocus}
-                    onBlur={handleBlur}
-                />
-            </div>
+            <InputWithExamples
+                ref={inputRef}
+                value={props.currentValue}
+                onChange={handleChange}
+                labelText={props.labelText}
+                examples={generateExamples(props.answerForms, context.strings)}
+                shouldShowExamples={shouldShowExamples(props.answerForms)}
+                onFocus={handleFocus}
+                onBlur={handleBlur}
+                id={props.widgetId}
+                disabled={props.apiOptions.readOnly}
+                style={styles.inputWithExamples}
+            />
         );
-    }
-    // (desktop-only) Otherwise, use the InputWithExamples component
-    return (
-        <InputWithExamples
-            ref={inputRef}
-            value={props.currentValue}
-            onChange={handleChange}
-            labelText={props.labelText}
-            examples={generateExamples(props.answerForms, context.strings)}
-            shouldShowExamples={shouldShowExamples(props.answerForms)}
-            onFocus={handleFocus}
-            onBlur={handleBlur}
-            id={props.widgetId}
-            disabled={props.apiOptions.readOnly}
-            style={styles.inputWithExamples}
-        />
-    );
-});
+    },
+);


### PR DESCRIPTION
## Summary:

The `numeric-input` widget uses two different input components depending on whether a custom keypad is enabled or not. We want to retain a ref to either of these inputs within the widget. Originally, the ref was defined as the union of these two components, but that leads to sporadic type check failures. 

This PR adjusts things so we define a common `interface` for these two components and then use that interface as the type for hte ref. This makes it so the ref is a very narrow type referencing only the fields that are used.

Issue: "none"

## Test plan:

`yarn typecheck`
`yarn tsc --watch` (make some changes, save, then revert to ensure the type checking doesn't fail)