### PR TITLE
docs(changeset): Add test for protecting against edgecase regressions regarding undefined correct value in Radio Widget.

### DIFF
--- a/.changeset/perfect-elephants-joke.md
+++ b/.changeset/perfect-elephants-joke.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Add test for protecting against edgecase regressions regarding undefined correct value in Radio Widget.

--- a/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
@@ -913,7 +913,7 @@ describe("Radio Widget", () => {
          * use the reviewChoice to determine correctness, but the choices were already shuffled
          * while the reviewChoice order remained the same.
          *
-         * The fix is to explicitly set choice.correct to a boolean value in radio.ts:
+         * The fix was to explicitly set choice.correct to a boolean value in radio.ts:
          * correct: Boolean(choice.correct)
          */
         it("handles undefined choice.correct properly when multipleSelect and randomize are enabled", async () => {

--- a/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
@@ -580,3 +580,41 @@ export const shuffledNoneQuestion: PerseusRenderer = {
         } as RadioWidget,
     },
 };
+
+export const questionWithUndefinedCorrect: PerseusRenderer = {
+    content:
+        "**Select the correct choice. This tests the LEMS-2909 bug fix.**\n\n[[\u2603 radio 1]]",
+    images: {},
+    widgets: {
+        "radio 1": {
+            graded: true,
+            version: {
+                major: 1,
+                minor: 0,
+            },
+            static: false,
+            type: "radio",
+            options: {
+                choices: [
+                    {
+                        content: "Choice A",
+                        correct: undefined,
+                    },
+                    {
+                        content: "Choice B",
+                        correct: true,
+                    },
+                    {
+                        content: "Choice C",
+                        correct: undefined,
+                    },
+                ],
+                hasNoneOfTheAbove: false,
+                multipleSelect: true,
+                randomize: true,
+                deselectEnabled: false,
+            },
+            alignment: "default",
+        } as RadioWidget,
+    },
+};


### PR DESCRIPTION
## Summary:
This micro-pr is part of the Radio Widget Project. 

All it does is add a test to help prevent regressions. :) 

Issue: LEMS-2931

## Test plan:
- new test passes. 
-- (Also confirmed that the test does NOT pass if I revert the fix from the original PR https://github.com/Khan/perseus/pull/2307/files)