### PR TITLE
Update dropdown labeling guidance to internal article

### DIFF
--- a/.changeset/wild-poets-press.md
+++ b/.changeset/wild-poets-press.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Update dropdown labeling doc to internal article

--- a/packages/perseus-editor/src/widgets/dropdown-editor.tsx
+++ b/packages/perseus-editor/src/widgets/dropdown-editor.tsx
@@ -147,11 +147,11 @@ class DropdownEditor extends React.Component<Props> {
                             exercise is accessible. For more information on
                             writing accessible labels, please see{" "}
                             <a
-                                href="https://www.w3.org/WAI/tips/designing/#ensure-that-form-elements-include-clearly-associated-labels"
+                                href="https://khanacademy.atlassian.net/wiki/spaces/A11Y/pages/3967615350/General+Guidance+for+Labeling+Dropdowns"
                                 target="_blank"
                                 rel="noreferrer"
                             >
-                                this article.
+                                this internal article.
                             </a>{" "}
                             If left blank, the value will default to
                             &quot;Select an answer&quot;.

--- a/packages/perseus-editor/src/widgets/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor.tsx
@@ -388,11 +388,11 @@ class ExpressionEditor extends React.Component<Props, State> {
                                     For more information on writting accessible
                                     labels, please see{" "}
                                     <a
-                                        href="https://www.w3.org/WAI/tips/designing/#ensure-that-form-elements-include-clearly-associated-labels"
+                                        href="https://khanacademy.atlassian.net/wiki/spaces/A11Y/pages/3967615350/General+Guidance+for+Labeling+Dropdowns"
                                         target="_blank"
                                         rel="noreferrer"
                                     >
-                                        this article.
+                                        this internal article.
                                     </a>
                                 </InfoTip>
                             </>


### PR DESCRIPTION
## Summary:
I got feedback from the Content team that the w3c-WAI article linked from the editor was too technical for the audience. So I created an internal doc that we can maintain, that also links to the previous article for those who are curious.

Issue: FEI-6288

## Test plan:
1. Ensure the links work (the doc is on Confluence)
2. Ensure the link text fits ("this internal article" instead of "this article")