### PR TITLE
[Interactive Graph][Point] Allow points on Point graphs to sit on edge of graph

### DIFF
--- a/.changeset/strange-snakes-lay.md
+++ b/.changeset/strange-snakes-lay.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Interactive Graph][point] Allow points on Point graphs to sit on edge of graph

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -1024,6 +1024,7 @@ exports[`Interactive Graph A none-type graph renders predictably: first render 1
                       <svg
                         height="400"
                         preserveAspectRatio="xMidYMin"
+                        style="overflow: hidden;"
                         viewBox="-200 -200 400 400"
                         width="400"
                         x="-200"
@@ -1186,6 +1187,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                       <svg
                         height="400"
                         preserveAspectRatio="xMidYMin"
+                        style="overflow: hidden;"
                         viewBox="-57.142857142857146 -342.85714285714283 400 400"
                         width="400"
                         x="-57.142857142857146"
@@ -1660,6 +1662,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                       <svg
                         height="400"
                         preserveAspectRatio="xMidYMin"
+                        style="overflow: hidden;"
                         viewBox="-200 -200 400 400"
                         width="400"
                         x="-200"
@@ -2111,6 +2114,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                       <svg
                         height="400"
                         preserveAspectRatio="xMidYMin"
+                        style="overflow: visible;"
                         viewBox="-200 -200 400 400"
                         width="400"
                         x="-200"
@@ -2363,6 +2367,7 @@ exports[`Interactive Graph question Should render predictably: after interaction
                       <svg
                         height="400"
                         preserveAspectRatio="xMidYMin"
+                        style="overflow: hidden;"
                         viewBox="-200 -266.66666666666663 400 400"
                         width="400"
                         x="-200"
@@ -2578,6 +2583,7 @@ exports[`Interactive Graph question Should render predictably: first render 1`] 
                       <svg
                         height="400"
                         preserveAspectRatio="xMidYMin"
+                        style="overflow: hidden;"
                         viewBox="-57.142857142857146 -342.85714285714283 400 400"
                         width="400"
                         x="-57.142857142857146"
@@ -3052,6 +3058,7 @@ exports[`Interactive Graph question Should render predictably: first render 2`] 
                       <svg
                         height="400"
                         preserveAspectRatio="xMidYMin"
+                        style="overflow: hidden;"
                         viewBox="-200 -200 400 400"
                         width="400"
                         x="-200"
@@ -3503,6 +3510,7 @@ exports[`Interactive Graph question Should render predictably: first render 3`] 
                       <svg
                         height="400"
                         preserveAspectRatio="xMidYMin"
+                        style="overflow: visible;"
                         viewBox="-200 -200 400 400"
                         width="400"
                         x="-200"
@@ -3755,6 +3763,7 @@ exports[`Interactive Graph question Should render predictably: first render 4`] 
                       <svg
                         height="400"
                         preserveAspectRatio="xMidYMin"
+                        style="overflow: hidden;"
                         viewBox="-200 -266.66666666666663 400 400"
                         width="400"
                         x="-200"

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -347,7 +347,21 @@ export const MafsGraph = (props: MafsGraphProps) => {
                                 height={height}
                             >
                                 {/* Intearctive Elements are nested in an SVG to lock them to graph bounds */}
-                                <svg {...nestedSVGAttributes}>
+                                <svg
+                                    {...nestedSVGAttributes}
+                                    style={{
+                                        // We want to allow points to be directly
+                                        // on the edge of the graph, so we need to
+                                        // set overflow to visible. For other
+                                        // graphs, we want to hide the overflow
+                                        // so that the graph can't go way off
+                                        // the edge.
+                                        overflow:
+                                            type === "point"
+                                                ? "visible"
+                                                : "hidden",
+                                    }}
+                                >
                                     {/* Protractor */}
                                     {props.showProtractor && <Protractor />}
                                     {/* Interactive layer */}

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -453,7 +453,8 @@ describe("movePoint on a point graph", () => {
         );
 
         invariant(updated.type === "point");
-        expect(updated.coords[0]).toEqual([9, 9]);
+        // Points can go on the edges of the graph.
+        expect(updated.coords[0]).toEqual([10, 10]);
     });
 
     it("sets hasBeenInteractedWith", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -12,7 +12,7 @@ import _ from "underscore";
 
 import {getArrayWithoutDuplicates} from "../graphs/utils";
 import {clamp, clampToBox, inset, snap, X, Y} from "../math";
-import {bound, isUnlimitedGraphState} from "../utils";
+import {bound, boundToEdge, isUnlimitedGraphState} from "../utils";
 
 import {initializeGraphState} from "./initialize-graph-state";
 import {
@@ -513,7 +513,10 @@ function doMovePoint(
                 coords: setAtIndex({
                     array: state.coords,
                     index: action.index,
-                    newValue: boundAndSnapToGrid(action.destination, state),
+                    newValue: boundToEdgeAndSnapToGrid(
+                        action.destination,
+                        state,
+                    ),
                 }),
             };
         }
@@ -782,6 +785,13 @@ function boundAndSnapToGrid(
     {snapStep, range}: {snapStep: vec.Vector2; range: [Interval, Interval]},
 ) {
     return snap(snapStep, bound({snapStep, range, point}));
+}
+
+function boundToEdgeAndSnapToGrid(
+    point: vec.Vector2,
+    {snapStep, range}: {snapStep: vec.Vector2; range: [Interval, Interval]},
+) {
+    return snap(snapStep, boundToEdge({range, point}));
 }
 
 function boundAndSnapAngleVertex(

--- a/packages/perseus/src/widgets/interactive-graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/utils.ts
@@ -66,6 +66,20 @@ export function bound({
     return clampToBox(boundingBox, point);
 }
 
+// Returns the closest point to the given `point` that is within or on the
+// edge of the graph bounds given in `state`.
+export function boundToEdge({
+    range,
+    point,
+}: {
+    range: [Interval, Interval];
+    point: vec.Vector2;
+}): vec.Vector2 {
+    // Use the full range instead of insetting it, allowing points to
+    // be placed on the edge of the graph.
+    return clampToBox(range, point);
+}
+
 export function isUnlimitedGraphState(
     state: InteractiveGraphState,
 ): state is UnlimitedGraphState {


### PR DESCRIPTION
## Summary:
We received a request from content authors to allow users to move a point to
the edge of the graph, specifically for the case that a graph start at 0 in
both the x and y direction (like in physics) and a point needs to sit at (0, 0).

To allow this, I'm making it so that the bounds are not inset and the overflow
is not hidden ONLY FOR POINT GRAPHS.

I'll explore other graph types if specifically requested, but this is not possible
for most graph types because of their overflow.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3213

| Before | After |
| --- | --- |
| <img width="368" height="388" alt="Screenshot 2025-07-16 at 3 30 45 PM" src="https://github.com/user-attachments/assets/00e5f058-75e5-4ae2-84a6-7dd770656ec9" /> | <img width="377" height="404" alt="Screenshot 2025-07-16 at 3 30 52 PM" src="https://github.com/user-attachments/assets/f09f0f00-aee8-4656-b4d0-64016147f43b" /> |


## Test plan:
`pnpm jest packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts`

Storybook
- http://localhost:6006/?path=/story/perseuseditor-widgets-interactive-graph--interactive-graph-point
- Move a point to the corner of the graph
- Confirm that it can sit at the corner of the graph, fully visible
- Confirm it can't go past the bounds of the graph