### PR TITLE
[Bug Fix] Ensure that we can handle missing rows in the user inputs for the Matrix Widget

### DIFF
--- a/.changeset/seven-kids-walk.md
+++ b/.changeset/seven-kids-walk.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-score": patch
+---
+
+Fix the Matrix Widget Validation when handling empty rows

--- a/packages/perseus-score/src/widgets/matrix/validate-matrix.test.ts
+++ b/packages/perseus-score/src/widgets/matrix/validate-matrix.test.ts
@@ -17,9 +17,14 @@ describe("matrixValidator", () => {
     });
 
     it("should return invalid when any answer row is empty", () => {
-        // Arrange
+        // Arrange - simulate what happens when user enters data in rows 0 and 2, skipping row 1
+        const sparseAnswers: any[][] = [];
+        sparseAnswers[0] = [1, 2, 3, 4]; // User fills row 0
+        // sparseAnswers[1] is undefined - user skipped this row
+        sparseAnswers[2] = [5]; // User only fills first cell of row 2
+
         const userInput: PerseusMatrixUserInput = {
-            answers: [[1, 2, 3], [], [7, 8, 9]],
+            answers: sparseAnswers,
         };
 
         // Act

--- a/packages/perseus-score/src/widgets/matrix/validate-matrix.ts
+++ b/packages/perseus-score/src/widgets/matrix/validate-matrix.ts
@@ -21,10 +21,10 @@ function validateMatrix(userInput: PerseusMatrixUserInput): ValidationResult {
 
     for (let row = 0; row < suppliedSize[0]; row++) {
         for (let col = 0; col < suppliedSize[1]; col++) {
-            if (
-                supplied[row][col] == null ||
-                supplied[row][col].toString().length === 0
-            ) {
+            // The row/cell value may be null if the user has not filled all the cells.
+            const rowData = supplied[row];
+            const cellValue = rowData?.[col];
+            if (cellValue == null || cellValue.toString().length === 0) {
                 return {
                     type: "invalid",
                     message: ErrorCodes.FILL_ALL_CELLS_ERROR,


### PR DESCRIPTION
## Summary:
Issue: Entering information in the first row of a Matrix Widget, and then skipping an entire row to interact with later rows would result in the page erroring out.

The way we're saving the user input for the Matrix Widget was causing issues with our validation logic, as it was attempting to access a property that did not exist. This minor PR ensures that our validation logic properly accounts for the user input format, and also fixes a test to properly mock how our user input is actually saved.

Issue: LEMS-3266

## Test plan:
- Tests pass
- Improved test