### PR TITLE
Add typesafe parser for Sorter's user input type

### DIFF
--- a/.changeset/wise-trainers-drum.md
+++ b/.changeset/wise-trainers-drum.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+Add typesafe parser for Sorter's user input type

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/sorter-user-input.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/sorter-user-input.ts
@@ -1,0 +1,6 @@
+import {array, boolean, object, string} from "../general-purpose-parsers";
+
+export const parseSorterUserInput = object({
+    options: array(string),
+    changed: boolean,
+});

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/sorter-user-input.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/sorter-user-input.typetest.ts
@@ -1,0 +1,17 @@
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseSorterUserInput} from "./sorter-user-input";
+import type {PerseusSorterUserInput} from "../../validation.types";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
+
+type Parsed = ParsedValue<typeof parseSorterUserInput>;
+
+summon<Parsed>() satisfies PerseusSorterUserInput;
+summon<PerseusSorterUserInput>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<PerseusSorterUserInput>;


### PR DESCRIPTION
## Summary:
Adds a user input type parser and typetest for Sorter

Issue: LEMS-3138

## Test plan:
- Confirm all checks pass
- Confirm Sorter still works as expected using Storybook