### PR TITLE
Add documentation warning for using Graphie component

### DIFF
--- a/.changeset/dirty-cougars-marry.md
+++ b/.changeset/dirty-cougars-marry.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Add documentation warning for using Graphie component

--- a/packages/perseus/src/components/__docs__/graphie.mdx
+++ b/packages/perseus/src/components/__docs__/graphie.mdx
@@ -1,0 +1,32 @@
+import {Canvas, Controls, Meta} from "@storybook/addon-docs/blocks";
+import Banner from "@khanacademy/wonder-blocks-banner";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import * as GraphieStories from "./graphie.stories";
+
+<Meta of={GraphieStories} />
+
+# Graphie
+
+<View style={{marginBlock: spacing.medium_16}}>
+    <Banner
+        kind="warning"
+        layout="full-width"
+        text="Graphie usage for graphing is deprecated at Khan Academy. For new graphs, please use the interactive-graph
+        widget instead (see Widgets/Interactive Graph docs). For translated illustrations with labels, use the Graphie 2000 editor."
+    />
+</View>
+
+### Pie Chart Graphie Labels
+
+<p>
+    A demonstration of a Graphie rendered using the Perseus `Renderer` complete
+    with overlaid labels and an image caption below.
+</p>
+
+<Canvas of={GraphieStories.PieChartGraphieLabels} />
+<Controls of={GraphieStories.PieChartGraphieLabels} />
+
+### Square Box Size and Otherwise Empty
+
+<Canvas of={GraphieStories.SquareBoxSizeAndOtherwiseEmpty} />

--- a/packages/perseus/src/components/__docs__/graphie.stories.tsx
+++ b/packages/perseus/src/components/__docs__/graphie.stories.tsx
@@ -4,6 +4,8 @@ import {ServerItemRendererWithDebugUI} from "../../../../../testing/server-item-
 import {itemWithPieChart} from "../../__testdata__/graphie.testdata";
 import Graphie from "../graphie";
 
+import GraphieDocsPage from "./graphie.mdx";
+
 import type {StoryObj, Meta} from "@storybook/react-vite";
 
 type Story = StoryObj<typeof Graphie>;
@@ -13,20 +15,31 @@ const size = 200;
 const meta: Meta = {
     title: "Components/Graphie",
     component: Graphie,
-    args: {
-        box: [size, size],
-        setup: () => {},
-        setDrawingAreaAvailable: () => {},
+    parameters: {
+        docs: {
+            page: GraphieDocsPage,
+        },
     },
 };
 export default meta;
-
-export const SquareBoxSizeAndOtherwiseEmpty: Story = {};
 
 /**
  * A demonstration of a Graphie rendered using the Perseus `Renderer` complete
  * with overlaid labels and an image caption below.
  */
-export const PieChartGraphieLabels = () => {
-    return <ServerItemRendererWithDebugUI item={itemWithPieChart} />;
+export const PieChartGraphieLabels: Story = {
+    args: {
+        box: [size, size],
+        setup: () => {},
+        setDrawingAreaAvailable: () => {},
+    },
+    render: (args) => <ServerItemRendererWithDebugUI item={itemWithPieChart} />,
+};
+
+export const SquareBoxSizeAndOtherwiseEmpty: Story = {
+    args: {
+        box: [size, size],
+        setup: () => {},
+        setDrawingAreaAvailable: () => {},
+    },
 };

--- a/types/assets.d.ts
+++ b/types/assets.d.ts
@@ -7,6 +7,7 @@ declare module "*.jpg";
 declare module "*.png";
 declare module "*.svg";
 declare module "*.css";
+declare module "*.mdx";
 
 // Support specific SVG paths from @phosphor-icons/core.
 declare type PhosphorRegular = string & {weight: "PhosphorRegular"};


### PR DESCRIPTION
## Summary:
Add documentation warning for using Graphie component
| Before | After |
| ------- | ---- |
| <img width="742" height="305" alt="image" src="https://github.com/user-attachments/assets/cc6baca7-fe46-4a38-a5a2-6650bf563f77" /> | <img width="765" height="301" alt="image" src="https://github.com/user-attachments/assets/c139dde9-409a-47bd-aec4-91fdcbd88b4e" /> |
