### PR TITLE
[Radio] Bugfix - Choice text not changing color when selected

### DIFF
--- a/.changeset/thick-dogs-double.md
+++ b/.changeset/thick-dogs-double.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Radio] Bugfix - Choice text not changing color when selected

--- a/packages/perseus/src/widgets/radio/__docs__/multiple-choice-interaction-regression.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/multiple-choice-interaction-regression.stories.tsx
@@ -128,6 +128,7 @@ export const ChoiceTextColorInSingleSelect = {
             name: /^\(Choice A\)/,
         });
         await userEvent.click(choiceToClick);
+        choiceToClick.blur();
     },
 };
 
@@ -148,6 +149,7 @@ export const ChoiceTextColorInMultipleSelect = {
             name: /^\(Choice D\)/,
         });
         await userEvent.click(choiceToClick);
+        choiceToClick.blur();
     },
 };
 

--- a/packages/perseus/src/widgets/radio/__docs__/multiple-choice-interaction-regression.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/multiple-choice-interaction-regression.stories.tsx
@@ -7,11 +7,11 @@ import {
     choicesWithMathFont,
     questionWithPassage,
 } from "../__tests__/radio.testdata";
+import {radioQuestionBuilder} from "../radio-question-builder";
 
 import type {APIOptions} from "../../../types";
 import type {PerseusItem} from "@khanacademy/perseus-core";
 import type {Meta} from "@storybook/react-vite";
-import {radioQuestionBuilder} from "../radio-question-builder";
 
 type StoryArgs = {
     // Story Option

--- a/packages/perseus/src/widgets/radio/__docs__/multiple-choice-interaction-regression.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/multiple-choice-interaction-regression.stories.tsx
@@ -3,11 +3,15 @@ import * as React from "react";
 
 import {ServerItemRendererWithDebugUI} from "../../../../../../testing/server-item-renderer-with-debug-ui";
 import {groupedRadioRationaleQuestion} from "../../graded-group/graded-group.testdata";
-import {questionWithPassage} from "../__tests__/radio.testdata";
+import {
+    choicesWithMathFont,
+    questionWithPassage,
+} from "../__tests__/radio.testdata";
 
 import type {APIOptions} from "../../../types";
 import type {PerseusItem} from "@khanacademy/perseus-core";
 import type {Meta} from "@storybook/react-vite";
+import {radioQuestionBuilder} from "../radio-question-builder";
 
 type StoryArgs = {
     // Story Option
@@ -109,5 +113,81 @@ export const GradedGroupWrapper = {
         })[0];
         await userEvent.click(checkAnswerButton);
         await checkAnswerButton.blur();
+    },
+};
+
+export const ChoiceTextColorInSingleSelect = {
+    args: {
+        item: generateTestPerseusItem({
+            question: choicesWithMathFont(),
+        }),
+    },
+    play: async ({canvas, userEvent}) => {
+        // eslint-disable-next-line testing-library/prefer-screen-queries
+        const choiceToClick = canvas.getByRole("button", {
+            name: /^\(Choice A\)/,
+        });
+        await userEvent.click(choiceToClick);
+    },
+};
+
+export const ChoiceTextColorInMultipleSelect = {
+    args: {
+        item: generateTestPerseusItem({
+            question: choicesWithMathFont({multipleSelect: true}),
+        }),
+    },
+    play: async ({canvas, userEvent}) => {
+        // eslint-disable-next-line testing-library/prefer-screen-queries
+        let choiceToClick = canvas.getByRole("button", {
+            name: /^\(Choice A\)/,
+        });
+        await userEvent.click(choiceToClick);
+        // eslint-disable-next-line testing-library/prefer-screen-queries
+        choiceToClick = canvas.getByRole("button", {
+            name: /^\(Choice D\)/,
+        });
+        await userEvent.click(choiceToClick);
+    },
+};
+
+export const FocusSingleSelect = {
+    args: {
+        item: generateTestPerseusItem({
+            question: radioQuestionBuilder()
+                .addChoice("Choice 1", {correct: true})
+                .addChoice("Choice 2")
+                .addChoice("Choice 3")
+                .addChoice("Choice 4")
+                .build(),
+        }),
+    },
+    play: async ({canvas}) => {
+        // eslint-disable-next-line testing-library/prefer-screen-queries
+        const choiceToFocus = canvas.getByRole("button", {
+            name: /^\(Choice A\)/,
+        });
+        choiceToFocus.focus();
+    },
+};
+
+export const FocusMultiSelect = {
+    args: {
+        item: generateTestPerseusItem({
+            question: radioQuestionBuilder()
+                .addChoice("Choice 1", {correct: true})
+                .addChoice("Choice 2")
+                .addChoice("Choice 3")
+                .addChoice("Choice 4")
+                .withMultipleSelect(true)
+                .build(),
+        }),
+    },
+    play: async ({canvas}) => {
+        // eslint-disable-next-line testing-library/prefer-screen-queries
+        const choiceToFocus = canvas.getByRole("button", {
+            name: /^\(Choice B\)/,
+        });
+        choiceToFocus.focus();
     },
 };

--- a/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.testdata.ts
@@ -465,3 +465,26 @@ export const choicesWithGraphie: PerseusRenderer = {
             },
     },
 };
+
+export const choicesWithMathFont = (options?: {
+    multipleSelect: boolean;
+}): PerseusRenderer => {
+    return radioQuestionBuilder()
+        .withContent(
+            "Which of the following values of $x$ satisfies the equation $\\sqrt{64}=x$ ?\n\n[[\u2603 radio 1]]\n\n",
+        )
+        .addChoice("Both $-8$ and $8$ satisfy the equation $\\sqrt{64}=x$", {
+            correct: false,
+        })
+        .addChoice("Only $-8$ satisfies the equation $\\sqrt{64}=x$", {
+            correct: false,
+        })
+        .addChoice("Only $8$ satisfies the equation $\\sqrt{64}=x$", {
+            correct: false,
+        })
+        .addChoice("No value of $x$ satisfies the equation $\\sqrt{64}=x$", {
+            correct: false,
+        })
+        .withMultipleSelect(options?.multipleSelect ?? false)
+        .build();
+};

--- a/packages/perseus/src/widgets/radio/choice.module.css
+++ b/packages/perseus/src/widgets/radio/choice.module.css
@@ -38,7 +38,7 @@
 }
 
 .choice:not(.is-correct):has(> button[aria-pressed="true"]) {
-    color: var(--wb-semanticColor-core-foreground-instructive-default)
+    color: var(--wb-semanticColor-core-foreground-instructive-default);
 }
 
 /*****************

--- a/packages/perseus/src/widgets/radio/choice.module.css
+++ b/packages/perseus/src/widgets/radio/choice.module.css
@@ -37,6 +37,10 @@
     cursor: pointer;
 }
 
+.choice:not(.is-correct):has(> button[aria-pressed="true"]) {
+    color: var(--wb-semanticColor-core-foreground-instructive-default)
+}
+
 /*****************
  BORDER MANAGEMENT
  *****************/


### PR DESCRIPTION
## Summary:
The text of choice should change color when that choice is selected.

Issue: LEMS-3357

## Affected UI:
### Before
<img width="242" height="278" alt="Before" src="https://github.com/user-attachments/assets/dfa1deba-565e-464c-b9e4-f5762cfbf3d1" />

### After
<img width="250" height="277" alt="After" src="https://github.com/user-attachments/assets/531a53c8-3252-486b-85fc-14fea2cf2585" />


## Test plan:
1. Open Storybook (either locally or linked in this PR)
1. Navigate to any example in Widgets => RadioNew => Docs
1. Choose any answer from the options shown
   - Note that the text of the choice changed color (matching the selected theme)