### PR TITLE
Add typesafe parser for Categorizer's user input type

### DIFF
--- a/.changeset/mean-trains-cover.md
+++ b/.changeset/mean-trains-cover.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+Add parsing validation for Categorizer's user input

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/categorizer-user-input.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/categorizer-user-input.ts
@@ -1,0 +1,5 @@
+import {object, array, number} from "../general-purpose-parsers";
+
+export const parseCategorizerUserInput = object({
+    values: array(number),
+});

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/categorizer-user-input.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/categorizer-user-input.typetest.ts
@@ -1,0 +1,17 @@
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseCategorizerUserInput} from "./categorizer-user-input";
+import type {PerseusCategorizerUserInput} from "../../validation.types";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
+
+type Parsed = ParsedValue<typeof parseCategorizerUserInput>;
+
+summon<Parsed>() satisfies PerseusCategorizerUserInput;
+summon<PerseusCategorizerUserInput>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<PerseusCategorizerUserInput>;


### PR DESCRIPTION
## Summary:
Added a user input parser and typetest for Categorizer

Issue: LEMS-3128

## Test plan:
- Confirm all checks pass
- Confirm categorizer still works as expected using Storybook