### PR TITLE
[Editor] Remove unused frameSource prop from EditorPage component

### DIFF
--- a/.changeset/tasty-jars-invent.md
+++ b/.changeset/tasty-jars-invent.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": major
+---
+
+Remove frameSource prop from EditorPage component

--- a/packages/perseus-editor/src/__docs__/editor-page-with-storybook-preview.tsx
+++ b/packages/perseus-editor/src/__docs__/editor-page-with-storybook-preview.tsx
@@ -61,7 +61,6 @@ function EditorPageWithStorybookPreview(props: Props) {
                 answerArea={answerArea}
                 question={question}
                 hints={hints}
-                frameSource="about:blank"
                 previewURL="about:blank"
                 itemId="1"
                 onChange={(props) => {

--- a/packages/perseus-editor/src/editor-page.test.tsx
+++ b/packages/perseus-editor/src/editor-page.test.tsx
@@ -59,7 +59,6 @@ describe("EditorPage", () => {
                 onPreviewDeviceChange={() => {}}
                 previewDevice="desktop"
                 previewURL=""
-                frameSource=""
                 itemId="itemId"
                 developerMode={false}
                 jsonMode={false}
@@ -83,7 +82,6 @@ describe("EditorPage", () => {
                 onPreviewDeviceChange={() => {}}
                 previewDevice="desktop"
                 previewURL=""
-                frameSource=""
                 itemId="itemId"
                 developerMode={false}
                 jsonMode={false}
@@ -142,7 +140,6 @@ describe("EditorPage", () => {
                 onPreviewDeviceChange={() => {}}
                 previewDevice="desktop"
                 previewURL=""
-                frameSource=""
                 itemId="itemId"
                 developerMode={false}
                 jsonMode={false}

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -36,8 +36,6 @@ type Props = {
     contentPaths?: ReadonlyArray<string>;
     /** "Power user" mode. Shows the raw JSON of the question. */
     developerMode: boolean;
-    /** Source HTML for the iframe to render */
-    frameSource: string;
     hints?: ReadonlyArray<Hint>; // related to the question,
     /** A function which takes a file object (guaranteed to be an image) and
      * a callback, then calls the callback with the url where the image

--- a/packages/perseus-editor/src/widgets/__docs__/interactive-graph-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__docs__/interactive-graph-editor.stories.tsx
@@ -212,7 +212,6 @@ export const WithSaveWarnings = (): React.ReactElement => {
                 answerArea={answerArea}
                 question={question}
                 hints={hints}
-                frameSource="about:blank"
                 previewURL="about:blank"
                 itemId="1"
                 onChange={(props) => {


### PR DESCRIPTION
## Summary:

I kept noticing that the `frameSource` prop is a required prop but we don't do anything with it, so this PR finally removes it. It looks like at one point it was related to preview, but now we use the `previewURL` instead.

Issue: "none"

## Test plan:

`pnpm tsc`