### PR TITLE
Add tab navigation to new radio widget

### DIFF
--- a/.changeset/eighty-swans-love.md
+++ b/.changeset/eighty-swans-love.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Add tab navigation to new radio widget

--- a/packages/perseus/src/components/scrollable-view.tsx
+++ b/packages/perseus/src/components/scrollable-view.tsx
@@ -96,6 +96,7 @@ function ScrollableView({
                 role={role}
                 style={mergeStyle}
                 ref={containerRef}
+                tabIndex={-1}
             >
                 {children}
             </div>

--- a/packages/perseus/src/components/scrollable-view.tsx
+++ b/packages/perseus/src/components/scrollable-view.tsx
@@ -96,7 +96,6 @@ function ScrollableView({
                 role={role}
                 style={mergeStyle}
                 ref={containerRef}
-                tabIndex={-1}
             >
                 {children}
             </div>

--- a/packages/perseus/src/widgets/radio/choice.new.tsx
+++ b/packages/perseus/src/widgets/radio/choice.new.tsx
@@ -182,6 +182,7 @@ const Choice = React.forwardRef<HTMLButtonElement, ChoiceProps>(
                         }}
                         ref={ref as any}
                         aria-hidden="true"
+                        hideDefaultFocusRing={true}
                     >
                         {({hovered, focused, pressed}) => (
                             <div style={styles.choiceRow}>


### PR DESCRIPTION
## Summary:
This PR will add the proper tab navigation to the new radio widget after the horizontal scrollbar was added. Removing the visible blue focus in the entire row instead of just the choice icon.

| Before | After |
| ------ | ------ |
| <img width="300" src="https://github.com/user-attachments/assets/e12c9939-a034-4975-a5a7-e36e0860e199" /> | <img width="300" src="https://github.com/user-attachments/assets/95a7cab1-1d46-47bd-8a28-23442530c987" /> |

**Note: Known Existing Issue**
When displaying an image as the content will cause an additional focus on the image.
| Before (Prod) | After |
| ------ | ------ |
| <img width="300" src="https://github.com/user-attachments/assets/87a82f00-01f0-48c9-b197-312f232ddff8" /> | <img width="300" src="https://github.com/user-attachments/assets/340d6a2f-5c46-4b2a-8667-fdbaa0263850" /> |

Issue: LEMS-3105


## Test plan:
- [ ] Confirm that the tab navigation works for the New Radio widget storybook