### PR TITLE
LabelImage: renderer user input state

### DIFF
--- a/.changeset/flat-wolves-drop.md
+++ b/.changeset/flat-wolves-drop.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-core": patch
+---
+
+LabelImage: use userInput/handleUserInput

--- a/packages/perseus-core/src/types.ts
+++ b/packages/perseus-core/src/types.ts
@@ -43,9 +43,8 @@ export type MarkerType = {
 };
 
 // Additional props that are set when user interacts with the marker.
+// TODO(LEMS-3199): don't mash together UI state with widget options
 export type InteractiveMarkerType = MarkerType & {
-    // The user selected list of answers, used to grade the question.
-    selected?: string[];
     // Reveal the correctness state of the user selected answers for the marker.
     showCorrectness?: "correct" | "incorrect";
     focused?: boolean;

--- a/packages/perseus-core/src/validation.types.ts
+++ b/packages/perseus-core/src/validation.types.ts
@@ -169,11 +169,13 @@ export type PerseusLabelImageRubric = {
     }>;
 };
 
+export type PerseusLabelImageUserInputMarker = {
+    selected?: string[];
+    label: string;
+};
+
 export type PerseusLabelImageUserInput = {
-    markers: Array<{
-        selected?: string[];
-        label: string;
-    }>;
+    markers: PerseusLabelImageUserInputMarker[];
 };
 
 export type PerseusMatcherRubric = {

--- a/packages/perseus/src/widgets/label-image/__tests__/label-image.test.ts
+++ b/packages/perseus/src/widgets/label-image/__tests__/label-image.test.ts
@@ -24,7 +24,6 @@ import type {UserEvent} from "@testing-library/user-event";
 const emptyMarker: InteractiveMarkerType = {
     label: "",
     answers: [],
-    selected: [],
     x: 0,
     y: 0,
 };

--- a/packages/perseus/src/widgets/label-image/__tests__/label-image.test.ts
+++ b/packages/perseus/src/widgets/label-image/__tests__/label-image.test.ts
@@ -13,12 +13,15 @@ import {
 import * as Dependencies from "../../../dependencies";
 import {scorePerseusItemTesting} from "../../../util/test-utils";
 import {renderQuestion} from "../../__testutils__/renderQuestion";
-import {LabelImage, getUpdatedMarkerState} from "../label-image";
+import {LabelImage, getComputedSelectedState} from "../label-image";
 
 import {shortTextQuestion, textQuestion} from "./label-image.testdata";
 
 import type {OptionalAnswersMarkerType} from "../label-image";
-import type {InteractiveMarkerType} from "@khanacademy/perseus-core";
+import type {
+    InteractiveMarkerType,
+    PerseusLabelImageUserInputMarker,
+} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
 
 const emptyMarker: InteractiveMarkerType = {
@@ -50,28 +53,32 @@ describe("LabelImage", function () {
         ) as jest.Mock;
     });
 
-    describe("getUpdatedMarkerState", function () {
+    describe("getComputedSelectedState", function () {
         it("should return original marker when feedback is not shown", function () {
             // Arrange
             const marker: OptionalAnswersMarkerType = {
                 label: "Test marker",
                 x: 50,
                 y: 50,
-                selected: ["User Choice"],
                 answers: ["Correct Answer"],
+            };
+            const userInputMarker: PerseusLabelImageUserInputMarker = {
+                label: "Test marker",
+                selected: ["User Choice"],
             };
             const reviewMode = false;
             const showSolutions = undefined;
 
             // Act
-            const result = getUpdatedMarkerState(
+            const result = getComputedSelectedState(
                 marker,
+                userInputMarker,
                 reviewMode,
                 showSolutions,
             );
 
             // Assert - Should return unchanged since showSolutions and reviewMode are false
-            expect(result).toEqual(marker);
+            expect(result).toEqual(userInputMarker);
         });
 
         it("should auto-select correct answers when showSolutions is 'all'", function () {
@@ -80,22 +87,26 @@ describe("LabelImage", function () {
                 label: "Test marker",
                 x: 50,
                 y: 50,
-                selected: ["Answer C"],
                 answers: ["Answer A", "Answer B"],
+            };
+            const userInputMarker: PerseusLabelImageUserInputMarker = {
+                label: "Test marker",
+                selected: ["Answer C"],
             };
             const reviewMode = false;
             const showSolutions = "all";
 
             // Act
-            const result = getUpdatedMarkerState(
+            const result = getComputedSelectedState(
                 marker,
+                userInputMarker,
                 reviewMode,
                 showSolutions,
             );
 
             // Assert
             expect(result).toEqual({
-                ...marker,
+                ...userInputMarker,
                 selected: ["Answer A", "Answer B"],
             });
         });
@@ -106,22 +117,26 @@ describe("LabelImage", function () {
                 label: "Test marker",
                 x: 50,
                 y: 50,
-                selected: ["Answer C"],
                 answers: ["Answer A", "Answer B"],
+            };
+            const userInputMarker: PerseusLabelImageUserInputMarker = {
+                label: "Test marker",
+                selected: ["Answer C"],
             };
             const reviewMode = true;
             const showSolutions = undefined;
 
             // Act
-            const result = getUpdatedMarkerState(
+            const result = getComputedSelectedState(
                 marker,
+                userInputMarker,
                 reviewMode,
                 showSolutions,
             );
 
             // Assert
             expect(result).toEqual({
-                ...marker,
+                ...userInputMarker,
                 selected: ["Answer A", "Answer B"],
             });
         });
@@ -132,22 +147,26 @@ describe("LabelImage", function () {
                 label: "Test marker",
                 x: 50,
                 y: 50,
-                selected: ["Some Choice"],
                 // No answers property - this is an answerless marker
+            };
+            const userInputMarker: PerseusLabelImageUserInputMarker = {
+                label: "Test marker",
+                selected: ["Some Choice"],
             };
             const reviewMode = false;
             const showSolutions = "all";
 
             // Act
-            const result = getUpdatedMarkerState(
+            const result = getComputedSelectedState(
                 marker,
+                userInputMarker,
                 reviewMode,
                 showSolutions,
             );
 
             // Assert
             expect(result).toEqual({
-                ...marker,
+                ...userInputMarker,
                 selected: undefined,
             });
         });
@@ -158,22 +177,26 @@ describe("LabelImage", function () {
                 label: "Test marker",
                 x: 50,
                 y: 50,
-                selected: ["User Choice"],
                 answers: [],
+            };
+            const userInputMarker: PerseusLabelImageUserInputMarker = {
+                label: "Test marker",
+                selected: ["User Choice"],
             };
             const reviewMode = true;
             const showSolutions = undefined;
 
             // Act
-            const result = getUpdatedMarkerState(
+            const result = getComputedSelectedState(
                 marker,
+                userInputMarker,
                 reviewMode,
                 showSolutions,
             );
 
             // Assert
             expect(result).toEqual({
-                ...marker,
+                ...userInputMarker,
                 selected: [],
             });
         });

--- a/packages/perseus/src/widgets/label-image/__tests__/label-image.test.ts
+++ b/packages/perseus/src/widgets/label-image/__tests__/label-image.test.ts
@@ -31,7 +31,6 @@ const emptyMarker: InteractiveMarkerType = {
 
 const emptyAnswerlessMarker: OptionalAnswersMarkerType = {
     label: "",
-    selected: [],
     x: 0,
     y: 0,
 };

--- a/packages/perseus/src/widgets/label-image/__tests__/serialize-label-image.test.ts
+++ b/packages/perseus/src/widgets/label-image/__tests__/serialize-label-image.test.ts
@@ -1,0 +1,226 @@
+import {
+    generateTestPerseusItem,
+    generateTestPerseusRenderer,
+} from "@khanacademy/perseus-core";
+import {screen, act} from "@testing-library/react";
+import {userEvent as userEventLib} from "@testing-library/user-event";
+
+import {testDependencies} from "../../../../../../testing/test-dependencies";
+import {renderQuestion} from "../../../__tests__/test-utils";
+import * as Dependencies from "../../../dependencies";
+import {registerAllWidgetsForTesting} from "../../../util/register-all-widgets-for-testing";
+
+import type {PerseusItem} from "@khanacademy/perseus-core";
+import type {UserEvent} from "@testing-library/user-event";
+
+/**
+ * [LEMS-3185] These are tests for the legacy Serialization API.
+ *
+ * This API is not built in a way that supports migrating data
+ * between versions of Perseus JSON. In fact serialization
+ * doesn't use WidgetOptions, but RenderProps; it's leveraging
+ * what is considered an internal implementation detail to support
+ * rehydrating previous state.
+ *
+ * The API is very fragile and likely broken. We have a ticket to remove it.
+ * However we don't have the bandwidth to implement an alternative right now,
+ * so I'm adding tests to make sure we're roughly still able to support
+ * what little we've been supporting so far.
+ *
+ * This API needs to be removed and these tests need to be removed with it.
+ */
+describe("LabelImage serialization", () => {
+    function generateBasicLabelImage(): PerseusItem {
+        const question = generateTestPerseusRenderer({
+            content: "[[☃ label-image 1]]",
+            widgets: {
+                "label-image 1": {
+                    type: "label-image",
+                    options: {
+                        static: false,
+                        choices: ["One", "Two", "Three"],
+                        imageAlt: "Alt text",
+                        imageUrl:
+                            "web+graphie://ka-perseus-graphie.s3.amazonaws.com/56c60c72e96cd353e4a8b5434506cd3a21e717af",
+                        imageWidth: 415,
+                        imageHeight: 314,
+                        markers: [
+                            {
+                                answers: ["One"],
+                                label: "Uno",
+                                x: 25,
+                                y: 17.7,
+                            },
+                            {
+                                answers: ["Two"],
+                                label: "Dos",
+                                x: 25,
+                                y: 35.3,
+                            },
+                            {
+                                answers: ["Three"],
+                                label: "Tres",
+                                x: 25,
+                                y: 53,
+                            },
+                        ],
+                        multipleAnswers: false,
+                        hideChoicesFromInstructions: true,
+                    },
+                },
+            },
+        });
+        const item = generateTestPerseusItem({question});
+        return item;
+    }
+
+    beforeAll(() => {
+        registerAllWidgetsForTesting();
+    });
+
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+
+        // Mocked for loading graphie in svg-image
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                text: () => "",
+                ok: true,
+            }),
+        ) as jest.Mock;
+    });
+
+    afterEach(() => {
+        // The Renderer uses a timer to wait for widgets to complete rendering.
+        // If we don't spin the timers here, then the timer fires in the test
+        // _after_ and breaks it because we do setState() in the callback,
+        // and by that point the component has been unmounted.
+        act(() => jest.runOnlyPendingTimers());
+    });
+
+    it("should serialize the current state", async () => {
+        // Arrange
+        const {renderer} = renderQuestion(generateBasicLabelImage());
+
+        const markerButton = await screen.findByLabelText("Uno");
+        await userEvent.click(markerButton);
+
+        const choice = screen.getByRole("option", {name: "One"});
+        await userEvent.click(choice);
+
+        // Act
+        const state = renderer.getSerializedState();
+
+        // Assert
+        expect(state).toEqual({
+            question: {
+                "label-image 1": {
+                    choices: ["One", "Two", "Three"],
+                    imageAlt: "Alt text",
+                    imageUrl:
+                        "web+graphie://ka-perseus-graphie.s3.amazonaws.com/56c60c72e96cd353e4a8b5434506cd3a21e717af",
+                    imageWidth: 415,
+                    imageHeight: 314,
+                    markers: [
+                        {
+                            answers: ["One"],
+                            label: "Uno",
+                            x: 25,
+                            y: 17.7,
+                            selected: ["One"],
+                        },
+                        {
+                            answers: ["Two"],
+                            label: "Dos",
+                            x: 25,
+                            y: 35.3,
+                        },
+                        {
+                            answers: ["Three"],
+                            label: "Tres",
+                            x: 25,
+                            y: 53,
+                        },
+                    ],
+                    multipleAnswers: false,
+                    hideChoicesFromInstructions: true,
+                },
+            },
+            hints: [],
+        });
+    });
+
+    it("should restore serialized state", () => {
+        // Arrange
+        const {renderer} = renderQuestion(generateBasicLabelImage());
+
+        // Act
+        act(() =>
+            renderer.restoreSerializedState({
+                question: {
+                    "label-image 1": {
+                        choices: ["One", "Two", "Three"],
+                        imageAlt: "Alt text",
+                        imageUrl:
+                            "web+graphie://ka-perseus-graphie.s3.amazonaws.com/56c60c72e96cd353e4a8b5434506cd3a21e717af",
+                        imageWidth: 415,
+                        imageHeight: 314,
+                        markers: [
+                            {
+                                answers: ["One"],
+                                label: "Uno",
+                                x: 25,
+                                y: 17.7,
+                                selected: ["One"],
+                            },
+                            {
+                                answers: ["Two"],
+                                label: "Dos",
+                                x: 25,
+                                y: 35.3,
+                            },
+                            {
+                                answers: ["Three"],
+                                label: "Tres",
+                                x: 25,
+                                y: 53,
+                            },
+                        ],
+                        multipleAnswers: false,
+                        hideChoicesFromInstructions: true,
+                        static: false,
+                    },
+                },
+                hints: [],
+            }),
+        );
+
+        const userInput = renderer.getUserInput();
+
+        // Assert
+        // there would be no "selected" if we didn't properly restore serialized state
+        expect(userInput).toEqual({
+            "label-image 1": {
+                markers: [
+                    {
+                        selected: ["One"], // <= important
+                        label: "Uno",
+                    },
+                    {
+                        label: "Dos",
+                    },
+                    {
+                        label: "Tres",
+                    },
+                ],
+            },
+        });
+    });
+});

--- a/packages/perseus/src/widgets/label-image/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image/label-image.tsx
@@ -737,6 +737,21 @@ export class LabelImage
         );
     }
 
+    /**
+     * @deprecated and likely very broken API
+     * [LEMS-3185] do not trust serializedState/restoreSerializedState
+     */
+    getSerializedState(): any {
+        const {userInput, markers, ...rest} = this.props;
+        return {
+            ...rest,
+            markers: markers.map((m, i) => ({
+                ...m,
+                selected: userInput.markers[i].selected,
+            })),
+        };
+    }
+
     render(): React.ReactNode {
         const {imageAlt, imageUrl, imageWidth, imageHeight} = this.props;
 
@@ -827,12 +842,28 @@ function getStartUserInput(
     };
 }
 
+/**
+ * @deprecated and likely a very broken API
+ * [LEMS-3185] do not trust serializedState/restoreSerializedState
+ */
+function getUserInputFromSerializedState(
+    serializedState: any,
+): PerseusLabelImageUserInput {
+    return {
+        markers: serializedState.markers.map((m) => ({
+            label: m.label,
+            selected: m.selected,
+        })),
+    };
+}
+
 export default {
     name: "label-image",
     displayName: "Label Image",
     widget: LabelImageWithDependencies,
     isLintable: true,
     getStartUserInput,
+    getUserInputFromSerializedState,
 } satisfies WidgetExports<typeof LabelImageWithDependencies>;
 
 const styles = StyleSheet.create({

--- a/packages/perseus/src/widgets/label-image/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image/label-image.tsx
@@ -101,7 +101,7 @@ function isAnswerful(
 }
 
 /**
- * Get marker with the appropriate selection state for current display mode.
+ * Get user input marker with the appropriate selection state for current display mode.
  * When showing solutions, it auto-selects correct answers, or clears
  * selections for markers without answers.
  *
@@ -513,14 +513,6 @@ export class LabelImage
     }
 
     renderMarkers(): ReadonlyArray<React.ReactNode> {
-        const {
-            markers,
-            questionCompleted,
-            preferredPopoverDirection,
-            userInput,
-        } = this.props;
-
-    renderMarkers(): ReadonlyArray<React.ReactNode> {
         const {markers, preferredPopoverDirection} = this.props;
         const {markersInteracted, activeMarkerIndex} = this.state;
 
@@ -613,13 +605,6 @@ export class LabelImage
                 }`]: 10, // move pill further from marker
             };
 
-            const answerChoicesActive = index === activeMarkerIndex;
-
-            const showAnswerChoice =
-                userInputMarker.selected &&
-                !answerChoicesActive &&
-                !this.state.hideAnswers;
-
             return (
                 <View
                     key={index}
@@ -635,8 +620,10 @@ export class LabelImage
                         key={`answers-${marker.x}.${marker.y}`}
                         choices={this.props.choices.map((choice) => ({
                             content: choice,
-                            checked: userInputMarker.selected
-                                ? userInputMarker.selected.includes(choice)
+                            checked: computedSelectedState.selected
+                                ? computedSelectedState.selected.includes(
+                                      choice,
+                                  )
                                 : false,
                         }))}
                         multipleSelect={this.props.multipleAnswers}

--- a/packages/perseus/src/widgets/label-image/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image/label-image.tsx
@@ -732,9 +732,9 @@ export class LabelImage
         const {userInput, markers, ...rest} = this.props;
         return {
             ...rest,
-            markers: markers.map((m, i) => ({
-                ...m,
-                selected: userInput.markers[i].selected,
+            markers: markers.map((marker, index) => ({
+                ...marker,
+                selected: userInput.markers[index].selected,
             })),
         };
     }

--- a/packages/perseus/src/widgets/label-image/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image/label-image.tsx
@@ -68,8 +68,7 @@ type Point = {
 
 export type OptionalAnswersMarkerType = Omit<
     InteractiveMarkerType,
-    | "selected" // get selected from user input
-    | "answers"
+    "answers"
 > & {
     answers?: string[];
 };
@@ -573,10 +572,10 @@ export class LabelImage
             );
 
             let score: InteractiveMarkerScore;
-            if (isAnswerful(updatedMarkerState)) {
+            if (isAnswerful(marker)) {
                 score = scoreLabelImageMarker(
-                    updatedMarkerState.selected,
-                    updatedMarkerState.answers,
+                    userInputMarker.selected,
+                    marker.answers,
                 );
             } else {
                 score = {


### PR DESCRIPTION
## Summary:

See the [parent PR](https://github.com/Khan/perseus/pull/2566) for more context. Part of [LEMS-3208](https://khanacademy.atlassian.net/browse/LEMS-3208).

In #2566 I add additional APIs to let widgets consume `userInput` from a parent and to update that parent state using `handleUserInput`, while also supporting the legacy way of storing user input (which was a combination of internal widget state and stashing state in a random blob in Renderer). This PR is part of a series of PRs that go widget-by-widget to use the new API.

This is a generic summary I'm putting on each PR and not every point will be applicable to every widget, but the common themes are:

- I added a test for serialization to make sure we're still backwards compatible (see [LEMS-3185](https://khanacademy.atlassian.net/browse/LEMS-3185)), then implemented the helpers `getSerializedState` and `getUserInputFromSerializedState` to keep supporting the expected results.
- I moved user input for the component into the new `userInput` state in Renderer. This means consuming `userInput` in the component and calling `handleUserInput` on change.
- When `transform` did something to initialize user input state, I moved the logic to `getStartUserInput`.
- When `staticTransform` did something to get correct state in static widgets, I moved the logic to `getCorrectUserInput`.
- Editors that use a widget to collect answer data are changed to support the new API.

Please see the [parent PR](https://github.com/Khan/perseus/pull/2566) for more information.

---

LabelImageEditor doesn't use LabelImage, so this shouldn't affect the editing experience

[LEMS-3208]: https://khanacademy.atlassian.net/browse/LEMS-3208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LEMS-3185]: https://khanacademy.atlassian.net/browse/LEMS-3185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ