### PR TITLE
Fix Label Image so PreferredPopoverDirection works

### DIFF
--- a/.changeset/hungry-comics-call.md
+++ b/.changeset/hungry-comics-call.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-core": minor
+"@khanacademy/perseus-editor": minor
+---
+
+Fix Label Image so the preferred popover direction can actually be set

--- a/packages/perseus-editor/src/widgets/__stories__/label-image-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__stories__/label-image-editor.stories.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 
 import LabelImageEditor from "../label-image-editor";
 
+import type {PreferredPopoverDirection} from "../../../../perseus/src/widgets/label-image/label-image";
 import type {PerseusLabelImageWidgetOptions} from "@khanacademy/perseus-core";
 
 type StoryArgs = Record<any, any>;
@@ -25,18 +26,19 @@ const styles = StyleSheet.create({
 
 type State = {
     imageAlt: string;
-    choices: ReadonlyArray<string>;
+    choices: string[];
     imageUrl: string;
     imageWidth: number;
     imageHeight: number;
     markers: PerseusLabelImageWidgetOptions["markers"];
+    preferredPopoverDirection: PreferredPopoverDirection;
 };
 
 class WithState extends React.Component<Empty, State> {
     // @ts-expect-error [FEI-5003] - TS2564 - Property '_widget' has no initializer and is not definitely assigned in the constructor.
     _widget: LabelImageEditor;
 
-    state = {
+    state: State = {
         imageAlt: "Map of Europe",
         choices: [
             "Lamborghini",
@@ -70,6 +72,7 @@ class WithState extends React.Component<Empty, State> {
                 y: 78.8,
             },
         ],
+        preferredPopoverDirection: "NONE",
     };
 
     render(): React.ReactNode {

--- a/packages/perseus-editor/src/widgets/label-image-editor.tsx
+++ b/packages/perseus-editor/src/widgets/label-image-editor.tsx
@@ -18,6 +18,7 @@ import Behavior from "./label-image/behavior";
 import QuestionMarkers from "./label-image/question-markers";
 import SelectImage from "./label-image/select-image";
 
+import type {PreferredPopoverDirection} from "@khanacademy/perseus/src/widgets/label-image/label-image";
 import type {
     PerseusLabelImageWidgetOptions,
     LabelImageDefaultWidgetOptions,
@@ -37,6 +38,8 @@ type Props = {
     multipleAnswers: boolean;
     // Whether to hide answer choices from user instructions.
     hideChoicesFromInstructions: boolean;
+    // Preferred popover direction
+    preferredPopoverDirection: PreferredPopoverDirection;
     // Callback for when a widget prop is changed.
     onChange: (options: any) => void;
 };
@@ -188,6 +191,7 @@ class LabelImageEditor extends React.Component<Props> {
             markers,
             multipleAnswers,
             hideChoicesFromInstructions,
+            preferredPopoverDirection,
         } = this.props;
 
         const imageSelected = imageUrl && imageWidth > 0 && imageHeight > 0;
@@ -231,7 +235,7 @@ class LabelImageEditor extends React.Component<Props> {
                 <div className={css(styles.largeSpacer)} />
 
                 <Behavior
-                    preferredPopoverDirection="NONE"
+                    preferredPopoverDirection={preferredPopoverDirection}
                     multipleAnswers={multipleAnswers}
                     hideChoicesFromInstructions={hideChoicesFromInstructions}
                     onChange={this.handleBehaviorChange}

--- a/packages/perseus/src/widgets/label-image/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image/label-image.tsx
@@ -39,7 +39,12 @@ import type {
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 import type {CSSProperties} from "aphrodite";
 
-type PreferredPopoverDirection = "NONE" | "UP" | "DOWN" | "LEFT" | "RIGHT";
+export type PreferredPopoverDirection =
+    | "NONE"
+    | "UP"
+    | "DOWN"
+    | "LEFT"
+    | "RIGHT";
 
 /**
  * Represents a direction vector.


### PR DESCRIPTION
## Summary:
This value was previously hardcoded in the Behavior component as "NONE". I was able to update the props to pass the value from the editor down to the Behaior component so the logic for popover direction has access to the information provided by the content creator.

Issue: LEMS-3110

## Test plan:
- Confirm all checks pass
- Test in Storybook and confirm changing PreferredPopoverDirection persists