### PR TITLE
Add typesafe parser for Input-number's user input type

### DIFF
--- a/.changeset/sixty-impalas-warn.md
+++ b/.changeset/sixty-impalas-warn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+Add typesafe parser for Input-number's user input type

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/input-number-user-input.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/input-number-user-input.ts
@@ -1,0 +1,5 @@
+import {object, string} from "../general-purpose-parsers";
+
+export const parseInputNumberUserInput = object({
+    currentValue: string,
+});

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/input-number-user-input.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/input-number-user-input.typetest.ts
@@ -1,0 +1,17 @@
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseInputNumberUserInput} from "./input-number-user-input";
+import type {PerseusInputNumberUserInput} from "../../validation.types";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
+
+type Parsed = ParsedValue<typeof parseInputNumberUserInput>;
+
+summon<Parsed>() satisfies PerseusInputNumberUserInput;
+summon<PerseusInputNumberUserInput>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<PerseusInputNumberUserInput>;


### PR DESCRIPTION
## Summary:
Add a user input type parser for the Input-number widget 

Issue: LEMS-3141

## Test plan:
- Confirm all checks pass
- Confirm widget acts as expected via Storybook