### PR TITLE
[Radio] Bugfix - Correctness indicator was missing in static widget

### DIFF
--- a/.changeset/gorgeous-eyes-cheat.md
+++ b/.changeset/gorgeous-eyes-cheat.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Radio] Bugfix - Correctness indicator was missing in static widget

--- a/packages/perseus/src/widgets/radio/multiple-choice-widget.new.tsx
+++ b/packages/perseus/src/widgets/radio/multiple-choice-widget.new.tsx
@@ -324,7 +324,9 @@ class MultipleChoiceWidget extends React.Component<Props> implements Widget {
         const {apiOptions, multipleSelect, countChoices, numCorrect} =
             this.props;
         const reviewMode =
-            this.props.reviewMode || this.props.showSolutions === "all";
+            this.props.reviewMode ||
+            this.props.static ||
+            this.props.showSolutions === "all";
 
         const onChoiceChange =
             apiOptions.readOnly || reviewMode


### PR DESCRIPTION
## Summary:
When the widget is in "static" mode, it should show the correctness of each choice, just like in "reviewMode".

Issue: LEMS-3356

## Affected UI:
### Before
<img width="306" height="435" alt="Before" src="https://github.com/user-attachments/assets/1016a5db-3d0e-4c25-aadb-066dae24bae7" />

### After
<img width="347" height="431" alt="After" src="https://github.com/user-attachments/assets/66d59add-a7b3-421e-af9f-1725ec7c7781" />

## Test plan:
1. Open Storybook (either locally or linked in this PR)
1. Navigate to the static examples:
   - Widgets => RadioNew => Visual Regression Tests => Static => Single Select Static
   - Widgets => RadioNew => Visual Regression Tests => Static => Multi Select Static
1. Note that correctness is shown for the options