### PR TITLE
Extend parseAndMigratePerseusItem to accept an object as well as string

### DIFF
--- a/.changeset/seven-toys-lay.md
+++ b/.changeset/seven-toys-lay.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": minor
+---
+
+Extend parseAndMigratePerseusItem so that it accepts either a JS object or a string (instead of only a string). When an object is passed, it skips calling `JSON.parse()`.

--- a/packages/perseus-core/src/parse-perseus-json/index.ts
+++ b/packages/perseus-core/src/parse-perseus-json/index.ts
@@ -50,7 +50,7 @@ export type ParseFailureDetail = {
  * @throws SyntaxError if the argument is not well-formed JSON.
  */
 export function parseAndMigratePerseusItem(
-    json: string | object,
+    json: string | unknown,
 ): Result<PerseusItem, ParseFailureDetail> {
     throwErrorIfCheatingDetected();
     const object = typeof json === "string" ? JSON.parse(json) : json;

--- a/packages/perseus-core/src/parse-perseus-json/index.ts
+++ b/packages/perseus-core/src/parse-perseus-json/index.ts
@@ -66,8 +66,9 @@ export function parseAndMigratePerseusItem(
 }
 
 /**
- * Parses a PerseusArticle from a JSON string, migrates old formats to the
- * latest schema, and runtime-typechecks the result.
+ * Parses a PerseusArticle from a plain object (or array) or JSON string,
+ * migrates old formats to the latest schema, and runtime-typechecks the
+ * result.
  *
  * @returns a {@link Result} of the parsed PerseusArticle. If the result is a
  * failure, it will contain an error message describing where in the tree

--- a/packages/perseus-core/src/parse-perseus-json/index.ts
+++ b/packages/perseus-core/src/parse-perseus-json/index.ts
@@ -39,10 +39,6 @@ export type ParseFailureDetail = {
     invalidObject: unknown;
 };
 
-function maybeParseJson(json: string | unknown): unknown {
-    return typeof json === "string" ? JSON.parse(json) : json;
-}
-
 /**
  * Parses a PerseusItem from a plain object or JSON string, migrates old
  * formats to the latest schema, and runtime-typechecks the result. Use this to
@@ -54,10 +50,10 @@ function maybeParseJson(json: string | unknown): unknown {
  * @throws SyntaxError if the argument is not well-formed JSON.
  */
 export function parseAndMigratePerseusItem(
-    json: string | unknown,
+    data: unknown,
 ): Result<PerseusItem, ParseFailureDetail> {
     throwErrorIfCheatingDetected();
-    const object: unknown = maybeParseJson(json);
+    const object: unknown = typeof data === "string" ? JSON.parse(data) : data;
     const result = parse(object, migrateAndTypecheckPerseusItem);
     if (isFailure(result)) {
         return failure({message: result.detail, invalidObject: object});
@@ -76,10 +72,10 @@ export function parseAndMigratePerseusItem(
  * @throws SyntaxError if the argument is not well-formed JSON.
  */
 export function parseAndMigratePerseusArticle(
-    json: unknown,
+    data: unknown,
 ): Result<PerseusArticle, ParseFailureDetail> {
     throwErrorIfCheatingDetected();
-    const object: unknown = maybeParseJson(json);
+    const object: unknown = typeof data === "string" ? JSON.parse(data) : data;
     const result = parse(object, migrateAndTypecheckPerseusArticle);
     if (isFailure(result)) {
         return failure({message: result.detail, invalidObject: object});

--- a/packages/perseus-core/src/parse-perseus-json/index.ts
+++ b/packages/perseus-core/src/parse-perseus-json/index.ts
@@ -39,6 +39,10 @@ export type ParseFailureDetail = {
     invalidObject: unknown;
 };
 
+function maybeParseJson(json: string | unknown): unknown {
+    return typeof json === "string" ? JSON.parse(json) : json;
+}
+
 /**
  * Parses a PerseusItem from a plain object or JSON string, migrates old
  * formats to the latest schema, and runtime-typechecks the result. Use this to
@@ -53,7 +57,7 @@ export function parseAndMigratePerseusItem(
     json: string | unknown,
 ): Result<PerseusItem, ParseFailureDetail> {
     throwErrorIfCheatingDetected();
-    const object: unknown = typeof json === "string" ? JSON.parse(json) : json;
+    const object = maybeParseJson(json);
     const result = parse(object, migrateAndTypecheckPerseusItem);
     if (isFailure(result)) {
         return failure({message: result.detail, invalidObject: object});
@@ -74,7 +78,7 @@ export function parseAndMigratePerseusArticle(
     json: string | unknown,
 ): Result<PerseusArticle, ParseFailureDetail> {
     throwErrorIfCheatingDetected();
-    const object: unknown = typeof json === "string" ? JSON.parse(json) : json;
+    const object = maybeParseJson(json);
     const result = parse(object, migrateAndTypecheckPerseusArticle);
     if (isFailure(result)) {
         return failure({message: result.detail, invalidObject: object});

--- a/packages/perseus-core/src/parse-perseus-json/index.ts
+++ b/packages/perseus-core/src/parse-perseus-json/index.ts
@@ -76,7 +76,7 @@ export function parseAndMigratePerseusItem(
  * @throws SyntaxError if the argument is not well-formed JSON.
  */
 export function parseAndMigratePerseusArticle(
-    json: string | unknown,
+    json: unknown,
 ): Result<PerseusArticle, ParseFailureDetail> {
     throwErrorIfCheatingDetected();
     const object: unknown = maybeParseJson(json);

--- a/packages/perseus-core/src/parse-perseus-json/index.ts
+++ b/packages/perseus-core/src/parse-perseus-json/index.ts
@@ -53,7 +53,7 @@ export function parseAndMigratePerseusItem(
     json: string | unknown,
 ): Result<PerseusItem, ParseFailureDetail> {
     throwErrorIfCheatingDetected();
-    const object = typeof json === "string" ? JSON.parse(json) : json;
+    const object: unknown = typeof json === "string" ? JSON.parse(json) : json;
     const result = parse(object, migrateAndTypecheckPerseusItem);
     if (isFailure(result)) {
         return failure({message: result.detail, invalidObject: object});

--- a/packages/perseus-core/src/parse-perseus-json/index.ts
+++ b/packages/perseus-core/src/parse-perseus-json/index.ts
@@ -40,9 +40,9 @@ export type ParseFailureDetail = {
 };
 
 /**
- * Parses a PerseusItem from a JSON string, migrates old formats to the latest
- * schema, and runtime-typechecks the result. Use this to parse assessmentItem
- * data.
+ * Parses a PerseusItem from a plain object or JSON string, migrates old
+ * formats to the latest schema, and runtime-typechecks the result. Use this to
+ * parse assessmentItem data.
  *
  * @returns a {@link Result} of the parsed PerseusItem. If the result is a
  * failure, it will contain an error message describing where in the tree
@@ -50,10 +50,10 @@ export type ParseFailureDetail = {
  * @throws SyntaxError if the argument is not well-formed JSON.
  */
 export function parseAndMigratePerseusItem(
-    json: string,
+    json: string | object,
 ): Result<PerseusItem, ParseFailureDetail> {
     throwErrorIfCheatingDetected();
-    const object: unknown = JSON.parse(json);
+    const object = typeof json === "string" ? JSON.parse(json) : json;
     const result = parse(object, migrateAndTypecheckPerseusItem);
     if (isFailure(result)) {
         return failure({message: result.detail, invalidObject: object});

--- a/packages/perseus-core/src/parse-perseus-json/index.ts
+++ b/packages/perseus-core/src/parse-perseus-json/index.ts
@@ -71,10 +71,10 @@ export function parseAndMigratePerseusItem(
  * @throws SyntaxError if the argument is not well-formed JSON.
  */
 export function parseAndMigratePerseusArticle(
-    json: string,
+    json: string | unknown,
 ): Result<PerseusArticle, ParseFailureDetail> {
     throwErrorIfCheatingDetected();
-    const object: unknown = JSON.parse(json);
+    const object: unknown = typeof json === "string" ? JSON.parse(json) : json;
     const result = parse(object, migrateAndTypecheckPerseusArticle);
     if (isFailure(result)) {
         return failure({message: result.detail, invalidObject: object});

--- a/packages/perseus-core/src/parse-perseus-json/index.ts
+++ b/packages/perseus-core/src/parse-perseus-json/index.ts
@@ -57,7 +57,7 @@ export function parseAndMigratePerseusItem(
     json: string | unknown,
 ): Result<PerseusItem, ParseFailureDetail> {
     throwErrorIfCheatingDetected();
-    const object = maybeParseJson(json);
+    const object: unknown = maybeParseJson(json);
     const result = parse(object, migrateAndTypecheckPerseusItem);
     if (isFailure(result)) {
         return failure({message: result.detail, invalidObject: object});
@@ -79,7 +79,7 @@ export function parseAndMigratePerseusArticle(
     json: string | unknown,
 ): Result<PerseusArticle, ParseFailureDetail> {
     throwErrorIfCheatingDetected();
-    const object = maybeParseJson(json);
+    const object: unknown = maybeParseJson(json);
     const result = parse(object, migrateAndTypecheckPerseusArticle);
     if (isFailure(result)) {
         return failure({message: result.detail, invalidObject: object});

--- a/packages/perseus-core/src/parse-perseus-json/parse-perseus-json.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/parse-perseus-json.test.ts
@@ -8,7 +8,7 @@ import {
 } from "./index";
 
 describe("parseAndMigratePerseusItem", () => {
-    it("should parse a JSON string", () => {
+    it("parses a JSON string", () => {
         const result = parseAndMigratePerseusItem(
             `{
                 "answerArea": {},
@@ -27,7 +27,7 @@ describe("parseAndMigratePerseusItem", () => {
         );
     });
 
-    it("should parse an object", () => {
+    it("parses an object", () => {
         const result = parseAndMigratePerseusItem({
             answerArea: {},
             hints: [],
@@ -44,8 +44,19 @@ describe("parseAndMigratePerseusItem", () => {
         );
     });
 
-    it("returns an error given an invalid PerseusItem", () => {
+    it("returns an error given an invalid PerseusItem string", () => {
         const result = parseAndMigratePerseusItem(`{"question": "bad value"}`);
+
+        assertFailure(result);
+        expect(result.detail.message).toContain(
+            `At (root).question -- expected object, but got "bad value"`,
+        );
+    });
+
+    it("returns an error given an invalid PerseusItem object", () => {
+        const result = parseAndMigratePerseusItem({
+            question: "bad value",
+        } as any);
 
         assertFailure(result);
         expect(result.detail.message).toContain(
@@ -75,7 +86,7 @@ describe("parseAndMigratePerseusItem", () => {
 });
 
 describe("parseAndMigratePerseusArticle", () => {
-    it("parses a single renderer", () => {
+    it("parses a single renderer from a string", () => {
         const result = parseAndMigratePerseusArticle(
             `{"content": "", "widgets": {}}`,
         );
@@ -89,7 +100,22 @@ describe("parseAndMigratePerseusArticle", () => {
         );
     });
 
-    it("parses an array of renderers", () => {
+    it("parses a single renderer", () => {
+        const result = parseAndMigratePerseusArticle({
+            content: "",
+            widgets: {},
+        });
+
+        expect(result).toEqual(
+            success({
+                content: "",
+                widgets: {},
+                images: {},
+            }),
+        );
+    });
+
+    it("parses an array of renderers from a string", () => {
         const result = parseAndMigratePerseusArticle(
             `[{"content": "one"}, {"content": "two"}]`,
         );
@@ -101,8 +127,30 @@ describe("parseAndMigratePerseusArticle", () => {
         );
     });
 
-    it("fails given invalid data", () => {
+    it("parses an array of renderers", () => {
+        const result = parseAndMigratePerseusArticle([
+            {content: "one"},
+            {content: "two"},
+        ]);
+        expect(result).toEqual(
+            success([
+                {content: "one", widgets: {}, images: {}},
+                {content: "two", widgets: {}, images: {}},
+            ]),
+        );
+    });
+
+    it("fails given an invalid data string", () => {
         const result = parseAndMigratePerseusArticle("[9]");
+
+        assertFailure(result);
+        expect(result.detail.message).toEqual(
+            "At (root)[0] -- expected object, but got 9",
+        );
+    });
+
+    it("fails given an invalid data ", () => {
+        const result = parseAndMigratePerseusArticle([9]);
 
         assertFailure(result);
         expect(result.detail.message).toEqual(

--- a/packages/perseus-core/src/parse-perseus-json/parse-perseus-json.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/parse-perseus-json.test.ts
@@ -8,7 +8,7 @@ import {
 } from "./index";
 
 describe("parseAndMigratePerseusItem", () => {
-    it("should parse JSON", () => {
+    it("should parse a JSON string", () => {
         const result = parseAndMigratePerseusItem(
             `{
                 "answerArea": {},
@@ -20,6 +20,23 @@ describe("parseAndMigratePerseusItem", () => {
                 }
             }`,
         );
+
+        assertSuccess(result);
+        expect(result.value.question.content).toBe(
+            "this is the question content",
+        );
+    });
+
+    it("should parse an object", () => {
+        const result = parseAndMigratePerseusItem({
+            answerArea: {},
+            hints: [],
+            question: {
+                content: "this is the question content",
+                widgets: {},
+                images: {},
+            },
+        });
 
         assertSuccess(result);
         expect(result.value.question.content).toBe(

--- a/packages/perseus-core/src/parse-perseus-json/parse-perseus-json.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/parse-perseus-json.test.ts
@@ -56,7 +56,7 @@ describe("parseAndMigratePerseusItem", () => {
     it("returns an error given an invalid PerseusItem object", () => {
         const result = parseAndMigratePerseusItem({
             question: "bad value",
-        } as any);
+        });
 
         assertFailure(result);
         expect(result.detail.message).toContain(


### PR DESCRIPTION
## Summary:

The `parseAndMigratePerseusItem` originally accepted only a `string` and started the process by `JSON.parse()`ing it. As we start building more things that need to parse perseus items, it's becoming clear we want to be able to parse objects that are already deserialized. 

So this PR updates the function to accept either a `string` or `object`. 

Issue: LEMS-3054

## Test plan:

`pnpm test`