### PR TITLE
[Radio] Adjust the transition time of the indicator so that it doesn't appear out of sync with the "Check" button

### DIFF
--- a/.changeset/odd-plums-juggle.md
+++ b/.changeset/odd-plums-juggle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Radio] Adjust the transition time of the indicator so that it doesn't appear out of sync with the "Check" button

--- a/packages/perseus/src/widgets/radio/choice-indicator.module.css
+++ b/packages/perseus/src/widgets/radio/choice-indicator.module.css
@@ -23,7 +23,7 @@
 @media (prefers-reduced-motion: no-preference) {
     .base {
         transition:
-            all 0.2s,
+            all 0.125s,
             outline-width 0s,
             outline-offset 0s;
     }


### PR DESCRIPTION
## Summary
The transition of the indicator color from a background of white to blue/purple is long enough to make it appear that there is a delay of registering the selection when compared to the color change of the "Check" button. This CSS change speeds up the transition time in an effort to reduce the apparent lag between the two.

Issue: LEMS-3354