### PR TITLE
Bugfix: fix hints in GradedGroups

### DIFF
--- a/.changeset/long-moose-refuse.md
+++ b/.changeset/long-moose-refuse.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Bugfix: undefined widget property in hint

--- a/packages/perseus-editor/src/hint-editor.tsx
+++ b/packages/perseus-editor/src/hint-editor.tsx
@@ -25,7 +25,11 @@ import type {
     DeviceType,
     ImageUploader,
 } from "@khanacademy/perseus";
-import type {Hint, PerseusWidgetsMap} from "@khanacademy/perseus-core";
+import type {
+    Hint,
+    PerseusRenderer,
+    PerseusWidgetsMap,
+} from "@khanacademy/perseus-core";
 
 const {InfoTip, InlineIcon} = components;
 
@@ -366,9 +370,8 @@ class CombinedHintsEditor extends React.Component<CombinedHintsEditorProps> {
     };
 
     addHint: () => void = () => {
-        const hints = this.props.hints.concat([
-            {content: "", images: {}, widgets: {}},
-        ]);
+        const hint: PerseusRenderer = {content: "", images: {}, widgets: {}};
+        const hints = [...this.props.hints, hint];
         this.props.onChange({hints: hints}, () => {
             const i = hints.length - 1;
             // eslint-disable-next-line react/no-string-refs

--- a/packages/perseus-editor/src/widgets/__tests__/graded-group-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/graded-group-editor.test.tsx
@@ -1,0 +1,53 @@
+import {Dependencies} from "@khanacademy/perseus";
+import {render, screen} from "@testing-library/react";
+import {userEvent as userEventLib} from "@testing-library/user-event";
+import * as React from "react";
+
+import {testDependencies} from "../../../../../testing/test-dependencies";
+import GradedGroupEditor from "../graded-group-editor";
+
+import type {PerseusRenderer} from "@khanacademy/perseus-core";
+import type {UserEvent} from "@testing-library/user-event";
+
+describe("GradedGroupEditor", () => {
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("should render", async () => {
+        render(<GradedGroupEditor onChange={() => undefined} />);
+
+        expect(
+            await screen.findByText("Graded Groups should contain a prompt"),
+        ).toBeInTheDocument();
+    });
+
+    /**
+     * Regression LEMS-3321: make sure a hint is a full PerseusRenderer
+     */
+    it("should add a full Renderer for a hint", async () => {
+        const onChangeMock = jest.fn();
+
+        render(<GradedGroupEditor onChange={onChangeMock} />);
+        await userEvent.click(screen.getByRole("button", {name: "Add a hint"}));
+
+        const expected: PerseusRenderer = {
+            content: "",
+            images: {},
+            widgets: {},
+        };
+
+        expect(onChangeMock).toHaveBeenCalledWith(
+            {hint: expected},
+            // this is just the changeable callback
+            expect.any(Function),
+        );
+    });
+});

--- a/packages/perseus-editor/src/widgets/graded-group-editor.tsx
+++ b/packages/perseus-editor/src/widgets/graded-group-editor.tsx
@@ -15,7 +15,10 @@ import _ from "underscore";
 import Editor from "../editor";
 import {iconPlus} from "../styles/icon-paths";
 
-import type {GradedGroupDefaultWidgetOptions} from "@khanacademy/perseus-core";
+import type {
+    GradedGroupDefaultWidgetOptions,
+    PerseusRenderer,
+} from "@khanacademy/perseus-core";
 
 const {InlineIcon, TextInput} = components;
 
@@ -44,7 +47,7 @@ class GradedGroupEditor extends React.Component<Props> {
     };
 
     handleAddHint: () => void = () => {
-        const hint = {content: "", images: {}, widgets: {}};
+        const hint: PerseusRenderer = {content: "", images: {}, widgets: {}};
         this.props.onChange({hint}, () => {
             this.hintEditor.current?.focus();
         });

--- a/packages/perseus-editor/src/widgets/graded-group-editor.tsx
+++ b/packages/perseus-editor/src/widgets/graded-group-editor.tsx
@@ -44,7 +44,7 @@ class GradedGroupEditor extends React.Component<Props> {
     };
 
     handleAddHint: () => void = () => {
-        const hint = {content: ""} as const;
+        const hint = {content: "", images: {}, widgets: {}};
         this.props.onChange({hint}, () => {
             this.hintEditor.current?.focus();
         });

--- a/packages/perseus/src/user-input-manager.test.tsx
+++ b/packages/perseus/src/user-input-manager.test.tsx
@@ -132,6 +132,15 @@ describe("sharedInitializeUserInput", () => {
             },
         });
     });
+
+    /**
+     * Regression LEMS-3321: this is a safety net if for some reason
+     * a PerseusRenderer doesn't happen to have `widgets` which is a
+     * bug we ran into.
+     */
+    it("handles undefined widget options", () => {
+        expect(sharedInitializeUserInput(undefined, 0)).toEqual({});
+    });
 });
 
 describe("UserInputManager", () => {

--- a/packages/perseus/src/user-input-manager.tsx
+++ b/packages/perseus/src/user-input-manager.tsx
@@ -46,10 +46,15 @@ type Props = {
  *   (which is why we need problemNum since it's the seed)
  */
 export function sharedInitializeUserInput(
-    widgetOptions: PerseusWidgetsMap,
+    widgetOptions: PerseusWidgetsMap | undefined,
     problemNum: number,
 ): UserInputMap {
     const startUserInput: UserInputMap = {};
+
+    if (!widgetOptions) {
+        return startUserInput;
+    }
+
     Object.entries(widgetOptions).forEach(([id, widgetInfo]) => {
         const widgetExports = Widgets.getWidgetExport(widgetInfo.type);
         if (widgetInfo.static && widgetExports?.getCorrectUserInput) {


### PR DESCRIPTION
## Summary:

So this was a little weird. I went through the repro steps, got the JSON, copy/pasted it, and gave it a `PerseusArticle` type. According to the type, the editor was making invalid JSON:

``` JSON
"hint": {
  "content": "((Hint))"
},
```

A hint is supposed to be a `PerseusRenderer` and that requires `widgets` and `images`. I think this was a long-time bug that just never showed itself:

``` TS
// hint-editor.tsx
// note it's a full PerseusRenderer 
const hints = this.props.hints.concat([
  {content: "", images: {}, widgets: {}},
]);

// graded-group-editor.tsx
// note it's an incomplete PerseusRenderer
const hint = {content: ""} as const;
```

Anyway, the reason this bug manifested now is: `PerseusRenderer` is supposed to have `widgets` and my new code was expecting `PerseusRenderer` to have `widgets`. So I also made my code more resilient.

Issue: LEMS-3321

## Test plan:

1. Navigate to [Khan Academy](https://www.khanacademy.org/devadmin/content/articles/dsat--practice-test--10-m-2/x90fb23c3f0cae50d#) 
2. Scroll down to Question 2
3. Add a hint to the Graded Group widget 
4. Type some text in the hint input (with no widgets)
5. In the preview, click Explain

Before: we would throw
After: we should not throw

I also added unit tests.