### PR TITLE
[Image] | (DX) | Fix alignment in regression stories

### DIFF
--- a/.changeset/brown-numbers-travel.md
+++ b/.changeset/brown-numbers-travel.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+[Image] | (DX) | Fix regression stories by adding width and height to images

--- a/packages/perseus/src/widgets/image/__docs__/image-regression.stories.tsx
+++ b/packages/perseus/src/widgets/image/__docs__/image-regression.stories.tsx
@@ -18,8 +18,11 @@ const ImageWidget = getWidget("image")!;
 
 type Story = StoryObj<typeof ImageWidget>;
 
-const earthMoonImageUrl =
-    "https://cdn.kastatic.org/ka-content-images/61831c1329dbc32036d7dd0d03e06e7e2c622718.jpg";
+const earthMoonImage = {
+    url: "https://cdn.kastatic.org/ka-content-images/61831c1329dbc32036d7dd0d03e06e7e2c622718.jpg",
+    width: 400,
+    height: 225,
+};
 const frescoImageUrl =
     "https://cdn.kastatic.org/ka-perseus-images/01f44d5b73290da6bec97c75a5316fb05ab61f12.jpg";
 
@@ -56,9 +59,7 @@ export default meta;
 export const Default: Story = {
     decorators: [rendererDecorator],
     args: {
-        backgroundImage: {
-            url: earthMoonImageUrl,
-        },
+        backgroundImage: earthMoonImage,
         alt: "Earth and Moon",
         title: "Earth and Moon",
         caption: "Earth and Moon",
@@ -68,18 +69,14 @@ export const Default: Story = {
 export const Image: Story = {
     decorators: [rendererDecorator],
     args: {
-        backgroundImage: {
-            url: earthMoonImageUrl,
-        },
+        backgroundImage: earthMoonImage,
     },
 };
 
 export const ImageWithAlt: Story = {
     decorators: [rendererDecorator],
     args: {
-        backgroundImage: {
-            url: earthMoonImageUrl,
-        },
+        backgroundImage: earthMoonImage,
         alt: "Earth and Moon",
     },
 };
@@ -87,9 +84,7 @@ export const ImageWithAlt: Story = {
 export const ImageWithCaption: Story = {
     decorators: [rendererDecorator],
     args: {
-        backgroundImage: {
-            url: earthMoonImageUrl,
-        },
+        backgroundImage: earthMoonImage,
         caption: "Earth and Moon",
     },
 };
@@ -97,9 +92,7 @@ export const ImageWithCaption: Story = {
 export const ImageWithTitle: Story = {
     decorators: [rendererDecorator],
     args: {
-        backgroundImage: {
-            url: earthMoonImageUrl,
-        },
+        backgroundImage: earthMoonImage,
         title: "Earth and Moon",
     },
 };

--- a/packages/perseus/src/widgets/image/__docs__/image.stories.tsx
+++ b/packages/perseus/src/widgets/image/__docs__/image.stories.tsx
@@ -57,6 +57,8 @@ export const BasicQuestion: Story = {
     args: {
         backgroundImage: {
             url: "https://cdn.kastatic.org/ka-content-images/61831c1329dbc32036d7dd0d03e06e7e2c622718.jpg",
+            width: 400,
+            height: 225,
         },
         alt: "",
         caption: "",


### PR DESCRIPTION
## Summary:
In order to fix the images' alignment in regression stories, I had to add
the width and height to the images in the testdata.

This is in line with real image data, as image widgets' `backgroundImage`s are
saved with the calculated widths and heights at publish.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3440

## Test plan:
Storybook
`/?path=/docs/widgets-image-visual-regression-tests--docs`
- Confirm that all the images are center aligned

Check the UI Tests github check below and confirm that all the images have gone
from being left-aligned to being center-aligned.