### PR TITLE
Remove showRationalesForCurrentlySelectedChoices and replace with showSolutions where appropriate

### DIFF
--- a/.changeset/spotty-planes-design.md
+++ b/.changeset/spotty-planes-design.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Removal of the showRationalesForCurrentlySelectedChoices option from Perseus

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -1392,55 +1392,6 @@ describe("renderer", () => {
             expect(el).not.toBeNull();
         });
 
-        it("should ask each widget to show rationales", () => {
-            // Arrange
-            const {renderer} = renderQuestion(definitionItem);
-            const widgets = renderer.findWidgets(
-                (_, info) => info.type === "definition",
-            );
-            widgets.forEach(
-                (w) =>
-                    (w.showRationalesForCurrentlySelectedChoices = jest.fn()),
-            );
-
-            // Guard: If our test data were to cause this to return an empty
-            // array, the rest of the assertions in this test would pass.
-            expect(widgets.length).toBeGreaterThan(0);
-
-            // Act
-            act(() => renderer.showRationalesForCurrentlySelectedChoices());
-
-            // Assert
-            widgets.forEach((w) =>
-                expect(
-                    w.showRationalesForCurrentlySelectedChoices,
-                ).toHaveBeenCalled(),
-            );
-        });
-
-        it("should ask each widget to deselect incorrect choices", () => {
-            // Arrange
-            const {renderer} = renderQuestion(definitionItem);
-            const widgets = renderer.findWidgets(
-                (_, info) => info.type === "definition",
-            );
-            widgets.forEach(
-                (w) => (w.deselectIncorrectSelectedChoices = jest.fn()),
-            );
-
-            // Guard: If our test data were to cause this to return an empty
-            // array, the rest of the assertions in this test would pass.
-            expect(widgets.length).toBeGreaterThan(0);
-
-            // Act
-            act(() => renderer.deselectIncorrectSelectedChoices());
-
-            // Assert
-            widgets.forEach((w) =>
-                expect(w.deselectIncorrectSelectedChoices).toHaveBeenCalled(),
-            );
-        });
-
         it("[DEPRECATED] should return user input array", async () => {
             // Arrange
             const {renderer} = renderQuestion({

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -741,38 +741,6 @@ class Renderer
     };
 
     /**
-     * Tell each of the radio widgets to show rationales for each of the
-     * currently selected choices inside of them. If the widget is correct, it
-     * shows rationales for all of the choices. This also disables interaction
-     * with the choices that we show rationales for.
-     */
-    showRationalesForCurrentlySelectedChoices: () => void = () => {
-        Object.keys(this.props.widgets).forEach((widgetId) => {
-            const widget = this.getWidgetInstance(widgetId);
-            if (widget && widget.showRationalesForCurrentlySelectedChoices) {
-                widget.showRationalesForCurrentlySelectedChoices(
-                    this._getWidgetInfo(widgetId).options,
-                );
-            }
-        });
-    };
-
-    /**
-     * Tells each of the radio widgets to deselect any of the incorrect choices
-     * that are currently selected (leaving correct choices still selected).
-     */
-    deselectIncorrectSelectedChoices: () => void = () => {
-        // TODO(emily): this has the exact same structure as
-        // showRationalesForCurrentlySelectedChoices above. Maybe DRY this up.
-        Object.keys(this.props.widgets).forEach((widgetId) => {
-            const widget = this.getWidgetInstance(widgetId);
-            if (widget && widget.deselectIncorrectSelectedChoices) {
-                widget.deselectIncorrectSelectedChoices();
-            }
-        });
-    };
-
-    /**
      * Allows inter-widget communication.
      *
      * This function yields this Renderer's own internal widgets, and it's used

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -398,14 +398,6 @@ export class ServerItemRenderer
         this.hintsRenderer.restoreSerializedState(state.hints, fireCallback);
     }
 
-    showRationalesForCurrentlySelectedChoices() {
-        this.questionRenderer.showRationalesForCurrentlySelectedChoices();
-    }
-
-    deselectIncorrectSelectedChoices() {
-        this.questionRenderer.deselectIncorrectSelectedChoices();
-    }
-
     // This must be pre-bound otherwise SvgImage's shouldComponentUpdate
     // won't behave correctly and we'll get an infinite loop.
     setAssetStatus: (assetKey: string, status: boolean) => void = (

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -27,6 +27,7 @@ import type {
     Relationship,
     LabelImageMarkerPublicData,
     PerseusLabelImageMarker,
+    ShowSolutions,
 } from "@khanacademy/perseus-core";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
 import type {Result} from "@khanacademy/wonder-blocks-data";
@@ -73,7 +74,6 @@ export interface Widget {
           }
         | boolean;
     getDOMNodeForPath?: (path: FocusPath) => Element | Text | null;
-    deselectIncorrectSelectedChoices?: () => void;
 
     /**
      * Returns widget state that can be passed back to `restoreSerializedState`
@@ -580,6 +580,7 @@ export type UniversalWidgetProps<
     onBlur: (blurPath: FocusPath) => void;
     findWidgets: (criterion: FilterCriterion) => ReadonlyArray<Widget>;
     reviewMode: boolean;
+    showSolutions?: ShowSolutions;
     onChange: ChangeHandler;
     isLastUsedWidget: boolean;
     // provided by widget-container.jsx#render()

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -99,7 +99,6 @@ export interface Widget {
     getUserInputMap?: () => UserInputMap | undefined;
     getUserInput?: () => UserInputArray | UserInput | undefined;
 
-    showRationalesForCurrentlySelectedChoices?: (options?: any) => void;
     getPromptJSON?: () => WidgetPromptJSON;
 }
 

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.stories.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.stories.tsx
@@ -1,6 +1,9 @@
 import {ArticleRendererWithDebugUI} from "../../../../../testing/article-renderer-with-debug-ui";
 
-import {article1, groupSetRadioQuestion} from "./graded-group-set.testdata";
+import {
+    article1,
+    groupSetRadioRationaleQuestion,
+} from "./graded-group-set.testdata";
 
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
@@ -20,6 +23,6 @@ export const Article1: Story = {
 
 export const GroupSetRadioQuestion: Story = {
     args: {
-        json: groupSetRadioQuestion,
+        json: groupSetRadioRationaleQuestion,
     },
 };

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.stories.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.stories.tsx
@@ -1,6 +1,6 @@
 import {ArticleRendererWithDebugUI} from "../../../../../testing/article-renderer-with-debug-ui";
 
-import {article1} from "./graded-group-set.testdata";
+import {article1, groupSetRadioQuestion} from "./graded-group-set.testdata";
 
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
@@ -15,5 +15,11 @@ type Story = StoryObj<typeof ArticleRendererWithDebugUI>;
 export const Article1: Story = {
     args: {
         json: article1,
+    },
+};
+
+export const GroupSetRadioQuestion: Story = {
+    args: {
+        json: groupSetRadioQuestion,
     },
 };

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.test.ts
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.test.ts
@@ -5,7 +5,10 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
-import {article1, groupSetRadioQuestion} from "./graded-group-set.testdata";
+import {
+    article1,
+    groupSetRadioRationaleQuestion,
+} from "./graded-group-set.testdata";
 
 import type {PerseusRenderer} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
@@ -315,7 +318,7 @@ describe("graded group widget", () => {
 
     it("should show rationales when answer is correct", async () => {
         // Arrange
-        renderQuestion(groupSetRadioQuestion);
+        renderQuestion(groupSetRadioRationaleQuestion);
 
         // Select the correct answer: "$8$" (index 2)
         await userEvent.click(screen.getAllByRole("radio")[2]);
@@ -331,7 +334,7 @@ describe("graded group widget", () => {
 
     it("should not show rationales when answer is incorrect", async () => {
         // Arrange
-        renderQuestion(groupSetRadioQuestion);
+        renderQuestion(groupSetRadioRationaleQuestion);
 
         // Select an incorrect answer: "$-8$" (index 1)
         await userEvent.click(screen.getAllByRole("radio")[1]);

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.test.ts
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.test.ts
@@ -5,7 +5,7 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
-import {article1} from "./graded-group-set.testdata";
+import {article1, groupSetRadioQuestion} from "./graded-group-set.testdata";
 
 import type {PerseusRenderer} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
@@ -310,6 +310,40 @@ describe("graded group widget", () => {
         expect(screen.getByRole("button", {name: "Explain"})).toBeVisible();
         expect(
             screen.queryByRole("button", {name: "Hide explanation"}),
+        ).not.toBeInTheDocument();
+    });
+
+    it("should show rationales when answer is correct", async () => {
+        // Arrange
+        renderQuestion(groupSetRadioQuestion);
+
+        // Select the correct answer: "$8$" (index 2)
+        await userEvent.click(screen.getAllByRole("radio")[2]);
+
+        // Act
+        await userEvent.click(screen.getByRole("button", {name: "Check"}));
+
+        // Assert
+        expect(screen.getByRole("alert", {name: "Correct"})).toBeVisible();
+        // Verify the rationale for the correct answer is shown
+        expect(screen.getByText("This is the correct answer.")).toBeVisible();
+    });
+
+    it("should not show rationales when answer is incorrect", async () => {
+        // Arrange
+        renderQuestion(groupSetRadioQuestion);
+
+        // Select an incorrect answer: "$-8$" (index 1)
+        await userEvent.click(screen.getAllByRole("radio")[1]);
+
+        // Act
+        await userEvent.click(screen.getByRole("button", {name: "Check"}));
+
+        // Assert
+        expect(screen.getByRole("alert", {name: "Incorrect"})).toBeVisible();
+        // Verify that rationales are not shown
+        expect(
+            screen.queryByText("This is not the correct answer."),
         ).not.toBeInTheDocument();
     });
 });

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.testdata.ts
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.testdata.ts
@@ -388,25 +388,25 @@ export const groupSetRadioQuestion: PerseusRenderer = {
                                         {
                                             content: "$-8$ and $8$",
                                             correct: false,
-                                            clue: "The square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number, so $x$ is equal to *only* $8$.",
+                                            clue: "This is not the correct answer.",
                                         },
                                         {
                                             content: "$-8$",
                                             correct: false,
-                                            clue: "While $(-8)^2=64$, the square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number.",
+                                            clue: "This is not the correct answer.",
                                         },
                                         {
                                             content: "$8$",
                                             correct: true,
                                             isNoneOfTheAbove: false,
-                                            clue: "$8$ is the positive square root of $64$.",
+                                            clue: "This is the correct answer.",
                                         },
                                         {
                                             content:
                                                 "No value of $x$ satisfies the equation.",
                                             correct: false,
                                             isNoneOfTheAbove: false,
-                                            clue: "$8$ satisfies the equation.",
+                                            clue: "This is not the correct answer.",
                                         },
                                     ],
                                     countChoices: false,
@@ -527,25 +527,25 @@ export const groupedRadioQuestion: PerseusRenderer = {
                                 {
                                     content: "$-8$ and $8$",
                                     correct: false,
-                                    clue: "The square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number, so $x$ is equal to *only* $8$.",
+                                    clue: "This is not the correct answer.",
                                 },
                                 {
                                     content: "$-8$",
                                     correct: false,
-                                    clue: "While $(-8)^2=64$, the square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number.",
+                                    clue: "This is not the correct answer.",
                                 },
                                 {
                                     content: "$8$",
                                     correct: true,
                                     isNoneOfTheAbove: false,
-                                    clue: "$8$ is the positive square root of $64$.",
+                                    clue: "This is the correct answer.",
                                 },
                                 {
                                     content:
                                         "No value of $x$ satisfies the equation.",
                                     correct: false,
                                     isNoneOfTheAbove: false,
-                                    clue: "$8$ satisfies the equation.",
+                                    clue: "This is not the correct answer.",
                                 },
                             ],
                             countChoices: false,

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.testdata.ts
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.testdata.ts
@@ -382,30 +382,32 @@ export const groupSetRadioRationaleQuestion: PerseusRenderer = {
                                 static: false,
                                 type: "radio",
                                 options: {
-                                    displayCount: null,
-                                    onePerLine: false,
                                     choices: [
                                         {
                                             content: "Incorrect",
                                             correct: false,
-                                            clue: "This is not the correct answer.",
+                                            rationale:
+                                                "This is not the correct answer.",
                                         },
                                         {
                                             content: "Incorrect",
                                             correct: false,
-                                            clue: "This is not the correct answer.",
+                                            rationale:
+                                                "This is not the correct answer.",
                                         },
                                         {
                                             content: "Correct",
                                             correct: true,
                                             isNoneOfTheAbove: false,
-                                            clue: "This is the correct answer.",
+                                            rationale:
+                                                "This is the correct answer.",
                                         },
                                         {
                                             content: "Incorrect",
                                             correct: false,
                                             isNoneOfTheAbove: false,
-                                            clue: "This is not the correct answer.",
+                                            rationale:
+                                                "This is not the correct answer.",
                                         },
                                     ],
                                     countChoices: false,
@@ -440,32 +442,34 @@ export const groupSetRadioRationaleQuestion: PerseusRenderer = {
                                 static: false,
                                 type: "radio",
                                 options: {
-                                    onePerLine: true,
-                                    displayCount: null,
                                     choices: [
                                         {
                                             content: "Hola",
                                             isNoneOfTheAbove: false,
                                             correct: true,
-                                            clue: "The Spanish-speaking countries typically say Hola.",
+                                            rationale:
+                                                "The Spanish-speaking countries typically say Hola.",
                                         },
                                         {
                                             content: "Hey",
                                             isNoneOfTheAbove: false,
                                             correct: true,
-                                            clue: "This is used to attract someone's attention.",
+                                            rationale:
+                                                "This is used to attract someone's attention.",
                                         },
                                         {
                                             content: "Hi",
                                             isNoneOfTheAbove: false,
                                             correct: true,
-                                            clue: "This is used as friendly greeting.",
+                                            rationale:
+                                                "This is used as friendly greeting.",
                                         },
                                         {
                                             content: "Goodbye",
                                             isNoneOfTheAbove: false,
                                             correct: false,
-                                            clue: "Some people like to say Goodbye.",
+                                            rationale:
+                                                "Some people like to say Goodbye.",
                                         },
                                         {
                                             content: "None of these",
@@ -520,31 +524,32 @@ export const groupedRadioQuestion: PerseusRenderer = {
                         static: false,
                         type: "radio",
                         options: {
-                            displayCount: null,
-                            onePerLine: false,
                             choices: [
                                 {
                                     content: "$-8$ and $8$",
                                     correct: false,
-                                    clue: "This is not the correct answer.",
+                                    rationale:
+                                        "This is not the correct answer.",
                                 },
                                 {
                                     content: "$-8$",
                                     correct: false,
-                                    clue: "This is not the correct answer.",
+                                    rationale:
+                                        "This is not the correct answer.",
                                 },
                                 {
                                     content: "$8$",
                                     correct: true,
                                     isNoneOfTheAbove: false,
-                                    clue: "This is the correct answer.",
+                                    rationale: "This is the correct answer.",
                                 },
                                 {
                                     content:
                                         "No value of $x$ satisfies the equation.",
                                     correct: false,
                                     isNoneOfTheAbove: false,
-                                    clue: "This is not the correct answer.",
+                                    rationale:
+                                        "This is not the correct answer.",
                                 },
                             ],
                             countChoices: false,

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.testdata.ts
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.testdata.ts
@@ -354,3 +354,216 @@ export const article1: PerseusRenderer = {
         },
     },
 };
+
+export const groupSetRadioQuestion: PerseusRenderer = {
+    content:
+        "#Section 1: Adding tenths less than one\n\n[[☃ graded-group-set 1]]\n\n\nBeautiful, let's move on to problems with whole numbers and tenths.",
+    images: {},
+    widgets: {
+        "graded-group-set 1": {
+            type: "graded-group-set",
+            alignment: "default",
+            static: false,
+            graded: true,
+            options: {
+                gradedGroups: [
+                    {
+                        title: "Question 1",
+                        content:
+                            "Which of the following values of $x$ satisfies the equation $\\sqrt{64}=x$ ?\n\n[[\u2603 radio 1]]\n\n",
+                        images: {},
+                        widgets: {
+                            "radio 1": {
+                                graded: true,
+                                version: {
+                                    major: 1,
+                                    minor: 0,
+                                },
+                                static: false,
+                                type: "radio",
+                                options: {
+                                    displayCount: null,
+                                    onePerLine: false,
+                                    choices: [
+                                        {
+                                            content: "$-8$ and $8$",
+                                            correct: false,
+                                            clue: "The square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number, so $x$ is equal to *only* $8$.",
+                                        },
+                                        {
+                                            content: "$-8$",
+                                            correct: false,
+                                            clue: "While $(-8)^2=64$, the square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number.",
+                                        },
+                                        {
+                                            content: "$8$",
+                                            correct: true,
+                                            isNoneOfTheAbove: false,
+                                            clue: "$8$ is the positive square root of $64$.",
+                                        },
+                                        {
+                                            content:
+                                                "No value of $x$ satisfies the equation.",
+                                            correct: false,
+                                            isNoneOfTheAbove: false,
+                                            clue: "$8$ satisfies the equation.",
+                                        },
+                                    ],
+                                    countChoices: false,
+                                    hasNoneOfTheAbove: false,
+                                    multipleSelect: false,
+                                    randomize: false,
+                                    deselectEnabled: false,
+                                },
+                                alignment: "default",
+                            },
+                        },
+                        hint: {
+                            content: "This is an example hint.",
+                            images: {},
+                            widgets: {},
+                        },
+                        widgetEnabled: true,
+                        immutableWidgets: false,
+                    },
+                    {
+                        title: "Question 2",
+                        content:
+                            "What are some ways to say hello?\n\n[[\u2603 radio 1]]",
+                        images: {},
+                        widgets: {
+                            "radio 1": {
+                                graded: true,
+                                version: {
+                                    major: 1,
+                                    minor: 0,
+                                },
+                                static: false,
+                                type: "radio",
+                                options: {
+                                    onePerLine: true,
+                                    displayCount: null,
+                                    choices: [
+                                        {
+                                            content: "Hola",
+                                            isNoneOfTheAbove: false,
+                                            correct: true,
+                                            clue: "The Spanish-speaking countries typically say Hola.",
+                                        },
+                                        {
+                                            content: "Hey",
+                                            isNoneOfTheAbove: false,
+                                            correct: true,
+                                            clue: "This is used to attract someone's attention.",
+                                        },
+                                        {
+                                            content: "Hi",
+                                            isNoneOfTheAbove: false,
+                                            correct: true,
+                                            clue: "This is used as friendly greeting.",
+                                        },
+                                        {
+                                            content: "Goodbye",
+                                            isNoneOfTheAbove: false,
+                                            correct: false,
+                                            clue: "Some people like to say Goodbye.",
+                                        },
+                                        {
+                                            content: "None of these",
+                                            isNoneOfTheAbove: true,
+                                            correct: false,
+                                        },
+                                    ],
+                                    hasNoneOfTheAbove: true,
+                                    multipleSelect: true,
+                                    randomize: false,
+                                    deselectEnabled: false,
+                                },
+                                alignment: "default",
+                            },
+                        },
+                        hint: {
+                            content: "This is an example hint.",
+                            images: {},
+                            widgets: {},
+                        },
+                        widgetEnabled: true,
+                        immutableWidgets: false,
+                    },
+                ],
+            },
+            version: {major: 0, minor: 0},
+        },
+    },
+};
+
+export const groupedRadioQuestion: PerseusRenderer = {
+    content: "---\n\n##Check your understanding!\n\n[[☃ graded-group 1]]\n\n",
+    images: {},
+    widgets: {
+        "graded-group 1": {
+            type: "graded-group",
+            alignment: "default",
+            static: false,
+            graded: true,
+            options: {
+                title: "Metabolic strategies of bacteria",
+                content:
+                    "Which of the following values of $x$ satisfies the equation $\\sqrt{64}=x$ ?\n\n[[\u2603 radio 1]]\n\n",
+                images: {},
+                widgets: {
+                    "radio 1": {
+                        graded: true,
+                        version: {
+                            major: 1,
+                            minor: 0,
+                        },
+                        static: false,
+                        type: "radio",
+                        options: {
+                            displayCount: null,
+                            onePerLine: false,
+                            choices: [
+                                {
+                                    content: "$-8$ and $8$",
+                                    correct: false,
+                                    clue: "The square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number, so $x$ is equal to *only* $8$.",
+                                },
+                                {
+                                    content: "$-8$",
+                                    correct: false,
+                                    clue: "While $(-8)^2=64$, the square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number.",
+                                },
+                                {
+                                    content: "$8$",
+                                    correct: true,
+                                    isNoneOfTheAbove: false,
+                                    clue: "$8$ is the positive square root of $64$.",
+                                },
+                                {
+                                    content:
+                                        "No value of $x$ satisfies the equation.",
+                                    correct: false,
+                                    isNoneOfTheAbove: false,
+                                    clue: "$8$ satisfies the equation.",
+                                },
+                            ],
+                            countChoices: false,
+                            hasNoneOfTheAbove: false,
+                            multipleSelect: false,
+                            randomize: false,
+                            deselectEnabled: false,
+                        },
+                        alignment: "default",
+                    },
+                },
+                hint: {
+                    content: "This is an example hint.",
+                    images: {},
+                    widgets: {},
+                },
+            },
+            version: {major: 0, minor: 0},
+        },
+    },
+};

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.testdata.ts
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.testdata.ts
@@ -355,7 +355,7 @@ export const article1: PerseusRenderer = {
     },
 };
 
-export const groupSetRadioQuestion: PerseusRenderer = {
+export const groupSetRadioRationaleQuestion: PerseusRenderer = {
     content:
         "#Section 1: Adding tenths less than one\n\n[[☃ graded-group-set 1]]\n\n\nBeautiful, let's move on to problems with whole numbers and tenths.",
     images: {},
@@ -370,7 +370,7 @@ export const groupSetRadioQuestion: PerseusRenderer = {
                     {
                         title: "Question 1",
                         content:
-                            "Which of the following values of $x$ satisfies the equation $\\sqrt{64}=x$ ?\n\n[[\u2603 radio 1]]\n\n",
+                            "Select the correct answer.\n\n[[\u2603 radio 1]]\n\n",
                         images: {},
                         widgets: {
                             "radio 1": {
@@ -386,24 +386,23 @@ export const groupSetRadioQuestion: PerseusRenderer = {
                                     onePerLine: false,
                                     choices: [
                                         {
-                                            content: "$-8$ and $8$",
+                                            content: "Incorrect",
                                             correct: false,
                                             clue: "This is not the correct answer.",
                                         },
                                         {
-                                            content: "$-8$",
+                                            content: "Incorrect",
                                             correct: false,
                                             clue: "This is not the correct answer.",
                                         },
                                         {
-                                            content: "$8$",
+                                            content: "Correct",
                                             correct: true,
                                             isNoneOfTheAbove: false,
                                             clue: "This is the correct answer.",
                                         },
                                         {
-                                            content:
-                                                "No value of $x$ satisfies the equation.",
+                                            content: "Incorrect",
                                             correct: false,
                                             isNoneOfTheAbove: false,
                                             clue: "This is not the correct answer.",

--- a/packages/perseus/src/widgets/graded-group/graded-group.stories.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.stories.tsx
@@ -2,7 +2,10 @@ import {generateTestPerseusItem} from "@khanacademy/perseus-core";
 
 import {ServerItemRendererWithDebugUI} from "../../../../../testing/server-item-renderer-with-debug-ui";
 
-import {groupedRadioQuestion, question1} from "./graded-group.testdata";
+import {
+    groupedRadioRationaleQuestion,
+    question1,
+} from "./graded-group.testdata";
 
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
@@ -19,5 +22,9 @@ export const Question1: Story = {
 };
 
 export const WithRadioWidget: Story = {
-    args: {item: generateTestPerseusItem({question: groupedRadioQuestion})},
+    args: {
+        item: generateTestPerseusItem({
+            question: groupedRadioRationaleQuestion,
+        }),
+    },
 };

--- a/packages/perseus/src/widgets/graded-group/graded-group.stories.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.stories.tsx
@@ -2,7 +2,7 @@ import {generateTestPerseusItem} from "@khanacademy/perseus-core";
 
 import {ServerItemRendererWithDebugUI} from "../../../../../testing/server-item-renderer-with-debug-ui";
 
-import {question1} from "./graded-group.testdata";
+import {groupedRadioQuestion, question1} from "./graded-group.testdata";
 
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
@@ -16,4 +16,8 @@ type Story = StoryObj<typeof ServerItemRendererWithDebugUI>;
 
 export const Question1: Story = {
     args: {item: generateTestPerseusItem({question: question1})},
+};
+
+export const WithRadioWidget: Story = {
+    args: {item: generateTestPerseusItem({question: groupedRadioQuestion})},
 };

--- a/packages/perseus/src/widgets/graded-group/graded-group.test.ts
+++ b/packages/perseus/src/widgets/graded-group/graded-group.test.ts
@@ -162,7 +162,7 @@ describe("graded-group", () => {
             ).not.toBeInTheDocument();
         });
 
-        it("should show solutions (clues) when answer is correct", async () => {
+        it("should show rationales when answer is correct", async () => {
             // Arrange
             renderQuestion(groupedRadioQuestion);
 
@@ -180,7 +180,7 @@ describe("graded-group", () => {
             ).toBeVisible();
         });
 
-        it("should not show solutions (clues) when answer is incorrect", async () => {
+        it("should not show rationales when answer is incorrect", async () => {
             // Arrange
             renderQuestion(groupedRadioQuestion);
 

--- a/packages/perseus/src/widgets/graded-group/graded-group.test.ts
+++ b/packages/perseus/src/widgets/graded-group/graded-group.test.ts
@@ -6,7 +6,7 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
-import {question1} from "./graded-group.testdata";
+import {question1, groupedRadioQuestion} from "./graded-group.testdata";
 
 import type {APIOptions} from "../../types";
 import type {UserEvent} from "@testing-library/user-event";
@@ -159,6 +159,44 @@ describe("graded-group", () => {
             // Assert
             expect(
                 screen.queryByText(/Some bacteria synthesize their own fuel/),
+            ).not.toBeInTheDocument();
+        });
+
+        it("should show solutions (clues) when answer is correct", async () => {
+            // Arrange
+            renderQuestion(groupedRadioQuestion);
+
+            // Select the correct answer: "$8$" (index 2)
+            await userEvent.click(screen.getAllByRole("radio")[2]);
+
+            // Act
+            await checkAnswer(userEvent);
+
+            // Assert
+            expect(screen.getByRole("alert", {name: "Correct"})).toBeVisible();
+            // Verify the rationale for the correct answer is shown
+            expect(
+                screen.getByText("This is the correct answer."),
+            ).toBeVisible();
+        });
+
+        it("should not show solutions (clues) when answer is incorrect", async () => {
+            // Arrange
+            renderQuestion(groupedRadioQuestion);
+
+            // Select an incorrect answer: "$-8$" (index 1)
+            await userEvent.click(screen.getAllByRole("radio")[1]);
+
+            // Act
+            await checkAnswer(userEvent);
+
+            // Assert
+            expect(
+                screen.getByRole("alert", {name: "Incorrect"}),
+            ).toBeVisible();
+            // Verify that rationales are not shown
+            expect(
+                screen.queryByText("This is not the correct answer."),
             ).not.toBeInTheDocument();
         });
     });

--- a/packages/perseus/src/widgets/graded-group/graded-group.test.ts
+++ b/packages/perseus/src/widgets/graded-group/graded-group.test.ts
@@ -6,7 +6,10 @@ import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
 import {renderQuestion} from "../__testutils__/renderQuestion";
 
-import {question1, groupedRadioQuestion} from "./graded-group.testdata";
+import {
+    question1,
+    groupedRadioRationaleQuestion,
+} from "./graded-group.testdata";
 
 import type {APIOptions} from "../../types";
 import type {UserEvent} from "@testing-library/user-event";
@@ -164,7 +167,7 @@ describe("graded-group", () => {
 
         it("should show rationales when answer is correct", async () => {
             // Arrange
-            renderQuestion(groupedRadioQuestion);
+            renderQuestion(groupedRadioRationaleQuestion);
 
             // Select the correct answer: "$8$" (index 2)
             await userEvent.click(screen.getAllByRole("radio")[2]);
@@ -182,7 +185,7 @@ describe("graded-group", () => {
 
         it("should not show rationales when answer is incorrect", async () => {
             // Arrange
-            renderQuestion(groupedRadioQuestion);
+            renderQuestion(groupedRadioRationaleQuestion);
 
             // Select an incorrect answer: "$-8$" (index 1)
             await userEvent.click(screen.getAllByRole("radio")[1]);

--- a/packages/perseus/src/widgets/graded-group/graded-group.testdata.ts
+++ b/packages/perseus/src/widgets/graded-group/graded-group.testdata.ts
@@ -66,3 +66,74 @@ export const question1: PerseusRenderer = {
         },
     },
 };
+
+export const groupedRadioQuestion: PerseusRenderer = {
+    content: "---\n\n##Check your understanding!\n\n[[☃ graded-group 1]]\n\n",
+    images: {},
+    widgets: {
+        "graded-group 1": {
+            type: "graded-group",
+            alignment: "default",
+            static: false,
+            graded: true,
+            options: {
+                title: "Metabolic strategies of bacteria",
+                content:
+                    "Which of the following values of $x$ satisfies the equation $\\sqrt{64}=x$ ?\n\n[[\u2603 radio 1]]\n\n",
+                images: {},
+                widgets: {
+                    "radio 1": {
+                        graded: true,
+                        version: {
+                            major: 1,
+                            minor: 0,
+                        },
+                        static: false,
+                        type: "radio",
+                        options: {
+                            displayCount: null,
+                            onePerLine: false,
+                            choices: [
+                                {
+                                    content: "$-8$ and $8$",
+                                    correct: false,
+                                    clue: "The square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number, so $x$ is equal to *only* $8$.",
+                                },
+                                {
+                                    content: "$-8$",
+                                    correct: false,
+                                    clue: "While $(-8)^2=64$, the square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number.",
+                                },
+                                {
+                                    content: "$8$",
+                                    correct: true,
+                                    isNoneOfTheAbove: false,
+                                    clue: "$8$ is the positive square root of $64$.",
+                                },
+                                {
+                                    content:
+                                        "No value of $x$ satisfies the equation.",
+                                    correct: false,
+                                    isNoneOfTheAbove: false,
+                                    clue: "$8$ satisfies the equation.",
+                                },
+                            ],
+                            countChoices: false,
+                            hasNoneOfTheAbove: false,
+                            multipleSelect: false,
+                            randomize: false,
+                            deselectEnabled: false,
+                        },
+                        alignment: "default",
+                    },
+                },
+                hint: {
+                    content: "This is an example hint.",
+                    images: {},
+                    widgets: {},
+                },
+            },
+            version: {major: 0, minor: 0},
+        },
+    },
+};

--- a/packages/perseus/src/widgets/graded-group/graded-group.testdata.ts
+++ b/packages/perseus/src/widgets/graded-group/graded-group.testdata.ts
@@ -97,25 +97,25 @@ export const groupedRadioQuestion: PerseusRenderer = {
                                 {
                                     content: "$-8$ and $8$",
                                     correct: false,
-                                    clue: "The square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number, so $x$ is equal to *only* $8$.",
+                                    clue: "This is not the correct answer.",
                                 },
                                 {
                                     content: "$-8$",
                                     correct: false,
-                                    clue: "While $(-8)^2=64$, the square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number.",
+                                    clue: "This is not the correct answer.",
                                 },
                                 {
                                     content: "$8$",
                                     correct: true,
                                     isNoneOfTheAbove: false,
-                                    clue: "$8$ is the positive square root of $64$.",
+                                    clue: "This is the correct answer.",
                                 },
                                 {
                                     content:
                                         "No value of $x$ satisfies the equation.",
                                     correct: false,
                                     isNoneOfTheAbove: false,
-                                    clue: "$8$ satisfies the equation.",
+                                    clue: "This is not the correct answer.",
                                 },
                             ],
                             countChoices: false,

--- a/packages/perseus/src/widgets/graded-group/graded-group.testdata.ts
+++ b/packages/perseus/src/widgets/graded-group/graded-group.testdata.ts
@@ -91,30 +91,31 @@ export const groupedRadioRationaleQuestion: PerseusRenderer = {
                         static: false,
                         type: "radio",
                         options: {
-                            displayCount: null,
-                            onePerLine: false,
                             choices: [
                                 {
                                     content: "Incorrect",
                                     correct: false,
-                                    clue: "This is not the correct answer.",
+                                    rationale:
+                                        "This is not the correct answer.",
                                 },
                                 {
                                     content: "Incorrect",
                                     correct: false,
-                                    clue: "This is not the correct answer.",
+                                    rationale:
+                                        "This is not the correct answer.",
                                 },
                                 {
                                     content: "Correct",
                                     correct: true,
                                     isNoneOfTheAbove: false,
-                                    clue: "This is the correct answer.",
+                                    rationale: "This is the correct answer.",
                                 },
                                 {
                                     content: "Incorrect",
                                     correct: false,
                                     isNoneOfTheAbove: false,
-                                    clue: "This is not the correct answer.",
+                                    rationale:
+                                        "This is not the correct answer.",
                                 },
                             ],
                             countChoices: false,

--- a/packages/perseus/src/widgets/graded-group/graded-group.testdata.ts
+++ b/packages/perseus/src/widgets/graded-group/graded-group.testdata.ts
@@ -67,7 +67,7 @@ export const question1: PerseusRenderer = {
     },
 };
 
-export const groupedRadioQuestion: PerseusRenderer = {
+export const groupedRadioRationaleQuestion: PerseusRenderer = {
     content: "---\n\n##Check your understanding!\n\n[[☃ graded-group 1]]\n\n",
     images: {},
     widgets: {
@@ -95,24 +95,23 @@ export const groupedRadioQuestion: PerseusRenderer = {
                             onePerLine: false,
                             choices: [
                                 {
-                                    content: "$-8$ and $8$",
+                                    content: "Incorrect",
                                     correct: false,
                                     clue: "This is not the correct answer.",
                                 },
                                 {
-                                    content: "$-8$",
+                                    content: "Incorrect",
                                     correct: false,
                                     clue: "This is not the correct answer.",
                                 },
                                 {
-                                    content: "$8$",
+                                    content: "Correct",
                                     correct: true,
                                     isNoneOfTheAbove: false,
                                     clue: "This is the correct answer.",
                                 },
                                 {
-                                    content:
-                                        "No value of $x$ satisfies the equation.",
+                                    content: "Incorrect",
                                     correct: false,
                                     isNoneOfTheAbove: false,
                                     clue: "This is not the correct answer.",

--- a/packages/perseus/src/widgets/graded-group/graded-group.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.tsx
@@ -303,6 +303,9 @@ export class GradedGroup
         const readOnly =
             apiOptions.readOnly || (apiOptions.isMobile && isCorrect);
 
+        // We only want to show the solutions and rationale if the answer is correct
+        const showSolutions = isCorrect ? "all" : "none";
+
         return (
             <div className={classes}>
                 {!!this.props.title && (
@@ -319,6 +322,7 @@ export class GradedGroup
                     {...this.props}
                     ref={this.rendererRef}
                     apiOptions={{...apiOptions, readOnly}}
+                    showSolutions={showSolutions}
                     onInteractWithWidget={this._onInteractWithWidget}
                     linterContext={this.props.linterContext}
                     strings={this.context.strings}
@@ -391,6 +395,7 @@ export class GradedGroup
                                 apiOptions={apiOptions}
                                 linterContext={this.props.linterContext}
                                 strings={this.context.strings}
+                                showSolutions={showSolutions}
                             />
                         </div>
                     ) : (

--- a/packages/perseus/src/widgets/graded-group/graded-group.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.tsx
@@ -171,7 +171,6 @@ export class GradedGroup
     };
 
     _checkAnswer: () => void = () => {
-        this.rendererRef.current?.showRationalesForCurrentlySelectedChoices();
         const score: PerseusScore = this.rendererRef.current?.score() || {
             type: "invalid",
         };

--- a/packages/perseus/src/widgets/group/group.test.tsx
+++ b/packages/perseus/src/widgets/group/group.test.tsx
@@ -510,22 +510,6 @@ describe("group widget", () => {
         expect(cb).toHaveBeenCalled();
     });
 
-    it("should show rationales for contained widgets", async () => {
-        // Arrange
-        const {renderer} = renderQuestion(question1);
-        await userEvent.click(screen.getAllByRole("radio")[2]); // Incorrect!
-
-        // Act
-        act(() => renderer.showRationalesForCurrentlySelectedChoices());
-
-        // Assert
-        expect(
-            screen.getByText(
-                "Here's some rationale, this isn't the correct answer!",
-            ),
-        ).toBeInTheDocument();
-    });
-
     it("handles answerless item data", () => {
         const itemData = getSplitGroupTestItem();
 

--- a/packages/perseus/src/widgets/group/group.tsx
+++ b/packages/perseus/src/widgets/group/group.tsx
@@ -28,15 +28,12 @@ import type {
 import type {GroupPromptJSON} from "../../widget-ai-utils/group/group-ai-utils";
 import type {
     PerseusGroupWidgetOptions,
-    ShowSolutions,
     UserInputArray,
     UserInputMap,
 } from "@khanacademy/perseus-core";
 
 type RenderProps = PerseusGroupWidgetOptions; // exports has no 'transform'
-type Props = WidgetProps<RenderProps> & {
-    showSolutions?: ShowSolutions; // Provided by the renderer
-};
+type Props = WidgetProps<RenderProps>;
 type DefaultProps = {
     content: Props["content"];
     widgets: Props["widgets"];

--- a/packages/perseus/src/widgets/group/group.tsx
+++ b/packages/perseus/src/widgets/group/group.tsx
@@ -28,12 +28,15 @@ import type {
 import type {GroupPromptJSON} from "../../widget-ai-utils/group/group-ai-utils";
 import type {
     PerseusGroupWidgetOptions,
+    ShowSolutions,
     UserInputArray,
     UserInputMap,
 } from "@khanacademy/perseus-core";
 
 type RenderProps = PerseusGroupWidgetOptions; // exports has no 'transform'
-type Props = WidgetProps<RenderProps>;
+type Props = WidgetProps<RenderProps> & {
+    showSolutions?: ShowSolutions; // Provided by the renderer
+};
 type DefaultProps = {
     content: Props["content"];
     widgets: Props["widgets"];
@@ -187,6 +190,7 @@ class Group extends React.Component<Props> implements Widget {
                     apiOptions={apiOptions}
                     findExternalWidgets={this.props.findWidgets}
                     reviewMode={this.props.reviewMode}
+                    showSolutions={this.props.showSolutions}
                     onInteractWithWidget={onInteractWithWidget}
                     linterContext={this.props.linterContext}
                     strings={this.context.strings}

--- a/packages/perseus/src/widgets/group/group.tsx
+++ b/packages/perseus/src/widgets/group/group.tsx
@@ -119,10 +119,6 @@ class Group extends React.Component<Props> implements Widget {
         this.rendererRef?.blurPath(path);
     };
 
-    showRationalesForCurrentlySelectedChoices: () => void = () => {
-        this.rendererRef?.showRationalesForCurrentlySelectedChoices();
-    };
-
     render(): React.ReactNode {
         const apiOptions: APIOptions = {
             ...ApiOptions.defaults,

--- a/packages/perseus/src/widgets/label-image/__tests__/label-image.test.ts
+++ b/packages/perseus/src/widgets/label-image/__tests__/label-image.test.ts
@@ -52,6 +52,136 @@ describe("LabelImage", function () {
         ) as jest.Mock;
     });
 
+    describe("getUpdatedMarkerState", function () {
+        it("should return original marker when feedback is not shown", function () {
+            // Arrange
+            const {renderer} = renderQuestion(shortTextQuestion);
+            const widget = renderer.findWidgets("label-image")[0] as LabelImage;
+
+            const marker: OptionalAnswersMarkerType = {
+                label: "Test marker",
+                x: 50,
+                y: 50,
+                selected: ["User Choice"],
+                answers: ["Correct Answer"],
+            };
+
+            // Act
+            const result = widget.getUpdatedMarkerState(marker);
+
+            // Assert - Should return unchanged since showSolutions and reviewMode are false
+            expect(result).toEqual(marker);
+        });
+
+        it("should auto-select correct answers when showSolutions is 'all'", function () {
+            // Arrange
+            const {renderer} = renderQuestion(
+                shortTextQuestion,
+                {},
+                {showSolutions: "all"}, // re-render with showSolutions
+            );
+            const widget = renderer.findWidgets("label-image")[0] as LabelImage;
+
+            const marker: OptionalAnswersMarkerType = {
+                label: "Test marker",
+                x: 50,
+                y: 50,
+                selected: ["Answer C"],
+                answers: ["Answer A", "Answer B"],
+            };
+
+            // Act
+            const result = widget.getUpdatedMarkerState(marker);
+
+            // Assert
+            expect(result).toEqual({
+                ...marker,
+                selected: ["Answer A", "Answer B"],
+            });
+        });
+
+        it("should auto-select correct answers when reviewMode is true", function () {
+            // Arrange
+            const {renderer} = renderQuestion(
+                shortTextQuestion,
+                {},
+                {reviewMode: true}, // re-render with reviewMode
+            );
+            const widget = renderer.findWidgets("label-image")[0] as LabelImage;
+
+            const marker: OptionalAnswersMarkerType = {
+                label: "Test marker",
+                x: 50,
+                y: 50,
+                selected: ["Answer C"],
+                answers: ["Answer A", "Answer B"],
+            };
+
+            // Act
+            const result = widget.getUpdatedMarkerState(marker);
+
+            // Assert
+            expect(result).toEqual({
+                ...marker,
+                selected: ["Answer A", "Answer B"],
+            });
+        });
+
+        it("should clear selection for answerless markers when showing feedback", function () {
+            // Arrange
+            const {renderer} = renderQuestion(
+                shortTextQuestion,
+                {},
+                {showSolutions: "all"}, // re-render with showSolutions
+            );
+            const widget = renderer.findWidgets("label-image")[0] as LabelImage;
+
+            const marker: OptionalAnswersMarkerType = {
+                label: "Test marker",
+                x: 50,
+                y: 50,
+                selected: ["Some Choice"],
+                // No answers property - this is an answerless marker
+            };
+
+            // Act
+            const result = widget.getUpdatedMarkerState(marker);
+
+            // Assert
+            expect(result).toEqual({
+                ...marker,
+                selected: undefined,
+            });
+        });
+
+        it("should handle markers with empty answers array", function () {
+            // Arrange
+            const {renderer} = renderQuestion(
+                shortTextQuestion,
+                {},
+                {reviewMode: true}, // re-render with reviewMode
+            );
+            const widget = renderer.findWidgets("label-image")[0] as LabelImage;
+
+            const marker: OptionalAnswersMarkerType = {
+                label: "Test marker",
+                x: 50,
+                y: 50,
+                selected: ["User Choice"],
+                answers: [],
+            };
+
+            // Act
+            const result = widget.getUpdatedMarkerState(marker);
+
+            // Assert
+            expect(result).toEqual({
+                ...marker,
+                selected: [],
+            });
+        });
+    });
+
     describe("imageSideForMarkerPosition", function () {
         it("should return side: top", function () {
             expect(

--- a/packages/perseus/src/widgets/label-image/__tests__/label-image.test.ts
+++ b/packages/perseus/src/widgets/label-image/__tests__/label-image.test.ts
@@ -13,7 +13,7 @@ import {
 import * as Dependencies from "../../../dependencies";
 import {scorePerseusItemTesting} from "../../../util/test-utils";
 import {renderQuestion} from "../../__testutils__/renderQuestion";
-import {LabelImage} from "../label-image";
+import {LabelImage, getUpdatedMarkerState} from "../label-image";
 
 import {shortTextQuestion, textQuestion} from "./label-image.testdata";
 
@@ -55,9 +55,6 @@ describe("LabelImage", function () {
     describe("getUpdatedMarkerState", function () {
         it("should return original marker when feedback is not shown", function () {
             // Arrange
-            const {renderer} = renderQuestion(shortTextQuestion);
-            const widget = renderer.findWidgets("label-image")[0] as LabelImage;
-
             const marker: OptionalAnswersMarkerType = {
                 label: "Test marker",
                 x: 50,
@@ -65,9 +62,15 @@ describe("LabelImage", function () {
                 selected: ["User Choice"],
                 answers: ["Correct Answer"],
             };
+            const reviewMode = false;
+            const showSolutions = undefined;
 
             // Act
-            const result = widget.getUpdatedMarkerState(marker);
+            const result = getUpdatedMarkerState(
+                marker,
+                reviewMode,
+                showSolutions,
+            );
 
             // Assert - Should return unchanged since showSolutions and reviewMode are false
             expect(result).toEqual(marker);
@@ -75,13 +78,6 @@ describe("LabelImage", function () {
 
         it("should auto-select correct answers when showSolutions is 'all'", function () {
             // Arrange
-            const {renderer} = renderQuestion(
-                shortTextQuestion,
-                {},
-                {showSolutions: "all"}, // re-render with showSolutions
-            );
-            const widget = renderer.findWidgets("label-image")[0] as LabelImage;
-
             const marker: OptionalAnswersMarkerType = {
                 label: "Test marker",
                 x: 50,
@@ -89,9 +85,15 @@ describe("LabelImage", function () {
                 selected: ["Answer C"],
                 answers: ["Answer A", "Answer B"],
             };
+            const reviewMode = false;
+            const showSolutions = "all";
 
             // Act
-            const result = widget.getUpdatedMarkerState(marker);
+            const result = getUpdatedMarkerState(
+                marker,
+                reviewMode,
+                showSolutions,
+            );
 
             // Assert
             expect(result).toEqual({
@@ -102,13 +104,6 @@ describe("LabelImage", function () {
 
         it("should auto-select correct answers when reviewMode is true", function () {
             // Arrange
-            const {renderer} = renderQuestion(
-                shortTextQuestion,
-                {},
-                {reviewMode: true}, // re-render with reviewMode
-            );
-            const widget = renderer.findWidgets("label-image")[0] as LabelImage;
-
             const marker: OptionalAnswersMarkerType = {
                 label: "Test marker",
                 x: 50,
@@ -116,9 +111,15 @@ describe("LabelImage", function () {
                 selected: ["Answer C"],
                 answers: ["Answer A", "Answer B"],
             };
+            const reviewMode = true;
+            const showSolutions = undefined;
 
             // Act
-            const result = widget.getUpdatedMarkerState(marker);
+            const result = getUpdatedMarkerState(
+                marker,
+                reviewMode,
+                showSolutions,
+            );
 
             // Assert
             expect(result).toEqual({
@@ -129,13 +130,6 @@ describe("LabelImage", function () {
 
         it("should clear selection for answerless markers when showing feedback", function () {
             // Arrange
-            const {renderer} = renderQuestion(
-                shortTextQuestion,
-                {},
-                {showSolutions: "all"}, // re-render with showSolutions
-            );
-            const widget = renderer.findWidgets("label-image")[0] as LabelImage;
-
             const marker: OptionalAnswersMarkerType = {
                 label: "Test marker",
                 x: 50,
@@ -143,9 +137,15 @@ describe("LabelImage", function () {
                 selected: ["Some Choice"],
                 // No answers property - this is an answerless marker
             };
+            const reviewMode = false;
+            const showSolutions = "all";
 
             // Act
-            const result = widget.getUpdatedMarkerState(marker);
+            const result = getUpdatedMarkerState(
+                marker,
+                reviewMode,
+                showSolutions,
+            );
 
             // Assert
             expect(result).toEqual({
@@ -156,13 +156,6 @@ describe("LabelImage", function () {
 
         it("should handle markers with empty answers array", function () {
             // Arrange
-            const {renderer} = renderQuestion(
-                shortTextQuestion,
-                {},
-                {reviewMode: true}, // re-render with reviewMode
-            );
-            const widget = renderer.findWidgets("label-image")[0] as LabelImage;
-
             const marker: OptionalAnswersMarkerType = {
                 label: "Test marker",
                 x: 50,
@@ -170,9 +163,15 @@ describe("LabelImage", function () {
                 selected: ["User Choice"],
                 answers: [],
             };
+            const reviewMode = true;
+            const showSolutions = undefined;
 
             // Act
-            const result = widget.getUpdatedMarkerState(marker);
+            const result = getUpdatedMarkerState(
+                marker,
+                reviewMode,
+                showSolutions,
+            );
 
             // Assert
             expect(result).toEqual({

--- a/packages/perseus/src/widgets/label-image/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image/label-image.tsx
@@ -529,13 +529,6 @@ export class LabelImage
                     hasAnswers: false,
                     isCorrect: false,
                 };
-                // For markers without answers, mark as correct when showing feedback
-                if (
-                    this.props.showSolutions === "all" ||
-                    this.props.reviewMode
-                ) {
-                    score.isCorrect = true;
-                }
             }
 
             // Once the question has been answered or skipped, show the markers

--- a/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
@@ -167,24 +167,6 @@ describe("Radio Widget", () => {
                     expect(gotFocus).toBe(true);
                 });
 
-                it("should deselect incorrect selected choices", async () => {
-                    // Arrange
-                    const {renderer} = renderQuestion(question, apiOptions, {
-                        reviewMode,
-                    });
-
-                    // Act
-                    // Since this is a single-select setup, just select the first
-                    // incorrect choice.
-                    await selectOption(userEvent, incorrect[0]);
-                    act(() => renderer.deselectIncorrectSelectedChoices());
-
-                    // Assert
-                    screen.getAllByRole("radio").forEach((r) => {
-                        expect(r).not.toBeChecked();
-                    });
-                });
-
                 it("should disable all radio inputs when static is true", async () => {
                     // Arrange
                     const staticQuestion = {
@@ -407,35 +389,6 @@ describe("Radio Widget", () => {
                 const passageRefRadio = screen.getAllByRole("listitem")[0];
                 expect(passageRefRadio).toHaveTextContent("lines 1–2");
             });
-        });
-
-        it("should render rationales for selected choices using method", async () => {
-            // Arrange
-            const {renderer} = renderQuestion(question, apiOptions);
-
-            // Act
-            await selectOption(userEvent, incorrect[0]);
-            act(() => renderer.showRationalesForCurrentlySelectedChoices());
-
-            // Assert
-            expect(
-                screen.queryAllByTestId(/perseus-radio-rationale-content/),
-            ).toHaveLength(1);
-        });
-
-        it("should render rationales for selected choices using prop", async () => {
-            // Arrange
-            const {rerender} = renderQuestion(question, apiOptions);
-
-            // Act
-            await selectOption(userEvent, incorrect[0]);
-
-            rerender(question, {showSolutions: "selected"});
-
-            // Assert
-            expect(
-                screen.queryAllByTestId(/perseus-radio-rationale-content/),
-            ).toHaveLength(1);
         });
 
         it("should render all rationales when showSolutions is 'all'", async () => {

--- a/packages/perseus/src/widgets/radio/radio-component.tsx
+++ b/packages/perseus/src/widgets/radio/radio-component.tsx
@@ -14,7 +14,6 @@ import type {WidgetProps, ChoiceState, Widget} from "../../types";
 import type {RadioPromptJSON} from "../../widget-ai-utils/radio/radio-ai-utils";
 import type {
     PerseusRadioChoice,
-    ShowSolutions,
     PerseusRadioRubric,
     PerseusRadioUserInput,
 } from "@khanacademy/perseus-core";
@@ -28,7 +27,6 @@ export type RenderProps = {
     deselectEnabled?: boolean;
     choices: RadioChoiceWithMetadata[];
     selectedChoices: PerseusRadioChoice["correct"][];
-    showSolutions?: ShowSolutions;
     choiceStates?: ChoiceState[];
     // Depreciated; support for legacy way of handling changes
     // Adds proptype for prop that is used but was lacking type
@@ -244,32 +242,6 @@ class Radio extends React.Component<Props> implements Widget {
         const userInput = Radio.getUserInputFromProps(this.props, false);
         return _getPromptJSON(this.props, userInput);
     }
-
-    /**
-     * Deselects any currently-selected choices that are not correct choices.
-     */
-    deselectIncorrectSelectedChoices: () => void = () => {
-        if (this.props.choiceStates) {
-            const newStates: ReadonlyArray<ChoiceState> =
-                this.props.choiceStates.map(
-                    (state: ChoiceState, i): ChoiceState => ({
-                        ...state,
-                        selected:
-                            state.selected && !!this.props.choices[i].correct,
-                        highlighted: false,
-                    }),
-                );
-
-            this.props.onChange(
-                {
-                    choiceStates: newStates,
-                },
-                // @ts-expect-error - TS2345 - Argument of type 'null' is not assignable to parameter of type '(() => unknown) | undefined'.
-                null, // cb
-                false, // silent
-            );
-        }
-    };
 
     render(): React.ReactNode {
         const {choices} = this.props;

--- a/packages/perseus/src/widgets/radio/radio.class.new.tsx
+++ b/packages/perseus/src/widgets/radio/radio.class.new.tsx
@@ -9,7 +9,6 @@ import type {WidgetProps, ChoiceState, Widget} from "../../types";
 import type {RadioPromptJSON} from "../../widget-ai-utils/radio/radio-ai-utils";
 import type {
     PerseusRadioChoice,
-    ShowSolutions,
     PerseusRadioRubric,
     PerseusRadioUserInput,
 } from "@khanacademy/perseus-core";
@@ -23,7 +22,6 @@ export type RenderProps = {
     deselectEnabled?: boolean;
     choices: ReadonlyArray<RadioChoiceWithMetadata>;
     selectedChoices: ReadonlyArray<PerseusRadioChoice["correct"]>;
-    showSolutions?: ShowSolutions;
     choiceStates?: ReadonlyArray<ChoiceState>;
     // Depreciated; support for legacy way of handling changes
     // Adds proptype for prop that is used but was lacking type
@@ -117,31 +115,6 @@ class Radio extends React.Component<Props> implements Widget {
         const userInput = Radio.getUserInputFromProps(this.props, false);
         return _getPromptJSON(this.props, userInput);
     }
-
-    /**
-     * Deselects any currently-selected choices that are not correct choices.
-     */
-    deselectIncorrectSelectedChoices: () => void = () => {
-        if (this.props.choiceStates) {
-            const newStates: ReadonlyArray<ChoiceState> =
-                this.props.choiceStates.map(
-                    (state: ChoiceState, i): ChoiceState => ({
-                        ...state,
-                        selected:
-                            state.selected && !!this.props.choices[i].correct,
-                        highlighted: false,
-                    }),
-                );
-
-            this.props.onChange(
-                {
-                    choiceStates: newStates,
-                },
-                () => {}, // cb
-                false, // silent
-            );
-        }
-    };
 
     render(): React.ReactNode {
         return <RadioComponent {...this.props} />;

--- a/packages/perseus/src/widgets/radio/radio.class.new.tsx
+++ b/packages/perseus/src/widgets/radio/radio.class.new.tsx
@@ -1,5 +1,4 @@
 import {linterContextDefault} from "@khanacademy/perseus-linter";
-import {scoreRadio} from "@khanacademy/perseus-score";
 import * as React from "react";
 
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/radio/radio-ai-utils";
@@ -13,7 +12,6 @@ import type {
     ShowSolutions,
     PerseusRadioRubric,
     PerseusRadioUserInput,
-    PerseusRadioWidgetOptions,
 } from "@khanacademy/perseus-core";
 
 // RenderProps is the return type for radio.jsx#transform
@@ -119,58 +117,6 @@ class Radio extends React.Component<Props> implements Widget {
         const userInput = Radio.getUserInputFromProps(this.props, false);
         return _getPromptJSON(this.props, userInput);
     }
-
-    /**
-     * Turn on rationale display for the currently selected choices. Note that
-     * this leaves rationales on for choices that are already showing
-     * rationales.
-     * TODO: LEMS-3077 Remove deprecated class function
-     * @deprecated Internal only. Use `showSolutions` prop instead.
-     */
-    showRationalesForCurrentlySelectedChoices: (
-        arg1: PerseusRadioWidgetOptions,
-    ) => void = (rubric) => {
-        const {choiceStates} = this.props;
-        if (choiceStates) {
-            const score = scoreRadio(this.getUserInput(), rubric);
-            const widgetCorrect =
-                score.type === "points" && score.total === score.earned;
-
-            const newStates: ReadonlyArray<ChoiceState> = choiceStates.map(
-                (state: ChoiceState): ChoiceState => ({
-                    ...state,
-                    highlighted: state.selected,
-                    // If the choice is selected, show the rationale now
-                    rationaleShown:
-                        state.selected ||
-                        // If the choice already had a rationale, keep it shown
-                        state.rationaleShown ||
-                        // If the widget is correctly answered, show the rationale
-                        // for all the choices
-                        widgetCorrect,
-                    // We use the same behavior for the readOnly flag as for
-                    // rationaleShown, but we keep it separate in case other
-                    // behaviors want to disable choices without showing rationales.
-                    readOnly:
-                        state.selected ||
-                        state.readOnly ||
-                        widgetCorrect ||
-                        this.props.showSolutions !== "none",
-                    correctnessShown: state.selected || state.correctnessShown,
-                    previouslyAnswered:
-                        state.previouslyAnswered || state.selected,
-                }),
-            );
-
-            this.props.onChange(
-                {
-                    choiceStates: newStates,
-                },
-                () => {}, // cb
-                true, // silent
-            );
-        }
-    };
 
     /**
      * Deselects any currently-selected choices that are not correct choices.

--- a/packages/perseus/src/widgets/radio/radio.new.tsx
+++ b/packages/perseus/src/widgets/radio/radio.new.tsx
@@ -29,7 +29,6 @@ export interface RenderProps {
     deselectEnabled?: boolean;
     choices: ReadonlyArray<RadioChoiceWithMetadata>;
     selectedChoices: ReadonlyArray<PerseusRadioChoice["correct"]>;
-    showSolutions?: ShowSolutions;
     choiceStates?: ReadonlyArray<ChoiceState>;
     // Depreciated; support for legacy way of handling changes
     // Adds proptype for prop that is used but was lacking type

--- a/testing/item-renderer-hooks.tsx
+++ b/testing/item-renderer-hooks.tsx
@@ -80,22 +80,10 @@ export const useItemRenderer = (
             interactionCallback: () => {
                 if (state.showPopover) {
                     dispatch({type: "TOGGLE_POPOVER", payload: false});
-                    // Only deselect incorrect choices when the score is not empty
-                    // This prevents deselection when clicking a new answer after
-                    // receiving an empty score
-                    if (state.score && !state.score.empty) {
-                        ref.current?.deselectIncorrectSelectedChoices();
-                    }
                 }
             },
         }),
-        [
-            apiOptions,
-            state.isMobile,
-            state.showPopover,
-            state.score,
-            state.showSolutions,
-        ],
+        [apiOptions, state.isMobile, state.showPopover, state.showSolutions],
     );
 
     const getScore = React.useCallback((): KEScore | undefined => {

--- a/testing/item-renderer-hooks.tsx
+++ b/testing/item-renderer-hooks.tsx
@@ -76,7 +76,7 @@ export const useItemRenderer = (
             ...apiOptions,
             isMobile: state.isMobile,
             customKeypad: state.isMobile, // Use the mobile keypad for mobile
-            showSolutions: undefined,
+            showSolutions: state.showSolutions,
             interactionCallback: () => {
                 if (state.showPopover) {
                     dispatch({type: "TOGGLE_POPOVER", payload: false});
@@ -89,7 +89,13 @@ export const useItemRenderer = (
                 }
             },
         }),
-        [apiOptions, state.isMobile, state.showPopover, state.score],
+        [
+            apiOptions,
+            state.isMobile,
+            state.showPopover,
+            state.score,
+            state.showSolutions,
+        ],
     );
 
     const getScore = React.useCallback((): KEScore | undefined => {
@@ -115,7 +121,8 @@ export const useItemRenderer = (
         );
 
         if (!keScore.empty) {
-            ref.current?.showRationalesForCurrentlySelectedChoices();
+            // Show solutions for selected answers when the score is not empty
+            dispatch({type: "SET_SHOW_SOLUTIONS", payload: "selected"});
         }
 
         return keScore;
@@ -145,6 +152,7 @@ export const useItemRenderer = (
     }, []);
 
     const handleSkip = React.useCallback(() => {
+        dispatch({type: "SET_ANSWERLESS", payload: false});
         dispatch({type: "SKIP_TO_SOLUTION"});
     }, []);
 


### PR DESCRIPTION
## History:
This PR started as part of the Radio Widget Project, and became a more holistic change to simplify Perseus. 

After much discussion across several teams, we've decided that we will now show all feedback/rationales/correctness information all at once, but only after a widget becomes "inactive" through one of these actions:
- User skips the question
- User answers correctly
- User requests hints (effectively skipping)
- Content Creator enables static mode

Previously, we were selectively showing rationals to users while they were still able to interact with the widgets — a feature which was causing several bugs across the widgets that supported it: 

- Radio Widget 
- Graded Group Widget 
- Label Image Widget 

This move allows us to:

- Solve numerous bugs/tickets in one fell swoop 
  - LEMS-3076, [LEMS-1243](https://khanacademy.atlassian.net/browse/LEMS-1243), [LEMS-279](https://khanacademy.atlassian.net/browse/LEMS-279), [LEMS-1222](https://khanacademy.atlassian.net/browse/LEMS-1222), [LEMS-256](https://khanacademy.atlassian.net/browse/LEMS-256), [LEMS-1987](https://khanacademy.atlassian.net/browse/LEMS-1987), [LEMS-3075](https://khanacademy.atlassian.net/browse/LEMS-3075)
- Provide a clearer and more consistent to our users across our Perseus widgets 
- Better align with upcoming SSS/Future Initiative goals 

## What's changed:

This PR accomplishes the following tasks:

1. Removes `showRationalesForCurrentlySelectedChoices` across Perseus, fully deprecating the feature. 
2. Fixes a bug in the Label Image Widget where the widget was still interactable when in "reviewMode".  Now the widget will correctly become non-interactive while auto-selecting the correct answers to provide the same holistic feedback as the other Perseus Widgets. 
3. Added `showSolutions` to Graded Group widgets so that the rationales can show when the user gets the correct answer. 
4. Adds several tests to help verify changes 

## Upstream requirements: 
A draft PR has been created for our platform to remove all calls to `showRationalesForCurrentlySelectedChoices` from the main repo as well. 

While the mobile repository does contain some old references to this feature, the entire parent folder (webview) is now unused and will be removed in a future release. 

Issue: LEMS-3077

## Test plan:
- Manual testing 
- Full QA Testing Review (Upcoming), which will include both the Perseus and upstream changes 
- New Tests

[LEMS-1243]: https://khanacademy.atlassian.net/browse/LEMS-1243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LEMS-279]: https://khanacademy.atlassian.net/browse/LEMS-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LEMS-1222]: https://khanacademy.atlassian.net/browse/LEMS-1222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LEMS-256]: https://khanacademy.atlassian.net/browse/LEMS-256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ