### PR TITLE
will convert any relative url to always use khanacademy legacy as the base but won't convert absolutes

### DIFF
--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -1142,6 +1142,16 @@ class Renderer
         const apiOptions = this.getApiOptions();
         const imagePlaceholder = apiOptions.imagePlaceholder;
 
+        if (node.type === "link") {
+            // allow this to reroute on either .dev or .org
+            const legacyOrigin = new URL(document.baseURI).origin.replace(
+                "classroom.",
+                "",
+            );
+            node.target = new URL(node.target, legacyOrigin).href;
+            console.log(node.target);
+        }
+
         if (node.type === "widget") {
             const widgetPlaceholder = apiOptions.widgetPlaceholder;
 

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -1149,7 +1149,6 @@ class Renderer
                 "",
             );
             node.target = new URL(node.target, legacyOrigin).href;
-            console.log(node.target);
         }
 
         if (node.type === "widget") {


### PR DESCRIPTION
## Summary:
We want perseus content to route to legacy domain (rather than classroom) subdomain. Was able to confirm outputting as expected in storybook but unable to get local dev to use this version of perseus to confirm on local build of webapp. Will ask about how to do this Monday but headed out for evening. Tried to build using this: [this](https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/2072412231/Testing+Perseus+locally+in+Mobile) but didn't seem to take as even logs weren't outputting. 

Issue: [TUT-2621](https://khanacademy.atlassian.net/browse/TUT-2621)

## Test plan:

[TUT-2621]: https://khanacademy.atlassian.net/browse/TUT-2621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ