### PR TITLE
docs(changeset): Updates to Radio Scoring to ensure non-specific multiselect questions are marked correctly.

### DIFF
--- a/.changeset/little-goats-prove.md
+++ b/.changeset/little-goats-prove.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-core": minor
+"@khanacademy/perseus-score": minor
+---
+
+Updates to Radio Scoring to ensure non-specific multiselect questions are marked correctly.

--- a/packages/perseus-core/src/validation.types.ts
+++ b/packages/perseus-core/src/validation.types.ts
@@ -256,6 +256,8 @@ export type PerseusPlotterUserInput = number[];
 export type PerseusRadioRubric = {
     // The choices provided to the user.
     choices: PerseusRadioChoice[];
+    // If true, the number of choices selected must match the number of correct choices.
+    countChoices?: boolean;
 };
 
 export type PerseusRadioUserInput = {

--- a/packages/perseus-score/src/widgets/radio/score-radio.test.ts
+++ b/packages/perseus-score/src/widgets/radio/score-radio.test.ts
@@ -6,7 +6,7 @@ import type {
 } from "@khanacademy/perseus-core";
 
 describe("scoreRadio", () => {
-    it("is invalid when number selected does not match number correct", () => {
+    it("is invalid when number selected does not match number correct and countChoices is true", () => {
         const userInput: PerseusRadioUserInput = {
             choicesSelected: [true, false, false, false],
         };
@@ -18,11 +18,32 @@ describe("scoreRadio", () => {
                 {content: "Choice 3", correct: false},
                 {content: "Choice 4", correct: false},
             ],
+            countChoices: true,
         };
 
         const score = scoreRadio(userInput, rubric);
 
         expect(score).toHaveInvalidInput();
+    });
+
+    it("is incorrect when number selected does not match number correct and countChoices is false", () => {
+        const userInput: PerseusRadioUserInput = {
+            choicesSelected: [true, false, false, false],
+        };
+
+        const rubric: PerseusRadioRubric = {
+            choices: [
+                {content: "Choice 1", correct: true},
+                {content: "Choice 2", correct: true},
+                {content: "Choice 3", correct: false},
+                {content: "Choice 4", correct: false},
+            ],
+            countChoices: false,
+        };
+
+        const score = scoreRadio(userInput, rubric);
+
+        expect(score).toHaveBeenAnsweredIncorrectly();
     });
 
     it("is invalid when none of the above and an answer are both selected", () => {

--- a/packages/perseus-score/src/widgets/radio/score-radio.ts
+++ b/packages/perseus-score/src/widgets/radio/score-radio.ts
@@ -19,12 +19,14 @@ function scoreRadio(
         return currentChoice.correct ? sum + 1 : sum;
     }, 0);
 
-    if (numCorrect > 1 && numSelected !== numCorrect) {
+    // If the number of correct answers is greater than 1 and the number of
+    // selected answers is not equal to the number of correct answers, and
+    // the countChoices option is true, then return an invalid score.
+    if (numCorrect > 1 && numSelected !== numCorrect && rubric.countChoices) {
         return {
             type: "invalid",
             message: ErrorCodes.CHOOSE_CORRECT_NUM_ERROR,
         };
-        // If NOTA and some other answer are checked, ...
     }
 
     const noneOfTheAboveSelected = rubric.choices.some(

--- a/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
@@ -724,6 +724,7 @@ describe("Radio Widget", () => {
                                     correct: false,
                                 },
                             ],
+                            countChoices: true,
                         },
                     },
                 },


### PR DESCRIPTION
## Summary:
This PR is part of the Radio Widget Upgrade Project. 

This work ensures that non-specific multi-select Radios don't trigger CHOOSE_CORRECT_NUM_ERRORs, and are instead marked as "incorrect". 

Issue: LEMS-2996

## Test plan:
- New scoring test 
- Previous tests pass (after making them specific) 