### PR TITLE
Remove RTL display in New Radio Widget to unblock Perseus from displaying the stories in RTL

### DIFF
--- a/.changeset/little-toys-share.md
+++ b/.changeset/little-toys-share.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Temporary remove RTL display in New Radio Widget to unblock Perseus from displaying the stories in RTL

--- a/packages/perseus/src/widgets/radio/__stories__/radio.new.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__stories__/radio.new.stories.tsx
@@ -181,22 +181,6 @@ export const SelectWithImagesAndScrollRTL = {
             question: SingleSelectOverflowImageContent,
         }),
     },
-    decorators: [
-        (Story) => {
-            // Set RTL for testing
-            document.body.setAttribute("dir", "rtl");
-
-            return (
-                <div style={{direction: "rtl"}}>
-                    <Story />
-                </div>
-            );
-        },
-    ],
-    play: async () => {
-        // Reset the direction after the story
-        document.body.removeAttribute("dir");
-    },
 };
 
 export const SingleSelectWithScrollRTL = {
@@ -205,22 +189,6 @@ export const SingleSelectWithScrollRTL = {
             question: SingleSelectOverflowContent,
         }),
     },
-    decorators: [
-        (Story) => {
-            // Set RTL for testing
-            document.body.setAttribute("dir", "rtl");
-
-            return (
-                <div style={{direction: "rtl"}}>
-                    <Story />
-                </div>
-            );
-        },
-    ],
-    play: async () => {
-        // Reset the direction after the story
-        document.body.removeAttribute("dir");
-    },
 };
 
 export const MultiSelectWithScrollRTL = {
@@ -228,21 +196,5 @@ export const MultiSelectWithScrollRTL = {
         item: generateTestPerseusItem({
             question: multiChoiceQuestionSimpleOverflowContent,
         }),
-    },
-    decorators: [
-        (Story) => {
-            // Set RTL for testing
-            document.body.setAttribute("dir", "rtl");
-
-            return (
-                <div style={{direction: "rtl"}}>
-                    <Story />
-                </div>
-            );
-        },
-    ],
-    play: async () => {
-        // Reset the direction after the story
-        document.body.removeAttribute("dir");
     },
 };


### PR DESCRIPTION
## Summary:
Temporary Remove RTL display in New Radio Widget to unblock Perseus from displaying the stories in RTL

Issue: none

## Test plan:
- Confirm that widgets in storybook including the New Radio widget is no longer displayed in RTL