### PR TITLE
[Radio] | (DX) | Use the new question builder in testdata file

### DIFF
--- a/.changeset/friendly-ties-glow.md
+++ b/.changeset/friendly-ties-glow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Radio] | (DX) | Create a question builder for the Radio widget

--- a/.changeset/proud-bananas-raise.md
+++ b/.changeset/proud-bananas-raise.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Radio] | (DX) | Use the new question builder in testdata file

--- a/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
@@ -1,59 +1,34 @@
+import {radioQuestionBuilder} from "../radio-question-builder";
+
 import type {
     PerseusRenderer,
     RadioWidget,
     PassageWidget,
 } from "@khanacademy/perseus-core";
 
-export const question: PerseusRenderer = {
-    content:
+export const question: PerseusRenderer = radioQuestionBuilder()
+    .withContent(
         "Which of the following values of $x$ satisfies the equation $\\sqrt{64}=x$ ?\n\n[[\u2603 radio 1]]\n\n",
-    images: {},
-    widgets: {
-        "radio 1": {
-            graded: true,
-            version: {
-                major: 1,
-                minor: 0,
-            },
-            static: false,
-            type: "radio",
-            options: {
-                choices: [
-                    {
-                        content: "$-8$ and $8$",
-                        correct: false,
-                        rationale:
-                            "The square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number, so $x$ is equal to *only* $8$.",
-                    },
-                    {
-                        content: "$-8$",
-                        correct: false,
-                        rationale:
-                            "While $(-8)^2=64$, the square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number.",
-                    },
-                    {
-                        content: "$8$",
-                        correct: true,
-                        isNoneOfTheAbove: false,
-                        rationale: "$8$ is the positive square root of $64$.",
-                    },
-                    {
-                        content: "No value of $x$ satisfies the equation.",
-                        correct: false,
-                        isNoneOfTheAbove: false,
-                        rationale: "$8$ satisfies the equation.",
-                    },
-                ],
-                countChoices: false,
-                hasNoneOfTheAbove: false,
-                multipleSelect: false,
-                randomize: false,
-                deselectEnabled: false,
-            },
-            alignment: "default",
-        } as RadioWidget,
-    },
-};
+    )
+    .addChoice("$-8$ and $8$", {
+        correct: false,
+        rationale:
+            "The square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number, so $x$ is equal to *only* $8$.",
+    })
+    .addChoice("$-8$", {
+        correct: false,
+        rationale:
+            "While $(-8)^2=64$, the square root operation ($\\sqrt{\\phantom{x}}$) calculates *only* the positive square root when performed on a number.",
+    })
+    .addChoice("$8$", {
+        correct: true,
+        rationale: "$8$ is the positive square root of $64$.",
+    })
+    .addChoice("No value of $x$ satisfies the equation.", {
+        correct: false,
+        rationale: "$8$ satisfies the equation.",
+    })
+    .build();
 
 export const questionAndAnswer: [
     PerseusRenderer,
@@ -61,6 +36,7 @@ export const questionAndAnswer: [
     ReadonlyArray<number>,
 ] = [question, 2, [0, 1, 3]];
 
+// Can't use radioQuestionBuilder here because it also includes a passage widget.
 export const questionWithPassage: PerseusRenderer = {
     content:
         "Read the following passage:\n\n[[\u2603 passage 1]]\n\nWhich of the following values of $x$ satisfies the equation $\\sqrt{64}=x$ ?\n\n[[\u2603 radio 1]]\n\n",
@@ -127,6 +103,7 @@ export const questionWithPassage: PerseusRenderer = {
     },
 };
 
+// Can't use radioQuestionBuilder here because it also includes a passage widget.
 export const choicesWithImages: PerseusRenderer = {
     content:
         "The following options have images. All but one of them should be on their own line. [[☃ radio 1]]",
@@ -211,51 +188,24 @@ export const choicesWithImages: PerseusRenderer = {
     },
 };
 
-export const SingleSelectOverflowImageContent: PerseusRenderer = {
-    content: "Select 9 ponies.[[\u2603 radio 1]]\n\n",
-    images: {},
-    widgets: {
-        "radio 1": {
-            graded: true,
-            version: {
-                major: 1,
-                minor: 0,
-            },
-            static: false,
-            type: "radio",
-            options: {
-                choices: [
-                    {
-                        content:
-                            "![A row of 9 ponies.](https://ka-perseus-graphie.s3.amazonaws.com/63a8f980544375ed1bb2540d9f48e8ac3716abc9.png)",
-                        correct: true,
-                        rationale: "Count the ponies in the image.",
-                    },
-                    {
-                        content:
-                            "![A row of 2 ponies.](https://ka-perseus-graphie.s3.amazonaws.com/019ec3915127c42fc055132f7cd35c56e6276216.png)",
-                        correct: false,
-                        rationale: "Count the ponies in the image.",
-                    },
-                    {
-                        content:
-                            "![A row of 5 ponies.](https://ka-perseus-graphie.s3.amazonaws.com/0be0944c8e2d0c23612d6709640c0f93feabbd76.png)",
-                        correct: false,
-                        isNoneOfTheAbove: false,
-                        rationale: "Count the ponies in the image.",
-                    },
-                ],
-                countChoices: false,
-                hasNoneOfTheAbove: false,
-                multipleSelect: false,
-                randomize: false,
-                deselectEnabled: false,
-            },
-            alignment: "default",
-        } as RadioWidget,
-    },
-};
+export const SingleSelectOverflowImageContent: PerseusRenderer =
+    radioQuestionBuilder()
+        .withContent("Select 9 ponies.[[\u2603 radio 1]]\n\n")
+        .addChoice(
+            "![A row of 9 ponies.](https://ka-perseus-graphie.s3.amazonaws.com/63a8f980544375ed1bb2540d9f48e8ac3716abc9.png)",
+            {correct: true, rationale: "Count the ponies in the image."},
+        )
+        .addChoice(
+            "![A row of 2 ponies.](https://ka-perseus-graphie.s3.amazonaws.com/019ec3915127c42fc055132f7cd35c56e6276216.png)",
+            {correct: false, rationale: "Count the ponies in the image."},
+        )
+        .addChoice(
+            "![A row of 5 ponies.](https://ka-perseus-graphie.s3.amazonaws.com/0be0944c8e2d0c23612d6709640c0f93feabbd76.png)",
+            {correct: false, rationale: "Count the ponies in the image."},
+        )
+        .build();
 
+// Can't use radioQuestionBuilder here because it also includes a passage widget.
 export const SingleSelectOverflowContent: PerseusRenderer = {
     content: "Which are the same as the number 75?[[\u2603 radio 1]]\n\n",
     images: {},
@@ -320,162 +270,71 @@ export const SingleSelectOverflowContent: PerseusRenderer = {
     },
 };
 
-export const multiChoiceQuestion: PerseusRenderer = {
-    content:
+export const multiChoiceQuestion: PerseusRenderer = radioQuestionBuilder()
+    .withContent(
         "**Select all input values for which $g(x)=2$.**\n\n[[\u2603 radio 1]]\n\n ![](web+graphie://ka-perseus-graphie.s3.amazonaws.com/4613e0d9c906b3053fb5523eed83d4f779fdf6bb)",
-    images: {},
-    widgets: {
-        "radio 1": {
-            graded: true,
-            version: {
-                major: 1,
-                minor: 0,
-            },
-            static: false,
-            type: "radio",
-            options: {
-                choices: [
-                    {
-                        content: "$x=-6$",
-                        correct: false,
-                    },
-                    {
-                        content: "$x=4$",
-                        correct: false,
-                    },
-                    {
-                        content: "$x=7$",
-                        isNoneOfTheAbove: false,
-                        correct: false,
-                    },
-                    {
-                        content: "There is no such input value.",
-                        isNoneOfTheAbove: true,
-                        correct: true,
-                    },
-                ],
-                hasNoneOfTheAbove: true,
-                multipleSelect: true,
-                randomize: false,
-                deselectEnabled: false,
-            },
-            alignment: "default",
-        } as RadioWidget,
-    },
-};
+    )
+    .addChoice("$x=-6$", {correct: false})
+    .addChoice("$x=4$", {correct: false})
+    .addChoice("$x=7$", {correct: false, isNoneOfTheAbove: false})
+    .addChoice("There is no such input value.", {
+        correct: true,
+        isNoneOfTheAbove: true,
+    })
+    .withHasNoneOfTheAbove(true)
+    .withMultipleSelect(true)
+    .withRandomize(false)
+    .build();
 
-export const multiChoiceQuestionSimple: PerseusRenderer = {
-    content: "What are some ways to say hello?\n\n[[\u2603 radio 1]]",
-    images: {},
-    widgets: {
-        "radio 1": {
-            graded: true,
-            version: {
-                major: 1,
-                minor: 0,
-            },
-            static: false,
-            type: "radio",
-            options: {
-                choices: [
-                    {
-                        content: "Hola",
-                        isNoneOfTheAbove: false,
-                        correct: true,
-                        rationale:
-                            "The Spanish-speaking countries typically say Hola.",
-                    },
-                    {
-                        content: "Hey",
-                        isNoneOfTheAbove: false,
-                        correct: true,
-                        rationale:
-                            "This is used to attract someone's attention.",
-                    },
-                    {
-                        content: "Hi",
-                        isNoneOfTheAbove: false,
-                        correct: true,
-                        rationale: "This is used as friendly greeting.",
-                    },
-                    {
-                        content: "Goodbye",
-                        isNoneOfTheAbove: false,
-                        correct: false,
-                        rationale: "Some people like to say Goodbye.",
-                    },
-                    {
-                        content: "None of these",
-                        isNoneOfTheAbove: true,
-                        correct: false,
-                    },
-                ],
-                hasNoneOfTheAbove: true,
-                multipleSelect: true,
-                randomize: false,
-                deselectEnabled: false,
-            },
-            alignment: "default",
-        } as RadioWidget,
-    },
-};
+export const multiChoiceQuestionSimple: PerseusRenderer = radioQuestionBuilder()
+    .withContent("What are some ways to say hello?\n\n[[\u2603 radio 1]]")
+    .addChoice("Hola", {
+        correct: true,
+        rationale: "The Spanish-speaking countries typically say Hola.",
+    })
+    .addChoice("Hey", {
+        correct: true,
+        rationale: "This is used to attract someone's attention.",
+    })
+    .addChoice("Hi", {
+        correct: true,
+        rationale: "This is used as friendly greeting.",
+    })
+    .addChoice("Goodbye", {
+        correct: false,
+        rationale: "Some people like to say Goodbye.",
+    })
+    .addChoice("None of these", {correct: false, isNoneOfTheAbove: true})
+    .withHasNoneOfTheAbove(true)
+    .withMultipleSelect(true)
+    .build();
 
-export const multiChoiceQuestionSimpleOverflowContent: PerseusRenderer = {
-    content: "Which are the same as the number 75?\n\n[[\u2603 radio 1]]",
-    images: {},
-    widgets: {
-        "radio 1": {
-            graded: true,
-            version: {
-                major: 1,
-                minor: 0,
-            },
-            static: false,
-            type: "radio",
-            options: {
-                onePerLine: true,
-                choices: [
-                    {
-                        content:
-                            "$1+1+1+1+1+5+5+1+1+1+1+1+7+2+1+1+9+5+3+1+1+6+4+10+3+2$",
-                        isNoneOfTheAbove: false,
-                        correct: true,
-                        rationale: "Add the following numbers to get 75.",
-                    },
-                    {
-                        content:
-                            "$5+4+1+9+1+2+2+2+2+2+3+3+3+1+4+4+2+5+5+10+3+2$",
-                        isNoneOfTheAbove: false,
-                        correct: true,
-                        rationale: "Add the following numbers to get 75.",
-                    },
-                    {
-                        content: "$10+10+10+10+10+10+10+5$",
-                        isNoneOfTheAbove: false,
-                        correct: true,
-                        rationale: "Add the following numbers to get 75.",
-                    },
-                    {
-                        content: "$10+10+10+10+10+10+10+3+2$",
-                        isNoneOfTheAbove: false,
-                        correct: false,
-                        rationale: "Add the following numbers to get 75.",
-                    },
-                    {
-                        content: "None of these",
-                        isNoneOfTheAbove: true,
-                        correct: false,
-                    },
-                ],
-                hasNoneOfTheAbove: true,
-                multipleSelect: true,
-                randomize: false,
-                deselectEnabled: false,
-            },
-            alignment: "default",
-        } as RadioWidget,
-    },
-};
+export const multiChoiceQuestionSimpleOverflowContent: PerseusRenderer =
+    radioQuestionBuilder()
+        .withContent(
+            "Which are the same as the number 75?\n\n[[\u2603 radio 1]]",
+        )
+        .addChoice("$1+1+1+1+1+5+5+1+1+1+1+1+7+2+1+1+9+5+3+1+1+6+4+10+3+2$", {
+            correct: true,
+            rationale: "Add the following numbers to get 75.",
+        })
+        .addChoice("$5+4+1+9+1+2+2+2+2+2+3+3+3+1+4+4+2+5+5+10+3+2$", {
+            correct: true,
+            rationale: "Add the following numbers to get 75.",
+        })
+        .addChoice("$10+10+10+10+10+10+10+5$", {
+            correct: true,
+            rationale: "Add the following numbers to get 75.",
+        })
+        .addChoice("$10+10+10+10+10+10+10+3+2$", {
+            correct: false,
+            rationale: "Add the following numbers to get 75.",
+        })
+        .addChoice("None of these", {correct: false, isNoneOfTheAbove: true})
+        .withHasNoneOfTheAbove(true)
+        .withMultipleSelect(true)
+        .withRandomize(false)
+        .build();
 
 export const multiChoiceQuestionAndAnswer: [
     PerseusRenderer,
@@ -492,129 +351,34 @@ export const multiChoiceQuestionAndAnswer: [
     ],
 ];
 
-export const shuffledQuestion: PerseusRenderer = {
-    content: "[[\u2603 radio 1]]",
-    images: {},
-    widgets: {
-        "radio 1": {
-            graded: true,
-            version: {
-                major: 1,
-                minor: 0,
-            },
-            static: false,
-            type: "radio",
-            options: {
-                choices: [
-                    {
-                        content: "Incorrect Choice 1",
-                        correct: false,
-                    },
-                    {
-                        content: "Incorrect Choice 2",
-                        correct: false,
-                    },
-                    {
-                        content: "Correct Choice",
-                        correct: true,
-                    },
-                    {
-                        content: "Incorrect Choice 3",
-                        correct: false,
-                    },
-                ],
-                countChoices: false,
-                hasNoneOfTheAbove: false,
-                multipleSelect: false,
-                randomize: true,
-                deselectEnabled: false,
-            },
-            alignment: "default",
-        } as RadioWidget,
-    },
-};
+export const shuffledQuestion: PerseusRenderer = radioQuestionBuilder()
+    .withContent("[[\u2603 radio 1]]")
+    .addChoice("Incorrect Choice 1", {correct: false})
+    .addChoice("Incorrect Choice 2", {correct: false})
+    .addChoice("Correct Choice", {correct: true})
+    .addChoice("Incorrect Choice 3", {correct: false})
+    .withRandomize(true)
+    .build();
 
-export const shuffledNoneQuestion: PerseusRenderer = {
-    content: "[[\u2603 radio 1]]",
-    images: {},
-    widgets: {
-        "radio 1": {
-            graded: true,
-            version: {
-                major: 1,
-                minor: 0,
-            },
-            static: false,
-            type: "radio",
-            options: {
-                choices: [
-                    {
-                        content: "Incorrect Choice 1",
-                        correct: false,
-                    },
-                    {
-                        content: "Incorrect Choice 2",
-                        correct: false,
-                    },
-                    {
-                        content: "Incorrect Choice 3",
-                        correct: false,
-                    },
-                    {
-                        content: "Incorrect Choice 4",
-                        correct: false,
-                    },
-                    {
-                        content: "None of the above",
-                        correct: true,
-                        isNoneOfTheAbove: true,
-                    },
-                ],
-                countChoices: false,
-                hasNoneOfTheAbove: true,
-                multipleSelect: false,
-                randomize: true,
-                deselectEnabled: false,
-            },
-            alignment: "default",
-        } as RadioWidget,
-    },
-};
+export const shuffledNoneQuestion: PerseusRenderer = radioQuestionBuilder()
+    .withContent("[[\u2603 radio 1]]")
+    .addChoice("Incorrect Choice 1", {correct: false})
+    .addChoice("Incorrect Choice 2", {correct: false})
+    .addChoice("Incorrect Choice 3", {correct: false})
+    .addChoice("Incorrect Choice 4", {correct: false})
+    .addChoice("None of the above", {correct: true, isNoneOfTheAbove: true})
+    .withHasNoneOfTheAbove(true)
+    .withRandomize(true)
+    .build();
 
-export const questionWithUndefinedCorrect: PerseusRenderer = {
-    content:
-        "**Select the correct choice. This tests the LEMS-2909 bug fix.**\n\n[[\u2603 radio 1]]",
-    images: {},
-    widgets: {
-        "radio 1": {
-            graded: true,
-            version: {
-                major: 1,
-                minor: 0,
-            },
-            static: false,
-            type: "radio",
-            options: {
-                choices: [
-                    {
-                        content: "Choice A",
-                        correct: undefined,
-                    },
-                    {
-                        content: "Choice B",
-                        correct: true,
-                    },
-                    {
-                        content: "Choice C",
-                        correct: undefined,
-                    },
-                ],
-                hasNoneOfTheAbove: false,
-                multipleSelect: true,
-                randomize: true,
-                deselectEnabled: false,
-            },
-            alignment: "default",
-        } as RadioWidget,
-    },
-};
+export const questionWithUndefinedCorrect: PerseusRenderer =
+    radioQuestionBuilder()
+        .withContent(
+            "**Select the correct choice. This tests the LEMS-2909 bug fix.**\n\n[[\u2603 radio 1]]",
+        )
+        .addChoice("Choice A", {correct: undefined})
+        .addChoice("Choice B", {correct: true})
+        .addChoice("Choice C", {correct: undefined})
+        .withMultipleSelect(true)
+        .withRandomize(true)
+        .build();

--- a/packages/perseus/src/widgets/radio/radio-question-builder.test.ts
+++ b/packages/perseus/src/widgets/radio/radio-question-builder.test.ts
@@ -1,0 +1,138 @@
+import {radioQuestionBuilder} from "./radio-question-builder";
+
+import type {PerseusRenderer} from "@khanacademy/perseus-core";
+
+describe("RadioQuestionBuilder", () => {
+    test("builds a default radio question", () => {
+        const question: PerseusRenderer = radioQuestionBuilder().build();
+
+        // Expect all default values
+        expect(question.content).toBe("[[☃ radio 1]]");
+        expect(question.images).toEqual({});
+        expect(question.widgets["radio 1"].graded).toBe(true);
+        expect(question.widgets["radio 1"].static).toBe(false);
+        expect(question.widgets["radio 1"].version).toEqual({
+            major: 0,
+            minor: 0,
+        });
+        expect(question.widgets["radio 1"].type).toBe("radio");
+        expect(question.widgets["radio 1"].alignment).toBe("default");
+
+        expect(question.widgets["radio 1"].options.choices).toEqual([]);
+        expect(question.widgets["radio 1"].options.hasNoneOfTheAbove).toBe(
+            undefined,
+        );
+        expect(question.widgets["radio 1"].options.multipleSelect).toBe(
+            undefined,
+        );
+        expect(question.widgets["radio 1"].options.randomize).toBe(undefined);
+        expect(question.widgets["radio 1"].options.countChoices).toBe(
+            undefined,
+        );
+    });
+
+    test("sets the content", () => {
+        const question: PerseusRenderer = radioQuestionBuilder()
+            .withContent("the content [[☃ radio 1]]")
+            .build();
+
+        expect(question.content).toBe("the content [[☃ radio 1]]");
+    });
+
+    test("sets countChoices", () => {
+        const question: PerseusRenderer = radioQuestionBuilder()
+            .withCountChoices(true)
+            .build();
+
+        expect(question.widgets["radio 1"].options.countChoices).toBe(true);
+    });
+
+    test("sets hasNoneOfTheAbove", () => {
+        const question: PerseusRenderer = radioQuestionBuilder()
+            .withHasNoneOfTheAbove(true)
+            .build();
+
+        expect(question.widgets["radio 1"].options.hasNoneOfTheAbove).toBe(
+            true,
+        );
+    });
+
+    test("sets multipleSelect", () => {
+        const question: PerseusRenderer = radioQuestionBuilder()
+            .withMultipleSelect(true)
+            .build();
+
+        expect(question.widgets["radio 1"].options.multipleSelect).toBe(true);
+    });
+
+    test("sets randomize", () => {
+        const question: PerseusRenderer = radioQuestionBuilder()
+            .withRandomize(true)
+            .build();
+
+        expect(question.widgets["radio 1"].options.randomize).toBe(true);
+    });
+
+    test("adds one choice", () => {
+        const question: PerseusRenderer = radioQuestionBuilder()
+            .addChoice("choice 1")
+            .build();
+
+        expect(question.widgets["radio 1"].options.choices).toEqual([
+            {content: "choice 1"},
+        ]);
+    });
+
+    test("adds one choice with options", () => {
+        const question: PerseusRenderer = radioQuestionBuilder()
+            .addChoice("choice 1", {
+                correct: true,
+                rationale: "rationale",
+                isNoneOfTheAbove: false,
+            })
+            .build();
+
+        expect(question.widgets["radio 1"].options.choices).toEqual([
+            {
+                content: "choice 1",
+                correct: true,
+                rationale: "rationale",
+                isNoneOfTheAbove: false,
+            },
+        ]);
+    });
+
+    test("adds two choices", () => {
+        const question: PerseusRenderer = radioQuestionBuilder()
+            .addChoice("choice 1")
+            .addChoice("choice 2")
+            .build();
+
+        expect(question.widgets["radio 1"].options.choices).toEqual([
+            {content: "choice 1"},
+            {content: "choice 2"},
+        ]);
+    });
+
+    test("adds two choices with options", () => {
+        const question: PerseusRenderer = radioQuestionBuilder()
+            .addChoice("choice 1", {
+                correct: true,
+                rationale: "This one is correct",
+            })
+            .addChoice("choice 2", {rationale: "This one is incorrect"})
+            .build();
+
+        expect(question.widgets["radio 1"].options.choices).toEqual([
+            {
+                content: "choice 1",
+                correct: true,
+                rationale: "This one is correct",
+            },
+            {
+                content: "choice 2",
+                rationale: "This one is incorrect",
+            },
+        ]);
+    });
+});

--- a/packages/perseus/src/widgets/radio/radio-question-builder.ts
+++ b/packages/perseus/src/widgets/radio/radio-question-builder.ts
@@ -1,6 +1,7 @@
 import type {
     PerseusRadioChoice,
     PerseusRenderer,
+    RadioWidget,
 } from "@khanacademy/perseus-core";
 
 export function radioQuestionBuilder(): RadioQuestionBuilder {
@@ -33,7 +34,7 @@ class RadioQuestionBuilder {
                         countChoices: this.countChoices,
                         randomize: this.randomize,
                     },
-                },
+                } satisfies RadioWidget,
             },
         };
     }

--- a/packages/perseus/src/widgets/radio/radio-question-builder.ts
+++ b/packages/perseus/src/widgets/radio/radio-question-builder.ts
@@ -1,0 +1,82 @@
+import type {
+    PerseusRadioChoice,
+    PerseusRenderer,
+} from "@khanacademy/perseus-core";
+
+export function radioQuestionBuilder(): RadioQuestionBuilder {
+    return new RadioQuestionBuilder();
+}
+
+class RadioQuestionBuilder {
+    private content: string = "[[☃ radio 1]]";
+    private choices: PerseusRadioChoice[] = [];
+    private countChoices?: boolean;
+    private hasNoneOfTheAbove?: boolean;
+    private multipleSelect?: boolean;
+    private randomize?: boolean;
+
+    build(): PerseusRenderer {
+        return {
+            content: this.content,
+            images: {},
+            widgets: {
+                "radio 1": {
+                    graded: true,
+                    version: {major: 0, minor: 0},
+                    static: false,
+                    type: "radio",
+                    alignment: "default",
+                    options: {
+                        choices: this.choices,
+                        hasNoneOfTheAbove: this.hasNoneOfTheAbove,
+                        multipleSelect: this.multipleSelect,
+                        countChoices: this.countChoices,
+                        randomize: this.randomize,
+                    },
+                },
+            },
+        };
+    }
+
+    withContent(content: string): RadioQuestionBuilder {
+        this.content = content;
+        return this;
+    }
+
+    withCountChoices(countChoices: boolean): RadioQuestionBuilder {
+        this.countChoices = countChoices;
+        return this;
+    }
+
+    withHasNoneOfTheAbove(hasNoneOfTheAbove: boolean): RadioQuestionBuilder {
+        this.hasNoneOfTheAbove = hasNoneOfTheAbove;
+        return this;
+    }
+
+    withMultipleSelect(multipleSelect: boolean): RadioQuestionBuilder {
+        this.multipleSelect = multipleSelect;
+        return this;
+    }
+
+    withRandomize(randomize: boolean): RadioQuestionBuilder {
+        this.randomize = randomize;
+        return this;
+    }
+
+    addChoice(
+        content: string,
+        options?: {
+            correct?: boolean;
+            rationale?: string;
+            isNoneOfTheAbove?: boolean;
+        },
+    ): RadioQuestionBuilder {
+        this.choices.push({
+            content,
+            correct: options?.correct,
+            rationale: options?.rationale,
+            isNoneOfTheAbove: options?.isNoneOfTheAbove,
+        });
+        return this;
+    }
+}


### PR DESCRIPTION
## Summary:
Now that we have a new question builder, we can use it to replace the
existing testdata json blobs to make them more readable.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3187

## Test plan:
`pnpm jest packages/perseus/src/widgets/radio/__tests__/radio.test.ts`

Look at all the radio stories in the RadioNew docs page:
http://localhost:6006/?path=/docs/perseus-widgets-radionew--docs