### PR TITLE
LEMS-3247: NumberLine inequality regression

### DIFF
--- a/.changeset/unlucky-dancers-compare.md
+++ b/.changeset/unlucky-dancers-compare.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Bugfix: NumberLine inequality buttons didn't change inequality

--- a/packages/perseus/src/widgets/number-line/number-line.stories.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.stories.tsx
@@ -2,7 +2,7 @@ import {generateTestPerseusItem} from "@khanacademy/perseus-core";
 
 import {ServerItemRendererWithDebugUI} from "../../../../../testing/server-item-renderer-with-debug-ui";
 
-import {question1, question2} from "./number-line.testdata";
+import {inequality, question1, question2} from "./number-line.testdata";
 
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
@@ -30,5 +30,11 @@ export const WithAnswerlessData: Story = {
     args: {
         item: generateTestPerseusItem({question: question1}),
         startAnswerless: true,
+    },
+};
+
+export const Inequality: Story = {
+    args: {
+        item: generateTestPerseusItem({question: inequality}),
     },
 };

--- a/packages/perseus/src/widgets/number-line/number-line.test.ts
+++ b/packages/perseus/src/widgets/number-line/number-line.test.ts
@@ -193,9 +193,8 @@ describe("number-line widget", () => {
             });
         });
 
-        // Regression (LEMS-3247)
-        test("can switch directions", async () => {
-            const options: PerseusNumberLineWidgetOptions = {
+        function getInequalityOptions(): PerseusNumberLineWidgetOptions {
+            return {
                 static: false, // <= important
                 isInequality: true, // <= important
                 correctRel: "le",
@@ -211,8 +210,14 @@ describe("number-line widget", () => {
                 snapDivisions: 1,
                 tickStep: 1,
             };
+        }
 
-            const item = getAnswerfulItem("number-line", options);
+        // Regression (LEMS-3247)
+        test("can switch directions", async () => {
+            const item = getAnswerfulItem(
+                "number-line",
+                getInequalityOptions(),
+            );
 
             const {renderer} = renderQuestion(item.question);
 
@@ -232,24 +237,10 @@ describe("number-line widget", () => {
 
         // Regression (LEMS-3247)
         test("can change circle fill", async () => {
-            const options: PerseusNumberLineWidgetOptions = {
-                static: false, // <= important
-                isInequality: true, // <= important
-                correctRel: "le",
-                correctX: -1,
-                divisionRange: [1, 12],
-                initialX: -5,
-                labelRange: [null, null],
-                labelStyle: "decimal",
-                labelTicks: true,
-                numDivisions: null,
-                range: [-5, 5],
-                showTooltips: false,
-                snapDivisions: 1,
-                tickStep: 1,
-            };
-
-            const item = getAnswerfulItem("number-line", options);
+            const item = getAnswerfulItem(
+                "number-line",
+                getInequalityOptions(),
+            );
 
             const {renderer} = renderQuestion(item.question);
 
@@ -300,7 +291,7 @@ describe("number-line widget", () => {
             numberLineOptions,
         ).question;
 
-        it.only("can be answered correctly", () => {
+        it("can be answered correctly", () => {
             // Arrange
             const apiOptions: APIOptions = {
                 isMobile: false,

--- a/packages/perseus/src/widgets/number-line/number-line.test.ts
+++ b/packages/perseus/src/widgets/number-line/number-line.test.ts
@@ -1,4 +1,5 @@
-import {act} from "@testing-library/react";
+import {screen, act} from "@testing-library/react";
+import {userEvent as userEventLib} from "@testing-library/user-event";
 
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
@@ -13,6 +14,7 @@ import {question1} from "./number-line.testdata";
 
 import type {APIOptions} from "../../types";
 import type {PerseusNumberLineWidgetOptions} from "@khanacademy/perseus-core";
+import type {UserEvent} from "@testing-library/user-event";
 
 describe("number-line widget", () => {
     beforeEach(() => {
@@ -183,6 +185,89 @@ describe("number-line widget", () => {
         });
     });
 
+    describe("button controls", () => {
+        let userEvent: UserEvent;
+        beforeEach(() => {
+            userEvent = userEventLib.setup({
+                advanceTimers: jest.advanceTimersByTime,
+            });
+        });
+
+        // Regression (LEMS-3247)
+        test("can switch directions", async () => {
+            const options: PerseusNumberLineWidgetOptions = {
+                static: false, // <= important
+                isInequality: true, // <= important
+                correctRel: "le",
+                correctX: -1,
+                divisionRange: [1, 12],
+                initialX: -5,
+                labelRange: [null, null],
+                labelStyle: "decimal",
+                labelTicks: true,
+                numDivisions: null,
+                range: [-5, 5],
+                showTooltips: false,
+                snapDivisions: 1,
+                tickStep: 1,
+            };
+
+            const item = getAnswerfulItem("number-line", options);
+
+            const {renderer} = renderQuestion(item.question);
+
+            const preUserInput = renderer.getUserInputMap();
+
+            await userEvent.click(
+                screen.getByRole("button", {name: "Switch direction"}),
+            );
+
+            const postUserInput = renderer.getUserInputMap();
+
+            // Assert the relationship changes direction
+            // when we hit "switch direction"
+            expect(preUserInput["number-line 1"].rel).toBe("ge");
+            expect(postUserInput["number-line 1"].rel).toBe("le");
+        });
+
+        // Regression (LEMS-3247)
+        test("can change circle fill", async () => {
+            const options: PerseusNumberLineWidgetOptions = {
+                static: false, // <= important
+                isInequality: true, // <= important
+                correctRel: "le",
+                correctX: -1,
+                divisionRange: [1, 12],
+                initialX: -5,
+                labelRange: [null, null],
+                labelStyle: "decimal",
+                labelTicks: true,
+                numDivisions: null,
+                range: [-5, 5],
+                showTooltips: false,
+                snapDivisions: 1,
+                tickStep: 1,
+            };
+
+            const item = getAnswerfulItem("number-line", options);
+
+            const {renderer} = renderQuestion(item.question);
+
+            const preUserInput = renderer.getUserInputMap();
+
+            await userEvent.click(
+                screen.getByRole("button", {name: "Make circle open"}),
+            );
+
+            const postUserInput = renderer.getUserInputMap();
+
+            // Assert the relationship changes direction
+            // when we hit "make circle open"
+            expect(preUserInput["number-line 1"].rel).toBe("ge");
+            expect(postUserInput["number-line 1"].rel).toBe("gt");
+        });
+    });
+
     const numberLineOptions: PerseusNumberLineWidgetOptions = {
         labelRange: [null, null],
         initialX: null,
@@ -215,12 +300,12 @@ describe("number-line widget", () => {
             numberLineOptions,
         ).question;
 
-        it("can be answered correctly", () => {
+        it.only("can be answered correctly", () => {
             // Arrange
             const apiOptions: APIOptions = {
                 isMobile: false,
             };
-            const {renderer} = renderQuestion(correctAnswer, apiOptions);
+            const {renderer} = renderQuestion(question, apiOptions);
 
             // Act
             const [numberLine] = renderer.findWidgets("number-line 1");

--- a/packages/perseus/src/widgets/number-line/number-line.testdata.ts
+++ b/packages/perseus/src/widgets/number-line/number-line.testdata.ts
@@ -60,3 +60,29 @@ export const question2: PerseusRenderer = {
         },
     },
 };
+
+export const inequality: PerseusRenderer = {
+    content: "[[☃ number-line 1]]",
+    images: {},
+    widgets: {
+        "number-line 1": {
+            type: "number-line",
+            options: {
+                correctRel: "le",
+                correctX: -1,
+                divisionRange: [1, 12],
+                initialX: -5,
+                isInequality: true,
+                labelRange: [null, null],
+                labelStyle: "decimal",
+                labelTicks: true,
+                numDivisions: null,
+                range: [-5, 5],
+                showTooltips: false,
+                snapDivisions: 1,
+                static: false,
+                tickStep: 1,
+            },
+        },
+    },
+};

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -852,7 +852,7 @@ function getStartUserInput(
     return {
         numDivisions: getStartNumDivisions(options),
         numLinePosition,
-        rel: "ge",
+        rel: options.isInequality ? "ge" : "eq",
     };
 }
 

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -550,22 +550,19 @@ class NumberLine extends React.Component<Props, State> implements Widget {
         });
     };
 
-    // @ts-expect-error - TS2322 - Type '(props: any) => any[]' is not assignable to type '(arg1: any) => [number, number]'.
-    _getInequalityEndpoint: (arg1: any) => [number, number] = (props) => {
-        const isGreater = _(["ge", "gt"]).contains(props.rel);
+    _getInequalityEndpoint(props: CalculatedProps): [number, number] {
+        const isGreater = _(["ge", "gt"]).contains(this.props.userInput.rel);
         const widthInPixels = 400;
         const range = props.range;
         const scale = (range[1] - range[0]) / widthInPixels;
         const buffer = horizontalPadding * scale;
         const left = range[0] - buffer;
         const right = range[1] + buffer;
-        const end = isGreater ? [right, 0] : [left, 0];
+        const end: [number, number] = isGreater ? [right, 0] : [left, 0];
         return end;
-    };
+    }
 
-    _renderInequality: (arg1: CalculatedProps) => React.ReactElement | null = (
-        props,
-    ) => {
+    _renderInequality(props: CalculatedProps): React.ReactElement | null {
         if (props.isInequality) {
             const end = this._getInequalityEndpoint(props);
             const style = {
@@ -576,24 +573,18 @@ class NumberLine extends React.Component<Props, State> implements Widget {
                 strokeWidth: 3.5,
             } as const;
 
-            const isGreater = ["ge", "gt"].includes(props.userInput.rel);
-
             return (
                 <Line
                     // We shift the line to either side of the dot so they don't
                     // intersect
-                    start={[
-                        (isGreater ? 0.4 : -0.4) +
-                            props.userInput.numLinePosition,
-                        0,
-                    ]}
+                    start={[props.userInput.numLinePosition, 0]}
                     end={end}
                     style={style}
                 />
             );
         }
         return null;
-    };
+    }
 
     _setupGraphie: (arg1: any, arg2: any) => void = (graphie, options) => {
         // Ensure a sane configuration to avoid infinite loops
@@ -861,7 +852,7 @@ function getStartUserInput(
     return {
         numDivisions: getStartNumDivisions(options),
         numLinePosition,
-        rel: "eq",
+        rel: "ge",
     };
 }
 


### PR DESCRIPTION
## Summary:
The problem had to do with how we default/initialize `rel` (relationship for inequalities). The logic around how we do this is pretty confusing TBH, but I think I came to a good place?

Issue: LEMS-3247

## Test plan:

- Go to the new story or the link in the ticket (prod/ZND)
- Note the arrow
  - Correct: arrow is pointing right
  - Broken: arrow is pointing left
- Hit "Switch direction"
  - Correct: arrow should switch direction
  - Broken: arrow does not switch direction
- Hit "Make circle open"
  - Correct: circle should become unfilled
  - Broken: circle stays filled

Fixed behavior:

https://github.com/user-attachments/assets/8d6fa9a0-d3bc-443b-b89a-c93abeaab9ec

Broken behavior:

https://github.com/user-attachments/assets/9872fe93-b1e6-4e5d-944c-f33ae36230c9
