### PR TITLE
Remove JSON mode checkbox from EditorPage

### DIFF
--- a/.changeset/green-spiders-jam.md
+++ b/.changeset/green-spiders-jam.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Stop passing jsonMode to onChange callback of EditorPage. This was almost certainly a bug. Nothing in webapp was using this behavior, but if it had been, extra jsonMode properties would have been written into assessmentItem data

--- a/packages/perseus-editor/src/__docs__/editor-page-with-storybook-preview.tsx
+++ b/packages/perseus-editor/src/__docs__/editor-page-with-storybook-preview.tsx
@@ -55,7 +55,9 @@ function EditorPageWithStorybookPreview(props: Props) {
                 <input
                     type="checkbox"
                     checked={jsonMode}
-                    onChange={(event) => setJsonMode(event.currentTarget.checked)}
+                    onChange={(event) =>
+                        setJsonMode(event.currentTarget.checked)
+                    }
                 />
             </label>
             <EditorPage

--- a/packages/perseus-editor/src/__docs__/editor-page-with-storybook-preview.tsx
+++ b/packages/perseus-editor/src/__docs__/editor-page-with-storybook-preview.tsx
@@ -31,7 +31,7 @@ const onChangeAction = action("onChange");
 function EditorPageWithStorybookPreview(props: Props) {
     const [previewDevice, setPreviewDevice] =
         React.useState<DeviceType>("phone");
-    const [jsonMode, setJsonMode] = React.useState<boolean | undefined>(false);
+    const [jsonMode, setJsonMode] = React.useState(false);
     const [answerArea, setAnswerArea] = React.useState<
         PerseusAnswerArea | undefined | null
     >();
@@ -50,6 +50,14 @@ function EditorPageWithStorybookPreview(props: Props) {
 
     return (
         <View>
+            <label>
+                Developer JSON Mode:{" "}
+                <input
+                    type="checkbox"
+                    checked={jsonMode}
+                    onChange={(event) => setJsonMode(event.currentTarget.checked)}
+                />
+            </label>
             <EditorPage
                 apiOptions={apiOptions}
                 previewDevice={previewDevice}
@@ -66,9 +74,6 @@ function EditorPageWithStorybookPreview(props: Props) {
                 onChange={(props) => {
                     onChangeAction(props);
 
-                    if ("jsonMode" in props) {
-                        setJsonMode(props.jsonMode);
-                    }
                     if ("answerArea" in props) {
                         setAnswerArea(props.answerArea);
                     }

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -132,19 +132,6 @@ class EditorPage extends React.Component<Props, State> {
         this._isMounted = false;
     }
 
-    toggleJsonMode: () => void = () => {
-        this.setState(
-            {
-                json: this.serialize({keepDeletedWidgets: true}),
-            },
-            () => {
-                this.props.onChange({
-                    jsonMode: !this.props.jsonMode,
-                });
-            },
-        );
-    };
-
     updateRenderer() {
         // Some widgets (namely the image widget) like to call onChange before
         // anything has actually been mounted, which causes problems here. We
@@ -237,20 +224,6 @@ class EditorPage extends React.Component<Props, State> {
         return (
             <div id="perseus" className={className}>
                 <div style={{marginBottom: 10}}>
-                    {this.props.developerMode && (
-                        <span>
-                            <label>
-                                {" "}
-                                Developer JSON Mode:{" "}
-                                <input
-                                    type="checkbox"
-                                    checked={this.props.jsonMode}
-                                    onChange={this.toggleJsonMode}
-                                />
-                            </label>{" "}
-                        </span>
-                    )}
-
                     {!this.props.jsonMode && (
                         <ViewportResizer
                             deviceType={this.props.previewDevice}

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -34,8 +34,6 @@ type Props = {
     answerArea?: PerseusAnswerArea | null; // related to the question,
     // TODO(CP-4838): Should this be a required prop?
     contentPaths?: ReadonlyArray<string>;
-    /** "Power user" mode. Shows the raw JSON of the question. */
-    developerMode: boolean;
     hints?: ReadonlyArray<Hint>; // related to the question,
     /** A function which takes a file object (guaranteed to be an image) and
      * a callback, then calls the callback with the url where the image
@@ -45,11 +43,22 @@ type Props = {
     imageUploader?: ImageUploader;
     /** The content ID of the AssessmentItem being edited. */
     itemId: string;
-    /** Whether the question is displaying as JSON or if it is
-     * showing the editor itself with the rendering
-     * Only used in the perseus demos. Consider removing.
+    /**
+     * If both jsonMode and developerMode are true, an editable text box with
+     * the item JSON is displayed. If either jsonMode or developerMode is
+     * false, the regular editor GUI is hidden.
+     *
+     * @see {@linkcode Props.developerMode}
      */
     jsonMode: boolean;
+    /**
+     * If both jsonMode and developerMode are true, an editable text box with
+     * the item JSON is displayed. If either jsonMode or developerMode is
+     * false, the regular editor GUI is hidden.
+     *
+     * @see {@linkcode Props.jsonMode}
+     */
+    developerMode: boolean;
     /** A function which is called with the new JSON blob of content. */
     onChange: ChangeHandler;
     /** A function which is called when the preview device changes. */

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -204,6 +204,7 @@ class EditorPage extends React.Component<Props, State> {
     handleChange: ChangeHandler = (toChange, cb, silent) => {
         const newProps = _(this.props).pick("question", "hints", "answerArea");
         _(newProps).extend(toChange);
+        this.setState({json: this.serialize()});
         this.props.onChange(newProps, cb, silent);
     };
 


### PR DESCRIPTION
While investigating how we might parse/migrate PerseusItem data before emitting
it from the editor, I noticed this weird `jsonMode` param in the `onChange`
callback. Nothing in webapp seems to be using it, so I'd just as soon remove
it. It's a footgun.

Issue: none

## Test plan:

```
pnpm storybook
open http://localhost:6006
```

View the EditorPage stories.