### PR TITLE
Enable react/display-name rule for better React dev tools support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -328,7 +328,6 @@ module.exports = {
          */
         "react/no-string-refs": "off", // on in react/recommended, but we have #legacy-code
         "react/no-find-dom-node": "off", // on in react/recommended, but we have #legacy-code
-        "react/display-name": "off", // on in react/recommended, but doesn't seem that useful to fix
         // On in react/recommended, but doesn't seem helpful
         // (requires quotes to be escaped to catch developer mistakes when other characters are misplaced)
         "react/no-unescaped-entities": "off",

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -541,14 +541,19 @@ const styles = StyleSheet.create({
     },
 });
 
-const ref = React.forwardRef<
+export default React.forwardRef<
     ServerItemRenderer,
     Omit<PropsFor<typeof ServerItemRenderer>, "onRendered">
->((props, ref) => (
-    <LoadingContext.Consumer>
-        {({onRendered}) => (
-            <ServerItemRenderer {...props} onRendered={onRendered} ref={ref} />
-        )}
-    </LoadingContext.Consumer>
-));
-export default ref;
+>(function ServerItemRendererWithRef(props, ref) {
+    return (
+        <LoadingContext.Consumer>
+            {({onRendered}) => (
+                <ServerItemRenderer
+                    {...props}
+                    onRendered={onRendered}
+                    ref={ref}
+                />
+            )}
+        </LoadingContext.Consumer>
+    );
+});

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -29,106 +29,105 @@ const hitboxSizePx = 48;
 // MovablePointView is a purely presentational component (i.e. it is a pure
 // function with no state or effects) that renders the SVG for a movable point
 // on an interactive graph.
-export const MovablePointView = forwardRef(
-    (props: Props, hitboxRef: ForwardedRef<SVGGElement>) => {
-        const {
-            markings,
-            showTooltips,
-            interactiveColor,
-            disableKeyboardInteraction,
-            snapStep,
-        } = useGraphConfig();
-        const {
-            point,
-            dragging,
-            focused,
-            cursor,
-            showFocusRing,
-            onClick = () => {},
-        } = props;
+export const MovablePointView = forwardRef(function MovablePointViewWithRef(
+    props: Props,
+    hitboxRef: ForwardedRef<SVGGElement>,
+) {
+    const {
+        markings,
+        showTooltips,
+        interactiveColor,
+        disableKeyboardInteraction,
+        snapStep,
+    } = useGraphConfig();
+    const {
+        point,
+        dragging,
+        focused,
+        cursor,
+        showFocusRing,
+        onClick = () => {},
+    } = props;
 
-        // WB Tooltip requires a WB color name for the background color.
-        // We use the blue color when the points are interactive, and
-        // offBlack64 when they are disabled.
-        // Note: The disabled point color is offBlack50 to contrast with
-        // the interactive blue color, but the tooltip background has to be
-        // darker to contrast with its white text - using offBlack64.
-        const wbColorName = disableKeyboardInteraction
-            ? "fadedOffBlack64" // not see-through
-            : "blue";
+    // WB Tooltip requires a WB color name for the background color.
+    // We use the blue color when the points are interactive, and
+    // offBlack64 when they are disabled.
+    // Note: The disabled point color is offBlack50 to contrast with
+    // the interactive blue color, but the tooltip background has to be
+    // darker to contrast with its white text - using offBlack64.
+    const wbColorName = disableKeyboardInteraction
+        ? "fadedOffBlack64" // not see-through
+        : "blue";
 
-        const pointClasses = classNames(
-            "movable-point",
-            dragging && "movable-point--dragging",
-            showFocusRing && "movable-point--focus",
-        );
+    const pointClasses = classNames(
+        "movable-point",
+        dragging && "movable-point--dragging",
+        showFocusRing && "movable-point--focus",
+    );
 
-        const [[x, y]] = useTransformVectorsToPixels(point);
+    const [[x, y]] = useTransformVectorsToPixels(point);
 
-        const showHairlines = (dragging || focused) && markings !== "none";
+    const showHairlines = (dragging || focused) && markings !== "none";
 
-        // Due to floating point errors, we need to round the point to the
-        // same number of significant digits as the relevant snap step.
-        const xSigFigs = countSignificantDecimals(snapStep[X]);
-        const ySigFigs = countSignificantDecimals(snapStep[Y]);
-        const xTickLabel = point[X].toFixed(xSigFigs);
-        const yTickLabel = point[Y].toFixed(ySigFigs);
-        const pointTooltipContent = `(${xTickLabel}, ${yTickLabel})`;
+    // Due to floating point errors, we need to round the point to the
+    // same number of significant digits as the relevant snap step.
+    const xSigFigs = countSignificantDecimals(snapStep[X]);
+    const ySigFigs = countSignificantDecimals(snapStep[Y]);
+    const xTickLabel = point[X].toFixed(xSigFigs);
+    const yTickLabel = point[Y].toFixed(ySigFigs);
+    const pointTooltipContent = `(${xTickLabel}, ${yTickLabel})`;
 
-        const svgForPoint = (
-            <g
-                // Use aria-hidden to hide the line from screen readers
-                // so it doesn't read as "image" with no context.
-                // The elements using this should have their own aria-labels,
-                // so this is okay.
-                aria-hidden={true}
-                ref={hitboxRef}
-                className={pointClasses}
-                style={
-                    {"--movable-point-color": interactiveColor, cursor} as any
-                }
-                data-testid="movable-point"
-                onClick={onClick}
-            >
-                <circle
-                    className="movable-point-hitbox"
-                    r={hitboxSizePx / 2}
-                    cx={x}
-                    cy={y}
-                />
-                <circle className="movable-point-halo" cx={x} cy={y} />
-                <circle className="movable-point-ring" cx={x} cy={y} />
-                <circle className="movable-point-focus-outline" cx={x} cy={y} />
-                <circle
-                    className="movable-point-center"
-                    cx={x}
-                    cy={y}
-                    style={{fill: interactiveColor}}
-                    data-testid="movable-point__center"
-                />
-            </g>
-        );
+    const svgForPoint = (
+        <g
+            // Use aria-hidden to hide the line from screen readers
+            // so it doesn't read as "image" with no context.
+            // The elements using this should have their own aria-labels,
+            // so this is okay.
+            aria-hidden={true}
+            ref={hitboxRef}
+            className={pointClasses}
+            style={{"--movable-point-color": interactiveColor, cursor} as any}
+            data-testid="movable-point"
+            onClick={onClick}
+        >
+            <circle
+                className="movable-point-hitbox"
+                r={hitboxSizePx / 2}
+                cx={x}
+                cy={y}
+            />
+            <circle className="movable-point-halo" cx={x} cy={y} />
+            <circle className="movable-point-ring" cx={x} cy={y} />
+            <circle className="movable-point-focus-outline" cx={x} cy={y} />
+            <circle
+                className="movable-point-center"
+                cx={x}
+                cy={y}
+                style={{fill: interactiveColor}}
+                data-testid="movable-point__center"
+            />
+        </g>
+    );
 
-        return (
-            <>
-                {showHairlines && <Hairlines point={point} />}
-                {showTooltips ? (
-                    <Tooltip
-                        autoUpdate={true}
-                        opened={true}
-                        backgroundColor={wbColorName}
-                        content={pointTooltipContent}
-                        contentStyle={{color: "white"}}
-                    >
-                        {svgForPoint}
-                    </Tooltip>
-                ) : (
-                    svgForPoint
-                )}
-            </>
-        );
-    },
-);
+    return (
+        <>
+            {showHairlines && <Hairlines point={point} />}
+            {showTooltips ? (
+                <Tooltip
+                    autoUpdate={true}
+                    opened={true}
+                    backgroundColor={wbColorName}
+                    content={pointTooltipContent}
+                    contentStyle={{color: "white"}}
+                >
+                    {svgForPoint}
+                </Tooltip>
+            ) : (
+                svgForPoint
+            )}
+        </>
+    );
+});
 
 // TODO(benchristel): Move this to a more central location if it's reused.
 // Or install the library.

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -30,17 +30,18 @@ type Props = {
     onMove?: (newPoint: vec.Vector2) => unknown;
 };
 
-export const MovablePoint = React.forwardRef(
-    (props: Props, pointRef: React.ForwardedRef<SVGGElement | null>) => {
-        const {visiblePoint, focusableHandle} = useControlPoint({
-            ...props,
-            forwardedRef: pointRef,
-        });
-        return (
-            <>
-                {focusableHandle}
-                {visiblePoint}
-            </>
-        );
-    },
-);
+export const MovablePoint = React.forwardRef(function MovablePointWithRef(
+    props: Props,
+    pointRef: React.ForwardedRef<SVGGElement | null>,
+) {
+    const {visiblePoint, focusableHandle} = useControlPoint({
+        ...props,
+        forwardedRef: pointRef,
+    });
+    return (
+        <>
+            {focusableHandle}
+            {visiblePoint}
+        </>
+    );
+});

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -53,7 +53,7 @@ export type StatefulMafsGraphType = {
 export const StatefulMafsGraph = React.forwardRef<
     StatefulMafsGraphType,
     StatefulMafsGraphProps
->((props, ref) => {
+>(function StatefulMafsGraphWithRef(props, ref) {
     const {onChange, graph} = props;
 
     const [state, dispatch] = React.useReducer(

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
@@ -23,7 +23,7 @@ import type {Focusable} from "../../types";
  * Input widget.
  */
 export const NumericInputComponent = forwardRef<Focusable, NumericInputProps>(
-    (props, ref) => {
+    function NumericInputComponent(props, ref) {
         const context = useContext(PerseusI18nContext);
         const inputRef = useRef<Focusable>(null);
         const [isFocused, setIsFocused] = useState<boolean>(false);

--- a/packages/perseus/src/widgets/radio/choice-none-above.new.tsx
+++ b/packages/perseus/src/widgets/radio/choice-none-above.new.tsx
@@ -21,38 +21,36 @@ interface ChoiceNoneAboveProps extends ChoiceProps {
 const ChoiceNoneAbove = React.forwardRef<
     HTMLButtonElement,
     ChoiceNoneAboveProps
->(
-    (
-        {content, showContent = true, ...otherChoiceProps},
-        forwardedRef,
-    ): React.ReactElement => {
-        const {strings} = usePerseusI18n();
+>(function ChoiceNoneAboveWithRef(
+    {content, showContent = true, ...otherChoiceProps},
+    forwardedRef,
+): React.ReactElement {
+    const {strings} = usePerseusI18n();
 
-        const choiceProps = {
-            ...otherChoiceProps,
-            content: showContent ? (
-                content
-            ) : (
-                // We use a Renderer here because that is how
-                // `this.props.content` is wrapped otherwise.
-                // We pass in a key here so that we avoid a semi-spurious
-                // react warning when we render this in the same place
-                // as the previous choice content renderer.
-                // Note this destroys state, but since all we're doing
-                // is outputting "None of the above", that is okay.
-                //
-                // todo(matthewc): this seems like way overkill
-                // just to render a string
-                <Renderer
-                    key="noneOfTheAboveRenderer"
-                    content={strings.noneOfTheAbove}
-                    strings={strings}
-                />
-            ),
-        } as const;
+    const choiceProps = {
+        ...otherChoiceProps,
+        content: showContent ? (
+            content
+        ) : (
+            // We use a Renderer here because that is how
+            // `this.props.content` is wrapped otherwise.
+            // We pass in a key here so that we avoid a semi-spurious
+            // react warning when we render this in the same place
+            // as the previous choice content renderer.
+            // Note this destroys state, but since all we're doing
+            // is outputting "None of the above", that is okay.
+            //
+            // todo(matthewc): this seems like way overkill
+            // just to render a string
+            <Renderer
+                key="noneOfTheAboveRenderer"
+                content={strings.noneOfTheAbove}
+                strings={strings}
+            />
+        ),
+    } as const;
 
-        return <Choice {...choiceProps} ref={forwardedRef} />;
-    },
-);
+    return <Choice {...choiceProps} ref={forwardedRef} />;
+});
 
 export default ChoiceNoneAbove;

--- a/packages/perseus/src/widgets/radio/choice-none-above.tsx
+++ b/packages/perseus/src/widgets/radio/choice-none-above.tsx
@@ -51,6 +51,8 @@ const ChoiceNoneAbove = function ({
     return <Choice {...choiceProps} ref={forwardedRef} />;
 };
 
-export default React.forwardRef<HTMLButtonElement, Props>((props, ref) => (
-    <ChoiceNoneAbove {...props} forwardedRef={ref} />
-));
+export default React.forwardRef<HTMLButtonElement, Props>(
+    function ChoiceNoneAboveWithRef(props, ref) {
+        return <ChoiceNoneAbove {...props} forwardedRef={ref} />;
+    },
+);

--- a/packages/perseus/src/widgets/radio/choice.new.tsx
+++ b/packages/perseus/src/widgets/radio/choice.new.tsx
@@ -51,7 +51,7 @@ export interface ChoiceProps {
  * TODO(LEMS-2994): Clean up this file.
  */
 const Choice = React.forwardRef<HTMLButtonElement, ChoiceProps>(
-    (
+    function ChoiceWithRef(
         {
             disabled = false,
             checked = false,
@@ -68,7 +68,7 @@ const Choice = React.forwardRef<HTMLButtonElement, ChoiceProps>(
             rationale,
         },
         ref,
-    ): React.ReactElement => {
+    ): React.ReactElement {
         const [isInputFocused, setIsInputFocused] = useState(false);
 
         const {strings} = usePerseusI18n();

--- a/packages/perseus/src/widgets/radio/choice.tsx
+++ b/packages/perseus/src/widgets/radio/choice.tsx
@@ -239,5 +239,7 @@ const styles = StyleSheet.create({
 });
 
 export default React.forwardRef<HTMLButtonElement, ChoiceProps>(
-    (props, ref) => <Choice {...props} forwardedRef={ref} />,
+    function ChoiceWithRef(props, ref) {
+        return <Choice {...props} forwardedRef={ref} />;
+    },
 );


### PR DESCRIPTION
## Summary:

React dev tools can do things like displaying a render tree of React components. This debugging view depends on React components having a display name. React derives this display name in a few ways:
 
  * By looking for a `.displayName` property attached to the component
  * By using the functional components function name (ie `function MyComponent() { ... }`). 

This PR enables the ESLint rule that ensures all React components have a derivable display name and fixes the issues that came up after enabling it. 

Issue: "none"

## Test plan:

`pnpm lint`