### PR TITLE
[Interactive Graph] Show min tick when axis doesn't go through it

### DIFF
--- a/.changeset/old-geese-shop.md
+++ b/.changeset/old-geese-shop.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Interactive Graph] Show min tick when axis doesn't go through it

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.test.ts
@@ -9,21 +9,50 @@ import type {Interval} from "mafs";
 
 describe("generateTickLocations", () => {
     it("should generate ticks from the origin", () => {
-        expect(generateTickLocations(10, 0, 100)).toEqual([
+        // Start from second tick (10) when the other axis min is negative
+        expect(generateTickLocations(10, 0, 100, -10)).toEqual([
             10, 20, 30, 40, 50, 60, 70, 80, 90,
         ]);
     });
 
     it("should generate ticks from the origin including negative", () => {
-        expect(generateTickLocations(10, -100, 100)).toEqual([
+        expect(generateTickLocations(10, -100, 100, -10)).toEqual([
             10, 20, 30, 40, 50, 60, 70, 80, 90, -10, -20, -30, -40, -50, -60,
             -70, -80, -90,
         ]);
     });
 
     it("should generate ticks from the origin for odd steps", () => {
-        expect(generateTickLocations(3, -10, 10)).toEqual([
+        expect(generateTickLocations(3, -10, 10, -10)).toEqual([
             3, 6, 9, -3, -6, -9,
+        ]);
+    });
+
+    it("should generate the 0 minimum tick when the other axis min is 0", () => {
+        // Generate ticks from 0 to 100 with a step of 10
+        expect(generateTickLocations(10, 0, 100, 0)).toEqual([
+            0, 10, 20, 30, 40, 50, 60, 70, 80, 90,
+        ]);
+    });
+
+    it("should generate the 0 minimum tick when the other axis min is positive", () => {
+        // Generate ticks from 0 to 100 with a step of 10
+        expect(generateTickLocations(10, 0, 100, 10)).toEqual([
+            0, 10, 20, 30, 40, 50, 60, 70, 80, 90,
+        ]);
+    });
+
+    it("should generate the positive minimum tick when the other axis min is 0", () => {
+        // Generate ticks from 20 to 100 with a step of 10
+        expect(generateTickLocations(10, 20, 100, 0)).toEqual([
+            20, 30, 40, 50, 60, 70, 80, 90,
+        ]);
+    });
+
+    it("should generate the positive minimum tick when the other axis min is positive", () => {
+        // Generate ticks from 20 to 100 with a step of 10
+        expect(generateTickLocations(10, 20, 100, 10)).toEqual([
+            20, 30, 40, 50, 60, 70, 80, 90,
         ]);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
@@ -159,8 +159,8 @@ export const AxisTicks = () => {
     const [xTickStep, yTickStep] = tickStep;
 
     // Generate the tick locations & labels for the x and y axes
-    const yGridTicks = generateTickLocations(yTickStep, yMin, yMax);
-    const xGridTicks = generateTickLocations(xTickStep, xMin, xMax);
+    const yGridTicks = generateTickLocations(yTickStep, yMin, yMax, xMin);
+    const xGridTicks = generateTickLocations(xTickStep, xMin, xMax, yMin);
 
     return (
         <g className="axis-ticks" role="presentation">

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/utils.ts
@@ -189,6 +189,12 @@ export const shouldShowLabel = (
     range: [Interval, Interval],
     tickStep: number,
 ) => {
+    // We want to show 0 if there's space for it.
+    // console.log(currentTick, range[X][MIN], range[X][MAX]);
+    // if (currentTick === 0 && range[X][MIN] >= 0) {
+    //     return true;
+    // }
+
     let showLabel = true;
 
     // If the y-axis is within the graph and currentTick equals -tickStep, hide the label
@@ -207,6 +213,7 @@ export function generateTickLocations(
     tickStep: number,
     min: number,
     max: number,
+    otherAxisMin: number,
 ): number[] {
     const ticks: number[] = [];
 
@@ -216,7 +223,14 @@ export function generateTickLocations(
 
     // Add ticks in the positive direction
     const start = Math.max(min, 0);
-    for (let i = start + tickStep; i < max; i += tickStep) {
+
+    // We need to offset by the tickStep to start at the second tick to avoid
+    // having the label overlap with the axis. However, this is not necessary
+    // when the min of the other axis is larger than the cartesian origin point
+    // (0,0) and therefore not going through the starting tick label.
+    const startOffset = otherAxisMin >= 0 ? 0 : tickStep;
+
+    for (let i = start + startOffset; i < max; i += tickStep) {
         // Match to the same number of decimal places as the tick step
         // to avoid floating point errors when working with small numbers
         ticks.push(parseFloat(i.toFixed(decimalSigFigs)));

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/utils.ts
@@ -189,12 +189,6 @@ export const shouldShowLabel = (
     range: [Interval, Interval],
     tickStep: number,
 ) => {
-    // We want to show 0 if there's space for it.
-    // console.log(currentTick, range[X][MIN], range[X][MAX]);
-    // if (currentTick === 0 && range[X][MIN] >= 0) {
-    //     return true;
-    // }
-
     let showLabel = true;
 
     // If the y-axis is within the graph and currentTick equals -tickStep, hide the label


### PR DESCRIPTION
## Summary:
Right now, the minimum tick is usually ommitted to make space for the axis.
However, this is not necessary if the axis doesn't go through this spot.

We got a request from content to show the 0s if possible in a 0-start graph,
and this can easily done by just checking for this case.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3214

| Before | After |
| --- | --- |
| <img width="542" height="531" alt="Screenshot 2025-07-23 at 4 38 51 PM" src="https://github.com/user-attachments/assets/8f0efa91-8018-4e4b-a323-a2a6888aac57" /> | <img width="528" height="523" alt="Screenshot 2025-07-23 at 4 38 55 PM" src="https://github.com/user-attachments/assets/b23c8295-4139-4bb7-8e85-72e4f230d379" /> |


## Test plan:
`pnpm jest packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.test.ts`

Storybook
- http://localhost:6006/?path=/story/perseus-widgets-interactive-graph-visual-regression-tests--mafs-with-y-axis-at-left
- http://localhost:6006/?path=/story/perseus-widgets-interactive-graph-visual-regression-tests--mafs-with-y-axis-at-right
- http://localhost:6006/?path=/story/perseus-widgets-interactive-graph-visual-regression-tests--mafs-with-x-axis-at-bottom
- http://localhost:6006/?path=/story/perseus-widgets-interactive-graph-visual-regression-tests--mafs-with-x-axis-off-top
- http://localhost:6006/?path=/story/perseus-widgets-interactive-graph-visual-regression-tests--mafs-with-labels-along-edge-at-left