### PR TITLE
Add typesafe parser for Iframe's user input type

### DIFF
--- a/.changeset/modern-dogs-try.md
+++ b/.changeset/modern-dogs-try.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+Add typesafe parser for Iframe's user input type

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/iframe-user-input.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/iframe-user-input.ts
@@ -1,0 +1,11 @@
+import {
+    enumeration,
+    nullable,
+    object,
+    string,
+} from "../general-purpose-parsers";
+
+export const parseIFrameUserInput = object({
+    status: enumeration("correct", "incorrect", "incomplete"),
+    message: nullable(string),
+});

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/iframe-user-input.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/iframe-user-input.typetest.ts
@@ -1,0 +1,17 @@
+import {summon} from "../general-purpose-parsers/test-helpers";
+
+import type {parseIFrameUserInput} from "./iframe-user-input";
+import type {PerseusIFrameUserInput} from "../../validation.types";
+import type {RecursiveRequired} from "../general-purpose-parsers/test-helpers";
+import type {ParsedValue} from "../parser-types";
+
+type Parsed = ParsedValue<typeof parseIFrameUserInput>;
+
+summon<Parsed>() satisfies PerseusIFrameUserInput;
+summon<PerseusIFrameUserInput>() satisfies Parsed;
+
+// The `RecursiveRequired` test ensures that any new optional properties added
+// to the types in data-schema.ts are also added to the parser.
+summon<
+    RecursiveRequired<Parsed>
+>() satisfies RecursiveRequired<PerseusIFrameUserInput>;


### PR DESCRIPTION
## Summary:
Add a user input type parser and typetest for the Iframe widget

Issue: LEMS-3133

## Test plan:
- Confirm all checks pass
- Confirm the widget still works as expected via Storybook