### PR TITLE
docs(changeset): Move traversal tests from perseus-editor and perseus into perseus-core

### DIFF
--- a/.changeset/green-pumas-know.md
+++ b/.changeset/green-pumas-know.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": major
+---
+
+Move traversal tests from perseus-editor and perseus into perseus-core

--- a/packages/perseus-core/src/traversal.test.ts
+++ b/packages/perseus-core/src/traversal.test.ts
@@ -1,0 +1,250 @@
+import {traverse} from "./traversal";
+import {registerCoreWidgets} from "./widgets/core-widget-registry";
+
+const missingOptions = {
+    content: "[[☃ radio 1]]\n\n",
+    images: {},
+    widgets: {
+        "radio 1": {
+            type: "radio",
+            graded: true,
+            static: false,
+            options: {
+                choices: [
+                    {
+                        content: "A",
+                        correct: true,
+                    },
+                    {
+                        correct: false,
+                        content: "B",
+                    },
+                ],
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+            alignment: "default",
+        },
+    },
+} as const;
+
+const clonedMissingOptions = JSON.parse(JSON.stringify(missingOptions));
+
+const sampleOptions = {
+    content: "[[☃ mock-widget 1]]",
+    images: {},
+    widgets: {
+        "mock-widget 1": {
+            type: "mock-widget",
+            graded: true,
+            static: false,
+            options: {
+                value: "0",
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+            alignment: "default",
+        },
+    },
+} as const;
+
+const clonedSampleOptions = JSON.parse(JSON.stringify(sampleOptions));
+
+const sampleOptions2 = {
+    content: "[[☃ radio 1]]\n\n",
+    images: {},
+    widgets: {
+        "radio 1": {
+            type: "radio",
+            graded: true,
+            static: false,
+            options: {
+                choices: [
+                    {
+                        content: "A",
+                        correct: true,
+                    },
+                    {
+                        correct: false,
+                        content: "B",
+                    },
+                ],
+                randomize: false,
+                multipleSelect: false,
+                displayCount: null,
+                noneOfTheAbove: false,
+                deselectEnabled: false,
+                countChoices: false,
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+            alignment: "default",
+        },
+    },
+} as const;
+
+const clonedSampleOptions2 = JSON.parse(JSON.stringify(sampleOptions2));
+
+const sampleGroup = {
+    content: "[[☃ group 1]]\n\n",
+    images: {},
+    widgets: {
+        "group 1": {
+            type: "group",
+            graded: true,
+            static: false,
+            options: {
+                content: "[[☃ radio 1]]\n\n",
+                images: {},
+                widgets: {
+                    "radio 1": {
+                        type: "radio",
+                        graded: true,
+                        static: false,
+                        options: {
+                            choices: [
+                                {
+                                    content: "A",
+                                    correct: true,
+                                },
+                                {
+                                    correct: false,
+                                    content: "B",
+                                },
+                            ],
+                            randomize: false,
+                            multipleSelect: false,
+                            displayCount: null,
+                            noneOfTheAbove: false,
+                            deselectEnabled: false,
+                            countChoices: false,
+                        },
+                        version: {
+                            major: 0,
+                            minor: 0,
+                        },
+                        alignment: "default",
+                    },
+                },
+            },
+            version: {
+                major: 0,
+                minor: 0,
+            },
+            alignment: "default",
+        },
+    },
+} as const;
+
+const clonedSampleGroup = JSON.parse(JSON.stringify(sampleGroup));
+
+const assertNonMutative = () => {
+    expect(missingOptions).toEqual(clonedMissingOptions);
+    expect(sampleOptions).toEqual(clonedSampleOptions);
+    expect(sampleOptions2).toEqual(clonedSampleOptions2);
+    expect(sampleGroup).toEqual(clonedSampleGroup);
+};
+
+describe("Traversal", () => {
+    beforeAll(() => {
+        registerCoreWidgets();
+    });
+
+    it("should call a root level content field", () => {
+        let readContent = null;
+        traverse(sampleOptions, (content) => {
+            expect(readContent === null).toBeTruthy();
+            readContent = content;
+        });
+
+        expect(readContent).toBe("[[☃ mock-widget 1]]");
+        assertNonMutative();
+    });
+
+    it("should be able to modify root level content", () => {
+        const newOptions = traverse(sampleOptions, (content) => {
+            return "new content text";
+        });
+        expect(newOptions).toEqual({
+            ...sampleOptions,
+            content: "new content text",
+        });
+        assertNonMutative();
+    });
+
+    it("should have access to widgets", () => {
+        const widgetMap: Record<string, any> = {};
+        traverse(sampleOptions, null, (widgetInfo) => {
+            widgetMap[widgetInfo.type] = (widgetMap[widgetInfo.type] || 0) + 1;
+        });
+        expect(widgetMap).toEqual({
+            "mock-widget": 1,
+        });
+        assertNonMutative();
+    });
+
+    it("should be able to modify widgetInfo", () => {
+        const newOptions = traverse(sampleOptions, null, (widgetInfo) => {
+            return {
+                ...widgetInfo,
+                graded: false,
+            };
+        });
+        expect(newOptions).toEqual({
+            ...sampleOptions,
+            widgets: {
+                "mock-widget 1": {
+                    ...sampleOptions.widgets["mock-widget 1"],
+                    graded: false,
+                },
+            },
+        });
+        assertNonMutative();
+    });
+
+    it("should have access to modify full renderer options", () => {
+        const newOptions = traverse(sampleOptions, null, null, (options) => {
+            return {
+                ...options,
+                content: `${options.content}\n\nnew content!`,
+            };
+        });
+        expect(newOptions.content).toBe("[[☃ mock-widget 1]]\n\nnew content!");
+        expect(newOptions.widgets).toEqual(sampleOptions.widgets);
+        assertNonMutative();
+    });
+
+    it("should be able to see group widgets", () => {
+        const widgetMap: Record<string, any> = {};
+        traverse(sampleGroup, null, (widgetInfo) => {
+            widgetMap[widgetInfo.type] = (widgetMap[widgetInfo.type] || 0) + 1;
+        });
+        expect(widgetMap).toEqual({
+            group: 1,
+            radio: 1,
+        });
+        assertNonMutative();
+    });
+
+    it("should ignore widgets without a type", () => {
+        const optionsWithEmptyWidget = {
+            content: "[[☃ no-type-widget 1]]",
+            images: {},
+            widgets: {
+                "no-type-widget 1": {},
+            },
+        };
+
+        const newOptions = traverse(
+            optionsWithEmptyWidget,
+            (content) => content,
+        );
+        expect(newOptions).toEqual(optionsWithEmptyWidget);
+    });
+});

--- a/packages/perseus-core/src/widgets/core-widget-registry.test.ts
+++ b/packages/perseus-core/src/widgets/core-widget-registry.test.ts
@@ -1,18 +1,75 @@
 import * as CoreWidgetRegistry from "./core-widget-registry";
+import {registerWidget, traverseChildWidgets} from "./core-widget-registry";
+
+const registryFnNames = [
+    "isWidgetRegistered",
+    "getCurrentVersion",
+    "getPublicWidgetOptionsFunction",
+    "getWidgetOptionsUpgrades",
+    "getDefaultWidgetOptions",
+    "getSupportedAlignments",
+    "getDefaultAlignment",
+];
+
+const mockWidgetType = "_test-mock-widget_";
 
 describe("core-widget-registry", () => {
-    test.each([
-        "isWidgetRegistered",
-        "getCurrentVersion",
-        "getPublicWidgetOptionsFunction",
-        "getWidgetOptionsUpgrades",
-        "getDefaultWidgetOptions",
-        "getSupportedAlignments",
-        "getDefaultAlignment",
-    ])("%s throws when called before registerWidget", (funName) => {
-        // eslint-disable-next-line import/namespace
-        expect(() => CoreWidgetRegistry[funName]?.("radio")).toThrow(
-            "Core widget registry accessed before initialization!",
-        );
+    test.each(registryFnNames)(
+        "%s throws when called before registerWidget",
+        (fnName) => {
+            const fn = (CoreWidgetRegistry as any)[fnName];
+            expect(() => fn("radio")).toThrow(
+                "Core widget registry accessed before initialization!",
+            );
+        },
+    );
+});
+
+describe("traverseChildWidgets", () => {
+    const realTraverseChildWidgets = (options, traverseRenderer) => {
+        return {
+            ...options,
+            traversed: true,
+        };
+    };
+
+    beforeEach(() => {
+        registerWidget(mockWidgetType, {
+            name: mockWidgetType,
+            traverseChildWidgets: realTraverseChildWidgets,
+        });
+    });
+
+    it("throws if traverseRenderer is not provided", () => {
+        expect(() =>
+            traverseChildWidgets({type: "radio", options: {}}, undefined),
+        ).toThrow("traverseRenderer must be provided, but was not");
+    });
+
+    it("returns the widget unchanged if widget type is unregistered", () => {
+        const widget = {type: "non-existent-widget", options: {foo: 1}};
+        const traverseRenderer = jest.fn();
+
+        expect(traverseChildWidgets(widget, traverseRenderer)).toBe(widget);
+    });
+
+    it("returns the widget unchanged if widget has no traverseChildWidgets", () => {
+        const widget = {type: "radio", options: {foo: 1}};
+        const traverseRenderer = jest.fn();
+
+        const result = traverseChildWidgets(widget, traverseRenderer);
+        expect(result).toBe(widget);
+    });
+
+    it("calls traverseChildWidgets when defined and returns updated widget", () => {
+        const widget = {type: mockWidgetType, options: {foo: 1}};
+        const traverseRenderer = jest.fn();
+
+        const result = traverseChildWidgets(widget, traverseRenderer);
+
+        expect(result).toEqual({
+            type: mockWidgetType,
+            options: {foo: 1, traversed: true},
+        });
     });
 });

--- a/packages/perseus-core/src/widgets/core-widget-registry.ts
+++ b/packages/perseus-core/src/widgets/core-widget-registry.ts
@@ -44,7 +44,7 @@ import type {Alignment} from "../types";
 
 const widgets = new Registry<WidgetLogic>("Core widget registry");
 
-function registerWidget(type: string, logic: WidgetLogic) {
+export function registerWidget(type: string, logic: WidgetLogic) {
     widgets.set(type, logic);
 }
 


### PR DESCRIPTION
## Summary:
This change restores deleted traversal tests by migrating them into the perseus-core, including general traversal tests and the traverseChildWidgets group widget test, to maintain coverage and centralize test logic.

Issue: LEMS-3146

## Test plan: