### PR TITLE
Sorter: renderer user input state

### DIFF
--- a/.changeset/fresh-olives-study.md
+++ b/.changeset/fresh-olives-study.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus-score": patch
+---
+
+Sorter: use userInput/handleUserInput

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -164,6 +164,7 @@ export {
     default as getSorterPublicWidgetOptions,
     shuffleSorter,
 } from "./widgets/sorter/sorter-util";
+export type {SorterPublicWidgetOptions} from "./widgets/sorter/sorter-util";
 export type {LabelImagePublicWidgetOptions} from "./widgets/label-image/label-image-util";
 export type {LabelImageMarkerPublicData} from "./widgets/label-image/label-image-util";
 export {default as getDropdownPublicWidgetOptions} from "./widgets/dropdown/dropdown-util";

--- a/packages/perseus-core/src/widgets/sorter/sorter-util.test.ts
+++ b/packages/perseus-core/src/widgets/sorter/sorter-util.test.ts
@@ -31,23 +31,25 @@ describe("getSorterPublicWidgetOptions", () => {
 
 describe("shuffleSorter", () => {
     it("does nothing given no cards", () => {
-        expect(shuffleSorter({correct: [], problemNum: 0})).toEqual([]);
+        expect(shuffleSorter({correct: []}, 0)).toEqual([]);
     });
 
     describe.each(range(0, 10))("when problemNum is %d", (problemNum) => {
         // problemNum is used as the seed for the shuffle.
 
         it("always moves the first card", () => {
-            const shuffled = shuffleSorter({
-                correct: ["1", "2", "3", "4"],
+            const shuffled = shuffleSorter(
+                {
+                    correct: ["1", "2", "3", "4"],
+                },
                 problemNum,
-            });
+            );
             expect(shuffled[0]).not.toEqual(["1"]);
         });
 
         it("preserves the set of cards", () => {
             const correct = ["1", "2", "3", "4"];
-            const shuffled = shuffleSorter({correct, problemNum});
+            const shuffled = shuffleSorter({correct}, problemNum);
             expect(new Set(shuffled)).toEqual(new Set(correct));
         });
     });

--- a/packages/perseus-core/src/widgets/sorter/sorter-util.ts
+++ b/packages/perseus-core/src/widgets/sorter/sorter-util.ts
@@ -6,7 +6,7 @@ import type {PerseusSorterWidgetOptions} from "../../data-schema";
  * For details on the individual options, see the
  * PerseusSorterWidgetOptions type
  */
-type SorterPublicWidgetOptions = {
+export type SorterPublicWidgetOptions = {
     // TODO(benchristel): rename to `cards`; the whole point of public widget
     // options is that this isn't the correct order!
     correct: PerseusSorterWidgetOptions["correct"];
@@ -31,11 +31,11 @@ function getSorterPublicWidgetOptions(
     };
 }
 
-export function shuffleSorter(props: {
-    correct: string[];
-    problemNum: number | null | undefined;
-}): string[] {
-    const {correct, problemNum} = props;
+export function shuffleSorter(
+    options: Pick<SorterPublicWidgetOptions, "correct">,
+    problemNum: number,
+): string[] {
+    const {correct} = options;
     const rng = seededRNG(problemNum ?? 0);
     // See getSorterPublicWidgetOptions for an explanation of why we need to
     // displace the first card.

--- a/packages/perseus-score/src/widgets/sorter/validate-sorter.ts
+++ b/packages/perseus-score/src/widgets/sorter/validate-sorter.ts
@@ -17,7 +17,7 @@ function validateSorter(userInput: PerseusSorterUserInput): ValidationResult {
     // assumption that the initial order isn't the correct order! However,
     // this should be rare if it happens, and interacting with the list
     // will enable the button, so they won't be locked out of progressing.
-    if (!userInput.changed) {
+    if (!userInput?.changed) {
         return {
             type: "invalid",
             message: null,

--- a/packages/perseus/src/components/__tests__/sorter.test.tsx
+++ b/packages/perseus/src/components/__tests__/sorter.test.tsx
@@ -14,6 +14,7 @@ import {question1} from "../__testdata__/sorter.testdata";
 
 import type {APIOptions} from "../../types";
 
+// TODO, this is in the wrong spot; it's in the "components" dir and not the "widgets" dir
 describe("sorter widget", () => {
     beforeEach(() => {
         /*
@@ -93,9 +94,10 @@ describe("sorter widget", () => {
             const {renderer} = renderQuestion(question);
 
             // Act
+            const userInput = renderer.getUserInputMap();
             const score = scorePerseusItemTesting(
                 answerfulItem.question,
-                renderer.getUserInputMap(),
+                userInput,
             );
 
             // Assert
@@ -110,14 +112,15 @@ describe("sorter widget", () => {
             // Act
             // Put the options in the correct order
             ["Zeroth", "First", "Second", "Third", "Fourth"].forEach(
-                (option) => {
-                    act(() => sorter.moveOptionToIndex(option, 4));
+                (option, index) => {
+                    act(() => sorter.moveOptionToIndex(option, index));
                 },
             );
 
+            const userInput = renderer.getUserInputMap();
             const score = scorePerseusItemTesting(
                 answerfulItem.question,
-                renderer.getUserInputMap(),
+                userInput,
             );
 
             // Assert

--- a/packages/perseus/src/widgets/sorter/serialize-sorter.test.ts
+++ b/packages/perseus/src/widgets/sorter/serialize-sorter.test.ts
@@ -1,0 +1,132 @@
+import {
+    generateTestPerseusItem,
+    generateTestPerseusRenderer,
+} from "@khanacademy/perseus-core";
+import {act} from "@testing-library/react";
+
+import {testDependencies} from "../../../../../testing/test-dependencies";
+import {renderQuestion} from "../../__tests__/test-utils";
+import * as Dependencies from "../../dependencies";
+import {registerAllWidgetsForTesting} from "../../util/register-all-widgets-for-testing";
+
+import type {PerseusItem} from "@khanacademy/perseus-core";
+
+/**
+ * [LEMS-3185] These are tests for the legacy Serialization API.
+ *
+ * This API is not built in a way that supports migrating data
+ * between versions of Perseus JSON. In fact serialization
+ * doesn't use WidgetOptions, but RenderProps; it's leveraging
+ * what is considered an internal implementation detail to support
+ * rehydrating previous state.
+ *
+ * The API is very fragile and likely broken. We have a ticket to remove it.
+ * However we don't have the bandwidth to implement an alternative right now,
+ * so I'm adding tests to make sure we're roughly still able to support
+ * what little we've been supporting so far.
+ *
+ * This API needs to be removed and these tests need to be removed with it.
+ */
+describe("Sorter serialization", () => {
+    function generateBasicSorter(): PerseusItem {
+        const question = generateTestPerseusRenderer({
+            content: "[[☃ sorter 1]]",
+            widgets: {
+                "sorter 1": {
+                    type: "sorter",
+                    options: {
+                        padding: true,
+                        layout: "horizontal",
+                        correct: ["First", "Second", "Third"],
+                    },
+                },
+            },
+        });
+        const item = generateTestPerseusItem({question});
+        return item;
+    }
+
+    beforeAll(() => {
+        registerAllWidgetsForTesting();
+    });
+
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    afterEach(() => {
+        // The Renderer uses a timer to wait for widgets to complete rendering.
+        // If we don't spin the timers here, then the timer fires in the test
+        // _after_ and breaks it because we do setState() in the callback,
+        // and by that point the component has been unmounted.
+        act(() => jest.runOnlyPendingTimers());
+    });
+
+    it("should serialize the current state", async () => {
+        // Arrange
+        const {renderer} = renderQuestion(generateBasicSorter());
+
+        // Just making sure we're shuffling before answering
+        expect(
+            generateBasicSorter().question.widgets["sorter 1"].options.correct,
+        ).not.toEqual(renderer.getUserInput()["sorter 1"].options);
+
+        // Put the options in the correct order
+        const sorter = renderer.questionRenderer.findWidgets("sorter 1")[0];
+        ["First", "Second", "Third"].forEach((option, index) => {
+            act(() => sorter.moveOptionToIndex(option, index));
+        });
+
+        // Act
+        const state = renderer.getSerializedState();
+
+        // Assert
+        expect(state).toEqual({
+            question: {
+                "sorter 1": {
+                    correct: ["First", "Second", "Third"],
+                    options: ["First", "Second", "Third"],
+                    changed: true,
+                    layout: "horizontal",
+                    padding: true,
+                },
+            },
+            hints: [],
+        });
+    });
+
+    it("should restore serialized state", () => {
+        // Arrange
+        const {renderer} = renderQuestion(generateBasicSorter());
+
+        // Just making sure things start shuffled
+        expect(
+            generateBasicSorter().question.widgets["sorter 1"].options.correct,
+        ).not.toEqual(renderer.getUserInput()["sorter 1"].options);
+
+        // Act
+        act(() =>
+            renderer.restoreSerializedState({
+                question: {
+                    "sorter 1": {
+                        correct: ["First", "Second", "Third"],
+                        options: ["First", "Second", "Third"],
+                        changed: true,
+                        layout: "horizontal",
+                        padding: true,
+                    },
+                },
+                hints: [],
+            }),
+        );
+
+        const userInput = renderer.getUserInput();
+
+        // Assert
+        expect(userInput).toEqual({
+            "sorter 1": {changed: true, options: ["First", "Second", "Third"]},
+        });
+    });
+});

--- a/packages/perseus/src/widgets/sorter/sorter.tsx
+++ b/packages/perseus/src/widgets/sorter/sorter.tsx
@@ -11,6 +11,7 @@ import type {SorterPromptJSON} from "../../widget-ai-utils/sorter/sorter-ai-util
 import type {
     PerseusSorterWidgetOptions,
     PerseusSorterUserInput,
+    SorterPublicWidgetOptions,
 } from "@khanacademy/perseus-core";
 
 type Props = WidgetProps<PerseusSorterWidgetOptions, PerseusSorterUserInput>;
@@ -20,15 +21,10 @@ type DefaultProps = {
     layout: Props["layout"];
     padding: Props["padding"];
     problemNum: Props["problemNum"];
-    onChange: Props["onChange"];
     linterContext: Props["linterContext"];
 };
 
-type State = {
-    changed: boolean;
-};
-
-class Sorter extends React.Component<Props, State> implements Widget {
+class Sorter extends React.Component<Props> implements Widget {
     _isMounted: boolean = false;
 
     static defaultProps: DefaultProps = {
@@ -36,12 +32,7 @@ class Sorter extends React.Component<Props, State> implements Widget {
         layout: "horizontal",
         padding: true,
         problemNum: 0,
-        onChange: function () {},
         linterContext: linterContextDefault,
-    };
-
-    state: State = {
-        changed: false,
     };
 
     componentDidMount() {
@@ -57,28 +48,32 @@ class Sorter extends React.Component<Props, State> implements Widget {
             return;
         }
 
-        this.setState({changed: true}, () => {
-            // Wait until all components have rendered. In React 16, the
-            // setState callback fires immediately after componentDidUpdate,
-            // and there is no guarantee that parent/siblings components have
-            // finished rendering.
-            // TODO(jeff, CP-3128): Use Wonder Blocks Timing API
-            // eslint-disable-next-line no-restricted-syntax
-            setTimeout(() => {
-                this.props.onChange(e as any);
-                this.props.trackInteraction();
-            }, 0);
+        this.props.handleUserInput({
+            options: this._getOptionsFromSortable(),
+            changed: true,
         });
+
+        this.props.trackInteraction();
     };
 
+    /**
+     * TODO: remove this when everything is pulling from Renderer state
+     * @deprecated get user input from Renderer state
+     */
     getUserInput(): PerseusSorterUserInput {
+        return this.props.userInput;
+    }
+
+    /**
+     * This is kind of a problem. Sortable maintains an internal state
+     * but we also want the user input state to include the same state.
+     * This is to help keep the two in sync for now.
+     */
+    _getOptionsFromSortable(): string[] {
         // eslint-disable-next-line react/no-string-refs
         // @ts-expect-error - TS2339 - Property 'getOptions' does not exist on type 'ReactInstance'.
         const options = this.refs.sortable.getOptions();
-        return {
-            options,
-            changed: this.state.changed,
-        };
+        return options;
     }
 
     getPromptJSON(): SorterPromptJSON {
@@ -94,16 +89,27 @@ class Sorter extends React.Component<Props, State> implements Widget {
         this.refs.sortable.moveOptionToIndex(option, index);
     };
 
-    render(): React.ReactNode {
-        const options = shuffleSorter(this.props);
+    /**
+     * @deprecated and likely very broken API
+     * [LEMS-3185] do not trust serializedState/restoreSerializedState
+     */
+    getSerializedState(): any {
+        const {userInput, ...rest} = this.props;
+        return {
+            ...rest,
+            changed: userInput.changed,
+            options: userInput.options,
+        };
+    }
 
-        const {apiOptions} = this.props;
+    render(): React.ReactNode {
+        const {apiOptions, userInput} = this.props;
         const marginPx = apiOptions.isMobile ? 8 : 5;
 
         return (
             <div className="perseus-widget-sorter perseus-clearfix">
                 <Sortable
-                    options={options}
+                    options={userInput.options}
                     layout={this.props.layout}
                     margin={marginPx}
                     padding={this.props.padding}
@@ -117,9 +123,36 @@ class Sorter extends React.Component<Props, State> implements Widget {
     }
 }
 
+function getStartUserInput(
+    options: SorterPublicWidgetOptions,
+    problemNum: number,
+): PerseusSorterUserInput {
+    const shuffled = shuffleSorter(options, problemNum);
+
+    return {
+        options: shuffled,
+        changed: false,
+    };
+}
+
+/**
+ * @deprecated and likely a very broken API
+ * [LEMS-3185] do not trust serializedState/restoreSerializedState
+ */
+function getUserInputFromSerializedState(
+    serializedState: any,
+): PerseusSorterUserInput {
+    return {
+        changed: serializedState.changed,
+        options: serializedState.options,
+    };
+}
+
 export default {
     name: "sorter",
     displayName: "Sorter",
     widget: Sorter,
     isLintable: true,
+    getStartUserInput,
+    getUserInputFromSerializedState,
 } satisfies WidgetExports<typeof Sorter>;


### PR DESCRIPTION
## Summary:

See the [parent PR](https://github.com/Khan/perseus/pull/2566) for more context. Part of [LEMS-3208](https://khanacademy.atlassian.net/browse/LEMS-3208).

In #2566 I add additional APIs to let widgets consume `userInput` from a parent and to update that parent state using `handleUserInput`, while also supporting the legacy way of storing user input (which was a combination of internal widget state and stashing state in a random blob in Renderer). This PR is part of a series of PRs that go widget-by-widget to use the new API.

This is a generic summary I'm putting on each PR and not every point will be applicable to every widget, but the common themes are:

- I added a test for serialization to make sure we're still backwards compatible (see [LEMS-3185](https://khanacademy.atlassian.net/browse/LEMS-3185)), then implemented the helpers `getSerializedState` and `getUserInputFromSerializedState` to keep supporting the expected results.
- I moved user input for the component into the new `userInput` state in Renderer. This means consuming `userInput` in the component and calling `handleUserInput` on change.
- When `transform` did something to initialize user input state, I moved the logic to `getStartUserInput`.
- When `staticTransform` did something to get correct state in static widgets, I moved the logic to `getCorrectUserInput`.
- Editors that use a widget to collect answer data are changed to support the new API.

Please see the [parent PR](https://github.com/Khan/perseus/pull/2566) for more information.

---

SorterEditor doesn't use Sorter, so this shouldn't affect the editing experience

[LEMS-3208]: https://khanacademy.atlassian.net/browse/LEMS-3208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LEMS-3185]: https://khanacademy.atlassian.net/browse/LEMS-3185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ