### PR TITLE
[Radio] Enhance content for screen reader access

### DIFF
--- a/.changeset/five-wasps-drum.md
+++ b/.changeset/five-wasps-drum.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Radio] Enhance content for screen reader access

--- a/packages/perseus/src/widgets/radio/__stories__/choice-indicator.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__stories__/choice-indicator.stories.tsx
@@ -3,6 +3,13 @@ import React, {useRef} from "react";
 
 import Indicator from "../choice-indicator.new";
 
+import type {IndicatorContent} from "../choice-indicator.new";
+
+const indicatorContent: IndicatorContent = {
+    visible: "A",
+    screenReader: "Choice A",
+};
+
 const Container = (props: {children: React.ReactNode}): React.ReactElement => {
     return (
         <div
@@ -35,7 +42,7 @@ export const AllSettings = (): React.ReactElement => {
                         buttonRef={buttonRef}
                         checked={false}
                         shape="circle"
-                        content="A"
+                        content={indicatorContent}
                         updateChecked={() => {}}
                     />
                     &nbsp;Selectable
@@ -45,7 +52,7 @@ export const AllSettings = (): React.ReactElement => {
                         buttonRef={buttonRef}
                         checked={true}
                         shape="circle"
-                        content="A"
+                        content={indicatorContent}
                         updateChecked={() => {}}
                     />
                     &nbsp;Checked/Selected
@@ -55,7 +62,7 @@ export const AllSettings = (): React.ReactElement => {
                         buttonRef={buttonRef}
                         checked={false}
                         shape="circle"
-                        content="A"
+                        content={indicatorContent}
                         showCorrectness="correct"
                         updateChecked={() => {}}
                     />
@@ -66,7 +73,7 @@ export const AllSettings = (): React.ReactElement => {
                         buttonRef={buttonRef}
                         checked={true}
                         shape="circle"
-                        content="A"
+                        content={indicatorContent}
                         showCorrectness="correct"
                         updateChecked={() => {}}
                     />
@@ -77,7 +84,7 @@ export const AllSettings = (): React.ReactElement => {
                         buttonRef={buttonRef}
                         checked={true}
                         shape="circle"
-                        content="A"
+                        content={indicatorContent}
                         showCorrectness="wrong"
                         updateChecked={() => {}}
                     />
@@ -88,7 +95,7 @@ export const AllSettings = (): React.ReactElement => {
                         buttonRef={buttonRef}
                         checked={false}
                         shape="circle"
-                        content="A"
+                        content={indicatorContent}
                         showCorrectness="wrong"
                         updateChecked={() => {}}
                     />
@@ -102,7 +109,7 @@ export const AllSettings = (): React.ReactElement => {
                         buttonRef={buttonRef}
                         checked={false}
                         shape="square"
-                        content="A"
+                        content={indicatorContent}
                         updateChecked={() => {}}
                     />
                     &nbsp;Selectable
@@ -112,7 +119,7 @@ export const AllSettings = (): React.ReactElement => {
                         buttonRef={buttonRef}
                         checked={true}
                         shape="square"
-                        content="A"
+                        content={indicatorContent}
                         updateChecked={() => {}}
                     />
                     &nbsp;Checked/Selected
@@ -122,7 +129,7 @@ export const AllSettings = (): React.ReactElement => {
                         buttonRef={buttonRef}
                         checked={false}
                         shape="square"
-                        content="A"
+                        content={indicatorContent}
                         showCorrectness="correct"
                         updateChecked={() => {}}
                     />
@@ -133,7 +140,7 @@ export const AllSettings = (): React.ReactElement => {
                         buttonRef={buttonRef}
                         checked={true}
                         shape="square"
-                        content="A"
+                        content={indicatorContent}
                         showCorrectness="correct"
                         updateChecked={() => {}}
                     />
@@ -144,7 +151,7 @@ export const AllSettings = (): React.ReactElement => {
                         buttonRef={buttonRef}
                         checked={true}
                         shape="square"
-                        content="A"
+                        content={indicatorContent}
                         showCorrectness="wrong"
                         updateChecked={() => {}}
                     />
@@ -155,7 +162,7 @@ export const AllSettings = (): React.ReactElement => {
                         buttonRef={buttonRef}
                         checked={false}
                         shape="square"
-                        content="A"
+                        content={indicatorContent}
                         showCorrectness="wrong"
                         updateChecked={() => {}}
                     />

--- a/packages/perseus/src/widgets/radio/__stories__/multiple-choice-option.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__stories__/multiple-choice-option.stories.tsx
@@ -2,6 +2,15 @@ import * as React from "react";
 
 import Choice from "../choice.new";
 
+import type {IndicatorContent} from "../choice-indicator.new";
+
+const getIndicatorContent = (letter: string): IndicatorContent => {
+    return {
+        visible: letter,
+        screenReader: `Choice ${letter}`,
+    };
+};
+
 const Container = (props: {children: React.ReactNode}): React.ReactElement => {
     return (
         <ul
@@ -25,7 +34,7 @@ export const SingleSelect = (): React.ReactElement => {
         <Container>
             <Choice
                 checked={false}
-                indicatorContent="A"
+                indicatorContent={getIndicatorContent("A")}
                 isMultiSelect={false}
                 updateChecked={() => {}}
             >
@@ -33,7 +42,7 @@ export const SingleSelect = (): React.ReactElement => {
             </Choice>
             <Choice
                 checked={false}
-                indicatorContent="B"
+                indicatorContent={getIndicatorContent("B")}
                 isMultiSelect={false}
                 updateChecked={() => {}}
             >
@@ -43,7 +52,7 @@ export const SingleSelect = (): React.ReactElement => {
             </Choice>
             <Choice
                 checked={false}
-                indicatorContent="C"
+                indicatorContent={getIndicatorContent("C")}
                 isMultiSelect={false}
                 updateChecked={() => {}}
             >
@@ -54,7 +63,7 @@ export const SingleSelect = (): React.ReactElement => {
             </Choice>
             <Choice
                 checked={true}
-                indicatorContent="D"
+                indicatorContent={getIndicatorContent("D")}
                 isMultiSelect={false}
                 showCorrectness="wrong"
                 updateChecked={() => {}}
@@ -63,7 +72,7 @@ export const SingleSelect = (): React.ReactElement => {
             </Choice>
             <Choice
                 checked={false}
-                indicatorContent="E"
+                indicatorContent={getIndicatorContent("E")}
                 isMultiSelect={false}
                 updateChecked={() => {}}
             >
@@ -71,7 +80,7 @@ export const SingleSelect = (): React.ReactElement => {
             </Choice>
             <Choice
                 checked={true}
-                indicatorContent="F"
+                indicatorContent={getIndicatorContent("F")}
                 isMultiSelect={false}
                 showCorrectness="correct"
                 updateChecked={() => {}}

--- a/packages/perseus/src/widgets/radio/__tests__/choice-indicator.test.tsx
+++ b/packages/perseus/src/widgets/radio/__tests__/choice-indicator.test.tsx
@@ -5,6 +5,13 @@ import * as React from "react";
 
 import Indicator from "../choice-indicator.new";
 
+import type {IndicatorContent} from "../choice-indicator.new";
+
+const indicatorContent: IndicatorContent = {
+    visible: "A",
+    screenReader: "Choice A",
+};
+
 describe("Multiple choice indicator", () => {
     let iconMock: jest.SpyInstance;
     let mockClickHandler: jest.Mock;
@@ -15,16 +22,21 @@ describe("Multiple choice indicator", () => {
         iconMock = jest.spyOn(PhosphorIcon, "render");
         mockClickHandler = jest.fn();
         buttonRef = React.createRef<HTMLButtonElement>();
+        jest.spyOn(React, "useId").mockReturnValue("id:foo");
     });
 
-    describe("with/without icons", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    describe("content", () => {
         it(`renders WITHOUT any icons when indicator is checked and NOT in review mode`, async () => {
             render(
                 <Indicator
                     buttonRef={buttonRef}
                     checked={true}
                     shape="circle"
-                    content="A"
+                    content={indicatorContent}
                     updateChecked={mockClickHandler}
                 />,
             );
@@ -38,7 +50,7 @@ describe("Multiple choice indicator", () => {
                     buttonRef={buttonRef}
                     checked={true}
                     shape="circle"
-                    content="A"
+                    content={indicatorContent}
                     showCorrectness={undefined}
                     updateChecked={mockClickHandler}
                 />,
@@ -55,7 +67,7 @@ describe("Multiple choice indicator", () => {
                         buttonRef={buttonRef}
                         checked={false}
                         shape="circle"
-                        content="A"
+                        content={indicatorContent}
                         showCorrectness={correctness}
                         updateChecked={mockClickHandler}
                     />,
@@ -71,7 +83,7 @@ describe("Multiple choice indicator", () => {
                     buttonRef={buttonRef}
                     checked={true}
                     shape="circle"
-                    content="A"
+                    content={indicatorContent}
                     showCorrectness="correct"
                     updateChecked={mockClickHandler}
                 />,
@@ -91,7 +103,7 @@ describe("Multiple choice indicator", () => {
                     buttonRef={buttonRef}
                     checked={true}
                     shape="circle"
-                    content="A"
+                    content={indicatorContent}
                     showCorrectness="wrong"
                     updateChecked={mockClickHandler}
                 />,
@@ -106,6 +118,68 @@ describe("Multiple choice indicator", () => {
                 .querySelector("[role='img']");
             expect(buttonIcon).toBeInTheDocument();
         });
+
+        it("only includes the aria label when no other aria information is provided", () => {
+            render(
+                <Indicator
+                    buttonRef={buttonRef}
+                    checked={true}
+                    shape="circle"
+                    content={indicatorContent}
+                    showCorrectness="wrong"
+                    updateChecked={mockClickHandler}
+                />,
+            );
+            const indicator = screen.getByRole("button");
+            expect(indicator).toHaveAttribute("aria-label", "Choice A");
+            expect(indicator).not.toHaveAttribute("aria-labelledby");
+            expect(indicator).not.toHaveAttribute("aria-describedby");
+        });
+
+        it("also includes any aria-labelledby information when provided", () => {
+            const contentWithLabel: IndicatorContent = {
+                ...indicatorContent,
+                labelledBy: ":bar:",
+            };
+            render(
+                <Indicator
+                    buttonRef={buttonRef}
+                    checked={true}
+                    shape="circle"
+                    content={contentWithLabel}
+                    showCorrectness="wrong"
+                    updateChecked={mockClickHandler}
+                />,
+            );
+            const indicator = screen.getByRole("button");
+            expect(indicator).toHaveAttribute("aria-label", "Choice A");
+            expect(indicator).toHaveAttribute(
+                "aria-labelledby",
+                "id:foo :bar:",
+            );
+            expect(indicator).not.toHaveAttribute("aria-describedby");
+        });
+
+        it("also includes any aria-describedby information when provided", () => {
+            const contentWithLabel: IndicatorContent = {
+                ...indicatorContent,
+                describedBy: ":zot:",
+            };
+            render(
+                <Indicator
+                    buttonRef={buttonRef}
+                    checked={true}
+                    shape="circle"
+                    content={contentWithLabel}
+                    showCorrectness="wrong"
+                    updateChecked={mockClickHandler}
+                />,
+            );
+            const indicator = screen.getByRole("button");
+            expect(indicator).toHaveAttribute("aria-label", "Choice A");
+            expect(indicator).not.toHaveAttribute("aria-labelledby");
+            expect(indicator).toHaveAttribute("aria-describedby", ":zot:");
+        });
     });
 
     describe("styling options", () => {
@@ -115,7 +189,7 @@ describe("Multiple choice indicator", () => {
                     buttonRef={buttonRef}
                     checked={false}
                     shape={shape}
-                    content="A"
+                    content={indicatorContent}
                     updateChecked={mockClickHandler}
                 />,
             );
@@ -131,7 +205,7 @@ describe("Multiple choice indicator", () => {
                     buttonRef={buttonRef}
                     checked={false}
                     shape="circle"
-                    content="A"
+                    content={indicatorContent}
                     updateChecked={mockClickHandler}
                 />,
             );
@@ -147,7 +221,7 @@ describe("Multiple choice indicator", () => {
                     buttonRef={buttonRef}
                     checked={false}
                     shape="circle"
-                    content="A"
+                    content={indicatorContent}
                     showCorrectness="correct"
                     updateChecked={mockClickHandler}
                 />,
@@ -174,7 +248,7 @@ describe("Multiple choice indicator", () => {
                         buttonRef={buttonRef}
                         checked={checked}
                         shape="circle"
-                        content="A"
+                        content={indicatorContent}
                         updateChecked={mockClickHandler}
                     />,
                 );

--- a/packages/perseus/src/widgets/radio/__tests__/multiple-choice-component.test.tsx
+++ b/packages/perseus/src/widgets/radio/__tests__/multiple-choice-component.test.tsx
@@ -17,6 +17,7 @@ type overrideProps = {
 const baseChoiceValues = {
     checked: false,
     content: "",
+    id: "choice-1",
     rationale: "",
     hasRationale: false,
     showRationale: false,
@@ -209,6 +210,31 @@ describe("Multiple choice component", () => {
             expect(
                 screen.queryByText(rationaleContent),
             ).not.toBeInTheDocument();
+        });
+
+        it.each`
+            reviewMode | isCorrect | expectedLabel            | shows              | when
+            ${true}    | ${true}   | ${"(Choice A, Correct)"} | ${"shows"}         | ${"when in review mode and choice is correct"}
+            ${true}    | ${false}  | ${"(Choice A)"}          | ${"does NOT show"} | ${"when in review mode and choice is NOT correct"}
+            ${false}   | ${true}   | ${"(Choice A)"}          | ${"does NOT show"} | ${"when NOT in review mode and choice is correct"}
+            ${false}   | ${false}  | ${"(Choice A)"}          | ${"does NOT show"} | ${"when NOT in review mode and choice is NOT correct"}
+        `("$shows correctness in the accessible name $when", (args) => {
+            type testArgs = {
+                reviewMode: boolean;
+                isCorrect: boolean;
+                expectedLabel: string;
+            };
+            const {reviewMode, isCorrect, expectedLabel} = args as testArgs;
+            const choiceOverrides = {correct: isCorrect};
+            const props = getComponentProps({
+                choiceOverrides,
+                reviewMode,
+            });
+            render(<MultipleChoiceComponent {...props} />);
+            expect(screen.getByRole("button")).toHaveAttribute(
+                "aria-label",
+                expectedLabel,
+            );
         });
     });
 

--- a/packages/perseus/src/widgets/radio/__tests__/multiple-choice-option.test.tsx
+++ b/packages/perseus/src/widgets/radio/__tests__/multiple-choice-option.test.tsx
@@ -5,6 +5,13 @@ import * as React from "react";
 import * as IndicatorComponent from "../choice-indicator.new";
 import Choice from "../choice.new";
 
+import type {IndicatorContent} from "../choice-indicator.new";
+
+const indicatorContent: IndicatorContent = {
+    visible: "A",
+    screenReader: "Choice A",
+};
+
 describe("Multiple choice option", () => {
     it.each`
         isMultiSelect | isOrIsNot   | shape
@@ -21,7 +28,7 @@ describe("Multiple choice option", () => {
             render(
                 <Choice
                     checked={false}
-                    indicatorContent="A"
+                    indicatorContent={indicatorContent}
                     isMultiSelect={isMultiSelect}
                     updateChecked={() => {}}
                 >
@@ -49,7 +56,7 @@ describe("Multiple choice option", () => {
         render(
             <Choice
                 checked={false}
-                indicatorContent="A"
+                indicatorContent={indicatorContent}
                 isMultiSelect={false}
                 showCorrectness={showCorrectness}
                 updateChecked={() => {}}
@@ -78,7 +85,7 @@ describe("Multiple choice option", () => {
             render(
                 <Choice
                     checked={false}
-                    indicatorContent="A"
+                    indicatorContent={indicatorContent}
                     isMultiSelect={false}
                     showCorrectness={showCorrectness}
                     updateChecked={updateCheckedMock}

--- a/packages/perseus/src/widgets/radio/choice-indicator.new.tsx
+++ b/packages/perseus/src/widgets/radio/choice-indicator.new.tsx
@@ -1,21 +1,33 @@
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import checkIcon from "@phosphor-icons/core/bold/check-bold.svg";
 import minusIcon from "@phosphor-icons/core/bold/minus-circle-bold.svg";
-import * as React from "react";
+import React, {useId} from "react";
 
 import styles from "./choice-indicator.module.css";
 
-export type IndicatorProps = {
+export interface IndicatorContent {
+    visible: string;
+    screenReader: string;
+    labelledBy?: string;
+    describedBy?: string;
+}
+
+export interface IndicatorProps {
     buttonRef: React.Ref<HTMLButtonElement>;
     checked: boolean;
-    content: string;
+    content: IndicatorContent;
     shape: "circle" | "square";
     showCorrectness?: "correct" | "wrong";
     updateChecked: (isChecked: boolean) => void;
-};
+}
 
 const Indicator = (props: IndicatorProps) => {
-    const {checked, showCorrectness} = props;
+    const {checked, content, showCorrectness} = props;
+    const indicatorId = useId();
+    const ariaLabelledby = content.labelledBy
+        ? `${indicatorId} ${content.labelledBy}`
+        : undefined;
+    const ariaDisabled = showCorrectness ? "true" : "false";
     const iconImage =
         checked && showCorrectness === "correct"
             ? checkIcon
@@ -43,14 +55,19 @@ const Indicator = (props: IndicatorProps) => {
 
     return (
         <button
+            aria-describedby={content.describedBy}
+            aria-disabled={ariaDisabled}
             aria-pressed={checked}
+            aria-label={content.screenReader}
+            aria-labelledby={ariaLabelledby}
             className={classes.join(" ")}
+            id={indicatorId}
             type="button"
             ref={props.buttonRef}
             onClick={handleClick}
         >
             {icon}
-            {props.content}
+            {content.visible}
         </button>
     );
 };

--- a/packages/perseus/src/widgets/radio/choice.module.css
+++ b/packages/perseus/src/widgets/radio/choice.module.css
@@ -5,6 +5,7 @@
      */
     .choice :global(.paragraph) {
         font-size: inherit;
+        font-weight: inherit;
         line-height: inherit;
     }
 }

--- a/packages/perseus/src/widgets/radio/choice.new.tsx
+++ b/packages/perseus/src/widgets/radio/choice.new.tsx
@@ -3,10 +3,12 @@ import React, {useRef} from "react";
 import Indicator from "./choice-indicator.new";
 import styles from "./choice.module.css";
 
+import type {IndicatorContent} from "./choice-indicator.new";
+
 export interface IndicatorProps {
     checked: boolean;
     children: React.ReactNode | React.ReactNode[];
-    indicatorContent: string; // This is the letter that shows for the choice
+    indicatorContent: IndicatorContent;
     isMultiSelect: boolean;
     showCorrectness?: "correct" | "wrong";
     updateChecked: (isChecked: boolean) => void;

--- a/packages/perseus/src/widgets/radio/multiple-choice-component.new.tsx
+++ b/packages/perseus/src/widgets/radio/multiple-choice-component.new.tsx
@@ -102,28 +102,25 @@ const ChoiceListItems = (props: ChoiceListItemsProps): React.ReactElement => {
         const contentId = `${listId}-choice-${i + 1}`;
         const choiceLetter = getChoiceLetter(i, i18nStrings);
         const srContent =
-            reviewMode === true
-                ? choice.correct
-                    ? i18nStrings.choiceCorrect
-                    : i18nStrings.choiceIncorrect
+            reviewMode && choice.correct
+                ? i18nStrings.choiceCorrect
                 : i18nStrings.choice;
         const indicatorContent: IndicatorContent = {
             visible: choiceLetter,
             screenReader: srContent({letter: choiceLetter}),
             labelledBy: contentId,
         };
-        const showCorrectness =
-            reviewMode === true
-                ? choice.correct
-                    ? "correct"
-                    : "wrong"
-                : undefined;
+        const showCorrectness = reviewMode
+            ? choice.correct
+                ? "correct"
+                : "wrong"
+            : undefined;
         const content = choice.isNoneOfTheAbove
             ? i18nStrings.noneOfTheAbove
             : choice.content;
         let rationale: React.ReactElement | undefined;
         if (reviewMode && choice.hasRationale) {
-            const rationaleId = `${contentId}-rationale-${i + 1}`;
+            const rationaleId = `${contentId}-rationale`;
             indicatorContent.describedBy = rationaleId;
             const rationaleClasses =
                 showCorrectness === "correct"
@@ -131,8 +128,6 @@ const ChoiceListItems = (props: ChoiceListItemsProps): React.ReactElement => {
                     : styles.rationale;
             rationale = (
                 <div id={rationaleId} className={rationaleClasses}>
-                    {/* Any prefix here needs to be translated */}
-                    <span className="perseus-sr-only">Here's why:</span>
                     {choice.rationale}
                 </div>
             );

--- a/packages/perseus/src/widgets/radio/multiple-choice.module.css
+++ b/packages/perseus/src/widgets/radio/multiple-choice.module.css
@@ -16,10 +16,7 @@
         var(--perseus-multiple-choice-spacing) +
             var(--perseus-multiple-choice-indicator-size)
     );
-    --perseus-multiple-choice-scroll-fade-width: calc(
-        var(--perseus-multiple-choice-content-margin) +
-            var(--perseus-multiple-choice-spacing)
-    );
+    --perseus-multiple-choice-fade-direction: 90deg; /* Default is left to right */
 
     min-width: auto; /* Needed for scrollable view to work */
     padding-inline-end: var(--perseus-multiple-choice-spacing);
@@ -37,52 +34,43 @@
     scrollbar-width: thin;
 }
 
-/* Fade bars for scrolling (Start) */
-.choice-list:before,
-.choice-list:after {
+.choice-list:dir(rtl) {
+    --perseus-multiple-choice-fade-direction: 270deg; /* Flip to right to left when in RTL mode */
+}
+
+/* FADE BARS FOR SCROLLING
+   A white bar starts on the left side and stays solid until a small amount (spacing / 2) past the indicator (content margin).
+   It then fades to transparent over that same small amount.
+   It stays transparent until the opposite side of the container,
+        where it fades back to white in the reverse order as just described.
+   In review mode, the left side starts fading to transparent at a further distance to account for the checkmark icon.
+   This is why --perseus-multiple-choice-content-margin is used on the left side,
+        but the right side uses --perseus-multiple-choice-spacing.
+   Also, in order to account for text direction, the direction is flipped when in RTL mode.
+*/
+.choice-list:before {
+    background: linear-gradient(
+        /* 90deg or 270deg */ var(--perseus-multiple-choice-fade-direction),
+        /* Accounts for theme color */ var(--wb-semanticColor-surface-primary)
+            calc(
+                var(--perseus-multiple-choice-content-margin) +
+                    (var(--perseus-multiple-choice-spacing) / 2)
+            ),
+        transparent
+            calc(
+                var(--perseus-multiple-choice-content-margin) +
+                    var(--perseus-multiple-choice-spacing)
+            )
+            calc(100% - (var(--perseus-multiple-choice-spacing) * 1.5)),
+        var(--wb-semanticColor-surface-primary)
+            calc(100% - var(--perseus-multiple-choice-spacing))
+    );
     content: "";
     display: block;
     height: 100%;
     position: fixed;
-    width: var(--perseus-multiple-choice-scroll-fade-width);
-    top: 0;
+    width: 100%;
 }
-
-.choice-list:dir(ltr):after {
-    /* Accounting for the padding in the containing fieldset and the choice item */
-    right: calc(
-        (var(--perseus-multiple-choice-spacing) * 2) -
-            var(--perseus-multiple-choice-scroll-fade-width)
-    );
-}
-
-.choice-list:dir(rtl):after {
-    left: calc(
-        (var(--perseus-multiple-choice-spacing) * 2) -
-            var(--perseus-multiple-choice-scroll-fade-width)
-    );
-}
-
-.choice-list:dir(ltr):before,
-.choice-list:dir(rtl):after {
-    background: linear-gradient(
-        to left,
-        transparent,
-        var(--wb-semanticColor-surface-primary)
-            calc(var(--perseus-multiple-choice-spacing) / 2)
-    );
-}
-
-.choice-list:dir(rtl):before,
-.choice-list:dir(ltr):after {
-    background: linear-gradient(
-        to right,
-        transparent,
-        var(--wb-semanticColor-surface-primary)
-            calc(var(--perseus-multiple-choice-spacing) / 2)
-    );
-}
-/* Fade bars for scrolling (End) */
 
 .content {
     display: flex;


### PR DESCRIPTION
## Summary:
Screen readers can access all the information in the radio widget, but some enhancements are needed to ensure clarity of what is being read. Specifically:
- The word "Choice" is prefixed to the choice letter
- The full choice content is connected to the choice button in order to present a complete readout of the choice
- The rationale is referenced via `aria-describedby` as additional material, leaving it to the screen reader to determine how to surface that information for the choice

Additionally, the choice button is marked with `aria-disabled` when in review mode to indicate that the button is no longer able to be activated.

Issue: LEMS-3364

## Test plan:
1. Launch Storybook locally
2. Navigate to Widgets => RadioNew => [Docs](http://localhost:6006/?path=/docs/widgets-radionew--docs)
3. Using a screen reader, traverse any of the examples using a keyboard (i.e. tab navigation)
   - Note how the screen reader announces the information for the widget as a whole, and for each choice within it
4. Using a screen reader, traverse any of the examples using the screen reader's key commands
   - Note how the screen reader announces each part of widget (more options than just using the tab key)
5. The announcements from the screen reader should make sense and reflect what is shown visually in the widget