### PR TITLE
Render LaTeX in Free Response Widget questions

### DIFF
--- a/packages/perseus-editor/src/widgets/__stories__/free-response-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/free-response-editor.stories.tsx
@@ -45,6 +45,12 @@ export const ThreeCriteria: Story = {
     },
 };
 
+export const QuestionWithWidget: Story = {
+    args: {
+        question: "[[\u2603 radio 1]]",
+    },
+};
+
 type State = Partial<PropsFor<typeof FreeResponseEditor>>;
 
 const WithState = () => {

--- a/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
@@ -145,6 +145,25 @@ describe("free-response editor", () => {
         ]);
     });
 
+    it("returns a warning when the question contains a widget placeholder", async () => {
+        // Arrange
+        const ref = React.createRef<FreeResponseEditor>();
+
+        // Act
+        render(
+            <FreeResponseEditor
+                ref={ref}
+                question="[[☃ radio 1]]"
+                onChange={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(ref.current?.getSaveWarnings()).toEqual([
+            "The question contains a widget",
+        ]);
+    });
+
     it("does not return a warning when the placeholder is empty", async () => {
         // Arrange
         const ref = React.createRef<FreeResponseEditor>();

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -1,3 +1,4 @@
+import {Util} from "@khanacademy/perseus";
 import {freeResponseLogic} from "@khanacademy/perseus-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -40,6 +41,9 @@ class FreeResponseEditor extends React.Component<Props> {
         const warnings: Array<string> = [];
         if (!this.props.question) {
             warnings.push("The question is empty");
+        }
+        if (this.props.question.match(Util.rWidgetRule) != null) {
+            warnings.push("The question contains a widget");
         }
         return warnings;
     }

--- a/packages/perseus/src/widgets/free-response/__snapshots__/free-response.test.tsx.snap
+++ b/packages/perseus/src/widgets/free-response/__snapshots__/free-response.test.tsx.snap
@@ -24,7 +24,20 @@ exports[`free-response widget should snapshot on mobile: first mobile render 1`]
               <span
                 class="text_f1191h-o_O-LabelLarge_5s82ln"
               >
-                test-question
+                <div
+                  class="perseus-renderer perseus-renderer-responsive"
+                >
+                  <div
+                    class="paragraph"
+                    data-perseus-paragraph-index="0"
+                  >
+                    <div
+                      class="paragraph"
+                    >
+                      test-question
+                    </div>
+                  </div>
+                </div>
               </span>
               <div
                 class="default_xu2jcg-o_O-inlineStyles_zdxht7"
@@ -32,7 +45,7 @@ exports[`free-response widget should snapshot on mobile: first mobile render 1`]
                 <textarea
                   aria-invalid="false"
                   aria-required="false"
-                  class="textarea_o89kg2-o_O-LabelMedium_1rew30o-o_O-default_l06vru-o_O-defaultFocus_lrnqlz-o_O-textarea_1x0fg6n"
+                  class="textarea_nfcfnx-o_O-LabelMedium_1rew30o-o_O-default_1elaks2-o_O-defaultFocus_drkasj-o_O-textarea_1x0fg6n"
                   id=":r1:"
                   placeholder="test-placeholder"
                 />
@@ -79,7 +92,20 @@ exports[`free-response widget should snapshot: first render 1`] = `
               <span
                 class="text_f1191h-o_O-LabelLarge_5s82ln"
               >
-                test-question
+                <div
+                  class="perseus-renderer perseus-renderer-responsive"
+                >
+                  <div
+                    class="paragraph"
+                    data-perseus-paragraph-index="0"
+                  >
+                    <div
+                      class="paragraph"
+                    >
+                      test-question
+                    </div>
+                  </div>
+                </div>
               </span>
               <div
                 class="default_xu2jcg-o_O-inlineStyles_zdxht7"
@@ -87,7 +113,7 @@ exports[`free-response widget should snapshot: first render 1`] = `
                 <textarea
                   aria-invalid="false"
                   aria-required="false"
-                  class="textarea_o89kg2-o_O-LabelMedium_1rew30o-o_O-default_l06vru-o_O-defaultFocus_lrnqlz-o_O-textarea_1x0fg6n"
+                  class="textarea_nfcfnx-o_O-LabelMedium_1rew30o-o_O-default_1elaks2-o_O-defaultFocus_drkasj-o_O-textarea_1x0fg6n"
                   id=":r0:"
                   placeholder="test-placeholder"
                 />

--- a/packages/perseus/src/widgets/free-response/free-response.stories.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.stories.tsx
@@ -36,3 +36,13 @@ export const UnlimitedCharacters: Story = {
         question: "What is the theme of the essay?",
     },
 };
+
+export const QuestionWithKatex: Story = {
+    args: {
+        allowUnlimitedCharacters: true,
+        characterLimit: 500,
+        placeholder: "Enter your answer here",
+        question:
+            "What changes are required to solve the following equation? $\\dfrac{6-3}{1-0}=\\dfrac{3}{1}=3$",
+    },
+};

--- a/packages/perseus/src/widgets/free-response/free-response.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.tsx
@@ -15,6 +15,7 @@ import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
 
 import {PerseusI18nContext} from "../../components/i18n-context";
+import Renderer from "../../renderer";
 
 import type {Widget, WidgetExports, WidgetProps} from "../../types";
 import type {
@@ -104,7 +105,12 @@ export class FreeResponse
         return (
             <View style={styles.container}>
                 <label className={css(styles.labelAndTextarea)}>
-                    <LabelLarge>{this.props.question}</LabelLarge>
+                    <LabelLarge>
+                        <Renderer
+                            content={this.props.question}
+                            strings={this.context.strings}
+                        />
+                    </LabelLarge>
                     <TextArea
                         error={this.isOverLimit()}
                         onChange={this.handleChange}


### PR DESCRIPTION
## Summary:
This commit adds code to render LaTeX formatted questions in the
Free Response Widget. The specific use case we want to support is
including Math expressions in the question. We use the same Renderer
that is used to render LaTeX elsewhere, but we don't want to support
nested widgets in the question, so we detect that as an issue when
saving in the editor.

Note that the spacing around the question is changed in this commit and
it doesn't match the designs, but that will be fixed in a later change.

Issue: https://khanacademy.atlassian.net/browse/AX-964

## Test plan:
- View the Free Response Widget in Storybook and verify that the
  "Question with Katex" story renders properly.