### PR TITLE
Fix a bug in the image uploader

### DIFF
--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -200,6 +200,14 @@ class Editor extends React.Component<Props, State> {
             .on("paste", this._maybePasteWidgets);
     }
 
+    // TODO(arun): This is a deprecated method, use the appropriate replacement
+    // eslint-disable-next-line react/no-unsafe
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
+        if (this.props.content !== nextProps.content) {
+            this.setState({textAreaValue: nextProps.content});
+        }
+    }
+
     componentDidUpdate(prevProps: Props) {
         const textarea = this.textarea.current;
 


### PR DESCRIPTION
The "upload image" feature in the article editor on khanacademy.org
was broken. The image widget placeholder did not appear in the article
text box when an image was uploaded.

[The cause appears to have been this commit](https://github.com/Khan/perseus/commit/801ca690b4b2ef8f491f830108ae258c5a29145c).

The bug happens because the image uploader modifies the article content
in the state of the article editor's parent component. Then the article
editor receives that new content via props and is expected to update
the state of the input box — but it doesn't anymore.

This PR reverts #2679 to fix the bug.

Issue: none

## Test plan:

Deploy in a ZND. Verify that the image uploading bug no longer occurs.