### PR TITLE
[Radio] | (CX) | Resize question box height when a word is too long in the editor

### DIFF
--- a/.changeset/ten-taxis-decide.md
+++ b/.changeset/ten-taxis-decide.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Radio] | (CX) | Resize question box height when a word is too long in the editor

--- a/packages/perseus-editor/src/styles/perseus-editor.css
+++ b/packages/perseus-editor/src/styles/perseus-editor.css
@@ -690,6 +690,8 @@ code {
 }
 .perseus-widget-radio .perseus-textarea-pair,
 .perseus-widget-radio .perseus-textarea-underlay {
+    /* Wrap when text area has a long image link that overflows. */
+    overflow-wrap: anywhere;
     display: block;
 }
 .perseus-widget-radio .perseus-textarea-pair > textarea,


### PR DESCRIPTION
## Summary:
If a word (or image link, specifically) is too long in the Radio editor, it overflows off the right of the question box.

We can quickly fix this by using the `overflow-wrap: anywhere` on the underlay (which determines the width) to break up the word/link.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3226

## Test plan:
- Go to http://localhost:6006/?path=/story/perseuseditor-editorpage--demo
- Add a radio widget
- Paste a long image link
  - Example: ![A grass plant with green leaves and yellow stalks at the top.](https://ka-perseus-images.s3.amazonaws.com/b2cdbddba41718aa1850501c7655ddd8bcac6066.png)
- Confirm that it does not overflow off the right edge of the text area