### PR TITLE
Ensure that our parser can handle empty strings for labelLocation for Interactive Graphs

### DIFF
--- a/.changeset/tricky-parents-hide.md
+++ b/.changeset/tricky-parents-hide.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-core": patch
+---
+
+Ensure that Interactive Graph's labelLocation property can be parsed properly

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.test.ts
@@ -140,6 +140,54 @@ describe("parseInteractiveGraphWidget", () => {
         );
     });
 
+    it("parses empty strings as onAxis", () => {
+        const emptyLabelLocationResult = parse(
+            {
+                type: "interactive-graph",
+                options: {
+                    step: [1, 1],
+                    markings: "grid",
+                    showProtractor: false,
+                    range: [
+                        [-10, 10],
+                        [-10, 10],
+                    ],
+                    correct: {
+                        type: "linear",
+                    },
+                    graph: {
+                        type: "linear",
+                    },
+                    labelLocation: "",
+                },
+            },
+            parseInteractiveGraphWidget,
+        );
+
+        expect(emptyLabelLocationResult).toEqual(
+            success({
+                type: "interactive-graph",
+                options: {
+                    step: [1, 1],
+                    markings: "grid",
+                    showProtractor: false,
+                    range: [
+                        [-10, 10],
+                        [-10, 10],
+                    ],
+                    correct: {
+                        type: "linear",
+                    },
+                    graph: {
+                        type: "linear",
+                    },
+                    labelLocation: "onAxis",
+                    lockedFigures: [],
+                },
+            }),
+        );
+    });
+
     it("rejects invalid labelLocation values", () => {
         const invalidResult = parse(
             {

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -9,10 +9,12 @@ import {
     object,
     optional,
     pair,
+    pipeParsers,
     string,
     trio,
     union,
 } from "../general-purpose-parsers";
+import {convert} from "../general-purpose-parsers/convert";
 import {defaulted} from "../general-purpose-parsers/defaulted";
 import {discriminatedUnionOn} from "../general-purpose-parsers/discriminated-union";
 
@@ -224,6 +226,11 @@ const parseLockedFigure = discriminatedUnionOn("type")
     .withBranch("function", parseLockedFunctionType)
     .withBranch("label", parseLockedLabelType).parser;
 
+const parseLabelLocation = union(enumeration("onAxis", "alongEdge")).or(
+    // If the labelLocation is an empty string, we default to "onAxis".
+    pipeParsers(constant("")).then(convert(() => "onAxis" as const)).parser,
+).parser;
+
 export const parseInteractiveGraphWidget = parseWidget(
     constant("interactive-graph"),
     object({
@@ -237,7 +244,7 @@ export const parseInteractiveGraphWidget = parseWidget(
         backgroundImage: optional(parsePerseusImageBackground),
         markings: enumeration("graph", "grid", "none", "axes"),
         labels: optional(array(string)),
-        labelLocation: optional(enumeration("onAxis", "alongEdge")),
+        labelLocation: optional(parseLabelLocation),
         showProtractor: boolean,
         showRuler: optional(boolean),
         showTooltips: optional(boolean),

--- a/packages/perseus-core/src/utils/split-perseus-item.test.ts
+++ b/packages/perseus-core/src/utils/split-perseus-item.test.ts
@@ -285,6 +285,7 @@ describe("splitPerseusItem", () => {
                         snapStep: [1, 1],
                         markings: "none",
                         labels: [],
+                        labelLocation: "onAxis",
                         showProtractor: false,
                         range: [
                             [0, 1],
@@ -311,6 +312,7 @@ describe("splitPerseusItem", () => {
                         snapStep: [1, 1],
                         markings: "none",
                         labels: [],
+                        labelLocation: "onAxis",
                         showProtractor: false,
                         range: [
                             [0, 1],

--- a/packages/perseus-core/src/utils/split-perseus-renderer.test.ts
+++ b/packages/perseus-core/src/utils/split-perseus-renderer.test.ts
@@ -284,6 +284,7 @@ describe("splitPerseusRenderer", () => {
                         snapStep: [1, 1],
                         markings: "none",
                         labels: [],
+                        labelLocation: "onAxis",
                         showProtractor: false,
                         range: [
                             [0, 1],
@@ -310,6 +311,7 @@ describe("splitPerseusRenderer", () => {
                         snapStep: [1, 1],
                         markings: "none",
                         labels: [],
+                        labelLocation: "onAxis",
                         showProtractor: false,
                         range: [
                             [0, 1],

--- a/packages/perseus-core/src/widgets/interactive-graph/index.ts
+++ b/packages/perseus-core/src/widgets/interactive-graph/index.ts
@@ -6,6 +6,7 @@ import type {WidgetLogic} from "../logic-export.types";
 export type InteractiveGraphDefaultWidgetOptions = Pick<
     PerseusInteractiveGraphWidgetOptions,
     | "labels"
+    | "labelLocation"
     | "range"
     | "step"
     | "backgroundImage"
@@ -18,6 +19,7 @@ export type InteractiveGraphDefaultWidgetOptions = Pick<
 
 const defaultWidgetOptions: InteractiveGraphDefaultWidgetOptions = {
     labels: ["x", "y"],
+    labelLocation: "onAxis",
     range: [
         [-10, 10],
         [-10, 10],

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -39,6 +39,7 @@ import type {
     MarkingsType,
     PerseusInteractiveGraphRubric,
     PerseusInteractiveGraphUserInput,
+    AxisLabelLocation,
 } from "@khanacademy/perseus-core";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
@@ -108,6 +109,10 @@ type RenderProps = {
      */
     labels: string[];
     /**
+     * Where to put the axis labels on the graph.  default: "onAxis"
+     */
+    labelLocation: AxisLabelLocation;
+    /**
      * Whether to show the Protractor tool overlaid on top of the graph
      */
     showProtractor: boolean;
@@ -175,6 +180,7 @@ type Props = WidgetProps<RenderProps>;
 type State = any;
 type DefaultProps = {
     labels: string[];
+    labelLocation: Props["labelLocation"];
     range: Props["range"];
     step: Props["step"];
     backgroundImage: Props["backgroundImage"];
@@ -252,6 +258,7 @@ class InteractiveGraph extends React.Component<Props, State> {
 
     static defaultProps: DefaultProps = {
         labels: ["x", "y"],
+        labelLocation: "onAxis",
         range: [
             [-10, 10],
             [-10, 10],


### PR DESCRIPTION
## Summary:
This PR implements a fix to ensure that our parser can handle empty string values for our labelLocation property on our Interactive Graphs. 

I have also updated several locations to be very specific about the default value, to ensure that this issue doesn't persist with new content. 

Issue: LEMS-3122

## Test plan:
- Tests pass 
  - Including new test 