### PR TITLE
`choicesSelected` bug in `getPromptJSON`

### DIFF
--- a/.changeset/five-pans-exist.md
+++ b/.changeset/five-pans-exist.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Bugfix: null check for Radio's getPromptJSON

--- a/packages/perseus/src/widget-ai-utils/radio/radio-ai-utils.test.ts
+++ b/packages/perseus/src/widget-ai-utils/radio/radio-ai-utils.test.ts
@@ -173,4 +173,53 @@ describe("Radio AI utils", () => {
             expect(isSelected).toBe(i === indexToSelect);
         });
     });
+
+    // regression (TUT-2738) TODO: we shouldn't have to handle this
+    // (user input should be initialized already)
+    // but there's a bug somewhere and an urgency to get this patched
+    it("should handle undefined/null user input", () => {
+        const renderProps: any = {
+            numCorrect: 1,
+            countChoices: false,
+            deselectEnabled: false,
+            hasNoneOfTheAbove: false,
+            multipleSelect: false,
+            choices: [
+                {
+                    content: "Content 4",
+                    originalIndex: 3,
+                },
+                {
+                    content: "Content 2",
+                    originalIndex: 1,
+                },
+                {
+                    content: "Content 1",
+                    originalIndex: 0,
+                },
+
+                {
+                    content: "Content 3",
+                    originalIndex: 2,
+                },
+            ],
+            selectedChoices: [true, false, false, false],
+        };
+
+        const resultJSON = getPromptJSON(renderProps, undefined as any);
+
+        expect(resultJSON).toEqual({
+            type: "radio",
+            hasNoneOfTheAbove: false,
+            options: [
+                {value: "Content 4"},
+                {value: "Content 2"},
+                {value: "Content 1"},
+                {value: "Content 3"},
+            ],
+            userInput: {
+                selectedOptions: [],
+            },
+        });
+    });
 });

--- a/packages/perseus/src/widget-ai-utils/radio/radio-ai-utils.ts
+++ b/packages/perseus/src/widget-ai-utils/radio/radio-ai-utils.ts
@@ -41,7 +41,7 @@ export const getPromptJSON = (
         hasNoneOfTheAbove: !!renderProps.hasNoneOfTheAbove,
         options,
         userInput: {
-            selectedOptions: userInput.choicesSelected.slice(),
+            selectedOptions: userInput?.choicesSelected?.slice() ?? [],
         },
     };
 };


### PR DESCRIPTION
## Summary:
Something's wrong with the way we're initializing user input or how Classroom is moving between questions: `userInput` shouldn't be null/undefined because it should be initialized by `getStartUserInput`. However it seems like TUT is running into a place where user input isn't initialized properly and it's blocking progression. This is a "hail mary" attempt to at least not block things from progressing.

Issue: [TUT-2738](https://khanacademy.atlassian.net/browse/TUT-2738)

[TUT-2738]: https://khanacademy.atlassian.net/browse/TUT-2738?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ