### PR TITLE
InputNumber: renderer user input state

### DIFF
--- a/.changeset/eighty-rice-buy.md
+++ b/.changeset/eighty-rice-buy.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+InputNumber: use userInput/handleUserInput

--- a/packages/perseus/src/widgets/input-number/input-number.tsx
+++ b/packages/perseus/src/widgets/input-number/input-number.tsx
@@ -61,7 +61,6 @@ type Props = ExternalProps & {
     linterContext: NonNullable<ExternalProps["linterContext"]>;
     rightAlign: NonNullable<ExternalProps["rightAlign"]>;
     size: NonNullable<ExternalProps["size"]>;
-    currentValue: string;
     // NOTE(kevinb): This was the only default prop that is listed as
     // not-required in PerseusInputNumberWidgetOptions.
     answerType: NonNullable<ExternalProps["answerType"]>;
@@ -71,10 +70,10 @@ type DefaultProps = Pick<
     Props,
     | "answerType"
     | "apiOptions"
-    | "currentValue"
     | "linterContext"
     | "rightAlign"
     | "size"
+    | "userInput"
 >;
 
 class InputNumber extends React.Component<Props> implements Widget {
@@ -82,7 +81,6 @@ class InputNumber extends React.Component<Props> implements Widget {
     declare context: React.ContextType<typeof PerseusI18nContext>;
 
     static defaultProps: DefaultProps = {
-        currentValue: "",
         size: "normal",
         answerType: "number",
         rightAlign: false,
@@ -90,6 +88,7 @@ class InputNumber extends React.Component<Props> implements Widget {
         // need to include it in defaultProps.
         apiOptions: ApiOptions.defaults,
         linterContext: linterContextDefault,
+        userInput: {currentValue: ""},
     };
 
     shouldShowExamples: () => boolean = () => {
@@ -97,7 +96,7 @@ class InputNumber extends React.Component<Props> implements Widget {
     };
 
     handleChange: (arg1: string, arg2: () => void) => void = (newValue, cb) => {
-        this.props.onChange({currentValue: newValue}, cb);
+        this.props.handleUserInput({currentValue: newValue}, cb);
     };
 
     _handleFocus: () => void = () => {
@@ -149,7 +148,7 @@ class InputNumber extends React.Component<Props> implements Widget {
         newValue,
         cb,
     ) => {
-        this.props.onChange(
+        this.props.handleUserInput(
             {
                 currentValue: newValue,
             },
@@ -157,10 +156,12 @@ class InputNumber extends React.Component<Props> implements Widget {
         );
     };
 
+    /**
+     * TODO: remove this when everything is pulling from Renderer state
+     * @deprecated get user input from Renderer state
+     */
     getUserInput(): PerseusInputNumberUserInput {
-        return {
-            currentValue: this.props.currentValue,
-        };
+        return this.props.userInput;
     }
 
     getPromptJSON(): InputNumberPromptJSON {
@@ -179,6 +180,18 @@ class InputNumber extends React.Component<Props> implements Widget {
         return [strings.yourAnswer].concat(examples);
     }
 
+    /**
+     * @deprecated and likely very broken API
+     * [LEMS-3185] do not trust serializedState/restoreSerializedState
+     */
+    getSerializedState(): any {
+        const {userInput, ...rest} = this.props;
+        return {
+            ...rest,
+            currentValue: userInput.currentValue,
+        };
+    }
+
     render(): React.ReactNode {
         if (this.props.apiOptions.customKeypad) {
             // TODO(charlie): Support "Review Mode".
@@ -186,7 +199,7 @@ class InputNumber extends React.Component<Props> implements Widget {
                 <SimpleKeypadInput
                     // eslint-disable-next-line react/no-string-refs
                     ref="input"
-                    value={this.props.currentValue}
+                    value={this.props.userInput.currentValue}
                     keypadElement={this.props.keypadElement}
                     onChange={this.handleChange}
                     onFocus={this._handleFocus}
@@ -210,7 +223,7 @@ class InputNumber extends React.Component<Props> implements Widget {
             this.props.rightAlign ? styles.rightAlign : styles.leftAlign,
         ];
         // Unanswered
-        if (this.props.reviewMode && !this.props.currentValue) {
+        if (this.props.reviewMode && !this.props.userInput.currentValue) {
             inputStyles.push(styles.answerStateUnanswered);
         }
 
@@ -218,7 +231,7 @@ class InputNumber extends React.Component<Props> implements Widget {
             <InputWithExamples
                 // eslint-disable-next-line react/no-string-refs
                 ref="input"
-                value={this.props.currentValue}
+                value={this.props.userInput.currentValue}
                 onChange={this.handleChange}
                 style={inputStyles}
                 examples={this.examples()}
@@ -284,7 +297,7 @@ function getOneCorrectAnswerFromRubric(rubric: any): string | undefined {
  * [LEMS-3185] do not trust serializedState/restoreSerializedState
  */
 function getUserInputFromSerializedState(
-    serializedState: Props,
+    serializedState: any,
 ): PerseusInputNumberUserInput {
     return {
         currentValue: serializedState.currentValue,

--- a/packages/perseus/src/widgets/input-number/serialize-input-number.test.ts
+++ b/packages/perseus/src/widgets/input-number/serialize-input-number.test.ts
@@ -1,0 +1,126 @@
+import {
+    generateTestPerseusItem,
+    generateTestPerseusRenderer,
+} from "@khanacademy/perseus-core";
+import {screen, act} from "@testing-library/react";
+import {userEvent as userEventLib} from "@testing-library/user-event";
+
+import {testDependencies} from "../../../../../testing/test-dependencies";
+import {renderQuestion} from "../../__tests__/test-utils";
+import * as Dependencies from "../../dependencies";
+import {registerAllWidgetsForTesting} from "../../util/register-all-widgets-for-testing";
+
+import type {PerseusItem} from "@khanacademy/perseus-core";
+import type {UserEvent} from "@testing-library/user-event";
+
+/**
+ * [LEMS-3185] These are tests for the legacy Serialization API.
+ *
+ * This API is not built in a way that supports migrating data
+ * between versions of Perseus JSON. In fact serialization
+ * doesn't use WidgetOptions, but RenderProps; it's leveraging
+ * what is considered an internal implementation detail to support
+ * rehydrating previous state.
+ *
+ * The API is very fragile and likely broken. We have a ticket to remove it.
+ * However we don't have the bandwidth to implement an alternative right now,
+ * so I'm adding tests to make sure we're roughly still able to support
+ * what little we've been supporting so far.
+ *
+ * This API needs to be removed and these tests need to be removed with it.
+ */
+describe("InputNumber serialization", () => {
+    function generateBasicInputNumber(): PerseusItem {
+        const question = generateTestPerseusRenderer({
+            content: "[[☃ input-number 1]]",
+            widgets: {
+                "input-number 1": {
+                    type: "input-number",
+                    options: {
+                        value: 42,
+                        simplify: "optional",
+                        size: "normal",
+                    },
+                },
+            },
+        });
+        const item = generateTestPerseusItem({question});
+        return item;
+    }
+
+    beforeAll(() => {
+        registerAllWidgetsForTesting();
+    });
+
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    afterEach(() => {
+        // The Renderer uses a timer to wait for widgets to complete rendering.
+        // If we don't spin the timers here, then the timer fires in the test
+        // _after_ and breaks it because we do setState() in the callback,
+        // and by that point the component has been unmounted.
+        act(() => jest.runOnlyPendingTimers());
+    });
+
+    it("should serialize the current state", async () => {
+        // Arrange
+        const {renderer} = renderQuestion(generateBasicInputNumber());
+
+        // Act
+        await userEvent.type(screen.getByRole("textbox"), "42");
+        const state = renderer.getSerializedState();
+
+        // Assert
+        expect(state).toEqual({
+            question: {
+                "input-number 1": {
+                    simplify: "optional",
+                    size: "normal",
+                    answerType: "number",
+                    rightAlign: false,
+                    // this is the stashed user input
+                    currentValue: "42",
+                },
+            },
+            hints: [],
+        });
+    });
+
+    it("should restore serialized state", () => {
+        // Arrange
+        const {renderer} = renderQuestion(generateBasicInputNumber());
+
+        const preUserInput = renderer.getUserInput();
+
+        // Act
+        act(() =>
+            renderer.restoreSerializedState({
+                question: {
+                    "input-number 1": {
+                        simplify: "optional",
+                        size: "normal",
+                        answerType: "number",
+                        rightAlign: false,
+                        currentValue: "42",
+                    },
+                },
+                hints: [],
+            }),
+        );
+
+        const postUserInput = renderer.getUserInput();
+
+        // Assert
+        expect(preUserInput).toEqual({"input-number 1": {currentValue: ""}});
+        expect(postUserInput).toEqual({"input-number 1": {currentValue: "42"}});
+    });
+});


### PR DESCRIPTION
## Summary:

See the [parent PR](https://github.com/Khan/perseus/pull/2566) for more context. Part of [LEMS-3208](https://khanacademy.atlassian.net/browse/LEMS-3208).

In #2566 I add additional APIs to let widgets consume `userInput` from a parent and to update that parent state using `handleUserInput`, while also supporting the legacy way of storing user input (which was a combination of internal widget state and stashing state in a random blob in Renderer). This PR is part of a series of PRs that go widget-by-widget to use the new API.

This is a generic summary I'm putting on each PR and not every point will be applicable to every widget, but the common themes are:

- I added a test for serialization to make sure we're still backwards compatible (see [LEMS-3185](https://khanacademy.atlassian.net/browse/LEMS-3185)), then implemented the helpers `getSerializedState` and `getUserInputFromSerializedState` to keep supporting the expected results.
- I moved user input for the component into the new `userInput` state in Renderer. This means consuming `userInput` in the component and calling `handleUserInput` on change.
- When `transform` did something to initialize user input state, I moved the logic to `getStartUserInput`.
- When `staticTransform` did something to get correct state in static widgets, I moved the logic to `getCorrectUserInput`.
- Editors that use a widget to collect answer data are changed to support the new API.

Please see the [parent PR](https://github.com/Khan/perseus/pull/2566) for more information.

---

InputNumberEditor doesn't use InputNumber, so this shouldn't affect the editing experience

[LEMS-3208]: https://khanacademy.atlassian.net/browse/LEMS-3208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LEMS-3185]: https://khanacademy.atlassian.net/browse/LEMS-3185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ