### PR TITLE
[Radio] | (CX) | Stop showing NOTA button if NOTA choice exists in the editor

### DIFF
--- a/.changeset/spotty-needles-divide.md
+++ b/.changeset/spotty-needles-divide.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Radio] | (CX) | Stop showing NOTA button if NOTA choice exists in the editor

--- a/packages/perseus-editor/src/widgets/__tests__/radio-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/radio-editor.test.tsx
@@ -236,6 +236,28 @@ describe("radio-editor", () => {
         expect(onChangeMock).not.toBeCalled();
     });
 
+    it("shows the 'None of the above' button when there is no 'None of the above' choice", async () => {
+        renderRadioEditor();
+        expect(
+            screen.getByRole("button", {name: "None of the above"}),
+        ).toBeInTheDocument();
+    });
+
+    it("hides the 'None of the above' button when there is a 'None of the above' choice", async () => {
+        renderRadioEditor(() => {}, {
+            choices: [
+                {content: "Choice 1", isNoneOfTheAbove: false},
+                {content: "Choice 2", isNoneOfTheAbove: false},
+                {content: "Choice 3", isNoneOfTheAbove: false},
+                {content: "None of the above", isNoneOfTheAbove: true},
+            ],
+            hasNoneOfTheAbove: true,
+        });
+        expect(
+            screen.queryByRole("button", {name: "None of the above"}),
+        ).not.toBeInTheDocument();
+    });
+
     it("serializes", () => {
         const editorRef = React.createRef<RadioEditor>();
 

--- a/packages/perseus-editor/src/widgets/radio/editor.tsx
+++ b/packages/perseus-editor/src/widgets/radio/editor.tsx
@@ -297,14 +297,16 @@ class RadioEditor extends React.Component<RadioEditorProps> {
                     >
                         Add a choice
                     </Button>
-                    <Button
-                        size="small"
-                        kind="tertiary"
-                        startIcon={plusIcon}
-                        onClick={this.addChoice.bind(this, true)}
-                    >
-                        None of the above
-                    </Button>
+                    {!this.props.hasNoneOfTheAbove && (
+                        <Button
+                            size="small"
+                            kind="tertiary"
+                            startIcon={plusIcon}
+                            onClick={this.addChoice.bind(this, true)}
+                        >
+                            None of the above
+                        </Button>
+                    )}
                 </div>
             </div>
         );


### PR DESCRIPTION
## Summary:
Redo of https://github.com/Khan/perseus/pull/2659 because it got messed up in an accidental merge.

Small update to new editor UI.

Right now, the editor allows the ability to add multiple "none of the above" choices.

In this PR, I'm hiding the "Add none of the above" button if there is already
a "none of the above" answer choice.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3229

## Test plan:
`pnpm jest packages/perseus-editor/src/widgets/__tests__/radio-editor.test.tsx`

Storybook
- http://localhost:6006/?path=/story/perseuseditor-editorpage-widgets-radio--multi-choice