### PR TITLE
[Radio] | (DX) | Add null check in radio.ff.tsx

### DIFF
--- a/.changeset/thick-pots-relax.md
+++ b/.changeset/thick-pots-relax.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Radio] | (DX) | Fix storybook preview

--- a/.changeset/thick-pots-relax.md
+++ b/.changeset/thick-pots-relax.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus": patch
 ---
 
-[Radio] | (DX) | Fix storybook preview
+[Radio] | (DX) | Add null check in radio.ff.tsx

--- a/packages/perseus/src/widgets/radio/radio.ff.tsx
+++ b/packages/perseus/src/widgets/radio/radio.ff.tsx
@@ -159,7 +159,7 @@ class Radio extends RadioOld {
             choiceStates: this.state.choiceStates?.map((choiceState, index) => {
                 const choice = this.props.choices[index];
                 const selected =
-                    this.props.userInput.choicesSelected[choice.originalIndex];
+                    this.props.userInput?.choicesSelected[choice.originalIndex];
                 return {
                     ...choiceState,
                     selected,


### PR DESCRIPTION
## Summary:
The preview in storybook was broken because of the following error
```
TypeError: Cannot read properties of undefined (reading 'choicesSelected')
```

Fixing that here.

| Before | After |
| --- | --- |
| <img width="492" height="601" alt="Screenshot 2025-07-25 at 3 19 52 PM" src="https://github.com/user-attachments/assets/cbffc071-1419-4cd3-ba22-d783dc266caa" /> | <img width="476" height="827" alt="Screenshot 2025-07-25 at 3 20 04 PM" src="https://github.com/user-attachments/assets/b13f506e-8e8f-44cb-9219-52114c606339" /> |


Issue: none

## Test plan:
- Go to http://localhost:6006/?path=/docs/widgets-radio-editor-demo--docs#multi-choice
- Confirm that the preview shows the Radio widget
- Confirm that the browser console has no errors