### PR TITLE
Add typesafe parser for Label-image's user input type

### DIFF
--- a/.changeset/calm-knives-behave.md
+++ b/.changeset/calm-knives-behave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+Add typesafe parser for Label-image's user input type

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/label-image-user-input.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/label-image-user-input.ts
@@ -1,0 +1,10 @@
+import {array, object, optional, string} from "../general-purpose-parsers";
+
+export const parseLabelImageUserInput = object({
+    markers: array(
+        object({
+            selected: optional(array(string)),
+            label: string,
+        }),
+    ),
+});

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/label-image-user-input.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/label-image-user-input.typetest.ts
@@ -1,0 +1,17 @@
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseLabelImageUserInput} from "./label-image-user-input";
+import type {PerseusLabelImageUserInput} from "../../validation.types";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
+
+type Parsed = ParsedValue<typeof parseLabelImageUserInput>;
+
+summon<Parsed>() satisfies PerseusLabelImageUserInput;
+summon<PerseusLabelImageUserInput>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<PerseusLabelImageUserInput>;


### PR DESCRIPTION
## Summary:
Add a user input type parser for the Label-image widget

Issue: LEMS-3135

## Test plan:
- Confirm all checks pass
- Confirm widget still acts as expected via Storybook