### PR TITLE
fix(LEMS-3339): Display "check" button for articles

### DIFF
--- a/packages/perseus/src/widgets/graded-group/graded-group.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.tsx
@@ -331,7 +331,7 @@ export class GradedGroup
                     )}
                 </UserInputManager>
 
-                {!apiOptions.isMobile && (
+                {(!apiOptions.isMobile || apiOptions.isArticle) && (
                     <>
                         {icon != null && (
                             <div className="group-icon">{icon}</div>
@@ -440,14 +440,16 @@ export class GradedGroup
                             {this.context.strings.explain}
                         </button>
                     ))}
-                {apiOptions.isMobile && answerBarState !== "HIDDEN" && (
-                    <GradedGroupAnswerBar
-                        apiOptions={apiOptions}
-                        answerBarState={answerBarState}
-                        onCheckAnswer={this._checkAnswer}
-                        onNextQuestion={this.props.onNextQuestion}
-                    />
-                )}
+                {apiOptions.isMobile &&
+                    !apiOptions.isArticle &&
+                    answerBarState !== "HIDDEN" && (
+                        <GradedGroupAnswerBar
+                            apiOptions={apiOptions}
+                            answerBarState={answerBarState}
+                            onCheckAnswer={this._checkAnswer}
+                            onNextQuestion={this.props.onNextQuestion}
+                        />
+                    )}
             </div>
         );
     }


### PR DESCRIPTION
## Summary:
"Check" button in articles is not displayed when users are on mobile.
This change checks whether the learner is on an article and optionally displays the "GradedGroupAnswerBar" if they are on mobile but not in an article. 

Issue: LEMS-3339

## Test plan: