### PR TITLE
docs(changeset): Bugfix to ensure Interactive Graph tooltips display points with the same granularity as the snapStep

### DIFF
--- a/.changeset/clever-melons-sparkle.md
+++ b/.changeset/clever-melons-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Bugfix to ensure Interactive Graph tooltips display points with the same granularity as the snapStep

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
@@ -5,6 +5,7 @@ import {MAX, MIN, X, Y} from "../math";
 import useGraphConfig from "../reducer/use-graph-config";
 
 import {
+    countSignificantDecimals,
     divideByAndShowPi,
     generateTickLocations,
     shouldShowLabel,
@@ -63,8 +64,9 @@ const YGridTick = ({
     // If the graph displays both the y and x axis lines within the graph, we want
     // to hide the label at -1 on the y-axis to prevent overlap with the x-axis label
     const showLabel = shouldShowLabel(y, range, tickStep);
+    const ySigfigs = countSignificantDecimals(tickStep);
 
-    const yLabel = showPi ? divideByAndShowPi(y) : y.toString();
+    const yLabel = showPi ? divideByAndShowPi(y) : y.toFixed(ySigfigs);
 
     return (
         <g className="tick" aria-hidden={true}>
@@ -87,10 +89,12 @@ const YGridTick = ({
 const XGridTick = ({
     x,
     range,
+    tickStep,
     showPi,
 }: {
     x: number;
     range: [Interval, Interval];
+    tickStep: number;
     // Whether to show the tick label as a multiple of pi
     showPi: boolean;
 }) => {
@@ -133,7 +137,9 @@ const XGridTick = ({
     const xPositionText = xPosition + xAdjustment;
     const yPositionText = yPosition + yAdjustment;
 
-    const xLabel = showPi ? divideByAndShowPi(x) : x.toString();
+    const xSigfigs = countSignificantDecimals(tickStep);
+
+    const xLabel = showPi ? divideByAndShowPi(x) : x.toFixed(xSigfigs);
 
     return (
         <g className="tick" aria-hidden={true}>
@@ -186,6 +192,7 @@ export const AxisTicks = () => {
                             x={x}
                             key={`x-grid-tick-${x}`}
                             range={range}
+                            tickStep={tickStep[X]}
                             // Show the tick labels as multiples of pi
                             // if the tick step is a multiple of pi.
                             showPi={tickStep[X] % Math.PI === 0}

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
@@ -65,8 +65,7 @@ const YGridTick = ({
     // to hide the label at -1 on the y-axis to prevent overlap with the x-axis label
     const showLabel = shouldShowLabel(y, range, tickStep);
 
-    // Due to floating point errors, we need to round the tick label to the
-    // same number of significant digits as the relevant tick step.
+    // Give all axis labels the same number of significant figures.
     const ySigfigs = countSignificantDecimals(tickStep);
     const yLabel = showPi ? divideByAndShowPi(y) : y.toFixed(ySigfigs);
 
@@ -139,8 +138,7 @@ const XGridTick = ({
     const xPositionText = xPosition + xAdjustment;
     const yPositionText = yPosition + yAdjustment;
 
-    // Due to floating point errors, we need to round the tick label to the
-    // same number of significant digits as the relevant tick step.
+    // Give all axis labels the same number of significant figures.
     const xSigfigs = countSignificantDecimals(tickStep);
     const xLabel = showPi ? divideByAndShowPi(x) : x.toFixed(xSigfigs);
 

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
@@ -64,8 +64,10 @@ const YGridTick = ({
     // If the graph displays both the y and x axis lines within the graph, we want
     // to hide the label at -1 on the y-axis to prevent overlap with the x-axis label
     const showLabel = shouldShowLabel(y, range, tickStep);
-    const ySigfigs = countSignificantDecimals(tickStep);
 
+    // Due to floating point errors, we need to round the tick label to the
+    // same number of significant digits as the relevant tick step.
+    const ySigfigs = countSignificantDecimals(tickStep);
     const yLabel = showPi ? divideByAndShowPi(y) : y.toFixed(ySigfigs);
 
     return (
@@ -137,8 +139,9 @@ const XGridTick = ({
     const xPositionText = xPosition + xAdjustment;
     const yPositionText = yPosition + yAdjustment;
 
+    // Due to floating point errors, we need to round the tick label to the
+    // same number of significant digits as the relevant tick step.
     const xSigfigs = countSignificantDecimals(tickStep);
-
     const xLabel = showPi ? divideByAndShowPi(x) : x.toFixed(xSigfigs);
 
     return (

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
@@ -66,8 +66,8 @@ const YGridTick = ({
     const showLabel = shouldShowLabel(y, range, tickStep);
 
     // Give all axis labels the same number of significant figures.
-    const ySigfigs = countSignificantDecimals(tickStep);
-    const yLabel = showPi ? divideByAndShowPi(y) : y.toFixed(ySigfigs);
+    const ySigFigs = countSignificantDecimals(tickStep);
+    const yLabel = showPi ? divideByAndShowPi(y) : y.toFixed(ySigFigs);
 
     return (
         <g className="tick" aria-hidden={true}>
@@ -139,8 +139,8 @@ const XGridTick = ({
     const yPositionText = yPosition + yAdjustment;
 
     // Give all axis labels the same number of significant figures.
-    const xSigfigs = countSignificantDecimals(tickStep);
-    const xLabel = showPi ? divideByAndShowPi(x) : x.toFixed(xSigfigs);
+    const xSigFigs = countSignificantDecimals(tickStep);
+    const xLabel = showPi ? divideByAndShowPi(x) : x.toFixed(xSigFigs);
 
     return (
         <g className="tick" aria-hidden={true}>

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -73,7 +73,7 @@ export const MovablePointView = forwardRef(
         const ySigFigs = countSignificantDecimals(snapStep[Y]);
         const xTickLabel = point[X].toFixed(xSigFigs);
         const yTickLabel = point[Y].toFixed(ySigFigs);
-        const pointTooltip = `(${xTickLabel}, ${yTickLabel})`;
+        const pointTooltipContent = `(${xTickLabel}, ${yTickLabel})`;
 
         const svgForPoint = (
             <g
@@ -117,7 +117,7 @@ export const MovablePointView = forwardRef(
                     <Tooltip
                         autoUpdate={true}
                         backgroundColor={wbColorName}
-                        content={pointTooltip}
+                        content={pointTooltipContent}
                         contentStyle={{color: "white"}}
                     >
                         {svgForPoint}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -2,6 +2,7 @@ import Tooltip from "@khanacademy/wonder-blocks-tooltip";
 import * as React from "react";
 import {forwardRef} from "react";
 
+import {countSignificantDecimals} from "../../backgrounds/utils";
 import {X, Y} from "../../math";
 import useGraphConfig from "../../reducer/use-graph-config";
 import {useTransformVectorsToPixels} from "../use-transform";
@@ -35,6 +36,7 @@ export const MovablePointView = forwardRef(
             showTooltips,
             interactiveColor,
             disableKeyboardInteraction,
+            snapStep,
         } = useGraphConfig();
         const {
             point,
@@ -64,6 +66,14 @@ export const MovablePointView = forwardRef(
         const [[x, y]] = useTransformVectorsToPixels(point);
 
         const showHairlines = (dragging || focused) && markings !== "none";
+
+        // Due to floating point errors, we need to round the point to the
+        // same number of significant digits as the tick step.
+        const xSigFigs = countSignificantDecimals(snapStep[X]);
+        const ySigFigs = countSignificantDecimals(snapStep[Y]);
+        const xTickLabel = point[X].toFixed(xSigFigs);
+        const yTickLabel = point[Y].toFixed(ySigFigs);
+        const pointTooltip = `(${xTickLabel}, ${yTickLabel})`;
 
         const svgForPoint = (
             <g
@@ -107,7 +117,7 @@ export const MovablePointView = forwardRef(
                     <Tooltip
                         autoUpdate={true}
                         backgroundColor={wbColorName}
-                        content={`(${point[X]}, ${point[Y]})`}
+                        content={pointTooltip}
                         contentStyle={{color: "white"}}
                     >
                         {svgForPoint}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -68,7 +68,7 @@ export const MovablePointView = forwardRef(
         const showHairlines = (dragging || focused) && markings !== "none";
 
         // Due to floating point errors, we need to round the point to the
-        // same number of significant digits as the tick step.
+        // same number of significant digits as the relevant snap step.
         const xSigFigs = countSignificantDecimals(snapStep[X]);
         const ySigFigs = countSignificantDecimals(snapStep[Y]);
         const xTickLabel = point[X].toFixed(xSigFigs);

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -121,6 +121,11 @@ class InteractiveGraphQuestionBuilder {
         return this;
     }
 
+    withTooltips(showTooltips: boolean): InteractiveGraphQuestionBuilder {
+        this.showTooltips = showTooltips;
+        return this;
+    }
+
     withStaticMode(staticMode: boolean): InteractiveGraphQuestionBuilder {
         this.staticMode = staticMode;
         return this;
@@ -171,11 +176,6 @@ class InteractiveGraphQuestionBuilder {
 
     withXRange(min: number, max: number): InteractiveGraphQuestionBuilder {
         this.xRange = [min, max];
-        return this;
-    }
-
-    withTooltips(showTooltips: boolean): InteractiveGraphQuestionBuilder {
-        this.showTooltips = showTooltips;
         return this;
     }
 

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -66,6 +66,7 @@ class InteractiveGraphQuestionBuilder {
     private snapStep: vec.Vector2 = [0.5, 0.5];
     private tickStep: vec.Vector2 = [1, 1];
     private showProtractor: boolean = false;
+    private showTooltips: boolean = false;
     private interactiveFigureConfig: InteractiveFigureConfig =
         new SegmentGraphConfig();
     private lockedFigures: LockedFigure[] = [];
@@ -95,6 +96,7 @@ class InteractiveGraphQuestionBuilder {
                         snapStep: this.snapStep,
                         step: this.tickStep,
                         lockedFigures: this.lockedFigures,
+                        showTooltips: this.showTooltips,
                     },
                     type: "interactive-graph",
                 },
@@ -169,6 +171,11 @@ class InteractiveGraphQuestionBuilder {
 
     withXRange(min: number, max: number): InteractiveGraphQuestionBuilder {
         this.xRange = [min, max];
+        return this;
+    }
+
+    withTooltips(showTooltips: boolean): InteractiveGraphQuestionBuilder {
+        this.showTooltips = showTooltips;
         return this;
     }
 

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-regression.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-regression.stories.tsx
@@ -433,6 +433,20 @@ export const LockedFiguresWithThickWeight: Story = {
     },
 };
 
+export const TooltipsWithFloatingPointIssues: Story = {
+    args: {
+        question: interactiveGraphQuestionBuilder()
+            .withPoints(5)
+            .withTooltips(true)
+            .withXRange(0, 5)
+            .withYRange(0, 3)
+            .withTickStep(1, 0.5)
+            .withGridStep(1, 0.1)
+            .withSnapStep(0.5, 0.1)
+            .build(),
+    },
+};
+
 function MafsQuestionRenderer(props: {question: PerseusRenderer}) {
     const {question} = props;
     return (

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-regression.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-regression.stories.tsx
@@ -8,6 +8,7 @@ import * as React from "react";
 import {ApiOptions} from "../../perseus-api";
 import Renderer from "../../renderer";
 import {mockStrings} from "../../strings";
+import UserInputManager from "../../user-input-manager";
 
 import {interactiveGraphQuestionBuilder} from "./interactive-graph-question-builder";
 import {sinusoidWithPiTicks} from "./interactive-graph.testdata";
@@ -450,12 +451,19 @@ export const TooltipsWithFloatingPointIssues: Story = {
 function MafsQuestionRenderer(props: {question: PerseusRenderer}) {
     const {question} = props;
     return (
-        <Renderer
-            strings={mockStrings}
-            content={question.content}
-            widgets={question.widgets}
-            images={question.images}
-            apiOptions={ApiOptions.defaults}
-        />
+        <UserInputManager widgets={question.widgets} problemNum={0}>
+            {({userInput, handleUserInput, initializeUserInput}) => (
+                <Renderer
+                    userInput={userInput}
+                    handleUserInput={handleUserInput}
+                    initializeUserInput={initializeUserInput}
+                    strings={mockStrings}
+                    content={question.content}
+                    widgets={question.widgets}
+                    images={question.images}
+                    apiOptions={ApiOptions.defaults}
+                />
+            )}
+        </UserInputManager>
     );
 }

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-regression.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-regression.stories.tsx
@@ -434,20 +434,6 @@ export const LockedFiguresWithThickWeight: Story = {
     },
 };
 
-export const TooltipsWithFloatingPointIssues: Story = {
-    args: {
-        question: interactiveGraphQuestionBuilder()
-            .withPoints(5)
-            .withTooltips(true)
-            .withXRange(0, 5)
-            .withYRange(0, 3)
-            .withTickStep(1, 0.5)
-            .withGridStep(1, 0.1)
-            .withSnapStep(0.5, 0.1)
-            .build(),
-    },
-};
-
 function MafsQuestionRenderer(props: {question: PerseusRenderer}) {
     const {question} = props;
     return (

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.stories.tsx
@@ -27,6 +27,7 @@ import {
     staticGraphQuestionWithAnotherWidget,
     segmentWithLockedLabels,
     unlimitedPolygonQuestion,
+    floatingPointIssueQuestion,
 } from "./interactive-graph.testdata";
 
 import type {Meta, StoryObj} from "@storybook/react-vite";
@@ -203,6 +204,14 @@ export const StaticGraphWithAnotherWidget: Story = {
     args: {
         item: generateTestPerseusItem({
             question: staticGraphQuestionWithAnotherWidget(),
+        }),
+    },
+};
+
+export const TooltipsWithFloatingPointIssues: Story = {
+    args: {
+        item: generateTestPerseusItem({
+            question: floatingPointIssueQuestion,
         }),
     },
 };

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -106,6 +106,17 @@ export const pointQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
     })
     .build();
 
+export const floatingPointIssueQuestion: PerseusRenderer =
+    interactiveGraphQuestionBuilder()
+        .withPoints(5)
+        .withTooltips(true)
+        .withXRange(0, 5)
+        .withYRange(0, 3)
+        .withTickStep(1, 0.5)
+        .withGridStep(1, 0.1)
+        .withSnapStep(0.5, 0.1)
+        .build();
+
 export const pointQuestionWithDefaultCorrect: PerseusRenderer =
     interactiveGraphQuestionBuilder().withPoints(1).build();
 


### PR DESCRIPTION
## Summary:
We've had bugs in Interactive Graph where certain labels are hitting the Javascript floating point issues. 

LEMS-3241
This PR fixes the floating point bug related to the point labels by ensuring that we're always showing the same number of significant digits as the snap step. This ensures that the labels are always a consistent length.

LEMS-3216
This PR also fixes LEMS-3216 with a very similar solution, in order to ensure the tick steps all have the same number of sig figs. 

Additionally, there's a minor bug-fix that was snuck in here to help fix a regression in a testing tool that's necessary to properly recreate some of these issues. All that was required to fix the issue was wrapping the new UserInputManager around the renderer in the interactive graph regression story file. 

Issue: LEMS-3241, LEMS-3216

## Test plan:
- New graph view for manual testing 