### PR TITLE
[Interactive Graph] [Polygon] Fix concave polygon vertex labels jumping between interior and exterior angles

### DIFF
--- a/.changeset/tiny-apes-love.md
+++ b/.changeset/tiny-apes-love.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Interactive Graph][polygon] Fix concave polygon vertex labels jumping between interior and exterior angles

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.test.ts
@@ -121,18 +121,18 @@ describe("shouldDrawArcOutsidePolygon", () => {
 
     // Test each point in this chevron shaped polygon with clockwise points.
     it.each([
-        {index: 0, expected: false}, // inside
-        {index: 1, expected: false}, // inside
-        {index: 2, expected: false}, // inside
-        {index: 3, expected: false}, // inside
-        {index: 4, expected: false}, // inside
-        {index: 5, expected: true}, // outside
+        {index: 0, isOutside: false},
+        {index: 1, isOutside: false},
+        {index: 2, isOutside: false},
+        {index: 3, isOutside: false},
+        {index: 4, isOutside: false},
+        {index: 5, isOutside: true},
     ] satisfies {
         index: number;
-        expected: boolean;
+        isOutside: boolean;
     }[])(
-        "should return $expected for concave clockwise polygon vertex $index",
-        ({index, expected}) => {
+        "should return $isOutside for concave clockwise polygon vertex $index",
+        ({index, isOutside}) => {
             // Get the previous and next vertices.
             const previousIndex =
                 (index - 1 + clockwiseConcaveCoords.length) %
@@ -147,7 +147,7 @@ describe("shouldDrawArcOutsidePolygon", () => {
             ] satisfies [vec.Vector2, vec.Vector2];
 
             expect(shouldDrawArcOutsidePolygon(vertex, endPoints)).toBe(
-                expected,
+                isOutside,
             );
         },
     );

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.test.ts
@@ -1,62 +1,99 @@
 import {angles} from "@khanacademy/kmath";
 
-import {shouldDrawArcOutside} from "./angle-indicators";
+import {
+    shouldDrawArcOutside,
+    shouldDrawArcOutsidePolygon,
+} from "./angle-indicators";
 
-import type {Coord} from "@khanacademy/perseus-core";
-import type {vec} from "mafs";
+import type {Coord, CollinearTuple} from "@khanacademy/perseus-core";
+import type {vec, Interval} from "mafs";
 
 const {getClockwiseAngle} = angles;
 
 describe("shouldDrawArcOutside", () => {
-    // Test points for the following counter-clockwise quadrilateral
-    // [[3.5, 1.5],
-    //  [3.5, 3.5],
-    //  [1.5, 3.5],
-    //  [1.5, 1.5]]
+    const range = [
+        [-1, 6],
+        [-1, 6],
+    ] satisfies [Interval, Interval];
+    const polygonLines = [
+        [
+            [3.5, 1.5],
+            [3.5, 3.5],
+        ],
+        [
+            [3.5, 3.5],
+            [1.5, 3.5],
+        ],
+        [
+            [1.5, 3.5],
+            [1.5, 1.5],
+        ],
+        [
+            [1.5, 1.5],
+            [3.5, 1.5],
+        ],
+    ] satisfies readonly CollinearTuple[];
+
     it.each<{
+        midpoint: vec.Vector2;
         vertex: vec.Vector2;
-        endPoints: [vec.Vector2, vec.Vector2];
+        range: [Interval, Interval];
+        polygonLines: readonly CollinearTuple[];
     }>([
         {
+            midpoint: [3.2, 1.8],
             vertex: [3.5, 1.5],
-            endPoints: [
-                [3.5, 3.5],
-                [1.5, 1.5],
-            ],
+            range,
+            polygonLines,
         },
         {
+            midpoint: [3.2, 3.2],
             vertex: [3.5, 3.5],
-            endPoints: [
-                [1.5, 3.5],
-                [3.5, 1.5],
-            ],
+            range,
+            polygonLines,
         },
         {
+            midpoint: [1.8, 3.2],
             vertex: [1.5, 3.5],
-            endPoints: [
-                [1.5, 1.5],
-                [3.5, 3.5],
-            ],
+            range,
+            polygonLines,
         },
         {
+            midpoint: [1.8, 1.8],
             vertex: [1.5, 1.5],
-            endPoints: [
-                [3.5, 1.5],
-                [1.5, 3.5],
-            ],
+            range,
+            polygonLines,
         },
     ])("should return false for all four angles in a quadrilateral", (args) => {
-        const {vertex, endPoints} = args;
-        expect(shouldDrawArcOutside(vertex, endPoints)).toBe(false);
+        const {midpoint, vertex, range, polygonLines} = args;
+        expect(
+            shouldDrawArcOutside(midpoint, vertex, range, polygonLines),
+        ).toBe(false);
     });
 
     it("should return true for a reflex angle inside a polygon", () => {
         expect(
             shouldDrawArcOutside(
+                [2.2395270573626624, 2.415106216609137],
                 [2.5, 2.75],
+                range,
                 [
-                    [0.5, 2.5],
-                    [3.25, 3.75],
+                    [
+                        [0.5, 2.5],
+                        [3.25, 3.75],
+                    ],
+                    [
+                        [3.25, 3.75],
+                        [2.75, 0.75],
+                    ],
+                    [
+                        [2.75, 0.75],
+                        [2.5, 2.75],
+                    ],
+                    [
+                        [2.5, 2.75],
+                        [0.5, 2.5],
+                    ],
                 ],
             ),
         ).toBe(true);
@@ -70,7 +107,9 @@ describe("shouldDrawArcOutside", () => {
         const coords: [Coord, Coord, Coord] = [point1, vertex, point2];
         expect(getClockwiseAngle(coords)).toBe(45);
     });
+});
 
+describe("shouldDrawArcOutsidePolygon", () => {
     const clockwiseConcaveCoords = [
         [-7, 5],
         [1, 5],
@@ -107,7 +146,9 @@ describe("shouldDrawArcOutside", () => {
                 clockwiseConcaveCoords[nextIndex],
             ] satisfies [vec.Vector2, vec.Vector2];
 
-            expect(shouldDrawArcOutside(vertex, endPoints)).toBe(expected);
+            expect(shouldDrawArcOutsidePolygon(vertex, endPoints)).toBe(
+                expected,
+            );
         },
     );
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.test.ts
@@ -104,4 +104,83 @@ describe("shouldDrawArcOutside", () => {
         const coords: [Coord, Coord, Coord] = [point1, vertex, point2];
         expect(getClockwiseAngle(coords)).toBe(45);
     });
+
+    // Test each point in this chevron shaped polygon.
+    it.each([
+        {
+            midpoint: [-6.487867965644036, 4.787867965644036],
+            vertex: [-7, 5],
+            expected: false, // inside
+        },
+        {
+            midpoint: [0.9121320343559642, 4.787867965644036],
+            vertex: [1, 5],
+            expected: false, // inside
+        },
+        {
+            midpoint: [5.575735931288072, 0],
+            vertex: [6, 0],
+            expected: false, // inside
+        },
+        {
+            midpoint: [0.9121320343559642, -4.787867965644036],
+            vertex: [1, -5],
+            expected: false, // inside
+        },
+        {
+            midpoint: [-6.487867965644036, -4.787867965644036],
+            vertex: [-7, -5],
+            expected: false, // inside
+        },
+        {
+            midpoint: [-2.4242640687119286, 0],
+            vertex: [-2, 0],
+            expected: true, // outside
+        },
+    ] satisfies {
+        midpoint: vec.Vector2;
+        vertex: vec.Vector2;
+        expected: boolean;
+    }[])(
+        "should return $expected for concave polygon vertex $vertex",
+        ({midpoint, vertex, expected}) => {
+            // The concave vertex is at [-2, 0]. This should have an angle
+            // greater than 180 degrees.
+            const range = [
+                [-10, 10],
+                [-10, 10],
+            ] satisfies [Interval, Interval];
+            // Makes a sort of chevron shape.
+            const polygonLines = [
+                [
+                    [-7, 5],
+                    [1, 5],
+                ],
+                [
+                    [1, 5],
+                    [6, 0],
+                ],
+                [
+                    [6, 0],
+                    [1, -5],
+                ],
+                [
+                    [1, -5],
+                    [-7, -5],
+                ],
+                [
+                    [-7, -5],
+                    [-2, 0],
+                ],
+                [
+                    [-2, 0],
+                    [-7, 5],
+                ],
+            ] satisfies readonly CollinearTuple[];
+
+            expect(
+                shouldDrawArcOutside(midpoint, vertex, range, polygonLines),
+            ).toBe(expected);
+        },
+    );
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.tsx
@@ -20,25 +20,22 @@ const {getAngleFromVertex} = angles;
 interface PolygonAngleProps {
     centerPoint: vec.Vector2;
     endPoints: [vec.Vector2, vec.Vector2];
-    polygonLines: readonly CollinearTuple[];
-    range: [Interval, Interval];
     showAngles: boolean;
     snapTo: SnapTo;
+    areClockwise: boolean;
 }
 
 export const PolygonAngle = ({
     centerPoint,
     endPoints,
-    range,
-    polygonLines,
     showAngles,
     snapTo,
+    areClockwise,
 }: PolygonAngleProps) => {
     const [centerX, centerY] = centerPoint;
-    const areClockwise = clockwise([centerPoint, ...endPoints]);
     const [[startX, startY], [endX, endY]] = areClockwise
         ? endPoints
-        : endPoints.reverse();
+        : endPoints.reverse(); // Make endpoints always clockwise
 
     const radius = 0.3;
 
@@ -80,13 +77,13 @@ export const PolygonAngle = ({
         ) : null;
     }
 
-    // Midpoint betwen ends of arc
-    const isOutside = shouldDrawArcOutside(
-        [x3, y3],
-        centerPoint,
-        range,
-        polygonLines,
-    );
+    // Use cross product to determine if the angle is outside the polygon.
+    // If the vertex is concave, the cross product will be positive with
+    // the assumed clockwise points.
+    const v1 = vec.sub(endPoints[1], centerPoint);
+    const v2 = vec.sub(endPoints[0], centerPoint);
+    const crossProduct = v1[0] * v2[1] - v1[1] * v2[0];
+    const isOutside = crossProduct > 0;
 
     const largeArcFlag = isOutside ? 1 : 0;
     const sweepFlag = isOutside ? 1 : 0;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.tsx
@@ -20,9 +20,9 @@ const {getAngleFromVertex} = angles;
 interface PolygonAngleProps {
     centerPoint: vec.Vector2;
     endPoints: [vec.Vector2, vec.Vector2];
+    areEndPointsClockwise: boolean;
     showAngles: boolean;
     snapTo: SnapTo;
-    areClockwise: boolean;
 }
 
 export const PolygonAngle = ({
@@ -30,10 +30,10 @@ export const PolygonAngle = ({
     endPoints,
     showAngles,
     snapTo,
-    areClockwise,
+    areEndPointsClockwise,
 }: PolygonAngleProps) => {
     const [centerX, centerY] = centerPoint;
-    const [[startX, startY], [endX, endY]] = areClockwise
+    const [[startX, startY], [endX, endY]] = areEndPointsClockwise
         ? endPoints
         : endPoints.reverse(); // Make endpoints always clockwise
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.test.tsx
@@ -8,6 +8,7 @@ import * as Dependencies from "../../../dependencies";
 import {MafsGraph} from "../mafs-graph";
 import {getBaseMafsGraphPropsForTests} from "../utils";
 
+import * as AngleIndicators from "./components/angle-indicators";
 import {
     getAngleSnapConstraint,
     getSideSnapConstraint,
@@ -16,6 +17,7 @@ import {
 
 import type {InteractiveGraphState, PolygonGraphState} from "../types";
 import type {UserEvent} from "@testing-library/user-event";
+import type {vec} from "mafs";
 
 const baseMafsGraphProps = getBaseMafsGraphPropsForTests();
 const baseLimitedPolygonState: InteractiveGraphState = {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.test.tsx
@@ -8,7 +8,6 @@ import * as Dependencies from "../../../dependencies";
 import {MafsGraph} from "../mafs-graph";
 import {getBaseMafsGraphPropsForTests} from "../utils";
 
-import * as AngleIndicators from "./components/angle-indicators";
 import {
     getAngleSnapConstraint,
     getSideSnapConstraint,
@@ -660,5 +659,85 @@ describe("getAngleSnapConstraint", () => {
             left: [1.8951844414339178, 1.9999999999999996],
             right: [2, 1.9999999999999996], // direction restricted due to going off the graph
         });
+    });
+});
+
+describe("Angle indicators", () => {
+    // Polygon that looks like a chevron, with a concave vertex on the left,
+    // drawn from the top left.
+    const concavePolygonClockwise = [
+        [-7, 5],
+        [1, 5],
+        [6, 0],
+        [1, -5],
+        [-7, -5],
+        [-2, 0], // concave vertex
+    ] satisfies vec.Vector2[];
+
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+        // Clear any previous calls to the mock
+        jest.clearAllMocks();
+    });
+
+    it("should show correct angles for concave polygons when the points are clockwise", () => {
+        // Arrange
+
+        // Act - render with angles showing
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseLimitedPolygonState,
+                    coords: concavePolygonClockwise,
+                    showAngles: true,
+                }}
+            />,
+        );
+
+        const angleIndicators = screen.getAllByText(/°/);
+
+        // Assert
+        expect(angleIndicators).toHaveLength(concavePolygonClockwise.length);
+        // Checking angles in render order
+        expect(angleIndicators[0]).toHaveTextContent("45°");
+        expect(angleIndicators[1]).toHaveTextContent("135°");
+        expect(angleIndicators[2]).toHaveTextContent("90°");
+        expect(angleIndicators[3]).toHaveTextContent("135°");
+        expect(angleIndicators[4]).toHaveTextContent("45°");
+        // Concave vertex, greater than 180 degrees
+        expect(angleIndicators[5]).toHaveTextContent("270°");
+    });
+
+    it("should show correct angles for concave polygons when the points are counter-clockwise", () => {
+        // Arrange
+
+        // Act - render with angles showing
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseLimitedPolygonState,
+                    // Reverse the points to make them counter-clockwise
+                    coords: [...concavePolygonClockwise].reverse(),
+                    showAngles: true,
+                }}
+            />,
+        );
+
+        const angleIndicators = screen.getAllByText(/°/);
+
+        // Assert
+        expect(angleIndicators).toHaveLength(concavePolygonClockwise.length);
+        // Checking angles in render order
+        // Concave vertex, greater than 180 degrees
+        expect(angleIndicators[0]).toHaveTextContent("270°");
+        expect(angleIndicators[1]).toHaveTextContent("45°");
+        expect(angleIndicators[2]).toHaveTextContent("135°");
+        expect(angleIndicators[3]).toHaveTextContent("90°");
+        expect(angleIndicators[4]).toHaveTextContent("135°");
+        expect(angleIndicators[5]).toHaveTextContent("45°");
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -252,9 +252,9 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
                         key={"angle-" + i}
                         centerPoint={point}
                         endPoints={[pt1, pt2]}
+                        areEndPointsClockwise={clockwise(points)}
                         showAngles={!!showAngles}
                         snapTo={snapTo}
-                        areClockwise={clockwise(points)}
                     />
                 );
             })}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -1,4 +1,4 @@
-import {angles} from "@khanacademy/kmath";
+import {angles, geometry} from "@khanacademy/kmath";
 import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 import {Polygon, Polyline, vec} from "mafs";
 import * as React from "react";
@@ -46,6 +46,7 @@ import type {
 import type {CollinearTuple} from "@khanacademy/perseus-core";
 import type {Interval} from "mafs";
 
+const {clockwise} = geometry;
 const {convertRadiansToDegrees} = angles;
 
 export function renderPolygonGraph(
@@ -251,10 +252,9 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
                         key={"angle-" + i}
                         centerPoint={point}
                         endPoints={[pt1, pt2]}
-                        range={range}
-                        polygonLines={lines}
                         showAngles={!!showAngles}
                         snapTo={snapTo}
+                        areClockwise={clockwise(points)}
                     />
                 );
             })}

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -187,13 +187,17 @@ export const unlimitedPolygonQuestion: PerseusRenderer =
 
 export const polygonWithStartingCoordsQuestion: PerseusRenderer =
     interactiveGraphQuestionBuilder()
+        .withMarkings("grid")
         .withPolygon("grid", {
             startCoords: [
-                [6, 6],
-                [8, 6],
-                [8, 8],
-                [6, 8],
+                [-7, 5],
+                [1, 5],
+                [6, 0],
+                [1, -5],
+                [-7, -5],
+                [-2, 0],
             ],
+            showAngles: true,
         })
         .build();
 

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -185,17 +185,35 @@ export const unlimitedPolygonQuestion: PerseusRenderer =
         })
         .build();
 
+// Clockwise points
+// export const polygonWithStartingCoordsQuestion: PerseusRenderer =
+//     interactiveGraphQuestionBuilder()
+//         .withMarkings("grid")
+//         .withPolygon("grid", {
+//             startCoords: [
+//                 [-7, 5],
+//                 [1, 5],
+//                 [6, 0],
+//                 [1, -5],
+//                 [-7, -5],
+//                 [-2, 0],
+//             ],
+//             showAngles: true,
+//         })
+//         .build();
+
+// Counter-clockwise points
 export const polygonWithStartingCoordsQuestion: PerseusRenderer =
     interactiveGraphQuestionBuilder()
         .withMarkings("grid")
         .withPolygon("grid", {
             startCoords: [
-                [-7, 5],
-                [1, 5],
-                [6, 0],
-                [1, -5],
-                [-7, -5],
                 [-2, 0],
+                [-7, -5],
+                [1, -5],
+                [6, 0],
+                [1, 5],
+                [-7, 5],
             ],
             showAngles: true,
         })

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -186,34 +186,17 @@ export const unlimitedPolygonQuestion: PerseusRenderer =
         .build();
 
 // Clockwise points
-// export const polygonWithStartingCoordsQuestion: PerseusRenderer =
-//     interactiveGraphQuestionBuilder()
-//         .withMarkings("grid")
-//         .withPolygon("grid", {
-//             startCoords: [
-//                 [-7, 5],
-//                 [1, 5],
-//                 [6, 0],
-//                 [1, -5],
-//                 [-7, -5],
-//                 [-2, 0],
-//             ],
-//             showAngles: true,
-//         })
-//         .build();
-
-// Counter-clockwise points
 export const polygonWithStartingCoordsQuestion: PerseusRenderer =
     interactiveGraphQuestionBuilder()
         .withMarkings("grid")
         .withPolygon("grid", {
             startCoords: [
-                [-2, 0],
-                [-7, -5],
-                [1, -5],
-                [6, 0],
-                [1, 5],
                 [-7, 5],
+                [1, 5],
+                [6, 0],
+                [1, -5],
+                [-7, -5],
+                [-2, 0],
             ],
             showAngles: true,
         })


### PR DESCRIPTION
## Summary:
There is currently an issue where a concave polygon will have its concave vertex jump between
its internal and external angle, only if the other vertices around it line up in the same
x and y values as each other. This is happening because of the raytracing method being
used to determine the angles, which has the wrong value when the rays intersect.

To fix this, I'm replacing the raytracing method with the cross product method to determine
if a particular vertex in the polygon is convex or concave.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3262

| Before | After | 
| --- | --- |
| ![image](https://github.com/user-attachments/assets/740be605-81dd-492a-811a-bfc9cb10edb8) | <img width="344" alt="image" src="https://github.com/user-attachments/assets/5cf567a6-13ab-45f0-be57-c4678d5943d4" /> |


## Test plan:
`pnpm jest packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.test.ts`
`pnpm jest packages/perseus/src/widgets/interactive-graphs/graphs/polygon.test.tsx`

Storybook
- http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--interactive-graph-polygon
- The starting coordinates are already set to the case that was having problems
- Confirm that the angles are all < 180 degrees except the convex vertex
- The convex vertex should be > 180 degrees
- Use the starting coordinate to reverse the coords (counter-clockwise instead of clockwise)
- Confirm the angles are the same as before