### PR TITLE
docs(changeset): Remove the isLastUsedWidget property from Perseus, as it is not used.

### DIFF
--- a/.changeset/weak-candles-hammer.md
+++ b/.changeset/weak-candles-hammer.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Remove the isLastUsedWidget property from Perseus, as it is not used.

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -198,7 +198,6 @@ describe("renderer", () => {
             // Assert
             expect(renderer.state.jiptContent).toBeNull();
             expect(renderer.state.translationLintErrors).toHaveLength(0);
-            expect(renderer.state.lastUsedWidgetId).toBeNull();
 
             expect(renderer.state.widgetInfo).toStrictEqual(question1.widgets);
         });

--- a/packages/perseus/src/mixins/widget-prop-denylist.ts
+++ b/packages/perseus/src/mixins/widget-prop-denylist.ts
@@ -38,7 +38,6 @@ const denylist = [
     "trackInteraction",
     "keypadElement",
     "linterContext",
-    "isLastUsedWidget",
     "handleUserInput",
     "analytics",
     "showSolutions",

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -157,7 +157,6 @@ type State = {
     translationLintErrors: ReadonlyArray<string>;
     widgetInfo: Readonly<PerseusWidgetsMap>;
     jiptContent: any;
-    lastUsedWidgetId: string | null | undefined;
 };
 
 type FullLinterContext = LinterContextProps & {
@@ -279,11 +278,6 @@ class Renderer
             // location. This is a list of error strings TranslationLinter
             // detected on its last run.
             translationLintErrors: [],
-
-            // The ID of the last widget the user interacted with. We'll
-            // use this to set the `isLastUsedWidget` flag on the
-            // corresponding widget.
-            lastUsedWidgetId: null,
 
             ...this._getInitialWidgetState(props),
         };
@@ -570,7 +564,6 @@ class Renderer
                 this.props.onInteractWithWidget(widgetId);
             },
             trackInteraction: interactionTracker.track,
-            isLastUsedWidget: widgetId === this.state.lastUsedWidgetId,
         };
     }
 
@@ -1449,49 +1442,34 @@ class Renderer
     }
 
     handleStateUpdate(id: string, cb: () => boolean, silent?: boolean) {
-        this.setState(
-            (prevState) => {
-                // Update the `lastUsedWidgetId` to this widget - unless we're
-                // in silent mode. We only want to track the last widget that
-                // was actually _used_, and silent updates generally don't come
-                // from _usage_.
-                const lastUsedWidgetId = silent
-                    ? prevState.lastUsedWidgetId
-                    : id;
-
-                return {
-                    lastUsedWidgetId,
-                };
-            },
-            () => {
-                // Wait until all components have rendered. In React 16 setState
-                // callback fires immediately after this componentDidUpdate, and
-                // there is no guarantee that parent/siblings components have
-                // finished rendering.
-                // TODO(jeff, CP-3128): Use Wonder Blocks Timing API
-                // eslint-disable-next-line no-restricted-syntax
-                setTimeout(() => {
-                    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-                    const cbResult = cb && cb();
-                    if (!silent) {
-                        this.props.onInteractWithWidget(id);
-                    }
-                    if (cbResult !== false) {
-                        // TODO(jack): For some reason, some widgets don't always
-                        // end up in refs here, which is repro-able if you make an
-                        // [[ orderer 1 ]] and copy-paste this, then change it to
-                        // be an [[ orderer 2 ]]. The resulting Renderer ends up
-                        // with an "orderer 2" ref but not an "orderer 1" ref.
-                        // @_@??
-                        // TODO(jack): Figure out why this is happening and fix it
-                        // As far as I can tell, this is only an issue in the
-                        // editor-page, so doing this shouldn't break clients
-                        // hopefully
-                        this._setCurrentFocus([id]);
-                    }
-                }, 0);
-            },
-        );
+        this.setState({}, () => {
+            // Wait until all components have rendered. In React 16 setState
+            // callback fires immediately after this componentDidUpdate, and
+            // there is no guarantee that parent/siblings components have
+            // finished rendering.
+            // TODO(jeff, CP-3128): Use Wonder Blocks Timing API
+            // eslint-disable-next-line no-restricted-syntax
+            setTimeout(() => {
+                // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+                const cbResult = cb && cb();
+                if (!silent) {
+                    this.props.onInteractWithWidget(id);
+                }
+                if (cbResult !== false) {
+                    // TODO(jack): For some reason, some widgets don't always
+                    // end up in refs here, which is repro-able if you make an
+                    // [[ orderer 1 ]] and copy-paste this, then change it to
+                    // be an [[ orderer 2 ]]. The resulting Renderer ends up
+                    // with an "orderer 2" ref but not an "orderer 1" ref.
+                    // @_@??
+                    // TODO(jack): Figure out why this is happening and fix it
+                    // As far as I can tell, this is only an issue in the
+                    // editor-page, so doing this shouldn't break clients
+                    // hopefully
+                    this._setCurrentFocus([id]);
+                }
+            }, 0);
+        });
     }
 
     /**

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -1442,34 +1442,32 @@ class Renderer
     }
 
     handleStateUpdate(id: string, cb: () => boolean, silent?: boolean) {
-        this.setState({}, () => {
-            // Wait until all components have rendered. In React 16 setState
-            // callback fires immediately after this componentDidUpdate, and
-            // there is no guarantee that parent/siblings components have
-            // finished rendering.
-            // TODO(jeff, CP-3128): Use Wonder Blocks Timing API
-            // eslint-disable-next-line no-restricted-syntax
-            setTimeout(() => {
-                // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-                const cbResult = cb && cb();
-                if (!silent) {
-                    this.props.onInteractWithWidget(id);
-                }
-                if (cbResult !== false) {
-                    // TODO(jack): For some reason, some widgets don't always
-                    // end up in refs here, which is repro-able if you make an
-                    // [[ orderer 1 ]] and copy-paste this, then change it to
-                    // be an [[ orderer 2 ]]. The resulting Renderer ends up
-                    // with an "orderer 2" ref but not an "orderer 1" ref.
-                    // @_@??
-                    // TODO(jack): Figure out why this is happening and fix it
-                    // As far as I can tell, this is only an issue in the
-                    // editor-page, so doing this shouldn't break clients
-                    // hopefully
-                    this._setCurrentFocus([id]);
-                }
-            }, 0);
-        });
+        // Wait until all components have rendered. In React 16 setState
+        // callback fires immediately after this componentDidUpdate, and
+        // there is no guarantee that parent/siblings components have
+        // finished rendering.
+        // TODO(jeff, CP-3128): Use Wonder Blocks Timing API
+        // eslint-disable-next-line no-restricted-syntax
+        setTimeout(() => {
+            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+            const cbResult = cb && cb();
+            if (!silent) {
+                this.props.onInteractWithWidget(id);
+            }
+            if (cbResult !== false) {
+                // TODO(jack): For some reason, some widgets don't always
+                // end up in refs here, which is repro-able if you make an
+                // [[ orderer 1 ]] and copy-paste this, then change it to
+                // be an [[ orderer 2 ]]. The resulting Renderer ends up
+                // with an "orderer 2" ref but not an "orderer 1" ref.
+                // @_@??
+                // TODO(jack): Figure out why this is happening and fix it
+                // As far as I can tell, this is only an issue in the
+                // editor-page, so doing this shouldn't break clients
+                // hopefully
+                this._setCurrentFocus([id]);
+            }
+        }, 0);
     }
 
     /**

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -574,7 +574,6 @@ export type UniversalWidgetProps<
         silent?: boolean,
     ) => void;
     userInput: TUserInput;
-    isLastUsedWidget: boolean;
     // provided by widget-container.jsx#render()
     linterContext: LinterContextProps;
     containerSizeClass: SizeClass;

--- a/packages/perseus/src/widgets/expression/__docs__/expression.stories.tsx
+++ b/packages/perseus/src/widgets/expression/__docs__/expression.stories.tsx
@@ -40,7 +40,6 @@ export const DesktopKitchenSink = (args: Story["args"]): React.ReactElement => {
                 ariaLabel=""
                 containerSizeClass="small"
                 findWidgets={(callback) => []}
-                isLastUsedWidget={false}
                 problemNum={1}
                 static={false}
                 handleUserInput={() => {}}

--- a/packages/perseus/src/widgets/passage/__tests__/passage.test.tsx
+++ b/packages/perseus/src/widgets/passage/__tests__/passage.test.tsx
@@ -41,7 +41,6 @@ function renderPassage(
         },
         containerSizeClass: "small",
         findWidgets: (callback) => [],
-        isLastUsedWidget: false,
         onBlur: () => {},
         onChange: () => {},
         handleUserInput: () => {},

--- a/packages/perseus/src/widgets/radio/__stories__/base-radio.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__stories__/base-radio.stories.tsx
@@ -55,11 +55,6 @@ const defaultProps = {
     // an array of boolean values, specifying the new checked and
     // crossed-out value of each choice.
     onChange: action("changed"),
-
-    // Whether this widget was the most recently used widget in this
-    // Renderer. Determines whether we'll auto-scroll the page upon
-    // entering review mode.
-    isLastUsedWidget: false,
 } as const;
 
 export const Interactive = (args: StoryArgs): React.ReactElement => {

--- a/packages/perseus/src/widgets/radio/__tests__/base-radio.test.tsx
+++ b/packages/perseus/src/widgets/radio/__tests__/base-radio.test.tsx
@@ -31,11 +31,6 @@ function renderBaseRadio(props) {
         // an array of boolean values, specifying the new checked and
         // crossed-out value of each choice.
         onChange: ({checked, crossedOut}) => {},
-
-        // Whether this widget was the most recently used widget in this
-        // Renderer. Determines whether we'll auto-scroll the page upon
-        // entering review mode.
-        isLastUsedWidget: false,
     } as const;
 
     const overwrittenProps = {...baseProps, ...props} as const;

--- a/packages/perseus/src/widgets/radio/base-radio.tsx
+++ b/packages/perseus/src/widgets/radio/base-radio.tsx
@@ -57,10 +57,6 @@ type Props = {
     // A callback indicating that this choice has changed. Its argument is an array of choice IDs for all currently selected choices
     onChange: (checkedChoiceIds: ReadonlyArray<string>) => void;
     registerFocusFunction?: (arg1: FocusFunction) => void;
-    // Whether this widget was the most recently used widget in this
-    // Renderer. Determines whether we'll auto-scroll the page upon
-    // entering review mode.
-    isLastUsedWidget?: boolean;
 };
 
 function getInstructionsText(
@@ -92,7 +88,6 @@ const BaseRadio = function ({
     labelWrap,
     countChoices,
     numCorrect,
-    isLastUsedWidget,
     onChange,
     registerFocusFunction,
 }: Props): React.ReactElement {
@@ -118,7 +113,6 @@ const BaseRadio = function ({
         // eye on this widget anymore).
         if (
             apiOptions.canScrollPage &&
-            isLastUsedWidget &&
             reviewMode &&
             prevReviewMode.current != null
         ) {
@@ -142,7 +136,7 @@ const BaseRadio = function ({
 
         // @ts-expect-error - TS2322 - Type 'PerseusRadioWidgetOptions | undefined' is not assignable to type 'undefined'.
         prevReviewMode.current = reviewMode;
-    }, [apiOptions, choices, isLastUsedWidget, reviewMode]);
+    }, [apiOptions, choices, reviewMode]);
 
     // When a particular choice's `onChange` handler is called, indicating a
     // change in a single choice's values, we need to call our `onChange`

--- a/packages/perseus/src/widgets/radio/radio-component.tsx
+++ b/packages/perseus/src/widgets/radio/radio-component.tsx
@@ -285,7 +285,6 @@ class Radio extends React.Component<Props> implements Widget {
                 reviewMode={this.props.reviewMode}
                 deselectEnabled={this.props.deselectEnabled}
                 apiOptions={this.props.apiOptions}
-                isLastUsedWidget={this.props.isLastUsedWidget}
                 registerFocusFunction={(i) => this.registerFocusFunction(i)}
             />
         );


### PR DESCRIPTION
## Summary:
Remove isLastWidgetUsed from Perseus as it was unused, and really only ever used for the Radio Widget. 

Issue: LEMS-3363

## Test plan:
- Tests pass