### PR TITLE
Remove Expression transform

### DIFF
--- a/.changeset/lovely-tomatoes-speak.md
+++ b/.changeset/lovely-tomatoes-speak.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Remove transform from Expression

--- a/packages/perseus/src/widgets/expression/__docs__/expression.stories.tsx
+++ b/packages/perseus/src/widgets/expression/__docs__/expression.stories.tsx
@@ -4,7 +4,6 @@ import {ServerItemRendererWithDebugUI} from "../../../../../../testing/server-it
 import expressionExport from "../expression";
 import {expressionItem2, expressionItem3} from "../expression.testdata";
 
-import type {KeypadConfiguration} from "@khanacademy/perseus-core";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 const meta: Meta = {
@@ -28,11 +27,6 @@ type Story = StoryObj<typeof ServerItemRendererWithDebugUI>;
 /** This story shows how the expression widget looks when the keypad is
  * configured with _every_ option it supports.  */
 export const DesktopKitchenSink = (args: Story["args"]): React.ReactElement => {
-    const keypadConfiguration: KeypadConfiguration = {
-        keypadType: "EXPRESSION",
-        extraKeys: ["x", "y", "z"],
-    };
-
     return (
         <div style={{padding: "2rem"}}>
             <expressionExport.widget
@@ -49,8 +43,16 @@ export const DesktopKitchenSink = (args: Story["args"]): React.ReactElement => {
                 userInput=""
                 trackInteraction={() => {}}
                 widgetId="expression"
-                keypadConfiguration={keypadConfiguration}
+                extraKeys={["x", "y", "z"]}
                 reviewMode={false}
+                answerForms={[
+                    {
+                        considered: "correct",
+                        form: false,
+                        simplify: false,
+                        value: "8675309",
+                    },
+                ]}
             />
         </div>
     );

--- a/packages/perseus/src/widgets/expression/expression.test.tsx
+++ b/packages/perseus/src/widgets/expression/expression.test.tsx
@@ -26,7 +26,6 @@ import {
 
 import type {
     PerseusItem,
-    PerseusExpressionWidgetOptions,
     PerseusRenderer,
     PerseusExpressionRubric,
 } from "@khanacademy/perseus-core";
@@ -502,96 +501,6 @@ describe("Expression Widget", function () {
             // In this case we know that it'll be valid so we can assert directly
             // @ts-expect-error - TS2339 - Property 'total' does not exist on type 'PerseusScore'.
             expect(score.total).toBe(1);
-        });
-    });
-
-    describe("transform", () => {
-        it("can transform widget options into render props", () => {
-            const widgetOptions: PerseusExpressionWidgetOptions = {
-                answerForms: [
-                    {
-                        considered: "correct",
-                        form: true,
-                        simplify: false,
-                        value: "16+88i",
-                    },
-                ],
-                buttonSets: [],
-                times: false,
-                functions: [],
-                buttonsVisible: "never",
-                visibleLabel: "Test visible label",
-                ariaLabel: "Test aria label",
-                extraKeys: ["i"],
-            };
-
-            const expected = {
-                keypadConfiguration: {
-                    keypadType: "EXPRESSION",
-                    extraKeys: ["i"],
-                    times: false,
-                },
-                times: false,
-                functions: [],
-                buttonSets: [],
-                buttonsVisible: "never",
-                visibleLabel: "Test visible label",
-                ariaLabel: "Test aria label",
-            };
-
-            const result = ExpressionWidgetExport.transform(widgetOptions);
-
-            expect(result).toEqual(expected);
-        });
-
-        it("should return expression keypad configuration by default", async () => {
-            // Arrange
-            // Act
-            const result = ExpressionWidgetExport.transform({
-                answerForms: [],
-                buttonSets: [],
-                times: false,
-                functions: [],
-            });
-
-            // Assert
-            expect(result.keypadConfiguration.keypadType).toEqual("EXPRESSION");
-        });
-
-        it("should forward extraKeys if present", async () => {
-            // Arrange
-            // Act
-            const result = ExpressionWidgetExport.transform({
-                buttonSets: [],
-                times: false,
-                functions: [],
-                extraKeys: ["i"],
-            });
-
-            // Assert
-            expect(result.keypadConfiguration.extraKeys).toEqual(["i"]);
-        });
-
-        it("should prioritize extraKeys over answerForms", async () => {
-            // Arrange
-            // Act
-            const result = ExpressionWidgetExport.transform({
-                answerForms: [
-                    {
-                        considered: "correct",
-                        form: true,
-                        simplify: false,
-                        value: "16+88i",
-                    },
-                ],
-                buttonSets: [],
-                times: false,
-                functions: [],
-                extraKeys: ["x"],
-            });
-
-            // Assert
-            expect(result.keypadConfiguration.extraKeys).toEqual(["x"]);
         });
     });
 

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -19,7 +19,6 @@ import type {WidgetProps, Widget, WidgetExports} from "../../types";
 import type {ExpressionPromptJSON} from "../../widget-ai-utils/expression/expression-ai-utils";
 import type {
     PerseusExpressionWidgetOptions,
-    ExpressionPublicWidgetOptions,
     KeypadConfiguration,
     KeypadKey,
     PerseusExpressionRubric,
@@ -54,17 +53,10 @@ const normalizeTex = (tex: string): string => {
     return anglicizeOperators(tex);
 };
 
-type RenderProps = {
-    buttonSets: PerseusExpressionWidgetOptions["buttonSets"];
-    buttonsVisible?: PerseusExpressionWidgetOptions["buttonsVisible"];
-    functions: PerseusExpressionWidgetOptions["functions"];
-    times: PerseusExpressionWidgetOptions["times"];
-    visibleLabel: PerseusExpressionWidgetOptions["visibleLabel"];
-    ariaLabel: PerseusExpressionWidgetOptions["ariaLabel"];
-    keypadConfiguration: KeypadConfiguration;
-};
-
-type ExternalProps = WidgetProps<RenderProps, PerseusExpressionUserInput>;
+type ExternalProps = WidgetProps<
+    PerseusExpressionWidgetOptions,
+    PerseusExpressionUserInput
+>;
 
 type Props = ExternalProps &
     Partial<React.ContextType<typeof DependenciesContext>> & {
@@ -207,19 +199,30 @@ export class Expression extends React.Component<Props> implements Widget {
         return [[]];
     };
 
+    getKeypadConfiguration(): KeypadConfiguration {
+        return {
+            keypadType: "EXPRESSION",
+            extraKeys: this.props.extraKeys,
+            times: this.props.times,
+        };
+    }
+
     /**
      * @deprecated and likely very broken API
      * [LEMS-3185] do not trust serializedState/restoreSerializedState
      */
     getSerializedState() {
-        const {userInput: _, ...rest} = this.props;
+        const {userInput: _, answerForms: __, ...rest} = this.props;
         return {
             ...rest,
             value: this.props.userInput,
+            keypadConfiguration: this.getKeypadConfiguration(),
         };
     }
 
     render() {
+        const keypadConfiguration = this.getKeypadConfiguration();
+
         if (this.props.apiOptions.customKeypad) {
             return (
                 <View className={css(styles.mobileLabelInputWrapper)}>
@@ -243,7 +246,7 @@ export class Expression extends React.Component<Props> implements Widget {
                             // when apiOptions.customKeypad is set, but how
                             // to convince TypeScript of this?
                             this.props.keypadElement?.configure(
-                                this.props.keypadConfiguration,
+                                keypadConfiguration,
                                 () => {
                                     if (this._isMounted) {
                                         this._handleFocus();
@@ -279,7 +282,7 @@ export class Expression extends React.Component<Props> implements Widget {
                             this.props.ariaLabel ||
                             this.context.strings.mathInputBox
                         }
-                        extraKeys={this.props.keypadConfiguration?.extraKeys}
+                        extraKeys={keypadConfiguration.extraKeys}
                         onAnalyticsEvent={
                             this.props.analytics?.onAnalyticsEvent ??
                             (async () => {})
@@ -326,34 +329,34 @@ export default {
     name: "expression",
     displayName: "Expression / Equation",
     widget: ExpressionWithDependencies,
-    transform: (
-        widgetOptions:
-            | PerseusExpressionWidgetOptions
-            | ExpressionPublicWidgetOptions,
-    ): RenderProps => {
-        const {
-            times,
-            functions,
-            buttonSets,
-            buttonsVisible,
-            visibleLabel,
-            ariaLabel,
-            extraKeys,
-        } = widgetOptions;
-        return {
-            keypadConfiguration: {
-                keypadType: "EXPRESSION",
-                extraKeys,
-                times,
-            },
-            times,
-            functions,
-            buttonSets,
-            buttonsVisible,
-            visibleLabel,
-            ariaLabel,
-        };
-    },
+    // transform: (
+    //     widgetOptions:
+    //         | PerseusExpressionWidgetOptions
+    //         | ExpressionPublicWidgetOptions,
+    // ): RenderProps => {
+    //     const {
+    //         times,
+    //         functions,
+    //         buttonSets,
+    //         buttonsVisible,
+    //         visibleLabel,
+    //         ariaLabel,
+    //         extraKeys,
+    //     } = widgetOptions;
+    //     return {
+    //         keypadConfiguration: {
+    //             keypadType: "EXPRESSION",
+    //             extraKeys,
+    //             times,
+    //         },
+    //         times,
+    //         functions,
+    //         buttonSets,
+    //         buttonsVisible,
+    //         visibleLabel,
+    //         ariaLabel,
+    //     };
+    // },
     version: expressionLogic.version,
 
     // For use by the editor

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -325,56 +325,30 @@ function getStartUserInput(): PerseusExpressionUserInput {
     return "";
 }
 
+function getOneCorrectAnswerFromRubric(
+    rubric: PerseusExpressionRubric,
+): string | null | undefined {
+    // TODO(LEMS-2656): remove TS suppression
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+    const correctAnswers = (rubric.answerForms || []).filter(
+        (answerForm) => answerForm.considered === "correct",
+    );
+    if (correctAnswers.length === 0) {
+        return;
+    }
+    return correctAnswers[0].value;
+}
+
 export default {
     name: "expression",
     displayName: "Expression / Equation",
     widget: ExpressionWithDependencies,
-    // transform: (
-    //     widgetOptions:
-    //         | PerseusExpressionWidgetOptions
-    //         | ExpressionPublicWidgetOptions,
-    // ): RenderProps => {
-    //     const {
-    //         times,
-    //         functions,
-    //         buttonSets,
-    //         buttonsVisible,
-    //         visibleLabel,
-    //         ariaLabel,
-    //         extraKeys,
-    //     } = widgetOptions;
-    //     return {
-    //         keypadConfiguration: {
-    //             keypadType: "EXPRESSION",
-    //             extraKeys,
-    //             times,
-    //         },
-    //         times,
-    //         functions,
-    //         buttonSets,
-    //         buttonsVisible,
-    //         visibleLabel,
-    //         ariaLabel,
-    //     };
-    // },
     version: expressionLogic.version,
 
     // For use by the editor
     isLintable: true,
 
-    // TODO(LEMS-2656): remove TS suppression
-    getOneCorrectAnswerFromRubric(
-        rubric: PerseusExpressionRubric,
-    ): string | null | undefined {
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        const correctAnswers = (rubric.answerForms || []).filter(
-            (answerForm) => answerForm.considered === "correct",
-        );
-        if (correctAnswers.length === 0) {
-            return;
-        }
-        return correctAnswers[0].value;
-    },
+    getOneCorrectAnswerFromRubric,
     getStartUserInput,
     getUserInputFromSerializedState,
 } satisfies WidgetExports<typeof ExpressionWithDependencies>;


### PR DESCRIPTION
## Summary:
The only thing the Expression transform was doing was using widget options to compute the keypad configuration. That's something it could just do internally in the widget.

Issue: LEMS-3199