### PR TITLE
[Image] | (CX) | Modernize the Image widget editor UI

### DIFF
--- a/.changeset/eight-trees-travel.md
+++ b/.changeset/eight-trees-travel.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Image] | (CX) | Modernize the Image widget editor UI

--- a/packages/perseus-editor/src/__tests__/editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/editor.test.tsx
@@ -88,7 +88,7 @@ describe("Editor", () => {
         await userEvent.click(widgetDisclosure);
 
         // Assert
-        const previewImage = screen.getByAltText("Editor preview of image");
+        const previewImage = screen.getByAltText(/Preview:/);
         expect(previewImage).toHaveAttribute(
             "src",
             "http://placekitten.com/200/300",
@@ -109,7 +109,8 @@ describe("Editor", () => {
         const captionInput = screen.getByLabelText(/Caption:/);
 
         await userEvent.clear(captionInput);
-        await userEvent.type(captionInput, "A picture of kittens");
+        captionInput.focus();
+        await userEvent.paste("kittens");
         await userEvent.tab(); // blurring the input triggers onChange to be called
 
         // Assert
@@ -120,7 +121,7 @@ describe("Editor", () => {
                         type: "image",
                         graded: true,
                         options: expect.objectContaining({
-                            caption: "A picture of kittens",
+                            caption: "kittens",
                         }),
                     }),
                 },

--- a/packages/perseus-editor/src/widgets/__docs__/image-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__docs__/image-editor.stories.tsx
@@ -84,6 +84,8 @@ export const Populated: Story = {
     args: {
         backgroundImage: {
             url: "https://cdn.kastatic.org/ka-content-images/61831c1329dbc32036d7dd0d03e06e7e2c622718.jpg",
+            width: 400,
+            height: 225,
         },
         alt: "The moon showing behind the Earth in space.",
         caption: "Captured via XYZ Telescope",

--- a/packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx
@@ -54,16 +54,16 @@ describe("image editor", () => {
             <ImageEditor
                 apiOptions={apiOptions}
                 backgroundImage={{url: realKhanImageUrl}}
-                alt="Earth and moon"
-                caption="Earth and moon"
+                alt="Earth and moon alt"
+                caption="Earth and moon caption"
                 onChange={() => {}}
             />,
         );
 
         const dimensionsLabel = screen.getByText("Dimensions:");
         const urlField = screen.getByRole("textbox", {name: "Image url:"});
-        const altField = screen.getAllByRole("textbox")[1]; // Second textarea is alt
-        const captionField = screen.getAllByRole("textbox")[2]; // Third textarea is caption
+        const altField = screen.getByRole("textbox", {name: "Alt text:"});
+        const captionField = screen.getByRole("textbox", {name: "Caption:"});
 
         // Assert
         expect(dimensionsLabel).toBeInTheDocument();
@@ -73,8 +73,8 @@ describe("image editor", () => {
 
         expect(screen.getByText("unknown")).toBeInTheDocument();
         expect(urlField).toHaveValue(realKhanImageUrl);
-        expect(altField).toHaveValue("Earth and moon");
-        expect(captionField).toHaveValue("Earth and moon");
+        expect(altField).toHaveValue("Earth and moon alt");
+        expect(captionField).toHaveValue("Earth and moon caption");
     });
 
     it("should render warning for non-Khan Academy image", async () => {

--- a/packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx
@@ -172,12 +172,8 @@ describe("image editor", () => {
 
         // Assert
         expect(onChangeMock).toHaveBeenCalledWith({
-            backgroundImage: {
-                url: "",
-                width: 0,
-                height: 0,
-            },
-            box: [0, 0],
+            backgroundImage: {},
+            box: undefined,
         });
     });
 
@@ -232,6 +228,28 @@ describe("image editor", () => {
         });
     });
 
+    it("should call onChange with undefined alt", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <ImageEditor
+                apiOptions={apiOptions}
+                backgroundImage={{url: realKhanImageUrl}}
+                alt="Earth and moon"
+                onChange={onChangeMock}
+            />,
+        );
+
+        // Act
+        const altField = screen.getByRole("textbox", {name: "Alt text:"});
+        await userEvent.clear(altField);
+
+        // Assert
+        expect(onChangeMock).toHaveBeenCalledWith({
+            alt: undefined,
+        });
+    });
+
     it("should call onChange with new caption", async () => {
         // Arrange
         const onChangeMock = jest.fn();
@@ -251,6 +269,28 @@ describe("image editor", () => {
         // Assert
         expect(onChangeMock).toHaveBeenCalledWith({
             caption: "Earth and moon",
+        });
+    });
+
+    it("should call onChange with undefined caption", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <ImageEditor
+                apiOptions={apiOptions}
+                backgroundImage={{url: realKhanImageUrl}}
+                caption="Earth and moon"
+                onChange={onChangeMock}
+            />,
+        );
+
+        // Act
+        const captionField = screen.getByRole("textbox", {name: "Caption:"});
+        await userEvent.clear(captionField);
+
+        // Assert
+        expect(onChangeMock).toHaveBeenCalledWith({
+            caption: undefined,
         });
     });
 });

--- a/packages/perseus-editor/src/widgets/image-editor/image-editor.module.css
+++ b/packages/perseus-editor/src/widgets/image-editor/image-editor.module.css
@@ -1,0 +1,17 @@
+.label-with-info-tip {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+}
+
+.dimensions-container {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    background-color: var(--wb-semanticColor-core-background-neutral-subtle);
+    border: 1px solid var(--wb-semanticColor-core-border-base-subtle);
+    border-radius: var(--wb-sizing-size_080);
+    margin-block-start: var(--wb-sizing-size_080);
+    margin-block-end: var(--wb-sizing-size_120);
+    padding: var(--wb-sizing-size_080);
+}

--- a/packages/perseus-editor/src/widgets/image-editor/image-editor.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/image-editor.tsx
@@ -1,54 +1,20 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
-import {components, EditorJsonify, Util} from "@khanacademy/perseus";
+import {EditorJsonify} from "@khanacademy/perseus";
 import {
     imageLogic,
     type ImageDefaultWidgetOptions,
-    type Range,
-    type Size,
     type PerseusImageWidgetOptions,
 } from "@khanacademy/perseus-core";
 import * as React from "react";
-import _ from "underscore";
-
-import BlurInput from "../../components/blur-input";
 
 import ImageSettings from "./image-settings";
+import ImageUrlInput from "./image-url-input";
 
 import type {APIOptions} from "@khanacademy/perseus";
 
-const {InfoTip} = components;
-
-// Match any image URL (including "web+graphie" links) that is hosted by KA.
-// We're somewhat generous in our AWS URL matching
-// ("ka-<something>.s3.amazonaws.com") so that we don't have to update Perseus
-// every time we add a new proxied AWS bucket.
-const INTERNALLY_HOSTED_DOMAINS =
-    "(" +
-    "ka-.*.s3.amazonaws.com|" +
-    "(fastly|cdn).kastatic.org|" +
-    "khanacademy.org|" +
-    "kasandbox.org" +
-    ")";
-const INTERNALLY_HOSTED_URL_RE = new RegExp(
-    "^(https?|web\\+graphie)://[^/]*" + INTERNALLY_HOSTED_DOMAINS,
-);
-
-interface Props {
+export interface Props extends PerseusImageWidgetOptions {
     apiOptions: APIOptions;
-
-    title: string;
-    range: [Readonly<Range>, Readonly<Range>];
-    box: Size;
-    backgroundImage: any;
-    labels: ReadonlyArray<string>;
-    alt: string;
-    caption: string;
     onChange: (newValues: Partial<PerseusImageWidgetOptions>) => void;
 }
-
-type State = {
-    backgroundImageError?: string;
-};
 
 // JSDoc will be shown in Storybook widget editor description
 /**
@@ -57,119 +23,21 @@ type State = {
 class ImageEditor extends React.Component<Props> {
     static displayName = "ImageEditor";
     static widgetName = "image";
-    _isMounted = false;
 
     static defaultProps: ImageDefaultWidgetOptions =
         imageLogic.defaultWidgetOptions;
-
-    state: State = {
-        backgroundImageError: "",
-    };
-
-    componentDidMount() {
-        // TODO(scottgrant): This is a hack to remove the deprecated call to
-        // this.isMounted() but is still considered an anti-pattern.
-        this._isMounted = true;
-    }
-
-    componentWillUnmount() {
-        this._isMounted = false;
-    }
-
-    setUrl(url, width, height, silent) {
-        // Because this calls into WidgetEditor._handleWidgetChange, which
-        // checks for this widget's ref to serialize it.
-        //
-        // Errors if you switch items before the `Image` from `onUrlChange`
-        // loads.
-        if (!this._isMounted) {
-            return;
-        }
-
-        const image = _.clone(this.props.backgroundImage);
-        image.url = url;
-        image.width = width;
-        image.height = height;
-        const box = [image.width, image.height] satisfies [number, number];
-        this.props.onChange({
-            backgroundImage: image,
-            box: box,
-        });
-    }
-
-    // silently load the image when the component mounts
-    // silently update url and sizes when the image loads
-    // noisily load the image in response to the author changing it
-    async onUrlChange(url: string | undefined | null, silent: boolean) {
-        // Check if we've been passed something that looks like a URL
-        if (!url) {
-            this.setUrl(url, 0, 0, silent);
-            return;
-        }
-
-        // All article content must be KA-owned!
-        if (!INTERNALLY_HOSTED_URL_RE.test(url)) {
-            this.setState({
-                backgroundImageError:
-                    "Images must be from sites hosted by Khan Academy. " +
-                    "Please input a Khan Academy-owned address, or use the " +
-                    "Add Image tool to rehost an existing image",
-            });
-            return;
-        }
-
-        // Clear previous errors
-        this.setState({backgroundImageError: ""});
-
-        try {
-            const size = await Util.getImageSizeModern(url);
-            this.setUrl(url, size[0], size[1], true);
-        } catch (error) {
-            this.setState({
-                backgroundImageError: `There was an error loading the image URL: ${JSON.stringify(
-                    error,
-                    null,
-                    2,
-                )}`,
-            });
-        }
-    }
 
     serialize() {
         return EditorJsonify.serialize.call(this);
     }
 
     render() {
-        const backgroundImage = this.props.backgroundImage;
-
-        const backgroundImageErrorText = (
-            <div className="renderer-widget-error">
-                {this.state.backgroundImageError}
-            </div>
-        );
-
         return (
             <div className="perseus-image-editor">
-                <label>
-                    Image url:
-                    <InfoTip>Paste an image or graphie image URL.</InfoTip>
-                    {this.state.backgroundImageError &&
-                        backgroundImageErrorText}
-                    <BlurInput
-                        value={backgroundImage.url || ""}
-                        style={{width: 332}}
-                        onChange={(url) => this.onUrlChange(url, false)}
-                    />
-                </label>
+                <ImageUrlInput {...this.props} />
 
-                {backgroundImage.url && (
-                    <ImageSettings
-                        apiOptions={this.props.apiOptions}
-                        backgroundImage={backgroundImage}
-                        alt={this.props.alt}
-                        caption={this.props.caption}
-                        onChange={this.props.onChange}
-                    />
+                {this.props.backgroundImage.url && (
+                    <ImageSettings {...this.props} />
                 )}
             </div>
         );

--- a/packages/perseus-editor/src/widgets/image-editor/image-settings.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/image-settings.tsx
@@ -1,95 +1,122 @@
 import {Util, components} from "@khanacademy/perseus";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {HeadingXSmall} from "@khanacademy/wonder-blocks-typography";
 import * as React from "react";
 
-import Editor from "../../editor";
+import {AutoResizingTextArea} from "../../components/auto-resizing-text-area";
 
-import type {APIOptions} from "@khanacademy/perseus";
-import type {PerseusImageWidgetOptions} from "@khanacademy/perseus-core";
+import styles from "./image-editor.module.css";
+
+import type {Props} from "./image-editor";
 
 const {InfoTip} = components;
 
-interface ImageSettingsProps extends PerseusImageWidgetOptions {
-    apiOptions: APIOptions;
-    onChange: (newValues: Partial<PerseusImageWidgetOptions>) => void;
-}
-
 export default function ImageSettings({
-    apiOptions,
     alt,
     backgroundImage,
     caption,
     onChange,
-}: ImageSettingsProps) {
+}: Props) {
+    const uniqueId = React.useId();
+    const altId = `${uniqueId}-alt`;
+    const captionId = `${uniqueId}-caption`;
+
     if (!backgroundImage.url) {
         return null;
     }
 
+    const dimensions = `${backgroundImage.width} x ${backgroundImage.height}`;
+    const dimensionString =
+        backgroundImage.width && backgroundImage.height
+            ? dimensions
+            : "unknown";
+
     return (
-        <div className="image-settings">
+        <>
             {!Util.isLabeledSVG(backgroundImage.url) && (
-                <div>
-                    {/* eslint-disable-next-line jsx-a11y/label-has-associated-control -- TODO(LEMS-2871): Address a11y error */}
-                    <label>
-                        <div>Preview:</div>
-                        {/* eslint-disable-next-line jsx-a11y/img-redundant-alt -- TODO(LEMS-2871): Address a11y error */}
-                        <img
-                            alt="Editor preview of image"
-                            src={backgroundImage.url}
-                            style={{
-                                width: "100%",
-                            }}
-                        />
-                    </label>
-                </div>
+                <>
+                    <HeadingXSmall
+                        style={{
+                            // TODO: Use CSS modules after Wonder Blocks styles
+                            // are moved to a different layer.
+                            paddingBlockStart: 0, // reset default padding
+                            marginBlockStart: sizing.size_120,
+                            marginBlockEnd: sizing.size_040,
+                            color: "var(--wb-semanticColor-core-foreground-neutral-strong)",
+                        }}
+                    >
+                        Preview:
+                    </HeadingXSmall>
+                    <img
+                        alt={`Preview: ${alt ?? "No alt text"}`}
+                        src={backgroundImage.url}
+                        style={{
+                            width: "100%",
+                        }}
+                    />
+                </>
             )}
-            <div>
-                <label>
-                    <div>Dimensions:</div>
-                    <p>
-                        {backgroundImage.width}x{backgroundImage.height}
-                    </p>
-                </label>
+
+            {/* Dimensions */}
+            <div className={styles.dimensionsContainer}>
+                <HeadingXSmall
+                    style={{
+                        // TODO: Use CSS modules after Wonder Blocks styles
+                        // are moved to a different layer.
+                        padding: 0, // reset default padding
+                        marginInlineEnd: sizing.size_080,
+                        color: "var(--wb-semanticColor-core-foreground-neutral-strong)",
+                    }}
+                >
+                    Dimensions:
+                </HeadingXSmall>
+                {dimensionString}
             </div>
 
-            <div>
-                {/* eslint-disable-next-line jsx-a11y/label-has-associated-control -- TODO(LEMS-2871): Address a11y error */}
-                <label>
-                    <div>
-                        Alt text:
-                        <InfoTip>
-                            This is important for screenreaders. The content of
-                            this alt text will be formatted as markdown (tables,
-                            emphasis, etc. are supported).
-                        </InfoTip>
-                    </div>
-                    <Editor
-                        apiOptions={apiOptions}
-                        content={alt}
-                        onChange={(props) => {
-                            if (props.content != null) {
-                                onChange({alt: props.content});
-                            }
-                        }}
-                        widgetEnabled={false}
-                    />
-                </label>
+            {/* Alt text */}
+            <div className={styles.labelWithInfoTip}>
+                <HeadingXSmall tag="label" htmlFor={altId}>
+                    Alt text:
+                </HeadingXSmall>
+                <InfoTip>
+                    This is important for screenreaders. The content of this alt
+                    text will be formatted as markdown (tables, emphasis, etc.
+                    are supported).
+                </InfoTip>
             </div>
-            <div>
-                {/* eslint-disable-next-line jsx-a11y/label-has-associated-control -- TODO(LEMS-2871): Address a11y error */}
-                <label>
-                    <div>Caption:</div>
-                    <Editor
-                        apiOptions={apiOptions}
-                        content={caption}
-                        onChange={(props) => {
-                            if (props.content != null) {
-                                onChange({caption: props.content});
-                            }
-                        }}
-                        widgetEnabled={false}
-                    />
-                </label>
-            </div>
-        </div>
+            <AutoResizingTextArea
+                id={altId}
+                value={alt ?? ""}
+                onChange={(value) =>
+                    // Avoid saving empty strings in the content data.
+                    onChange({alt: value === "" ? undefined : value})
+                }
+                style={{
+                    // TODO: Use CSS modules after Wonder Blocks styles
+                    // are moved to a different layer.
+                    marginBlockStart: sizing.size_040,
+                    marginBlockEnd: sizing.size_080,
+                }}
+            />
+
+            {/* Caption */}
+            <HeadingXSmall tag="label" htmlFor={captionId}>
+                Caption:
+            </HeadingXSmall>
+            <AutoResizingTextArea
+                id={captionId}
+                value={caption ?? ""}
+                onChange={(value) =>
+                    // Avoid saving empty strings in the content data.
+                    onChange({caption: value === "" ? undefined : value})
+                }
+                style={{
+                    // TODO: Use CSS modules after Wonder Blocks styles
+                    // are moved to a different layer.
+                    marginBlockStart: sizing.size_040,
+                    marginBlockEnd: sizing.size_080,
+                }}
+            />
+        </>
     );
 }

--- a/packages/perseus-editor/src/widgets/image-editor/image-url-input.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/image-url-input.tsx
@@ -1,0 +1,119 @@
+import {components, Util} from "@khanacademy/perseus";
+import Banner from "@khanacademy/wonder-blocks-banner";
+import {TextField} from "@khanacademy/wonder-blocks-form";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {HeadingXSmall} from "@khanacademy/wonder-blocks-typography";
+import React from "react";
+
+import styles from "./image-editor.module.css";
+
+import type {Props} from "./image-editor";
+
+const {InfoTip} = components;
+
+// Match any image URL (including "web+graphie" links) that is hosted by KA.
+// We're somewhat generous in our AWS URL matching
+// ("ka-<something>.s3.amazonaws.com") so that we don't have to update Perseus
+// every time we add a new proxied AWS bucket.
+const INTERNALLY_HOSTED_DOMAINS =
+    "(" +
+    "ka-.*.s3.amazonaws.com|" +
+    "(fastly|cdn).kastatic.org|" +
+    "khanacademy.org|" +
+    "kasandbox.org" +
+    ")";
+const INTERNALLY_HOSTED_URL_RE = new RegExp(
+    "^(https?|web\\+graphie)://[^/]*" + INTERNALLY_HOSTED_DOMAINS,
+);
+
+export default function ImageUrlInput({backgroundImage, onChange}: Props) {
+    const uniqueId = React.useId();
+    const urlId = `${uniqueId}-url`;
+
+    const [urlFieldValue, setUrlFieldValue] = React.useState<string>(
+        backgroundImage.url || "",
+    );
+    const [backgroundImageError, setBackgroundImageError] = React.useState<
+        string | null
+    >(null);
+
+    function setUrl(url: string, width: number, height: number) {
+        const image = {...backgroundImage};
+        image.url = url;
+        image.width = width;
+        image.height = height;
+        const box = [image.width, image.height] satisfies [number, number];
+        onChange({
+            backgroundImage: image,
+            box: box,
+        });
+    }
+
+    async function onUrlChange(url: string) {
+        // Don't try to load the image if there is no URL.
+        if (!url) {
+            setBackgroundImageError(null);
+            setUrl("", 0, 0);
+            return;
+        }
+
+        // Require the image to be hosted by Khan Academy.
+        if (url && !INTERNALLY_HOSTED_URL_RE.test(url)) {
+            setBackgroundImageError(
+                "Images must be from sites hosted by Khan Academy. " +
+                    "Please input a Khan Academy-owned address, or use the " +
+                    "Add Image tool to rehost an existing image",
+            );
+            return;
+        }
+
+        // Clear previous errors
+        setBackgroundImageError(null);
+
+        // Try to load the image.
+        try {
+            const size = await Util.getImageSizeModern(url);
+            setUrl(url, size[0], size[1]);
+        } catch (error) {
+            setBackgroundImageError(
+                `There was an error loading the image URL: ${JSON.stringify(
+                    error,
+                    null,
+                    2,
+                )}`,
+            );
+        }
+    }
+
+    return (
+        <>
+            <div className={styles.labelWithInfoTip}>
+                <HeadingXSmall tag="label" htmlFor={urlId}>
+                    Image url:
+                </HeadingXSmall>
+                <InfoTip>Paste an image or graphie image URL.</InfoTip>
+            </div>
+
+            {backgroundImageError && (
+                <Banner
+                    kind="critical"
+                    layout="floating"
+                    text={backgroundImageError}
+                />
+            )}
+
+            <TextField
+                id={urlId}
+                value={urlFieldValue}
+                onBlur={(e) => onUrlChange(e.target.value)}
+                onChange={(value) => setUrlFieldValue(value)}
+                style={{
+                    // TODO: Use CSS modules after Wonder Blocks styles
+                    // are moved to a different layer.
+                    marginBlockStart: sizing.size_040,
+                    marginBlockEnd: sizing.size_080,
+                }}
+            />
+        </>
+    );
+}

--- a/packages/perseus-editor/src/widgets/image-editor/image-url-input.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/image-url-input.tsx
@@ -39,6 +39,7 @@ export default function ImageUrlInput({backgroundImage, onChange}: Props) {
 
     function setUrl(url: string, width: number, height: number) {
         const image = {...backgroundImage};
+        // Don't save empty strings in the content data.
         image.url = url;
         image.width = width;
         image.height = height;
@@ -53,7 +54,10 @@ export default function ImageUrlInput({backgroundImage, onChange}: Props) {
         // Don't try to load the image if there is no URL.
         if (!url) {
             setBackgroundImageError(null);
-            setUrl("", 0, 0);
+            onChange({
+                backgroundImage: {},
+                box: undefined,
+            });
             return;
         }
 


### PR DESCRIPTION
## Summary:
Make the Image widget editor UI nicer to look at and use.

- Replace existing inputs with Wonder Blocks components
- Make the spacing look nicer

Bonus:
- Add more tests
- Break out the image URL input into a new file

Issue: https://khanacademy.atlassian.net/browse/LEMS-3386

## Screenshots

Case | Before | After |
| --- | --- | --- |
| Empty | <img width="391" height="474" alt="Screenshot 2025-08-27 at 12 59 50 PM" src="https://github.com/user-attachments/assets/bf13d446-9af6-4ae7-afa5-6c23feef9950" /> | <img width="386" height="505" alt="Screenshot 2025-08-27 at 1 00 08 PM" src="https://github.com/user-attachments/assets/cf93a284-5dba-4ef3-a57e-ad2dbf748c02" /> |
| Warning | <img width="396" height="525" alt="Screenshot 2025-08-27 at 1 00 30 PM" src="https://github.com/user-attachments/assets/0039bb9f-82ab-434d-9c7d-4044fbad9de5" /> | <img width="388" height="625" alt="Screenshot 2025-08-27 at 1 00 36 PM" src="https://github.com/user-attachments/assets/75b4d78a-3ec1-4c51-8286-9814caab6e0b" /> |
| Populated | <img width="374" height="535" alt="Screenshot 2025-08-27 at 1 01 00 PM" src="https://github.com/user-attachments/assets/841fc55f-eafd-49e3-b33d-6fea0226b239" /> | <img width="358" height="544" alt="Screenshot 2025-08-27 at 1 01 07 PM" src="https://github.com/user-attachments/assets/3bb1bc2e-b826-4e7a-a07c-72187ba0b326" /> |


## Test plan:
`pnpm jest packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx`

Storybook
`/?path=/docs/widgets-image-editor-demo--docs#populated-within-editor-page`