### PR TITLE
Replace custom icons with WB components for consistent styling in Perseus Editor

### DIFF
--- a/.changeset/chatty-cats-pretend.md
+++ b/.changeset/chatty-cats-pretend.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": major
+---
+
+Unify chevrons in Perseus Editor using WB components

--- a/packages/perseus-editor/src/__tests__/editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/editor.test.tsx
@@ -84,9 +84,7 @@ describe("Editor", () => {
         render(<Harnessed />);
 
         // Act
-        const widgetDisclosure = screen.getByRole("link", {
-            name: "image 1",
-        });
+        const widgetDisclosure = screen.getByText("image 1");
         await userEvent.click(widgetDisclosure);
 
         // Assert
@@ -105,9 +103,7 @@ describe("Editor", () => {
         render(<Harnessed onChange={changeFn} />);
 
         // Act
-        const widgetDisclosure = screen.getByRole("link", {
-            name: "image 1",
-        });
+        const widgetDisclosure = screen.getByText("image 1");
         await userEvent.click(widgetDisclosure);
 
         const captionInput = screen.getByLabelText(/Caption:/);

--- a/packages/perseus-editor/src/__tests__/issues-panel.test.tsx
+++ b/packages/perseus-editor/src/__tests__/issues-panel.test.tsx
@@ -82,10 +82,10 @@ describe("IssuesPanel", () => {
     it("opens the panel when the heading is clicked", async () => {
         // Arrange
         render(<IssuesPanel issues={[makeIssue("warn1")]} />);
-        const headingButton = screen.getByRole("button"); // The button in the heading
+        const toggleableCaret = screen.getByTestId("issues-toggle-caret");
 
         //Act
-        await userEvent.click(headingButton); // Simulate click to open panel
+        await userEvent.click(toggleableCaret); // Simulate click to open panel
 
         //Assert
         expect(screen.getByText("Warning: warn1")).toBeInTheDocument();
@@ -94,12 +94,12 @@ describe("IssuesPanel", () => {
     it("closes the panel when the heading icon is clicked again", async () => {
         //Arrange
         render(<IssuesPanel issues={[makeIssue("warn1")]} />);
-        const headingButton = screen.getByRole("button");
-        await userEvent.click(headingButton);
+        const toggleableCaret = screen.getByTestId("issues-toggle-caret");
+        await userEvent.click(toggleableCaret);
         expect(screen.getByText("Warning: warn1")).toBeInTheDocument();
 
         //Act
-        await userEvent.click(headingButton);
+        await userEvent.click(toggleableCaret);
 
         //Assert
         expect(screen.queryByText("Warning: warn1")).not.toBeInTheDocument();

--- a/packages/perseus-editor/src/__tests__/issues-panel.test.tsx
+++ b/packages/perseus-editor/src/__tests__/issues-panel.test.tsx
@@ -82,24 +82,24 @@ describe("IssuesPanel", () => {
     it("opens the panel when the heading is clicked", async () => {
         // Arrange
         render(<IssuesPanel issues={[makeIssue("warn1")]} />);
-        const toggleableCaret = screen.getByTestId("issues-toggle-caret");
+        const toggleHeader = screen.getByText("Issues");
 
         //Act
-        await userEvent.click(toggleableCaret); // Simulate click to open panel
+        await userEvent.click(toggleHeader); // Simulate click to open panel
 
         //Assert
         expect(screen.getByText("Warning: warn1")).toBeInTheDocument();
     });
 
-    it("closes the panel when the heading icon is clicked again", async () => {
+    it("closes the panel when the heading is clicked again", async () => {
         //Arrange
         render(<IssuesPanel issues={[makeIssue("warn1")]} />);
-        const toggleableCaret = screen.getByTestId("issues-toggle-caret");
-        await userEvent.click(toggleableCaret);
+        const toggleHeader = screen.getByText("Issues");
+        await userEvent.click(toggleHeader);
         expect(screen.getByText("Warning: warn1")).toBeInTheDocument();
 
         //Act
-        await userEvent.click(toggleableCaret);
+        await userEvent.click(toggleHeader);
 
         //Assert
         expect(screen.queryByText("Warning: warn1")).not.toBeInTheDocument();

--- a/packages/perseus-editor/src/components/widget-editor.tsx
+++ b/packages/perseus-editor/src/components/widget-editor.tsx
@@ -167,14 +167,19 @@ class WidgetEditor extends React.Component<
                 >
                     <div className="perseus-widget-editor-title-id">
                         <View
-                            style={{marginRight: 5, flexGrow: 0}}
+                            style={{
+                                display: "flex",
+                                flexDirection: "row",
+                                alignItems: "center",
+                                gap: "0.25em",
+                            }}
                             onClick={this._toggleWidget}
                         >
                             <ToggleableCaret
                                 isExpanded={this.state.showWidget}
                             />
+                            <span>{this.props.id}</span>
                         </View>
-                        <span>{this.props.id}</span>
                     </div>
 
                     {supportsStaticMode && (

--- a/packages/perseus-editor/src/components/widget-editor.tsx
+++ b/packages/perseus-editor/src/components/widget-editor.tsx
@@ -1,31 +1,24 @@
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
-import {
-    components,
-    Widgets,
-    WIDGET_PROP_DENYLIST,
-    iconChevronDown,
-    iconTrash,
-} from "@khanacademy/perseus";
+import {Widgets, WIDGET_PROP_DENYLIST, iconTrash} from "@khanacademy/perseus";
 import {
     CoreWidgetRegistry,
     applyDefaultsToWidget,
 } from "@khanacademy/perseus-core";
+import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Switch from "@khanacademy/wonder-blocks-switch";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import caretDown from "@phosphor-icons/core/regular/caret-down.svg";
+import caretRight from "@phosphor-icons/core/regular/caret-right.svg";
 import * as React from "react";
 import {useId} from "react";
 import _ from "underscore";
-
-import {iconChevronRight} from "../styles/icon-paths";
 
 import SectionControlButton from "./section-control-button";
 
 import type Editor from "../editor";
 import type {APIOptions} from "@khanacademy/perseus";
 import type {Alignment, PerseusWidget} from "@khanacademy/perseus-core";
-
-const {InlineIcon} = components;
 
 type WidgetEditorProps = {
     // Unserialized props
@@ -165,6 +158,12 @@ class WidgetEditor extends React.Component<
 
         const supportsStaticMode = Widgets.supportsStaticMode(widgetInfo.type);
 
+        const toggleIcon = this.state.showWidget ? caretDown : caretRight;
+        const buttonStyle = {
+            marginRight: 0,
+            flexGrow: 0,
+        };
+
         return (
             <div className="perseus-widget-editor">
                 <div
@@ -173,19 +172,17 @@ class WidgetEditor extends React.Component<
                         (this.state.showWidget ? "open" : "closed")
                     }
                 >
-                    {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                    <a
-                        className="perseus-widget-editor-title-id"
-                        href="#"
-                        onClick={this._toggleWidget}
-                    >
-                        {this.props.id}
-                        {this.state.showWidget ? (
-                            <InlineIcon {...iconChevronDown} />
-                        ) : (
-                            <InlineIcon {...iconChevronRight} />
-                        )}
-                    </a>
+                    <div className="perseus-widget-editor-title-id">
+                        <IconButton
+                            icon={toggleIcon}
+                            kind="tertiary"
+                            size="small"
+                            onClick={this._toggleWidget}
+                            actionType="neutral"
+                            style={buttonStyle}
+                        />
+                        <span>{this.props.id}</span>
+                    </div>
 
                     {supportsStaticMode && (
                         <LabeledSwitch

--- a/packages/perseus-editor/src/components/widget-editor.tsx
+++ b/packages/perseus-editor/src/components/widget-editor.tsx
@@ -4,17 +4,16 @@ import {
     CoreWidgetRegistry,
     applyDefaultsToWidget,
 } from "@khanacademy/perseus-core";
-import IconButton from "@khanacademy/wonder-blocks-icon-button";
+import {View} from "@khanacademy/wonder-blocks-core";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import Switch from "@khanacademy/wonder-blocks-switch";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
-import caretDown from "@phosphor-icons/core/regular/caret-down.svg";
-import caretRight from "@phosphor-icons/core/regular/caret-right.svg";
 import * as React from "react";
 import {useId} from "react";
 import _ from "underscore";
 
 import SectionControlButton from "./section-control-button";
+import ToggleableCaret from "./toggleable-caret";
 
 import type Editor from "../editor";
 import type {APIOptions} from "@khanacademy/perseus";
@@ -158,12 +157,6 @@ class WidgetEditor extends React.Component<
 
         const supportsStaticMode = Widgets.supportsStaticMode(widgetInfo.type);
 
-        const toggleIcon = this.state.showWidget ? caretDown : caretRight;
-        const buttonStyle = {
-            marginRight: 0,
-            flexGrow: 0,
-        };
-
         return (
             <div className="perseus-widget-editor">
                 <div
@@ -173,14 +166,14 @@ class WidgetEditor extends React.Component<
                     }
                 >
                     <div className="perseus-widget-editor-title-id">
-                        <IconButton
-                            icon={toggleIcon}
-                            kind="tertiary"
-                            size="small"
+                        <View
+                            style={{marginRight: 5, flexGrow: 0}}
                             onClick={this._toggleWidget}
-                            actionType="neutral"
-                            style={buttonStyle}
-                        />
+                        >
+                            <ToggleableCaret
+                                isExpanded={this.state.showWidget}
+                            />
+                        </View>
                         <span>{this.props.id}</span>
                     </div>
 

--- a/packages/perseus-editor/src/issues-panel.tsx
+++ b/packages/perseus-editor/src/issues-panel.tsx
@@ -45,13 +45,17 @@ const IssuesPanel = ({issues = []}: IssuesPanelProps) => {
             <div className="perseus-widget-editor-title">
                 <div className="perseus-widget-editor-title-id">
                     <View
-                        style={{marginRight: 5, flexGrow: 0}}
+                        style={{
+                            display: "flex",
+                            flexDirection: "row",
+                            alignItems: "center",
+                            gap: "0.25em",
+                        }}
                         onClick={togglePanel}
-                        testId="issues-toggle-caret"
                     >
                         <ToggleableCaret isExpanded={showPanel} />
+                        <span>Issues</span>
                     </View>
-                    <span>Issues</span>
                 </div>
                 <PhosphorIcon
                     icon={icon}

--- a/packages/perseus-editor/src/issues-panel.tsx
+++ b/packages/perseus-editor/src/issues-panel.tsx
@@ -1,13 +1,12 @@
+import {View} from "@khanacademy/wonder-blocks-core";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {color as wbColor} from "@khanacademy/wonder-blocks-tokens";
 import iconPass from "@phosphor-icons/core/fill/check-circle-fill.svg";
 import iconWarning from "@phosphor-icons/core/fill/warning-fill.svg";
-import caretDown from "@phosphor-icons/core/regular/caret-down.svg";
-import caretRight from "@phosphor-icons/core/regular/caret-right.svg";
 import * as React from "react";
 import {useState} from "react";
 
+import ToggleableCaret from "./components/toggleable-caret";
 import IssueDetails from "./issue-details";
 
 export type IssueImpact = "low" | "medium" | "high";
@@ -25,15 +24,15 @@ type IssuesPanelProps = {
 };
 
 const IssuesPanel = ({issues = []}: IssuesPanelProps) => {
-    const hasWarnings = issues.length > 0;
     const [showPanel, setShowPanel] = useState(false);
-    const icon = hasWarnings ? iconWarning : iconPass;
-    const iconColor = hasWarnings ? wbColor.gold : wbColor.green;
+
+    const hasWarnings = issues.length > 0;
     const issuesCount = `${issues.length} issue${
         issues.length === 1 ? "" : "s"
     }`;
 
-    const toggleIcon = showPanel ? caretDown : caretRight;
+    const icon = hasWarnings ? iconWarning : iconPass;
+    const iconColor = hasWarnings ? wbColor.gold : wbColor.green;
 
     const togglePanel = () => {
         if (hasWarnings) {
@@ -45,14 +44,13 @@ const IssuesPanel = ({issues = []}: IssuesPanelProps) => {
         <div className="perseus-widget-editor">
             <div className="perseus-widget-editor-title">
                 <div className="perseus-widget-editor-title-id">
-                    <IconButton
-                        icon={toggleIcon}
-                        kind="tertiary"
-                        size="small"
+                    <View
+                        style={{marginRight: 5, flexGrow: 0}}
                         onClick={togglePanel}
-                        actionType="neutral"
-                        style={{marginRight: 0, flexGrow: 0}}
-                    />
+                        testId="issues-toggle-caret"
+                    >
+                        <ToggleableCaret isExpanded={showPanel} />
+                    </View>
                     <span>Issues</span>
                 </div>
                 <PhosphorIcon

--- a/packages/perseus-editor/src/issues-panel.tsx
+++ b/packages/perseus-editor/src/issues-panel.tsx
@@ -1,15 +1,14 @@
-import {components, iconChevronDown} from "@khanacademy/perseus";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {color as wbColor} from "@khanacademy/wonder-blocks-tokens";
 import iconPass from "@phosphor-icons/core/fill/check-circle-fill.svg";
 import iconWarning from "@phosphor-icons/core/fill/warning-fill.svg";
+import caretDown from "@phosphor-icons/core/regular/caret-down.svg";
+import caretRight from "@phosphor-icons/core/regular/caret-right.svg";
 import * as React from "react";
 import {useState} from "react";
 
 import IssueDetails from "./issue-details";
-import {iconChevronRight} from "./styles/icon-paths";
-
-const {InlineIcon} = components;
 
 export type IssueImpact = "low" | "medium" | "high";
 export type Issue = {
@@ -34,7 +33,7 @@ const IssuesPanel = ({issues = []}: IssuesPanelProps) => {
         issues.length === 1 ? "" : "s"
     }`;
 
-    const editorClasses = `perseus-widget-editor${showPanel ? " perseus-widget-editor-open" : ""}`;
+    const toggleIcon = showPanel ? caretDown : caretRight;
 
     const togglePanel = () => {
         if (hasWarnings) {
@@ -43,26 +42,17 @@ const IssuesPanel = ({issues = []}: IssuesPanelProps) => {
     };
 
     return (
-        <div className={editorClasses}>
+        <div className="perseus-widget-editor">
             <div className="perseus-widget-editor-title">
                 <div className="perseus-widget-editor-title-id">
-                    <button
+                    <IconButton
+                        icon={toggleIcon}
+                        kind="tertiary"
+                        size="small"
                         onClick={togglePanel}
-                        disabled={!hasWarnings}
-                        style={{
-                            marginInlineEnd: 0,
-                            flexGrow: 0,
-                            border: "none",
-                            backgroundColor: "transparent",
-                            cursor: hasWarnings ? "pointer" : "not-allowed",
-                        }}
-                    >
-                        {showPanel ? (
-                            <InlineIcon {...iconChevronDown} />
-                        ) : (
-                            <InlineIcon {...iconChevronRight} />
-                        )}
-                    </button>
+                        actionType="neutral"
+                        style={{marginRight: 0, flexGrow: 0}}
+                    />
                     <span>Issues</span>
                 </div>
                 <PhosphorIcon

--- a/packages/perseus-editor/src/styles/perseus-editor.css
+++ b/packages/perseus-editor/src/styles/perseus-editor.css
@@ -117,6 +117,7 @@ code {
     display: flex;
     align-items: center;
     position: relative;
+    cursor: pointer;
 }
 .perseus-widget-editor .perseus-widget-editor-title.closed {
     border-radius: 3px;

--- a/packages/perseus-editor/src/styles/perseus-editor.css
+++ b/packages/perseus-editor/src/styles/perseus-editor.css
@@ -166,6 +166,10 @@ code {
     align-self: center;
     padding-right: 0.5em;
 }
+.perseus-widget-editor-title-id {
+    display: inline-flex;
+    align-items: center;
+}
 .perseus-widget-editor-title-id > svg {
     float: left;
     font-size: 14px;


### PR DESCRIPTION
## Summary:
Replace custom icons with WB components for consistent styling in Perseus Editor

This PR updates the styling in the Perseus Editor to create a more unified and accessible experience across components.

- Replaced the anchor tag used for panel toggling with a Wonder Blocks IconButton.
- Applied consistent styles and toggle behavior across widget-editor.tsx and issues-panel.tsx.
- Partially implements styling and structure from [Mark Fitzgerald’s POC #2219](https://github.com/Khan/perseus/pull/2219) to align with design direction.

![Screenshot 2025-06-12 at 9 51 37 AM](https://github.com/user-attachments/assets/728f8063-01db-465a-bd2b-014999a0742f)

Issue: LEMS-3125

## Test plan: