### PR TITLE
Answerless Grapher

### DIFF
--- a/.changeset/real-coats-march.md
+++ b/.changeset/real-coats-march.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-core": minor
+"@khanacademy/perseus": patch
+---
+
+Add tests and stories for Answerless Grapher with minor refactoring

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -144,6 +144,7 @@ export {default as getCSProgramPublicWidgetOptions} from "./widgets/cs-program/c
 export {default as getExpressionPublicWidgetOptions} from "./widgets/expression/expression-util";
 export type {ExpressionPublicWidgetOptions} from "./widgets/expression/expression-util";
 export {default as getGrapherPublicWidgetOptions} from "./widgets/grapher/grapher-util";
+export type {GrapherPublicWidgetOptions} from "./widgets/grapher/grapher-util";
 export {default as getGroupPublicWidgetOptions} from "./widgets/group/group-util";
 export {
     default as getInteractiveGraphPublicWidgetOptions,

--- a/packages/perseus-core/src/widgets/grapher/grapher-util.ts
+++ b/packages/perseus-core/src/widgets/grapher/grapher-util.ts
@@ -1,6 +1,6 @@
 import type {PerseusGrapherWidgetOptions} from "../../data-schema";
 
-type GrapherPublicWidgetOptions = Pick<
+export type GrapherPublicWidgetOptions = Pick<
     PerseusGrapherWidgetOptions,
     "availableTypes" | "graph"
 >;

--- a/packages/perseus/src/widgets/grapher/grapher.cypress.ts
+++ b/packages/perseus/src/widgets/grapher/grapher.cypress.ts
@@ -1,3 +1,8 @@
+import {
+    generateTestPerseusItem,
+    splitPerseusItem,
+} from "@khanacademy/perseus-core";
+
 import renderQuestionWithCypress from "../../../../../testing/render-question-with-cypress";
 import {cypressTestDependencies} from "../../../../../testing/test-dependencies";
 import * as Perseus from "../../index";
@@ -31,602 +36,783 @@ describe("Grapher widget", () => {
     });
 
     describe("absolute value graph", () => {
-        it("should be correctly answerable", () => {
-            // Arrange
-            const getRenderer = renderQuestionWithCypress(
-                absoluteValueQuestion,
+        const answerful = generateTestPerseusItem({
+            question: absoluteValueQuestion,
+        });
+        const answerless = splitPerseusItem(answerful);
+
+        it("should not have answerful data in answerless item", () => {
+            cy.wrap(answerless.question.widgets["grapher 1"].options).should(
+                "not.have.property",
+                "correct",
             );
-
-            // Act
-            cy.get(GRAPHIE)
-                .should("exist")
-                .then((node) => {
-                    const {left, top} = node[0].getBoundingClientRect();
-                    cy.get(POINTS)
-                        .eq(0)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 360, y: top + 180});
-                    cy.get(POINTS)
-                        .eq(1)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 340, y: top + 140});
-                });
-
-            // Assert
-            cy.then(() => {
-                const userInput = getRenderer().getUserInputMap();
-                const score = scorePerseusItemTesting(
-                    absoluteValueQuestion,
-                    userInput,
-                );
-                expect(score).toStrictEqual({
-                    type: "points",
-                    earned: 1,
-                    total: 1,
-                    message: null,
-                });
-            });
         });
 
-        it("should be incorrectly answerable", () => {
-            // Arrange
-            const getRenderer = renderQuestionWithCypress(
-                absoluteValueQuestion,
-            );
+        const data = [
+            {name: "answerful", item: answerful},
+            {name: "answerless", item: answerless},
+        ];
 
-            // Act
-            cy.get(GRAPHIE)
-                .should("exist")
-                .then((node) => {
-                    const {left, top} = node[0].getBoundingClientRect();
-                    cy.get(POINTS)
-                        .eq(0)
+        data.forEach((d) => {
+            const {name, item} = d;
+
+            describe(name, () => {
+                it("should be correctly answerable", () => {
+                    // Arrange
+                    const getRenderer = renderQuestionWithCypress(
+                        item.question,
+                    );
+
+                    // Act
+                    cy.get(GRAPHIE)
                         .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 200, y: top + 200});
-                    cy.get(POINTS)
-                        .eq(1)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 100, y: top + 100});
+                        .then((node) => {
+                            const {left, top} = node[0].getBoundingClientRect();
+                            cy.get(POINTS)
+                                .eq(0)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 360, y: top + 180});
+                            cy.get(POINTS)
+                                .eq(1)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 340, y: top + 140});
+                        });
+
+                    // Assert
+                    cy.then(() => {
+                        const userInput = getRenderer().getUserInputMap();
+                        const score = scorePerseusItemTesting(
+                            answerful.question,
+                            userInput,
+                        );
+                        expect(score).toStrictEqual({
+                            type: "points",
+                            earned: 1,
+                            total: 1,
+                            message: null,
+                        });
+                    });
                 });
 
-            // Assert
-            cy.then(() => {
-                const userInput = getRenderer().getUserInputMap();
-                const score = scorePerseusItemTesting(
-                    absoluteValueQuestion,
-                    userInput,
-                );
-                expect(score).toStrictEqual({
-                    type: "points",
-                    earned: 0,
-                    total: 1,
-                    message: null,
+                it("should be incorrectly answerable", () => {
+                    // Arrange
+                    const getRenderer = renderQuestionWithCypress(
+                        item.question,
+                    );
+
+                    // Act
+                    cy.get(GRAPHIE)
+                        .should("exist")
+                        .then((node) => {
+                            const {left, top} = node[0].getBoundingClientRect();
+                            cy.get(POINTS)
+                                .eq(0)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 200, y: top + 200});
+                            cy.get(POINTS)
+                                .eq(1)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 100, y: top + 100});
+                        });
+
+                    // Assert
+                    cy.then(() => {
+                        const userInput = getRenderer().getUserInputMap();
+                        const score = scorePerseusItemTesting(
+                            answerful.question,
+                            userInput,
+                        );
+                        expect(score).toStrictEqual({
+                            type: "points",
+                            earned: 0,
+                            total: 1,
+                            message: null,
+                        });
+                    });
                 });
             });
         });
     });
 
     describe("exponential graph", () => {
-        it("should be correctly answerable", () => {
-            // Arrange
-            const getRenderer = renderQuestionWithCypress(exponentialQuestion);
+        const answerful = generateTestPerseusItem({
+            question: exponentialQuestion,
+        });
+        const answerless = splitPerseusItem(answerful);
 
-            // Act
-            cy.get(GRAPHIE)
-                .should("exist")
-                .then((node) => {
-                    const {left, top} = node[0].getBoundingClientRect();
-                    cy.get(LINES)
-                        .eq(0)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 200, y: top + 75});
-                    // [0, 3],
-                    // [1, -1],
-                    cy.get(POINTS)
-                        .eq(0)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 200, y: top + 120});
-                    cy.get(POINTS)
-                        .eq(1)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 225, y: top + 225});
-                });
-
-            // Assert
-            cy.then(() => {
-                const userInput = getRenderer().getUserInputMap();
-                const score = scorePerseusItemTesting(
-                    exponentialQuestion,
-                    userInput,
-                );
-                expect(score).toStrictEqual({
-                    type: "points",
-                    earned: 1,
-                    total: 1,
-                    message: null,
-                });
-            });
+        it("should not have answerful data in answerless item", () => {
+            cy.wrap(answerless.question.widgets["grapher 1"].options).should(
+                "not.have.property",
+                "correct",
+            );
         });
 
-        it("should be incorrectly answerable", () => {
-            // Arrange
-            const getRenderer = renderQuestionWithCypress(exponentialQuestion);
+        const data = [
+            {name: "answerful", item: answerful},
+            {name: "answerless", item: answerless},
+        ];
 
-            // Act
-            cy.get(GRAPHIE)
-                .should("exist")
-                .then((node) => {
-                    const {left, top} = node[0].getBoundingClientRect();
-                    cy.get(LINES)
-                        .eq(0)
+        data.forEach((d) => {
+            const {name, item} = d;
+
+            describe(name, () => {
+                it("should be correctly answerable", () => {
+                    // Arrange
+                    const getRenderer = renderQuestionWithCypress(
+                        item.question,
+                    );
+
+                    // Act
+                    cy.get(GRAPHIE)
                         .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 200, y: top + 200});
-                    cy.get(POINTS)
-                        .eq(0)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 25, y: top + 25});
-                    cy.get(POINTS)
-                        .eq(1)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 200, y: top + 200});
+                        .then((node) => {
+                            const {left, top} = node[0].getBoundingClientRect();
+                            cy.get(LINES)
+                                .eq(0)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 200, y: top + 75});
+                            // [0, 3],
+                            // [1, -1],
+                            cy.get(POINTS)
+                                .eq(0)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 200, y: top + 120});
+                            cy.get(POINTS)
+                                .eq(1)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 225, y: top + 225});
+                        });
+
+                    // Assert
+                    cy.then(() => {
+                        const userInput = getRenderer().getUserInputMap();
+                        const score = scorePerseusItemTesting(
+                            answerful.question,
+                            userInput,
+                        );
+                        expect(score).toStrictEqual({
+                            type: "points",
+                            earned: 1,
+                            total: 1,
+                            message: null,
+                        });
+                    });
                 });
 
-            // Assert
-            cy.then(() => {
-                const userInput = getRenderer().getUserInputMap();
-                const score = scorePerseusItemTesting(
-                    exponentialQuestion,
-                    userInput,
-                );
-                expect(score).toStrictEqual({
-                    type: "points",
-                    earned: 0,
-                    total: 1,
-                    message: null,
+                it("should be incorrectly answerable", () => {
+                    // Arrange
+                    const getRenderer = renderQuestionWithCypress(
+                        item.question,
+                    );
+
+                    // Act
+                    cy.get(GRAPHIE)
+                        .should("exist")
+                        .then((node) => {
+                            const {left, top} = node[0].getBoundingClientRect();
+                            cy.get(LINES)
+                                .eq(0)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 200, y: top + 200});
+                            cy.get(POINTS)
+                                .eq(0)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 25, y: top + 25});
+                            cy.get(POINTS)
+                                .eq(1)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 200, y: top + 200});
+                        });
+
+                    // Assert
+                    cy.then(() => {
+                        const userInput = getRenderer().getUserInputMap();
+                        const score = scorePerseusItemTesting(
+                            answerful.question,
+                            userInput,
+                        );
+                        expect(score).toStrictEqual({
+                            type: "points",
+                            earned: 0,
+                            total: 1,
+                            message: null,
+                        });
+                    });
                 });
             });
         });
     });
 
     describe("linear graph", () => {
-        it("should be correctly answerable", () => {
-            // Arrange
-            const getRenderer = renderQuestionWithCypress(linearQuestion);
+        const answerful = generateTestPerseusItem({
+            question: linearQuestion,
+        });
+        const answerless = splitPerseusItem(answerful);
 
-            // Act
-            cy.get(GRAPHIE)
-                .should("exist")
-                .then((node) => {
-                    const {left, top} = node[0].getBoundingClientRect();
-                    cy.get(POINTS)
-                        .eq(0)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 200, y: top + 100});
-                    cy.get(POINTS)
-                        .eq(1)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 260, y: top + 200});
-                });
-
-            // Assert
-            cy.then(() => {
-                const userInput = getRenderer().getUserInputMap();
-                const score = scorePerseusItemTesting(
-                    linearQuestion,
-                    userInput,
-                );
-                expect(score).toStrictEqual({
-                    type: "points",
-                    earned: 1,
-                    total: 1,
-                    message: null,
-                });
-            });
+        it("should not have answerful data in answerless item", () => {
+            cy.wrap(answerless.question.widgets["grapher 1"].options).should(
+                "not.have.property",
+                "correct",
+            );
         });
 
-        it("should be incorrectly answerable", () => {
-            // Arrange
-            const getRenderer = renderQuestionWithCypress(linearQuestion);
+        const data = [
+            {name: "answerful", item: answerful},
+            {name: "answerless", item: answerless},
+        ];
 
-            // Act
-            cy.get(GRAPHIE)
-                .should("exist")
-                .then((node) => {
-                    const {left, top} = node[0].getBoundingClientRect();
-                    cy.get(POINTS)
-                        .eq(0)
+        data.forEach((d) => {
+            const {name, item} = d;
+
+            describe(name, () => {
+                it("should be correctly answerable", () => {
+                    // Arrange
+                    const getRenderer = renderQuestionWithCypress(
+                        item.question,
+                    );
+
+                    // Act
+                    cy.get(GRAPHIE)
                         .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 100, y: top + 100});
-                    cy.get(POINTS)
-                        .eq(1)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 300, y: top + 300});
+                        .then((node) => {
+                            const {left, top} = node[0].getBoundingClientRect();
+                            cy.get(POINTS)
+                                .eq(0)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 200, y: top + 100});
+                            cy.get(POINTS)
+                                .eq(1)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 260, y: top + 200});
+                        });
+
+                    // Assert
+                    cy.then(() => {
+                        const userInput = getRenderer().getUserInputMap();
+                        const score = scorePerseusItemTesting(
+                            answerful.question,
+                            userInput,
+                        );
+                        expect(score).toStrictEqual({
+                            type: "points",
+                            earned: 1,
+                            total: 1,
+                            message: null,
+                        });
+                    });
                 });
 
-            // Assert
-            cy.then(() => {
-                const userInput = getRenderer().getUserInputMap();
-                const score = scorePerseusItemTesting(
-                    linearQuestion,
-                    userInput,
-                );
-                expect(score).toStrictEqual({
-                    type: "points",
-                    earned: 0,
-                    total: 1,
-                    message: null,
+                it("should be incorrectly answerable", () => {
+                    // Arrange
+                    const getRenderer = renderQuestionWithCypress(
+                        item.question,
+                    );
+
+                    // Act
+                    cy.get(GRAPHIE)
+                        .should("exist")
+                        .then((node) => {
+                            const {left, top} = node[0].getBoundingClientRect();
+                            cy.get(POINTS)
+                                .eq(0)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 100, y: top + 100});
+                            cy.get(POINTS)
+                                .eq(1)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 300, y: top + 300});
+                        });
+
+                    // Assert
+                    cy.then(() => {
+                        const userInput = getRenderer().getUserInputMap();
+                        const score = scorePerseusItemTesting(
+                            answerful.question,
+                            userInput,
+                        );
+                        expect(score).toStrictEqual({
+                            type: "points",
+                            earned: 0,
+                            total: 1,
+                            message: null,
+                        });
+                    });
                 });
             });
         });
     });
 
     describe("logarithm graph", () => {
-        it("should be correctly answerable", () => {
-            // Arrange
-            const getRenderer = renderQuestionWithCypress(logarithmQuestion);
+        const answerful = generateTestPerseusItem({
+            question: logarithmQuestion,
+        });
+        const answerless = splitPerseusItem(answerful);
 
-            // Act
-            cy.get(GRAPHIE)
-                .should("exist")
-                .then((node) => {
-                    const {left, top} = node[0].getBoundingClientRect();
-                    // Move the Asymptote to x=-6
-                    cy.get(LINES)
-                        .eq(0)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({
-                            x: left + 50,
-                            y: top + 200, // It's a vertical line, so this doesn't matter much
-                        });
-                    // Move point A
-                    cy.get(POINTS)
-                        .eq(0)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({
-                            x: left + 100,
-                            y: top + 275,
-                        });
-                    // Move point B
-                    cy.get(POINTS)
-                        .eq(1)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({
-                            x: left + 75,
-                            y: top + 375,
-                        });
-                });
-
-            // Assert
-            cy.then(() => {
-                const userInput = getRenderer().getUserInputMap();
-                const score = scorePerseusItemTesting(
-                    logarithmQuestion,
-                    userInput,
-                );
-                expect(score).toStrictEqual({
-                    type: "points",
-                    earned: 1,
-                    total: 1,
-                    message: null,
-                });
-            });
+        it("should not have answerful data in answerless item", () => {
+            cy.wrap(answerless.question.widgets["grapher 1"].options).should(
+                "not.have.property",
+                "correct",
+            );
         });
 
-        it("should be incorrectly answerable", () => {
-            // Arrange
-            const getRenderer = renderQuestionWithCypress(logarithmQuestion);
+        const data = [
+            {name: "answerful", item: answerful},
+            {name: "answerless", item: answerless},
+        ];
 
-            // Act
-            cy.get(GRAPHIE)
-                .should("exist")
-                .then((node) => {
-                    const {left, top} = node[0].getBoundingClientRect();
-                    // Move the Asymptote to x=-6
-                    cy.get(LINES)
-                        .eq(0)
+        data.forEach((d) => {
+            const {name, item} = d;
+
+            describe(name, () => {
+                it("should be correctly answerable", () => {
+                    // Arrange
+                    const getRenderer = renderQuestionWithCypress(
+                        item.question,
+                    );
+
+                    // Act
+                    cy.get(GRAPHIE)
                         .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({
-                            x: left + 50,
-                            y: top + 200, // It's a vertical line, so this doesn't matter much
+                        .then((node) => {
+                            const {left, top} = node[0].getBoundingClientRect();
+                            // Move the Asymptote to x=-6
+                            cy.get(LINES)
+                                .eq(0)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({
+                                    x: left + 50,
+                                    y: top + 200, // It's a vertical line, so this doesn't matter much
+                                });
+                            // Move point A
+                            cy.get(POINTS)
+                                .eq(0)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({
+                                    x: left + 100,
+                                    y: top + 275,
+                                });
+                            // Move point B
+                            cy.get(POINTS)
+                                .eq(1)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({
+                                    x: left + 75,
+                                    y: top + 375,
+                                });
                         });
-                    // Move point A
-                    cy.get(POINTS)
-                        .eq(0)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({
-                            x: left + 225,
-                            y: top + 125,
+
+                    // Assert
+                    cy.then(() => {
+                        const userInput = getRenderer().getUserInputMap();
+                        const score = scorePerseusItemTesting(
+                            answerful.question,
+                            userInput,
+                        );
+                        expect(score).toStrictEqual({
+                            type: "points",
+                            earned: 1,
+                            total: 1,
+                            message: null,
                         });
-                    // Move point B
-                    cy.get(POINTS)
-                        .eq(1)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({
-                            x: left + 100,
-                            y: top + 300,
-                        });
+                    });
                 });
 
-            // Assert
-            cy.then(() => {
-                const userInput = getRenderer().getUserInputMap();
-                const score = scorePerseusItemTesting(
-                    logarithmQuestion,
-                    userInput,
-                );
-                expect(score).toStrictEqual({
-                    type: "points",
-                    earned: 0,
-                    total: 1,
-                    message: null,
+                it("should be incorrectly answerable", () => {
+                    // Arrange
+                    const getRenderer = renderQuestionWithCypress(
+                        item.question,
+                    );
+
+                    // Act
+                    cy.get(GRAPHIE)
+                        .should("exist")
+                        .then((node) => {
+                            const {left, top} = node[0].getBoundingClientRect();
+                            // Move the Asymptote to x=-6
+                            cy.get(LINES)
+                                .eq(0)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({
+                                    x: left + 50,
+                                    y: top + 200, // It's a vertical line, so this doesn't matter much
+                                });
+                            // Move point A
+                            cy.get(POINTS)
+                                .eq(0)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({
+                                    x: left + 225,
+                                    y: top + 125,
+                                });
+                            // Move point B
+                            cy.get(POINTS)
+                                .eq(1)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({
+                                    x: left + 100,
+                                    y: top + 300,
+                                });
+                        });
+
+                    // Assert
+                    cy.then(() => {
+                        const userInput = getRenderer().getUserInputMap();
+                        const score = scorePerseusItemTesting(
+                            answerful.question,
+                            userInput,
+                        );
+                        expect(score).toStrictEqual({
+                            type: "points",
+                            earned: 0,
+                            total: 1,
+                            message: null,
+                        });
+                    });
                 });
             });
         });
     });
 
     describe("quadratic graph", () => {
-        it("should be correctly answerable", () => {
-            // Arrange
-            const getRenderer = renderQuestionWithCypress(quadraticQuestion);
+        const answerful = generateTestPerseusItem({
+            question: quadraticQuestion,
+        });
+        const answerless = splitPerseusItem(answerful);
 
-            // Act
-            cy.get(GRAPHIE)
-                .should("exist")
-                .then((node) => {
-                    const {left, top} = node[0].getBoundingClientRect();
-                    // Move point A
-                    cy.get(POINTS)
-                        .eq(0)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 260, y: top + 360});
-                    // Move point B
-                    cy.get(POINTS)
-                        .eq(1)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 220, y: top + 200});
-                });
-
-            // Assert
-            cy.then(() => {
-                const userInput = getRenderer().getUserInputMap();
-                const score = scorePerseusItemTesting(
-                    quadraticQuestion,
-                    userInput,
-                );
-                expect(score).toStrictEqual({
-                    type: "points",
-                    earned: 1,
-                    total: 1,
-                    message: null,
-                });
-            });
+        it("should not have answerful data in answerless item", () => {
+            cy.wrap(answerless.question.widgets["grapher 1"].options).should(
+                "not.have.property",
+                "correct",
+            );
         });
 
-        it("should be incorrectly answerable", () => {
-            // Arrange
-            const getRenderer = renderQuestionWithCypress(quadraticQuestion);
+        const data = [
+            {name: "answerful", item: answerful},
+            {name: "answerless", item: answerless},
+        ];
 
-            // Act
-            cy.get(GRAPHIE)
-                .should("exist")
-                .then((node) => {
-                    const {left, top} = node[0].getBoundingClientRect();
-                    // Move point A
-                    cy.get(POINTS)
-                        .eq(0)
+        data.forEach((d) => {
+            const {name, item} = d;
+
+            describe(name, () => {
+                it("should be correctly answerable", () => {
+                    // Arrange
+                    const getRenderer = renderQuestionWithCypress(
+                        item.question,
+                    );
+
+                    // Act
+                    cy.get(GRAPHIE)
                         .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 50, y: top + 50});
-                    // Move point B
-                    cy.get(POINTS)
-                        .eq(1)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 200, y: top + 300});
+                        .then((node) => {
+                            const {left, top} = node[0].getBoundingClientRect();
+                            // Move point A
+                            cy.get(POINTS)
+                                .eq(0)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 260, y: top + 360});
+                            // Move point B
+                            cy.get(POINTS)
+                                .eq(1)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 220, y: top + 200});
+                        });
+
+                    // Assert
+                    cy.then(() => {
+                        const userInput = getRenderer().getUserInputMap();
+                        const score = scorePerseusItemTesting(
+                            answerful.question,
+                            userInput,
+                        );
+                        expect(score).toStrictEqual({
+                            type: "points",
+                            earned: 1,
+                            total: 1,
+                            message: null,
+                        });
+                    });
                 });
 
-            // Assert
-            cy.then(() => {
-                const userInput = getRenderer().getUserInputMap();
-                const score = scorePerseusItemTesting(
-                    quadraticQuestion,
-                    userInput,
-                );
-                expect(score).toStrictEqual({
-                    type: "points",
-                    earned: 0,
-                    total: 1,
-                    message: null,
+                it("should be incorrectly answerable", () => {
+                    // Arrange
+                    const getRenderer = renderQuestionWithCypress(
+                        item.question,
+                    );
+
+                    // Act
+                    cy.get(GRAPHIE)
+                        .should("exist")
+                        .then((node) => {
+                            const {left, top} = node[0].getBoundingClientRect();
+                            // Move point A
+                            cy.get(POINTS)
+                                .eq(0)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 50, y: top + 50});
+                            // Move point B
+                            cy.get(POINTS)
+                                .eq(1)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 200, y: top + 300});
+                        });
+
+                    // Assert
+                    cy.then(() => {
+                        const userInput = getRenderer().getUserInputMap();
+                        const score = scorePerseusItemTesting(
+                            answerful.question,
+                            userInput,
+                        );
+                        expect(score).toStrictEqual({
+                            type: "points",
+                            earned: 0,
+                            total: 1,
+                            message: null,
+                        });
+                    });
                 });
             });
         });
     });
 
     describe("sinusoid graph", () => {
-        it("should be correctly answerable", () => {
-            // Arrange
-            const getRenderer = renderQuestionWithCypress(sinusoidQuestion);
+        const answerful = generateTestPerseusItem({
+            question: sinusoidQuestion,
+        });
+        const answerless = splitPerseusItem(answerful);
 
-            // Act
-            cy.get(GRAPHIE)
-                .should("exist")
-                .then((node) => {
-                    const {left, top} = node[0].getBoundingClientRect();
-
-                    cy.get(POINTS)
-                        .eq(0)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 220, y: top + 140});
-                    cy.get(POINTS)
-                        .eq(1)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 200, y: top + 220});
-                });
-
-            // Assert
-            cy.then(() => {
-                const userInput = getRenderer().getUserInputMap();
-                const score = scorePerseusItemTesting(
-                    sinusoidQuestion,
-                    userInput,
-                );
-                expect(score).toStrictEqual({
-                    type: "points",
-                    earned: 1,
-                    total: 1,
-                    message: null,
-                });
-            });
+        it("should not have answerful data in answerless item", () => {
+            cy.wrap(answerless.question.widgets["grapher 1"].options).should(
+                "not.have.property",
+                "correct",
+            );
         });
 
-        it("should be incorrectly answerable", () => {
-            // Arrange
-            const getRenderer = renderQuestionWithCypress(sinusoidQuestion);
+        const data = [
+            {name: "answerful", item: answerful},
+            {name: "answerless", item: answerless},
+        ];
 
-            // Act
-            cy.get(GRAPHIE)
-                .should("exist")
-                .then((node) => {
-                    const {left, top} = node[0].getBoundingClientRect();
+        data.forEach((d) => {
+            const {name, item} = d;
 
-                    cy.get(POINTS)
-                        .eq(0)
+            describe(name, () => {
+                it("should be correctly answerable", () => {
+                    // Arrange
+                    const getRenderer = renderQuestionWithCypress(
+                        item.question,
+                    );
+
+                    // Act
+                    cy.get(GRAPHIE)
                         .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 100, y: top + 140});
-                    cy.get(POINTS)
-                        .eq(1)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 200, y: top + 220});
+                        .then((node) => {
+                            const {left, top} = node[0].getBoundingClientRect();
+
+                            cy.get(POINTS)
+                                .eq(0)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 220, y: top + 140});
+                            cy.get(POINTS)
+                                .eq(1)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 200, y: top + 220});
+                        });
+
+                    // Assert
+                    cy.then(() => {
+                        const userInput = getRenderer().getUserInputMap();
+                        const score = scorePerseusItemTesting(
+                            answerful.question,
+                            userInput,
+                        );
+                        expect(score).toStrictEqual({
+                            type: "points",
+                            earned: 1,
+                            total: 1,
+                            message: null,
+                        });
+                    });
                 });
 
-            // Assert
-            cy.then(() => {
-                const userInput = getRenderer().getUserInputMap();
-                const score = scorePerseusItemTesting(
-                    sinusoidQuestion,
-                    userInput,
-                );
-                expect(score).toStrictEqual({
-                    type: "points",
-                    earned: 0,
-                    total: 1,
-                    message: null,
+                it("should be incorrectly answerable", () => {
+                    // Arrange
+                    const getRenderer = renderQuestionWithCypress(
+                        item.question,
+                    );
+
+                    // Act
+                    cy.get(GRAPHIE)
+                        .should("exist")
+                        .then((node) => {
+                            const {left, top} = node[0].getBoundingClientRect();
+
+                            cy.get(POINTS)
+                                .eq(0)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 100, y: top + 140});
+                            cy.get(POINTS)
+                                .eq(1)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 200, y: top + 220});
+                        });
+
+                    // Assert
+                    cy.then(() => {
+                        const userInput = getRenderer().getUserInputMap();
+                        const score = scorePerseusItemTesting(
+                            answerful.question,
+                            userInput,
+                        );
+                        expect(score).toStrictEqual({
+                            type: "points",
+                            earned: 0,
+                            total: 1,
+                            message: null,
+                        });
+                    });
                 });
             });
         });
     });
 
     describe("complex graph question", () => {
-        it("should be correctly answerable", () => {
-            // Arrange
-            const getRenderer = renderQuestionWithCypress(
-                multipleAvailableTypesQuestion,
+        const answerful = generateTestPerseusItem({
+            question: multipleAvailableTypesQuestion,
+        });
+        const answerless = splitPerseusItem(answerful);
+
+        it("should not have answerful data in answerless item", () => {
+            cy.wrap(answerless.question.widgets["grapher 1"].options).should(
+                "not.have.property",
+                "correct",
             );
-
-            // Act
-            cy.get("button[title=Absolute_value]").click();
-
-            cy.get(GRAPHIE)
-                .should("exist")
-                .then((node) => {
-                    const rect = node[0].getBoundingClientRect();
-                    const left = rect.left + window.scrollX;
-                    const top = rect.top + window.scrollY;
-
-                    cy.get(POINTS)
-                        .eq(0)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 220, y: top + 260});
-                    cy.get(POINTS)
-                        .eq(1)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 200, y: top + 200});
-                });
-
-            // Assert
-            cy.then(() => {
-                const userInput = getRenderer().getUserInputMap();
-                const score = scorePerseusItemTesting(
-                    multipleAvailableTypesQuestion,
-                    userInput,
-                );
-                expect(score).toStrictEqual({
-                    type: "points",
-                    earned: 1,
-                    total: 1,
-                    message: null,
-                });
-            });
         });
 
-        it("should be incorrectly answerable", () => {
-            // Arrange
-            const getRenderer = renderQuestionWithCypress(
-                multipleAvailableTypesQuestion,
-            );
+        const data = [
+            {name: "answerful", item: answerful},
+            {name: "answerless", item: answerless},
+        ];
 
-            // Act
-            cy.get("button[title=Absolute_value]").click();
+        data.forEach((d) => {
+            const {name, item} = d;
 
-            cy.get(GRAPHIE)
-                .should("exist")
-                .then((node) => {
-                    const rect = node[0].getBoundingClientRect();
-                    const left = rect.left + window.scrollX;
-                    const top = rect.top + window.scrollY;
+            describe(name, () => {
+                it("should be correctly answerable", () => {
+                    // Arrange
+                    const getRenderer = renderQuestionWithCypress(
+                        item.question,
+                    );
 
-                    cy.get(POINTS)
-                        .eq(0)
+                    // Act
+                    cy.get("button[title=Absolute_value]").click();
+
+                    cy.get(GRAPHIE)
                         .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 200, y: top + 200});
-                    cy.get(POINTS)
-                        .eq(1)
-                        .should("exist")
-                        // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
-                        .dragTo({x: left + 100, y: top + 100});
+                        .then((node) => {
+                            const rect = node[0].getBoundingClientRect();
+                            const left = rect.left + window.scrollX;
+                            const top = rect.top + window.scrollY;
+
+                            cy.get(POINTS)
+                                .eq(0)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 220, y: top + 260});
+                            cy.get(POINTS)
+                                .eq(1)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 200, y: top + 200});
+                        });
+
+                    // Assert
+                    cy.then(() => {
+                        const userInput = getRenderer().getUserInputMap();
+                        const score = scorePerseusItemTesting(
+                            answerful.question,
+                            userInput,
+                        );
+                        expect(score).toStrictEqual({
+                            type: "points",
+                            earned: 1,
+                            total: 1,
+                            message: null,
+                        });
+                    });
                 });
 
-            // Assert
-            cy.then(() => {
-                const userInput = getRenderer().getUserInputMap();
-                const score = scorePerseusItemTesting(
-                    multipleAvailableTypesQuestion,
-                    userInput,
-                );
-                expect(score).toStrictEqual({
-                    type: "points",
-                    earned: 0,
-                    total: 1,
-                    message: null,
+                it("should be incorrectly answerable", () => {
+                    // Arrange
+                    const getRenderer = renderQuestionWithCypress(
+                        item.question,
+                    );
+
+                    // Act
+                    cy.get("button[title=Absolute_value]").click();
+
+                    cy.get(GRAPHIE)
+                        .should("exist")
+                        .then((node) => {
+                            const rect = node[0].getBoundingClientRect();
+                            const left = rect.left + window.scrollX;
+                            const top = rect.top + window.scrollY;
+
+                            cy.get(POINTS)
+                                .eq(0)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 200, y: top + 200});
+                            cy.get(POINTS)
+                                .eq(1)
+                                .should("exist")
+                                // @ts-expect-error - TS2339 - Property 'dragTo' does not exist on type 'Chainable<JQuery<HTMLElement>>'.
+                                .dragTo({x: left + 100, y: top + 100});
+                        });
+
+                    // Assert
+                    cy.then(() => {
+                        const userInput = getRenderer().getUserInputMap();
+                        const score = scorePerseusItemTesting(
+                            answerful.question,
+                            userInput,
+                        );
+                        expect(score).toStrictEqual({
+                            type: "points",
+                            earned: 0,
+                            total: 1,
+                            message: null,
+                        });
+                    });
                 });
             });
         });

--- a/packages/perseus/src/widgets/grapher/grapher.stories.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.stories.tsx
@@ -65,3 +65,10 @@ export const ComplexQuestion: Story = {
         }),
     },
 };
+
+export const AnswerlessQuestion: Story = {
+    args: {
+        item: generateTestPerseusItem({question: absoluteValueQuestion}),
+        startAnswerless: true,
+    },
+};

--- a/packages/perseus/src/widgets/grapher/grapher.test.ts
+++ b/packages/perseus/src/widgets/grapher/grapher.test.ts
@@ -1,8 +1,3 @@
-import {
-    generateTestPerseusItem,
-    splitPerseusItem,
-} from "@khanacademy/perseus-core";
-
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import {waitForInitialGraphieRender} from "../../../../../testing/wait";
 import * as Dependencies from "../../dependencies";
@@ -28,14 +23,6 @@ describe("grapher widget", () => {
                 ok: true,
             }),
         ) as jest.Mock;
-    });
-
-    it("should remove answerful data in answerless data", () => {
-        const answerful = generateTestPerseusItem({question: linearQuestion});
-        const answerless = splitPerseusItem(answerful);
-        expect(
-            answerless.question.widgets["grapher 1"].options.correct,
-        ).toBeUndefined();
     });
 
     it("should snapshot linear graph question", async () => {

--- a/packages/perseus/src/widgets/grapher/grapher.test.ts
+++ b/packages/perseus/src/widgets/grapher/grapher.test.ts
@@ -1,3 +1,8 @@
+import {
+    generateTestPerseusItem,
+    splitPerseusItem,
+} from "@khanacademy/perseus-core";
+
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import {waitForInitialGraphieRender} from "../../../../../testing/wait";
 import * as Dependencies from "../../dependencies";
@@ -23,6 +28,14 @@ describe("grapher widget", () => {
                 ok: true,
             }),
         ) as jest.Mock;
+    });
+
+    it("should remove answerful data in answerless data", () => {
+        const answerful = generateTestPerseusItem({question: linearQuestion});
+        const answerless = splitPerseusItem(answerful);
+        expect(
+            answerless.question.widgets["grapher 1"].options.correct,
+        ).toBeUndefined();
     });
 
     it("should snapshot linear graph question", async () => {

--- a/packages/perseus/src/widgets/grapher/grapher.testdata.ts
+++ b/packages/perseus/src/widgets/grapher/grapher.testdata.ts
@@ -265,10 +265,10 @@ export const quadraticQuestion: PerseusRenderer = {
 
 export const sinusoidQuestion: PerseusRenderer = {
     content:
-        "###The answer\n\nWe found that the graph of $y=-4\\cos\\left(x\\right)+3$ has a minimum point at $(0,-1)$ and then intersects its midline at $\\left(\\dfrac{1}{2}\\pi,3\\right)$.\n\n[[☃ grapher 3]]\n  ",
+        "###The answer\n\nWe found that the graph of $y=-4\\cos\\left(x\\right)+3$ has a minimum point at $(0,-1)$ and then intersects its midline at $\\left(\\dfrac{1}{2}\\pi,3\\right)$.\n\n[[☃ grapher 1]]\n  ",
     images: {},
     widgets: {
-        "grapher 3": {
+        "grapher 1": {
             alignment: "default",
             graded: true,
             options: {

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -3,9 +3,8 @@ import {
     vector as kvector,
     point as kpoint,
 } from "@khanacademy/kmath";
-import {GrapherUtil} from "@khanacademy/perseus-core";
+import {deepClone, GrapherUtil} from "@khanacademy/perseus-core";
 import * as React from "react";
-import _ from "underscore";
 
 import ButtonGroup from "../../components/button-group";
 import Graphie from "../../components/graphie";
@@ -248,10 +247,12 @@ class FunctionGrapher extends React.Component<FunctionGrapherProps> {
                             ) {
                                 const extraConstraint =
                                     this.props.model.extraCoordConstraint;
-                                // Calculat resulting coords and verify that
+                                // Calculate resulting coords and verify that
                                 // they're valid for this graph
-                                const proposedCoords = _.clone(this._coords());
-                                const oldCoord = _.clone(proposedCoords[i]);
+                                const proposedCoords = deepClone(
+                                    this._coords(),
+                                );
+                                const oldCoord = deepClone(proposedCoords[i]);
                                 proposedCoords[i] = coord;
                                 return extraConstraint(
                                     coord,
@@ -278,7 +279,7 @@ class FunctionGrapher extends React.Component<FunctionGrapherProps> {
                                 return kpoint.reflectOverLine(coord, asymptote);
                             });
                         } else {
-                            coords = _.clone(this._coords());
+                            coords = deepClone(this._coords());
                         }
                         coords[i] = newCoord;
                         this.props.onChange({

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -39,6 +39,7 @@ import type {
     MarkingsType,
     PerseusGrapherWidgetOptions,
     PerseusGrapherUserInput,
+    GrapherPublicWidgetOptions,
 } from "@khanacademy/perseus-core";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
@@ -345,10 +346,11 @@ class FunctionGrapher extends React.Component<FunctionGrapherProps> {
     }
 }
 
-type RenderProps = {
-    availableTypes: PerseusGrapherWidgetOptions["availableTypes"];
-    graph: PerseusGrapherWidgetOptions["graph"];
-    plot?: any;
+type RenderProps = Pick<
+    GrapherPublicWidgetOptions,
+    "availableTypes" | "graph"
+> & {
+    plot?: PerseusGrapherWidgetOptions["correct"];
 };
 
 type ExternalProps = WidgetProps<RenderProps>;
@@ -549,7 +551,7 @@ class Grapher extends React.Component<Props> implements Widget {
     render(): React.ReactNode {
         const type = this.props.plot.type;
         const coords = this.props.plot.coords;
-        const asymptote = this.props.plot.asymptote;
+        const asymptote = (this.props.plot as any).asymptote;
 
         const typeSelector = (
             <div style={typeSelectorStyle}>
@@ -615,7 +617,7 @@ class Grapher extends React.Component<Props> implements Widget {
     }
 }
 
-const propTransform: (arg1: PerseusGrapherWidgetOptions) => RenderProps = (
+const transform: (arg1: GrapherPublicWidgetOptions) => RenderProps = (
     editorProps,
 ) => {
     const widgetProps: RenderProps = {
@@ -642,7 +644,7 @@ const staticTransform: (arg1: PerseusGrapherWidgetOptions) => RenderProps = (
     editorProps,
 ) => {
     return {
-        ...propTransform(editorProps),
+        ...transform(editorProps),
         // Don't display graph type choices if we're in static mode
         availableTypes: [editorProps.correct.type],
         // Display the same graph marked as correct in the widget editor.
@@ -655,6 +657,6 @@ export default {
     displayName: "Grapher",
     hidden: true,
     widget: Grapher,
-    transform: propTransform,
-    staticTransform: staticTransform,
+    transform,
+    staticTransform,
 } satisfies WidgetExports<typeof Grapher>;

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -434,7 +434,7 @@ class Grapher extends React.Component<Props> implements Widget {
         if (options.markings === "graph") {
             graphie.graphInit({
                 range: options.range,
-                scale: _.pluck(options.gridConfig, "scale"),
+                scale: options.gridConfig.map((e) => e.scale),
                 axisArrows: "<->",
                 labelFormat: function (s) {
                     return "\\small{" + s + "}";
@@ -447,9 +447,9 @@ class Grapher extends React.Component<Props> implements Widget {
                           options.step,
                           options.range,
                       )
-                    : _.pluck(options.gridConfig, "tickStep"),
+                    : options.gridConfig.map((e) => e.tickStep),
                 labelStep: 1,
-                unityLabels: _.pluck(options.gridConfig, "unityLabel"),
+                unityLabels: options.gridConfig.map((e) => e.unityLabel),
                 isMobile: isMobile,
             });
             graphie.label(
@@ -465,7 +465,7 @@ class Grapher extends React.Component<Props> implements Widget {
         } else if (options.markings === "grid") {
             graphie.graphInit({
                 range: options.range,
-                scale: _.pluck(options.gridConfig, "scale"),
+                scale: options.gridConfig.map((e) => e.scale),
                 gridStep: options.gridStep,
                 axes: false,
                 ticks: false,
@@ -475,7 +475,7 @@ class Grapher extends React.Component<Props> implements Widget {
         } else if (options.markings === "none") {
             graphie.init({
                 range: options.range,
-                scale: _.pluck(options.gridConfig, "scale"),
+                scale: options.gridConfig.map((e) => e.scale),
             });
         }
 

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -160,7 +160,7 @@ class FunctionGrapher extends React.Component<FunctionGrapherProps> {
                     onMove={(newCoord, oldCoord) => {
                         // Calculate and apply displacement
                         const delta = kvector.subtract(newCoord, oldCoord);
-                        const newAsymptote = _.map(this._asymptote(), (coord) =>
+                        const newAsymptote = this._asymptote().map((coord) =>
                             kvector.add(coord, delta),
                         );
                         this.props.onChange({
@@ -175,8 +175,7 @@ class FunctionGrapher extends React.Component<FunctionGrapherProps> {
                         (newCoord, oldCoord: any) => {
                             // Calculate and apply proposed displacement
                             const delta = kvector.subtract(newCoord, oldCoord);
-                            const proposedAsymptote = _.map(
-                                this._asymptote(),
+                            const proposedAsymptote = this._asymptote().map(
                                 (coord) => kvector.add(coord, delta),
                             );
                             // Verify that resulting asymptote is valid for graph
@@ -195,7 +194,7 @@ class FunctionGrapher extends React.Component<FunctionGrapherProps> {
                     normalStyle={dashed}
                     highlightStyle={dashed}
                 >
-                    {_.map(asymptote, (coord, i) => (
+                    {asymptote.map((coord, i) => (
                         <MovablePoint
                             key={`asymptoteCoord-${i}`}
                             coord={coord}
@@ -276,7 +275,7 @@ class FunctionGrapher extends React.Component<FunctionGrapherProps> {
                             this.props.model.allowReflectOverAsymptote &&
                             isFlipped(newCoord, oldCoord, asymptote)
                         ) {
-                            coords = _.map(this._coords(), (coord) => {
+                            coords = this._coords().map((coord) => {
                                 return kpoint.reflectOverLine(coord, asymptote);
                             });
                         } else {
@@ -294,7 +293,7 @@ class FunctionGrapher extends React.Component<FunctionGrapherProps> {
                 />
             );
         };
-        const points = _.map(this._coords(), pointForCoord);
+        const points = this._coords().map(pointForCoord);
         const box = this.props.graph.box;
 
         const imageDescription = this.props.graph.backgroundImage;
@@ -379,7 +378,7 @@ class Grapher extends React.Component<Props> implements Widget {
     }
 
     handlePlotChanges: (arg1: any) => any = (newPlot) => {
-        const plot = _.extend({}, this.props.plot, newPlot);
+        const plot = {...this.props.plot, ...newPlot};
         this.props.onChange({
             plot: plot,
         });
@@ -388,11 +387,10 @@ class Grapher extends React.Component<Props> implements Widget {
 
     handleActiveTypeChange: (arg1: any) => any = (newType) => {
         const graph = this.props.graph;
-        const plot = _.extend(
-            {},
-            this.props.plot,
-            defaultPlotProps(newType, graph),
-        );
+        const plot = {
+            ...this.props.plot,
+            ...defaultPlotProps(newType, graph),
+        };
         this.props.onChange({
             plot: plot,
         });
@@ -558,7 +556,7 @@ class Grapher extends React.Component<Props> implements Widget {
                 <ButtonGroup
                     value={type}
                     allowEmpty={true}
-                    buttons={_.map(this.props.availableTypes, typeToButton)}
+                    buttons={this.props.availableTypes.map(typeToButton)}
                     onChange={this.handleActiveTypeChange}
                 />
             </div>

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -224,8 +224,7 @@ class FunctionGrapher extends React.Component<FunctionGrapherProps> {
                         Interactive2.MovablePoint.constraints.snap(),
                         (coord: any) => {
                             // Always enforce that this is a function
-                            const isFunction = _.all(
-                                this._coords(),
+                            const isFunction = this._coords().every(
                                 (otherCoord, j) => {
                                     return (
                                         i === j ||

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -551,7 +551,10 @@ class Grapher extends React.Component<Props> implements Widget {
     render(): React.ReactNode {
         const type = this.props.plot.type;
         const coords = this.props.plot.coords;
-        const asymptote = (this.props.plot as any).asymptote;
+        const asymptote =
+            "asymptote" in this.props.plot
+                ? this.props.plot.asymptote
+                : undefined;
 
         const typeSelector = (
             <div style={typeSelectorStyle}>


### PR DESCRIPTION
## Summary:
Making sure Grapher can work in an Answerless world. For the most part this PR:

- Updates all Cypress tests to test both answerful and aswerless¹
- Adds an Answerless story
- Removes Underscore from Grapher

¹ Grapher is an inaccessible widget that requires drag-and-drop behavior that [can't be tested with React Testing Library](https://github.com/testing-library/user-event/issues/440#issuecomment-685010755), which is why we use Cypress

Issue: LEMS-2985

## Test plan:
Grapher should continue to work as it's always worked.