### PR TITLE
Add splitPerseusItemJSON for CP use in Publish

### DIFF
--- a/packages/perseus-core/src/utils/split-perseus-item.test.ts
+++ b/packages/perseus-core/src/utils/split-perseus-item.test.ts
@@ -1,15 +1,34 @@
+import {assertFailure, assertSuccess} from "../parse-perseus-json/result";
 import {registerCoreWidgets} from "../widgets/core-widget-registry";
 import {getUpgradedWidgetOptions} from "../widgets/upgrade";
 
-import splitPerseusItem from "./split-perseus-item";
+import splitPerseusItem, {splitPerseusItemJSON} from "./split-perseus-item";
 import {generateTestPerseusItem} from "./test-utils";
 
-import type {PerseusRenderer, RadioWidget} from "../data-schema";
+import type {PerseusItem, PerseusRenderer, RadioWidget} from "../data-schema";
 
 describe("splitPerseusItem", () => {
     beforeAll(() => {
         registerCoreWidgets();
     });
+
+    function getFullRadio(): RadioWidget {
+        return {
+            type: "radio",
+            options: {
+                choices: [
+                    {
+                        content: "Correct",
+                        correct: true,
+                    },
+                    {
+                        content: "Incorrect",
+                        correct: false,
+                    },
+                ],
+            },
+        };
+    }
 
     it("doesn't do anything with an empty item", () => {
         // Arrange
@@ -338,24 +357,6 @@ describe("splitPerseusItem", () => {
     });
 
     it("handles multiple widgets", () => {
-        function getFullRadio(): RadioWidget {
-            return {
-                type: "radio",
-                options: {
-                    choices: [
-                        {
-                            content: "Correct",
-                            correct: true,
-                        },
-                        {
-                            content: "Incorrect",
-                            correct: false,
-                        },
-                    ],
-                },
-            };
-        }
-
         // Arrange
         const question: PerseusRenderer = {
             content: "[[☃ radio 1]] [[☃ radio 2]]",
@@ -466,5 +467,98 @@ describe("splitPerseusItem", () => {
 
         expect(item.hints[0]).toEqual(hint);
         expect(rv.hints).toEqual([]);
+    });
+});
+
+describe("splitPerseusItemJSON", () => {
+    function getBlankItem(): PerseusItem {
+        return {
+            question: {
+                content: "",
+                widgets: {},
+                images: {},
+            },
+            hints: [],
+            answerArea: {
+                calculator: false,
+                chi2Table: false,
+                financialCalculatorMonthlyPayment: false,
+                financialCalculatorTotalAmount: false,
+                financialCalculatorTimeToPayOff: false,
+                periodicTable: false,
+                periodicTableWithKey: false,
+                tTable: false,
+                zTable: false,
+            },
+        };
+    }
+
+    it("accepts JSON", () => {
+        // Arrange
+        const item = getBlankItem();
+        const json = JSON.stringify(item);
+
+        // Act
+        const rv = splitPerseusItemJSON(json);
+
+        // Assert
+        assertSuccess(rv);
+        expect(JSON.parse(rv.value)).toEqual(item);
+    });
+
+    it("accepts an object", () => {
+        // Arrange
+        const item = getBlankItem();
+
+        // Act
+        const rv = splitPerseusItemJSON(item);
+
+        // Assert
+        assertSuccess(rv);
+        expect(JSON.parse(rv.value)).toEqual(item);
+    });
+
+    it("is idempotent", () => {
+        // Arrange
+        const item = getBlankItem();
+
+        // Act
+        const rv1 = splitPerseusItemJSON(item);
+        assertSuccess(rv1);
+        const rv2 = splitPerseusItemJSON(rv1.value);
+
+        // Assert
+        assertSuccess(rv2);
+        expect(rv1.value).toBe(rv2.value);
+    });
+
+    it("removes answer-revealing information, e.g. hints", () => {
+        // Arrange
+        const item: PerseusItem = {
+            ...getBlankItem(),
+            hints: [{content: "a hint", widgets: {}, images: {}}],
+        };
+
+        // Act
+        const rv = splitPerseusItemJSON(item);
+
+        // Assert
+        assertSuccess(rv);
+        expect(JSON.parse(rv.value).hints).toEqual([]);
+    });
+
+    it("returns failure given an invalid PerseusItem", () => {
+        // Act
+        const rv = splitPerseusItemJSON(`"not an item"`);
+
+        // Assert
+        assertFailure(rv);
+        expect(rv.detail).toBe(
+            `At (root) -- expected object, but got "not an item"`,
+        );
+    });
+
+    it("throws on a JSON parse error", () => {
+        expect(() => splitPerseusItemJSON("")).toThrow(SyntaxError);
     });
 });

--- a/packages/perseus-core/src/utils/split-perseus-item.ts
+++ b/packages/perseus-core/src/utils/split-perseus-item.ts
@@ -3,7 +3,10 @@ import _ from "underscore";
 import deepClone from "./deep-clone";
 import splitPerseusRenderer from "./split-perseus-renderer";
 
+import {parsePerseusItem} from "../parse-perseus-json/perseus-parsers/perseus-item"
+
 import type {PerseusItem} from "../data-schema";
+
 
 /**
  * Return a copy of a PerseusItem with rubric data removed (ie answers)
@@ -20,4 +23,21 @@ export default function splitPerseusItem(original: PerseusItem): PerseusItem {
         // so we consider that part of the answer data
         hints: [],
     };
+}
+
+/**
+ * Return a JSON copy of a PerseusItem with rubric data removed (ie answers)
+ *
+ * This will work on any valid JSON produced from the editors
+ *
+ * CP calls this on every item of content (in every locale) as part of publish
+ * If it throws on an item, Perseus upgrades are blocked
+ *
+ * It should also have a consistent 1-to-1 mapping from input to output
+ * as CP uses that consistency to validate publish
+ *
+ * @param originalJSON - the original, full PerseusItem as JSON (which includes the rubric - aka answer data)
+ */
+export function splitPerseusItemExternal(originalJSON: string): string {
+    return JSON.stringify(splitPerseusItem(parsePerseusItem(originalJSON)));
 }


### PR DESCRIPTION
## Summary:
This seeks to encode the main interface and collaboration between LEMS and CP for splitting Perseus items.

The Server Side Scoring project is going to include adding a step to publish that removes the answer data
and storing that "public" data/file alongside the existing data.

Publish seeks to treat Perseus data as a "black box" that is passed around, but leaves the parsing, migration, validation, etc. of the data to those who know it best, LEMS, closest to where it is handled, the Perseus code.

To that end CP is requesting a function that is closer to a "blob in, blob out" external interface.
This will have the benefits of the interface between the two teams being encoded and captured in the
behavior and semantics of this function.

Explanation of the requirements from CP's perspective:
```
* This will work on any valid JSON produced from the editors
```
Publish should only be a conduit for perseus JSON from the editors, so validation is best
handled there where action is possible to edit/fix the JSON also.

```
 * CP calls this on every item of content (in every locale) as part of publish
 * If it throws on an item, Perseus upgrades are blocked
```
CP publish code runs this function on every item in every locale in publish.
That means it needs to work on all items. If it throws on any item that will break publish.
Publish being broken means CP cannot produce content for the site, so that effectively
means that the perseus upgrade cannot proceed.

```
 * It should also have a consistent 1-to-1 mapping from input to output
 * as CP uses that consistency to validate publish
```
CP has a test that ensures (from experience of a previous site outage) that across changes
to the publish worker...the produced data (which includes the public perseus data from this
splitting function) is an exact match for the previous data from the last publish before the change.
As a result if the same full data is passed to this function, it should produce the same output as
previous calls so that the content snapshot produced is the same and publish can be verified as correct.

The special case is of course updates that intentionally change the output of this function.
Those obviously will not match the previous output, but should be communicated to CP
as they can be reviewed and verified in the diffs across the two publishes as part of the
upgrade.

For more information on the publish process and upgrades see:
https://khanacademy.atlassian.net/wiki/spaces/CP/pages/299204611/Publish+Process+Technical+Documentation#Deploying-a-new-publish-worker-image

Issue: "none"

## Test plan:
Run a local publish for all locales against the latest prod snapshot
ensuring that the function completes for all items in all locales

Update the publish worker and run a publish for all locales