### PR TITLE
Mark `deprecated-standin` widget as accessible

### DIFF
--- a/.changeset/loud-cups-ring.md
+++ b/.changeset/loud-cups-ring.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": minor
+---
+
+Change deprecated-standin widget to be considered accessible

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -10781,7 +10781,12 @@ exports[`parseAndMigratePerseusItem given lights-puzzle.json returns the same re
             ],
           ],
         },
+        "static": false,
         "type": "deprecated-standin",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
       },
     },
   },
@@ -13565,6 +13570,7 @@ Heart rate is described as the number of heart beats per minute.  The normal hum
             },
           ],
         },
+        "static": false,
         "type": "deprecated-standin",
         "version": {
           "major": 0,
@@ -18977,6 +18983,7 @@ exports[`parseAndMigratePerseusItem given simulator-widget.json returns the same
           "xAxisLabel": "Proportion (%)",
           "yAxisLabel": "Number of times seen",
         },
+        "static": false,
         "type": "deprecated-standin",
         "version": {
           "major": 0,
@@ -19333,6 +19340,7 @@ exports[`parseAndMigratePerseusItem given transformer-widget.json returns the sa
           },
           "version": 1.2,
         },
+        "static": false,
         "type": "deprecated-standin",
         "version": {
           "major": 0,

--- a/packages/perseus-core/src/widgets/core-widget-registry.ts
+++ b/packages/perseus-core/src/widgets/core-widget-registry.ts
@@ -5,6 +5,7 @@ import Registry from "../utils/registry";
 import categorizerWidgetLogic from "./categorizer";
 import csProgramWidgetLogic from "./cs-program";
 import definitionWidgetLogic from "./definition";
+import deprecatedStandinWidgetLogic from "./deprecated-standin";
 import dropdownWidgetLogic from "./dropdown";
 import explanationWidgetLogic from "./explanation";
 import expressionWidgetLogic from "./expression";
@@ -163,6 +164,7 @@ export function registerCoreWidgets() {
         categorizerWidgetLogic,
         csProgramWidgetLogic,
         definitionWidgetLogic,
+        deprecatedStandinWidgetLogic,
         dropdownWidgetLogic,
         explanationWidgetLogic,
         expressionWidgetLogic,

--- a/packages/perseus-core/src/widgets/deprecated-standin/index.ts
+++ b/packages/perseus-core/src/widgets/deprecated-standin/index.ts
@@ -1,0 +1,8 @@
+import type {WidgetLogic} from "../logic-export.types";
+
+const deprecatedStandinWidgetLogic: WidgetLogic = {
+    name: "deprecated-standin",
+    accessible: true,
+};
+
+export default deprecatedStandinWidgetLogic;


### PR DESCRIPTION
## Summary:

This PR adds a missing widget registration to `perseus-core` for the `deprecated-standin` widget. Technically, this widget does nothing, but our default for widgets that don't have an explicit registration is to be _inaccessible_. This means that we would consider assessment items having a deprecated widget as inaccessible when, in fact, they are (because the `deprecated-standin` has no interactive elements). 

This PR has some snapshot updates caused by use having an entry in the core registry for the deprecated-standin widget now (specifically because when we apply defaults for a widget, we leave the widget options unchanged [if no widget is registered](https://github.com/Khan/perseus/blob/843d66257ceb32b7c3d3eea4dea47dfda58e7945/packages/perseus-core/src/widgets/apply-defaults.ts#L33), but when we find a registration, we proceed to set some defaults like `static` and `version`).

Issue: LEMS-3096

## Test plan:

  * ✅ Run tests: `pnpm test`