### PR TITLE
[Image] | (DX) | Revert to old way of saving empty string data for the sake of data consistency

### DIFF
--- a/.changeset/fast-ways-buy.md
+++ b/.changeset/fast-ways-buy.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Image] | (DX) | Revert to old way of saving empty string data for the sake of data consistency

--- a/packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx
@@ -176,8 +176,12 @@ describe("image editor", () => {
 
         // Assert
         expect(onChangeMock).toHaveBeenCalledWith({
-            backgroundImage: {},
-            box: undefined,
+            backgroundImage: {
+                url: "",
+                width: 0,
+                height: 0,
+            },
+            box: [0, 0],
         });
     });
 
@@ -232,7 +236,7 @@ describe("image editor", () => {
         });
     });
 
-    it("should call onChange with undefined alt", async () => {
+    it("should call onChange with empty alt", async () => {
         // Arrange
         const onChangeMock = jest.fn();
         render(
@@ -250,7 +254,7 @@ describe("image editor", () => {
 
         // Assert
         expect(onChangeMock).toHaveBeenCalledWith({
-            alt: undefined,
+            alt: "",
         });
     });
 
@@ -276,7 +280,7 @@ describe("image editor", () => {
         });
     });
 
-    it("should call onChange with undefined caption", async () => {
+    it("should call onChange with empty caption", async () => {
         // Arrange
         const onChangeMock = jest.fn();
         render(
@@ -294,7 +298,7 @@ describe("image editor", () => {
 
         // Assert
         expect(onChangeMock).toHaveBeenCalledWith({
-            caption: undefined,
+            caption: "",
         });
     });
     it("should call onChange with new title", async () => {
@@ -319,7 +323,7 @@ describe("image editor", () => {
         });
     });
 
-    it("should call onChange with undefined title", async () => {
+    it("should call onChange with empty title", async () => {
         // Arrange
         const onChangeMock = jest.fn();
         render(
@@ -337,7 +341,7 @@ describe("image editor", () => {
 
         // Assert
         expect(onChangeMock).toHaveBeenCalledWith({
-            title: undefined,
+            title: "",
         });
     });
 });

--- a/packages/perseus-editor/src/widgets/image-editor/image-settings.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/image-settings.tsx
@@ -89,10 +89,7 @@ export default function ImageSettings({
             <AutoResizingTextArea
                 id={altId}
                 value={alt ?? ""}
-                onChange={(value) =>
-                    // Avoid saving empty strings in the content data.
-                    onChange({alt: value === "" ? undefined : value})
-                }
+                onChange={(value) => onChange({alt: value})}
                 style={textAreaStyle}
             />
 
@@ -103,10 +100,7 @@ export default function ImageSettings({
             <AutoResizingTextArea
                 id={titleId}
                 value={title ?? ""}
-                onChange={(value) =>
-                    // Avoid saving empty strings in the content data.
-                    onChange({title: value === "" ? undefined : value})
-                }
+                onChange={(value) => onChange({title: value})}
                 style={textAreaStyle}
             />
 
@@ -117,10 +111,7 @@ export default function ImageSettings({
             <AutoResizingTextArea
                 id={captionId}
                 value={caption ?? ""}
-                onChange={(value) =>
-                    // Avoid saving empty strings in the content data.
-                    onChange({caption: value === "" ? undefined : value})
-                }
+                onChange={(value) => onChange({caption: value})}
                 style={textAreaStyle}
             />
         </>

--- a/packages/perseus-editor/src/widgets/image-editor/image-url-input.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/image-url-input.tsx
@@ -39,7 +39,7 @@ export default function ImageUrlInput({backgroundImage, onChange}: Props) {
 
     function setUrl(url: string, width: number, height: number) {
         const image = {...backgroundImage};
-        // Don't save empty strings in the content data.
+
         image.url = url;
         image.width = width;
         image.height = height;
@@ -54,10 +54,7 @@ export default function ImageUrlInput({backgroundImage, onChange}: Props) {
         // Don't try to load the image if there is no URL.
         if (!url) {
             setBackgroundImageError(null);
-            onChange({
-                backgroundImage: {},
-                box: undefined,
-            });
+            setUrl(url, 0, 0);
             return;
         }
 


### PR DESCRIPTION
## Summary:
It seems like saving empty strings as undefined might introduce inconsistency in our data.
Since these have been saved as `""` for years, I'm going back to doing it that way so
it's easier to understand our data in the future.

[Discussion](https://khanacademy.slack.com/archives/C01AZ9H8TTQ/p1756321954129759)

Issue: none

## Test plan:
`pnpm jest packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx`