### PR TITLE
[Analytics] Removing deprecated analytics event PerseusInteractiveGraphWidgetRendered

### DIFF
--- a/.changeset/warm-sheep-join.md
+++ b/.changeset/warm-sheep-join.md
@@ -3,4 +3,4 @@
 "@khanacademy/perseus-core": patch
 ---
 
-Removing deprecated analytics event for graph rendering
+Removing deprecated analytics event:  `perseus:interactive-graph-widget:rendered`

--- a/.changeset/warm-sheep-join.md
+++ b/.changeset/warm-sheep-join.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-core": patch
+---
+
+Removing deprecated analytics event for graph rendering

--- a/packages/perseus-core/src/analytics.ts
+++ b/packages/perseus-core/src/analytics.ts
@@ -26,15 +26,6 @@ export type PerseusAnalyticsEvent =
               userAgent: string;
           };
       }
-    // TODO(LEMS-2827): Remove this error type in LEMS-2827
-    | {
-          type: "perseus:interactive-graph-widget:rendered";
-          payload: {
-              type: string;
-              widgetType: string;
-              widgetId: string;
-          };
-      }
     | {
           type: "perseus:widget:rendered:ti";
           payload: {

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -150,15 +150,7 @@ describe("MafsGraph", () => {
         );
 
         // Assert
-        expect(onAnalyticsEventSpy).toHaveBeenNthCalledWith(1, {
-            type: "perseus:interactive-graph-widget:rendered",
-            payload: {
-                type: "segment",
-                widgetType: "INTERACTIVE_GRAPH",
-                widgetId: "interactive-graph",
-            },
-        });
-        expect(onAnalyticsEventSpy).toHaveBeenNthCalledWith(2, {
+        expect(onAnalyticsEventSpy).toHaveBeenCalledWith({
             type: "perseus:widget:rendered:ti",
             payload: {
                 widgetSubType: "segment",

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -130,15 +130,6 @@ export const MafsGraph = (props: MafsGraphProps) => {
 
     useOnMountEffect(() => {
         analytics.onAnalyticsEvent({
-            // TODO(LEMS-2827): Remove analytics event in LEMS-2827 in favor of ti below.
-            type: "perseus:interactive-graph-widget:rendered",
-            payload: {
-                type,
-                widgetType: "INTERACTIVE_GRAPH",
-                widgetId: "interactive-graph",
-            },
-        });
-        analytics.onAnalyticsEvent({
             type: "perseus:widget:rendered:ti",
             payload: {
                 widgetSubType: type,


### PR DESCRIPTION
## Summary:
Removing the deprecated analytics event PerseusInteractiveGraphWidgetRendered, in favor of the PerseusWidgetRenderedTI event we've been using

Issue: LEMS-2827

## Test plan:
Run `pnpm test` should pass all tests.