### PR TITLE
feat(LEMS-3069): Consumes choice Ids in radio widget

### DIFF
--- a/.changeset/wild-hotels-help.md
+++ b/.changeset/wild-hotels-help.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Consumes choice Ids in radio widget

--- a/packages/perseus/src/widgets/radio/__tests__/base-radio.testdata.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/base-radio.testdata.ts
@@ -2,6 +2,7 @@ import type {ChoiceType} from "../base-radio";
 
 export function generateChoice(options: Partial<ChoiceType>): ChoiceType {
     const base = {
+        id: "",
         checked: false,
         crossedOut: false,
         content: "",

--- a/packages/perseus/src/widgets/radio/base-radio.tsx
+++ b/packages/perseus/src/widgets/radio/base-radio.tsx
@@ -28,6 +28,7 @@ const {captureScratchpadTouchStart} = Util;
 
 // exported for tests
 export type ChoiceType = {
+    id: string;
     checked: boolean;
     content: React.ReactNode;
     rationale: React.ReactNode;
@@ -255,6 +256,7 @@ const BaseRadio = function ({
                     // @ts-expect-error - TS2322 - Type 'RefObject<unknown>' is not assignable to type 'never'.
                     choiceRefs.current[i] = ref;
                     const elementProps = {
+                        id: choice.id,
                         apiOptions: apiOptions,
                         multipleSelect: multipleSelect,
                         checked: choice.checked,
@@ -370,7 +372,7 @@ const BaseRadio = function ({
                     return (
                         // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions -- TODO(LEMS-2871): Address a11y error
                         <li
-                            key={i}
+                            key={choice.id}
                             ref={(e) => (listElem = e)}
                             className={className}
                             onClick={clickHandler}

--- a/packages/perseus/src/widgets/radio/multiple-choice-component.new.tsx
+++ b/packages/perseus/src/widgets/radio/multiple-choice-component.new.tsx
@@ -114,10 +114,10 @@ const ChoiceListItems = (props: ChoiceListItemsProps): React.ReactElement => {
             reviewMode && choice.hasRationale ? (
                 <div className={rationaleClasses}>{choice.rationale}</div>
             ) : undefined;
-        // TODO: Use choice ID as key once it's available
+
         return (
             <Choice
-                key={i}
+                key={choice.id}
                 checked={choice.checked}
                 indicatorContent={choiceLetter}
                 isMultiSelect={multipleSelect}

--- a/packages/perseus/src/widgets/radio/multiple-choice-widget.new.tsx
+++ b/packages/perseus/src/widgets/radio/multiple-choice-widget.new.tsx
@@ -23,6 +23,7 @@ import type {LinterContextProps} from "@khanacademy/perseus-linter";
  * Represents a single choice in the MultipleChoiceComponent
  */
 export interface ChoiceType {
+    id: string;
     checked: boolean;
     content: React.ReactNode;
     rationale: React.ReactNode;
@@ -263,6 +264,7 @@ class MultipleChoiceWidget extends React.Component<Props> implements Widget {
             const reviewChoice = reviewModeRubric?.choices[i];
 
             return {
+                id: choice.id,
                 content: this.renderContent(content),
                 checked: selected,
                 correct:

--- a/packages/perseus/src/widgets/radio/radio-component.tsx
+++ b/packages/perseus/src/widgets/radio/radio-component.tsx
@@ -272,6 +272,7 @@ class Radio extends React.Component<Props> implements Widget {
                 const reviewChoice = this.props.reviewModeRubric?.choices[i];
 
                 return {
+                    id: choice.id,
                     content: this._renderRenderer(content),
                     checked: selected,
                     // Current versions of the radio widget always pass in the


### PR DESCRIPTION
## Summary:
Consumes choice ids in radio widget 

### Note
- Accidentally swapped JIRA numbers - landed 3070 with changes for 3069; will be using 3069 for this change

Issue: LEMS-3069

## Test plan:
In Local Dev, validated
- User able to answer question
- Content Author able to add, delete, update, move choices

### Screen recording
Editor add, delete, update, move choice

https://github.com/user-attachments/assets/ff323649-2414-4aa9-a877-4ae454597a38



