### PR TITLE
WIP - Rename getUserInputMap to getUserInput

### DIFF
--- a/dev/flipbook.tsx
+++ b/dev/flipbook.tsx
@@ -321,7 +321,7 @@ function GradableRenderer(props: QuestionRendererProps) {
                             if (rendererRef.current) {
                                 const score = scorePerseusItem(
                                     question,
-                                    rendererRef.current.getUserInputMap(),
+                                    rendererRef.current.getUserInput(),
                                     "en",
                                 );
                                 setScore(score);

--- a/packages/perseus/src/__tests__/renderer-api.test.tsx
+++ b/packages/perseus/src/__tests__/renderer-api.test.tsx
@@ -50,7 +50,7 @@ describe("Perseus API", function () {
 
             const score = scorePerseusItemTesting(
                 mockWidget1Item.question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -66,7 +66,7 @@ describe("Perseus API", function () {
 
             const score = scorePerseusItemTesting(
                 mockWidget1Item.question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -81,7 +81,7 @@ describe("Perseus API", function () {
 
             let score = scorePerseusItemTesting(
                 mockWidget1Item.question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             expect(score).toHaveBeenAnsweredIncorrectly();
@@ -90,7 +90,7 @@ describe("Perseus API", function () {
 
             score = scorePerseusItemTesting(
                 mockWidget1Item.question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             expect(score).toHaveInvalidInput();
@@ -101,7 +101,7 @@ describe("Perseus API", function () {
                 const {renderer} = renderQuestion(mockWidget1Item.question);
                 act(() =>
                     renderer.setInputValue(["mock-widget 1"], "3", function () {
-                        const guess = renderer.getUserInputMap()[
+                        const guess = renderer.getUserInput()[
                             "mock-widget 1"
                         ] as PerseusMockWidgetUserInput;
                         expect(guess?.currentValue).toBe("3");

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -866,7 +866,7 @@ describe("renderer", () => {
         await userEvent.click(screen.getByRole("combobox"));
         await userEvent.click(screen.getAllByRole("option")[1]);
 
-        expect(renderer.getUserInputMap()).toEqual({
+        expect(renderer.getUserInput()).toEqual({
             "dropdown 1": {
                 value: 1,
             },
@@ -876,7 +876,7 @@ describe("renderer", () => {
         rerender(answerful.question);
 
         // Assert
-        expect(renderer.getUserInputMap()).toEqual({
+        expect(renderer.getUserInput()).toEqual({
             "dropdown 1": {
                 value: 1,
             },
@@ -1698,7 +1698,7 @@ describe("renderer", () => {
         });
     });
 
-    describe("getUserInputMap", () => {
+    describe("getUserInput", () => {
         it("should return user input for all rendered widgets", async () => {
             // Arrange
             const {renderer} = renderQuestion({
@@ -1724,7 +1724,7 @@ describe("renderer", () => {
             await userEvent.click(screen.getAllByRole("option")[1]);
 
             // Act
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
 
             // Assert
             expect(userInput).toMatchInlineSnapshot(`

--- a/packages/perseus/src/components/__tests__/sorter.test.tsx
+++ b/packages/perseus/src/components/__tests__/sorter.test.tsx
@@ -95,7 +95,7 @@ describe("sorter widget", () => {
             // Act
             const score = scorePerseusItemTesting(
                 answerfulItem.question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -117,7 +117,7 @@ describe("sorter widget", () => {
 
             const score = scorePerseusItemTesting(
                 answerfulItem.question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -134,7 +134,7 @@ describe("sorter widget", () => {
 
             const score = scorePerseusItemTesting(
                 answerfulItem.question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -1612,7 +1612,7 @@ class Renderer
         return emptyWidgetsFunctional(
             this.state.widgetInfo,
             this.widgetIds,
-            this.getUserInputMap(),
+            this.getUserInput(),
             this.context.locale,
         );
     }
@@ -1696,7 +1696,7 @@ class Renderer
     /**
      * Returns an object of the widget `.getUserInput()` results
      */
-    getUserInputMap(): UserInputMap {
+    getUserInput(): UserInputMap {
         const userInputMap = {};
         this.widgetIds.forEach((id: string) => {
             const widget = this.getWidgetInstance(id);
@@ -1747,7 +1747,7 @@ class Renderer
         const scores = scoreWidgetsFunctional(
             this.state.widgetInfo,
             this.widgetIds,
-            this.getUserInputMap(),
+            this.getUserInput(),
             this.context.locale,
         );
         const combinedScore = flattenScores(scores);

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -321,7 +321,7 @@ export class ServerItemRenderer
 
         // Call the interactionCallback, if it exists, with the current user input data
         this.props.apiOptions?.interactionCallback?.(
-            this.questionRenderer.getUserInputMap(),
+            this.questionRenderer.getUserInput(),
         );
     };
 
@@ -347,7 +347,7 @@ export class ServerItemRenderer
      * Returns an object of the widget `.getUserInput()` results
      */
     getUserInput(): UserInputMap {
-        return this.questionRenderer.getUserInputMap();
+        return this.questionRenderer.getUserInput();
     }
 
     /**

--- a/packages/perseus/src/widgets/categorizer/categorizer.test.ts
+++ b/packages/perseus/src/widgets/categorizer/categorizer.test.ts
@@ -67,7 +67,7 @@ describe("categorizer widget", () => {
         // Act
         const score = scorePerseusItem(
             question1,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
             "en",
         );
 
@@ -90,7 +90,7 @@ describe("categorizer widget", () => {
         // act
         const score = scorePerseusItem(
             question1,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
             "en",
         );
 
@@ -129,7 +129,7 @@ describe("categorizer widget", () => {
 
         const score = scorePerseusItemTesting(
             question1,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
         );
 
         // assert
@@ -203,7 +203,7 @@ describe("categorizer widget", () => {
                 })[1],
             );
 
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
             const score = scorePerseusItem(
                 getAnswerfulItem("categorizer", options).question,
                 userInput,

--- a/packages/perseus/src/widgets/cs-program/cs-program.test.ts
+++ b/packages/perseus/src/widgets/cs-program/cs-program.test.ts
@@ -45,7 +45,7 @@ describe("cs-program widget", () => {
         } as const;
 
         const {renderer} = renderQuestion(question1, apiOptions);
-        const userInput = renderer.getUserInputMap()[
+        const userInput = renderer.getUserInput()[
             "cs-program 1"
         ] as PerseusCSProgramUserInput;
 

--- a/packages/perseus/src/widgets/definition/definition.test.ts
+++ b/packages/perseus/src/widgets/definition/definition.test.ts
@@ -130,7 +130,7 @@ describe("Definition widget", () => {
         // Act
         const score = scorePerseusItemTesting(
             question,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
         );
 
         // Assert

--- a/packages/perseus/src/widgets/deprecated-standin/deprecated-standin.test.ts
+++ b/packages/perseus/src/widgets/deprecated-standin/deprecated-standin.test.ts
@@ -48,7 +48,7 @@ describe("Deprecated Standin widget", () => {
         // Act
         const score = scorePerseusItemTesting(
             question,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
         );
 
         // Assert

--- a/packages/perseus/src/widgets/dropdown/dropdown.test.ts
+++ b/packages/perseus/src/widgets/dropdown/dropdown.test.ts
@@ -72,7 +72,7 @@ describe("Dropdown widget", () => {
         await userEvent.click(screen.getByText("less than or equal to"));
         const score = scorePerseusItemTesting(
             basicDropdown,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
         );
 
         // Assert
@@ -90,7 +90,7 @@ describe("Dropdown widget", () => {
         await userEvent.click(screen.getByText("greater than or equal to"));
         const score = scorePerseusItemTesting(
             basicDropdown,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
         );
 
         // Assert
@@ -105,7 +105,7 @@ describe("Dropdown widget", () => {
         // Act
         const score = scorePerseusItemTesting(
             basicDropdown,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
         );
 
         // Assert
@@ -214,7 +214,7 @@ describe("Dropdown widget", () => {
                     screen.getByRole("option", {name: "Correct"}),
                 );
 
-                const userInput = renderer.getUserInputMap();
+                const userInput = renderer.getUserInput();
                 const score = scorePerseusItem(
                     getAnswerfulItem().question,
                     userInput,

--- a/packages/perseus/src/widgets/expression/expression.test.tsx
+++ b/packages/perseus/src/widgets/expression/expression.test.tsx
@@ -59,7 +59,7 @@ const assertCorrect = async (
     );
     const score = scorePerseusItemTesting(
         itemData.question,
-        renderer.getUserInputMap(),
+        renderer.getUserInput(),
     );
     expect(score).toHaveBeenAnsweredCorrectly();
 };
@@ -77,7 +77,7 @@ const assertIncorrect = async (
     );
     const score = scorePerseusItemTesting(
         itemData.question,
-        renderer.getUserInputMap(),
+        renderer.getUserInput(),
     );
     expect(score).toHaveBeenAnsweredIncorrectly();
 };
@@ -98,7 +98,7 @@ const assertInvalid = async (
     act(() => jest.runOnlyPendingTimers());
     const score = scorePerseusItemTesting(
         itemData.question,
-        renderer.getUserInputMap(),
+        renderer.getUserInput(),
     );
     expect(score).toHaveInvalidInput();
 };
@@ -465,7 +465,7 @@ describe("Expression Widget", function () {
             act(() => jest.runOnlyPendingTimers());
             const score = scorePerseusItem(
                 expressionItem2.question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
                 "en",
             );
 
@@ -489,7 +489,7 @@ describe("Expression Widget", function () {
             // act
             const score = scorePerseusItem(
                 expressionItem2.question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
                 "en",
             );
 
@@ -715,7 +715,7 @@ describe("Expression Widget", function () {
                 await userEvent.click(screen.getByRole("button", {name: "i"}));
                 act(() => jest.runOnlyPendingTimers());
 
-                const userInput = renderer.getUserInputMap();
+                const userInput = renderer.getUserInput();
                 const score = scorePerseusItem(
                     getFullItem().question,
                     userInput,

--- a/packages/perseus/src/widgets/free-response/free-response.test.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.test.tsx
@@ -124,7 +124,7 @@ describe("free-response widget", () => {
         );
 
         // Act
-        const userInput = renderer.getUserInputMap();
+        const userInput = renderer.getUserInput();
 
         // Assert
         expect(userInput).toMatchObject({

--- a/packages/perseus/src/widgets/grapher/grapher.cypress.ts
+++ b/packages/perseus/src/widgets/grapher/grapher.cypress.ts
@@ -82,7 +82,7 @@ describe("Grapher widget", () => {
 
                     // Assert
                     cy.then(() => {
-                        const userInput = getRenderer().getUserInputMap();
+                        const userInput = getRenderer().getUserInput();
                         const score = scorePerseusItemTesting(
                             answerful.question,
                             userInput,
@@ -121,7 +121,7 @@ describe("Grapher widget", () => {
 
                     // Assert
                     cy.then(() => {
-                        const userInput = getRenderer().getUserInputMap();
+                        const userInput = getRenderer().getUserInput();
                         const score = scorePerseusItemTesting(
                             answerful.question,
                             userInput,
@@ -192,7 +192,7 @@ describe("Grapher widget", () => {
 
                     // Assert
                     cy.then(() => {
-                        const userInput = getRenderer().getUserInputMap();
+                        const userInput = getRenderer().getUserInput();
                         const score = scorePerseusItemTesting(
                             answerful.question,
                             userInput,
@@ -236,7 +236,7 @@ describe("Grapher widget", () => {
 
                     // Assert
                     cy.then(() => {
-                        const userInput = getRenderer().getUserInputMap();
+                        const userInput = getRenderer().getUserInput();
                         const score = scorePerseusItemTesting(
                             answerful.question,
                             userInput,
@@ -300,7 +300,7 @@ describe("Grapher widget", () => {
 
                     // Assert
                     cy.then(() => {
-                        const userInput = getRenderer().getUserInputMap();
+                        const userInput = getRenderer().getUserInput();
                         const score = scorePerseusItemTesting(
                             answerful.question,
                             userInput,
@@ -339,7 +339,7 @@ describe("Grapher widget", () => {
 
                     // Assert
                     cy.then(() => {
-                        const userInput = getRenderer().getUserInputMap();
+                        const userInput = getRenderer().getUserInput();
                         const score = scorePerseusItemTesting(
                             answerful.question,
                             userInput,
@@ -420,7 +420,7 @@ describe("Grapher widget", () => {
 
                     // Assert
                     cy.then(() => {
-                        const userInput = getRenderer().getUserInputMap();
+                        const userInput = getRenderer().getUserInput();
                         const score = scorePerseusItemTesting(
                             answerful.question,
                             userInput,
@@ -476,7 +476,7 @@ describe("Grapher widget", () => {
 
                     // Assert
                     cy.then(() => {
-                        const userInput = getRenderer().getUserInputMap();
+                        const userInput = getRenderer().getUserInput();
                         const score = scorePerseusItemTesting(
                             answerful.question,
                             userInput,
@@ -542,7 +542,7 @@ describe("Grapher widget", () => {
 
                     // Assert
                     cy.then(() => {
-                        const userInput = getRenderer().getUserInputMap();
+                        const userInput = getRenderer().getUserInput();
                         const score = scorePerseusItemTesting(
                             answerful.question,
                             userInput,
@@ -583,7 +583,7 @@ describe("Grapher widget", () => {
 
                     // Assert
                     cy.then(() => {
-                        const userInput = getRenderer().getUserInputMap();
+                        const userInput = getRenderer().getUserInput();
                         const score = scorePerseusItemTesting(
                             answerful.question,
                             userInput,
@@ -648,7 +648,7 @@ describe("Grapher widget", () => {
 
                     // Assert
                     cy.then(() => {
-                        const userInput = getRenderer().getUserInputMap();
+                        const userInput = getRenderer().getUserInput();
                         const score = scorePerseusItemTesting(
                             answerful.question,
                             userInput,
@@ -688,7 +688,7 @@ describe("Grapher widget", () => {
 
                     // Assert
                     cy.then(() => {
-                        const userInput = getRenderer().getUserInputMap();
+                        const userInput = getRenderer().getUserInput();
                         const score = scorePerseusItemTesting(
                             answerful.question,
                             userInput,
@@ -757,7 +757,7 @@ describe("Grapher widget", () => {
 
                     // Assert
                     cy.then(() => {
-                        const userInput = getRenderer().getUserInputMap();
+                        const userInput = getRenderer().getUserInput();
                         const score = scorePerseusItemTesting(
                             answerful.question,
                             userInput,
@@ -801,7 +801,7 @@ describe("Grapher widget", () => {
 
                     // Assert
                     cy.then(() => {
-                        const userInput = getRenderer().getUserInputMap();
+                        const userInput = getRenderer().getUserInput();
                         const score = scorePerseusItemTesting(
                             answerful.question,
                             userInput,

--- a/packages/perseus/src/widgets/group/group.test.tsx
+++ b/packages/perseus/src/widgets/group/group.test.tsx
@@ -187,7 +187,7 @@ describe("group widget", () => {
         await userEvent.type(screen.getAllByRole("textbox")[0], "99");
 
         // Act
-        const userInput = renderer.getUserInputMap();
+        const userInput = renderer.getUserInput();
 
         // Assert
         expect(userInput).toMatchInlineSnapshot(`
@@ -430,9 +430,9 @@ describe("group widget", () => {
             "200",
         );
 
-        const guess = renderer.getUserInputMap();
+        const guess = renderer.getUserInput();
         const score = scorePerseusItem(question1, guess, "en");
-        const guessAndScore = [renderer.getUserInputMap(), score];
+        const guessAndScore = [renderer.getUserInput(), score];
 
         // Assert
         expect(score).toHaveBeenAnsweredCorrectly();
@@ -564,7 +564,7 @@ describe("group widget", () => {
             );
 
             // Assert
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
             expect(userInput).toEqual({
                 "group 1": {
                     "dropdown 1": {
@@ -585,7 +585,7 @@ describe("group widget", () => {
                 screen.getByRole("option", {name: "Correct"}),
             );
 
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
             const score = scorePerseusItemTesting(
                 getFullGroupTestItem().question,
                 userInput,
@@ -606,7 +606,7 @@ describe("group widget", () => {
                 screen.getByRole("option", {name: "Incorrect"}),
             );
 
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
             const score = scorePerseusItemTesting(
                 getFullGroupTestItem().question,
                 userInput,
@@ -620,7 +620,7 @@ describe("group widget", () => {
             // Act
             const {renderer} = renderQuestion(question);
 
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
             const score = scorePerseusItemTesting(
                 getFullGroupTestItem().question,
                 userInput,

--- a/packages/perseus/src/widgets/group/group.tsx
+++ b/packages/perseus/src/widgets/group/group.tsx
@@ -65,7 +65,7 @@ class Group extends React.Component<Props> implements Widget {
     };
 
     getUserInputMap(): UserInputMap | undefined {
-        return this.rendererRef?.getUserInputMap();
+        return this.rendererRef?.getUserInput();
     }
 
     getPromptJSON(): GroupPromptJSON {

--- a/packages/perseus/src/widgets/iframe/iframe.test.ts
+++ b/packages/perseus/src/widgets/iframe/iframe.test.ts
@@ -58,7 +58,7 @@ describe("iframe widget", () => {
 
             const score = scorePerseusItemTesting(
                 question1,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
             expect(score).toHaveBeenAnsweredCorrectly();
             expect(score.message).toBe("Nicely done!");
@@ -78,7 +78,7 @@ describe("iframe widget", () => {
 
             const score = scorePerseusItemTesting(
                 question1,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
             expect(score).toHaveBeenAnsweredIncorrectly();
             expect(score.message).toBe("Try again.");
@@ -88,7 +88,7 @@ describe("iframe widget", () => {
             const {renderer} = renderQuestion(question1);
             const initialScore = scorePerseusItemTesting(
                 question1,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
             const expectedInitialMessage = "Keep going, you're not there yet!";
             expect(initialScore).toHaveInvalidInput(expectedInitialMessage);
@@ -106,7 +106,7 @@ describe("iframe widget", () => {
 
             const currentScore = scorePerseusItemTesting(
                 question1,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
             expect(currentScore).toHaveInvalidInput(expectedInitialMessage);
         });
@@ -115,7 +115,7 @@ describe("iframe widget", () => {
             const {renderer} = renderQuestion(question1);
             const initialScore = scorePerseusItemTesting(
                 question1,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
             const expectedInitialMessage = "Keep going, you're not there yet!";
             expect(initialScore).toHaveInvalidInput(expectedInitialMessage);
@@ -129,7 +129,7 @@ describe("iframe widget", () => {
 
             const currentScore = scorePerseusItemTesting(
                 question1,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
             expect(currentScore).toHaveInvalidInput(expectedInitialMessage);
         });

--- a/packages/perseus/src/widgets/image/image.test.ts
+++ b/packages/perseus/src/widgets/image/image.test.ts
@@ -43,7 +43,7 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
         const {renderer} = renderQuestion(question, apiOptions);
         const score = scorePerseusItemTesting(
             question,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
         );
 
         // Assert

--- a/packages/perseus/src/widgets/input-number/input-number.test.ts
+++ b/packages/perseus/src/widgets/input-number/input-number.test.ts
@@ -46,7 +46,7 @@ describe("input-number", function () {
             await userEvent.type(textbox, "1/2");
             const score = scorePerseusItemTesting(
                 question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -63,7 +63,7 @@ describe("input-number", function () {
             await userEvent.type(textbox, "0.7");
             const score = scorePerseusItemTesting(
                 question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -80,7 +80,7 @@ describe("input-number", function () {
             await userEvent.type(textbox, "0..7");
             const score = scorePerseusItemTesting(
                 question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -214,7 +214,7 @@ describe("input-number", function () {
             await userEvent.type(textbox, correct);
             const score = scorePerseusItemTesting(
                 question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -231,7 +231,7 @@ describe("input-number", function () {
             await userEvent.type(textbox, incorrect);
             const score = scorePerseusItemTesting(
                 question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -410,7 +410,7 @@ describe.each([
         const {renderer} = renderQuestion(question);
 
         await userEvent.type(screen.getByRole("textbox"), "42");
-        const userInput = renderer.getUserInputMap();
+        const userInput = renderer.getUserInput();
 
         // Assert
         expect(userInput).toEqual({
@@ -425,7 +425,7 @@ describe.each([
         const {renderer} = renderQuestion(question);
 
         await userEvent.type(screen.getByRole("textbox"), "42");
-        const userInput = renderer.getUserInputMap();
+        const userInput = renderer.getUserInput();
         const score = scorePerseusItemTesting(
             getAnswerfulInputNumber().question,
             userInput,
@@ -440,7 +440,7 @@ describe.each([
         const {renderer} = renderQuestion(question);
 
         await userEvent.type(screen.getByRole("textbox"), "8675309");
-        const userInput = renderer.getUserInputMap();
+        const userInput = renderer.getUserInput();
         const score = scorePerseusItemTesting(
             getAnswerfulInputNumber().question,
             userInput,
@@ -454,7 +454,7 @@ describe.each([
         // Act
         const {renderer} = renderQuestion(question);
 
-        const userInput = renderer.getUserInputMap();
+        const userInput = renderer.getUserInput();
         const score = scorePerseusItemTesting(
             getAnswerfulInputNumber().question,
             userInput,

--- a/packages/perseus/src/widgets/interaction/interaction.test.ts
+++ b/packages/perseus/src/widgets/interaction/interaction.test.ts
@@ -33,7 +33,7 @@ describe("interaction widget", () => {
         // Act
         const score = scorePerseusItemTesting(
             question1,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
         );
 
         // Assert

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -134,7 +134,7 @@ describe("Interactive Graph", function () {
                 );
                 const score = scorePerseusItemTesting(
                     question,
-                    renderer.getUserInputMap(),
+                    renderer.getUserInput(),
                 );
 
                 // Assert
@@ -169,7 +169,7 @@ describe("Interactive Graph", function () {
                 // Act
                 const score = scorePerseusItemTesting(
                     question,
-                    renderer.getUserInputMap(),
+                    renderer.getUserInput(),
                 );
 
                 // Assert
@@ -191,7 +191,7 @@ describe("Interactive Graph", function () {
 
                 const score = scorePerseusItemTesting(
                     question,
-                    renderer.getUserInputMap(),
+                    renderer.getUserInput(),
                 );
 
                 // Assert
@@ -217,7 +217,7 @@ describe("Interactive Graph", function () {
             const {renderer} = renderQuestion(question, blankOptions);
             const score = scorePerseusItemTesting(
                 question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             expect(score).toHaveBeenAnsweredCorrectly({
@@ -286,7 +286,7 @@ describe("Interactive Graph", function () {
                 // Act
                 const score = scorePerseusItemTesting(
                     question,
-                    renderer.getUserInputMap(),
+                    renderer.getUserInput(),
                 );
 
                 // Assert
@@ -319,7 +319,7 @@ describe("Interactive Graph", function () {
                     () => {
                         const score = scorePerseusItemTesting(
                             question,
-                            renderer.getUserInputMap(),
+                            renderer.getUserInput(),
                         );
                         expect(score).toHaveBeenAnsweredIncorrectly();
                     },
@@ -343,7 +343,7 @@ describe("Interactive Graph", function () {
                     () => {
                         const score = scorePerseusItemTesting(
                             question,
-                            renderer.getUserInputMap(),
+                            renderer.getUserInput(),
                         );
                         expect(score).toHaveBeenAnsweredCorrectly();
                     },
@@ -367,7 +367,7 @@ describe("Interactive Graph", function () {
                     () => {
                         const score = scorePerseusItemTesting(
                             question,
-                            renderer.getUserInputMap(),
+                            renderer.getUserInput(),
                         );
                         expect(score).toHaveInvalidInput();
                     },

--- a/packages/perseus/src/widgets/label-image/__tests__/label-image.test.ts
+++ b/packages/perseus/src/widgets/label-image/__tests__/label-image.test.ts
@@ -742,7 +742,7 @@ describe("LabelImage", function () {
             // render component
             const {renderer} = renderQuestion(textQuestion);
 
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
 
             expect(userInput).toEqual({
                 "label-image 1": {
@@ -777,7 +777,7 @@ describe("LabelImage", function () {
             // Act
             const score = scorePerseusItemTesting(
                 textQuestion,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -827,7 +827,7 @@ describe("LabelImage", function () {
             const choice = screen.getByRole("option", {name: "SUVs"});
             await userEvent.click(choice);
 
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
 
             // Assert
             expect(userInput).toEqual({
@@ -847,7 +847,7 @@ describe("LabelImage", function () {
             const {renderer} = renderQuestion(question);
 
             // Act
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
             const score = scorePerseusItem(
                 answerfulItem.question,
                 userInput,
@@ -873,7 +873,7 @@ describe("LabelImage", function () {
 
             const score = scorePerseusItemTesting(
                 answerfulItem.question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -895,7 +895,7 @@ describe("LabelImage", function () {
 
             const score = scorePerseusItemTesting(
                 answerfulItem.question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert

--- a/packages/perseus/src/widgets/matcher/matcher.test.tsx
+++ b/packages/perseus/src/widgets/matcher/matcher.test.tsx
@@ -129,7 +129,7 @@ describe("matcher widget", () => {
             });
             const score = scorePerseusItemTesting(
                 answerfulItem.question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // assert
@@ -155,7 +155,7 @@ describe("matcher widget", () => {
             });
             const score = scorePerseusItemTesting(
                 answerfulItem.question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -176,7 +176,7 @@ describe("matcher widget", () => {
             const {renderer} = renderQuestion(question);
             const score = scorePerseusItemTesting(
                 answerfulItem.question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert

--- a/packages/perseus/src/widgets/matrix/matrix.test.ts
+++ b/packages/perseus/src/widgets/matrix/matrix.test.ts
@@ -71,7 +71,7 @@ describe("matrix widget", () => {
         }
         const score = scorePerseusItemTesting(
             question1,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
         );
 
         // assert
@@ -92,7 +92,7 @@ describe("matrix widget", () => {
         }
         const score = scorePerseusItemTesting(
             question1,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
         );
 
         // Assert
@@ -131,7 +131,7 @@ describe("matrix widget", () => {
             await userEvent.type(screen.getAllByRole("textbox")[0], "5");
             await userEvent.type(screen.getAllByRole("textbox")[1], "-2");
 
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
             const score = scorePerseusItem(
                 getAnswerfulItem("matrix", matrixOptions).question,
                 userInput,

--- a/packages/perseus/src/widgets/number-line/number-line.test.ts
+++ b/packages/perseus/src/widgets/number-line/number-line.test.ts
@@ -232,7 +232,7 @@ describe("number-line widget", () => {
             act(() => numberLine.movePosition(-2.5));
             const score = scorePerseusItemTesting(
                 correctAnswer,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // assert
@@ -251,7 +251,7 @@ describe("number-line widget", () => {
             act(() => numberLine.movePosition(3.5));
             const score = scorePerseusItemTesting(
                 correctAnswer,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -268,7 +268,7 @@ describe("number-line widget", () => {
             // Act
             const score = scorePerseusItemTesting(
                 correctAnswer,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
@@ -57,7 +57,7 @@ describe("numeric-input widget", () => {
         );
         const score = scorePerseusItemTesting(
             question,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
         );
 
         // Assert
@@ -75,7 +75,7 @@ describe("numeric-input widget", () => {
         );
         const score = scorePerseusItemTesting(
             question,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
         );
 
         // Assert
@@ -315,7 +315,7 @@ describe("Numeric input widget", () => {
         await userEvent.type(screen.getByRole("textbox", {hidden: true}), "1");
         const score = scorePerseusItemTesting(
             multipleAnswers,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
         );
 
         // Assert
@@ -330,7 +330,7 @@ describe("Numeric input widget", () => {
         await userEvent.type(screen.getByRole("textbox", {hidden: true}), "2");
         const score = scorePerseusItemTesting(
             multipleAnswers,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
         );
 
         // Assert
@@ -348,7 +348,7 @@ describe("Numeric input widget", () => {
         );
         const score = scorePerseusItemTesting(
             duplicatedAnswers,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
         );
 
         // Assert
@@ -366,7 +366,7 @@ describe("Numeric input widget", () => {
         );
         const score = scorePerseusItemTesting(
             withCoefficient,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
         );
 
         // Assert
@@ -384,7 +384,7 @@ describe("Numeric input widget", () => {
         );
         const score = scorePerseusItemTesting(
             percentageProblem,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
         );
 
         // Assert
@@ -402,7 +402,7 @@ describe("Numeric input widget", () => {
         );
         const score = scorePerseusItemTesting(
             multipleAnswersWithDecimals,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
         );
 
         // Assert
@@ -603,7 +603,7 @@ describe("interactive: full vs answerless", () => {
                 "42",
             );
 
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
             const score = scorePerseusItem(
                 getAnswerfulItem().question,
                 userInput,

--- a/packages/perseus/src/widgets/orderer/orderer.test.ts
+++ b/packages/perseus/src/widgets/orderer/orderer.test.ts
@@ -94,7 +94,7 @@ describe("orderer widget", () => {
             // Act
             const [orderer] = renderer.findWidgets("orderer 1");
             act(() => orderer.setListValues(["37"]));
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
 
             // Assert
             expect(userInput).toEqual({"orderer 1": {current: ["37"]}});
@@ -105,7 +105,7 @@ describe("orderer widget", () => {
             const {renderer} = renderQuestion(question);
 
             // Act
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
             const score = scorePerseusItem(
                 getAnswerfulItem("orderer", ordererOptions).question,
                 userInput,
@@ -124,7 +124,7 @@ describe("orderer widget", () => {
             const [orderer] = renderer.findWidgets("orderer 1");
 
             act(() => orderer.setListValues(["1", "2", "3"]));
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
 
             const score = scorePerseusItem(
                 getAnswerfulItem("orderer", ordererOptions).question,
@@ -144,7 +144,7 @@ describe("orderer widget", () => {
             const [orderer] = renderer.findWidgets("orderer 1");
 
             act(() => orderer.setListValues(["2", "3", "1"]));
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
 
             const score = scorePerseusItem(
                 getAnswerfulItem("orderer", ordererOptions).question,

--- a/packages/perseus/src/widgets/passage-ref/passage-ref.test.ts
+++ b/packages/perseus/src/widgets/passage-ref/passage-ref.test.ts
@@ -163,7 +163,7 @@ describe("passage-ref widget", () => {
         act(() => jest.runOnlyPendingTimers());
         const score = scorePerseusItemTesting(
             question1,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
         );
 
         // Assert

--- a/packages/perseus/src/widgets/passage/__tests__/passage.test.tsx
+++ b/packages/perseus/src/widgets/passage/__tests__/passage.test.tsx
@@ -136,7 +136,7 @@ describe("passage widget", () => {
         // Act
         const score = scorePerseusItem(
             question2,
-            renderer.getUserInputMap(),
+            renderer.getUserInput(),
             "en",
         );
 

--- a/packages/perseus/src/widgets/plotter/plotter.test.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.test.tsx
@@ -110,7 +110,7 @@ describe("plotter widget", () => {
             const {renderer} = renderQuestion(question);
 
             // Act
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
             const score = scorePerseusItem(
                 getAnswerfulItem("plotter", plotterOptions).question,
                 userInput,
@@ -130,7 +130,7 @@ describe("plotter widget", () => {
             const [plotter] = renderer.findWidgets("plotter 1");
 
             act(() => plotter.setState({values: [15]}));
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
 
             const score = scorePerseusItem(
                 getAnswerfulItem("plotter", plotterOptions).question,
@@ -151,7 +151,7 @@ describe("plotter widget", () => {
             const [plotter] = renderer.findWidgets("plotter 1");
 
             act(() => plotter.setState({values: [7]})); // mock user entering a value
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
 
             const score = scorePerseusItem(
                 getAnswerfulItem("plotter", plotterOptions).question,

--- a/packages/perseus/src/widgets/radio/__tests__/answerless-radio.test.tsx
+++ b/packages/perseus/src/widgets/radio/__tests__/answerless-radio.test.tsx
@@ -129,7 +129,7 @@ describe("interactive: full vs answerless", () => {
             // assert that functionality previous based on answers still works
             expect(screen.getByRole("group", {name: "Choose 2 answers:"}));
 
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
             const score = scorePerseusItem(
                 getAnswerfulItem().question,
                 userInput,

--- a/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
@@ -553,10 +553,7 @@ describe("Radio Widget", () => {
                 name: "(Choice D) None of the above",
             });
             await userEvent.click(noneOption);
-            const score = scorePerseusItemTesting(
-                q,
-                renderer.getUserInput(),
-            );
+            const score = scorePerseusItemTesting(q, renderer.getUserInput());
 
             // Assert
             expect(score).toHaveBeenAnsweredCorrectly();

--- a/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
@@ -107,7 +107,7 @@ describe("Radio Widget", () => {
                     await selectOption(userEvent, correct);
                     const score = scorePerseusItemTesting(
                         question,
-                        renderer.getUserInputMap(),
+                        renderer.getUserInput(),
                     );
 
                     // Assert
@@ -129,7 +129,7 @@ describe("Radio Widget", () => {
                     fireEvent.click(correctRadio);
                     const score = scorePerseusItemTesting(
                         question,
-                        renderer.getUserInputMap(),
+                        renderer.getUserInput(),
                     );
 
                     // Assert
@@ -146,7 +146,7 @@ describe("Radio Widget", () => {
                         await selectOption(userEvent, incorrect);
                         const score = scorePerseusItemTesting(
                             question,
-                            renderer.getUserInputMap(),
+                            renderer.getUserInput(),
                         );
 
                         // Assert
@@ -317,7 +317,7 @@ describe("Radio Widget", () => {
                 await userEvent.click(screen.getAllByRole("radio")[0]);
                 const score = scorePerseusItemTesting(
                     q,
-                    renderer.getUserInputMap(),
+                    renderer.getUserInput(),
                 );
 
                 // Assert
@@ -470,7 +470,7 @@ describe("Radio Widget", () => {
             const {renderer} = renderQuestion(question, apiOptions);
             const score = scorePerseusItemTesting(
                 question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -555,7 +555,7 @@ describe("Radio Widget", () => {
             await userEvent.click(noneOption);
             const score = scorePerseusItemTesting(
                 q,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -580,7 +580,7 @@ describe("Radio Widget", () => {
             }
             const score = scorePerseusItemTesting(
                 question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -693,7 +693,7 @@ describe("Radio Widget", () => {
             const {renderer} = renderQuestion(question, apiOptions);
             const score = scorePerseusItemTesting(
                 question,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -742,7 +742,7 @@ describe("Radio Widget", () => {
             await userEvent.click(option[2]); // incorrect
             const score = scorePerseusItemTesting(
                 multipleCorrectChoicesQuestion,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -762,7 +762,7 @@ describe("Radio Widget", () => {
                 }
                 const score = scorePerseusItemTesting(
                     question,
-                    renderer.getUserInputMap(),
+                    renderer.getUserInput(),
                 );
 
                 // Assert
@@ -783,7 +783,7 @@ describe("Radio Widget", () => {
                 }
                 const score = scorePerseusItemTesting(
                     question,
-                    renderer.getUserInputMap(),
+                    renderer.getUserInput(),
                 );
 
                 // Assert
@@ -807,14 +807,14 @@ describe("Radio Widget", () => {
                 screen.getByRole("radio", {name: /Correct Choice$/}),
             );
 
-            const userInput = renderer.getUserInputMap()[
+            const userInput = renderer.getUserInput()[
                 "radio 1"
             ] as PerseusRadioUserInput;
             const rubric = shuffledQuestion.widgets["radio 1"].options;
             const widgetScore = scoreRadio(userInput, rubric);
             const rendererScore = scorePerseusItemTesting(
                 shuffledQuestion,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -836,14 +836,14 @@ describe("Radio Widget", () => {
                 screen.getByRole("radio", {name: /Incorrect Choice 1$/}),
             );
 
-            const userInput = renderer.getUserInputMap()[
+            const userInput = renderer.getUserInput()[
                 "radio 1"
             ] as PerseusRadioUserInput;
             const rubric = shuffledQuestion.widgets["radio 1"].options;
             const widgetScore = scoreRadio(userInput, rubric);
             const rendererScore = scorePerseusItemTesting(
                 shuffledQuestion,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -865,14 +865,14 @@ describe("Radio Widget", () => {
                 screen.getByRole("radio", {name: /None of the above$/}),
             );
 
-            const userInput = renderer.getUserInputMap()[
+            const userInput = renderer.getUserInput()[
                 "radio 1"
             ] as PerseusRadioUserInput;
             const rubric = shuffledNoneQuestion.widgets["radio 1"].options;
             const widgetScore = scoreRadio(userInput, rubric);
             const rendererScore = scorePerseusItemTesting(
                 shuffledNoneQuestion,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert
@@ -894,14 +894,14 @@ describe("Radio Widget", () => {
                 screen.getByRole("radio", {name: /Incorrect Choice 1$/}),
             );
 
-            const userInput = renderer.getUserInputMap()[
+            const userInput = renderer.getUserInput()[
                 "radio 1"
             ] as PerseusRadioUserInput;
             const rubric = shuffledNoneQuestion.widgets["radio 1"].options;
             const widgetScore = scoreRadio(userInput, rubric);
             const rendererScore = scorePerseusItemTesting(
                 shuffledQuestion,
-                renderer.getUserInputMap(),
+                renderer.getUserInput(),
             );
 
             // Assert

--- a/packages/perseus/src/widgets/table/table.test.tsx
+++ b/packages/perseus/src/widgets/table/table.test.tsx
@@ -55,7 +55,7 @@ describe("table", () => {
                 await userEvent.type(inputs[i], "8675309");
             }
 
-            expect(renderer.getUserInputMap()).toEqual({
+            expect(renderer.getUserInput()).toEqual({
                 "table 1": [
                     ["8675309", "8675309"],
                     ["8675309", "8675309"],
@@ -71,7 +71,7 @@ describe("table", () => {
                 await userEvent.type(inputs[i], "42");
             }
 
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
             const answerful = generateTableRenderer();
             const score = scorePerseusItem(answerful, userInput, "en");
 
@@ -86,7 +86,7 @@ describe("table", () => {
                 await userEvent.type(inputs[i], `${i}`);
             }
 
-            const userInput = renderer.getUserInputMap();
+            const userInput = renderer.getUserInput();
             expect(userInput).toEqual({
                 "table 1": [
                     ["0", "1"],


### PR DESCRIPTION
## Summary:
After https://github.com/Khan/perseus/pull/2590, to finalize the consolidation of the two types of getUserInput on renderer, this PR renames getUserInputMap to just getUserInput so there is no confusion or reference to multiple user input methods.

Issue: LEMS-2523

## Test plan:
- Confirm all tests pass
- Do a test bump in Webapp and see what code needs to be updated with the new name
- Confirm all Webapp tests pass
- Maybe some manual testing