### PR TITLE
[Simple Markdown] Remove deprecated APIs and features (html output)

### DIFF
--- a/.changeset/simple-markdown-remove-html-output.md
+++ b/.changeset/simple-markdown-remove-html-output.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/simple-markdown": major
+---
+
+Remove HTML output support from `@khanacademy/simple-markdown`. The package now only produces React output.
+
+Removed APIs: `markdownToHtml`, `htmlFor`, `defaultHtmlOutput`, `htmlTag`, and the HTML-related types (`HtmlOutput`, `HtmlNodeOutput`, `HtmlOutputRule`, `HtmlRules`). The `html` field on default rules and on rules passed to `parserFor`/`outputFor` is no longer used; only `react` is supported. Consumers that need an HTML string should call `react`-output and serialize the resulting React tree.

--- a/packages/simple-markdown/README.md
+++ b/packages/simple-markdown/README.md
@@ -148,14 +148,6 @@ third `_`.
         react: function(node, output) {
             return React.DOM.u(null, output(node.content));
         },
-
-        // Or an html element:
-        // (Note: you may only need to make one of `react:` or
-        // `html:`, as long as you never ask for an outputter
-        // for the other type.)
-        html: function(node, output) {
-            return '<u>' + output(node.content) + '</u>';
-        },
     };
 ```
 
@@ -167,7 +159,7 @@ Then, we need to add this rule to the other rules:
     });
 ```
 
-Finally, we need to build our parser and outputters:
+Finally, we need to build our parser and outputter:
 
 ```javascript
     var rawBuiltParser = SimpleMarkdown.parserFor(rules);
@@ -175,10 +167,7 @@ Finally, we need to build our parser and outputters:
         var blockSource = source + "\n\n";
         return rawBuiltParser(blockSource, {inline: false});
     };
-    // You probably only need one of these: choose depending on
-    // whether you want react nodes or an html string:
     var reactOutput = SimpleMarkdown.outputFor(rules, 'react');
-    var htmlOutput = SimpleMarkdown.outputFor(rules, 'html');
 
 ```
 
@@ -212,10 +201,6 @@ markdown with underlines!
         _owner: null,
         _context: {},
         _store: { validated: false, props: [Object] } } ]
-
-    htmlOutput(syntaxTree)
-
-    => '<div class="paragraph"><u>hello underlines</u></div>'
 ```
 
 
@@ -242,15 +227,12 @@ Parses `source` as block if it ends with `\n\n`, or inline if not.
 
 Returns React-renderable output for `syntaxTree`.
 
-*Note: raw html output will be coming soon*
-
 
 ## Extension Overview
 
 Elements in simple-markdown are generally created from rules.
 For parsing, rules must specify `match` and `parse` methods.
-For output, rules must specify a `react` or `html` method
-(or both), depending on which outputter you create afterwards.
+For output, rules must specify a `react` method.
 
 Here is an example rule, a slightly modified version of what
 simple-markdown uses for parsing **strong** (**bold**) text:
@@ -267,9 +249,6 @@ simple-markdown uses for parsing **strong** (**bold**) text:
         },
         react: function(node, recurseOutput) {
             return React.DOM.strong(null, recurseOutput(node.content));
-        },
-        html: function(node, recurseOutput) {
-            return '<strong>' + recurseOutput(node.content) + '</strong>';
         },
     },
 ```
@@ -375,8 +354,8 @@ intermediate steps in the parsing/output process, if necessary.
 
 The default rules, specified as an object, where the keys are
 the rule types, and the values are objects containing `order`,
-`match`, `parse`, `react`, and `html` fields (these rules can
-be used for both parsing and outputting).
+`match`, `parse`, and `react` fields (these rules can be used
+for both parsing and outputting).
 
 #### `SimpleMarkdown.parserFor(rules)`
 
@@ -391,8 +370,8 @@ object must contain a `match` and a `parse` function.
 
 Takes a `rules` object and a `key` that indicates which key in
 the rules object is mapped to the function that generates the
-output type you want. This will be `'react'` or `'html'` unless
-you are defining a custom output type.
+output type you want. This will be `'react'` unless you are
+defining a custom output type.
 
 It returns a function that outputs a single syntax tree node of
 any type that is in the `rules` object, given a node and a
@@ -421,17 +400,14 @@ var rules = {
 };
 
 var parser = SimpleMarkdown.parserFor(rules);
-var reactOutput = SimpleMarkdown.outputFor(rules, 'react'));
-var htmlOutput = SimpleMarkdown.outputFor(rules, 'html'));
+var reactOutput = SimpleMarkdown.outputFor(rules, 'react');
 
 var blockParseAndOutput = function(source) {
     // Many rules require content to end in \n\n to be interpreted
     // as a block.
     var blockSource = source + "\n\n";
     var parseTree = parser(blockSource, {inline: false});
-    var outputResult = htmlOutput(parseTree);
-    // Or for react output, use:
-    // var outputResult = reactOutput(parseTree);
+    var outputResult = reactOutput(parseTree);
     return outputResult;
 };
 ```

--- a/packages/simple-markdown/src/__tests__/simple-markdown.test.tsx
+++ b/packages/simple-markdown/src/__tests__/simple-markdown.test.tsx
@@ -12,7 +12,6 @@ var inlineParse = SimpleMarkdown.defaultInlineParse;
 var blockParse = SimpleMarkdown.defaultBlockParse;
 var implicitParse = SimpleMarkdown.defaultImplicitParse;
 var defaultReactOutput = SimpleMarkdown.defaultReactOutput;
-var defaultHtmlOutput = SimpleMarkdown.defaultHtmlOutput;
 
 /**
  * Asset that two ast parse trees are equal
@@ -57,29 +56,10 @@ var htmlFromReactMarkdown = function (source) {
 
 /**
  * @param {string} source
- * @returns {string}
- */
-var htmlFromMarkdown = function (source) {
-    var html = defaultHtmlOutput(implicitParse(source));
-    var simplifiedHtml = html.replace(/\s+/g, " ");
-    return simplifiedHtml;
-};
-
-/**
- * @param {string} source
  * @param {string} html
  */
 var assertParsesToReact = function (source: string, html: string) {
     var actualHtml = htmlFromReactMarkdown(source);
-    assert.strictEqual(actualHtml, html);
-};
-
-/**
- * @param {string} source
- * @param {string} html
- */
-var assertParsesToHtml = function (source: string, html) {
-    var actualHtml = htmlFromMarkdown(source);
     assert.strictEqual(actualHtml, html);
 };
 
@@ -4005,37 +3985,36 @@ describe("simple markdown", function () {
                         {},
                         SimpleMarkdown.defaultRules.paragraph,
                         {
-                            html: function (
+                            react: function (
                                 /** @type {SimpleMarkdown.SingleASTNode} */ node,
-                                /** @type {SimpleMarkdown.HtmlOutput} */ output,
+                                /** @type {SimpleMarkdown.ReactOutput} */ output,
                             ) {
-                                return "<p>" + output(node.content) + "</p>";
+                                return SimpleMarkdown.reactElement("p", null, {
+                                    children: output(node.content),
+                                });
                             },
                         },
                     ),
                     text: Object.assign({}, SimpleMarkdown.defaultRules.text, {
-                        html: function (
+                        react: function (
                             /** @type {SimpleMarkdown.SingleASTNode} */ node,
-                            /** @type {SimpleMarkdown.HtmlOutput} */ output,
+                            /** @type {SimpleMarkdown.ReactOutput} */ output,
                             /** @type {SimpleMarkdown.State} */ state,
                         ) {
-                            return (
-                                '<span class="' +
-                                (state.spanClass || "default") +
-                                '">' +
-                                /*SimpleMarkdown.sanitizeText*/ node.content +
-                                "</span>"
-                            );
+                            return SimpleMarkdown.reactElement("span", null, {
+                                className: state.spanClass || "default",
+                                children: node.content,
+                            });
                         },
                     }),
                 },
-                "html",
+                "react",
             );
 
             var parsed1 = SimpleMarkdown.defaultBlockParse("hi there!");
             var result1 = output(parsed1, {spanClass: "special"});
             assert.strictEqual(
-                result1,
+                reactToHtml(result1),
                 '<p><span class="special">hi there!</span></p>',
             );
 
@@ -4043,7 +4022,7 @@ describe("simple markdown", function () {
             var parsed2 = SimpleMarkdown.defaultBlockParse("hi there!");
             var result2 = output(parsed2);
             assert.strictEqual(
-                result2,
+                reactToHtml(result2),
                 '<p><span class="default">hi there!</span></p>',
             );
         });
@@ -4062,23 +4041,22 @@ describe("simple markdown", function () {
                     ) {
                         return {content: parse(capture[1])};
                     },
-                    html: function (
+                    react: function (
                         /** @type {SimpleMarkdown.SingleASTNode} */ node,
-                        /** @type {SimpleMarkdown.HtmlOutput} */ output,
+                        /** @type {SimpleMarkdown.ReactOutput} */ output,
                     ) {
-                        return (
-                            '<span style="background: black;">' +
-                            output(node.content) +
-                            "</span>"
-                        );
+                        return SimpleMarkdown.reactElement("span", null, {
+                            style: {background: "black"},
+                            children: output(node.content),
+                        });
                     },
                 },
                 text: SimpleMarkdown.defaultRules.text,
             };
 
-            // @ts-expect-error - TS2345 - Argument of type '{ Array: { readonly react: ArrayNodeOutput<ReactNode>; readonly html: ArrayNodeOutput<string>; }; spoiler: { order: number; match: (source: any) => RegExpExecArray | null; parse: (capture: any, parse: any) => { ...; }; html: (node: any, output: any) => string; }; text: TextInOutRule; }' is not assignable to parameter of type 'ParserRules'.
+            // @ts-expect-error - TS2345 - custom rules object is structurally compatible at runtime but not assignable to the strict ParserRules type
             var parse = SimpleMarkdown.parserFor(rules, {inline: true});
-            var output = SimpleMarkdown.outputFor(rules, "html");
+            var output = SimpleMarkdown.outputFor(rules, "react");
 
             var parsed1 = parse("Hi this is a [[spoiler]]");
             validateParse(parsed1, [
@@ -4090,7 +4068,7 @@ describe("simple markdown", function () {
             ]);
             var result1 = output(parsed1);
             assert.strictEqual(
-                result1,
+                reactToHtml(result1),
                 'Hi this is a <span style="background: black;">spoiler</span>',
             );
         });
@@ -4427,301 +4405,6 @@ describe("simple markdown", function () {
                 html,
                 '<span class="text">Hi! You! Are! &lt;3!</span>',
             );
-        });
-    });
-
-    describe("html output", function () {
-        it("should sanitize dangerous links", function () {
-            var markdown = "[link](javascript:alert%28%27hi%27%29)";
-            assertParsesToHtml(markdown, "<a>link</a>");
-
-            var markdown2 =
-                "[link][1]\n\n" + "[1]: javascript:alert('hi');\n\n";
-            assertParsesToHtml(
-                markdown2,
-                '<div class="paragraph"><a>link</a></div>',
-            );
-
-            var markdown3 =
-                "[link](data:text/html;base64,PHNjcmlwdD5hbGVydCgnaGknKTwvc2NyaXB0Pg==)";
-            assertParsesToHtml(markdown3, "<a>link</a>");
-
-            var markdown4 =
-                "[link][1]\n\n" +
-                "[1]: data:text/html;base64,PHNjcmlwdD5hbGVydCgnaGknKTwvc2NyaXB0Pg==\n\n";
-            assertParsesToHtml(
-                markdown4,
-                '<div class="paragraph"><a>link</a></div>',
-            );
-
-            var markdown5 = "[link](vbscript:alert)";
-            assertParsesToHtml(markdown5, "<a>link</a>");
-
-            var markdown6 = "[link][1]\n\n" + "[1]: vbscript:alert\n\n";
-            assertParsesToHtml(
-                markdown6,
-                '<div class="paragraph"><a>link</a></div>',
-            );
-        });
-
-        it("should not sanitize safe links", function () {
-            var html = htmlFromMarkdown("[link](https://www.google.com)");
-            assert.strictEqual(
-                html,
-                '<a href="https://www.google.com">link</a>',
-            );
-
-            var html2 = htmlFromMarkdown(
-                "[link][1]\n\n" + "[1]: https://www.google.com\n\n",
-            );
-            assert.strictEqual(
-                html2,
-                '<div class="paragraph">' +
-                    '<a href="https://www.google.com">link</a>' +
-                    "</div>",
-            );
-        });
-
-        it("should output headings", function () {
-            assertParsesToHtml("### Heading!\n\n", "<h3>Heading!</h3>");
-
-            assertParsesToHtml("## hi! ##\n\n", "<h2>hi!</h2>");
-
-            assertParsesToHtml("Yay!\n====\n\n", "<h1>Yay!</h1>");
-
-            assertParsesToHtml("Success\n---\n\n", "<h2>Success</h2>");
-        });
-
-        it("should output hrs", function () {
-            assertParsesToHtml("-----\n\n", '<hr aria-hidden="true">');
-            assertParsesToHtml(" * * * \n\n", '<hr aria-hidden="true">');
-            assertParsesToHtml("___\n\n", '<hr aria-hidden="true">');
-        });
-
-        it("should output codeblocks", function () {
-            var html = htmlFromMarkdown(
-                "    var microwave = new TimeMachine();\n\n",
-            );
-            assert.strictEqual(
-                html,
-                "<pre><code>var microwave = new TimeMachine();</code></pre>",
-            );
-
-            var html2 = htmlFromMarkdown(
-                "~~~\n" + "var computer = new IBN(5100);\n" + "~~~\n\n",
-            );
-            assert.strictEqual(
-                html2,
-                "<pre><code>var computer = new IBN(5100);</code></pre>",
-            );
-
-            var html3 = htmlFromMarkdown(
-                "```yavascript\n" +
-                    "var undefined = function() { return 5; }" +
-                    "```\n\n",
-            );
-            assert.strictEqual(
-                html3,
-                '<pre><code class="markdown-code-yavascript">' +
-                    "var undefined = function() { return 5; }" +
-                    "</code></pre>",
-            );
-        });
-
-        it("should output blockQuotes", function () {
-            assertParsesToHtml(
-                "> hi there this is a\ntest\n\n",
-                '<blockquote><div class="paragraph">' +
-                    "hi there this is a test" +
-                    "</div></blockquote>",
-            );
-
-            assertParsesToHtml(
-                "> hi there this is a\n> test\n\n",
-                '<blockquote><div class="paragraph">' +
-                    "hi there this is a test" +
-                    "</div></blockquote>",
-            );
-        });
-
-        it("should output lists", function () {
-            assertParsesToHtml(
-                " * first\n" + " * second\n" + " * third\n\n",
-                "<ul>" +
-                    "<li>first</li>" +
-                    "<li>second</li>" +
-                    "<li>third</li>" +
-                    "</ul>",
-            );
-
-            assertParsesToHtml(
-                "1. first\n" + "2. second\n" + "3. third\n\n",
-                '<ol start="1">' +
-                    "<li>first</li>" +
-                    "<li>second</li>" +
-                    "<li>third</li>" +
-                    "</ol>",
-            );
-
-            assertParsesToHtml(
-                " * first\n" + " * second\n" + "    * inner\n" + " * third\n\n",
-                "<ul>" +
-                    "<li>first</li>" +
-                    "<li>second <ul><li>inner</li></ul></li>" +
-                    "<li>third</li>" +
-                    "</ul>",
-            );
-        });
-
-        it("should output tables", function () {
-            assertParsesToHtml(
-                "h1 | h2 | h3\n" + "---|----|---\n" + "d1 | d2 | d3\n" + "\n",
-                "<table><thead>" +
-                    '<tr><th scope="col">h1</th><th scope="col">h2</th><th scope="col">h3</th></tr>' +
-                    "</thead><tbody>" +
-                    "<tr><td>d1</td><td>d2</td><td>d3</td></tr>" +
-                    "</tbody></table>",
-            );
-
-            assertParsesToHtml(
-                "| h1 | h2 | h3 |\n" +
-                    "|----|----|----|\n" +
-                    "| d1 | d2 | d3 |\n" +
-                    "\n",
-                "<table><thead>" +
-                    '<tr><th scope="col">h1</th><th scope="col">h2</th><th scope="col">h3</th></tr>' +
-                    "</thead><tbody>" +
-                    "<tr><td>d1</td><td>d2</td><td>d3</td></tr>" +
-                    "</tbody></table>",
-            );
-
-            assertParsesToHtml(
-                "h1 | h2 | h3\n" + ":--|:--:|--:\n" + "d1 | d2 | d3\n" + "\n",
-                "<table><thead>" +
-                    "<tr>" +
-                    '<th style="text-align:left;" scope="col">h1</th>' +
-                    '<th style="text-align:center;" scope="col">h2</th>' +
-                    '<th style="text-align:right;" scope="col">h3</th>' +
-                    "</tr>" +
-                    "</thead><tbody>" +
-                    "<tr>" +
-                    '<td style="text-align:left;">d1</td>' +
-                    '<td style="text-align:center;">d2</td>' +
-                    '<td style="text-align:right;">d3</td>' +
-                    "</tr>" +
-                    "</tbody></table>",
-            );
-        });
-
-        it("should output paragraphs", function () {
-            var html = htmlFromMarkdown("hi\n\n");
-            assert.strictEqual(html, '<div class="paragraph">hi</div>');
-
-            var html2 = htmlFromMarkdown("hi\n\n" + "bye\n\n");
-            assert.strictEqual(
-                html2,
-                '<div class="paragraph">hi</div>' +
-                    '<div class="paragraph">bye</div>',
-            );
-        });
-
-        it("should output escaped text", function () {
-            assertParsesToHtml(
-                "\\#escaping\\^symbols\\*is\\[legal](yes)",
-                "#escaping^symbols*is[legal](yes)",
-            );
-        });
-
-        it("should output links", function () {
-            assertParsesToHtml(
-                "<https://www.khanacademy.org>",
-                '<a href="https://www.khanacademy.org">' +
-                    "https://www.khanacademy.org" +
-                    "</a>",
-            );
-
-            assertParsesToHtml(
-                "<aria@khanacademy.org>",
-                '<a href="mailto:aria@khanacademy.org">' +
-                    "aria@khanacademy.org" +
-                    "</a>",
-            );
-
-            assertParsesToHtml(
-                "https://www.khanacademy.org",
-                '<a href="https://www.khanacademy.org">' +
-                    "https://www.khanacademy.org" +
-                    "</a>",
-            );
-
-            assertParsesToHtml(
-                "[KA](https://www.khanacademy.org)",
-                '<a href="https://www.khanacademy.org">' + "KA" + "</a>",
-            );
-
-            assertParsesToHtml(
-                "[KA][1]\n\n[1]: https://www.khanacademy.org\n\n",
-                '<div class="paragraph">' +
-                    '<a href="https://www.khanacademy.org">' +
-                    "KA" +
-                    "</a>" +
-                    "</div>",
-            );
-        });
-
-        it("should output strong", function () {
-            assertParsesToHtml("**bold**", "<strong>bold</strong>");
-        });
-
-        it("should output u", function () {
-            assertParsesToHtml("__underscore__", "<u>underscore</u>");
-        });
-
-        it("should output em", function () {
-            assertParsesToHtml("*italics*", "<em>italics</em>");
-        });
-
-        it("should output simple combined bold/italics", function () {
-            assertParsesToHtml(
-                "***bolditalics***",
-                "<em><strong>bolditalics</strong></em>",
-            );
-            assertParsesToHtml(
-                "**bold *italics***",
-                "<strong>bold <em>italics</em></strong>",
-            );
-        });
-
-        it("should output complex combined bold/italics", function () {
-            assertParsesToHtml(
-                "***bold** italics*",
-                "<em><strong>bold</strong> italics</em>",
-            );
-            assertParsesToHtml(
-                "*hi **there you***",
-                "<em>hi <strong>there you</strong></em>",
-            );
-        });
-
-        it("should output del", function () {
-            assertParsesToHtml("~~strikethrough~~", "<del>strikethrough</del>");
-        });
-
-        it("should output inline code", function () {
-            assertParsesToHtml(
-                "here is some `inline code`.",
-                "here is some <code>inline code</code>.",
-            );
-        });
-
-        it("should output text", function () {
-            assertParsesToHtml("Yay text!", "Yay text!");
-        });
-
-        it("shouldn't split text into multiple spans", function () {
-            var parsed = SimpleMarkdown.defaultInlineParse("hi, there!");
-            var elements = SimpleMarkdown.defaultHtmlOutput(parsed);
-            assert.deepEqual(elements, "hi, there!");
         });
     });
 

--- a/packages/simple-markdown/src/__tests__/simple-markdown.test.tsx
+++ b/packages/simple-markdown/src/__tests__/simple-markdown.test.tsx
@@ -4738,18 +4738,6 @@ describe("simple markdown", function () {
             });
         });
 
-        describe("markdownToHtml", function () {
-            it("should work on a basic 2 paragraph input", function () {
-                var html = SimpleMarkdown.markdownToHtml("Hi there!\n\nYay!");
-
-                assert.strictEqual(
-                    html,
-                    '<div class="paragraph">Hi there!</div>' +
-                        '<div class="paragraph">Yay!</div>',
-                );
-            });
-        });
-
         describe("ReactMarkdown component", function () {
             it("should work on a basic 2 paragraph input", function () {
                 var elem = React.createElement(SimpleMarkdown.ReactMarkdown, {

--- a/packages/simple-markdown/src/__tests__/simple-markdown.test.tsx
+++ b/packages/simple-markdown/src/__tests__/simple-markdown.test.tsx
@@ -3989,9 +3989,7 @@ describe("simple markdown", function () {
                                 /** @type {SimpleMarkdown.SingleASTNode} */ node,
                                 /** @type {SimpleMarkdown.ReactOutput} */ output,
                             ) {
-                                return SimpleMarkdown.reactElement("p", null, {
-                                    children: output(node.content),
-                                });
+                                return <p>{output(node.content)}</p>;
                             },
                         },
                     ),
@@ -4001,10 +3999,11 @@ describe("simple markdown", function () {
                             /** @type {SimpleMarkdown.ReactOutput} */ output,
                             /** @type {SimpleMarkdown.State} */ state,
                         ) {
-                            return SimpleMarkdown.reactElement("span", null, {
-                                className: state.spanClass || "default",
-                                children: node.content,
-                            });
+                            return (
+                                <span className={state.spanClass || "default"}>
+                                    {node.content}
+                                </span>
+                            );
                         },
                     }),
                 },
@@ -4045,10 +4044,11 @@ describe("simple markdown", function () {
                         /** @type {SimpleMarkdown.SingleASTNode} */ node,
                         /** @type {SimpleMarkdown.ReactOutput} */ output,
                     ) {
-                        return SimpleMarkdown.reactElement("span", null, {
-                            style: {background: "black"},
-                            children: output(node.content),
-                        });
+                        return (
+                            <span style={{background: "black"}}>
+                                {output(node.content)}
+                            </span>
+                        );
                     },
                 },
                 text: SimpleMarkdown.defaultRules.text,

--- a/packages/simple-markdown/src/index.ts
+++ b/packages/simple-markdown/src/index.ts
@@ -77,8 +77,6 @@ type ArrayNodeOutput<Result> = (
 
 type ReactOutput = Output<ReactElements>;
 type ReactNodeOutput = NodeOutput<ReactElements>;
-type HtmlOutput = Output<string>;
-type HtmlNodeOutput = NodeOutput<string>;
 
 type ParserRule = {
     readonly order: number;
@@ -110,15 +108,9 @@ type ReactOutputRule = {
     readonly react: ReactNodeOutput | null;
 };
 
-type HtmlOutputRule = {
-    readonly html: HtmlNodeOutput | null;
-};
-
 type ArrayRule = {
     // @ts-expect-error - TS2411 - Property 'react' of type 'ArrayNodeOutput<ReactNode> | undefined' is not assignable to 'string' index type 'ArrayNodeOutput<any>'.
     readonly react?: ArrayNodeOutput<ReactElements>;
-    // @ts-expect-error - TS2411 - Property 'html' of type 'ArrayNodeOutput<string> | undefined' is not assignable to 'string' index type 'ArrayNodeOutput<any>'.
-    readonly html?: ArrayNodeOutput<string>;
     readonly [key: string]: ArrayNodeOutput<any>;
 };
 
@@ -145,13 +137,6 @@ type ReactRules = {
     };
     readonly [type: string]: ParserRule & ReactOutputRule;
 };
-type HtmlRules = {
-    // @ts-expect-error - TS2411 - Property 'Array' of type '{ readonly html: ArrayNodeOutput<string>; } | undefined' is not assignable to 'string' index type 'ParserRule & HtmlOutputRule'.
-    readonly Array?: {
-        readonly html: ArrayNodeOutput<string>;
-    };
-    readonly [type: string]: ParserRule & HtmlOutputRule;
-};
 
 // We want to clarify our defaultRules types a little bit more so clients can
 // reuse defaultRules built-ins. So we make some stronger guarantess when
@@ -165,25 +150,14 @@ type ElementReactOutputRule = {
 type TextReactOutputRule = {
     readonly react: NodeOutput<string>;
 };
-type NonNullHtmlOutputRule = {
-    readonly html: HtmlNodeOutput;
-};
-
-type DefaultInRule = SingleNodeParserRule & ReactOutputRule & HtmlOutputRule;
-type TextInOutRule = SingleNodeParserRule &
-    TextReactOutputRule &
-    NonNullHtmlOutputRule;
-type LenientInOutRule = SingleNodeParserRule &
-    NonNullReactOutputRule &
-    NonNullHtmlOutputRule;
-type DefaultInOutRule = SingleNodeParserRule &
-    ElementReactOutputRule &
-    NonNullHtmlOutputRule;
+type DefaultInRule = SingleNodeParserRule & ReactOutputRule;
+type TextInOutRule = SingleNodeParserRule & TextReactOutputRule;
+type LenientInOutRule = SingleNodeParserRule & NonNullReactOutputRule;
+type DefaultInOutRule = SingleNodeParserRule & ElementReactOutputRule;
 
 type DefaultRules = {
     readonly Array: {
         readonly react: ArrayNodeOutput<ReactElements>;
-        readonly html: ArrayNodeOutput<string>;
     };
     readonly heading: DefaultInOutRule;
     readonly nptable: DefaultInRule;
@@ -534,46 +508,6 @@ var reactElement = function (
         _owner: null,
     } as any;
     return element;
-};
-
-/** Returns a closed HTML tag.
- * @param {string} tagName - Name of HTML tag (eg. "em" or "a")
- * @param {string} content - Inner content of tag
- * @param {{ [attr: string]: SimpleMarkdown.Attr }} [attributes] - Optional extra attributes of tag as an object of key-value pairs
- *   eg. { "href": "http://google.com" }. Falsey attributes are filtered out.
- * @param {boolean} [isClosed] - boolean that controls whether tag is closed or not (eg. img tags).
- *   defaults to true
- */
-var htmlTag = function (
-    tagName: string,
-    content: string,
-    attributes?: Partial<Record<any, Attr | null | undefined>> | null,
-    isClosed?: boolean | null,
-) {
-    attributes = attributes || {};
-    isClosed = typeof isClosed !== "undefined" ? isClosed : true;
-
-    var attributeString = "";
-    for (var attr in attributes) {
-        var attribute = attributes[attr];
-        // Removes falsey attributes
-        if (
-            Object.prototype.hasOwnProperty.call(attributes, attr) &&
-            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-            attribute
-        ) {
-            attributeString +=
-                " " + sanitizeText(attr) + '="' + sanitizeText(attribute) + '"';
-        }
-    }
-
-    var unclosedTag = "<" + tagName + attributeString + ">";
-
-    if (isClosed) {
-        return unclosedTag + content + "</" + tagName + ">";
-    } else {
-        return unclosedTag;
-    }
 };
 
 var EMPTY_PROPS: Record<string, any> = {};
@@ -930,28 +864,6 @@ var defaultRules: DefaultRules = {
             state.key = oldKey;
             return result;
         },
-        html: function (arr, output, state) {
-            var result = "";
-
-            // map output over the ast, except group any text
-            // nodes together into a single string output.
-            for (var i = 0; i < arr.length; i++) {
-                var node = arr[i];
-                if (node.type === "text") {
-                    node = {type: "text", content: node.content};
-                    for (
-                        ;
-                        i + 1 < arr.length && arr[i + 1].type === "text";
-                        i++
-                    ) {
-                        node.content += arr[i + 1].content;
-                    }
-                }
-
-                result += output(node, state);
-            }
-            return result;
-        },
     },
     heading: {
         order: currOrder++,
@@ -967,16 +879,12 @@ var defaultRules: DefaultRules = {
                 children: output(node.content, state),
             });
         },
-        html: function (node, output, state) {
-            return htmlTag("h" + node.level, output(node.content, state));
-        },
     },
     nptable: {
         order: currOrder++,
         match: blockRegex(TABLES.NPTABLE_REGEX),
         parse: TABLES.parseNpTable,
         react: null,
-        html: null,
     },
     lheading: {
         order: currOrder++,
@@ -989,7 +897,6 @@ var defaultRules: DefaultRules = {
             };
         },
         react: null,
-        html: null,
     },
     hr: {
         order: currOrder++,
@@ -997,9 +904,6 @@ var defaultRules: DefaultRules = {
         parse: ignoreCapture,
         react: function (node, output, state) {
             return reactElement("hr", state.key, {"aria-hidden": true});
-        },
-        html: function (node, output, state) {
-            return '<hr aria-hidden="true">';
         },
     },
     codeBlock: {
@@ -1024,16 +928,6 @@ var defaultRules: DefaultRules = {
                 }),
             });
         },
-        html: function (node, output, state) {
-            var className = node.lang
-                ? "markdown-code-" + node.lang
-                : undefined;
-
-            var codeBlock = htmlTag("code", sanitizeText(node.content), {
-                class: className,
-            });
-            return htmlTag("pre", codeBlock);
-        },
     },
     fence: {
         order: currOrder++,
@@ -1048,7 +942,6 @@ var defaultRules: DefaultRules = {
             };
         },
         react: null,
-        html: null,
     },
     blockQuote: {
         order: currOrder++,
@@ -1063,9 +956,6 @@ var defaultRules: DefaultRules = {
             return reactElement("blockquote", state.key, {
                 children: output(node.content, state),
             });
-        },
-        html: function (node, output, state) {
-            return htmlTag("blockquote", output(node.content, state));
         },
     },
     list: {
@@ -1185,19 +1075,6 @@ var defaultRules: DefaultRules = {
                 }),
             });
         },
-        html: function (node, output, state) {
-            var listItems = node.items
-                .map(function (item: ASTNode) {
-                    return htmlTag("li", output(item, state));
-                })
-                .join("");
-
-            var listTag = node.ordered ? "ol" : "ul";
-            var attributes = {
-                start: node.start,
-            };
-            return htmlTag(listTag, listItems, attributes);
-        },
     },
     def: {
         order: currOrder++,
@@ -1248,9 +1125,6 @@ var defaultRules: DefaultRules = {
         },
         react: function () {
             return null;
-        },
-        html: function () {
-            return "";
         },
     },
     table: {
@@ -1306,50 +1180,12 @@ var defaultRules: DefaultRules = {
                 ],
             });
         },
-        html: function (node, output, state) {
-            var getStyle = function (colIndex: number): string {
-                return node.align[colIndex] == null
-                    ? ""
-                    : "text-align:" + node.align[colIndex] + ";";
-            };
-
-            var headers = node.header
-                .map(function (content: ASTNode, i: number) {
-                    return htmlTag("th", output(content, state), {
-                        style: getStyle(i),
-                        scope: "col",
-                    });
-                })
-                .join("");
-
-            var rows = node.cells
-                .map(function (row: Array<ASTNode>) {
-                    var cols = row
-                        .map(function (content: ASTNode, c: number) {
-                            return htmlTag("td", output(content, state), {
-                                style: getStyle(c),
-                            });
-                        })
-                        .join("");
-
-                    return htmlTag("tr", cols);
-                })
-                .join("");
-
-            var thead = htmlTag("thead", htmlTag("tr", headers));
-            var tbody = htmlTag("tbody", rows);
-
-            return htmlTag("table", thead + tbody);
-        },
     },
     newline: {
         order: currOrder++,
         match: blockRegex(/^(?:\n *)*\n/),
         parse: ignoreCapture,
         react: function (node, output, state) {
-            return "\n";
-        },
-        html: function (node, output, state) {
             return "\n";
         },
     },
@@ -1362,12 +1198,6 @@ var defaultRules: DefaultRules = {
                 className: "paragraph",
                 children: output(node.content, state),
             });
-        },
-        html: function (node, output, state) {
-            var attributes = {
-                class: "paragraph",
-            };
-            return htmlTag("div", output(node.content, state), attributes);
         },
     },
     escape: {
@@ -1384,7 +1214,6 @@ var defaultRules: DefaultRules = {
             };
         },
         react: null,
-        html: null,
     },
     tableSeparator: {
         order: currOrder++,
@@ -1400,9 +1229,6 @@ var defaultRules: DefaultRules = {
         // These shouldn't be reached, but in case they are, be reasonable:
         react: function () {
             return " | ";
-        },
-        html: function () {
-            return " &vert; ";
         },
     },
     autolink: {
@@ -1421,7 +1247,6 @@ var defaultRules: DefaultRules = {
             };
         },
         react: null,
-        html: null,
     },
     mailto: {
         order: currOrder++,
@@ -1447,7 +1272,6 @@ var defaultRules: DefaultRules = {
             };
         },
         react: null,
-        html: null,
     },
     url: {
         order: currOrder++,
@@ -1466,7 +1290,6 @@ var defaultRules: DefaultRules = {
             };
         },
         react: null,
-        html: null,
     },
     link: {
         order: currOrder++,
@@ -1489,14 +1312,6 @@ var defaultRules: DefaultRules = {
                 title: node.title,
                 children: output(node.content, state),
             });
-        },
-        html: function (node, output, state) {
-            var attributes = {
-                href: sanitizeUrl(node.target),
-                title: node.title,
-            };
-
-            return htmlTag("a", output(node.content, state), attributes);
         },
     },
     image: {
@@ -1525,15 +1340,6 @@ var defaultRules: DefaultRules = {
                 title: node.title,
             });
         },
-        html: function (node, output, state) {
-            var attributes = {
-                src: sanitizeUrl(node.target),
-                alt: node.alt,
-                title: node.title,
-            };
-
-            return htmlTag("img", "", attributes, false);
-        },
     },
     reflink: {
         order: currOrder++,
@@ -1554,7 +1360,6 @@ var defaultRules: DefaultRules = {
             });
         },
         react: null,
-        html: null,
     },
     refimage: {
         order: currOrder++,
@@ -1575,7 +1380,6 @@ var defaultRules: DefaultRules = {
             });
         },
         react: null,
-        html: null,
     },
     em: {
         order: currOrder /* same as strong/u */,
@@ -1621,9 +1425,6 @@ var defaultRules: DefaultRules = {
                 children: output(node.content, state),
             });
         },
-        html: function (node, output, state) {
-            return htmlTag("em", output(node.content, state));
-        },
     },
     strong: {
         order: currOrder /* same as em */,
@@ -1637,9 +1438,6 @@ var defaultRules: DefaultRules = {
             return reactElement("strong", state.key, {
                 children: output(node.content, state),
             });
-        },
-        html: function (node, output, state) {
-            return htmlTag("strong", output(node.content, state));
         },
     },
     u: {
@@ -1655,9 +1453,6 @@ var defaultRules: DefaultRules = {
                 children: output(node.content, state),
             });
         },
-        html: function (node, output, state) {
-            return htmlTag("u", output(node.content, state));
-        },
     },
     del: {
         order: currOrder++,
@@ -1669,9 +1464,6 @@ var defaultRules: DefaultRules = {
             return reactElement("del", state.key, {
                 children: output(node.content, state),
             });
-        },
-        html: function (node, output, state) {
-            return htmlTag("del", output(node.content, state));
         },
     },
     inlineCode: {
@@ -1690,9 +1482,6 @@ var defaultRules: DefaultRules = {
                 children: node.content,
             });
         },
-        html: function (node, output, state) {
-            return htmlTag("code", sanitizeText(node.content));
-        },
     },
     br: {
         order: currOrder++,
@@ -1700,9 +1489,6 @@ var defaultRules: DefaultRules = {
         parse: ignoreCapture,
         react: function (node, output, state) {
             return reactElement("br", state.key, EMPTY_PROPS);
-        },
-        html: function (node, output, state) {
-            return "<br>";
         },
     },
     text: {
@@ -1722,9 +1508,6 @@ var defaultRules: DefaultRules = {
         react: function (node, output, state) {
             return node.content;
         },
-        html: function (node, output, state) {
-            return sanitizeText(node.content);
-        },
     },
 };
 
@@ -1736,8 +1519,8 @@ var ruleOutput = function <Rule>(
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!property && typeof console !== "undefined") {
         console.warn(
-            "simple-markdown ruleOutput should take 'react' or " +
-                "'html' as the second argument.",
+            "simple-markdown ruleOutput should take 'react' as the " +
+                "second argument.",
         );
     }
 
@@ -1874,7 +1657,6 @@ var defaultImplicitParse = function (
 };
 
 var defaultReactOutput: ReactOutput = outputFor(defaultRules, "react");
-var defaultHtmlOutput: HtmlOutput = outputFor(defaultRules, "html");
 
 var markdownToReact = function (
     source: string,
@@ -1954,22 +1736,12 @@ type Exports = {
         state?: State | null | undefined,
     ) => Array<SingleASTNode>;
     readonly defaultReactOutput: ReactOutput;
-    readonly defaultHtmlOutput: HtmlOutput;
     readonly preprocess: (source: string) => string;
     readonly sanitizeText: (text: Attr) => string;
     readonly sanitizeUrl: (
         url?: string | null | undefined,
     ) => string | null | undefined;
     readonly unescapeUrl: (url: string) => string;
-    readonly htmlTag: (
-        tagName: string,
-        content: string,
-        attributes?:
-            | Partial<Record<any, Attr | null | undefined>>
-            | null
-            | undefined,
-        isClosed?: boolean | null | undefined,
-    ) => string;
     readonly reactElement: (
         type: string,
         key: string | null,
@@ -1996,7 +1768,6 @@ export type {
     Parser,
     Output,
     ReactOutput,
-    HtmlOutput,
     // Most of the following types should be considered experimental and
     // subject to change or change names. Again, they shouldn't be necessary,
     // but if they are I'd love to hear how so I can better support them!
@@ -2011,13 +1782,11 @@ export type {
     // Single rules:
     ParserRule,
     ReactOutputRule,
-    HtmlOutputRule,
     // Sets of rules:
     ParserRules,
     OutputRules,
     Rules,
     ReactRules,
-    HtmlRules,
     SingleASTNode,
 };
 
@@ -2041,13 +1810,11 @@ var SimpleMarkdown: Exports = {
     defaultImplicitParse: defaultImplicitParse,
 
     defaultReactOutput: defaultReactOutput,
-    defaultHtmlOutput: defaultHtmlOutput,
 
     preprocess: preprocess,
     sanitizeText: sanitizeText,
     sanitizeUrl: sanitizeUrl,
     unescapeUrl: unescapeUrl,
-    htmlTag: htmlTag,
     reactElement: reactElement,
 
     // deprecated:

--- a/packages/simple-markdown/src/index.ts
+++ b/packages/simple-markdown/src/index.ts
@@ -1791,24 +1791,6 @@ var reactFor = function (outputFunc: ReactNodeOutput): ReactOutput {
     return nestedOutput;
 };
 
-/** (deprecated)
- */
-var htmlFor = function (outputFunc: HtmlNodeOutput): HtmlOutput {
-    var nestedOutput: HtmlOutput = function (ast, state) {
-        state = state || {};
-        if (Array.isArray(ast)) {
-            return ast
-                .map(function (node) {
-                    return nestedOutput(node, state);
-                })
-                .join("");
-        } else {
-            return outputFunc(ast, nestedOutput, state);
-        }
-    };
-    return nestedOutput;
-};
-
 var outputFor = function <Rule>(
     rules: OutputRules<Rule>,
     property: keyof Rule,
@@ -1938,7 +1920,6 @@ type Exports = {
         param: keyof Rule,
     ) => NodeOutput<any>;
     readonly reactFor: (arg1: ReactNodeOutput) => ReactOutput;
-    readonly htmlFor: (arg1: HtmlNodeOutput) => HtmlOutput;
     readonly inlineRegex: (regex: RegExp) => MatchFunction;
     readonly blockRegex: (regex: RegExp) => MatchFunction;
     readonly anyScopeRegex: (regex: RegExp) => MatchFunction;
@@ -2082,7 +2063,6 @@ var SimpleMarkdown: Exports = {
     defaultRawParse: defaultRawParse,
     ruleOutput: ruleOutput,
     reactFor: reactFor,
-    htmlFor: htmlFor,
 
     defaultParse: function (...args) {
         if (typeof console !== "undefined") {

--- a/packages/simple-markdown/src/index.ts
+++ b/packages/simple-markdown/src/index.ts
@@ -1883,10 +1883,6 @@ var markdownToReact = function (
     return defaultReactOutput(defaultBlockParse(source, state), state);
 };
 
-var markdownToHtml = function (source: string, state?: State | null): string {
-    return defaultHtmlOutput(defaultBlockParse(source, state), state);
-};
-
 type Props = any;
 var ReactMarkdown = function (props: Props): React.ReactElement {
     var divProps: Record<string, any> = {};
@@ -1937,10 +1933,6 @@ type Exports = {
         source: string,
         state?: State | null | undefined,
     ) => ReactElements;
-    readonly markdownToHtml: (
-        source: string,
-        state?: State | null | undefined,
-    ) => string;
     readonly ReactMarkdown: (props: {
         source: string;
         [key: string]: any;
@@ -2042,7 +2034,6 @@ var SimpleMarkdown: Exports = {
 
     // default wrappers:
     markdownToReact: markdownToReact,
-    markdownToHtml: markdownToHtml,
     ReactMarkdown: ReactMarkdown,
 
     defaultBlockParse: defaultBlockParse,


### PR DESCRIPTION
## Summary:

This PR removes long-deprecated features and APIs from the `@khanacademy/simple-markdown` project. We haven't used HTML output for a long, long time (everything is rendered to React) and so that is being removed. 

There are also a few APIs that are marked as deprecated that I've verified as unused, which we can delete.

This work is being done because I need to make another change and thought it would be handy to clean up the library a bit before doing any new work.

Note that the `output => html` is still used in tests (which is unrelated to this deprecated removal) to validate rendering to React, but we take the React and render it to HTML so we can assert compared to an HTML string. Eventually we could migrate that to comparing the React elements to JSX. I didn't do that in this PR to avoid too much churn. 

Issue: 

## Test plan:

`pnpm tsc`
`pnpm test`

Install the snapshot version of the package in the frontend repo and type check everything there.