### PR TITLE
Fire onRendered callback at least once

### DIFF
--- a/.changeset/green-coins-applaud.md
+++ b/.changeset/green-coins-applaud.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix a bug where the ServerItemRenderer and LoadingContext did not fire the `onRendered` prop callback when the PerseusItem being rendered did not have any assets.

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -331,10 +331,14 @@ jobs:
                       steps.publish-snapshot.outputs.npm_snapshot_tag }}
                       ```
 
-                      If you are working in Khan Academy's webapp, you can run the below command. 
-                      If this is for backend code, change the static flag (-s) from y/yes to n/no.
+                      If you are working in Khan Academy's frontend, you can run the below command.
                       ```sh
-                      ./dev/tools/bump_perseus_version.js -s y -t PR${{ github.event.pull_request.number }}
+                      ./tools/bump_perseus_version.js -t PR${{ github.event.pull_request.number }}
+                      ```
+
+                      If you are working in Khan Academy's webapp, you can run the below command.
+                      ```sh
+                      ./dev/tools/bump_perseus_version.js -s n -t PR${{ github.event.pull_request.number }}
                       ```
 
             - name: Create or update npm snapshot comment - failure, snapshot publish failed

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -3,6 +3,7 @@ import {within, render, screen, act} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
+import {LoadingContext} from "..";
 import {
     testDependencies,
     testDependenciesV2,
@@ -266,6 +267,86 @@ describe("server item renderer", () => {
         // this test.
         const widget = mockedWidget as MockAssetLoadingWidget;
         act(() => widget.setAssetStatus?.("ABC", true));
+
+        // Assert
+        expect(onRendered).toHaveBeenCalledWith(true);
+    });
+
+    it("should call the onRendered callback when if no assets in content", () => {
+        const content: PerseusItem = {
+            question: {
+                content:
+                    "\n**What is the meaning of *intrigued*, as it is used in paragraph 2?**\n\n[[☃ radio 1]]\n\n\n\n\n\n",
+                images: {},
+                widgets: {
+                    "radio 1": {
+                        type: "radio",
+                        alignment: "default",
+                        static: false,
+                        graded: true,
+                        options: {
+                            choices: [
+                                {
+                                    content: "inventive",
+                                    correct: false,
+                                },
+                                {
+                                    content: "easily distracted",
+                                    correct: false,
+                                },
+                                {
+                                    content: "very interested",
+                                    correct: true,
+                                },
+                                {
+                                    content: "competitive",
+                                    correct: false,
+                                },
+                            ],
+                            randomize: false,
+                            multipleSelect: false,
+                            countChoices: false,
+                            displayCount: null,
+                            hasNoneOfTheAbove: false,
+                            deselectEnabled: false,
+                            numCorrect: 1,
+                        },
+                        version: {
+                            major: 2,
+                            minor: 0,
+                        },
+                    },
+                },
+            },
+            answerArea: {
+                zTable: false,
+                calculator: false,
+                chi2Table: false,
+                financialCalculatorMonthlyPayment: false,
+                financialCalculatorTotalAmount: false,
+                financialCalculatorTimeToPayOff: false,
+                periodicTable: false,
+                periodicTableWithKey: false,
+                tTable: false,
+            },
+            hints: [],
+        };
+
+        const onRendered = jest.fn();
+
+        // Act
+        render(
+            <RenderStateRoot>
+                <LoadingContext.Provider value={{onRendered}}>
+                    <WrappedServerItemRenderer
+                        item={content}
+                        problemNum={0}
+                        reviewMode={false}
+                        dependencies={testDependenciesV2}
+                    />
+                </LoadingContext.Provider>
+            </RenderStateRoot>,
+        );
 
         // Assert
         expect(onRendered).toHaveBeenCalledWith(true);

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -3,7 +3,6 @@ import {within, render, screen, act} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
-import {LoadingContext} from "..";
 import {
     testDependencies,
     testDependenciesV2,
@@ -275,48 +274,9 @@ describe("server item renderer", () => {
     it("should call the onRendered callback with no assets in content", () => {
         const content: PerseusItem = {
             question: {
-                content:
-                    "\n**What is the meaning of *intrigued*, as it is used in paragraph 2?**\n\n[[☃ radio 1]]\n\n\n\n\n\n",
+                content: "Content without any assets",
                 images: {},
-                widgets: {
-                    "radio 1": {
-                        type: "radio",
-                        alignment: "default",
-                        static: false,
-                        graded: true,
-                        options: {
-                            choices: [
-                                {
-                                    content: "inventive",
-                                    correct: false,
-                                },
-                                {
-                                    content: "easily distracted",
-                                    correct: false,
-                                },
-                                {
-                                    content: "very interested",
-                                    correct: true,
-                                },
-                                {
-                                    content: "competitive",
-                                    correct: false,
-                                },
-                            ],
-                            randomize: false,
-                            multipleSelect: false,
-                            countChoices: false,
-                            displayCount: null,
-                            hasNoneOfTheAbove: false,
-                            deselectEnabled: false,
-                            numCorrect: 1,
-                        },
-                        version: {
-                            major: 2,
-                            minor: 0,
-                        },
-                    },
-                },
+                widgets: {},
             },
             answerArea: {
                 zTable: false,

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -337,14 +337,13 @@ describe("server item renderer", () => {
         // Act
         render(
             <RenderStateRoot>
-                <LoadingContext.Provider value={{onRendered}}>
-                    <WrappedServerItemRenderer
-                        item={content}
-                        problemNum={0}
-                        reviewMode={false}
-                        dependencies={testDependenciesV2}
-                    />
-                </LoadingContext.Provider>
+                <ServerItemRenderer
+                    item={content}
+                    problemNum={0}
+                    reviewMode={false}
+                    dependencies={testDependenciesV2}
+                    onRendered={onRendered}
+                />
             </RenderStateRoot>,
         );
 

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -272,7 +272,7 @@ describe("server item renderer", () => {
         expect(onRendered).toHaveBeenCalledWith(true);
     });
 
-    it("should call the onRendered callback when if no assets in content", () => {
+    it("should call the onRendered callback with no assets in content", () => {
         const content: PerseusItem = {
             question: {
                 content:

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -132,6 +132,9 @@ export class ServerItemRenderer
         // In cases where we are rendering content that doesn't have any assets
         // (things that are async loaded/rendered, such as images or TeX), we
         // want to ensure that we fire the onRendered callback at least once.
+        // By the time the component mounts, assets will already be registered,
+        // but may not be loaded. So we will know if all assets are loaded at
+        // this point in the component lifecycle.
         this.maybeCallOnRendered();
     }
 

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -128,6 +128,11 @@ export class ServerItemRenderer
     componentDidMount() {
         this._currentFocus = null;
         this._fullyRendered = false;
+
+        // In cases where we are rendering content that doesn't have any assets
+        // (things that are async loaded/rendered, such as images or TeX), we
+        // want to ensure that we fire the onRendered callback at least once.
+        this.maybeCallOnRendered();
     }
 
     // eslint-disable-next-line react/no-unsafe
@@ -145,15 +150,7 @@ export class ServerItemRenderer
             answerableCallback(isAnswerable);
         }
 
-        if (!this._fullyRendered) {
-            const assetsLoaded = Object.values(this.state.assetStatuses).every(
-                Boolean,
-            );
-            if (assetsLoaded) {
-                this._fullyRendered = true;
-                this.props.onRendered(true);
-            }
-        }
+        this.maybeCallOnRendered();
 
         if (this.props.score && this.props.score !== prevProps.score) {
             const emptyQuestionAreaWidgets =
@@ -172,6 +169,19 @@ export class ServerItemRenderer
             // eslint-disable-next-line no-restricted-syntax
             clearTimeout(this.blurTimeoutID);
             this.blurTimeoutID = null;
+        }
+    }
+
+    maybeCallOnRendered() {
+        if (!this._fullyRendered) {
+            const assetsLoaded = Object.values(this.state.assetStatuses).every(
+                Boolean,
+            );
+
+            if (assetsLoaded) {
+                this._fullyRendered = true;
+                this.props.onRendered(true);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary:

The ServerItemRenderer (and the `<LoadingContext>`) call an `onRendered(true)` prop when all assets are loaded (things that are loaded/rendered asynchronously). However, in cases where the rendered item does not have any assets, it wasn't ever calling `onRendered(true)`. 

This PR updates the `ServerItemRenderer` to check if any assets were registered in `componentDidMount`. If not, we can safely call `onRendered(true)` knowing that the item is ready for interaction and fully rendered.

Issue: LEMS-3200

## Test plan:

All tests pass. 

I will also take the snapshot PR and spin up a ZND to test the classroom link that was broken.