### PR TITLE
Wonder Blocks: Remove deprecated semanticColor.text and semanticColor.border token instances

### DIFF
--- a/.changeset/eighty-kiwis-thank.md
+++ b/.changeset/eighty-kiwis-thank.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Updates styles to use `semanticColor.core` WB tokens instead of the now deprecated sc.text and sc.border tokens

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -231,7 +231,7 @@ const styles = StyleSheet.create({
     criterionContainer: {
         paddingTop: spacing.xSmall_8,
         paddingBottom: spacing.xSmall_8,
-        borderBottom: `1px solid ${semanticColor.border.primary}`,
+        borderBottom: `1px solid ${semanticColor.core.border.neutral.subtle}`,
         ":last-child": {
             borderBottom: "none",
         },

--- a/packages/perseus/src/widgets/free-response/__snapshots__/free-response.test.tsx.snap
+++ b/packages/perseus/src/widgets/free-response/__snapshots__/free-response.test.tsx.snap
@@ -68,7 +68,7 @@ exports[`free-response widget should snapshot on mobile: first mobile render 1`]
               class="default_xu2jcg"
             >
               <span
-                class="text_f1191h-o_O-characterCountText_1shcjz1"
+                class="text_f1191h-o_O-characterCountText_1iy49wk"
                 role="status"
               >
                 0 / 500 Characters
@@ -150,7 +150,7 @@ exports[`free-response widget should snapshot: first render 1`] = `
               class="default_xu2jcg"
             >
               <span
-                class="text_f1191h-o_O-characterCountText_1shcjz1"
+                class="text_f1191h-o_O-characterCountText_1iy49wk"
                 role="status"
               >
                 0 / 500 Characters

--- a/packages/perseus/src/widgets/free-response/free-response.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.tsx
@@ -152,7 +152,7 @@ const styles = StyleSheet.create({
         gap: spacing.xSmall_8,
     },
     characterCountText: {
-        color: semanticColor.text.secondary,
+        color: semanticColor.core.foreground.neutral.default,
         fontSize: font.size.small,
     },
     overCharacterLimit: {

--- a/utils/extract-css.js
+++ b/utils/extract-css.js
@@ -29,10 +29,10 @@ const cssFilePath = path.join(fileDirectory, cssFileName);
 const indentation = "    ";
 const wbColorValues = {
     // from node_modules/@khanacademy/wonder-blocks-tokens/dist/css/index.css
-    "#21242c": "--wb-semanticColor-text-primary",
-    "#5f6167": "--wb-semanticColor-text-secondary",
-    "#b8b9bb": "--wb-semanticColor-text-disabled",
-    "#ffffff": "--wb-semanticColor-text-inverse",
+    "#21242c": "--wb-semanticColor-core-foreground-neutral-strong",
+    "#5f6167": "--wb-semanticColor-core-foreground-neutral-default",
+    "#b8b9bb": "--wb-semanticColor-core-foreground-disabled-default",
+    "#ffffff": "--wb-semanticColor-core-foreground-inverse-strong",
 };
 const mediaQueries = {
     // from packages/perseus/src/styles/media-queries.ts


### PR DESCRIPTION
## Summary:

Updates styles to use `semanticColor.core` WB tokens instead of the now
deprecated sc.text and sc.border tokens, which were previously used
for text and border colors.

This change is part of the ongoing effort to standardize our new `core` semantic
color tokens across repositories, so that we can have a consistent approach
with Design specs.

Docs: https://khan.github.io/wonder-blocks/?path=/docs/foundations-using-color--docs#core

Issue: "none"

## Test plan:

Verify that the following components render without any visual changes:

- Free response editor

| BEFORE | AFTER |
|--------|--------|
| <img width="1294" alt="Screenshot 2025-06-19 at 3 37 50 PM" src="https://github.com/user-attachments/assets/6b5ecd86-d409-4049-9819-f09c78f15998" /> | <img width="1393" alt="Screenshot 2025-06-19 at 3 38 13 PM" src="https://github.com/user-attachments/assets/23bb3ad5-39b0-40a0-bcd5-cff16f066210" /> | 

- Free response widget

| BEFORE | AFTER |
|--------|--------|
| <img width="1539" alt="Screenshot 2025-06-19 at 3 39 54 PM" src="https://github.com/user-attachments/assets/9ba81a47-f4b7-45f7-90fd-f7d813db5c90" /> | <img width="1505" alt="Screenshot 2025-06-19 at 3 40 02 PM" src="https://github.com/user-attachments/assets/7c971bbb-0f8e-4f4b-b971-46c3ad40bf3c" /> | 