### PR TITLE
Parse ELA radio widgets

### DIFF
--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.ts
@@ -32,6 +32,12 @@ function getDefaultOptions() {
     };
 }
 
+const parseOnePerLine = defaulted(optional(boolean), () => undefined);
+const parseNoneOfTheAbove = defaulted(
+    optional(constant(false)),
+    () => undefined,
+);
+
 const version3 = optional(object({major: constant(3), minor: number}));
 const parseRadioWidgetV3 = parseWidgetWithVersion(
     version3,
@@ -77,12 +83,12 @@ const parseRadioWidgetV2 = parseWidgetWithVersion(
             multipleSelect: optional(boolean),
             deselectEnabled: optional(boolean),
             // deprecated
-            onePerLine: optional(boolean),
+            onePerLine: parseOnePerLine,
             // deprecated
             displayCount: optional(any),
             // v0 props
             // `noneOfTheAbove` is still in use (but only set to `false`).
-            noneOfTheAbove: optional(constant(false)),
+            noneOfTheAbove: parseNoneOfTheAbove,
         }),
         getDefaultOptions,
     ),
@@ -110,12 +116,12 @@ const parseRadioWidgetV1 = parseWidgetWithVersion(
             multipleSelect: optional(boolean),
             deselectEnabled: optional(boolean),
             // deprecated
-            onePerLine: optional(boolean),
+            onePerLine: parseOnePerLine,
             // deprecated
             displayCount: optional(any),
             // v0 props
             // `noneOfTheAbove` is still in use (but only set to `false`).
-            noneOfTheAbove: optional(constant(false)),
+            noneOfTheAbove: parseNoneOfTheAbove,
         }),
         getDefaultOptions,
     ),
@@ -143,12 +149,12 @@ const parseRadioWidgetV0 = parseWidgetWithVersion(
             multipleSelect: optional(boolean),
             deselectEnabled: optional(boolean),
             // deprecated
-            onePerLine: optional(boolean),
+            onePerLine: parseOnePerLine,
             // deprecated
             displayCount: optional(any),
             // v0 props
             // `noneOfTheAbove` is still in use (but only set to `false`).
-            noneOfTheAbove: optional(constant(false)),
+            noneOfTheAbove: parseNoneOfTheAbove,
         }),
         getDefaultOptions,
     ),

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -10903,6 +10903,235 @@ B &= \\{x: x \\text{ is a square in the plane P} \\}
 }
 `;
 
+exports[`parseAndMigratePerseusItem given radio-with-extra-fields-from-go-schema.json returns the same result as before 1`] = `
+{
+  "_multi": null,
+  "answer": null,
+  "answerArea": {
+    "calculator": false,
+    "chi2Table": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTimeToPayOff": false,
+    "financialCalculatorTotalAmount": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+    "tTable": false,
+    "zTable": false,
+  },
+  "hints": [],
+  "itemDataVersion": {
+    "major": 0,
+    "minor": 1,
+  },
+  "question": {
+    "content": "
+[[☃ image 1]]
+
+##A seriously play-ful(l) proposal
+
+1. The United Nations has declared that playing is a basic human right. Yet we, the children of the United States, have been told that recess isn’t important and needs to be cut in favor of more class time. The average kid in the U.S. gets just 27 minutes of recess a day. This is unacceptable! Recess is important for developing students’ healthy habits alongside a wide range of skills.
+
+###Recess improves our [[☃ definition 1]] and [[☃ definition 3]] health
+
+2. Research shows that exercise makes people healthier and happier. So, by giving students enough time to move their bodies, schools would make their bodies stronger and improve their mental wellbeing. The Center for Disease Control recommends that kids get 60 minutes of active play a day, yet schools give many of us 20 minutes or less of recess! And the practices we develop now affect us far into the future—research has found that the most active kids remain active as adults. If schools cared about the health of our bodies and our minds, they would make sure we had time to develop the healthy habits we need for success.
+
+###Free play builds soft skills
+
+3. 	Some people might wonder: What about gym class? That could help students develop healthy habits.
+
+4. 	I agree that gym class can be important, but it’s no replacement for free play. Study after study has shown that play develops creativity, flexibility, and social skills. When we organize a game with friends, play by ourselves, or resolve a conflict with peers, we’re building our abilities to work together and be creative. These are the skills we need to deal with challenges later in life. These skills will help us be ready to be successful in 21st-century careers. Memorizing facts won’t be enough to prepare us to be engineers, scientists, and leaders–we also need to learn to critically think and collaborate.
+
+###Recess increases learning
+
+5. 	As the amount of time we spend taking standardized tests has grown, our recess has shrunk. School leaders tell us that we need the time for English class. We need the time for math class. There’s no benefit to recess. These are the untruths they’ve pushed on us.
+
+6. 	Because the research is clear: Recess has been linked to higher grades and higher standardized test scores. Furthermore, several studies show that students focus better in class when they have recess during the school day. So, if we really want students to succeed on tests, they need more time at recess, not less.
+
+###Looking to the world
+
+7. 	There are many places in the world where students get more recess than we do here in the United States. We should look to those countries and align our efforts with theirs. For example, in Finland, where students get some of the top scores on world tests, kids get a 15-minute recess after each 45 minutes of instruction. That means they get a total of 75 minutes of recess a day! In Uganda, students get a half hour of recess in the morning and 1.5 hours of choice activity, including free play, in the afternoon. And in Costa Rica, students get short breaks after every two classes and a longer recess after lunch. These countries, and many others, show that it is possible for the United States to do better. For the sake of our physical and mental health, we deserve the right to play that the United Nations has promised us. Let’s stand up for our right to recess!
+
+
+[[☃ explanation 1]]=====
+**Eliana infers that the author believes recess can help students develop [[☃ definition 2]] healthy habits. Which line from paragraph 2 best supports this inference?**
+
+[[☃ radio 1]]
+
+",
+    "images": {},
+    "metadata": null,
+    "replace": null,
+    "widgets": {
+      "definition 1": {
+        "alignment": "default",
+        "graded": true,
+        "id": null,
+        "key": null,
+        "options": {
+          "definition": "Phy·si·cal (fih-sic-ull): Having to do with the body",
+          "static": false,
+          "togglePrompt": "physical",
+        },
+        "static": false,
+        "type": "definition",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+      "definition 2": {
+        "alignment": "default",
+        "graded": true,
+        "id": null,
+        "key": null,
+        "options": {
+          "definition": "Life·long (life-long): Lasting your whole life",
+          "static": false,
+          "togglePrompt": "lifelong",
+        },
+        "static": false,
+        "type": "definition",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+      "definition 3": {
+        "alignment": "default",
+        "graded": true,
+        "id": null,
+        "key": null,
+        "options": {
+          "definition": "Men·tal (men-tull): Having to do with the mind",
+          "static": false,
+          "togglePrompt": "mental",
+        },
+        "static": false,
+        "type": "definition",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+      "explanation 1": {
+        "alignment": "default",
+        "graded": true,
+        "id": null,
+        "key": null,
+        "options": {
+          "explanation": "Public domain image provided by [Pxhere](https://pxhere.com/en/photo/1033461)",
+          "hidePrompt": "Hide attribution",
+          "showPrompt": "Attribution",
+          "static": false,
+          "widgets": {},
+        },
+        "static": false,
+        "type": "explanation",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+      "image 1": {
+        "alignment": "block",
+        "graded": true,
+        "id": null,
+        "key": null,
+        "options": {
+          "alt": "Empty swings",
+          "backgroundImage": {
+            "bottom": undefined,
+            "height": 3448,
+            "left": undefined,
+            "scale": undefined,
+            "top": 0,
+            "url": "https://cdn.kastatic.org/ka-content-images/4a9f1e5d57a20ab339b1d69734b9289f042a373b.jpg",
+            "width": 4592,
+          },
+          "box": [
+            4592,
+            3448,
+          ],
+          "caption": "",
+          "labels": [],
+          "range": [
+            [
+              0,
+              10,
+            ],
+            [
+              0,
+              10,
+            ],
+          ],
+          "static": false,
+          "title": "",
+        },
+        "static": false,
+        "type": "image",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+      "radio 1": {
+        "alignment": "default",
+        "graded": true,
+        "id": null,
+        "key": null,
+        "options": {
+          "choices": [
+            {
+              "content": "“Research shows that exercise makes people healthier and happier.” 
+",
+              "correct": false,
+              "isNoneOfTheAbove": false,
+              "rationale": "This choice doesn’t support Eliana’s inference. It mentions that exercise can make people healthier and happier but doesn’t suggest that  students would keep exercising later in life.
+",
+            },
+            {
+              "content": "“So, by giving students enough time to move their bodies, schools would make their bodies stronger and improve their mental wellbeing.”",
+              "correct": false,
+              "isNoneOfTheAbove": false,
+              "rationale": "This choice doesn’t support Eliana’s inference. It mentions that exercise can make people healthier in their bodies and minds but doesn’t suggest that students would keep exercising later in life.
+",
+            },
+            {
+              "content": "“The Center for Disease Control recommends that kids get 60 minutes of active play a day, yet, for many of us, schools give us 20 minutes or less of recess!” 
+",
+              "correct": false,
+              "isNoneOfTheAbove": false,
+              "rationale": "This choice doesn’t support Eliana’s inference. It mentions how much exercise the Center for Disease Control recommends but doesn’t suggest this would lead to lifelong healthy habits.
+",
+            },
+            {
+              "content": "“And the practices we develop now affect us far into the future– research has found that the most active kids remain active as adults.”
+",
+              "correct": true,
+              "isNoneOfTheAbove": false,
+              "rationale": "**This is the best choice.** It mentions that “research has found that the most active kids remain active as adults,” which shows that kids who exercise are likely to keep up this healthy habit later in their lives.
+",
+            },
+          ],
+          "countChoices": false,
+          "deselectEnabled": false,
+          "hasNoneOfTheAbove": false,
+          "multipleSelect": false,
+          "numCorrect": 0,
+          "randomize": false,
+        },
+        "static": false,
+        "type": "radio",
+        "version": {
+          "major": 3,
+          "minor": 0,
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`parseAndMigratePerseusItem given radio-with-null-options.json returns the same result as before 1`] = `
 {
   "answerArea": {

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/radio-with-extra-fields-from-go-schema.json
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/radio-with-extra-fields-from-go-schema.json
@@ -1,0 +1,209 @@
+{
+  "question": {
+    "content": "\n[[☃ image 1]]\n\n##A seriously play-ful(l) proposal\n\n1. The United Nations has declared that playing is a basic human right. Yet we, the children of the United States, have been told that recess isn’t important and needs to be cut in favor of more class time. The average kid in the U.S. gets just 27 minutes of recess a day. This is unacceptable! Recess is important for developing students’ healthy habits alongside a wide range of skills.\n\n###Recess improves our [[☃ definition 1]] and [[☃ definition 3]] health\n\n2. Research shows that exercise makes people healthier and happier. So, by giving students enough time to move their bodies, schools would make their bodies stronger and improve their mental wellbeing. The Center for Disease Control recommends that kids get 60 minutes of active play a day, yet schools give many of us 20 minutes or less of recess! And the practices we develop now affect us far into the future—research has found that the most active kids remain active as adults. If schools cared about the health of our bodies and our minds, they would make sure we had time to develop the healthy habits we need for success.\n\n###Free play builds soft skills\n\n3. \tSome people might wonder: What about gym class? That could help students develop healthy habits.\n\n4. \tI agree that gym class can be important, but it’s no replacement for free play. Study after study has shown that play develops creativity, flexibility, and social skills. When we organize a game with friends, play by ourselves, or resolve a conflict with peers, we’re building our abilities to work together and be creative. These are the skills we need to deal with challenges later in life. These skills will help us be ready to be successful in 21st-century careers. Memorizing facts won’t be enough to prepare us to be engineers, scientists, and leaders–we also need to learn to critically think and collaborate.\n\n###Recess increases learning\n\n5. \tAs the amount of time we spend taking standardized tests has grown, our recess has shrunk. School leaders tell us that we need the time for English class. We need the time for math class. There’s no benefit to recess. These are the untruths they’ve pushed on us.\n\n6. \tBecause the research is clear: Recess has been linked to higher grades and higher standardized test scores. Furthermore, several studies show that students focus better in class when they have recess during the school day. So, if we really want students to succeed on tests, they need more time at recess, not less.\n\n###Looking to the world\n\n7. \tThere are many places in the world where students get more recess than we do here in the United States. We should look to those countries and align our efforts with theirs. For example, in Finland, where students get some of the top scores on world tests, kids get a 15-minute recess after each 45 minutes of instruction. That means they get a total of 75 minutes of recess a day! In Uganda, students get a half hour of recess in the morning and 1.5 hours of choice activity, including free play, in the afternoon. And in Costa Rica, students get short breaks after every two classes and a longer recess after lunch. These countries, and many others, show that it is possible for the United States to do better. For the sake of our physical and mental health, we deserve the right to play that the United Nations has promised us. Let’s stand up for our right to recess!\n\n\n[[☃ explanation 1]]=====\n**Eliana infers that the author believes recess can help students develop [[☃ definition 2]] healthy habits. Which line from paragraph 2 best supports this inference?**\n\n[[☃ radio 1]]\n\n",
+    "widgets": {
+      "definition 1": {
+        "type": "definition",
+        "static": false,
+        "graded": true,
+        "alignment": "default",
+        "id": null,
+        "key": null,
+        "version": {
+          "major": 0,
+          "minor": 0
+        },
+        "options": {
+          "togglePrompt": "physical",
+          "definition": "Phy·si·cal (fih-sic-ull): Having to do with the body",
+          "static": false
+        }
+      },
+      "definition 2": {
+        "type": "definition",
+        "static": false,
+        "graded": true,
+        "alignment": "default",
+        "id": null,
+        "key": null,
+        "version": {
+          "major": 0,
+          "minor": 0
+        },
+        "options": {
+          "togglePrompt": "lifelong",
+          "definition": "Life·long (life-long): Lasting your whole life",
+          "static": false
+        }
+      },
+      "definition 3": {
+        "type": "definition",
+        "static": false,
+        "graded": true,
+        "alignment": "default",
+        "id": null,
+        "key": null,
+        "version": {
+          "major": 0,
+          "minor": 0
+        },
+        "options": {
+          "togglePrompt": "mental",
+          "definition": "Men·tal (men-tull): Having to do with the mind",
+          "static": false
+        }
+      },
+      "explanation 1": {
+        "type": "explanation",
+        "static": false,
+        "graded": true,
+        "alignment": "default",
+        "id": null,
+        "key": null,
+        "version": {
+          "major": 0,
+          "minor": 0
+        },
+        "options": {
+          "showPrompt": "Attribution",
+          "hidePrompt": "Hide attribution",
+          "explanation": "Public domain image provided by [Pxhere](https://pxhere.com/en/photo/1033461)",
+          "widgets": {},
+          "static": false
+        }
+      },
+      "image 1": {
+        "type": "image",
+        "static": false,
+        "graded": true,
+        "alignment": "block",
+        "id": null,
+        "key": null,
+        "version": {
+          "major": 0,
+          "minor": 0
+        },
+        "options": {
+          "title": "",
+          "labels": [],
+          "caption": "",
+          "alt": "Empty swings",
+          "backgroundImage": {
+            "url": "https://cdn.kastatic.org/ka-content-images/4a9f1e5d57a20ab339b1d69734b9289f042a373b.jpg",
+            "width": 4592,
+            "height": 3448,
+            "top": 0,
+            "scale": null,
+            "bottom": null,
+            "left": null
+          },
+          "static": false,
+          "range": [
+            [
+              0,
+              10
+            ],
+            [
+              0,
+              10
+            ]
+          ],
+          "box": [
+            4592,
+            3448
+          ]
+        }
+      },
+      "radio 1": {
+        "type": "radio",
+        "static": false,
+        "graded": true,
+        "alignment": "default",
+        "id": null,
+        "key": null,
+        "version": {
+          "major": 1,
+          "minor": 0
+        },
+        "options": {
+          "choices": [
+            {
+              "content": "“Research shows that exercise makes people healthier and happier.” \n",
+              "rationale": "",
+              "correct": false,
+              "isNoneOfTheAbove": false,
+              "id": "",
+              "widgets": null,
+              "clue": "This choice doesn’t support Eliana’s inference. It mentions that exercise can make people healthier and happier but doesn’t suggest that  students would keep exercising later in life.\n"
+            },
+            {
+              "content": "“So, by giving students enough time to move their bodies, schools would make their bodies stronger and improve their mental wellbeing.”",
+              "rationale": "",
+              "correct": false,
+              "isNoneOfTheAbove": false,
+              "id": "",
+              "widgets": null,
+              "clue": "This choice doesn’t support Eliana’s inference. It mentions that exercise can make people healthier in their bodies and minds but doesn’t suggest that students would keep exercising later in life.\n"
+            },
+            {
+              "content": "“The Center for Disease Control recommends that kids get 60 minutes of active play a day, yet, for many of us, schools give us 20 minutes or less of recess!” \n",
+              "rationale": "",
+              "correct": false,
+              "isNoneOfTheAbove": false,
+              "id": "",
+              "widgets": null,
+              "clue": "This choice doesn’t support Eliana’s inference. It mentions how much exercise the Center for Disease Control recommends but doesn’t suggest this would lead to lifelong healthy habits.\n"
+            },
+            {
+              "content": "“And the practices we develop now affect us far into the future– research has found that the most active kids remain active as adults.”\n",
+              "rationale": "",
+              "correct": true,
+              "isNoneOfTheAbove": false,
+              "id": "",
+              "widgets": null,
+              "clue": "**This is the best choice.** It mentions that “research has found that the most active kids remain active as adults,” which shows that kids who exercise are likely to keep up this healthy habit later in their lives.\n"
+            }
+          ],
+          "numCorrect": 0,
+          "hasNoneOfTheAbove": false,
+          "countChoices": false,
+          "deselectEnabled": false,
+          "randomize": false,
+          "multipleSelect": false,
+          "displayCount": null,
+          "noneOfTheAbove": null,
+          "onePerLine": null
+        }
+      }
+    },
+    "replace": null,
+    "metadata": null,
+    "images": {}
+  },
+  "hints": [],
+  "answerArea": {
+    "type": "",
+    "static": false,
+    "graded": false,
+    "alignment": "",
+    "id": null,
+    "key": null,
+    "version": null,
+    "zTable": false,
+    "chi2Table": false,
+    "tTable": false,
+    "calculator": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTotalAmount": false,
+    "financialCalculatorTimeToPayOff": false,
+    "options": null
+  },
+  "_multi": null,
+  "itemDataVersion": {
+    "major": 0,
+    "minor": 1
+  },
+  "answer": null
+}


### PR DESCRIPTION
In [ELA exercises] on Khan Academy, widgets are parsed by Go code and
re-serialized as JSON before being served to the frontend. The Go parser fills
in zero values for any missing fields, e.g. `nil` (which serializes to JSON
`null`). Previously our Radio widget parser didn't accept `null` values for
`onePerLine` and `noneOfTheAbove`; it wanted `undefined`. As a result, we saw
parse errors in ELA exercises when we tried to deploy the recent Radio v3
upgrade.

This PR fixes the parser so it can handle Radio widgets that have had `null`
filled in for `onePerLine` and `noneOfTheAbove`.

[ELA exercises]: https://www.khanacademy.org/ela/new-6th-grade-reading-and-vocabulary/x8ddea1200317e822:the-rules-we-live-by-mixed-skills-lpassage-practice/x8ddea1200317e822:reading-argumentative-texts/e/a-seriously-play-ful-proposal-a-text-about-recess

Issue: none

## Test plan:

`pnpm test`