### PR TITLE
Pass data between EditorPage and ItemEditor via new props

### DIFF
--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -54,6 +54,14 @@ type Props = {
     question?: PerseusRenderer;
     // URL of the route to show on initial load of the preview frames.
     previewURL: string;
+    issues?: Array<{
+        id: string;
+        description: string;
+        help: string;
+        helpUrl: string;
+        impact: string;
+        message: string;
+    }>;
 };
 
 type DefaultProps = {
@@ -282,6 +290,7 @@ class EditorPage extends React.Component<Props, State> {
                         widgetIsOpen={this.state.widgetsAreOpen}
                         apiOptions={deviceBasedApiOptions}
                         previewURL={this.props.previewURL}
+                        issues={this.props.issues}
                     />
                 )}
 

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -36,6 +36,14 @@ type Props = {
     // The content ID of the AssessmentItem being edited. It may not be set
     // for non-content library exercise questions.
     itemId?: string;
+    issues?: Array<{
+        id: string;
+        description: string;
+        help: string;
+        helpUrl: string;
+        impact: string;
+        message: string;
+    }>;
 };
 
 type State = {
@@ -83,22 +91,42 @@ class ItemEditor extends React.Component<Props, State> {
             stack: [],
         };
 
-        return {
-            issues: PerseusLinter.runLinter(parsed, linterContext, false)?.map(
-                (linterWarning) => {
-                    if (linterWarning.rule === "inaccessible-widget") {
-                        return WARNINGS.inaccessibleWidget(
-                            linterWarning.metadata?.widgetType ?? "unknown",
-                            linterWarning.metadata?.widgetId ?? "unknown",
-                        );
-                    }
+        // return {
+        //     issues: PerseusLinter.runLinter(parsed, linterContext, false)?.map(
+        //         (linterWarning) => {
+        //             if (linterWarning.rule === "inaccessible-widget") {
+        //                 return WARNINGS.inaccessibleWidget(
+        //                     linterWarning.metadata?.widgetType ?? "unknown",
+        //                     linterWarning.metadata?.widgetId ?? "unknown",
+        //                 );
+        //             }
 
-                    return WARNINGS.genericLinterWarning(
-                        linterWarning.rule,
-                        linterWarning.message,
-                    );
-                },
-            ),
+        //             return WARNINGS.genericLinterWarning(
+        //                 linterWarning.rule,
+        //                 linterWarning.message,
+        //             );
+        //         },
+        //     ),
+        // };
+
+        return {
+            issues: [
+                ...(props.issues ?? []),
+                ...(PerseusLinter.runLinter(parsed, linterContext, false)?.map(
+                    (linterWarning) => {
+                        if (linterWarning.rule === "inaccessible-widget") {
+                            return WARNINGS.inaccessibleWidget(
+                                linterWarning.metadata?.widgetType ?? "unknown",
+                                linterWarning.metadata?.widgetId ?? "unknown",
+                            );
+                        }
+                        return WARNINGS.genericLinterWarning(
+                            linterWarning.rule,
+                            linterWarning.message,
+                        );
+                    },
+                ) ?? []),
+            ],
         };
     }
 


### PR DESCRIPTION
## Summary:
This change is a step toward addressing LEMS-2973: “Show a warning message when content creators mark items as requiring a screen or mouse.”

This step pertains to changes in Perseus where data is received from the webapp through props.
- Added new prop to EditorPage and ItemEditor to enable data flow
- Refactored getDerivedStateFromProps to handle props from webapp

Issue: LEMS-2973

## Test plan: