### PR TITLE
[Radio] Use choice IDs for the choice keys in the editor

### DIFF
--- a/.changeset/new-bugs-burn.md
+++ b/.changeset/new-bugs-burn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Radio] Use choice IDs for the choice keys in the editor

--- a/packages/perseus-editor/src/widgets/radio/editor.tsx
+++ b/packages/perseus-editor/src/widgets/radio/editor.tsx
@@ -296,7 +296,7 @@ class RadioEditor extends React.Component<RadioEditorProps> {
 
                 {this.props.choices.map((choice, index) => (
                     <RadioOptionSettings
-                        key={`choice-${index}}`}
+                        key={`choice-${choice.id}}`}
                         index={index}
                         choice={choice}
                         multipleSelect={this.props.multipleSelect}


### PR DESCRIPTION
## Summary:
This just provides more accurate keys to React.

As a result of that, the focus order stays on the same choice when keyboard nav
is used to press a reorder button.

Note: There is something that's not right with the choice IDs in the editor storybook
currently, but I was able to add some manually to test this locally. Anakaren is going
to look into why the IDs are not being generated by the parser in a separate ticket.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3322

### Before:
https://github.com/user-attachments/assets/2fe74afe-b34f-4092-a0ee-a1af5003e0cd 

### After:
https://github.com/user-attachments/assets/1da4cbc2-b8e5-429e-b818-3440de5ba37f 



## Test plan:
- Manually put choice IDs in packages/perseus-editor/src/__testdata__/radio.testdata.ts
- Go to http://localhost:6006/?path=/docs/widgets-radionew-editor-demo--docs#multi-choice
- Use the keyboard to navigate to a reorder button
- Press the button and confirm that the focus stays on the same choice after reordering,
  NOT the same index when the choice has no been moved to a different index