### PR TITLE
MockWidget: renderer user input state

### DIFF
--- a/.changeset/large-swans-bake.md
+++ b/.changeset/large-swans-bake.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+MockWidget: use userInput/handleUserInput


### PR DESCRIPTION
## Summary:

See the [parent PR](https://github.com/Khan/perseus/pull/2566) for more context. Part of [LEMS-3208](https://khanacademy.atlassian.net/browse/LEMS-3208).

In #2566 I add additional APIs to let widgets consume `userInput` from a parent and to update that parent state using `handleUserInput`, while also supporting the legacy way of storing user input (which was a combination of internal widget state and stashing state in a random blob in Renderer). This PR is part of a series of PRs that go widget-by-widget to use the new API.

This is a generic summary I'm putting on each PR and not every point will be applicable to every widget, but the common themes are:

- I added a test for serialization to make sure we're still backwards compatible (see [LEMS-3185](https://khanacademy.atlassian.net/browse/LEMS-3185)), then implemented the helpers `getSerializedState` and `getUserInputFromSerializedState` to keep supporting the expected results.
- I moved user input for the component into the new `userInput` state in Renderer. This means consuming `userInput` in the component and calling `handleUserInput` on change.
- When `transform` did something to initialize user input state, I moved the logic to `getStartUserInput`.
- When `staticTransform` did something to get correct state in static widgets, I moved the logic to `getCorrectUserInput`.
- Editors that use a widget to collect answer data are changed to support the new API.

Please see the [parent PR](https://github.com/Khan/perseus/pull/2566) for more information.

---

MockWidget doesn't have an editor, so no impact on the editing experience.

[LEMS-3208]: https://khanacademy.atlassian.net/browse/LEMS-3208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LEMS-3185]: https://khanacademy.atlassian.net/browse/LEMS-3185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ