### PR TITLE
[Radio] Adjust horizontal scroll fade bar color to use background color of container

### DIFF
--- a/.changeset/spotty-planes-check.md
+++ b/.changeset/spotty-planes-check.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Radio] Adjust horizontal scroll fade bar color to use background color of container

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -308,6 +308,10 @@ const styles = StyleSheet.create({
         borderTop: `1px solid ${gray76}`,
         borderBottom: `1px solid ${gray76}`,
         backgroundColor: tableBackgroundAccent,
+        // The following CSS variable is put into place to let child widgets know that there is a background color in effect.
+        // For example, this is helpful for the radio widget to properly color its horizontal scroll fade bars.
+        //  @ts-expect-error TS2353: Object literal may only specify known properties
+        "--perseus-widget-background-color": tableBackgroundAccent,
         marginLeft: negativePhoneMargin,
         marginRight: negativePhoneMargin,
         paddingBottom: phoneMargin,

--- a/packages/perseus/src/widgets/radio/__docs__/radio.new.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/radio.new.stories.tsx
@@ -10,6 +10,7 @@ import {
     multiChoiceQuestionSimpleOverflowContent,
     SingleSelectOverflowContent,
     SingleSelectOverflowImageContent,
+    overflowContentInGradedGroupSet,
 } from "../__tests__/radio.testdata";
 
 import type {APIOptions} from "../../../types";
@@ -157,6 +158,14 @@ export const MultiSelectWithScroll = {
     args: {
         item: generateTestPerseusItem({
             question: multiChoiceQuestionSimpleOverflowContent,
+        }),
+    },
+};
+
+export const ScrollingInGradedGroupSet = {
+    args: {
+        item: generateTestPerseusItem({
+            question: overflowContentInGradedGroupSet,
         }),
     },
 };

--- a/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
@@ -396,3 +396,40 @@ export const questionWithUndefinedCorrect: PerseusRenderer =
         .withMultipleSelect(true)
         .withRandomize(true)
         .build();
+
+export const overflowContentInGradedGroupSet: PerseusRenderer = {
+    content:
+        "#Testing scrollbar color when background color exists\n\n[[☃ graded-group-set 1]]\n\n\nFade color should match the background.",
+    images: {},
+    widgets: {
+        "graded-group-set 1": {
+            type: "graded-group-set",
+            alignment: "default",
+            static: false,
+            graded: true,
+            options: {
+                gradedGroups: [
+                    {
+                        ...SingleSelectOverflowContent,
+                        title: "Single Select - Math",
+                        widgetEnabled: true,
+                        immutableWidgets: false,
+                    },
+                    {
+                        ...SingleSelectOverflowImageContent,
+                        title: "Single Select - Image",
+                        widgetEnabled: true,
+                        immutableWidgets: false,
+                    },
+                    {
+                        ...multiChoiceQuestionSimpleOverflowContent,
+                        title: "Multi Choice - Math",
+                        widgetEnabled: true,
+                        immutableWidgets: false,
+                    },
+                ],
+            },
+            version: {major: 0, minor: 0},
+        },
+    },
+};

--- a/packages/perseus/src/widgets/radio/multiple-choice.module.css
+++ b/packages/perseus/src/widgets/radio/multiple-choice.module.css
@@ -17,6 +17,10 @@
             var(--perseus-multiple-choice-indicator-size)
     );
     --perseus-multiple-choice-fade-direction: 90deg; /* Default is left to right */
+    --perseus-multiple-choice-fade-color: var(
+        --perseus-widget-background-color,
+        var(--wb-semanticColor-surface-primary)
+    ); /* Accounts for theme color, unless a background color is specified (i.e. from Graded Group Set) */
 
     min-width: auto; /* Needed for scrollable view to work */
     padding-inline-end: var(--perseus-multiple-choice-spacing);
@@ -51,7 +55,7 @@
 .choice-list:before {
     background: linear-gradient(
         /* 90deg or 270deg */ var(--perseus-multiple-choice-fade-direction),
-        /* Accounts for theme color */ var(--wb-semanticColor-surface-primary)
+        var(--perseus-multiple-choice-fade-color)
             calc(
                 var(--perseus-multiple-choice-content-margin) +
                     (var(--perseus-multiple-choice-spacing) / 2)
@@ -62,7 +66,7 @@
                     var(--perseus-multiple-choice-spacing)
             )
             calc(100% - (var(--perseus-multiple-choice-spacing) * 1.5)),
-        var(--wb-semanticColor-surface-primary)
+        var(--perseus-multiple-choice-fade-color)
             calc(100% - var(--perseus-multiple-choice-spacing))
     );
     content: "";


### PR DESCRIPTION
## Summary
The Graded Group Set has a background color that is not the page color.
When a radio widget is included in this widget, the fade bars used for horizontal scrolling show as white against the gray background.
The radio widget doesn't know that it is being displayed in the graded group set.
This bugfix adds a CSS variable to the graded group set container element that indicates the background color.
The fade bars in the radio widget now reference this new background color variable, but falls back to the semantic color for backgrounds if a container color doesn't exist.

Issue: LEMS-3405

## Test plan:
1. Open Storybook (either for this PR, or locally)
1. Navigate to the new story: Widges => RadioNew => Docs => Scrolling in Graded Group Set
1. Note that when scrolling horizontally, the fade bars match the background color