### PR TITLE
Ensure that we properly parse any decimals in the userInput's according to the user's locale

### DIFF
--- a/.changeset/sharp-timers-notice.md
+++ b/.changeset/sharp-timers-notice.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-score": patch
+---
+
+Added a check to Numeric and Input Widgets to ensure we're parsing decimals in user input according to locale

--- a/packages/perseus-score/src/util/answer-types.ts
+++ b/packages/perseus-score/src/util/answer-types.ts
@@ -223,10 +223,10 @@ const KhanAnswerTypes = {
                     const decimal = forms.decimal(text);
                     const rounded = forms.decimal(text, 1);
                     if (
-                        (decimal[0].value != null &&
-                            decimal[0].value === rounded[0].value) ||
-                        (decimal[1].value != null &&
-                            decimal[1].value === rounded[1].value)
+                        (decimal[0]?.value != null &&
+                            decimal[0].value === rounded[0]?.value) ||
+                        (decimal[1]?.value != null &&
+                            decimal[1].value === rounded[1]?.value)
                     ) {
                         return decimal;
                     }
@@ -540,10 +540,14 @@ const KhanAnswerTypes = {
                         return normal(text);
                     };
 
-                    return [
-                        {value: normal(text), exact: true},
-                        {value: commas(text), exact: true},
-                    ];
+                    const results = [{value: normal(text), exact: true}];
+
+                    // Only include the comma interpretation if the locale uses commas as decimal separators
+                    if (options.decimal_separator === ",") {
+                        results.push({value: commas(text), exact: true});
+                    }
+
+                    return results;
                 },
             } as const;
 

--- a/packages/perseus-score/src/util/answer-types.ts
+++ b/packages/perseus-score/src/util/answer-types.ts
@@ -225,6 +225,8 @@ const KhanAnswerTypes = {
                     if (
                         (decimal[0]?.value != null &&
                             decimal[0].value === rounded[0]?.value) ||
+                        // decimal[1] may be undefined if the user is not in a locale that
+                        // supports commas as decimal separators.
                         (decimal[1]?.value != null &&
                             decimal[1].value === rounded[1]?.value)
                     ) {

--- a/packages/perseus-score/src/widgets/input-number/score-input-number.test.ts
+++ b/packages/perseus-score/src/widgets/input-number/score-input-number.test.ts
@@ -126,4 +126,61 @@ describe("scoreInputNumber", () => {
             type: "invalid",
         });
     });
+
+    it("should not consider commas as a decimal separator in the US locale", () => {
+        const rubric: PerseusInputNumberRubric = {
+            maxError: 0.1,
+            inexact: false,
+            value: 16,
+            simplify: "optional",
+            answerType: "number",
+        };
+
+        const userInput: PerseusInputNumberUserInput = {
+            currentValue: "16,000",
+        };
+
+        const score = scoreInputNumber(userInput, rubric, "en");
+
+        expect(score).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("should consider commas as a decimal separator in the French locale", () => {
+        const rubric: PerseusInputNumberRubric = {
+            maxError: 0.1,
+            inexact: false,
+            value: 16.5,
+            simplify: "optional",
+            answerType: "decimal",
+        };
+
+        const userInput: PerseusInputNumberUserInput = {
+            currentValue: "16,5",
+        };
+
+        // Using French locale where comma is decimal separator
+        const score = scoreInputNumber(userInput, rubric, "fr");
+
+        expect(score).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("should reject European decimal format in US locale", () => {
+        const rubric: PerseusInputNumberRubric = {
+            maxError: 0.1,
+            inexact: false,
+            value: 16.5,
+            simplify: "optional",
+            answerType: "decimal",
+        };
+
+        const userInput: PerseusInputNumberUserInput = {
+            currentValue: "16,5",
+        };
+
+        // Using US locale where comma is thousands separator
+        const score = scoreInputNumber(userInput, rubric, "en");
+
+        // "16,5" is invalid input in US locale (not a recognized number format)
+        expect(score).toHaveInvalidInput("EXTRA_SYMBOLS_ERROR");
+    });
 });

--- a/packages/perseus-score/src/widgets/input-number/score-input-number.test.ts
+++ b/packages/perseus-score/src/widgets/input-number/score-input-number.test.ts
@@ -127,7 +127,7 @@ describe("scoreInputNumber", () => {
         });
     });
 
-    it("should not consider commas as a decimal separator in the US locale", () => {
+    it("should not consider commas as a decimal separator in the EN locale", () => {
         const rubric: PerseusInputNumberRubric = {
             maxError: 0.1,
             inexact: false,
@@ -145,7 +145,27 @@ describe("scoreInputNumber", () => {
         expect(score).toHaveBeenAnsweredIncorrectly();
     });
 
-    it("should consider commas as a decimal separator in the French locale", () => {
+    it("should reject European decimal format in EN locale", () => {
+        const rubric: PerseusInputNumberRubric = {
+            maxError: 0.1,
+            inexact: false,
+            value: 16.5,
+            simplify: "optional",
+            answerType: "decimal",
+        };
+
+        const userInput: PerseusInputNumberUserInput = {
+            currentValue: "16,5",
+        };
+
+        // Using US locale where comma is thousands separator
+        const score = scoreInputNumber(userInput, rubric, "en");
+
+        // "16,5" is invalid input in US locale (not a recognized number format)
+        expect(score).toHaveInvalidInput("EXTRA_SYMBOLS_ERROR");
+    });
+
+    it("should consider commas as the decimal separator in the FR locale", () => {
         const rubric: PerseusInputNumberRubric = {
             maxError: 0.1,
             inexact: false,
@@ -164,7 +184,7 @@ describe("scoreInputNumber", () => {
         expect(score).toHaveBeenAnsweredCorrectly();
     });
 
-    it("should reject European decimal format in US locale", () => {
+    it("should consider decimals as the thousands separator in FR locale", () => {
         const rubric: PerseusInputNumberRubric = {
             maxError: 0.1,
             inexact: false,
@@ -174,13 +194,11 @@ describe("scoreInputNumber", () => {
         };
 
         const userInput: PerseusInputNumberUserInput = {
-            currentValue: "16,5",
+            currentValue: "16.500,00",
         };
 
-        // Using US locale where comma is thousands separator
-        const score = scoreInputNumber(userInput, rubric, "en");
+        const score = scoreInputNumber(userInput, rubric, "fr");
 
-        // "16,5" is invalid input in US locale (not a recognized number format)
-        expect(score).toHaveInvalidInput("EXTRA_SYMBOLS_ERROR");
+        expect(score).toHaveBeenAnsweredCorrectly();
     });
 });

--- a/packages/perseus-score/src/widgets/input-number/score-input-number.ts
+++ b/packages/perseus-score/src/widgets/input-number/score-input-number.ts
@@ -1,3 +1,5 @@
+import {getDecimalSeparator} from "@khanacademy/perseus-core";
+
 import KhanAnswerTypes from "../../util/answer-types";
 import {parseTex} from "../../util/tex-wrangler";
 
@@ -45,6 +47,7 @@ export const inputNumberAnswerTypes = {
 function scoreInputNumber(
     userInput: PerseusInputNumberUserInput,
     rubric: PerseusInputNumberRubric,
+    locale?: string,
 ): PerseusScore {
     if (rubric.answerType == null) {
         rubric.answerType = "number";
@@ -59,6 +62,9 @@ function scoreInputNumber(
         inexact: rubric.inexact || undefined,
         maxError: rubric.maxError,
         forms: inputNumberAnswerTypes[rubric.answerType].forms,
+        // Pass locale-specific decimal separator to ensure that
+        // we're properly parsing numbers according to the locale.
+        ...(locale && {decimal_separator: getDecimalSeparator(locale)}),
     });
 
     // We may have received TeX; try to parse it before grading.

--- a/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
+++ b/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
@@ -77,31 +77,6 @@ describe("scoreNumericInput", () => {
         expect(score).toHaveBeenAnsweredIncorrectly();
     });
 
-    it("should consider commas as a decimal separator in the French locale", () => {
-        const rubric: PerseusNumericInputRubric = {
-            answers: [
-                {
-                    value: 16.5,
-                    status: "correct",
-                    maxError: 0,
-                    simplify: "optional",
-                    strict: false,
-                    message: "",
-                },
-            ],
-            coefficient: false,
-        };
-
-        const userInput = {
-            currentValue: "16,5",
-        } as const;
-
-        // Using French locale where comma is decimal separator
-        const score = scoreNumericInput(userInput, rubric, "fr");
-
-        expect(score).toHaveBeenAnsweredCorrectly();
-    });
-
     it("should reject European decimal format in US locale", () => {
         const rubric: PerseusNumericInputRubric = {
             answers: [
@@ -151,6 +126,57 @@ describe("scoreNumericInput", () => {
         const score = scoreNumericInput(userInput, rubric, "en");
 
         // "16,500.00" is valid input in US locale
+        expect(score).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("should consider commas as a decimal separator in the French locale", () => {
+        const rubric: PerseusNumericInputRubric = {
+            answers: [
+                {
+                    value: 16.5,
+                    status: "correct",
+                    maxError: 0,
+                    simplify: "optional",
+                    strict: false,
+                    message: "",
+                },
+            ],
+            coefficient: false,
+        };
+
+        const userInput = {
+            currentValue: "16,5",
+        } as const;
+
+        // Using French locale where comma is decimal separator
+        const score = scoreNumericInput(userInput, rubric, "fr");
+
+        expect(score).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("should still accept periods as thousands separator in FR locale", () => {
+        const rubric: PerseusNumericInputRubric = {
+            answers: [
+                {
+                    value: 16500,
+                    status: "correct",
+                    maxError: 0,
+                    simplify: "optional",
+                    strict: false,
+                    message: "",
+                },
+            ],
+            coefficient: false,
+        };
+
+        const userInput = {
+            currentValue: "16.500,00",
+        } as const;
+
+        // Using US locale where comma is thousands separator
+        const score = scoreNumericInput(userInput, rubric, "fr");
+
+        // "16.500,00" is valid input in FR locale
         expect(score).toHaveBeenAnsweredCorrectly();
     });
 

--- a/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
+++ b/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
@@ -53,6 +53,81 @@ describe("scoreNumericInput", () => {
         expect(score).toHaveBeenAnsweredCorrectly();
     });
 
+    it("should not consider commas as a decimal separator in the US locale", () => {
+        const rubric: PerseusNumericInputRubric = {
+            answers: [
+                {
+                    value: 16,
+                    status: "correct",
+                    maxError: 0,
+                    simplify: "optional",
+                    strict: false,
+                    message: "",
+                },
+            ],
+            coefficient: true,
+        };
+
+        const userInput = {
+            currentValue: "16,000",
+        } as const;
+
+        const score = scoreNumericInput(userInput, rubric, "en");
+
+        expect(score).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("should consider commas as a decimal separator in the French locale", () => {
+        const rubric: PerseusNumericInputRubric = {
+            answers: [
+                {
+                    value: 16.5,
+                    status: "correct",
+                    maxError: 0,
+                    simplify: "optional",
+                    strict: false,
+                    message: "",
+                },
+            ],
+            coefficient: false,
+        };
+
+        const userInput = {
+            currentValue: "16,5",
+        } as const;
+
+        // Using French locale where comma is decimal separator
+        const score = scoreNumericInput(userInput, rubric, "fr");
+
+        expect(score).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("should reject European decimal format in US locale", () => {
+        const rubric: PerseusNumericInputRubric = {
+            answers: [
+                {
+                    value: 16.5,
+                    status: "correct",
+                    maxError: 0,
+                    simplify: "optional",
+                    strict: false,
+                    message: "",
+                },
+            ],
+            coefficient: false,
+        };
+
+        const userInput = {
+            currentValue: "16,5",
+        } as const;
+
+        // Using US locale where comma is thousands separator
+        const score = scoreNumericInput(userInput, rubric, "en");
+
+        // "16,5" is invalid input in US locale (not a recognized number format)
+        expect(score).toHaveInvalidInput("EXTRA_SYMBOLS_ERROR");
+    });
+
     it("with nonsense", () => {
         const rubric: PerseusNumericInputRubric = {
             answers: [

--- a/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
+++ b/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
@@ -53,7 +53,7 @@ describe("scoreNumericInput", () => {
         expect(score).toHaveBeenAnsweredCorrectly();
     });
 
-    it("should not consider commas as a decimal separator in the US locale", () => {
+    it("should not consider commas as a decimal separator in the EN locale", () => {
         const rubric: PerseusNumericInputRubric = {
             answers: [
                 {
@@ -77,33 +77,7 @@ describe("scoreNumericInput", () => {
         expect(score).toHaveBeenAnsweredIncorrectly();
     });
 
-    it("should reject European decimal format in US locale", () => {
-        const rubric: PerseusNumericInputRubric = {
-            answers: [
-                {
-                    value: 16.5,
-                    status: "correct",
-                    maxError: 0,
-                    simplify: "optional",
-                    strict: false,
-                    message: "",
-                },
-            ],
-            coefficient: false,
-        };
-
-        const userInput = {
-            currentValue: "16,5",
-        } as const;
-
-        // Using US locale where comma is thousands separator
-        const score = scoreNumericInput(userInput, rubric, "en");
-
-        // "16,5" is invalid input in US locale (not a recognized number format)
-        expect(score).toHaveInvalidInput("EXTRA_SYMBOLS_ERROR");
-    });
-
-    it("should still accept commas as thousands separator in US locale", () => {
+    it("should consider commas as the thousands separator in the EN locale", () => {
         const rubric: PerseusNumericInputRubric = {
             answers: [
                 {
@@ -129,7 +103,33 @@ describe("scoreNumericInput", () => {
         expect(score).toHaveBeenAnsweredCorrectly();
     });
 
-    it("should consider commas as a decimal separator in the French locale", () => {
+    it("should reject European decimal format if input is not a valid number in the EN locale", () => {
+        const rubric: PerseusNumericInputRubric = {
+            answers: [
+                {
+                    value: 16.5,
+                    status: "correct",
+                    maxError: 0,
+                    simplify: "optional",
+                    strict: false,
+                    message: "",
+                },
+            ],
+            coefficient: false,
+        };
+
+        const userInput = {
+            currentValue: "16,5",
+        } as const;
+
+        // Using US locale where comma is thousands separator
+        const score = scoreNumericInput(userInput, rubric, "en");
+
+        // "16,5" is invalid input in US locale (not a recognized number format)
+        expect(score).toHaveInvalidInput("EXTRA_SYMBOLS_ERROR");
+    });
+
+    it("should consider commas as the decimal separator in the FR locale", () => {
         const rubric: PerseusNumericInputRubric = {
             answers: [
                 {
@@ -154,7 +154,7 @@ describe("scoreNumericInput", () => {
         expect(score).toHaveBeenAnsweredCorrectly();
     });
 
-    it("should still accept periods as thousands separator in FR locale", () => {
+    it("should still accept periods as the thousands separator in FR locale", () => {
         const rubric: PerseusNumericInputRubric = {
             answers: [
                 {

--- a/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
+++ b/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
@@ -128,6 +128,32 @@ describe("scoreNumericInput", () => {
         expect(score).toHaveInvalidInput("EXTRA_SYMBOLS_ERROR");
     });
 
+    it("should still accept commas as thousands separator in US locale", () => {
+        const rubric: PerseusNumericInputRubric = {
+            answers: [
+                {
+                    value: 16500,
+                    status: "correct",
+                    maxError: 0,
+                    simplify: "optional",
+                    strict: false,
+                    message: "",
+                },
+            ],
+            coefficient: false,
+        };
+
+        const userInput = {
+            currentValue: "16,500.00",
+        } as const;
+
+        // Using US locale where comma is thousands separator
+        const score = scoreNumericInput(userInput, rubric, "en");
+
+        // "16,500.00" is valid input in US locale
+        expect(score).toHaveBeenAnsweredCorrectly();
+    });
+
     it("with nonsense", () => {
         const rubric: PerseusNumericInputRubric = {
             answers: [

--- a/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.ts
+++ b/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.ts
@@ -98,7 +98,8 @@ function scoreNumericInput(
             inexact: true, // TODO(merlob) backfill / delete
             maxError: answer.maxError,
             forms: validatorForms,
-            // Pass locale-specific decimal separator like expression scorer does
+            // Pass locale-specific decimal separator to ensure that
+            // we're properly parsing numbers according to the locale.
             ...(locale && {decimal_separator: getDecimalSeparator(locale)}),
         });
     };

--- a/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.ts
+++ b/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.ts
@@ -1,3 +1,5 @@
+import {getDecimalSeparator} from "@khanacademy/perseus-core";
+
 import KhanAnswerTypes from "../../util/answer-types";
 import {parseTex} from "../../util/tex-wrangler";
 
@@ -66,6 +68,7 @@ export function maybeParsePercentInput(
 function scoreNumericInput(
     userInput: PerseusNumericInputUserInput,
     rubric: PerseusNumericInputRubric,
+    locale?: string,
 ): PerseusScore {
     const defaultAnswerForms = answerFormButtons
         .map((e) => e["value"])
@@ -95,6 +98,8 @@ function scoreNumericInput(
             inexact: true, // TODO(merlob) backfill / delete
             maxError: answer.maxError,
             forms: validatorForms,
+            // Pass locale-specific decimal separator like expression scorer does
+            ...(locale && {decimal_separator: getDecimalSeparator(locale)}),
         });
     };
 


### PR DESCRIPTION
## Summary:
This PR fixes a bug where users would be erroneously marked correct if they entered `16,000` when the answer is `16`.

The issue was that we weren't properly handling locale-specific decimal separators in the Numeric Input and Input Number Widgets. While `scoreExpression` was already passing the locale to get the appropriate decimal separator (albeit with KAS), the other two widgets were missing this functionality.

Changes made:
1. Added locale parameter to `scoreInputNumber` and  `scoreNumericInput` functions
2. Added logic to pass the locale-specific decimal separator to the validators
3. Added tests to verify correct behavior with different locales

This ensures consistent behavior across all three scoring functions and prevents incorrect grading when users enter numbers with thousands separators or decimal separators that don't match their locale.

Issue: LEMS-3197

## Test plan:
- New tests pass 