### PR TITLE
Proof-of-concept: tighten up prop types for Categorizer

### DIFF
--- a/.changeset/witty-guests-happen.md
+++ b/.changeset/witty-guests-happen.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: tighten up prop types for Categorizer

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -575,10 +575,10 @@ export type WidgetProps<
 /**
  * The props passed to every widget, regardless of its `type`.
  */
-export type UniversalWidgetProps<
+export interface UniversalWidgetProps<
     ReviewModeRubric = Empty,
     TrackingExtraArgs = Empty,
-> = {
+> {
     reviewModeRubric?: ReviewModeRubric | null | undefined;
     // This is slightly different from the `trackInteraction` function in
     // APIOptions. This provides the widget an easy way to notify the renderer
@@ -607,7 +607,7 @@ export type UniversalWidgetProps<
     // provided by widget-container.jsx#render()
     linterContext: LinterContextProps;
     containerSizeClass: SizeClass;
-};
+}
 
 // Used to type the `change` method on all widgets.
 export type ChangeFn = (

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -33,6 +33,8 @@ interface InternalProps extends UniversalWidgetProps {
 
 type ExternalProps = PropsFor<typeof Categorizer>;
 
+type RenderProps = Omit<ExternalProps, keyof UniversalWidgetProps>;
+
 type DefaultProps = Pick<
     InternalProps,
     "items" | "categories" | "values" | "linterContext"
@@ -293,8 +295,6 @@ const styles = StyleSheet.create({
         color: "#888",
     },
 });
-
-type RenderProps = Omit<ExternalProps, keyof UniversalWidgetProps>;
 
 export default {
     name: "categorizer",

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -15,7 +15,12 @@ import mediaQueries from "../../styles/media-queries";
 import sharedStyles from "../../styles/shared";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/categorizer/categorizer-ai-utils";
 
-import type {UniversalWidgetProps, Widget, WidgetExports} from "../../types";
+import type {
+    ChangeFn,
+    UniversalWidgetProps,
+    Widget,
+    WidgetExports,
+} from "../../types";
 import type {CategorizerPromptJSON} from "../../widget-ai-utils/categorizer/categorizer-ai-utils";
 import type {
     PerseusCategorizerWidgetOptions,
@@ -68,8 +73,7 @@ export class Categorizer
         return {values: props.values};
     }
 
-    change: (...args: ReadonlyArray<unknown>) => any = (...args) => {
-        // @ts-expect-error - TS2345 - Argument of type 'readonly unknown[]' is not assignable to parameter of type 'any[]'.
+    change: (...args: Parameters<ChangeFn>) => any = (...args) => {
         return Changeable.change.apply(this, args);
     };
 

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -15,31 +15,35 @@ import mediaQueries from "../../styles/media-queries";
 import sharedStyles from "../../styles/shared";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/categorizer/categorizer-ai-utils";
 
-import type {Widget, WidgetExports, WidgetProps} from "../../types";
+import type {UniversalWidgetProps, Widget, WidgetExports} from "../../types";
 import type {CategorizerPromptJSON} from "../../widget-ai-utils/categorizer/categorizer-ai-utils";
 import type {
     PerseusCategorizerWidgetOptions,
     PerseusCategorizerUserInput,
     CategorizerPublicWidgetOptions,
 } from "@khanacademy/perseus-core";
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
-type Props = WidgetProps<RenderProps> & {
-    values: ReadonlyArray<string>;
-};
+interface InternalProps extends UniversalWidgetProps {
+    values: number[];
+    items: PerseusCategorizerWidgetOptions["items"];
+    categories: PerseusCategorizerWidgetOptions["categories"];
+    randomizeItems: PerseusCategorizerWidgetOptions["randomizeItems"];
+}
 
-type DefaultProps = {
-    items: Props["items"];
-    categories: Props["categories"];
-    values: Props["values"];
-    linterContext: Props["linterContext"];
-};
+type ExternalProps = PropsFor<typeof Categorizer>;
+
+type DefaultProps = Pick<
+    InternalProps,
+    "items" | "categories" | "values" | "linterContext"
+>;
 
 type State = {
     uniqueId: string;
 };
 
 export class Categorizer
-    extends React.Component<Props, State>
+    extends React.Component<InternalProps, State>
     implements Widget
 {
     static contextType = PerseusI18nContext;
@@ -56,7 +60,9 @@ export class Categorizer
         uniqueId: _.uniqueId("perseus_radio_"),
     };
 
-    static getUserInputFromProps(props: Props): PerseusCategorizerUserInput {
+    static getUserInputFromProps(
+        props: InternalProps,
+    ): PerseusCategorizerUserInput {
         return {values: props.values};
     }
 
@@ -75,7 +81,6 @@ export class Categorizer
 
     onChange(itemNum, catNum) {
         const values = [...this.props.values];
-        // @ts-expect-error - TS2322 - Type 'number' is not assignable to type 'never'.
         values[itemNum] = catNum;
         this.change("values", values);
         this.props.trackInteraction();
@@ -289,13 +294,7 @@ const styles = StyleSheet.create({
     },
 });
 
-type RenderProps = {
-    items: PerseusCategorizerWidgetOptions["items"];
-    categories: PerseusCategorizerWidgetOptions["categories"];
-    randomizeItems: PerseusCategorizerWidgetOptions["randomizeItems"];
-    // Depends on whether the widget is in static mode
-    values?: PerseusCategorizerWidgetOptions["values"];
-};
+type RenderProps = Omit<ExternalProps, keyof UniversalWidgetProps>;
 
 export default {
     name: "categorizer",


### PR DESCRIPTION
## Summary:
It's come to my attention that our prop types for many widgets don't quite
reflect reality, due to the internal and external props of class components
not being handled appropriately. E.g. in some places, we are deriving the
widget's internal props from the `RenderProps` returned from the `transform`
and `staticTransform` functions, which isn't correct — the _external_ props
need to match `RenderProps`.

This PR is a proof of concept for what a fix might look like.
The proposed design is currently documented in the linked issue, [LEMS-3086].
I will document it in architecture.md if we end up moving forward with this.

[LEMS-3086]: https://khanacademy.atlassian.net/browse/LEMS-3086

Issue: LEMS-3086

## Test plan:

`pnpm tsc`