### PR TITLE
WIP/POC: Dropdown: store user input in Renderer state

### DIFF
--- a/.changeset/swift-pants-smash.md
+++ b/.changeset/swift-pants-smash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal, Dropdown: separate user input state from widget prop state in Renderer

--- a/packages/perseus/src/__tests__/server-item-renderer-serialization.test.ts
+++ b/packages/perseus/src/__tests__/server-item-renderer-serialization.test.ts
@@ -1,0 +1,182 @@
+import {
+    generateTestPerseusItem,
+    generateTestPerseusRenderer,
+} from "@khanacademy/perseus-core";
+import {screen, act} from "@testing-library/react";
+import {userEvent as userEventLib} from "@testing-library/user-event";
+
+import {testDependencies} from "../../../../testing/test-dependencies";
+import {itemWithMockWidget} from "../__testdata__/server-item-renderer.testdata";
+import * as Dependencies from "../dependencies";
+import {registerAllWidgetsForTesting} from "../util/register-all-widgets-for-testing";
+import {registerWidget} from "../widgets";
+import {MockWidget} from "../widgets/mock-widgets";
+
+import {renderQuestion} from "./test-util";
+
+import type {PerseusItem} from "@khanacademy/perseus-core";
+import type {UserEvent} from "@testing-library/user-event";
+
+describe("ServerItemRenderer state serialization/restoration", () => {
+    beforeAll(() => {
+        registerAllWidgetsForTesting();
+        registerWidget("mock-widget", MockWidget);
+    });
+
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    afterEach(() => {
+        // The Renderer uses a timer to wait for widgets to complete rendering.
+        // If we don't spin the timers here, then the timer fires in the test
+        // _after_ and breaks it because we do setState() in the callback,
+        // and by that point the component has been unmounted.
+        act(() => jest.runOnlyPendingTimers());
+    });
+
+    describe("MockWidget", () => {
+        it("should serialize the current state", async () => {
+            // Arrange
+            const {renderer} = renderQuestion({
+                ...itemWithMockWidget,
+                hints: [
+                    {content: "Hint #1", images: {}, widgets: {}},
+                    {content: "Hint #2", images: {}, widgets: {}},
+                    {content: "Hint #3", images: {}, widgets: {}},
+                ],
+            });
+            await userEvent.type(screen.getByRole("textbox"), "-42");
+
+            // Act
+            const state = renderer.getSerializedState();
+
+            // Assert
+            expect(state).toEqual({
+                hints: [{}, {}, {}],
+                question: {
+                    "mock-widget 1": {
+                        currentValue: "-42",
+                        value: "3",
+                    },
+                },
+            });
+        });
+
+        it("should restore serialized state", () => {
+            // Arrange
+            const callback = jest.fn();
+            const {renderer} = renderQuestion(itemWithMockWidget);
+
+            // Act
+            act(() =>
+                renderer.restoreSerializedState(
+                    {
+                        hints: [{}, {}, {}],
+                        question: {
+                            "mock-widget 1": {
+                                currentValue: "-42",
+                            },
+                        },
+                    },
+                    callback,
+                ),
+            );
+            act(() => jest.runOnlyPendingTimers());
+
+            // Assert
+            expect(callback).toHaveBeenCalled();
+            expect(screen.getByRole("textbox")).toHaveValue("-42");
+        });
+    });
+
+    describe("Dropdown", () => {
+        function generateBasicDropdown(): PerseusItem {
+            const question = generateTestPerseusRenderer({
+                content: "[[☃ dropdown 1]]",
+                widgets: {
+                    "dropdown 1": {
+                        type: "dropdown",
+                        options: {
+                            static: false,
+                            placeholder: "Choose",
+                            choices: [
+                                {
+                                    content: "Correct",
+                                    correct: true,
+                                },
+                                {
+                                    content: "Incorrect",
+                                    correct: false,
+                                },
+                            ],
+                        },
+                    },
+                },
+            });
+            const item = generateTestPerseusItem({question});
+            return item;
+        }
+
+        it("should serialize the current state", async () => {
+            // Arrange
+            const {renderer} = renderQuestion(generateBasicDropdown());
+
+            await userEvent.click(
+                screen.getByRole("combobox", {name: "Select an answer"}),
+            );
+            await userEvent.click(
+                screen.getByRole("option", {name: "Correct"}),
+            );
+
+            // Act
+            const state = renderer.getSerializedState();
+
+            // Assert
+            expect(state).toEqual({
+                question: {
+                    "dropdown 1": {
+                        choices: ["Correct", "Incorrect"],
+                        placeholder: "Choose",
+                        // selected is added to Dropdown props and
+                        // represents user input
+                        selected: 1,
+                    },
+                },
+                hints: [],
+            });
+        });
+
+        it("should restore serialized state", () => {
+            // Arrange
+            const {renderer} = renderQuestion(generateBasicDropdown());
+
+            // Act
+            act(() =>
+                renderer.restoreSerializedState({
+                    question: {
+                        "dropdown 1": {
+                            choices: ["Correct", "Incorrect"],
+                            placeholder: "Choose",
+                            selected: 2,
+                        },
+                    },
+                    hints: [],
+                }),
+            );
+
+            const userInput = renderer.getUserInput();
+
+            // Assert
+            // `value` would be 0 if we didn't properly restore serialized state
+            expect(userInput).toEqual({"dropdown 1": {value: 2}});
+        });
+    });
+});

--- a/packages/perseus/src/__tests__/test-util.tsx
+++ b/packages/perseus/src/__tests__/test-util.tsx
@@ -1,8 +1,12 @@
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import {render} from "@testing-library/react";
-import {testDependenciesV2} from "perseus/testing/test-dependencies";
 import * as React from "react";
 
+import {
+    testDependenciesV2,
+    // eslint-disable-next-line import/no-relative-packages
+} from "../../../../testing/test-dependencies";
 import WrappedServerItemRenderer from "../server-item-renderer";
 
 import type {ServerItemRenderer} from "../server-item-renderer";

--- a/packages/perseus/src/__tests__/test-util.tsx
+++ b/packages/perseus/src/__tests__/test-util.tsx
@@ -1,0 +1,45 @@
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
+import {render} from "@testing-library/react";
+import {testDependenciesV2} from "perseus/testing/test-dependencies";
+import * as React from "react";
+
+import WrappedServerItemRenderer from "../server-item-renderer";
+
+import type {ServerItemRenderer} from "../server-item-renderer";
+import type {APIOptions} from "../types";
+import type {PerseusItem} from "@khanacademy/perseus-core";
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
+
+// This looks alot like `widgets/__tests__/renderQuestion.jsx', except we use
+// the ServerItemRenderer instead of Renderer
+export const renderQuestion = (
+    question: PerseusItem,
+    apiOptions: APIOptions = Object.freeze({}),
+    optionalProps: Partial<
+        PropsFor<typeof WrappedServerItemRenderer>
+    > = Object.freeze({}),
+): {
+    container: HTMLElement;
+    renderer: ServerItemRenderer;
+} => {
+    let renderer: ServerItemRenderer | null = null;
+
+    const {container} = render(
+        <RenderStateRoot>
+            <WrappedServerItemRenderer
+                ref={(node) => (renderer = node)}
+                apiOptions={apiOptions}
+                item={question}
+                problemNum={0}
+                reviewMode={false}
+                dependencies={testDependenciesV2}
+                {...optionalProps}
+            />
+        </RenderStateRoot>,
+    );
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+    if (!renderer) {
+        throw new Error(`Failed to render!`);
+    }
+    return {container, renderer};
+};

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -658,7 +658,7 @@ class Renderer
      */
     /**
      * @deprecated and likely very broken API
-     * do not trust serializedState/restoreSerializedState
+     * [LEMS-3185] do not trust serializedState/restoreSerializedState
      */
     getSerializedState: (widgetProps?: any) => {
         [id: string]: any;
@@ -681,7 +681,7 @@ class Renderer
 
     /**
      * @deprecated and likely very broken API
-     * do not trust serializedState/restoreSerializedState
+     * [LEMS-3185] do not trust serializedState/restoreSerializedState
      */
     restoreSerializedState: (
         serializedState: SerializedState,

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -477,9 +477,12 @@ type WidgetOptions = any;
 // TODO(jeremy): Make this generic so that the WidgetOptions and output type
 // become strongly typed.
 export type WidgetTransform = (
-    arg1: WidgetOptions,
+    widgetOptions: WidgetOptions,
     strings: PerseusStrings,
     problemNumber?: number,
+    // TODO-1 make this generic so we have properly typed UserInput
+    // TODO-2 move this after `widgetOptions`
+    userInput?: UserInput,
 ) => any;
 
 export type WidgetExports<
@@ -585,6 +588,10 @@ export type UniversalWidgetProps<
     findWidgets: (criterion: FilterCriterion) => ReadonlyArray<Widget>;
     reviewMode: boolean;
     onChange: ChangeHandler;
+    // TODO: Widget should have a widget type arg,
+    // to be used to determine the return type of handleUserInput
+    handleUserInput: (newUserInput: UserInput) => void;
+    userInput: UserInput;
     isLastUsedWidget: boolean;
     // provided by widget-container.jsx#render()
     linterContext: LinterContextProps;

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -493,9 +493,6 @@ export type WidgetTransform = (
     widgetOptions: WidgetOptions,
     strings: PerseusStrings,
     problemNumber?: number,
-    // TODO-1 make this generic so we have properly typed UserInput
-    // TODO-2 move this after `widgetOptions`
-    userInput?: UserInput,
 ) => any;
 
 export type WidgetExports<

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -86,17 +86,17 @@ export interface Widget {
     // key/value list of all widget states (i think!)
     /**
      * @deprecated and likely very broken API
-     * do not trust serializedState/restoreSerializedState
+     * [LEMS-3185] do not trust serializedState/restoreSerializedState
      */
     getSerializedState?: () => SerializedState; // SUSPECT,
     /**
      * @deprecated and likely very broken API
-     * do not trust serializedState/restoreSerializedState
+     * [LEMS-3185] do not trust serializedState/restoreSerializedState
      */
     getUserInputFromSerializedState?: (state: any) => UserInput;
     /**
      * @deprecated and likely very broken API
-     * do not trust serializedState/restoreSerializedState
+     * [LEMS-3185] do not trust serializedState/restoreSerializedState
      */
     restoreSerializedState?: (props: any, callback: () => void) => any;
 

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -84,7 +84,20 @@ export interface Widget {
     // TODO(jeremy): I think this return value is wrong. The widget
     // getSerializedState should just return _its_ serialized state, not a
     // key/value list of all widget states (i think!)
+    /**
+     * @deprecated and likely very broken API
+     * do not trust serializedState/restoreSerializedState
+     */
     getSerializedState?: () => SerializedState; // SUSPECT,
+    /**
+     * @deprecated and likely very broken API
+     * do not trust serializedState/restoreSerializedState
+     */
+    getUserInputFromSerializedState?: (state: any) => UserInput;
+    /**
+     * @deprecated and likely very broken API
+     * do not trust serializedState/restoreSerializedState
+     */
     restoreSerializedState?: (props: any, callback: () => void) => any;
 
     blurInputPath?: (path: FocusPath) => void;

--- a/packages/perseus/src/widgets/dropdown/dropdown.tsx
+++ b/packages/perseus/src/widgets/dropdown/dropdown.tsx
@@ -82,7 +82,7 @@ class Dropdown extends React.Component<Props> implements Widget {
 
     /**
      * @deprecated and likely very broken API
-     * do not trust serializedState/restoreSerializedState
+     * [LEMS-3185] do not trust serializedState/restoreSerializedState
      */
     getSerializedState(): any {
         return {
@@ -94,7 +94,7 @@ class Dropdown extends React.Component<Props> implements Widget {
 
     /**
      * @deprecated and likely very broken API
-     * do not trust serializedState/restoreSerializedState
+     * [LEMS-3185] do not trust serializedState/restoreSerializedState
      */
     getUserInputFromSerializedState(serialized: any): PerseusDropdownUserInput {
         return {

--- a/packages/perseus/src/widgets/dropdown/dropdown.tsx
+++ b/packages/perseus/src/widgets/dropdown/dropdown.tsx
@@ -80,6 +80,28 @@ class Dropdown extends React.Component<Props> implements Widget {
         return _getPromptJSON(this.props, this.props.userInput);
     }
 
+    /**
+     * @deprecated and likely very broken API
+     * do not trust serializedState/restoreSerializedState
+     */
+    getSerializedState(): any {
+        return {
+            choices: this.props.choices,
+            placeholder: this.props.placeholder,
+            selected: this.props.userInput.value,
+        };
+    }
+
+    /**
+     * @deprecated and likely very broken API
+     * do not trust serializedState/restoreSerializedState
+     */
+    getUserInputFromSerializedState(serialized: any): PerseusDropdownUserInput {
+        return {
+            value: serialized.selected,
+        };
+    }
+
     render(): React.ReactNode {
         const children = [
             <OptionItem

--- a/packages/perseus/src/widgets/expression/expression.stories.tsx
+++ b/packages/perseus/src/widgets/expression/expression.stories.tsx
@@ -35,6 +35,8 @@ export const DesktopKitchenSink = (args: Story["args"]): React.ReactElement => {
                 findWidgets={(callback) => []}
                 isLastUsedWidget={false}
                 onChange={() => {}}
+                handleUserInput={() => {}}
+                userInput={{}}
                 problemNum={1}
                 static={false}
                 trackInteraction={() => {}}

--- a/packages/perseus/src/widgets/passage/__tests__/passage.test.tsx
+++ b/packages/perseus/src/widgets/passage/__tests__/passage.test.tsx
@@ -44,6 +44,8 @@ function renderPassage(
         isLastUsedWidget: false,
         onBlur: () => {},
         onChange: () => {},
+        handleUserInput: () => {},
+        userInput: {},
         onFocus: () => {},
         problemNum: 1,
         static: true,


### PR DESCRIPTION
## Summary:

Read the comments in [LEMS-3113](https://khanacademy.atlassian.net/browse/LEMS-3113) for context.

**tl;dr**

We think it would be best for SSS and Perseus as a whole if we hoisted user input state above widgets (for now, in Renderer) and to separate state from widget options. This is me experimenting with that idea for Dropdown.

**New Problem**

Right now most tests are passing ~except for serialization and restoring serialized state~ have a possible fix. As mentioned in the comments of the issue, we expected this to be a little bit of a problem and we also discovered that the serialization code is probably horribly broken. As far as we could tell, restoring serialized state doesn't go through the migration/upgrade logic so there's no way for us to handle old serialized state. This becomes even more problematic with the changes in this PR because I'm trying to split widget options from user input and historically we kind of just meshed the two of those together. Still investigating, but pushing to get thoughts/feels.

Issue: [LEMS-3185](https://khanacademy.atlassian.net/browse/LEMS-3185)

Part of [LEMS-3113](https://khanacademy.atlassian.net/browse/LEMS-3113)

[LEMS-3113]: https://khanacademy.atlassian.net/browse/LEMS-3113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LEMS-3113]: https://khanacademy.atlassian.net/browse/LEMS-3113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[LEMS-3185]: https://khanacademy.atlassian.net/browse/LEMS-3185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ