### PR TITLE
Remove the expression widget validation tooltip

### DIFF
--- a/.changeset/sharp-taxis-joke.md
+++ b/.changeset/sharp-taxis-joke.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+remove the tooltip invalid error from the expression widget

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -62,7 +62,6 @@ type Props = {
     ariaLabel: string;
     onFocus?: () => void;
     onBlur?: () => void;
-    hasError?: boolean;
     extraKeys?: ReadonlyArray<KeypadKey>;
     /**
      * Whether to show the keypad buttons.
@@ -313,7 +312,6 @@ class InnerMathInput extends React.Component<InnerProps, State> {
                 style={[
                     styles.outerWrapper,
                     this.state.focused && styles.wrapperFocused,
-                    this.props.hasError && styles.wrapperError,
                 ]}
             >
                 {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events -- TODO(LEMS-2871): Address a11y error */}

--- a/packages/perseus/src/styles/widgets/expression.css
+++ b/packages/perseus/src/styles/widgets/expression.css
@@ -1,25 +1,9 @@
 .perseus-widget-expression {
     position: relative;
 }
-.perseus-widget-expression > span,
-.perseus-widget-expression .error-tooltip {
+.perseus-widget-expression > span {
     display: inline-block;
     vertical-align: middle;
-}
-.perseus-widget-expression .error-tooltip {
-    position: absolute;
-    right: 6px;
-    top: -2px;
-}
-.perseus-widget-expression .error-icon {
-    color: #fcc335;
-    cursor: pointer;
-    font-size: 20px;
-}
-.perseus-widget-expression .error-text {
-    background-color: #fff;
-    padding: 5px;
-    width: 210px;
 }
 .perseus-widget-expression .perseus-formats-tooltip {
     width: 190px;

--- a/packages/perseus/src/widgets/expression/expression.test.tsx
+++ b/packages/perseus/src/widgets/expression/expression.test.tsx
@@ -4,7 +4,7 @@ import {
     generateTestPerseusItem,
 } from "@khanacademy/perseus-core";
 import {scorePerseusItem} from "@khanacademy/perseus-score";
-import {act, screen, waitFor} from "@testing-library/react";
+import {act, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 
 import {
@@ -498,54 +498,6 @@ describe("Expression Widget", function () {
             // In this case we know that it'll be valid so we can assert directly
             // @ts-expect-error - TS2339 - Property 'total' does not exist on type 'PerseusScore'.
             expect(score.total).toBe(1);
-        });
-    });
-
-    describe("error tooltip", () => {
-        beforeEach(() => {
-            jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
-                testDependencies,
-            );
-            jest.useFakeTimers();
-        });
-
-        it("shows error text in tooltip", async () => {
-            // Arrange
-            const {renderer} = renderQuestion(expressionItem2.question);
-            const expression = renderer.findWidgets("expression 1")[0];
-
-            // Act
-            // Note(jeremy): You might think you could collapse all of these calls
-            // inside a single act() block, but that didn't work. The only way this
-            // test passes is with each statement in its own act() call. :/
-            act(() => expression.insert("x&&&&&^1"));
-            act(() => jest.runOnlyPendingTimers());
-            act(() => screen.getByRole("textbox").blur());
-            act(() => jest.runOnlyPendingTimers());
-
-            // Assert
-            await waitFor(() =>
-                expect(
-                    screen.getByText("Oops! Sorry, I don't understand that!"),
-                ).toBeVisible(),
-            );
-        });
-
-        it("does not show error text when the sen() function is used (Portuguese for sin())", async () => {
-            // Arrange
-            const {renderer} = renderQuestion(expressionItem2.question);
-            const expression = renderer.findWidgets("expression 1")[0];
-
-            // Act
-            act(() => expression.insert("sen(x)"));
-            act(() => jest.runOnlyPendingTimers());
-            act(() => screen.getByRole("textbox").blur());
-
-            // Assert
-            expect(screen.queryByText("Oops!")).toBeNull();
-            expect(
-                screen.queryByText("Sorry, I don't understand that!"),
-            ).toBeNull();
         });
     });
 

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -1,9 +1,7 @@
-import * as KAS from "@khanacademy/kas";
 import {KeypadInput} from "@khanacademy/math-input";
-import {getDecimalSeparator, expressionLogic} from "@khanacademy/perseus-core";
+import {expressionLogic} from "@khanacademy/perseus-core";
 import {linterContextDefault} from "@khanacademy/perseus-linter";
 import {View} from "@khanacademy/wonder-blocks-core";
-import Tooltip from "@khanacademy/wonder-blocks-tooltip";
 import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import {css, StyleSheet} from "aphrodite";
 import classNames from "classnames";
@@ -15,7 +13,6 @@ import {PerseusI18nContext} from "../../components/i18n-context";
 import MathInput from "../../components/math-input";
 import {useDependencies} from "../../dependencies";
 import {ApiOptions} from "../../perseus-api";
-import a11y from "../../util/a11y";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/expression/expression-ai-utils";
 
 import type {DependenciesContext} from "../../dependencies";
@@ -83,12 +80,6 @@ type Props = ExternalProps &
         ariaLabel: PerseusExpressionWidgetOptions["ariaLabel"];
     };
 
-type ExpressionState = {
-    invalid: boolean;
-    showErrorTooltip: boolean;
-    showErrorStyle: boolean;
-};
-
 type DefaultProps = {
     apiOptions: Props["apiOptions"];
     buttonSets: Props["buttonSets"];
@@ -101,10 +92,7 @@ type DefaultProps = {
 };
 
 // The new, MathQuill input expression widget
-export class Expression
-    extends React.Component<Props, ExpressionState>
-    implements Widget
-{
+export class Expression extends React.Component<Props> implements Widget {
     static contextType = PerseusI18nContext;
     declare context: React.ContextType<typeof PerseusI18nContext>;
 
@@ -124,15 +112,7 @@ export class Expression
 
     displayName = "Expression";
 
-    state: ExpressionState = {
-        invalid: false,
-        showErrorTooltip: false,
-        showErrorStyle: false,
-    };
-
     componentDidMount: () => void = () => {
-        document.addEventListener("mousedown", this._handleMouseDown);
-
         // TODO(scottgrant): This is a hack to remove the deprecated call to
         // this.isMounted() but is still considered an anti-pattern.
         this._isMounted = true;
@@ -150,38 +130,8 @@ export class Expression
         }
     };
 
-    // Whenever the input value changes, attempt to parse it.
-    //
-    // Clear any errors if this parse succeeds, show an error within a second
-    // if it fails.
-    componentDidUpdate: (prevProps: Props) => void = (prevProps) => {
-        if (
-            !_.isEqual(this.props.userInput, prevProps.userInput) ||
-            !_.isEqual(this.props.functions, prevProps.functions)
-        ) {
-            this.setState({
-                invalid: false,
-                showErrorTooltip: false,
-                showErrorStyle: false,
-            });
-            if (!this.parse(this.props.userInput, this.props).parsed) {
-                this.setState({
-                    invalid: true,
-                });
-            }
-        }
-    };
-
     componentWillUnmount: () => void = () => {
         this._isMounted = false;
-    };
-
-    _handleMouseDown = () => {
-        if (this._isMounted && this.state.showErrorTooltip) {
-            this.setState({
-                showErrorTooltip: false,
-            });
-        }
     };
 
     /**
@@ -195,20 +145,6 @@ export class Expression
     getPromptJSON(): ExpressionPromptJSON {
         return _getPromptJSON(this.props, this.getUserInput());
     }
-
-    parse: (value: string, props: Props) => any = (
-        value: string,
-        props: Props,
-    ) => {
-        // TODO(jack): Disable icu for content creators here, or
-        // make it so that solution answers with ','s or '.'s work
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        const options = _.pick(props || this.props, "functions");
-        _.extend(options, {
-            decimal_separator: getDecimalSeparator(this.context.locale),
-        });
-        return KAS.parse(normalizeTex(value), options);
-    };
 
     changeAndTrack: (userInput: string, cb: () => void) => void = (
         userInput: string,
@@ -238,11 +174,7 @@ export class Expression
             // eslint-disable-next-line react/no-string-refs
             // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'ReactInstance'.
             this.refs.input.focus();
-        } else {
-            // The buttons are often on top of text you're trying to read, so
-            // don't focus the editor automatically.
         }
-
         return true;
     };
 
@@ -340,10 +272,7 @@ export class Expression
 
         const className = classNames({
             "perseus-widget-expression": true,
-            "show-error-tooltip": this.state.showErrorTooltip,
         });
-
-        const {ERROR_MESSAGE, ERROR_TITLE} = this.context.strings;
 
         return (
             <View className={css(styles.desktopLabelInputWrapper)}>
@@ -353,58 +282,26 @@ export class Expression
                     </LabelSmall>
                 )}
                 {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions -- TODO(LEMS-2871): Address a11y error */}
-                <div
-                    className={className}
-                    onBlur={() =>
-                        this.state.invalid &&
-                        this.setState({
-                            showErrorTooltip: true,
-                            showErrorStyle: true,
-                        })
-                    }
-                    onFocus={() =>
-                        this.setState({
-                            showErrorTooltip: false,
-                        })
-                    }
-                >
-                    {/**
-                * This is a visually hidden container for the error tooltip.
-                https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/alert_role#example_3_visually_hidden_alert_container_for_screen_reader_notifications
-            */}
-                    <View style={a11y.srOnly} role="alert">
-                        {this.state.showErrorTooltip &&
-                            ERROR_TITLE + " " + ERROR_MESSAGE}
-                    </View>
-                    <Tooltip
-                        forceAnchorFocusivity={false}
-                        opened={this.state.showErrorTooltip}
-                        title={ERROR_TITLE}
-                        content={ERROR_MESSAGE}
-                    >
-                        <MathInput
-                            // eslint-disable-next-line react/no-string-refs
-                            ref="input"
-                            value={this.props.userInput}
-                            onChange={this.changeAndTrack}
-                            convertDotToTimes={this.props.times}
-                            buttonSets={this.props.buttonSets}
-                            onFocus={this._handleFocus}
-                            onBlur={this._handleBlur}
-                            hasError={this.state.showErrorStyle}
-                            ariaLabel={
-                                this.props.ariaLabel ||
-                                this.context.strings.mathInputBox
-                            }
-                            extraKeys={
-                                this.props.keypadConfiguration?.extraKeys
-                            }
-                            onAnalyticsEvent={
-                                this.props.analytics?.onAnalyticsEvent ??
-                                (async () => {})
-                            }
-                        />
-                    </Tooltip>
+                <div className={className}>
+                    <MathInput
+                        // eslint-disable-next-line react/no-string-refs
+                        ref="input"
+                        value={this.props.userInput}
+                        onChange={this.changeAndTrack}
+                        convertDotToTimes={this.props.times}
+                        buttonSets={this.props.buttonSets}
+                        onFocus={this._handleFocus}
+                        onBlur={this._handleBlur}
+                        ariaLabel={
+                            this.props.ariaLabel ||
+                            this.context.strings.mathInputBox
+                        }
+                        extraKeys={this.props.keypadConfiguration?.extraKeys}
+                        onAnalyticsEvent={
+                            this.props.analytics?.onAnalyticsEvent ??
+                            (async () => {})
+                        }
+                    />
                 </div>
             </View>
         );


### PR DESCRIPTION
## Summary:
this is an anti-pattern, no other widget (to my knowledge) has this type of realtime feedback - feedback is generally provided after submit - including for this invalid use case. It is causing a styling issue with assessment and a pattern we want to move away from, so removing this code.

Issue: LEMS-3292

## Test plan:
1. go to an expression widget
2. enter an invalid input such as just a single hyphen
3. observe that there is no immediate feedback that your answer is invalid
(upon submitting, user should be warned their answer is invalid and not scored incorrectly, maintaining the existing behavior)