### PR TITLE
[Interactive Graph] Stop alongEdge labels from overflowing out of graph container

### DIFF
--- a/.changeset/pink-rats-matter.md
+++ b/.changeset/pink-rats-matter.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Interactive Graph] Stop alongEdge labels from overflowing out of graph container

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.tsx
@@ -5,27 +5,20 @@ import {X, Y} from "../math";
 import useGraphConfig from "../reducer/use-graph-config";
 import {replaceOutsideTeX} from "../utils";
 
-import {fontSize, getLabelPosition, getLabelTransform} from "./utils";
+import {fontSize, getLabelTransform} from "./utils";
 
 import type {I18nContextType} from "../../../components/i18n-context";
-import type {GraphDimensions} from "../types";
 
-export default function AxisLabels({i18n}: {i18n: I18nContextType}) {
-    const {range, labels, width, height, labelLocation, tickStep} =
-        useGraphConfig();
-
-    const graphInfo: GraphDimensions = {
-        range,
-        width,
-        height,
-    };
-
-    // Get the position of the main axis labels
-    const [xAxisLabelLocation, yAxisLabelLocation] = getLabelPosition(
-        graphInfo,
-        labelLocation,
-        tickStep,
-    );
+export default function AxisLabels({
+    i18n,
+    xAxisLabelLocation,
+    yAxisLabelLocation,
+}: {
+    i18n: I18nContextType;
+    xAxisLabelLocation: [number, number];
+    yAxisLabelLocation: [number, number];
+}) {
+    const {labels, labelLocation} = useGraphConfig();
 
     const [xAxisLabelText, yAxisLabelText] = labels;
 

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/utils.ts
@@ -7,8 +7,8 @@ import type {GraphConfig} from "../reducer/use-graph-config";
 import type {GraphDimensions} from "../types";
 import type {Interval} from "mafs";
 
-// Exported for testing purposes
 export const fontSize = 14;
+export const fontSizeYAxisLabelMultiplier = 1.25;
 
 /* Calculate the position of the main axis labels based on the labelLocation
  * and the ranges of the graph. Exported for testing purposes.
@@ -33,7 +33,10 @@ export const clampLabelPosition = (
     const y = Math.max(
         // The maximum y value is the height of the graph + 1.25 font sizes, which aligns the label with the axis ticks
         // when the y-axis is out of bounds below the graph.
-        Math.min(labelPosition[Y], graphInfo.height + fontSize * 1.25),
+        Math.min(
+            labelPosition[Y],
+            graphInfo.height + fontSize * fontSizeYAxisLabelMultiplier,
+        ),
         // The minimum y value is -2 font sizes, which aligns the label with the axis ticks
         // when the y-axis is out of bounds above the graph.
         -fontSize * 2,

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -24,7 +24,11 @@ import AxisLabels from "./backgrounds/axis-labels";
 import {AxisTicks} from "./backgrounds/axis-ticks";
 import {Grid} from "./backgrounds/grid";
 import {LegacyGrid} from "./backgrounds/legacy-grid";
-import {getLabelPosition} from "./backgrounds/utils";
+import {
+    fontSize,
+    fontSizeYAxisLabelMultiplier,
+    getLabelPosition,
+} from "./backgrounds/utils";
 import GraphLockedLabelsLayer from "./graph-locked-labels-layer";
 import GraphLockedLayer from "./graph-locked-layer";
 import {renderAngleGraph} from "./graphs/angle";
@@ -64,6 +68,8 @@ import type {vec} from "mafs";
 
 import "mafs/core.css";
 import "./mafs-styles.css";
+
+const GRAPH_LEFT_MARGIN = 20;
 
 export type MafsGraphProps = {
     box: [number, number];
@@ -171,20 +177,27 @@ export const MafsGraph = (props: MafsGraphProps) => {
         tickStep,
     );
 
-    // -17.5 is the standard label offset on the graphs with alongEdge labels.
+    // (-fontSize * fontSizeYAxisLabelMultiplier) is the standard label offset
+    // on the graphs with alongEdge labels. fontSize is currently assumed to be
+    // 14px.
     // There is a very specific range of values for which the label needs a
     // different offset to avoid overlapping with the tick labels. We have to
     // compensate for this specific case.
     const needsExtraMargin =
-        labelLocation === "alongEdge" && yAxisLabelLocation[0] < -17.5;
+        labelLocation === "alongEdge" &&
+        yAxisLabelLocation[0] < -fontSize * fontSizeYAxisLabelMultiplier;
+
+    // marginLabelDiff is currently 2.5px (20px - (14px * 1.25) = 2.5px)
+    const marginLabelDiff =
+        GRAPH_LEFT_MARGIN - fontSize * fontSizeYAxisLabelMultiplier;
 
     // If the graph needs the extra margin, this is the offset.
     // yAxisLabelLocation[X] is how far off the edge of the graph the label is.
     // We want to move the graph over by the same amount so that the label is
-    // visible, which is why we multiply by -1. The 2.5 is to make sure the
-    // label stays in the exact same position as the standard margin, which
-    // is 20px margin minus the 17.5px standard label offset = 2.5px.
-    const extraMarginOffset = -1 * (yAxisLabelLocation[X] - 2.5);
+    // visible, which is why we multiply by -1. The marginLabelDiff is to make
+    // sure the label stays in the exact same position as the standard margin.
+    const marginWithExtraOffset =
+        -1 * (yAxisLabelLocation[X] - marginLabelDiff);
 
     return (
         <GraphConfigContext.Provider
@@ -220,8 +233,8 @@ export const MafsGraph = (props: MafsGraphProps) => {
                         // Move the graph over by the label offset so that
                         // the label is visible
                         marginLeft: needsExtraMargin
-                            ? `${extraMarginOffset}px`
-                            : "20px",
+                            ? `${marginWithExtraOffset}px`
+                            : `${GRAPH_LEFT_MARGIN}px`,
                         marginBottom: "30px",
                         pointerEvents: props.static ? "none" : "auto",
                         userSelect: "none",

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -171,12 +171,20 @@ export const MafsGraph = (props: MafsGraphProps) => {
         tickStep,
     );
 
-    // -17.5 is the standard margin on the graphs with alongEdge labels.
+    // -17.5 is the standard label offset on the graphs with alongEdge labels.
     // There is a very specific range of values for which the label needs a
     // different offset to avoid overlapping with the tick labels. We have to
     // compensate for this specific case.
     const needsExtraMargin =
         labelLocation === "alongEdge" && yAxisLabelLocation[0] < -17.5;
+
+    // If the graph needs the extra margin, this is the offset.
+    // yAxisLabelLocation[X] is how far off the edge of the graph the label is.
+    // We want to move the graph over by the same amount so that the label is
+    // visible, which is why we multiply by -1. The 2.5 is to make sure the
+    // label stays in the exact same position as the standard margin, which
+    // is 20px margin minus the 17.5px standard label offset = 2.5px.
+    const extraMarginOffset = -1 * (yAxisLabelLocation[X] - 2.5);
 
     return (
         <GraphConfigContext.Provider
@@ -212,7 +220,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                         // Move the graph over by the label offset so that
                         // the label is visible
                         marginLeft: needsExtraMargin
-                            ? `${-1 * yAxisLabelLocation[X]}px`
+                            ? `${extraMarginOffset}px`
                             : "20px",
                         marginBottom: "30px",
                         pointerEvents: props.static ? "none" : "auto",


### PR DESCRIPTION
## Summary:
The alongEdge graph label overflows out of the container on web, and is completely cut off on mobile.

This only happens for very specific cases where the y-axis tick labels are rendered outside the graph. This means when the x range is greater than 0, 0, or relatively close to 0.

To fix this, I added extra padding by the exact offset needed for these edge cases.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3282

## Screenshots and demo

| Before | After |
| --- | --- |
| <img width="425" height="533" alt="Screenshot 2025-07-16 at 12 52 11 PM" src="https://github.com/user-attachments/assets/23c4141b-38f0-4f40-852b-53db95c980ab" /> | <img width="395" height="495" alt="image" src="https://github.com/user-attachments/assets/b887e77e-23bb-47d6-879d-c5eb3d2924f4" /> |

Observe how the y-axis label stays in the same spot no matter what the range of the graph is or where the tick labels are.

https://github.com/user-attachments/assets/b44cc732-20c1-40c6-8083-d25f9d2df574


## Test plan:
Storybook
- http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--interactive-graph-linear
- Set the label location to "along edge"
- Set the x Range start to 0
- Confirm that the y label is still visible in the preview
- Try all 0.1 interavals between -1 and 0 for the x range start
- Confirm that the y label is sitll visible in all the cases