### PR TITLE
[Interactive Graph] [Locked Figures] Add `weight` option to locked polygon and locked polygon settings

### DIFF
--- a/.changeset/shaggy-apricots-lay.md
+++ b/.changeset/shaggy-apricots-lay.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus-editor": patch
+---
+
+[Interactive Graph][locked figures] Add `weight` option to locked polygon and locked polygon settings

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -873,6 +873,7 @@ export type LockedPolygonType = {
     showVertices: boolean;
     fillStyle: LockedFigureFillType;
     strokeStyle: LockedLineStyle;
+    weight?: "thin" | "medium" | "thick";
     labels: LockedLabelType[];
     ariaLabel?: string;
 };

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -137,6 +137,8 @@ const parseLockedFigureFillType = enumeration(
 
 const parseLockedLineStyle = enumeration("solid", "dashed");
 
+const parseStrokeWeight = optional(enumeration("medium", "thin", "thick"));
+
 const parseLockedLabelType = object({
     type: constant("label"),
     coord: pairOfNumbers,
@@ -193,6 +195,7 @@ const parseLockedPolygonType = object({
     showVertices: boolean,
     fillStyle: parseLockedFigureFillType,
     strokeStyle: parseLockedLineStyle,
+    weight: parseStrokeWeight,
     labels: defaulted(array(parseLockedLabelType), () => []),
     ariaLabel: optional(string),
 });

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/line-weight-select.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/line-weight-select.tsx
@@ -2,27 +2,34 @@ import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelMedium} from "@khanacademy/wonder-blocks-typography";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-type StyleOptions = "solid" | "dashed";
 type Props = {
-    selectedValue: StyleOptions;
-    onChange: (newValue: StyleOptions) => void;
+    selectedValue: "thin" | "medium" | "thick";
+    onChange: (newValue: "thin" | "medium" | "thick") => void;
     containerStyle?: StyleType;
 };
 
-const LineStrokeSelect = (props: Props) => {
+const LineWeightSelect = (props: Props) => {
     const {selectedValue, containerStyle, onChange} = props;
 
     return (
         <LabelMedium
             tag="label"
-            style={[styles.lineStrokeSelect, containerStyle]}
+            style={[
+                {
+                    display: "flex",
+                    flexDirection: "row",
+                    alignItems: "center",
+                    // Allow truncation, stop bleeding over the edge.
+                    minWidth: 0,
+                },
+                containerStyle,
+            ]}
         >
-            stroke
+            weight
             <Strut size={spacing.xxxSmall_4} />
             <SingleSelect
                 selectedValue={selectedValue}
@@ -30,21 +37,12 @@ const LineStrokeSelect = (props: Props) => {
                 // Placeholder is required, but never gets used.
                 placeholder=""
             >
-                <OptionItem value="solid" label="solid" />
-                <OptionItem value="dashed" label="dashed" />
+                <OptionItem value="thin" label="thin" />
+                <OptionItem value="medium" label="medium" />
+                <OptionItem value="thick" label="thick" />
             </SingleSelect>
         </LabelMedium>
     );
 };
 
-const styles = StyleSheet.create({
-    lineStrokeSelect: {
-        display: "flex",
-        flexDirection: "row",
-        alignItems: "center",
-        // Allow truncation, stop bleeding over the edge.
-        minWidth: 0,
-    },
-});
-
-export default LineStrokeSelect;
+export default LineWeightSelect;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.test.tsx
@@ -354,6 +354,42 @@ describe("LockedPolygonSettings", () => {
         });
     });
 
+    test("calls onChange when the weight is changed", async () => {
+        // Arrange
+        const onChangeSpy = jest.fn();
+        render(
+            <LockedPolygonSettings
+                {...defaultProps}
+                onChangeProps={onChangeSpy}
+            />,
+            {
+                wrapper: RenderStateRoot,
+            },
+        );
+
+        // Act
+        const weightSelect = screen.getByRole("combobox", {name: "weight"});
+        await userEvent.click(weightSelect);
+        const weightOption = screen.getByRole("option", {name: "thick"});
+        await userEvent.click(weightOption);
+
+        // Assert
+        expect(onChangeSpy).toHaveBeenCalledWith({weight: "thick"});
+    });
+
+    test("default weight is medium", () => {
+        // Arrange
+
+        // Act - render with undefined weight
+        render(<LockedPolygonSettings {...defaultProps} weight={undefined} />, {
+            wrapper: RenderStateRoot,
+        });
+
+        // Assert - defaults to medium
+        const weightSelect = screen.getByRole("combobox", {name: "weight"});
+        expect(weightSelect).toHaveTextContent("medium");
+    });
+
     describe("Labels", () => {
         test("Renders a label when a label is provided", () => {
             // Arrange

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
@@ -28,6 +28,7 @@ import PerseusEditorAccordion from "../../../components/perseus-editor-accordion
 
 import ColorSelect from "./color-select";
 import LineStrokeSelect from "./line-stroke-select";
+import LineWeightSelect from "./line-weight-select";
 import LockedFigureAria from "./locked-figure-aria";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 import LockedLabelSettings from "./locked-label-settings";
@@ -56,6 +57,7 @@ const LockedPolygonSettings = (props: Props) => {
         showVertices,
         fillStyle,
         strokeStyle,
+        weight = "medium",
         labels,
         ariaLabel,
         expanded,
@@ -225,6 +227,18 @@ const LockedPolygonSettings = (props: Props) => {
             <LineStrokeSelect
                 selectedValue={strokeStyle}
                 onChange={(value) => onChangeProps({strokeStyle: value})}
+                containerStyle={styles.spaceUnder}
+            />
+
+            {/* Weight */}
+            <LineWeightSelect
+                selectedValue={weight}
+                onChange={(value) =>
+                    onChangeProps({
+                        weight: value,
+                    })
+                }
+                containerStyle={styles.spaceUnder}
             />
 
             {/* Show vertices switch */}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.test.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.test.ts
@@ -93,6 +93,7 @@ describe("getDefaultFigureForType", () => {
             showVertices: false,
             fillStyle: "none",
             strokeStyle: "solid",
+            weight: "medium",
             labels: [],
         });
     });

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.ts
@@ -86,6 +86,7 @@ export function getDefaultFigureForType(type: LockedFigureType): LockedFigure {
                 showVertices: false,
                 fillStyle: "none",
                 strokeStyle: "solid",
+                weight: "medium",
                 labels: [],
             };
         case "function":

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
@@ -1166,6 +1166,7 @@ describe("InteractiveGraphQuestionBuilder", () => {
                 showVertices: false,
                 fillStyle: "none",
                 strokeStyle: "solid",
+                weight: "medium",
                 labels: [],
             },
         ]);
@@ -1184,6 +1185,7 @@ describe("InteractiveGraphQuestionBuilder", () => {
                     showVertices: true,
                     fillStyle: "translucent",
                     strokeStyle: "dashed",
+                    weight: "thin",
                     labels: [{text: "a label"}],
                     ariaLabel: "an aria label",
                 },
@@ -1203,6 +1205,7 @@ describe("InteractiveGraphQuestionBuilder", () => {
                 showVertices: true,
                 fillStyle: "translucent",
                 strokeStyle: "dashed",
+                weight: "thin",
                 labels: [
                     {
                         type: "label",
@@ -1244,6 +1247,7 @@ describe("InteractiveGraphQuestionBuilder", () => {
                 showVertices: false,
                 fillStyle: "none",
                 strokeStyle: "solid",
+                weight: "medium",
                 labels: [
                     {
                         type: "label",

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -431,6 +431,7 @@ class InteractiveGraphQuestionBuilder {
             showVertices?: boolean;
             fillStyle?: LockedFigureFillType;
             strokeStyle?: "solid" | "dashed";
+            weight?: "thin" | "medium" | "thick";
             labels?: LockedFigureLabelOptions[];
             ariaLabel?: string;
         },
@@ -442,6 +443,7 @@ class InteractiveGraphQuestionBuilder {
             showVertices: false,
             fillStyle: "none",
             strokeStyle: "solid",
+            weight: options?.weight ?? "medium",
             ...options,
             labels:
                 options?.labels?.map((label) => ({

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -931,6 +931,46 @@ describe("Interactive Graph", function () {
             });
         });
 
+        it.each([
+            {weight: "thin", expectedStrokeWidth: 1},
+            {weight: "medium", expectedStrokeWidth: 2},
+            {weight: "thick", expectedStrokeWidth: 4},
+        ] as {
+            weight: "thin" | "medium" | "thick";
+            expectedStrokeWidth: number;
+        }[])(
+            "should render locked polygons with specific weight",
+            ({weight, expectedStrokeWidth}) => {
+                // Arrange
+                const {container} = renderQuestion(
+                    interactiveGraphQuestionBuilder()
+                        .addLockedPolygon(
+                            [
+                                [0, 0],
+                                [0, 1],
+                                [1, 1],
+                            ],
+                            {weight: weight},
+                        )
+                        .build(),
+                    blankOptions,
+                );
+
+                // Act
+                // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+                const polygons = container.querySelectorAll(
+                    ".locked-polygon polygon",
+                );
+
+                // Assert
+                expect(polygons).toHaveLength(1);
+                expect(polygons[0]).toHaveAttribute(
+                    "stroke-width",
+                    `${expectedStrokeWidth}`,
+                );
+            },
+        );
+
         it("should render locked polygons with white fill", async () => {
             // Arrange
             const {container} = renderQuestion(

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
@@ -10,8 +10,21 @@ import {X, Y} from "../math";
 
 import type {LockedPolygonType} from "@khanacademy/perseus-core";
 
+const weightMap = {
+    thin: 1,
+    medium: 2,
+    thick: 4,
+};
+
 const LockedPolygon = (props: LockedPolygonType) => {
-    const {points, color, showVertices, fillStyle, strokeStyle} = props;
+    const {
+        points,
+        color,
+        showVertices,
+        fillStyle,
+        strokeStyle,
+        weight = "medium",
+    } = props;
 
     const hasAria = !!props.ariaLabel;
 
@@ -27,6 +40,7 @@ const LockedPolygon = (props: LockedPolygonType) => {
                 fillOpacity={lockedFigureFillStyles[fillStyle]}
                 strokeStyle={strokeStyle}
                 color={lockedFigureColors[color]}
+                weight={weightMap[weight]}
                 // We need to override the svg props if we want to have a
                 // different fill color than the stroke color (specifically,
                 // in the case where the fillStyle is "white").


### PR DESCRIPTION
## Summary:

To make locked figures easier to see over axis lines, and to give content authors a bit more freedom
in how the locked figures look, we're adding a `weight` option to locked figures.

Adding this `weight` select to the locked polygon editor and hooking it up to the rendered locked
polygon here.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3201

## Test plan:
`pnpm jest packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx`
`pnpm jest packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.test.ts`
`pnpm jest packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.test.tsx`

Storybook
- Go to http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--locked-figures
- Open the locked polygon settings
- Change the weight using the weight select
- Confirm that it updates the polygon in the preview