### PR TITLE
Remove long-outdated "star property hack"

### DIFF
--- a/.changeset/swift-jobs-poke.md
+++ b/.changeset/swift-jobs-poke.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Remove old CSS hack for IE7 and earlier browsers (no longer supported)

--- a/packages/perseus/src/styles/util.css
+++ b/packages/perseus/src/styles/util.css
@@ -9,9 +9,6 @@
     position: absolute;
     width: 1px;
 }
-.perseus-clearfix {
-    *zoom: 1;
-}
 .perseus-clearfix:before,
 .perseus-clearfix:after {
     content: "";

--- a/packages/perseus/src/styles/widgets/radio.css
+++ b/packages/perseus/src/styles/widgets/radio.css
@@ -9,9 +9,6 @@
     position: absolute;
     width: 1px;
 }
-.perseus-clearfix {
-    *zoom: 1;
-}
 .perseus-clearfix:before,
 .perseus-clearfix:after {
     content: "";


### PR DESCRIPTION
## Summary:

This PR removes an old CSS hack that are no longer relevant in our codebase (it's for IE7!)

Specifically, I noticed the CSS compiler balking at: `*zoom: 1`. So I asked the Genie about it and here's the explanation it gave. 

> The `*` in `*zoom: 1;` is a CSS hack called the "star property hack" 
> or "IE7 hack". It's used to target Internet Explorer 7 specifically.
> 
> Here's what it does:
>   * The * prefix makes the property only apply to Internet Explorer 7 
>     and earlier versions. 
>   * Other browsers ignore properties that start with `*`.
>   * `zoom: 1` is a Microsoft-specific CSS property that triggers 
>     "hasLayout" in IE, which is needed for certain layout behaviors 
>     to work correctly.
>
> In this case, it's being used as part of a clearfix implementation. 
> The clearfix is a CSS technique to ensure that a container properly 
> contains its floated children. The *zoom: 1 ensures that IE7 properly 
> handles the layout of the clearfix container.
> 
> However, this hack is quite outdated since:
>   * Internet Explorer 7 was discontinued in 2015
>   * Modern browsers have much better CSS support
>   * There are cleaner ways to achieve the same layout effects today
> 
> The linter error you're seeing is likely because the linter doesn't 
> recognize the `*` prefix as valid CSS syntax, which is expected since 
> it's a browser-specific hack rather than standard CSS.

Issue: <none>

## Test plan:

I don't think this is a risky change as it's documented as being ignored by modern browsers and specifically for IE7!