### PR TITLE
Remove forced bold from Free Response question

### DIFF
--- a/.changeset/olive-news-report.md
+++ b/.changeset/olive-news-report.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Remove forced bolding from Free Response Widget question text

--- a/packages/perseus/src/styles/widgets/free-response.css
+++ b/packages/perseus/src/styles/widgets/free-response.css
@@ -1,10 +1,5 @@
 .framework-perseus {
     .free-response .free-response-question {
-        /* Default to bold text in the question. */
-        .paragraph {
-            font-weight: 700;
-        }
-
         /* Remove the top margin from the first paragraph, so there isn't forced
            spacing above the question. */
         :nth-child(1 of .paragraph) {

--- a/packages/perseus/src/widgets/free-response/__snapshots__/free-response.test.tsx.snap
+++ b/packages/perseus/src/widgets/free-response/__snapshots__/free-response.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`free-response widget should snapshot on mobile: first mobile render 1`]
                 class="default_xu2jcg-o_O-labelContainer_1qlbwdv"
               >
                 <label
-                  class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_1r6q8ju-o_O-labelWithNoDescription_i032sc-o_O-questionLabel_shsy80"
+                  class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_1r6q8ju-o_O-labelWithNoDescription_i032sc"
                   for=":r2:-labeled-field-field"
                   id=":r2:-labeled-field-label"
                 >
@@ -111,7 +111,7 @@ exports[`free-response widget should snapshot: first render 1`] = `
                 class="default_xu2jcg-o_O-labelContainer_1qlbwdv"
               >
                 <label
-                  class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_1r6q8ju-o_O-labelWithNoDescription_i032sc-o_O-questionLabel_shsy80"
+                  class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_1r6q8ju-o_O-labelWithNoDescription_i032sc"
                   for=":r0:-labeled-field-field"
                   id=":r0:-labeled-field-label"
                 >

--- a/packages/perseus/src/widgets/free-response/free-response.stories.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.stories.tsx
@@ -38,13 +38,23 @@ export const CharacterLimit: Story = {
     },
 };
 
+
+export const BoldedQuestion: Story = {
+    args: {
+        allowUnlimitedCharacters: false,
+        characterLimit: 500,
+        placeholder: "Enter your answer here",
+        question: "**What is the theme of the essay?**",
+    },
+};
+
 export const UnlimitedCharacters: Story = {
     args: {
         allowUnlimitedCharacters: true,
         characterLimit: 500,
         placeholder: "Enter your answer here",
         question:
-            "What is the theme of the essay?\n\nPut your answer in your own words.",
+            "What is the theme of the essay?\n\n**Put your answer in your own words.**",
     },
 };
 

--- a/packages/perseus/src/widgets/free-response/free-response.stories.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.stories.tsx
@@ -38,7 +38,6 @@ export const CharacterLimit: Story = {
     },
 };
 
-
 export const BoldedQuestion: Story = {
     args: {
         allowUnlimitedCharacters: false,

--- a/packages/perseus/src/widgets/free-response/free-response.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.tsx
@@ -124,9 +124,6 @@ export class FreeResponse extends React.Component<Props> implements Widget {
                             value={this.props.userInput.currentValue}
                         />
                     }
-                    styles={{
-                        label: styles.questionLabel,
-                    }}
                 />
                 {this.renderCharacterCount()}
             </View>
@@ -163,9 +160,6 @@ const styles = StyleSheet.create({
     },
     overCharacterLimit: {
         color: color.red,
-    },
-    questionLabel: {
-        fontWeight: font.weight.bold,
     },
     textarea: {
         padding: spacing.medium_16,


### PR DESCRIPTION
## Summary:
This commit changes the styling on the Free Respone Widget to no longer
force bold styling of the question text. Instead, we will allow the
content creators to use Markdown to bold all or part of the question, if
they want to.

Issue: https://khanacademy.atlassian.net/browse/AX-1596

## Test plan:
- Open the Free Response Widget in Storybook.
- View the question on the Primary story.
- Verify that it is not rendered bold.
- In the browser DevTools, inspect the question text.
- Verify that it is not surrounded by `<strong>` tags.
- In the browser DevTools, inspect the question text of the "Bolded
  Question" story.
- Verify that it is surrounded by `<strong>` tags.