### PR TITLE
docs(changeset): [Interactive Graph] | (DX) | Shorten interactive-graph-editor.tsx to avoid 1000+ line lint error

### DIFF
--- a/.changeset/strange-emus-nail.md
+++ b/.changeset/strange-emus-nail.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Interactive Graph] | (DX) | Shorten interactive-graph-editor.tsx to avoid 1000+ line lint error

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-answer-specifications.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-answer-specifications.tsx
@@ -1,0 +1,337 @@
+import {components} from "@khanacademy/perseus";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
+import {Checkbox} from "@khanacademy/wonder-blocks-form";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+import invariant from "tiny-invariant";
+import _ from "underscore";
+
+import {parsePointCount} from "../../../util/points";
+import LabeledRow from "../locked-figures/labeled-row";
+
+import GraphPointsCountSelector from "./graph-points-count-selector";
+import SegmentCountSelector from "./segment-count-selector";
+
+import type {
+    PerseusGraphType,
+    PerseusGraphTypePolygon,
+} from "@khanacademy/perseus-core";
+
+const {InfoTip} = components;
+
+const POLYGON_SIDES = _.map(_.range(3, 13), function (value) {
+    return (
+        <OptionItem
+            key={`polygon-sides-${value}`}
+            value={`${value}`}
+            label={`${value} sides`}
+        />
+    );
+});
+
+interface Props {
+    correct: PerseusGraphType;
+    graph: PerseusGraphType | undefined;
+    onChange: (props: Partial<Props>) => void;
+}
+
+export const GraphTypeAnswerSpecifications = ({
+    correct,
+    graph,
+    onChange,
+}: Props) => {
+    return (
+        <>
+            {correct?.type === "point" && (
+                <LabeledRow label="Number of Points:">
+                    <GraphPointsCountSelector
+                        numPoints={correct?.numPoints}
+                        onChange={(points) => {
+                            onChange({
+                                correct: {
+                                    type: "point",
+                                    numPoints: points,
+                                },
+                                graph: {
+                                    type: "point",
+                                    numPoints: points,
+                                },
+                            });
+                        }}
+                    />
+                </LabeledRow>
+            )}
+            {correct?.type === "angle" && (
+                <>
+                    <View style={styles.row}>
+                        <Checkbox
+                            label={<LabelSmall>Show angle measures</LabelSmall>}
+                            checked={
+                                // Don't show indeterminate checkbox state
+                                !!correct?.showAngles
+                            }
+                            onChange={(newValue) => {
+                                if (graph?.type === "angle") {
+                                    invariant(
+                                        correct.type === "angle",
+                                        `Expected graph type to be angle, but got ${correct.type}`,
+                                    );
+                                    onChange({
+                                        correct: {
+                                            ...correct,
+                                            showAngles: newValue,
+                                        },
+                                        graph: {
+                                            ...graph,
+                                            showAngles: newValue,
+                                        },
+                                    });
+                                }
+                            }}
+                        />
+                        <InfoTip>
+                            <p>Displays the interior angle measures.</p>
+                        </InfoTip>
+                    </View>
+                    <View style={styles.row}>
+                        <Checkbox
+                            label={<LabelSmall>Allow reflex angles</LabelSmall>}
+                            checked={
+                                // Don't show indeterminate checkbox state
+                                !!correct?.allowReflexAngles
+                            }
+                            onChange={(newValue) => {
+                                invariant(
+                                    correct.type === "angle",
+                                    `Expected graph type to be angle, but got ${correct.type}`,
+                                );
+                                invariant(
+                                    graph?.type === "angle",
+                                    `Expected graph type to be angle, but got ${graph?.type}`,
+                                );
+
+                                const update = {
+                                    allowReflexAngles: newValue,
+                                };
+
+                                onChange({
+                                    correct: {
+                                        ...correct,
+                                        ...update,
+                                    },
+                                    graph: {
+                                        ...graph,
+                                        ...update,
+                                    },
+                                });
+                            }}
+                        />
+                        <InfoTip>
+                            <p>
+                                Allow students to be able to create reflex
+                                angles.
+                            </p>
+                        </InfoTip>
+                    </View>
+                </>
+            )}
+            {correct?.type === "polygon" && (
+                <>
+                    <LabeledRow label="Number of sides:">
+                        <SingleSelect
+                            key="polygon-select"
+                            selectedValue={
+                                // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+                                correct?.numSides ? `${correct.numSides}` : "3"
+                            }
+                            placeholder=""
+                            onChange={(newValue) => {
+                                invariant(graph?.type === "polygon");
+                                const updates = {
+                                    numSides: parsePointCount(newValue),
+                                    coords: undefined,
+                                    startCoords: undefined,
+                                    // reset the snap for UNLIMITED, which
+                                    // only supports "grid"
+                                    // From: D6578
+                                    snapTo: "grid",
+                                } as const;
+
+                                onChange({
+                                    correct: {
+                                        ...correct,
+                                        ...updates,
+                                    },
+                                    graph: {
+                                        ...graph,
+                                        ...updates,
+                                    },
+                                });
+                            }}
+                            style={styles.singleSelectShort}
+                        >
+                            {[
+                                ...POLYGON_SIDES,
+                                <OptionItem
+                                    key="unlimited"
+                                    value="unlimited"
+                                    label="unlimited sides"
+                                />,
+                            ]}
+                        </SingleSelect>
+                    </LabeledRow>
+                    <LabeledRow label="Snap to:">
+                        <SingleSelect
+                            selectedValue={correct?.snapTo || "grid"}
+                            // Never uses placeholder, always has value
+                            placeholder=""
+                            onChange={(newValue) => {
+                                invariant(
+                                    correct.type === "polygon",
+                                    `Expected correct answer type to be polygon, but got ${correct.type}`,
+                                );
+                                invariant(
+                                    graph?.type === "polygon",
+                                    `Expected graph type to be polygon, but got ${graph?.type}`,
+                                );
+
+                                const updates = {
+                                    snapTo: newValue as PerseusGraphTypePolygon["snapTo"],
+                                    coords: null,
+                                } as const;
+
+                                onChange({
+                                    correct: {
+                                        ...correct,
+                                        ...updates,
+                                    },
+                                    graph: {
+                                        ...graph,
+                                        ...updates,
+                                    },
+                                });
+                            }}
+                            style={styles.singleSelectShort}
+                        >
+                            <OptionItem value="grid" label="grid" />
+                            {correct?.numSides !== "unlimited" && (
+                                <OptionItem
+                                    value="angles"
+                                    label="interior angles"
+                                />
+                            )}
+                            {correct?.numSides !== "unlimited" && (
+                                <OptionItem
+                                    value="sides"
+                                    label="side measures"
+                                />
+                            )}
+                        </SingleSelect>
+                        <InfoTip>
+                            <p>
+                                These options affect the movement of the vertex
+                                points. The grid option will guide the points to
+                                the nearest half step along the grid.
+                            </p>
+                            <p>
+                                The interior angle and side measure options
+                                guide the points to the nearest whole angle or
+                                side measure respectively.
+                            </p>
+                        </InfoTip>
+                    </LabeledRow>
+                    <View style={styles.row}>
+                        <Checkbox
+                            label={<LabelSmall>Show angle measures</LabelSmall>}
+                            checked={
+                                // Don't show indeterminate checkbox state
+                                !!correct?.showAngles
+                            }
+                            onChange={() => {
+                                if (graph?.type === "polygon") {
+                                    invariant(
+                                        correct.type === "polygon",
+                                        `Expected graph type to be polygon, but got ${correct.type}`,
+                                    );
+                                    onChange({
+                                        correct: {
+                                            ...correct,
+                                            showAngles: !correct.showAngles,
+                                        },
+                                        graph: {
+                                            ...graph,
+                                            showAngles: !graph.showAngles,
+                                        },
+                                    });
+                                }
+                            }}
+                        />
+                        <InfoTip>
+                            <p>Displays the interior angle measures.</p>
+                        </InfoTip>
+                    </View>
+                    <View style={styles.row}>
+                        <Checkbox
+                            label={<LabelSmall>Show side measures</LabelSmall>}
+                            checked={
+                                // Don't show indeterminate checkbox state
+                                !!correct?.showSides
+                            }
+                            onChange={() => {
+                                if (
+                                    graph?.type === "polygon" &&
+                                    correct.type === "polygon"
+                                ) {
+                                    onChange({
+                                        correct: {
+                                            ...correct,
+                                            showSides: !correct.showSides,
+                                        },
+                                        graph: {
+                                            ...graph,
+                                            showSides: !graph.showSides,
+                                        },
+                                    });
+                                }
+                            }}
+                        />
+                        <InfoTip>
+                            <p>Displays the side lengths.</p>
+                        </InfoTip>
+                    </View>
+                </>
+            )}
+            {correct?.type === "segment" && (
+                <LabeledRow label="Number of segments:">
+                    <SegmentCountSelector
+                        numSegments={correct?.numSegments}
+                        onChange={(sides) => {
+                            onChange({
+                                correct: {
+                                    type: "segment",
+                                    numSegments: sides,
+                                    coords: null,
+                                },
+                                graph: {
+                                    type: "segment",
+                                    numSegments: sides,
+                                },
+                            });
+                        }}
+                    />
+                </LabeledRow>
+            )}
+        </>
+    );
+};
+
+const styles = StyleSheet.create({
+    row: {
+        flexDirection: "row",
+        marginTop: spacing.xSmall_8,
+        alignItems: "center",
+    },
+});

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -19,24 +19,18 @@ import {
 } from "@khanacademy/perseus-core";
 import {Id, View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
-import {Checkbox} from "@khanacademy/wonder-blocks-form";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
-import {LabelSmall} from "@khanacademy/wonder-blocks-typography";
 import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 import invariant from "tiny-invariant";
 import _ from "underscore";
 
-import {parsePointCount} from "../../util/points";
-
-import GraphPointsCountSelector from "./components/graph-points-count-selector";
+import {GraphTypeAnswerSpecifications} from "./components/graph-type-answer-specifications";
 import GraphTypeSelector from "./components/graph-type-selector";
 import {InteractiveGraphCorrectAnswer} from "./components/interactive-graph-correct-answer";
 import InteractiveGraphDescription from "./components/interactive-graph-description";
 import InteractiveGraphSettings from "./components/interactive-graph-settings";
 import InteractiveGraphSRTree from "./components/interactive-graph-sr-tree";
-import SegmentCountSelector from "./components/segment-count-selector";
 import LabeledRow from "./locked-figures/labeled-row";
 import LockedFiguresSection from "./locked-figures/locked-figures-section";
 import StartCoordsSettings from "./start-coords/start-coords-settings";
@@ -49,16 +43,6 @@ const {InfoTip} = components;
 const InteractiveGraph = InteractiveGraphWidget.widget;
 
 type InteractiveGraphProps = PropsFor<typeof InteractiveGraph>;
-
-const POLYGON_SIDES = _.map(_.range(3, 13), function (value) {
-    return (
-        <OptionItem
-            key={`polygon-sides-${value}`}
-            value={`${value}`}
-            label={`${value} sides`}
-        />
-    );
-});
 
 type Range = [min: number, max: number];
 type PerseusGraphTypePolygon = Extract<PerseusGraphType, {type: "polygon"}>;
@@ -397,344 +381,11 @@ class InteractiveGraphEditor extends React.Component<Props> {
                         >
                             {graph}
                         </InteractiveGraphCorrectAnswer>
-                        {this.props.correct?.type === "point" && (
-                            <LabeledRow label="Number of Points:">
-                                <GraphPointsCountSelector
-                                    numPoints={this.props.correct?.numPoints}
-                                    onChange={(points) => {
-                                        this.props.onChange({
-                                            correct: {
-                                                type: "point",
-                                                numPoints: points,
-                                            },
-                                            graph: {
-                                                type: "point",
-                                                numPoints: points,
-                                            },
-                                        });
-                                    }}
-                                />
-                            </LabeledRow>
-                        )}
-                        {this.props.correct?.type === "angle" && (
-                            <>
-                                <View style={styles.row}>
-                                    <Checkbox
-                                        label={
-                                            <LabelSmall>
-                                                Show angle measures
-                                            </LabelSmall>
-                                        }
-                                        checked={
-                                            // Don't show indeterminate checkbox state
-                                            !!this.props.correct?.showAngles
-                                        }
-                                        onChange={(newValue) => {
-                                            if (
-                                                this.props.graph?.type ===
-                                                "angle"
-                                            ) {
-                                                invariant(
-                                                    this.props.correct.type ===
-                                                        "angle",
-                                                    `Expected graph type to be angle, but got ${this.props.correct.type}`,
-                                                );
-                                                this.props.onChange({
-                                                    correct: {
-                                                        ...this.props.correct,
-                                                        showAngles: newValue,
-                                                    },
-                                                    graph: {
-                                                        ...this.props.graph,
-                                                        showAngles: newValue,
-                                                    },
-                                                });
-                                            }
-                                        }}
-                                    />
-                                    <InfoTip>
-                                        <p>
-                                            Displays the interior angle
-                                            measures.
-                                        </p>
-                                    </InfoTip>
-                                </View>
-                                <View style={styles.row}>
-                                    <Checkbox
-                                        label={
-                                            <LabelSmall>
-                                                Allow reflex angles
-                                            </LabelSmall>
-                                        }
-                                        checked={
-                                            // Don't show indeterminate checkbox state
-                                            !!this.props.correct
-                                                ?.allowReflexAngles
-                                        }
-                                        onChange={(newValue) => {
-                                            invariant(
-                                                this.props.correct.type ===
-                                                    "angle",
-                                                `Expected graph type to be angle, but got ${this.props.correct.type}`,
-                                            );
-                                            invariant(
-                                                this.props.graph?.type ===
-                                                    "angle",
-                                                `Expected graph type to be angle, but got ${this.props.graph?.type}`,
-                                            );
-
-                                            const update = {
-                                                allowReflexAngles: newValue,
-                                            };
-
-                                            this.props.onChange({
-                                                correct: {
-                                                    ...this.props.correct,
-                                                    ...update,
-                                                },
-                                                graph: {
-                                                    ...this.props.graph,
-                                                    ...update,
-                                                },
-                                            });
-                                        }}
-                                    />
-                                    <InfoTip>
-                                        <p>
-                                            Allow students to be able to create
-                                            reflex angles.
-                                        </p>
-                                    </InfoTip>
-                                </View>
-                            </>
-                        )}
-                        {this.props.correct?.type === "polygon" && (
-                            <>
-                                <LabeledRow label="Number of sides:">
-                                    <SingleSelect
-                                        key="polygon-select"
-                                        selectedValue={
-                                            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-                                            this.props.correct?.numSides
-                                                ? `${this.props.correct.numSides}`
-                                                : "3"
-                                        }
-                                        placeholder=""
-                                        onChange={(newValue) => {
-                                            invariant(
-                                                this.props.graph?.type ===
-                                                    "polygon",
-                                            );
-                                            const updates = {
-                                                numSides:
-                                                    parsePointCount(newValue),
-                                                coords: undefined,
-                                                startCoords: undefined,
-                                                // reset the snap for UNLIMITED, which
-                                                // only supports "grid"
-                                                // From: D6578
-                                                snapTo: "grid",
-                                            } as const;
-
-                                            this.props.onChange({
-                                                correct: {
-                                                    ...this.props.correct,
-                                                    ...updates,
-                                                },
-                                                graph: {
-                                                    ...this.props.graph,
-                                                    ...updates,
-                                                },
-                                            });
-                                        }}
-                                        style={styles.singleSelectShort}
-                                    >
-                                        {[
-                                            ...POLYGON_SIDES,
-                                            <OptionItem
-                                                key="unlimited"
-                                                value="unlimited"
-                                                label="unlimited sides"
-                                            />,
-                                        ]}
-                                    </SingleSelect>
-                                </LabeledRow>
-                                <LabeledRow label="Snap to:">
-                                    <SingleSelect
-                                        selectedValue={
-                                            this.props.correct?.snapTo || "grid"
-                                        }
-                                        // Never uses placeholder, always has value
-                                        placeholder=""
-                                        onChange={(newValue) => {
-                                            invariant(
-                                                this.props.correct.type ===
-                                                    "polygon",
-                                                `Expected correct answer type to be polygon, but got ${this.props.correct.type}`,
-                                            );
-                                            invariant(
-                                                this.props.graph?.type ===
-                                                    "polygon",
-                                                `Expected graph type to be polygon, but got ${this.props.graph?.type}`,
-                                            );
-
-                                            const updates = {
-                                                snapTo: newValue as PerseusGraphTypePolygon["snapTo"],
-                                                coords: null,
-                                            } as const;
-
-                                            this.props.onChange({
-                                                correct: {
-                                                    ...this.props.correct,
-                                                    ...updates,
-                                                },
-                                                graph: {
-                                                    ...this.props.graph,
-                                                    ...updates,
-                                                },
-                                            });
-                                        }}
-                                        style={styles.singleSelectShort}
-                                    >
-                                        <OptionItem value="grid" label="grid" />
-                                        {this.props.correct?.numSides !==
-                                            "unlimited" && (
-                                            <OptionItem
-                                                value="angles"
-                                                label="interior angles"
-                                            />
-                                        )}
-                                        {this.props.correct?.numSides !==
-                                            "unlimited" && (
-                                            <OptionItem
-                                                value="sides"
-                                                label="side measures"
-                                            />
-                                        )}
-                                    </SingleSelect>
-                                    <InfoTip>
-                                        <p>
-                                            These options affect the movement of
-                                            the vertex points. The grid option
-                                            will guide the points to the nearest
-                                            half step along the grid.
-                                        </p>
-                                        <p>
-                                            The interior angle and side measure
-                                            options guide the points to the
-                                            nearest whole angle or side measure
-                                            respectively.
-                                        </p>
-                                    </InfoTip>
-                                </LabeledRow>
-                                <View style={styles.row}>
-                                    <Checkbox
-                                        label={
-                                            <LabelSmall>
-                                                Show angle measures
-                                            </LabelSmall>
-                                        }
-                                        checked={
-                                            // Don't show indeterminate checkbox state
-                                            !!this.props.correct?.showAngles
-                                        }
-                                        onChange={() => {
-                                            if (
-                                                this.props.graph?.type ===
-                                                "polygon"
-                                            ) {
-                                                invariant(
-                                                    this.props.correct.type ===
-                                                        "polygon",
-                                                    `Expected graph type to be polygon, but got ${this.props.correct.type}`,
-                                                );
-                                                this.props.onChange({
-                                                    correct: {
-                                                        ...this.props.correct,
-                                                        showAngles:
-                                                            !this.props.correct
-                                                                .showAngles,
-                                                    },
-                                                    graph: {
-                                                        ...this.props.graph,
-                                                        showAngles:
-                                                            !this.props.graph
-                                                                .showAngles,
-                                                    },
-                                                });
-                                            }
-                                        }}
-                                    />
-                                    <InfoTip>
-                                        <p>
-                                            Displays the interior angle
-                                            measures.
-                                        </p>
-                                    </InfoTip>
-                                </View>
-                                <View style={styles.row}>
-                                    <Checkbox
-                                        label={
-                                            <LabelSmall>
-                                                Show side measures
-                                            </LabelSmall>
-                                        }
-                                        checked={
-                                            // Don't show indeterminate checkbox state
-                                            !!this.props.correct?.showSides
-                                        }
-                                        onChange={() => {
-                                            if (
-                                                this.props.graph?.type ===
-                                                    "polygon" &&
-                                                this.props.correct.type ===
-                                                    "polygon"
-                                            ) {
-                                                this.props.onChange({
-                                                    correct: {
-                                                        ...this.props.correct,
-                                                        showSides:
-                                                            !this.props.correct
-                                                                .showSides,
-                                                    },
-                                                    graph: {
-                                                        ...this.props.graph,
-                                                        showSides:
-                                                            !this.props.graph
-                                                                .showSides,
-                                                    },
-                                                });
-                                            }
-                                        }}
-                                    />
-                                    <InfoTip>
-                                        <p>Displays the side lengths.</p>
-                                    </InfoTip>
-                                </View>
-                            </>
-                        )}
-                        {this.props.correct?.type === "segment" && (
-                            <LabeledRow label="Number of segments:">
-                                <SegmentCountSelector
-                                    numSegments={
-                                        this.props.correct?.numSegments
-                                    }
-                                    onChange={(sides) => {
-                                        this.props.onChange({
-                                            correct: {
-                                                type: "segment",
-                                                numSegments: sides,
-                                                coords: null,
-                                            },
-                                            graph: {
-                                                type: "segment",
-                                                numSegments: sides,
-                                            },
-                                        });
-                                    }}
-                                />
-                            </LabeledRow>
-                        )}
+                        <GraphTypeAnswerSpecifications
+                            correct={this.props.correct}
+                            graph={this.props.graph}
+                            onChange={this.props.onChange}
+                        />
                         {this.props.graph?.type &&
                             shouldShowStartCoordsUI(
                                 this.props.graph,
@@ -982,11 +633,6 @@ const styles = StyleSheet.create({
         // Non-standard spacing, but it's the smallest we can go
         // without running into styling issues with the dropdown.
         height: 26,
-    },
-    row: {
-        flexDirection: "row",
-        marginTop: spacing.xSmall_8,
-        alignItems: "center",
     },
 });
 


### PR DESCRIPTION
## Summary:
I wanted to add a couple lines of code in a different branch, and I got a lint error saying
that this file (interactive-graph-editor.tsx) is too long.

Shortening it here by breaking out the individual graph specifications into a separate file.

Issue: none

## Test plan:
`pnpm jest`

Storybook
http://localhost:6006/?path=/docs/widgets-interactive-graph-editor-demo--docs
- Confirm that all the graph types' specific settings still work right