### PR TITLE
Plotter: renderer user input state

### DIFF
--- a/.changeset/early-walls-walk.md
+++ b/.changeset/early-walls-walk.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Plotter: use userInput/handleUserInput

--- a/packages/perseus-editor/src/widgets/plotter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/plotter-editor.tsx
@@ -14,6 +14,7 @@ import type {
     PerseusPlotterWidgetOptions,
     PlotterDefaultWidgetOptions,
 } from "@khanacademy/perseus-core";
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 const {InfoTip, NumberInput, RangeInput, TextListEditor} = components;
 const Plotter = PlotterWidget.widget;
@@ -285,10 +286,16 @@ class PlotterEditor extends React.Component<Props, State> {
             this.props.type,
         );
         const canChangeSnaps = !_.contains(["pic", "dotplot"], this.props.type);
-        const props = {
-            trackInteraction: () => {},
+        const plotterProps: any = {
             ...this.props,
-        } as const;
+            trackInteraction: () => {},
+            starting: this.props[this.state.editing],
+            onChange: this.handlePlotterChange,
+            userInput: this.props.correct,
+            handleUserInput: (userInput) => {
+                this.props.onChange({correct: userInput});
+            },
+        };
 
         return (
             <div className="perseus-widget-plotter-editor">
@@ -493,12 +500,7 @@ class PlotterEditor extends React.Component<Props, State> {
                         </p>
                     </InfoTip>
                 </div>
-                {/* @ts-expect-error - TS2769 */}
-                <Plotter
-                    {...props}
-                    starting={this.props[this.state.editing]}
-                    onChange={this.handlePlotterChange}
-                />
+                <Plotter {...(plotterProps as PropsFor<typeof Plotter>)} />
             </div>
         );
     }

--- a/packages/perseus/src/widgets/plotter/plotter.stories.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.stories.tsx
@@ -2,7 +2,7 @@ import {generateTestPerseusItem} from "@khanacademy/perseus-core";
 
 import {ServerItemRendererWithDebugUI} from "../../../../../testing/server-item-renderer-with-debug-ui";
 
-import {question1} from "./plotter.testdata";
+import {question1, simple} from "./plotter.testdata";
 
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
@@ -23,6 +23,13 @@ export const Basic: Story = {
 export const AnswerlessPlotter: Story = {
     args: {
         item: generateTestPerseusItem({question: question1}),
+        startAnswerless: true,
+    },
+};
+
+export const SimplePlotter: Story = {
+    args: {
+        item: generateTestPerseusItem({question: simple}),
         startAnswerless: true,
     },
 };

--- a/packages/perseus/src/widgets/plotter/plotter.testdata.ts
+++ b/packages/perseus/src/widgets/plotter/plotter.testdata.ts
@@ -35,3 +35,24 @@ export const question1: PerseusRenderer = {
         },
     },
 };
+
+export const simple: PerseusRenderer = {
+    content: "Match the horizontal with the vertical.\n\n[[☃ plotter 1]]",
+    images: {},
+    widgets: {
+        "plotter 1": {
+            type: "plotter",
+            options: {
+                categories: ["0", "1", "2"],
+                plotDimensions: [300, 300],
+                correct: [0, 1, 2],
+                labels: ["Horizontal", "Vertical"],
+                maxY: 2,
+                scaleY: 1,
+                snapsPerLine: 1,
+                starting: [0, 0, 0],
+                type: "bar",
+            },
+        },
+    },
+};

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -1165,9 +1165,16 @@ export class Plotter extends React.Component<Props, State> implements Widget {
     }
 }
 
+function getStartUserInput(
+    options: PlotterPublicWidgetOptions,
+): PerseusPlotterUserInput {
+    return options.starting;
+}
+
 export default {
     name: "plotter",
     displayName: "Plotter",
     hidden: true,
     widget: Plotter,
+    // getStartUserInput,
 } satisfies WidgetExports<typeof Plotter>;

--- a/packages/perseus/src/widgets/plotter/serialize-plotter.test.ts
+++ b/packages/perseus/src/widgets/plotter/serialize-plotter.test.ts
@@ -1,0 +1,155 @@
+import {
+    generateTestPerseusItem,
+    generateTestPerseusRenderer,
+} from "@khanacademy/perseus-core";
+import {screen, act} from "@testing-library/react";
+import {userEvent as userEventLib} from "@testing-library/user-event";
+
+import {testDependencies} from "../../../../../testing/test-dependencies";
+import {renderQuestion} from "../../__tests__/test-utils";
+import * as Dependencies from "../../dependencies";
+import {registerAllWidgetsForTesting} from "../../util/register-all-widgets-for-testing";
+
+import type {PerseusItem} from "@khanacademy/perseus-core";
+import type {UserEvent} from "@testing-library/user-event";
+
+/**
+ * [LEMS-3185] These are tests for the legacy Serialization API.
+ *
+ * This API is not built in a way that supports migrating data
+ * between versions of Perseus JSON. In fact serialization
+ * doesn't use WidgetOptions, but RenderProps; it's leveraging
+ * what is considered an internal implementation detail to support
+ * rehydrating previous state.
+ *
+ * The API is very fragile and likely broken. We have a ticket to remove it.
+ * However we don't have the bandwidth to implement an alternative right now,
+ * so I'm adding tests to make sure we're roughly still able to support
+ * what little we've been supporting so far.
+ *
+ * This API needs to be removed and these tests need to be removed with it.
+ */
+describe.skip("Plotter serialization", () => {
+    function generateBasicPlotter(): PerseusItem {
+        const question = generateTestPerseusRenderer({
+            content:
+                "Match the horizontal with the vertical.\n\n[[☃ plotter 1]]",
+            images: {},
+            widgets: {
+                "plotter 1": {
+                    type: "plotter",
+                    options: {
+                        categories: ["0", "1", "2"],
+                        plotDimensions: [300, 300],
+                        correct: [0, 1, 2],
+                        labels: ["Horizontal", "Vertical"],
+                        maxY: 2,
+                        scaleY: 1,
+                        snapsPerLine: 1,
+                        starting: [0, 0, 0],
+                        type: "bar",
+                    },
+                },
+            },
+        });
+        const item = generateTestPerseusItem({question});
+        return item;
+    }
+
+    beforeAll(() => {
+        registerAllWidgetsForTesting();
+    });
+
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    afterEach(() => {
+        // The Renderer uses a timer to wait for widgets to complete rendering.
+        // If we don't spin the timers here, then the timer fires in the test
+        // _after_ and breaks it because we do setState() in the callback,
+        // and by that point the component has been unmounted.
+        act(() => jest.runOnlyPendingTimers());
+    });
+
+    it("should serialize the current state", async () => {
+        // Arrange
+        const {renderer} = renderQuestion(generateBasicPlotter());
+
+        const [plotter] = renderer.questionRenderer.findWidgets("plotter 1");
+        // TODO this is horrific
+        act(() => plotter.setState({values: [3, 3, 3]}));
+
+        // Act
+        const state = renderer.getSerializedState();
+        const userInput = renderer.getUserInput();
+
+        // Assert
+        expect(userInput).toEqual({
+            "plotter 1": [3, 3, 3],
+        });
+        expect(state).toEqual({
+            question: {
+                "plotter 1": {
+                    scaleY: 1,
+                    maxY: 2,
+                    snapsPerLine: 1,
+                    correct: [0, 1, 2],
+                    starting: [0, 0, 0],
+                    type: "bar",
+                    labels: ["Horizontal", "Vertical"],
+                    categories: ["0", "1", "2"],
+                    picSize: 30,
+                    picBoxHeight: 36,
+                    plotDimensions: [300, 300],
+                    labelInterval: 1,
+                    picUrl: null,
+                },
+            },
+            hints: [],
+        });
+    });
+
+    it("should restore serialized state", () => {
+        // Arrange
+        const {renderer} = renderQuestion(generateBasicPlotter());
+
+        // Act
+        act(() =>
+            renderer.restoreSerializedState({
+                question: {
+                    "plotter 1": {
+                        scaleY: 1,
+                        maxY: 2,
+                        snapsPerLine: 1,
+                        correct: [0, 1, 2],
+                        starting: [0, 0, 0],
+                        type: "bar",
+                        labels: ["Horizontal", "Vertical"],
+                        categories: ["0", "1", "2"],
+                        picSize: 30,
+                        picBoxHeight: 36,
+                        plotDimensions: [300, 300],
+                        labelInterval: 1,
+                        picUrl: null,
+                        values: [3, 3, 3],
+                    },
+                },
+                hints: [],
+            }),
+        );
+
+        const userInput = renderer.getUserInput();
+
+        // Assert
+        // `value` would be 0 if we didn't properly restore serialized state
+        expect(userInput).toEqual({"plotter 1": [3, 3, 3]});
+    });
+});

--- a/packages/perseus/src/widgets/plotter/serialize-plotter.test.ts
+++ b/packages/perseus/src/widgets/plotter/serialize-plotter.test.ts
@@ -2,8 +2,7 @@ import {
     generateTestPerseusItem,
     generateTestPerseusRenderer,
 } from "@khanacademy/perseus-core";
-import {screen, act} from "@testing-library/react";
-import {userEvent as userEventLib} from "@testing-library/user-event";
+import {act} from "@testing-library/react";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import {renderQuestion} from "../../__tests__/test-utils";
@@ -11,7 +10,6 @@ import * as Dependencies from "../../dependencies";
 import {registerAllWidgetsForTesting} from "../../util/register-all-widgets-for-testing";
 
 import type {PerseusItem} from "@khanacademy/perseus-core";
-import type {UserEvent} from "@testing-library/user-event";
 
 /**
  * [LEMS-3185] These are tests for the legacy Serialization API.
@@ -29,7 +27,7 @@ import type {UserEvent} from "@testing-library/user-event";
  *
  * This API needs to be removed and these tests need to be removed with it.
  */
-describe.skip("Plotter serialization", () => {
+describe("Plotter serialization", () => {
     function generateBasicPlotter(): PerseusItem {
         const question = generateTestPerseusRenderer({
             content:
@@ -60,12 +58,7 @@ describe.skip("Plotter serialization", () => {
         registerAllWidgetsForTesting();
     });
 
-    let userEvent: UserEvent;
     beforeEach(() => {
-        userEvent = userEventLib.setup({
-            advanceTimers: jest.advanceTimersByTime,
-        });
-
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );
@@ -84,8 +77,7 @@ describe.skip("Plotter serialization", () => {
         const {renderer} = renderQuestion(generateBasicPlotter());
 
         const [plotter] = renderer.questionRenderer.findWidgets("plotter 1");
-        // TODO this is horrific
-        act(() => plotter.setState({values: [3, 3, 3]}));
+        act(() => plotter._testInsertUserInput([3, 3, 3]));
 
         // Act
         const state = renderer.getSerializedState();
@@ -111,6 +103,8 @@ describe.skip("Plotter serialization", () => {
                     plotDimensions: [300, 300],
                     labelInterval: 1,
                     picUrl: null,
+                    // manually added to serialized state
+                    values: [3, 3, 3],
                 },
             },
             hints: [],
@@ -139,6 +133,7 @@ describe.skip("Plotter serialization", () => {
                         plotDimensions: [300, 300],
                         labelInterval: 1,
                         picUrl: null,
+                        // the stashed user input
                         values: [3, 3, 3],
                     },
                 },


### PR DESCRIPTION
## Summary:

See the [parent PR](https://github.com/Khan/perseus/pull/2566) for more context. Part of [LEMS-3208](https://khanacademy.atlassian.net/browse/LEMS-3208).

In #2566 I add additional APIs to let widgets consume `userInput` from a parent and to update that parent state using `handleUserInput`, while also supporting the legacy way of storing user input (which was a combination of internal widget state and stashing state in a random blob in Renderer). This PR is part of a series of PRs that go widget-by-widget to use the new API.

This is a generic summary I'm putting on each PR and not every point will be applicable to every widget, but the common themes are:

- I added a test for serialization to make sure we're still backwards compatible (see [LEMS-3185](https://khanacademy.atlassian.net/browse/LEMS-3185)), then implemented the helpers `getSerializedState` and `getUserInputFromSerializedState` to keep supporting the expected results.
- I moved user input for the component into the new `userInput` state in Renderer. This means consuming `userInput` in the component and calling `handleUserInput` on change.
- When `transform` did something to initialize user input state, I moved the logic to `getStartUserInput`.
- When `staticTransform` did something to get correct state in static widgets, I moved the logic to `getCorrectUserInput`.
- Editors that use a widget to collect answer data are changed to support the new API.

Please see the [parent PR](https://github.com/Khan/perseus/pull/2566) for more information.

---

PlotterEditor does use Plotter, so this will affect the editing experience

[LEMS-3208]: https://khanacademy.atlassian.net/browse/LEMS-3208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LEMS-3185]: https://khanacademy.atlassian.net/browse/LEMS-3185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ