### PR TITLE
[Radio] | (CX) | Add dynamically resizing text areas to Radio editor UI

### DIFF
--- a/.changeset/honest-ghosts-attend.md
+++ b/.changeset/honest-ghosts-attend.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Radio] | (CX) | Add dynamically resizing text areas to Radio editor UI

--- a/packages/perseus-editor/src/widgets/radio/auto-resizing-text-area.tsx
+++ b/packages/perseus-editor/src/widgets/radio/auto-resizing-text-area.tsx
@@ -1,0 +1,40 @@
+import {TextArea} from "@khanacademy/wonder-blocks-form";
+import * as React from "react";
+
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
+
+type TextAreaProps = Omit<PropsFor<typeof TextArea>, "rows">;
+
+// TODO(3326): Remove this whole component once WB TextArea supports
+// dynamic resizing.
+export const AutoResizingTextArea = (props: TextAreaProps) => {
+    const textAreaRef = React.useRef<HTMLTextAreaElement>(null);
+
+    React.useEffect(() => {
+        function adjustHeight() {
+            const textArea = textAreaRef.current;
+            if (textArea) {
+                // Reset the height to get the correct scrollHeight.
+                // 42px is the default height of the Wonder Blocks TextArea
+                // when it has one row.
+                textArea.style.height = "42px";
+                // Set height to scrollHeight to fit all content.
+                textArea.style.height = `${textArea.scrollHeight}px`;
+            }
+        }
+
+        adjustHeight();
+    }, [props.value]);
+
+    return (
+        <TextArea
+            {...props}
+            ref={textAreaRef}
+            resizeType="none"
+            style={{
+                overflow: "hidden",
+                ...props.style,
+            }}
+        />
+    );
+};

--- a/packages/perseus-editor/src/widgets/radio/auto-resizing-text-area.tsx
+++ b/packages/perseus-editor/src/widgets/radio/auto-resizing-text-area.tsx
@@ -11,19 +11,15 @@ export const AutoResizingTextArea = (props: TextAreaProps) => {
     const textAreaRef = React.useRef<HTMLTextAreaElement>(null);
 
     React.useEffect(() => {
-        function adjustHeight() {
-            const textArea = textAreaRef.current;
-            if (textArea) {
-                // Reset the height to get the correct scrollHeight.
-                // 42px is the default height of the Wonder Blocks TextArea
-                // when it has one row.
-                textArea.style.height = "42px";
-                // Set height to scrollHeight to fit all content.
-                textArea.style.height = `${textArea.scrollHeight}px`;
-            }
+        const textArea = textAreaRef.current;
+        if (textArea) {
+            // Reset the height to get the correct scrollHeight.
+            // 42px is the default height of the Wonder Blocks TextArea
+            // when it has one row.
+            textArea.style.height = "42px";
+            // Set height to scrollHeight to fit all content.
+            textArea.style.height = `${textArea.scrollHeight}px`;
         }
-
-        adjustHeight();
     }, [props.value]);
 
     return (

--- a/packages/perseus-editor/src/widgets/radio/radio-editor.module.css
+++ b/packages/perseus-editor/src/widgets/radio/radio-editor.module.css
@@ -11,10 +11,6 @@
     margin-block-end: 12px;
 }
 
-.content-heading {
-    margin-block-end: 1.2rem;
-}
-
 .radio-option-actions-container {
     display: flex;
     flex-direction: row;

--- a/packages/perseus-editor/src/widgets/radio/radio-option-settings.tsx
+++ b/packages/perseus-editor/src/widgets/radio/radio-option-settings.tsx
@@ -1,9 +1,9 @@
-import {TextArea} from "@khanacademy/wonder-blocks-form";
 import Pill from "@khanacademy/wonder-blocks-pill";
 import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {HeadingXSmall} from "@khanacademy/wonder-blocks-typography";
 import * as React from "react";
 
+import {AutoResizingTextArea} from "./auto-resizing-text-area";
 import styles from "./radio-editor.module.css";
 import {RadioOptionSettingsActions} from "./radio-option-settings-actions";
 import {RadioStatusPill} from "./radio-status-pill";
@@ -37,6 +37,9 @@ export function RadioOptionSettings({
     onMove,
 }: RadioOptionSettingsProps) {
     const {content, rationale, correct, isNoneOfTheAbove} = choice;
+    const uniqueId = React.useId();
+    const contentTextAreaId = `${uniqueId}-content-textarea`;
+    const rationaleTextAreaId = `${uniqueId}-rationale-textarea`;
 
     return (
         <div className={styles.tile}>
@@ -93,32 +96,25 @@ export function RadioOptionSettings({
             </fieldset>
 
             {/* Content and rationale text areas */}
-            <HeadingXSmall tag="label" className={styles.contentHeading}>
+            <HeadingXSmall tag="label" htmlFor={contentTextAreaId}>
                 Content
-                <TextArea
-                    value={isNoneOfTheAbove ? "None of the above" : content}
-                    disabled={isNoneOfTheAbove}
-                    placeholder="Type a choice here..."
-                    // This unfortunately doesn't match the dynamic resizing
-                    // behavior that it had before, but we should be able to add
-                    // that in after WB-1843 is completed.
-                    resizeType="vertical"
-                    rows={1}
-                    onChange={(value) => {
-                        onContentChange(index, value);
-                    }}
-                />
             </HeadingXSmall>
-            <HeadingXSmall tag="label">
+            <AutoResizingTextArea
+                id={contentTextAreaId}
+                value={isNoneOfTheAbove ? "None of the above" : content}
+                disabled={isNoneOfTheAbove}
+                placeholder="Type a choice here..."
+                onChange={(value) => {
+                    onContentChange(index, value);
+                }}
+                style={{marginBlockEnd: sizing.size_080}}
+            />
+            <HeadingXSmall tag="label" htmlFor={rationaleTextAreaId}>
                 Rationale
-                <TextArea
+                <AutoResizingTextArea
+                    id={rationaleTextAreaId}
                     value={rationale ?? ""}
                     placeholder={`Why is this choice ${correct ? "correct" : "incorrect"}?`}
-                    // This unfortunately doesn't match the dynamic resizing
-                    // behavior that it had before, but we should be able to add
-                    // that in after WB-1843 is completed.
-                    resizeType="vertical"
-                    rows={1}
                     onChange={(value) => {
                         onRationaleChange(index, value);
                     }}


### PR DESCRIPTION
## Summary:
We got a request from content authors to dynamically resize the text area as they type
so that they don't have to manually resize the text area all the time.

There is actually already a ticket for this in Wonder Blocks for Wonder Blocks TextArea,
but I have this quick solution in the meantime. I put a TODO to make sure that we use WB
whenever it's ready.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3327

## Before:

https://github.com/user-attachments/assets/ad67e558-e0db-474d-9f3a-38d51ba4faa4

## After:

https://github.com/user-attachments/assets/897470e2-e051-48df-8347-ab9a53c1c75e

## Test plan:
Unfortunately there isn't really a way to unit test styles...?

Storybook
- http://localhost:6006/?path=/docs/widgets-radio-editor-demo--docs#single-choice-2
- Type a bunch of stuff in `content` and `rationale` text areas
- Confirm that they dynamically resize with new lines
- select all and delete everything
- Confirm that the text areas dynamically resize back down to one row