### PR TITLE
Schema change detection - change diff format

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -279,7 +279,7 @@ jobs:
                   # delimeter in the diff output doesn't cause problems.
                   DELIM=$(uuidgen)
                   echo "SCHEMA_DIFF<<$DELIM" >> "$GITHUB_OUTPUT"
-                  diff -u --context 3 ${{ runner.temp }}/schema-base.d.ts ${{ runner.temp }}/schema-pr.d.ts >> "$GITHUB_OUTPUT"
+                  diff --unified 3 ${{ runner.temp }}/schema-base.d.ts ${{ runner.temp }}/schema-pr.d.ts >> "$GITHUB_OUTPUT"
                   DIFF_EXIT_CODE=$? # Capture the exit code of diff
                   echo "$DELIM" >> "$GITHUB_OUTPUT"
                   echo "diff_exit_code=$DIFF_EXIT_CODE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -279,7 +279,7 @@ jobs:
                   # delimeter in the diff output doesn't cause problems.
                   DELIM=$(uuidgen)
                   echo "SCHEMA_DIFF<<$DELIM" >> "$GITHUB_OUTPUT"
-                  diff --unified 3 ${{ runner.temp }}/schema-base.d.ts ${{ runner.temp }}/schema-pr.d.ts >> "$GITHUB_OUTPUT"
+                  diff --unified ${{ runner.temp }}/schema-base.d.ts ${{ runner.temp }}/schema-pr.d.ts >> "$GITHUB_OUTPUT"
                   DIFF_EXIT_CODE=$? # Capture the exit code of diff
                   echo "$DELIM" >> "$GITHUB_OUTPUT"
                   echo "diff_exit_code=$DIFF_EXIT_CODE" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -279,7 +279,7 @@ jobs:
                   # delimeter in the diff output doesn't cause problems.
                   DELIM=$(uuidgen)
                   echo "SCHEMA_DIFF<<$DELIM" >> "$GITHUB_OUTPUT"
-                  diff -C 3 ${{ runner.temp }}/schema-base.d.ts ${{ runner.temp }}/schema-pr.d.ts >> "$GITHUB_OUTPUT"
+                  diff -u --context 3 ${{ runner.temp }}/schema-base.d.ts ${{ runner.temp }}/schema-pr.d.ts >> "$GITHUB_OUTPUT"
                   DIFF_EXIT_CODE=$? # Capture the exit code of diff
                   echo "$DELIM" >> "$GITHUB_OUTPUT"
                   echo "diff_exit_code=$DIFF_EXIT_CODE" >> "$GITHUB_OUTPUT"

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -527,6 +527,7 @@ export const PerseusExpressionAnswerFormConsidered = [
     "correct",
     "wrong",
     "ungraded",
+    "what-were-you-thinking",
 ] as const;
 
 export type PerseusExpressionAnswerForm = {
@@ -1247,7 +1248,7 @@ export type PerseusNumericInputAnswer = {
 
 export type PerseusNumberLineWidgetOptions = {
     // The position of the endpoints of the number line. Setting the range constrains the position of the answer and the labels.
-    range: number[];
+    range: string[];
     // This controls the position of the left / right labels. By default, the labels are set by the range.  Note:  Ensure that the labels line up with the tick marks, or it may be confusing for users.
     labelRange: Array<number | null>;
     // This controls the styling of the labels for the two main labels as well as all the tick mark labels, if applicable. Options: "decimal", "improper", "mixed", "non-reduced"
@@ -1283,7 +1284,7 @@ export type PerseusOrdererWidgetOptions = {
     // All of the options available to the user. Place the cards in the correct order. The same card can be used more than once in the answer but will only be displayed once at the top of a stack of identical cards.
     options: PerseusRenderer[];
     // The correct order of the options
-    correctOptions: PerseusRenderer[];
+    correctOptions?: PerseusRenderer[];
     // Cards that are not part of the answer
     otherOptions: PerseusRenderer[];
     // "normal" for text options.  "auto" for image options.
@@ -1324,8 +1325,6 @@ export const plotterPlotTypes = [
 export type PlotType = (typeof plotterPlotTypes)[number];
 
 export type PerseusPlotterWidgetOptions = {
-    // Translatable Text; The Axis labels. e.g. ["X Label", "Y Label"]
-    labels: string[];
     // Translatable Text; Categories to display along the X access.  e.g. [">0", ">6", ">12", ">18"]
     categories: string[];
     // The type of the graph. options "bar", "line", "pic", "histogram", "dotplot"

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -527,7 +527,6 @@ export const PerseusExpressionAnswerFormConsidered = [
     "correct",
     "wrong",
     "ungraded",
-    "what-were-you-thinking",
 ] as const;
 
 export type PerseusExpressionAnswerForm = {
@@ -1248,7 +1247,7 @@ export type PerseusNumericInputAnswer = {
 
 export type PerseusNumberLineWidgetOptions = {
     // The position of the endpoints of the number line. Setting the range constrains the position of the answer and the labels.
-    range: string[];
+    range: number[];
     // This controls the position of the left / right labels. By default, the labels are set by the range.  Note:  Ensure that the labels line up with the tick marks, or it may be confusing for users.
     labelRange: Array<number | null>;
     // This controls the styling of the labels for the two main labels as well as all the tick mark labels, if applicable. Options: "decimal", "improper", "mixed", "non-reduced"
@@ -1284,7 +1283,7 @@ export type PerseusOrdererWidgetOptions = {
     // All of the options available to the user. Place the cards in the correct order. The same card can be used more than once in the answer but will only be displayed once at the top of a stack of identical cards.
     options: PerseusRenderer[];
     // The correct order of the options
-    correctOptions?: PerseusRenderer[];
+    correctOptions: PerseusRenderer[];
     // Cards that are not part of the answer
     otherOptions: PerseusRenderer[];
     // "normal" for text options.  "auto" for image options.
@@ -1325,6 +1324,8 @@ export const plotterPlotTypes = [
 export type PlotType = (typeof plotterPlotTypes)[number];
 
 export type PerseusPlotterWidgetOptions = {
+    // Translatable Text; The Axis labels. e.g. ["X Label", "Y Label"]
+    labels: string[];
     // Translatable Text; Categories to display along the X access.  e.g. [">0", ">6", ">12", ">18"]
     categories: string[];
     // The type of the graph. options "bar", "line", "pic", "histogram", "dotplot"


### PR DESCRIPTION
## Summary:

A small PR to tweak the diff format used for schema change notices. Switching to `--unified` diffs makes for much clearer output.

Issue: <none>

## Test plan:

Compare output. Note that the change of `range` from `number[]` to `string[]` is split up in the **Before** but is together in the **After** (seems much more readable (to me at least)). 

| Before | After | 
| -- | -- |
| <img width="637" height="673" alt="image" src="https://github.com/user-attachments/assets/3c42cc21-d45b-4df5-8201-45ab40bfff9a" /> | <img width="907" height="806" alt="image" src="https://github.com/user-attachments/assets/e0643aef-2dd7-462b-9fe6-8e89ca573836" /> | 
