### PR TITLE
[Radio] Fix to allow users to scroll content after multiple choice is checked

### DIFF
--- a/.changeset/strong-candles-argue.md
+++ b/.changeset/strong-candles-argue.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix to allow users to still scroll the scrollable content when the fieldset is disabled and staticOverlayStyles is applied after the user checked the answer

--- a/packages/perseus/src/components/scrollable-view.test.tsx
+++ b/packages/perseus/src/components/scrollable-view.test.tsx
@@ -45,8 +45,8 @@ const setupScrollableMock = (isScrollable: boolean) => {
         options?: ScrollToOptions | undefined,
     ) {
         if (options !== undefined && options !== null) {
-            const currentScrollLeft = (this as any).scrollLeft || 0;
-            (this as any).scrollLeft = currentScrollLeft + (options.left || 0);
+            const currentScrollLeft = this.scrollLeft ?? 0;
+            this.scrollLeft = currentScrollLeft + (options.left || 0);
         }
     }) as any;
 };

--- a/packages/perseus/src/components/scrollable-view.tsx
+++ b/packages/perseus/src/components/scrollable-view.tsx
@@ -17,19 +17,38 @@ type ScrollAxisY = {
     overflowX?: React.CSSProperties["overflowX"];
 };
 
-interface ScrollableViewPropsBase extends React.HTMLAttributes<HTMLDivElement> {
+interface ScrollableAreaPropsBase extends React.HTMLAttributes<HTMLDivElement> {
     children?: React.ReactNode;
     role?: string;
     scrollDescription?: string;
+    id?: string;
 }
-type ScrollableViewProps = (ScrollAxisX | ScrollAxisY) &
-    ScrollableViewPropsBase;
+type ScrollableAreaProps = (ScrollAxisX | ScrollAxisY) &
+    ScrollableAreaPropsBase;
+
+interface ScrollControlsProps {
+    target?: string;
+    scrollDescription?: string;
+}
+
+interface ScrollState {
+    isScrollable: boolean;
+    canScrollStart: boolean;
+    canScrollEnd: boolean;
+    isRTL: boolean;
+    scroll: (direction: "start" | "end") => void;
+    scrollDescription: string;
+}
 
 // This is the number of pixels to scroll when the left or right scroll buttons
 // are clicked. Adjust this value to change the scroll amount as needed.
 const SCROLL_DISTANCE = 100;
 
-function ScrollableView({
+// Global registry for scroll instances
+const scrollInstances = new Map<string, ScrollState>();
+
+// This renders the scrollable area and will be used with the ScrollControls component
+function ScrollableArea({
     overflowX,
     overflowY,
     children,
@@ -37,15 +56,19 @@ function ScrollableView({
     scrollDescription,
     style,
     role = "group",
+    id: providedId,
     ...additionalProps
-}: ScrollableViewProps) {
+}: ScrollableAreaProps) {
     const {strings} = usePerseusI18n();
     const containerRef = useRef<HTMLDivElement>(null);
     const [isScrollable, setIsScrollable] = useState(false);
-    const [canScrollStart, setCanScrollStart] = useState(false);
-    const [canScrollEnd, setCanScrollEnd] = useState(false);
     const [isRtl, setIsRtl] = useState(false);
     const [isScrolling, setIsScrolling] = useState(false);
+
+    // Generate unique ID if not provided
+    const generatedId = React.useId();
+    const id = providedId || generatedId;
+
     const scrollableThreshold = React.useMemo(() => {
         /**
          * Determines the scrollable threshold based on device width to prevent
@@ -58,6 +81,43 @@ function ScrollableView({
          */
         return window.innerWidth <= 767 ? 8 : 5;
     }, []);
+
+    const scroll = React.useCallback(
+        (direction: "start" | "end") => {
+            if (!containerRef.current || isScrolling) {
+                return; // Prevent rapid clicks while scrolling
+            }
+
+            // Set scrolling state to prevent rapid clicks
+            setIsScrolling(true);
+
+            const scrollNegative =
+                (isRtl && direction !== "start") ||
+                (!isRtl && direction === "start");
+            const scrollAmount = scrollNegative
+                ? -SCROLL_DISTANCE
+                : SCROLL_DISTANCE;
+
+            /**
+             * Note on Chrome browser scroll behavior:
+             * Chrome handles smooth scrolling differently than other browsers.
+             * The scrollbar may briefly disappear when scrolling from extreme
+             * positions (beginning or end of scroll area).
+             * This occurs both when starting the initial scroll from position 0 and
+             * when scrolling back to the start from the end position.
+             */
+            containerRef.current.scrollBy({
+                left: scrollAmount,
+                behavior: "smooth",
+            });
+
+            // Clear scrolling state after a short delay to allow next scroll
+            setTimeout(() => {
+                setIsScrolling(false);
+            }, 150); // Short delay to prevent rapid clicking but allow normal usage
+        },
+        [isRtl, isScrolling],
+    );
 
     /**
      * Updates scroll state variables based on current scroll position.
@@ -88,64 +148,50 @@ function ScrollableView({
         }
 
         const {scrollLeft, scrollWidth, clientWidth} = containerRef.current;
-        setIsRtl(getComputedStyle(containerRef.current).direction === "rtl");
+        const newIsRtl =
+            getComputedStyle(containerRef.current).direction === "rtl";
+        setIsRtl(newIsRtl);
 
         // Only consider content scrollable if there's a meaningful amount to scroll
-        // Using a slightly higher threshold to prevent micro-scrolling issues
-        // Using the pre-calculated threshold to avoid performance issues during scroll events
-        setIsScrollable(scrollWidth > clientWidth + scrollableThreshold);
+        const newIsScrollable = scrollWidth > clientWidth + scrollableThreshold;
+        setIsScrollable(newIsScrollable);
 
         // In RTL mode, scrollLeft values work differently (can be negative)
         // We need to handle this to ensure the correct buttons are enabled
-        if (isRtl) {
+        let newCanScrollStart: boolean;
+        let newCanScrollEnd: boolean;
+
+        if (newIsRtl) {
             // For RTL, scrollLeft is negative when scrolling to the end (right side in visual terms)
             // Math.abs to get a positive value for comparison
-            setCanScrollStart(
+            newCanScrollStart =
                 Math.abs(scrollLeft) <
-                    scrollWidth - clientWidth - scrollableThreshold,
-            );
-            setCanScrollEnd(scrollLeft < -scrollableThreshold);
+                scrollWidth - clientWidth - scrollableThreshold;
+            newCanScrollEnd = scrollLeft < -scrollableThreshold;
         } else {
-            setCanScrollStart(scrollLeft > scrollableThreshold);
-            setCanScrollEnd(
-                scrollLeft + clientWidth < scrollWidth - scrollableThreshold,
-            );
-        }
-    }, [isRtl, scrollableThreshold]);
-
-    const scroll = (direction: "start" | "end") => {
-        if (!containerRef.current || isScrolling) {
-            return; // Prevent rapid clicks while scrolling
+            newCanScrollStart = scrollLeft > scrollableThreshold;
+            newCanScrollEnd =
+                scrollLeft + clientWidth < scrollWidth - scrollableThreshold;
         }
 
-        // Set scrolling state to prevent rapid clicks
-        setIsScrolling(true);
+        // Update global registry
+        const scrollState: ScrollState = {
+            isScrollable: newIsScrollable,
+            canScrollStart: newCanScrollStart,
+            canScrollEnd: newCanScrollEnd,
+            isRTL: newIsRtl,
+            scroll,
+            scrollDescription: scrollDescription || strings.scrollAnswers,
+        };
 
-        const scrollNegative =
-            (isRtl && direction !== "start") ||
-            (!isRtl && direction === "start");
-        const scrollAmount = scrollNegative
-            ? -SCROLL_DISTANCE
-            : SCROLL_DISTANCE;
-
-        /**
-         * Note on Chrome browser scroll behavior:
-         * Chrome handles smooth scrolling differently than other browsers.
-         * The scrollbar may briefly disappear when scrolling from extreme
-         * positions (beginning or end of scroll area).
-         * This occurs both when starting the initial scroll from position 0 and
-         * when scrolling back to the start from the end position.
-         */
-        containerRef.current.scrollBy({
-            left: scrollAmount,
-            behavior: "smooth",
-        });
-
-        // Clear scrolling state after a short delay to allow next scroll
-        setTimeout(() => {
-            setIsScrolling(false);
-        }, 150); // Short delay to prevent rapid clicking but allow normal usage
-    };
+        scrollInstances.set(id, scrollState);
+    }, [
+        id,
+        scrollableThreshold,
+        scrollDescription,
+        strings.scrollAnswers,
+        scroll,
+    ]);
 
     useEffect(() => {
         const container = containerRef.current;
@@ -160,8 +206,10 @@ function ScrollableView({
         return () => {
             container.removeEventListener("scroll", updateScrollState);
             window.removeEventListener("resize", updateScrollState);
+            // Clean up from global registry
+            scrollInstances.delete(id);
         };
-    }, [children, updateScrollState]);
+    }, [children, updateScrollState, id]);
 
     const mergeStyle: React.CSSProperties = {
         // For Chrome, we need to explicitly set overflow to 'scroll' when scrollable
@@ -173,81 +221,110 @@ function ScrollableView({
         ...style,
     };
 
+    // Render scrollable area and the controls are handled separately via ScrollableView.Controls
     return (
-        <>
-            <div
-                {...additionalProps}
-                role={role}
-                className={className}
-                style={mergeStyle}
-                ref={containerRef}
-            >
-                {children}
-            </div>
-            {isScrollable && (
-                <ScrollButtons
-                    onScrollStart={() =>
-                        isRtl ? scroll("end") : scroll("start")
-                    }
-                    onScrollEnd={() =>
-                        isRtl ? scroll("start") : scroll("end")
-                    }
-                    canScrollStart={canScrollStart}
-                    canScrollEnd={canScrollEnd}
-                    scrollDescription={
-                        scrollDescription
-                            ? scrollDescription
-                            : strings.scrollAnswers
-                    }
-                    isRTL={isRtl}
-                />
-            )}
-        </>
-    );
-}
-
-interface ScrollButtonsProps {
-    onScrollStart: () => void;
-    onScrollEnd: () => void;
-    canScrollStart: boolean;
-    canScrollEnd: boolean;
-    scrollDescription: string;
-    isRTL: boolean;
-}
-
-function ScrollButtons({
-    onScrollStart,
-    onScrollEnd,
-    canScrollStart,
-    canScrollEnd,
-    scrollDescription,
-    isRTL,
-}: ScrollButtonsProps) {
-    const {strings} = usePerseusI18n();
-
-    return (
-        <div className={styles.scrollButtonsContainer}>
-            <IconButton
-                icon={isRTL ? caretRightIcon : caretLeftIcon}
-                actionType="neutral"
-                kind="secondary"
-                size="small"
-                onClick={isRTL ? onScrollEnd : onScrollStart}
-                aria-label={strings.scrollStart}
-                disabled={isRTL ? !canScrollEnd : !canScrollStart}
-            />
-            <IconButton
-                icon={isRTL ? caretLeftIcon : caretRightIcon}
-                actionType="neutral"
-                kind="secondary"
-                size="small"
-                onClick={isRTL ? onScrollStart : onScrollEnd}
-                aria-label={strings.scrollEnd}
-                disabled={isRTL ? !canScrollStart : !canScrollEnd}
-            />
-            <LabelSmall>{scrollDescription}</LabelSmall>
+        <div
+            {...additionalProps}
+            id={id}
+            role={role}
+            className={className}
+            style={mergeStyle}
+            ref={containerRef}
+        >
+            {children}
         </div>
     );
 }
+
+// ScrollControls component - renders independently and connects to ScrollableArea by ID
+function ScrollControls({
+    target,
+    scrollDescription: overrideDescription,
+}: ScrollControlsProps) {
+    const {strings} = usePerseusI18n();
+    const [scrollState, setScrollState] = useState<ScrollState | null>(null);
+
+    // Monitor the target scroll instance
+    useEffect(() => {
+        if (!target) {
+            return;
+        }
+
+        const checkForScrollState = () => {
+            const state = scrollInstances.get(target);
+            if (state) {
+                setScrollState(state);
+            }
+        };
+
+        // Check immediately
+        checkForScrollState();
+
+        // Set up polling to detect changes (better would be event-based, but this works)
+        const interval = setInterval(checkForScrollState, 100);
+
+        return () => {
+            clearInterval(interval);
+        };
+    }, [target]);
+
+    if (!scrollState || !scrollState.isScrollable) {
+        return null;
+    }
+
+    const description = overrideDescription || scrollState.scrollDescription;
+
+    return (
+        <div
+            className={styles.scrollButtonsContainer}
+            aria-live="polite"
+            role="group"
+            aria-label={description}
+        >
+            <IconButton
+                icon={scrollState.isRTL ? caretRightIcon : caretLeftIcon}
+                actionType="neutral"
+                kind="secondary"
+                size="small"
+                onClick={() =>
+                    scrollState.isRTL
+                        ? scrollState.scroll("end")
+                        : scrollState.scroll("start")
+                }
+                aria-label={strings.scrollStart}
+                disabled={
+                    scrollState.isRTL
+                        ? !scrollState.canScrollEnd
+                        : !scrollState.canScrollStart
+                }
+            />
+            <IconButton
+                icon={scrollState.isRTL ? caretLeftIcon : caretRightIcon}
+                actionType="neutral"
+                kind="secondary"
+                size="small"
+                onClick={() =>
+                    scrollState.isRTL
+                        ? scrollState.scroll("start")
+                        : scrollState.scroll("end")
+                }
+                aria-label={strings.scrollEnd}
+                disabled={
+                    scrollState.isRTL
+                        ? !scrollState.canScrollStart
+                        : !scrollState.canScrollEnd
+                }
+            />
+            <LabelSmall>{description}</LabelSmall>
+        </div>
+    );
+}
+
+// Create compound component that includes both ScrollableArea and ScrollControls
+const ScrollableView = ScrollableArea as typeof ScrollableArea & {
+    Controls: typeof ScrollControls;
+};
+
+ScrollableView.Controls = ScrollControls;
 
 export default ScrollableView;

--- a/packages/perseus/src/widgets/radio/multiple-choice-component.new.tsx
+++ b/packages/perseus/src/widgets/radio/multiple-choice-component.new.tsx
@@ -71,30 +71,38 @@ const MultipleChoiceComponent = ({
         ? `${styles.choiceList} ${styles.reviewAnswers}`
         : styles.choiceList;
 
+    const scrollId = useId() + "-scroll";
+
     return (
-        <fieldset
-            className={styles.container}
-            data-feature-flag="feature flag is ON"
-        >
-            <legend
-                id={legendId}
-                aria-hidden="true"
-                className={styles.instructions}
+        <>
+            <fieldset
+                className={styles.container}
+                data-feature-flag="feature flag is ON"
             >
-                {instructions}
-            </legend>
-            <ScrollableView overflowX="auto">
-                <ul aria-labelledby={legendId} className={choiceListClasses}>
-                    <ChoiceListItems
-                        choices={choices}
-                        i18nStrings={strings}
-                        onChoiceChange={onChoiceChange}
-                        reviewMode={reviewMode}
-                        multipleSelect={multipleSelect}
-                    />
-                </ul>
-            </ScrollableView>
-        </fieldset>
+                <legend
+                    id={legendId}
+                    aria-hidden="true"
+                    className={styles.instructions}
+                >
+                    {instructions}
+                </legend>
+                <ScrollableView id={scrollId} overflowX="auto">
+                    <ul
+                        aria-labelledby={legendId}
+                        className={choiceListClasses}
+                    >
+                        <ChoiceListItems
+                            choices={choices}
+                            i18nStrings={strings}
+                            onChoiceChange={onChoiceChange}
+                            reviewMode={reviewMode}
+                            multipleSelect={multipleSelect}
+                        />
+                    </ul>
+                </ScrollableView>
+            </fieldset>
+            <ScrollableView.Controls target={scrollId} />
+        </>
     );
 };
 


### PR DESCRIPTION
## Summary:
Fix to allow users to still scroll the scrollable content when the fieldset is disabled and staticOverlayStyles is applied after the user checked the answer

**Before**
https://github.com/user-attachments/assets/c63567f9-771e-4b60-bb7c-7d0dd4e7ff20

**After**
<img src="https://github.com/user-attachments/assets/ba643599-9852-4404-a0bf-9b682992c111" width="250" />

Issue: LEMS-3406

## Test plan:
1. Navigate to the [ZND link](https://prod-znd-250826-3249-4e4c9ff.khanacademy.org/math/early-math/cc-early-math-add-sub-basics/cc-early-math[%E2%80%A6]b-word-problem-within-10/e/addition-word-problems-within-10)
2. In a question with a scrollable view, select the correct answer
3. After the question is marked correct
- [ ] Confirm that the scroll buttons still works left and right