### PR TITLE
LEMS-3257: Fix IG regression regarding user input

### DIFF
--- a/.changeset/ten-lamps-breathe.md
+++ b/.changeset/ten-lamps-breathe.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Bugfix: IG regression related to user input and `getGradableGraph`

--- a/packages/perseus/src/widgets/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graph.tsx
@@ -307,7 +307,15 @@ class InteractiveGraph extends React.Component<Props, State> {
         const mafsProps = {
             ...this.props,
             graph: this.props.userInput,
-            onChange: (userInput) => this.props.handleUserInput(userInput),
+            onChange: () =>
+                this.props.handleUserInput(
+                    // StatefulMafsGraph maintains its own internal state
+                    // and manipulates that state when calling getUserInput.
+                    // So we watch for changes in StatefulMafsGraph and call
+                    // getUserInput so we can pass the parent the most up-to-date
+                    // user input.
+                    this.mafsRef.current?.getUserInput() as PerseusGraphType,
+                ),
         };
 
         return (


### PR DESCRIPTION
## Summary:
The core of the problem is that IG doesn't treat "user input" as real "user input" - there's two layers:

1. The user input that represents the current state of the graph
2. The user input the represents the scoreable data that comes from `StatefulMafsGraph`

In my original PR, I passed the #1 user input up to Renderer which included all the coordinates. However StatefulMafsGraph hides additional data, in this case `closedPolygon`, which determines if `getUserInput` returns `null` or the coordinates the user has placed. This isn't ideal, but changing it would be tricky and is way beyond the scope of the PR.

Instead I'm leveraging the existing logic to convert StatefulMafsGraph state into a scoreable graph (`getGradableGraph`) via StatefulMafsGraph's `getUserInput`.

Issue: LEMS-3257

## Test plan:

I can't figure out how to write tests for IG

https://github.com/user-attachments/assets/7d9e9f09-e73b-4166-9aa6-8aec6ec96434
