### PR TITLE
Fix getSaveWarnings in Free Response widget

### DIFF
--- a/.changeset/dirty-singers-arrive.md
+++ b/.changeset/dirty-singers-arrive.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": minor
+---
+
+Fix getSaveWarnings in Free Response widget and unhide it

--- a/.changeset/nervous-cycles-try.md
+++ b/.changeset/nervous-cycles-try.md
@@ -1,5 +1,0 @@
----
-"@khanacademy/perseus-editor": patch
----
-
-Fix the getSaveWarnings function in the Free Response widget

--- a/.changeset/nervous-cycles-try.md
+++ b/.changeset/nervous-cycles-try.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Fix the getSaveWarnings function in the Free Response widget

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -28,7 +28,7 @@ class FreeResponseEditor extends React.Component<Props> {
 
     static widgetName = "free-response" as const;
 
-    serialize(): PerseusFreeResponseWidgetOptions {
+    serialize: () => PerseusFreeResponseWidgetOptions = () => {
         return {
             allowUnlimitedCharacters: this.props.allowUnlimitedCharacters,
             characterLimit: this.props.characterLimit,
@@ -36,9 +36,9 @@ class FreeResponseEditor extends React.Component<Props> {
             question: this.props.question,
             scoringCriteria: this.props.scoringCriteria,
         };
-    }
+    };
 
-    getSaveWarnings(): Array<string> {
+    getSaveWarnings: () => Array<string> = () => {
         const warnings: Array<string> = [];
         if (!this.props.question) {
             warnings.push("The question is empty");
@@ -47,7 +47,7 @@ class FreeResponseEditor extends React.Component<Props> {
             warnings.push("The question contains a widget");
         }
         return warnings;
-    }
+    };
 
     handleUpdateCharacterLimit: ChangeEventHandler<HTMLInputElement> = (e) => {
         const val = parseInt(e.target.value);
@@ -74,7 +74,7 @@ class FreeResponseEditor extends React.Component<Props> {
         });
     };
 
-    handleDeleteCriterion = (index: number) => {
+    handleDeleteCriterion: (index: number) => void = (index: number) => {
         this.props.onChange({
             scoringCriteria: this.props.scoringCriteria.filter(
                 (_, i) => i !== index,
@@ -82,13 +82,13 @@ class FreeResponseEditor extends React.Component<Props> {
         });
     };
 
-    handleAddCriterion = () => {
+    handleAddCriterion: () => void = () => {
         this.props.onChange({
             scoringCriteria: [...this.props.scoringCriteria, {text: ""}],
         });
     };
 
-    renderCriteriaList = () => {
+    renderCriteriaList: () => React.ReactNode = () => {
         const isDeletable = this.props.scoringCriteria.length > 1;
 
         return this.props.scoringCriteria.map((criterion, index) => {

--- a/packages/perseus/src/widgets/free-response/free-response.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.tsx
@@ -144,8 +144,7 @@ export default {
     accessible: true,
     displayName: "Free Response",
     widget: FreeResponse,
-    // Hides widget from content creators until full release
-    hidden: true,
+    hidden: false,
 } as WidgetExports<typeof FreeResponse>;
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
## Summary:
This commit changes the getSaveWarnings() function definition in the
Free Response widget editor to be defined using public class field syntax of
the public method syntax. Previously, `this` wasn't being bound
properly, so the function was unable to read `this.props`. Additionally,
the Free Response widget is unhidden, so that it will appear in the widgets
dropdown in the exercise editor.

The commit also adds some more type annotations and changes all methods
on the widget editor to be defined in the same way.

Issue: https://khanacademy.atlassian.net/browse/AX-1005

## Test plan:
- Load the PR's Perseus bundle in local webapp.
- Go to the exercise editor in devadmin and verify that there is a "Free Response"
  option in the "Add a widget..." dropdown.
![image](https://github.com/user-attachments/assets/41b830b1-2f63-4d43-b774-87a402f83fa5)

- Add a Free Response widget in the exercise editor and verify that it
  renders properly.
![image](https://github.com/user-attachments/assets/2e2057ba-6b58-4a7d-9ba9-be429b279eeb)