### PR TITLE
Add typesafe parser for Orderer's user input type

### DIFF
--- a/.changeset/perfect-keys-grin.md
+++ b/.changeset/perfect-keys-grin.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+Add typesafe parser for Orderer's user input type

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/orderer-user-input.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/orderer-user-input.ts
@@ -1,0 +1,5 @@
+import {array, object, string} from "../general-purpose-parsers";
+
+export const parseOrdererUserInput = object({
+    current: array(string),
+});

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/orderer-user-input.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/orderer-user-input.typetest.ts
@@ -1,0 +1,17 @@
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseOrdererUserInput} from "./orderer-user-input";
+import type {PerseusOrdererUserInput} from "../../validation.types";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
+
+type Parsed = ParsedValue<typeof parseOrdererUserInput>;
+
+summon<Parsed>() satisfies PerseusOrdererUserInput;
+summon<PerseusOrdererUserInput>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<PerseusOrdererUserInput>;


### PR DESCRIPTION
## Summary:
Add a user input parser and typetest for the Orderer widget

Issue: LEMS-3143

## Test plan:
- Confirm all checks pass
- Confirm Orderer still acts as expected using Storybook