### PR TITLE
Edit area cleanup

### DIFF
--- a/.changeset/odd-ladybugs-remain.md
+++ b/.changeset/odd-ladybugs-remain.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": major
+---
+
+Remove deprecated EditorPage props: workAreaSelector, solutionAreaSelector, and hintsAreaSelector

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -57,8 +57,6 @@ type Props = {
 
 type State = {
     json: PerseusItem;
-    gradeMessage: string;
-    wasAnswered: boolean;
     highlightLint: boolean;
     widgetsAreOpen: boolean;
 };
@@ -285,8 +283,6 @@ class EditorPage extends React.Component<Props, State> {
                         answerArea={this.props.answerArea}
                         imageUploader={this.props.imageUploader}
                         onChange={this.handleChange}
-                        wasAnswered={this.state.wasAnswered}
-                        gradeMessage={this.state.gradeMessage}
                         deviceType={this.props.previewDevice}
                         widgetIsOpen={this.state.widgetsAreOpen}
                         apiOptions={deviceBasedApiOptions}

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -16,6 +16,7 @@ import type {
 } from "@khanacademy/perseus";
 import type {
     Hint,
+    PerseusAnswerArea,
     PerseusItem,
     PerseusRenderer,
 } from "@khanacademy/perseus-core";
@@ -24,7 +25,7 @@ const {HUD} = components;
 
 type Props = {
     apiOptions?: APIOptions;
-    answerArea?: any; // related to the question,
+    answerArea?: PerseusAnswerArea | null; // related to the question,
     // TODO(CP-4838): Should this be a required prop?
     contentPaths?: ReadonlyArray<string>;
     // "Power user" mode. Shows the raw JSON of the question.

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -166,14 +166,7 @@ class EditorPage extends React.Component<Props, State> {
                 },
                 reviewMode: true,
                 legacyPerseusLint: this.itemEditor.current?.getSaveWarnings(),
-            }).extend(
-                _(this.props).pick(
-                    "workAreaSelector",
-                    "solutionAreaSelector",
-                    "hintsAreaSelector",
-                    "problemNum",
-                ),
-            ),
+            }).extend(_(this.props).pick("problemNum")),
         });
     }
 

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -56,6 +56,12 @@ type Props = {
     previewURL: string;
 };
 
+type DefaultProps = {
+    developerMode: Props["developerMode"];
+    jsonMode: Props["jsonMode"];
+    onChange: Props["onChange"];
+};
+
 type State = {
     json: PerseusItem;
     highlightLint: boolean;
@@ -64,16 +70,11 @@ type State = {
 
 class EditorPage extends React.Component<Props, State> {
     _isMounted: boolean;
-    renderer: any;
 
     itemEditor = React.createRef<ItemEditor>();
     hintsEditor = React.createRef<CombinedHintsEditor>();
 
-    static defaultProps: {
-        developerMode: boolean;
-        jsonMode: boolean;
-        onChange: () => void;
-    } = {
+    static defaultProps: DefaultProps = {
         developerMode: false,
         jsonMode: false,
         onChange: () => {},

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -12,7 +12,10 @@ import type {
     ChangeHandler,
     DeviceType,
 } from "@khanacademy/perseus";
-import type {PerseusRenderer} from "@khanacademy/perseus-core";
+import type {
+    PerseusAnswerArea,
+    PerseusRenderer,
+} from "@khanacademy/perseus-core";
 
 type Props = {
     apiOptions?: APIOptions;
@@ -20,7 +23,7 @@ type Props = {
     widgetIsOpen?: boolean;
     imageUploader?: ImageUploader;
     question?: PerseusRenderer;
-    answerArea?: any;
+    answerArea?: PerseusAnswerArea | null;
     // URL of the route to show on initial load of the preview frames.
     previewURL: string;
     onChange: ChangeHandler;
@@ -60,9 +63,9 @@ class ItemEditor extends React.Component<Props> {
         this.updateProps({question}, cb, silent);
     };
 
-    handleItemExtrasChange: ChangeHandler = (newProps, cb, silent) => {
+    handleItemExtrasChange = (newProps: Partial<PerseusAnswerArea>) => {
         const answerArea = _.extend({}, this.props.answerArea, newProps);
-        this.updateProps({answerArea}, cb, silent);
+        this.updateProps({answerArea}, () => {}, true);
     };
 
     getSaveWarnings: () => any = () => {
@@ -70,7 +73,7 @@ class ItemEditor extends React.Component<Props> {
     };
 
     serialize: (options?: any) => {
-        answerArea: any;
+        answerArea: PerseusAnswerArea | undefined;
         question: any;
     } = (options: any) => {
         return {

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -18,9 +18,7 @@ type Props = {
     apiOptions?: APIOptions;
     deviceType?: DeviceType;
     widgetIsOpen?: boolean;
-    gradeMessage?: string;
     imageUploader?: ImageUploader;
-    wasAnswered?: boolean;
     question?: PerseusRenderer;
     answerArea?: any;
     // URL of the route to show on initial load of the preview frames.


### PR DESCRIPTION
## Summary:

As I was working on the accessibility checks for our linting system I came across some things that can be cleaned up. So this PR cleans these things, mostly editor area pieces, some types, some long-deprecated and unused props:

  * Remove references to long-deprecated concepts: `workArea`, `solutionsArea`, `hintsArea`. Perseus used to allow the hosting application to provide selectors to existing elements on the page. Today, the `ServerItemRenderer` and `Renderer` fully control the DOM within their respective root nodes, so these concepts are no longer needed.
  * Remove unused field and create explicit type for `DefaultProps`
  * Type editor props for `answerArea` correctly
  * Remove deprecated props from EditorPage: `wasAnswered`, `gradeMessage`

Issue: "none"

## Test plan:

`pnpm tsc`
`pnpm test`
Storybook testing