### PR TITLE
Replace WB surface and foreground/border inverse semantic color token usage (js tokens)

### DIFF
--- a/packages/perseus-editor/src/widgets/radio/radio-option-content-and-image-editor.tsx
+++ b/packages/perseus-editor/src/widgets/radio/radio-option-content-and-image-editor.tsx
@@ -189,7 +189,8 @@ export const RadioOptionContentAndImageEditor = (props: Props) => {
                     expanded={true}
                     containerStyle={{
                         // White to contrast with the blue choice tile.
-                        backgroundColor: semanticColor.surface.primary,
+                        backgroundColor:
+                            semanticColor.core.background.base.default,
                         marginBlockStart: sizing.size_040,
                         marginBlockEnd: sizing.size_040,
                     }}

--- a/testing/debug-check-answer-footer.tsx
+++ b/testing/debug-check-answer-footer.tsx
@@ -160,7 +160,7 @@ const styles = {
         left: 0,
         right: 0,
         padding: `${sizing.size_120} ${sizing.size_160}`,
-        backgroundColor: semanticColor.core.foreground.inverse.strong,
+        backgroundColor: semanticColor.core.background.base.default,
         border: `${border.width.thin} solid ${semanticColor.core.border.neutral.subtle}`,
     },
     buttonContainer: {


### PR DESCRIPTION
## Summary:
In https://github.com/Khan/perseus/pull/2835, WB css variable usage was updated so that WB tokens that will be removed are no longer used in perseus.

This PR updates existing usage of the JS tokens that will be removed in an upcoming version of Wonder Blocks 

Context:

There are some upcoming breaking changes in WB semantic color tokens:
- The `surface.*` tokens will be removed in favour of new `core.background.base.*` and `core.background.overlay.default` tokens
- The `foreground.inverse.*` and `border.inverse.*` tokens will be removed in favour of new `foreground.knockout.default` and `border.knockout.default` tokens
- The `background.neutral.subtle` value in the Shape Your Learning (Thunder Blocks) theme will be updated from white to a light gray 

Here are the semantic color token docs for reference:
- [Using semantic colors](https://khan.github.io/wonder-blocks/?path=/docs/foundations-using-color--docs)
- [Semantic color tokens](https://khan.github.io/wonder-blocks/?path=/docs/packages-tokens-semantic-color--docs)


Issue: WB-2050

## Test plan:

1. Confirm the following tokens are no longer used and that the replacement tokens are suitable for the use case:
- surface tokens
- foreground inverse tokens
- border inverse tokens
2. Check usage of the background neutral subtle token and confirm that it is fine if the value changes to light gray in the TB theme
    - Looks like `--wb-semanticColor-core-background-neutral-subtle` is only used once in perseus currently for the [scrollable view stories](https://github.com/Khan/perseus/blob/ae8f7b2d0d98d0bc11654fc086ace74c96384eff/packages/perseus/src/components/__docs__/scrollable-view.stories.module.css#L18). This looks like it should be fine if the value is light gray in both Classic and TB themes, so no changes were necessary!

## Implementation plan: 
1. Add new knockout and background tokens https://github.com/Khan/wonder-blocks/pull/2761 and https://github.com/Khan/frontend/pull/3045
2. Migrate off of old tokens in WB, frontend, perseus:
  - WB
    - inverse tokens: https://github.com/Khan/wonder-blocks/pull/2758
    - surface tokens: https://github.com/Khan/wonder-blocks/pull/2766
  - frontend
    - inverse tokens: https://github.com/Khan/frontend/pull/3180
    - surface tokens:
      - primary https://github.com/Khan/frontend/pull/3201
      - secondary https://github.com/Khan/frontend/pull/3203
      - emphasis, overlay, inverse https://github.com/Khan/frontend/pull/3205
  - perseus
    - https://github.com/Khan/perseus/pull/2835
    - **(this PR)** https://github.com/Khan/perseus/pull/2835
3. Remove old tokens