### PR TITLE
[Image] | (CX) | Add the Title field back in the Image editor

### DIFF
--- a/.changeset/khaki-pens-sneeze.md
+++ b/.changeset/khaki-pens-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+[Image] | (CX) | Add the Title field back in the Image editor

--- a/packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx
@@ -56,6 +56,7 @@ describe("image editor", () => {
                 backgroundImage={{url: realKhanImageUrl}}
                 alt="Earth and moon alt"
                 caption="Earth and moon caption"
+                title="Earth and moon title"
                 onChange={() => {}}
             />,
         );
@@ -64,17 +65,20 @@ describe("image editor", () => {
         const urlField = screen.getByRole("textbox", {name: "Image url:"});
         const altField = screen.getByRole("textbox", {name: "Alt text:"});
         const captionField = screen.getByRole("textbox", {name: "Caption:"});
+        const titleField = screen.getByRole("textbox", {name: "Title:"});
 
         // Assert
         expect(dimensionsLabel).toBeInTheDocument();
         expect(urlField).toBeInTheDocument();
         expect(altField).toBeInTheDocument();
         expect(captionField).toBeInTheDocument();
+        expect(titleField).toBeInTheDocument();
 
         expect(screen.getByText("unknown")).toBeInTheDocument();
         expect(urlField).toHaveValue(realKhanImageUrl);
         expect(altField).toHaveValue("Earth and moon alt");
         expect(captionField).toHaveValue("Earth and moon caption");
+        expect(titleField).toHaveValue("Earth and moon title");
     });
 
     it("should render warning for non-Khan Academy image", async () => {
@@ -291,6 +295,49 @@ describe("image editor", () => {
         // Assert
         expect(onChangeMock).toHaveBeenCalledWith({
             caption: undefined,
+        });
+    });
+    it("should call onChange with new title", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <ImageEditor
+                apiOptions={apiOptions}
+                backgroundImage={{url: realKhanImageUrl}}
+                onChange={onChangeMock}
+            />,
+        );
+
+        // Act
+        const titleField = screen.getByRole("textbox", {name: "Title:"});
+        titleField.focus();
+        await userEvent.paste("Earth and moon");
+
+        // Assert
+        expect(onChangeMock).toHaveBeenCalledWith({
+            title: "Earth and moon",
+        });
+    });
+
+    it("should call onChange with undefined title", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <ImageEditor
+                apiOptions={apiOptions}
+                backgroundImage={{url: realKhanImageUrl}}
+                title="Earth and moon"
+                onChange={onChangeMock}
+            />,
+        );
+
+        // Act
+        const titleField = screen.getByRole("textbox", {name: "Title:"});
+        await userEvent.clear(titleField);
+
+        // Assert
+        expect(onChangeMock).toHaveBeenCalledWith({
+            title: undefined,
         });
     });
 });

--- a/packages/perseus-editor/src/widgets/image-editor/image-settings.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/image-settings.tsx
@@ -15,10 +15,12 @@ export default function ImageSettings({
     alt,
     backgroundImage,
     caption,
+    title,
     onChange,
 }: Props) {
     const uniqueId = React.useId();
     const altId = `${uniqueId}-alt`;
+    const titleId = `${uniqueId}-title`;
     const captionId = `${uniqueId}-caption`;
 
     if (!backgroundImage.url) {
@@ -91,12 +93,21 @@ export default function ImageSettings({
                     // Avoid saving empty strings in the content data.
                     onChange({alt: value === "" ? undefined : value})
                 }
-                style={{
-                    // TODO: Use CSS modules after Wonder Blocks styles
-                    // are moved to a different layer.
-                    marginBlockStart: sizing.size_040,
-                    marginBlockEnd: sizing.size_080,
-                }}
+                style={textAreaStyle}
+            />
+
+            {/* Title */}
+            <HeadingXSmall tag="label" htmlFor={titleId}>
+                Title:
+            </HeadingXSmall>
+            <AutoResizingTextArea
+                id={titleId}
+                value={title ?? ""}
+                onChange={(value) =>
+                    // Avoid saving empty strings in the content data.
+                    onChange({title: value === "" ? undefined : value})
+                }
+                style={textAreaStyle}
             />
 
             {/* Caption */}
@@ -110,13 +121,15 @@ export default function ImageSettings({
                     // Avoid saving empty strings in the content data.
                     onChange({caption: value === "" ? undefined : value})
                 }
-                style={{
-                    // TODO: Use CSS modules after Wonder Blocks styles
-                    // are moved to a different layer.
-                    marginBlockStart: sizing.size_040,
-                    marginBlockEnd: sizing.size_080,
-                }}
+                style={textAreaStyle}
             />
         </>
     );
 }
+
+// TODO: Use CSS modules after Wonder Blocks styles
+// are moved to a different layer.
+const textAreaStyle = {
+    marginBlockStart: sizing.size_040,
+    marginBlockEnd: sizing.size_120,
+};


### PR DESCRIPTION
## Summary:
Adding the `title` field back in the Image editor.

It got removed in 2017 without any reason as far as I can tell, but
the `title` prop is still used in a number of images.

It seems like something that could be valuable, so we decided to bring it back.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3427

## Test plan:
`pnpm jest packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx`

Storybook
`/?path=/docs/widgets-image-editor-demo--docs#populated-within-editor-page`