### PR TITLE
[Image] (UX) Remove the custom mobile styling for title and caption

### DIFF
--- a/.changeset/heavy-beers-carry.md
+++ b/.changeset/heavy-beers-carry.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Image](UX) Remove the custom mobile styling for title and caption

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -512,13 +512,6 @@
         line-height: 1.3;
         text-align: left;
     }
-    .framework-perseus.perseus-mobile
-        .perseus-image-caption.has-title
-        .paragraph
-        .paragraph
-        strong:first-child {
-        color: #3b3e40;
-    }
     .framework-perseus.perseus-mobile mjx-container:not(.mafs-graph *) {
         font-size: 21px;
         line-height: 1.2;
@@ -683,13 +676,6 @@
         line-height: 1.4;
         text-align: left;
     }
-    .framework-perseus.perseus-mobile
-        .perseus-image-caption.has-title
-        .paragraph
-        .paragraph
-        strong:first-child {
-        color: #3b3e40;
-    }
     .framework-perseus.perseus-mobile mjx-container:not(.mafs-graph *) {
         font-size: 23px;
         line-height: 1.3;
@@ -853,13 +839,6 @@
         font-size: 20px;
         line-height: 1.4;
         text-align: left;
-    }
-    .framework-perseus.perseus-mobile
-        .perseus-image-caption.has-title
-        .paragraph
-        .paragraph
-        strong:first-child {
-        color: #3b3e40;
     }
     .framework-perseus.perseus-mobile mjx-container:not(.mafs-graph *) {
         font-size: 25px;

--- a/packages/perseus/src/widgets/image/__snapshots__/image.test.ts.snap
+++ b/packages/perseus/src/widgets/image/__snapshots__/image.test.ts.snap
@@ -206,6 +206,24 @@ exports[`image widget - isMobile(true) should snapshot: first render 1`] = `
                   style="max-width: 420px;"
                 >
                   <div
+                    class="perseus-image-title"
+                  >
+                    <div
+                      class="perseus-renderer perseus-renderer-responsive"
+                    >
+                      <div
+                        class="paragraph"
+                        data-perseus-paragraph-index="0"
+                      >
+                        <div
+                          class="paragraph"
+                        >
+                          Image Title
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div
                     class="fixed-to-responsive svg-image"
                     style="max-width: 420px; max-height: 345px;"
                   >
@@ -234,25 +252,20 @@ exports[`image widget - isMobile(true) should snapshot: first render 1`] = `
                     </span>
                   </div>
                   <figcaption
-                    class="perseus-image-caption has-title"
+                    class="perseus-image-caption"
                     style="max-width: 420px;"
                   >
-                    <div>
+                    <div
+                      class="perseus-renderer perseus-renderer-responsive"
+                    >
                       <div
-                        class="perseus-renderer perseus-renderer-responsive"
+                        class="paragraph"
+                        data-perseus-paragraph-index="0"
                       >
                         <div
                           class="paragraph"
-                          data-perseus-paragraph-index="0"
                         >
-                          <div
-                            class="paragraph"
-                          >
-                            <strong>
-                              Image Title.
-                            </strong>
-                             Image Caption
-                          </div>
+                          Image Caption
                         </div>
                       </div>
                     </div>

--- a/packages/perseus/src/widgets/image/image.tsx
+++ b/packages/perseus/src/widgets/image/image.tsx
@@ -1,5 +1,4 @@
 import {linterContextDefault} from "@khanacademy/perseus-linter";
-import classNames from "classnames";
 import * as React from "react";
 import _ from "underscore";
 
@@ -105,90 +104,6 @@ class ImageWidget extends React.Component<Props> implements Widget {
             );
         }
 
-        // For mobile we combine an image's title and caption.
-        if (apiOptions.isMobile) {
-            let titleAndCaption;
-
-            if (this.props.title || this.props.caption) {
-                let title = this.props.title;
-
-                // Bold the title, and make it the first sentence of the
-                // caption.
-                if (title) {
-                    // We add a period to separate the title from the caption
-                    // (if it exists), unless the title already ends with a
-                    // punctuation symbol (whitespace ignored). Copied from
-                    // webapp: https://github.com/Khan/webapp/blob/6e930637edb65696d0749ea0f7558214aee32b4e/javascript/tutorial-shared-package/components/content-description.jsx#L80
-                    // TODO(charlie): Internationalize this check, and the
-                    // delimiter that is being inserted.
-                    if (this.props.caption && !/[.?!"']\s*$/.test(title)) {
-                        title += ".";
-                    }
-
-                    title = `**${title}** `;
-                }
-
-                const className = classNames({
-                    "perseus-image-caption": true,
-                    "has-title": !!title,
-                });
-
-                // Caption is left-aligned within a container that's centered
-                // below the image, with these width constraints:
-                //
-                // 1. Size caption to width of the image on-screen.
-                // 2. ... but constrain its width to a range based on the
-                //    device to optimize readability - e.g. [320px, 450px] for
-                //    phones.
-                // 3. ... unless the image is floated, in which case we don't
-                //    want the caption to overflow the image size.
-                //
-                // TODO(david): If caption is only 1 line long, center-align
-                //     the text.
-                const alignment = this.props.alignment;
-                const isImageFullWidth =
-                    alignment === "block" || alignment === "full-width";
-
-                // This minWidth takes precedence over minWidth applied via
-                // Aphrodite.
-                const minWidth = isImageFullWidth ? null : "0 !important";
-
-                titleAndCaption = (
-                    <figcaption
-                        className={className}
-                        style={{
-                            maxWidth: backgroundImage.width,
-                        }}
-                    >
-                        <div
-                            style={{
-                                // @ts-expect-error - TS2322 - Type 'string | null' is not assignable to type 'MinWidth<string | number> | undefined'.
-                                minWidth: minWidth,
-                            }}
-                        >
-                            <Renderer
-                                content={title + this.props.caption}
-                                apiOptions={apiOptions}
-                                linterContext={this.props.linterContext}
-                                strings={this.context.strings}
-                            />
-                        </div>
-                    </figcaption>
-                );
-            }
-
-            return (
-                <figure
-                    className="perseus-image-widget"
-                    style={{
-                        maxWidth: backgroundImage.width,
-                    }}
-                >
-                    {image}
-                    {titleAndCaption}
-                </figure>
-            );
-        }
         let title;
         let caption;
 


### PR DESCRIPTION
## Summary:
As part of an archaic mobile design rehaul, the image widget had the
title added to its caption section and bolded. The code for this is
somewhat convoluted, and this separate design is not necessary.

Uniting the desktop/mobile code by removing the custom mobile section.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3381

### Desktop

| Before | After |
| --- | --- |
| <img width="560" height="699" alt="Screenshot 2025-08-18 at 4 50 33 PM" src="https://github.com/user-attachments/assets/8e831868-91fc-45f5-bbd1-f613267d58db" /> | <img width="569" height="711" alt="Screenshot 2025-08-18 at 4 50 39 PM" src="https://github.com/user-attachments/assets/e9ccc04e-1a8e-4745-943e-1a74e3e7b2ad" /> |

### Mobile
| Before | After |
| --- | --- |
| <img width="575" height="660" alt="Screenshot 2025-08-18 at 4 50 44 PM" src="https://github.com/user-attachments/assets/9f49490e-473d-4bab-95c9-1d8497473675" /> | <img width="564" height="713" alt="Screenshot 2025-08-18 at 4 59 12 PM" src="https://github.com/user-attachments/assets/dafaaf0d-3334-43e6-89f8-84d8f70ac3ab" /> |

## Test plan:
Storybook:
- http://localhost:6006/?path=/docs/widgets-image--docs
- Click on the mobile preview switch, and confirm it's the same as desktop