### PR TITLE
[Radio] | (DX) | Create a question builder for the Radio widget

### DIFF
--- a/.changeset/friendly-ties-glow.md
+++ b/.changeset/friendly-ties-glow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Radio] | (DX) | Create a question builder for the Radio widget

--- a/packages/perseus/src/widgets/radio/radio-question-builder.test.ts
+++ b/packages/perseus/src/widgets/radio/radio-question-builder.test.ts
@@ -1,0 +1,138 @@
+import {radioQuestionBuilder} from "./radio-question-builder";
+
+import type {PerseusRenderer} from "@khanacademy/perseus-core";
+
+describe("RadioQuestionBuilder", () => {
+    test("builds a default radio question", () => {
+        const question: PerseusRenderer = radioQuestionBuilder().build();
+
+        // Expect all default values
+        expect(question.content).toBe("[[☃ radio 1]]");
+        expect(question.images).toEqual({});
+        expect(question.widgets["radio 1"].graded).toBe(true);
+        expect(question.widgets["radio 1"].static).toBe(false);
+        expect(question.widgets["radio 1"].version).toEqual({
+            major: 0,
+            minor: 0,
+        });
+        expect(question.widgets["radio 1"].type).toBe("radio");
+        expect(question.widgets["radio 1"].alignment).toBe("default");
+
+        expect(question.widgets["radio 1"].options.choices).toEqual([]);
+        expect(question.widgets["radio 1"].options.hasNoneOfTheAbove).toBe(
+            undefined,
+        );
+        expect(question.widgets["radio 1"].options.multipleSelect).toBe(
+            undefined,
+        );
+        expect(question.widgets["radio 1"].options.randomize).toBe(undefined);
+        expect(question.widgets["radio 1"].options.countChoices).toBe(
+            undefined,
+        );
+    });
+
+    test("sets the content", () => {
+        const question: PerseusRenderer = radioQuestionBuilder()
+            .withContent("the content [[☃ radio 1]]")
+            .build();
+
+        expect(question.content).toBe("the content [[☃ radio 1]]");
+    });
+
+    test("sets countChoices", () => {
+        const question: PerseusRenderer = radioQuestionBuilder()
+            .withCountChoices(true)
+            .build();
+
+        expect(question.widgets["radio 1"].options.countChoices).toBe(true);
+    });
+
+    test("sets hasNoneOfTheAbove", () => {
+        const question: PerseusRenderer = radioQuestionBuilder()
+            .withHasNoneOfTheAbove(true)
+            .build();
+
+        expect(question.widgets["radio 1"].options.hasNoneOfTheAbove).toBe(
+            true,
+        );
+    });
+
+    test("sets multipleSelect", () => {
+        const question: PerseusRenderer = radioQuestionBuilder()
+            .withMultipleSelect(true)
+            .build();
+
+        expect(question.widgets["radio 1"].options.multipleSelect).toBe(true);
+    });
+
+    test("sets randomize", () => {
+        const question: PerseusRenderer = radioQuestionBuilder()
+            .withRandomize(true)
+            .build();
+
+        expect(question.widgets["radio 1"].options.randomize).toBe(true);
+    });
+
+    test("adds one choice", () => {
+        const question: PerseusRenderer = radioQuestionBuilder()
+            .addChoice("choice 1")
+            .build();
+
+        expect(question.widgets["radio 1"].options.choices).toEqual([
+            {content: "choice 1"},
+        ]);
+    });
+
+    test("adds one choice with options", () => {
+        const question: PerseusRenderer = radioQuestionBuilder()
+            .addChoice("choice 1", {
+                correct: true,
+                rationale: "rationale",
+                isNoneOfTheAbove: false,
+            })
+            .build();
+
+        expect(question.widgets["radio 1"].options.choices).toEqual([
+            {
+                content: "choice 1",
+                correct: true,
+                rationale: "rationale",
+                isNoneOfTheAbove: false,
+            },
+        ]);
+    });
+
+    test("adds two choices", () => {
+        const question: PerseusRenderer = radioQuestionBuilder()
+            .addChoice("choice 1")
+            .addChoice("choice 2")
+            .build();
+
+        expect(question.widgets["radio 1"].options.choices).toEqual([
+            {content: "choice 1"},
+            {content: "choice 2"},
+        ]);
+    });
+
+    test("adds two choices with options", () => {
+        const question: PerseusRenderer = radioQuestionBuilder()
+            .addChoice("choice 1", {
+                correct: true,
+                rationale: "This one is correct",
+            })
+            .addChoice("choice 2", {rationale: "This one is incorrect"})
+            .build();
+
+        expect(question.widgets["radio 1"].options.choices).toEqual([
+            {
+                content: "choice 1",
+                correct: true,
+                rationale: "This one is correct",
+            },
+            {
+                content: "choice 2",
+                rationale: "This one is incorrect",
+            },
+        ]);
+    });
+});

--- a/packages/perseus/src/widgets/radio/radio-question-builder.ts
+++ b/packages/perseus/src/widgets/radio/radio-question-builder.ts
@@ -1,6 +1,7 @@
 import type {
     PerseusRadioChoice,
     PerseusRenderer,
+    RadioWidget,
 } from "@khanacademy/perseus-core";
 
 export function radioQuestionBuilder(): RadioQuestionBuilder {
@@ -33,7 +34,7 @@ class RadioQuestionBuilder {
                         countChoices: this.countChoices,
                         randomize: this.randomize,
                     },
-                },
+                } satisfies RadioWidget,
             },
         };
     }

--- a/packages/perseus/src/widgets/radio/radio-question-builder.ts
+++ b/packages/perseus/src/widgets/radio/radio-question-builder.ts
@@ -1,0 +1,82 @@
+import type {
+    PerseusRadioChoice,
+    PerseusRenderer,
+} from "@khanacademy/perseus-core";
+
+export function radioQuestionBuilder(): RadioQuestionBuilder {
+    return new RadioQuestionBuilder();
+}
+
+class RadioQuestionBuilder {
+    private content: string = "[[☃ radio 1]]";
+    private choices: PerseusRadioChoice[] = [];
+    private countChoices?: boolean;
+    private hasNoneOfTheAbove?: boolean;
+    private multipleSelect?: boolean;
+    private randomize?: boolean;
+
+    build(): PerseusRenderer {
+        return {
+            content: this.content,
+            images: {},
+            widgets: {
+                "radio 1": {
+                    graded: true,
+                    version: {major: 0, minor: 0},
+                    static: false,
+                    type: "radio",
+                    alignment: "default",
+                    options: {
+                        choices: this.choices,
+                        hasNoneOfTheAbove: this.hasNoneOfTheAbove,
+                        multipleSelect: this.multipleSelect,
+                        countChoices: this.countChoices,
+                        randomize: this.randomize,
+                    },
+                },
+            },
+        };
+    }
+
+    withContent(content: string): RadioQuestionBuilder {
+        this.content = content;
+        return this;
+    }
+
+    withCountChoices(countChoices: boolean): RadioQuestionBuilder {
+        this.countChoices = countChoices;
+        return this;
+    }
+
+    withHasNoneOfTheAbove(hasNoneOfTheAbove: boolean): RadioQuestionBuilder {
+        this.hasNoneOfTheAbove = hasNoneOfTheAbove;
+        return this;
+    }
+
+    withMultipleSelect(multipleSelect: boolean): RadioQuestionBuilder {
+        this.multipleSelect = multipleSelect;
+        return this;
+    }
+
+    withRandomize(randomize: boolean): RadioQuestionBuilder {
+        this.randomize = randomize;
+        return this;
+    }
+
+    addChoice(
+        content: string,
+        options?: {
+            correct?: boolean;
+            rationale?: string;
+            isNoneOfTheAbove?: boolean;
+        },
+    ): RadioQuestionBuilder {
+        this.choices.push({
+            content,
+            correct: options?.correct,
+            rationale: options?.rationale,
+            isNoneOfTheAbove: options?.isNoneOfTheAbove,
+        });
+        return this;
+    }
+}


### PR DESCRIPTION
## Summary:
In order to make it easier to build out Perseus JSON for Radio tests,
we need a builder function.

Using the interactive graph question builder as inspiration, I created
a radio builder here.

NOTE: I will replace the existing testdata in a follow-up PR.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3187

## Test plan:
`pnpm jest packages/perseus/src/widgets/radio/radio-question-builder.test.ts`

Double check the schema and confirm that everything that's not deprecated
or unused is possible to create using the builder.

Double check the existing `radio.testdata.ts` file and confirm that everything
is possible to create using the builder.