### PR TITLE
IFrame: renderer user input state

### DIFF
--- a/.changeset/ten-cheetahs-confess.md
+++ b/.changeset/ten-cheetahs-confess.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+IFrame: use userInput/handleUserInput

--- a/packages/perseus/src/widgets/iframe/serialize-iframe.test.ts
+++ b/packages/perseus/src/widgets/iframe/serialize-iframe.test.ts
@@ -1,0 +1,128 @@
+import {
+    generateTestPerseusItem,
+    generateTestPerseusRenderer,
+} from "@khanacademy/perseus-core";
+import {act} from "@testing-library/react";
+
+import {testDependencies} from "../../../../../testing/test-dependencies";
+import {renderQuestion} from "../../__tests__/test-utils";
+import * as Dependencies from "../../dependencies";
+import {registerAllWidgetsForTesting} from "../../util/register-all-widgets-for-testing";
+
+import type {PerseusItem} from "@khanacademy/perseus-core";
+
+/**
+ * [LEMS-3185] These are tests for the legacy Serialization API.
+ *
+ * This API is not built in a way that supports migrating data
+ * between versions of Perseus JSON. In fact serialization
+ * doesn't use WidgetOptions, but RenderProps; it's leveraging
+ * what is considered an internal implementation detail to support
+ * rehydrating previous state.
+ *
+ * The API is very fragile and likely broken. We have a ticket to remove it.
+ * However we don't have the bandwidth to implement an alternative right now,
+ * so I'm adding tests to make sure we're roughly still able to support
+ * what little we've been supporting so far.
+ *
+ * This API needs to be removed and these tests need to be removed with it.
+ */
+describe("IFrame serialization", () => {
+    function generateBasicIFrame(): PerseusItem {
+        const question = generateTestPerseusRenderer({
+            content: "[[☃ iframe 1]]",
+            widgets: {
+                "iframe 1": {
+                    type: "iframe",
+                    options: {
+                        settings: [],
+                        url: "https://hotmail.com",
+                        height: "410",
+                        width: "410",
+                        allowFullScreen: true,
+                        static: false,
+                    },
+                },
+            },
+        });
+        const item = generateTestPerseusItem({question});
+        return item;
+    }
+
+    beforeAll(() => {
+        registerAllWidgetsForTesting();
+    });
+
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    afterEach(() => {
+        // The Renderer uses a timer to wait for widgets to complete rendering.
+        // If we don't spin the timers here, then the timer fires in the test
+        // _after_ and breaks it because we do setState() in the callback,
+        // and by that point the component has been unmounted.
+        act(() => jest.runOnlyPendingTimers());
+    });
+
+    it("should serialize the current state", async () => {
+        // Arrange
+        const {renderer} = renderQuestion(generateBasicIFrame());
+
+        // Act
+        const state = renderer.getSerializedState();
+
+        // Assert
+        expect(state).toEqual({
+            question: {
+                "iframe 1": {
+                    url: "https://hotmail.com",
+                    settings: [],
+                    width: "410",
+                    height: "410",
+                    allowFullScreen: true,
+                    allowTopNavigation: false,
+                    static: false,
+                },
+            },
+            hints: [],
+        });
+    });
+
+    it("should restore serialized state", () => {
+        // Arrange
+        const {renderer} = renderQuestion(generateBasicIFrame());
+
+        // Act
+        act(() =>
+            renderer.restoreSerializedState({
+                question: {
+                    "iframe 1": {
+                        settings: [],
+                        url: "https://hotmail.com",
+                        height: "410",
+                        width: "410",
+                        allowFullScreen: true,
+                        status: "correct",
+                        message: "cool message",
+                        static: false,
+                    },
+                },
+                hints: [],
+            }),
+        );
+
+        const userInput = renderer.getUserInput();
+
+        // Assert
+        // `value` would be 0 if we didn't properly restore serialized state
+        expect(userInput).toEqual({
+            "iframe 1": {
+                status: "correct",
+                message: "cool message",
+            },
+        });
+    });
+});


### PR DESCRIPTION
## Summary:

See the [parent PR](https://github.com/Khan/perseus/pull/2566) for more context. Part of [LEMS-3208](https://khanacademy.atlassian.net/browse/LEMS-3208).

In #2566 I add additional APIs to let widgets consume `userInput` from a parent and to update that parent state using `handleUserInput`, while also supporting the legacy way of storing user input (which was a combination of internal widget state and stashing state in a random blob in Renderer). This PR is part of a series of PRs that go widget-by-widget to use the new API.

This is a generic summary I'm putting on each PR and not every point will be applicable to every widget, but the common themes are:

- I added a test for serialization to make sure we're still backwards compatible (see [LEMS-3185](https://khanacademy.atlassian.net/browse/LEMS-3185)), then implemented the helpers `getSerializedState` and `getUserInputFromSerializedState` to keep supporting the expected results.
- I moved user input for the component into the new `userInput` state in Renderer. This means consuming `userInput` in the component and calling `handleUserInput` on change.
- When `transform` did something to initialize user input state, I moved the logic to `getStartUserInput`.
- When `staticTransform` did something to get correct state in static widgets, I moved the logic to `getCorrectUserInput`.
- Editors that use a widget to collect answer data are changed to support the new API.

Please see the [parent PR](https://github.com/Khan/perseus/pull/2566) for more information.

---

IFrameEditor doesn't use IFrame, so this shouldn't affect the editing experience

[LEMS-3208]: https://khanacademy.atlassian.net/browse/LEMS-3208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LEMS-3185]: https://khanacademy.atlassian.net/browse/LEMS-3185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ