### PR TITLE
Fix the RTL display in docs (storybook)

### DIFF
--- a/.changeset/hot-trees-lay.md
+++ b/.changeset/hot-trees-lay.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix the RTL display in docs (storybook)

--- a/packages/perseus/src/widgets/radio/__stories__/radio.new.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__stories__/radio.new.stories.tsx
@@ -1,6 +1,7 @@
 import {generateTestPerseusItem} from "@khanacademy/perseus-core";
 import * as React from "react";
 
+import {rtlStoryRenderer} from "../../../../../../testing/rtl-story-renderer";
 import {ServerItemRendererWithDebugUI} from "../../../../../../testing/server-item-renderer-with-debug-ui";
 import {
     questionWithPassage,
@@ -181,6 +182,11 @@ export const SelectWithImagesAndScrollRTL = {
             question: SingleSelectOverflowImageContent,
         }),
     },
+    parameters: {
+        direction: "rtl",
+    },
+    render: (args: StoryArgs) =>
+        rtlStoryRenderer(args, applyStoryArgs, buildApiOptions),
 };
 
 export const SingleSelectWithScrollRTL = {
@@ -189,6 +195,11 @@ export const SingleSelectWithScrollRTL = {
             question: SingleSelectOverflowContent,
         }),
     },
+    parameters: {
+        direction: "rtl",
+    },
+    render: (args: StoryArgs) =>
+        rtlStoryRenderer(args, applyStoryArgs, buildApiOptions),
 };
 
 export const MultiSelectWithScrollRTL = {
@@ -197,4 +208,9 @@ export const MultiSelectWithScrollRTL = {
             question: multiChoiceQuestionSimpleOverflowContent,
         }),
     },
+    parameters: {
+        direction: "rtl",
+    },
+    render: (args: StoryArgs) =>
+        rtlStoryRenderer(args, applyStoryArgs, buildApiOptions),
 };

--- a/testing/rtl-story-renderer.tsx
+++ b/testing/rtl-story-renderer.tsx
@@ -1,0 +1,50 @@
+import * as React from "react";
+
+import {ServerItemRendererWithDebugUI} from "./server-item-renderer-with-debug-ui";
+
+/**
+ * This is for rendering RTL (right-to-left) stories in Storybook.
+ * This wraps the ServerItemRendererWithDebugUI inside a div with RTL direction
+ * to properly display right-to-left content in Storybook.
+ *
+ * Usage example:
+ * ```
+ * export const MyComponentRTL = {
+ *     args: {
+ *         // your args here
+ *     },
+ *     parameters: {
+ *         direction: "rtl",
+ *     },
+ *     render: rtlStoryRenderer,
+ * };
+ * ```
+ */
+export const rtlStoryRenderer = <
+    T extends {
+        item: any;
+        reviewMode?: boolean;
+        showSolutions?: "none" | "all" | "selected";
+        startAnswerless?: boolean;
+    },
+>(
+    args: T,
+    applyArgsFunc?: (args: T) => any,
+    buildApiOptionsFunc?: (args: T) => any,
+) => {
+    // Default implementation for applyArgs and buildApiOptions if not provided
+    const applyArgs = applyArgsFunc || ((args: T) => args.item);
+    const buildApiOptions = buildApiOptionsFunc || (() => ({}));
+
+    return (
+        <div dir="rtl">
+            <ServerItemRendererWithDebugUI
+                item={applyArgs(args)}
+                apiOptions={buildApiOptions(args)}
+                reviewMode={args.reviewMode}
+                showSolutions={args.showSolutions}
+                startAnswerless={args.startAnswerless}
+            />
+        </div>
+    );
+};


### PR DESCRIPTION
## Summary:
Fix the RTL display in docs (storybook) and only show the RTL for the following new radio widget stories
- Select With Images And Scroll RTL
- Single Select With Scroll RTL
- Multi Select With Scroll RTL

Issue: none 

**Context**
- It was reported that recently all in Perseus docs are rendered in RTL instead of specific stories only in new radio widget
- This [PR](https://github.com/Khan/perseus/pull/2576) was done to temporarily remove the RTL display that was causing issues with other widgets

## Test plan:
1. Navigate to Radio New widget and confirm that the docs section is displayed in LTR
2. Navigate to Single Select with Scroll and confirm that the radio widget is displayed in LTR
3. Navigate to any other widget and confirm that it is displayed in LTR

ℹ️ PR assisted with :copilot: