### PR TITLE
[Radio] | (CX) | Update the style guide link

### DIFF
--- a/.changeset/four-news-visit.md
+++ b/.changeset/four-news-visit.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus-editor": patch
 ---
 
-[Radio] | (CX) | Update the style guide link
+[Radio] | (CX) | Update the style guide link in the Radio widget editor

--- a/.changeset/four-news-visit.md
+++ b/.changeset/four-news-visit.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Radio] | (CX) | Update the style guide link

--- a/packages/perseus-editor/src/widgets/radio/editor.tsx
+++ b/packages/perseus-editor/src/widgets/radio/editor.tsx
@@ -298,12 +298,12 @@ class RadioEditor extends React.Component<RadioEditorProps> {
                     <a
                         href={
                             // This is an editor component, not user-facing.
-                            "https://docs.google.com/document/d/1frZf7yrWVWb1n4tVjqlzqVUiv1pn4cZXbxgP62-JDBY/edit#heading=h.8ng1isya19nu"
+                            "https://www.khanacademy.org/internal-courses/content-creation-best-practices/xe46daa512cd9c644:question-writing/xe46daa512cd9c644:multiple-choice/a/stems"
                         }
                         target="_blank"
                         rel="noreferrer"
                     >
-                        Multiple choice style guide
+                        Multiple choice best practices
                     </a>
                     <br />
                     <div className="perseus-widget-left-col">


### PR DESCRIPTION
## Summary:
The "Multiple choice style guide" link in the editor needs to be updated

- Update the copy to say "Multiple choice best practices"
- Update the destination to https://www.khanacademy.org/internal-courses/content-creation-best-practices/xe46daa512cd9c644:question-writing/xe46daa512cd9c644:multiple-choice/a/stems

Issue: https://khanacademy.atlassian.net/browse/LEMS-3035

## Test plan:
- Go to http://localhost:6006/?path=/story/perseuseditor-editorpage--demo
- Add a radio widget
- Confirm that the link now says "Multiple choice best practices"
- Confirm that it goes to the Khan Academy lesson rather than a Google doc