### PR TITLE
[CX] Stop steps from auto-updating when range is changed in Interactive Graph editor

### DIFF
--- a/.changeset/mighty-kangaroos-grow.md
+++ b/.changeset/mighty-kangaroos-grow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Interactive graph editor] Stop steps from auto-updating when range is changed

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-settings.tsx
@@ -9,6 +9,7 @@ import {
     Util,
 } from "@khanacademy/perseus";
 import Banner from "@khanacademy/wonder-blocks-banner";
+import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
@@ -364,20 +365,48 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
     changeRange = (i, values) => {
         const ranges = this.state.rangeTextbox.slice();
         ranges[i] = values;
+
+        this.setState(
+            {
+                rangeTextbox: ranges as [[number, number], [number, number]],
+            },
+            this.changeGraph,
+        );
+    };
+
+    changeStepsBasedOnRange = () => {
+        const ranges = this.state.rangeTextbox.slice();
+
         const step = this.state.stepTextbox.slice();
         const gridStep = this.state.gridStepTextbox.slice();
         const snapStep = this.state.snapStepTextbox.slice();
-        const scale = Util.scaleFromExtent(ranges[i], this.props.box[i]);
-        if (this.validRange(ranges[i]) === true) {
-            step[i] = Util.tickStepFromExtent(ranges[i], this.props.box[i]);
 
-            const gridStepValue = Util.gridStepFromTickStep(step[i], scale);
+        // Update values based on X range
+        const scaleX = Util.scaleFromExtent(ranges[0], this.props.box[0]);
+        if (this.validRange(ranges[0]) === true) {
+            step[0] = Util.tickStepFromExtent(ranges[0], this.props.box[0]);
+
+            const gridStepValue = Util.gridStepFromTickStep(step[0], scaleX);
             if (gridStepValue) {
-                gridStep[i] = gridStepValue;
+                gridStep[0] = gridStepValue;
             }
 
-            snapStep[i] = gridStep[i] / 2;
+            snapStep[0] = gridStep[0] / 2;
         }
+
+        // Update values based on Y range
+        const scaleY = Util.scaleFromExtent(ranges[1], this.props.box[1]);
+        if (this.validRange(ranges[1]) === true) {
+            step[1] = Util.tickStepFromExtent(ranges[1], this.props.box[1]);
+
+            const gridStepValue = Util.gridStepFromTickStep(step[1], scaleY);
+            if (gridStepValue) {
+                gridStep[1] = gridStepValue;
+            }
+
+            snapStep[1] = gridStep[1] / 2;
+        }
+
         this.setState(
             {
                 stepTextbox: step as [number, number],
@@ -574,6 +603,32 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
                                             allowPiTruncation={true}
                                         />
                                     </LabeledRow>
+                                </div>
+                                <div className="perseus-widget-right-col">
+                                    <Button
+                                        size="small"
+                                        kind="tertiary"
+                                        onClick={() => {
+                                            this.changeStepsBasedOnRange();
+                                        }}
+                                    >
+                                        Auto-adjust steps
+                                    </Button>
+                                    <InfoTip>
+                                        <p>
+                                            Use the "Auto-adjust" steps button
+                                            to update the tick step, grid step,
+                                            and snap step to values that are
+                                            valid for the current range.
+                                        </p>
+                                        <br />
+                                        <p>
+                                            This is useful when the range is
+                                            changed, and the graph errors due to
+                                            the step sizes being too large or
+                                            too small.
+                                        </p>
+                                    </InfoTip>
                                 </div>
                             </div>
                             <div className="perseus-widget-row">


### PR DESCRIPTION
## Summary:
Right now, when a content author changes the range in the interactive graph settings,
the tick step, grid step, and snap step all update to a specific ratio of the range.

Sometimes content authors don't want this to happen. We've received a request to
stop the auto-updates.

In this PR, I'm stopping the auto-updates, and adding a button that can be clicked
if a content author wants the steps updated the way they used to be.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3217

## Demo:

https://github.com/user-attachments/assets/9903b0a7-f285-4ea4-acc4-644f7f3a0b39

## Test plan:
`pnpm jest packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-settings.test.tsx`

Storybook
- Go to http://localhost:6006/iframe.html?globals=&args=&id=perseuseditor-widgets-interactive-graph--interactive-graph-with-aria-label&viewMode=story
- Change the x Range min to -100
- Confirm that the preview graph shows an error instead
- Press the "Auto-adjust steps" button
- Confirm that the graph shows up normally again
- Confirm that the tick step, grid step, and snap step are all updated
- Repeat for x Range max, y Range min, and y Range max