### PR TITLE
Add typesafe parser for Matrix's user input type

### DIFF
--- a/.changeset/curvy-glasses-walk.md
+++ b/.changeset/curvy-glasses-walk.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+Add parsing validation for Matrix's user input

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matrix-user-input.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matrix-user-input.ts
@@ -1,0 +1,5 @@
+import {array, number, object} from "../general-purpose-parsers";
+
+export const parseMatrixUserInput = object({
+    answers: array(array(number)),
+});

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matrix-user-input.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matrix-user-input.typetest.ts
@@ -1,0 +1,15 @@
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseMatrixUserInput} from "./matrix-user-input";
+import type {PerseusMatrixUserInput} from "../../validation.types";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
+
+type Parsed = ParsedValue<typeof parseMatrixUserInput>;
+
+summon<Parsed>() satisfies PerseusMatrixUserInput;
+summon<PerseusMatrixUserInput>() satisfies Parsed;
+
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<PerseusMatrixUserInput>;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matrix-user-input.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matrix-user-input.typetest.ts
@@ -10,6 +10,8 @@ type Parsed = ParsedValue<typeof parseMatrixUserInput>;
 summon<Parsed>() satisfies PerseusMatrixUserInput;
 summon<PerseusMatrixUserInput>() satisfies Parsed;
 
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
 summon<
     RecursiveRequired<Parsed>
 >() satisfies RecursiveRequired<PerseusMatrixUserInput>;


### PR DESCRIPTION
## Summary:
Adds a user input parser and typetest for Matrix

Issue: LEMS-3129

## Test plan:
- Confirm all checks pass
- Confirm Matrix still works as expected using Storybook