### PR TITLE
[Storybook] Fix docs (and enable TOC on stories)

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -38,8 +38,11 @@ const config: StorybookConfig = {
         // dir.
         "../packages/*/src/**/*@(.stories|.fixturestories).@(ts|tsx)",
     ],
-
-    addons: ["@storybook/addon-links", "@storybook/addon-a11y"],
+    addons: [
+        "@storybook/addon-a11y",
+        "@storybook/addon-docs",
+        "@storybook/addon-links",
+    ],
 
     // NOTE(kevinb): We customize the padding a bit so that so that stories
     // using the on-screen keypad render correctly.  Storybook adds its own

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -87,6 +87,9 @@ const preview: Preview = {
                 value,
             })),
         },
+        docs: {
+            toc: true,
+        },
     },
     tags: [
         //👇 Enables auto-generated documentation for all stories

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "@rollup/plugin-swc": "^0.4.0",
         "@sheerun/mutationobserver-shim": "^0.3.3",
         "@storybook/addon-a11y": "^9.0.4",
+        "@storybook/addon-docs": "^9.0.5",
         "@storybook/addon-links": "^9.0.4",
         "@storybook/react-vite": "^9.0.4",
         "@swc-node/register": "^1.10.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,9 @@ importers:
       '@storybook/addon-a11y':
         specifier: ^9.0.4
         version: 9.0.4(storybook@9.0.4(@testing-library/dom@10.3.1)(prettier@3.2.5))
+      '@storybook/addon-docs':
+        specifier: ^9.0.5
+        version: 9.0.5(@types/react@18.2.79)(storybook@9.0.4(@testing-library/dom@10.3.1)(prettier@3.2.5))
       '@storybook/addon-links':
         specifier: ^9.0.4
         version: 9.0.4(react@18.2.0)(storybook@9.0.4(@testing-library/dom@10.3.1)(prettier@3.2.5))
@@ -2497,6 +2500,12 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
+  '@mdx-js/react@3.1.0':
+    resolution: {integrity: sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
+
   '@napi-rs/wasm-runtime@0.2.8':
     resolution: {integrity: sha512-OBlgKdX7gin7OIq4fadsjpg+cp2ZphvAIKucHsNfTdJiqdOmOEwQd/bHi0VwNrcw5xpBJyUw6cK/QilCqy1BSg==}
 
@@ -2837,6 +2846,11 @@ packages:
     peerDependencies:
       storybook: ^9.0.4
 
+  '@storybook/addon-docs@9.0.5':
+    resolution: {integrity: sha512-1MjbYmagssswSmvmTIfw4A/4z1wW8kBkIxGVyEXLzYHyX15eRbaY4q77P6oTm3pISdFSUJ/qsFBVlkzJu3LB7A==}
+    peerDependencies:
+      storybook: ^9.0.5
+
   '@storybook/addon-links@9.0.4':
     resolution: {integrity: sha512-lvO/8wOEmhybxWBNIVbyNLy4cBYIaMFct7Mz6Yw0SxvEJoglktJt7gBAknbMN36XFJxj4bAnnPglP55s4wf7sg==}
     peerDependencies:
@@ -2857,8 +2871,20 @@ packages:
     peerDependencies:
       storybook: ^9.0.4
 
+  '@storybook/csf-plugin@9.0.5':
+    resolution: {integrity: sha512-dO+2J3GlIK1pRpXVL9CXhENwmaF0bF6jji+MtUXRHooHtbgtogaTGlYffBnIojuXHnskR6BAaMUPPLVOVY6Ctw==}
+    peerDependencies:
+      storybook: ^9.0.5
+
   '@storybook/global@5.0.0':
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+
+  '@storybook/icons@1.4.0':
+    resolution: {integrity: sha512-Td73IeJxOyalzvjQL+JXx72jlIYHgs+REaHiREOqfpo3A2AYYG71AUbcv+lg7mEDIweKVCxsMQ0UKo634c8XeA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
 
   '@storybook/react-dom-shim@9.0.4':
     resolution: {integrity: sha512-KZYb0/7VzWfCupiioFyFCITDixSeEpuww95VjanAxlwkjq78ufWZ4MnlXk9vzVDghRQN3+JoNEvTCJXN37KWjQ==}
@@ -2866,6 +2892,13 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       storybook: ^9.0.4
+
+  '@storybook/react-dom-shim@9.0.5':
+    resolution: {integrity: sha512-lMlYoiuJJm9UcUPYYkVNtJu8Xv23fMKqf0k0SF3JB/efaSiaiCNR+fH2g81FrdntOkfFU3YWQ8DUY5TYH73HeA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+      storybook: ^9.0.5
 
   '@storybook/react-vite@9.0.4':
     resolution: {integrity: sha512-0uuG+sebsBHlnM4MmKXh3r6ZbZoAMtlf5+bRQ7l5vscHd7WF28+BoCx2P55gkT7feh2919wzBmyeNCOgzsO/dA==}
@@ -3135,6 +3168,9 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/mdx@2.0.13':
+    resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
 
   '@types/minimist@1.2.2':
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
@@ -11156,6 +11192,12 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@mdx-js/react@3.1.0(@types/react@18.2.79)(react@18.3.1)':
+    dependencies:
+      '@types/mdx': 2.0.13
+      '@types/react': 18.2.79
+      react: 18.3.1
+
   '@napi-rs/wasm-runtime@0.2.8':
     dependencies:
       '@emnapi/core': 1.4.0
@@ -11453,6 +11495,19 @@ snapshots:
       axe-core: 4.10.2
       storybook: 9.0.4(@testing-library/dom@10.3.1)(prettier@3.2.5)
 
+  '@storybook/addon-docs@9.0.5(@types/react@18.2.79)(storybook@9.0.4(@testing-library/dom@10.3.1)(prettier@3.2.5))':
+    dependencies:
+      '@mdx-js/react': 3.1.0(@types/react@18.2.79)(react@18.3.1)
+      '@storybook/csf-plugin': 9.0.5(storybook@9.0.4(@testing-library/dom@10.3.1)(prettier@3.2.5))
+      '@storybook/icons': 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@storybook/react-dom-shim': 9.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.0.4(@testing-library/dom@10.3.1)(prettier@3.2.5))
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      storybook: 9.0.4(@testing-library/dom@10.3.1)(prettier@3.2.5)
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@storybook/addon-links@9.0.4(react@18.2.0)(storybook@9.0.4(@testing-library/dom@10.3.1)(prettier@3.2.5))':
     dependencies:
       '@storybook/global': 5.0.0
@@ -11472,12 +11527,28 @@ snapshots:
       storybook: 9.0.4(@testing-library/dom@10.3.1)(prettier@3.2.5)
       unplugin: 1.5.0
 
+  '@storybook/csf-plugin@9.0.5(storybook@9.0.4(@testing-library/dom@10.3.1)(prettier@3.2.5))':
+    dependencies:
+      storybook: 9.0.4(@testing-library/dom@10.3.1)(prettier@3.2.5)
+      unplugin: 1.5.0
+
   '@storybook/global@5.0.0': {}
+
+  '@storybook/icons@1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
 
   '@storybook/react-dom-shim@9.0.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@9.0.4(@testing-library/dom@10.3.1)(prettier@3.2.5))':
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+      storybook: 9.0.4(@testing-library/dom@10.3.1)(prettier@3.2.5)
+
+  '@storybook/react-dom-shim@9.0.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@9.0.4(@testing-library/dom@10.3.1)(prettier@3.2.5))':
+    dependencies:
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       storybook: 9.0.4(@testing-library/dom@10.3.1)(prettier@3.2.5)
 
   '@storybook/react-vite@9.0.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.37.0)(storybook@9.0.4(@testing-library/dom@10.3.1)(prettier@3.2.5))(typescript@5.7.2)(vite@5.1.0(@types/node@20.17.6)(less@4.2.0)(terser@5.39.1))':
@@ -11759,6 +11830,8 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/mdx@2.0.13': {}
 
   '@types/minimist@1.2.2': {}
 


### PR DESCRIPTION
## Summary:

@Third [noticed](https://github.com/Khan/perseus/pull/2543#discussion_r2132669840) that our Storybook docs weren't working anymore. This is a regression that happened during the Storybook v9 upgrade. 

This PR fixes autodocs (and enables the TOC feature which is a nice little addition). 


Issue: "none"

## Test plan:

`pnpm install; pnpm start` -> stories have a "Docs" entry again