### PR TITLE
[Interactive Graph] [Locked Figures] Add weight option to locked function and locked function settings

### DIFF
--- a/.changeset/big-paws-sort.md
+++ b/.changeset/big-paws-sort.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus-editor": patch
+---
+
+[Interactive Graph][locked figures] Add weight option to locked function and locked function settings

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -887,6 +887,7 @@ export type LockedFunctionType = {
     type: "function";
     color: LockedFigureColor;
     strokeStyle: LockedLineStyle;
+    weight: StrokeWeight;
     /**
      * This is the user-defined equation (as it was typed)
      */

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -219,6 +219,7 @@ const parseLockedFunctionType = object({
     type: constant("function"),
     color: parseLockedFigureColor,
     strokeStyle: parseLockedLineStyle,
+    weight: parseStrokeWeight,
     equation: string,
     directionalAxis: enumeration("x", "y"),
     domain: parseLockedFunctionDomain,

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -6858,6 +6858,7 @@ exports[`parseAndMigratePerseusItem given interactive-graph-locked-figures-missi
               "labels": [],
               "strokeStyle": "solid",
               "type": "function",
+              "weight": "medium",
             },
             {
               "color": "orange",
@@ -7127,6 +7128,7 @@ exports[`parseAndMigratePerseusItem given interactive-graph-locked-figures-missi
               "labels": [],
               "strokeStyle": "solid",
               "type": "function",
+              "weight": "medium",
             },
             {
               "color": "orange",
@@ -7224,6 +7226,7 @@ exports[`parseAndMigratePerseusItem given interactive-graph-locked-function-with
               "labels": [],
               "strokeStyle": "solid",
               "type": "function",
+              "weight": "medium",
             },
           ],
           "markings": "graph",
@@ -7311,6 +7314,7 @@ exports[`parseAndMigratePerseusItem given interactive-graph-locked-function-with
               "labels": [],
               "strokeStyle": "solid",
               "type": "function",
+              "weight": "medium",
             },
           ],
           "markings": "graph",

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.test.tsx
@@ -251,6 +251,28 @@ describe("Locked Function Settings", () => {
             expect(onChangeProps).toHaveBeenCalledWith({strokeStyle: "dashed"});
         });
 
+        test("calls 'onChangeProps' when stroke style is changed", async () => {
+            // Arrange
+            render(
+                <LockedFunctionSettings
+                    {...defaultProps}
+                    expanded={true}
+                    onChangeProps={onChangeProps}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            // Change the stroke
+            const weightSwitch = screen.getByLabelText("weight");
+            await userEvent.click(weightSwitch);
+            const weightOption = screen.getByText("thick");
+            await userEvent.click(weightOption);
+
+            // Assert
+            expect(onChangeProps).toHaveBeenCalledWith({weight: "thick"});
+        });
+
         test("calls 'onChangeProps' when equation is changed (as keys are pressed)", async () => {
             // Arrange
             render(

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.tsx
@@ -10,7 +10,7 @@ import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {color, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {color, sizing, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {LabelLarge, LabelMedium} from "@khanacademy/wonder-blocks-typography";
 import copyIcon from "@phosphor-icons/core/assets/regular/copy.svg";
 import autoPasteIcon from "@phosphor-icons/core/assets/regular/note-pencil.svg";
@@ -24,6 +24,7 @@ import PerseusEditorAccordion from "../../../components/perseus-editor-accordion
 import ColorSelect from "./color-select";
 import LineStrokeSelect from "./line-stroke-select";
 import LineSwatch from "./line-swatch";
+import LineWeightSelect from "./line-weight-select";
 import LockedFigureAria from "./locked-figure-aria";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 import examples from "./locked-function-examples";
@@ -56,6 +57,7 @@ const LockedFunctionSettings = (props: Props) => {
         equation,
         directionalAxis,
         domain,
+        weight,
         ariaLabel,
         onChangeProps,
         onMove,
@@ -104,6 +106,8 @@ const LockedFunctionSettings = (props: Props) => {
         const functionAppearance = generateLockedFigureAppearanceDescription(
             lineColor,
             strokeStyle,
+            undefined, // fillStyle is not used for functions
+            weight,
         );
         str += functionAppearance;
 
@@ -192,7 +196,7 @@ const LockedFunctionSettings = (props: Props) => {
                 </View>
             }
         >
-            <View style={[styles.row, styles.spaceUnder]}>
+            <View style={[styles.row, {marginBottom: sizing.size_080}]}>
                 {/* Line color settings */}
                 <ColorSelect
                     selectedValue={lineColor}
@@ -208,6 +212,12 @@ const LockedFunctionSettings = (props: Props) => {
                     }}
                 />
             </View>
+
+            {/* Line weight settings */}
+            <LineWeightSelect
+                selectedValue={weight}
+                onChange={(value) => onChangeProps({weight: value})}
+            />
 
             <View style={[styles.row, styles.rowSpace]}>
                 {/* Directional axis (x or y) */}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.test.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.test.ts
@@ -108,6 +108,7 @@ describe("getDefaultFigureForType", () => {
             type: "function",
             color: "grayH",
             strokeStyle: "solid",
+            weight: "medium",
             equation: "x^2",
             directionalAxis: "x",
             domain: [-Infinity, Infinity],

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/util.ts
@@ -98,6 +98,7 @@ export function getDefaultFigureForType(type: LockedFigureType): LockedFigure {
                 type: "function",
                 color: DEFAULT_COLOR,
                 strokeStyle: "solid",
+                weight: "medium",
                 equation: "x^2",
                 domain: [-Infinity, Infinity],
                 directionalAxis: "x",

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.test.ts
@@ -1287,6 +1287,7 @@ describe("InteractiveGraphQuestionBuilder", () => {
                 equation: "x^2",
                 color: "grayH",
                 strokeStyle: "solid",
+                weight: "medium",
                 directionalAxis: "x",
                 domain: [-Infinity, Infinity],
                 labels: [],
@@ -1299,6 +1300,7 @@ describe("InteractiveGraphQuestionBuilder", () => {
             .addLockedFunction("x^2", {
                 color: "green",
                 strokeStyle: "dashed",
+                weight: "thick",
                 directionalAxis: "y",
                 domain: [-5, 5],
                 labels: [{text: "a label"}],
@@ -1313,6 +1315,7 @@ describe("InteractiveGraphQuestionBuilder", () => {
                 equation: "x^2",
                 color: "green",
                 strokeStyle: "dashed",
+                weight: "thick",
                 directionalAxis: "y",
                 domain: [-5, 5],
                 labels: [
@@ -1343,6 +1346,7 @@ describe("InteractiveGraphQuestionBuilder", () => {
                 equation: "x^2",
                 color: "grayH",
                 strokeStyle: "solid",
+                weight: "medium",
                 directionalAxis: "x",
                 domain: [-Infinity, Infinity],
                 labels: [

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -26,6 +26,7 @@ import type {Interval} from "mafs";
 export type LockedFunctionOptions = {
     color?: LockedFigureColor;
     strokeStyle?: LockedLineStyle;
+    weight?: StrokeWeight;
     directionalAxis?: "x" | "y";
     domain?: [min: number, max: number];
     labels?: LockedFigureLabelOptions[];
@@ -473,6 +474,7 @@ class InteractiveGraphQuestionBuilder {
             equation,
             color: "grayH",
             strokeStyle: "solid",
+            weight: "medium",
             directionalAxis: "x",
             domain: [-Infinity, Infinity],
             ...options,

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-regression.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-regression.stories.tsx
@@ -352,6 +352,7 @@ function lockedFiguresQuestionWithWeight(weight: "thin" | "medium" | "thick") {
             ],
             {weight, color: "pink"},
         )
+        .addLockedFunction("x^2", {weight, color: "red"})
         .build();
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -1405,6 +1405,41 @@ describe("Interactive Graph", function () {
                 );
             });
 
+            it.each([
+                {weight: "thin", expectedStrokeWidth: 1},
+                {weight: "medium", expectedStrokeWidth: 2},
+                {weight: "thick", expectedStrokeWidth: 4},
+            ] satisfies {
+                weight: StrokeWeight;
+                expectedStrokeWidth: number;
+            }[])(
+                "Locked function should render with specific weight",
+                ({weight, expectedStrokeWidth}) => {
+                    // Arrange
+                    const {container} = renderQuestion(
+                        interactiveGraphQuestionBuilder()
+                            .withMarkings("none")
+                            .addLockedFunction("x^2", {
+                                weight,
+                            })
+                            .build(),
+                        blankOptions,
+                    );
+
+                    // Act
+                    const functions =
+                        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+                        container.querySelectorAll(`.locked-function > path`);
+
+                    // Assert
+                    expect(functions).toHaveLength(1);
+                    expect(functions[0]).toHaveAttribute(
+                        "stroke-width",
+                        `${expectedStrokeWidth}`,
+                    );
+                },
+            );
+
             it("should render locked function with aria label when one is provided", () => {
                 // Arrange
                 const lockedFunctionWithAriaLabelQuestion =

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.test.tsx
@@ -16,6 +16,7 @@ const baseLockedFunctionProps = {
     type: "function",
     color: "grayH",
     strokeStyle: "solid",
+    weight: "medium",
     equation: "x/2",
     directionalAxis: "x",
     domain: [-10, 10],

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.tsx
@@ -6,7 +6,7 @@ import {useState, useEffect} from "react";
 
 import useGraphConfig from "../reducer/use-graph-config";
 
-import {clampDomain} from "./utils";
+import {clampDomain, strokeWeights} from "./utils";
 
 import type {LockedFunctionType} from "@khanacademy/perseus-core";
 
@@ -20,10 +20,11 @@ const LockedFunction = (props: LockedFunctionType) => {
         Equation | undefined,
         React.Dispatch<React.SetStateAction<Equation | undefined>>,
     ] = useState();
-    const {color, strokeStyle, directionalAxis, domain} = props;
+    const {color, strokeStyle, weight, directionalAxis, domain} = props;
     const plotProps = {
         color: lockedFigureColors[color],
         style: strokeStyle,
+        weight: strokeWeights[weight],
     };
 
     const hasAria = !!props.ariaLabel;


### PR DESCRIPTION
## Summary:
To make locked figures easier to see over axis lines, and to give content authors a bit more freedom in how the locked figures look, we're adding a weight option to locked figures.

Adding this weight select to the locked function editor and hooking it up to the rendered locked function here.

Note: The schema has already been updated in the backend in widgets.go, so we should be okay to release this whenever.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3201

## Test plan:
`pnpm jest packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx`
`pnpm jest packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.test.ts`
`pnpm jest packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.test.tsx`

Storybook
- Go to http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--locked-figures
- Open the locked function settings
- Change the weight using the weight select
- Confirmt hat it updates the function in the preview