### PR TITLE
docs(changeset): Bugfix for regression that causes keypad to no longer work in graded groups.

### DIFF
--- a/.changeset/slimy-sloths-listen.md
+++ b/.changeset/slimy-sloths-listen.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Bugfix for regression that causes keypad to no longer work in graded groups.

--- a/packages/perseus/src/widgets/graded-group/graded-group.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.tsx
@@ -322,6 +322,7 @@ export class GradedGroup
                             //     });
                             // }}
                             ref={this.rendererRef}
+                            keypadElement={this.props.keypadElement}
                             apiOptions={{...apiOptions, readOnly}}
                             showSolutions={showSolutions}
                             linterContext={this.props.linterContext}


### PR DESCRIPTION
## Summary:
A regression was introduced recently while implementing a new approach to user input, which also gave us greater specificity into which props we were passing down into the renderer. However, the `keypadElement` was hidden in that `this.props` monolith, and was no longer being provided to the Graded Group widget. This PR adds it back. 

You can test this by comparing the following two storybook pages. (Make sure to turn on mobile mode)

Production: https://khan.github.io/perseus/?path=/docs/widgets-graded-group-set--docs
This PR: https://650db21c3f5d1b2f13c02952-rikyqkpyck.chromatic.com/?path=/docs/widgets-graded-group-set--docs

Issue: LEMS-3324 

## Test plan:
- Tests pass 