### PR TITLE
Remove Radio transforms (take 2)

### DIFF
--- a/.changeset/purple-taxis-itch.md
+++ b/.changeset/purple-taxis-itch.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": major
+"@khanacademy/perseus-core": major
+---
+
+Remove Radio transform/staticTransform. Replace randomness with deterministic shuffling for Radio.

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -188,12 +188,7 @@ export {
     shuffleMatcher,
 } from "./widgets/matcher/matcher-util";
 export type {MatcherPublicWidgetOptions} from "./widgets/matcher/matcher-util";
-export {
-    shuffle,
-    randomizeArrayElements,
-    seededRNG,
-    random,
-} from "./utils/random-util";
+export {shuffle, seededRNG, random} from "./utils/random-util";
 export {default as PerseusFeatureFlags} from "./feature-flags";
 
 export {traverse} from "./traversal";

--- a/packages/perseus-core/src/utils/random-util.ts
+++ b/packages/perseus-core/src/utils/random-util.ts
@@ -95,22 +95,3 @@ export function randomIntInRange(
 }
 
 export const random: RNG = seededRNG(new Date().getTime() & 0xffffffff);
-
-/**
- * Randomizes an array using the sort-by-random-key method
- *
- * @param inputArray - The array of elements to randomize
- * @returns A new array containing the same elements in randomized order
- */
-export function randomizeArrayElements<T>(inputArray: ReadonlyArray<T>): T[] {
-    return inputArray
-        .map((element) => {
-            const randomSortNumber = Math.random();
-            return {
-                element,
-                randomSortNumber,
-            };
-        })
-        .sort((a, b) => a.randomSortNumber - b.randomSortNumber)
-        .map((item) => item.element);
-}

--- a/packages/perseus/src/__testdata__/renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/renderer.testdata.ts
@@ -253,7 +253,6 @@ export const mockedShuffledRadioProps: {[key in string]: RenderProps} = {
                 originalIndex: 2,
             },
         ],
-        selectedChoices: [false, false, true, false],
     },
     "radio 2": {
         numCorrect: 1,
@@ -288,6 +287,5 @@ export const mockedShuffledRadioProps: {[key in string]: RenderProps} = {
                 originalIndex: 2,
             },
         ],
-        selectedChoices: [false, false, true, false],
     },
 };

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -55,7 +55,6 @@ describe("renderer", () => {
     });
 
     let userEvent: UserEvent;
-    let mathRandomSpy: jest.SpyInstance;
 
     beforeEach(() => {
         userEvent = userEventLib.setup({
@@ -73,21 +72,6 @@ describe("renderer", () => {
                 ok: true,
             }),
         ) as jest.Mock;
-
-        // Mock Math.random to return a deterministic sequence for consistent test results
-        mathRandomSpy = jest.spyOn(Math, "random");
-        let callCount = 0;
-        mathRandomSpy.mockImplementation(() => {
-            // This ensures consistent shuffling behavior in radio widgets
-            // Values calculated to produce specific shuffle: [3, 1, 0, 2] from [0, 1, 2, 3]
-            const values = [0.3, 0.2, 0.4, 0.1, 0.8, 0.7, 0.9, 0.6, 0.5];
-            return values[callCount++ % values.length];
-        });
-    });
-
-    afterEach(() => {
-        // Restore Math.random to its original implementation
-        mathRandomSpy.mockRestore();
     });
 
     describe("snapshots", () => {

--- a/packages/perseus/src/__tests__/widgets.test.ts
+++ b/packages/perseus/src/__tests__/widgets.test.ts
@@ -1,6 +1,5 @@
 import {mockStrings} from "../strings";
 import {registerAllWidgetsForTesting} from "../util/register-all-widgets-for-testing";
-import {generateTestRadioWidget} from "../util/test-utils";
 import * as Widgets from "../widgets";
 
 describe("Widget API support", () => {
@@ -23,15 +22,6 @@ describe("Widget API support", () => {
         it("returns null for unknown widget types", () => {
             // Coolbeans is not a real widget sadly
             expect(Widgets.getWidget("coolbeans")).toBe(null);
-        });
-
-        it("returns a transform function when widgets provide one", () => {
-            const widgetOptions = generateTestRadioWidget().options;
-            // Radio provides a `transform` function
-            const transform = Widgets.getTransform("radio");
-            expect(transform?.(widgetOptions, mockStrings)).not.toEqual(
-                widgetOptions,
-            );
         });
 
         it("returns an identity function when widgets don't provide a transform", () => {

--- a/packages/perseus/src/mixins/widget-prop-denylist.ts
+++ b/packages/perseus/src/mixins/widget-prop-denylist.ts
@@ -44,6 +44,7 @@ const denylist = [
     "showSolutions",
     "reviewMode",
     "reviewModeRubric",
+    "widgetIndex",
 ];
 
 export function excludeDenylistKeys(obj: Record<any, any>) {

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -594,6 +594,24 @@ class Renderer
         return null;
     };
 
+    _getWidgetIndexById(id: string) {
+        const widgetIndex = Object.keys(this.props.widgets).indexOf(id);
+        if (widgetIndex < 0) {
+            Log.error(
+                "Unable to get widget index in _getWidgetIndexById",
+                Errors.Internal,
+                {
+                    loggedMetadata: {
+                        widgets: JSON.stringify(this.props.widgets),
+                        widgetId: JSON.stringify(id),
+                    },
+                },
+            );
+            return 0;
+        }
+        return widgetIndex;
+    }
+
     getWidgetProps(
         widgetId: string,
     ): WidgetProps<any, any, PerseusWidgetOptions> {
@@ -627,6 +645,7 @@ class Renderer
             ...widgetProps,
             userInput: this.props.userInput?.[widgetId],
             widgetId: widgetId,
+            widgetIndex: this._getWidgetIndexById(widgetId),
             alignment: widgetInfo && widgetInfo.alignment,
             static: widgetInfo?.static,
             problemNum: this.props.problemNum,

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -595,7 +595,7 @@ class Renderer
     };
 
     _getWidgetIndexById(id: string) {
-        const widgetIndex = Object.keys(this.props.widgets).indexOf(id);
+        const widgetIndex = this.widgetIds.indexOf(id);
         if (widgetIndex < 0) {
             Log.error(
                 "Unable to get widget index in _getWidgetIndexById",

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -570,6 +570,7 @@ export type UniversalWidgetProps<
     trackInteraction: (extraData?: TrackingExtraArgs) => void;
     // provided by renderer.jsx#getWidgetProps()
     widgetId: string;
+    widgetIndex: number;
     alignment: string | null | undefined;
     static: boolean | null | undefined;
     problemNum: number | null | undefined;

--- a/packages/perseus/src/widget-ai-utils/radio/radio-ai-utils.test.ts
+++ b/packages/perseus/src/widget-ai-utils/radio/radio-ai-utils.test.ts
@@ -64,7 +64,6 @@ const shuffledQuestion: PerseusRenderer = {
 
 describe("Radio AI utils", () => {
     let userEvent: UserEvent;
-    let mathRandomSpy: jest.SpyInstance;
 
     beforeEach(() => {
         userEvent = userEventLib.setup({
@@ -74,20 +73,6 @@ describe("Radio AI utils", () => {
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );
-
-        // Mock Math.random to return a deterministic sequence for consistent test results
-        mathRandomSpy = jest.spyOn(Math, "random");
-        let callCount = 0;
-        mathRandomSpy.mockImplementation(() => {
-            // This ensures consistent shuffling behavior in radio widgets
-            const values = [0.2, 0.3, 0.8, 0.9, 0.1, 0.4, 0.6, 0.7, 0.5];
-            return values[callCount++ % values.length];
-        });
-    });
-
-    afterEach(() => {
-        // Restore Math.random to its original implementation
-        mathRandomSpy.mockRestore();
     });
 
     // why are these tests named the same?

--- a/packages/perseus/src/widget-ai-utils/radio/radio-ai-utils.test.ts
+++ b/packages/perseus/src/widget-ai-utils/radio/radio-ai-utils.test.ts
@@ -194,7 +194,6 @@ describe("Radio AI utils", () => {
                     originalIndex: 2,
                 },
             ],
-            selectedChoices: [true, false, false, false],
         };
 
         const resultJSON = getPromptJSON(renderProps, undefined as any);

--- a/packages/perseus/src/widgets/expression/__docs__/expression.stories.tsx
+++ b/packages/perseus/src/widgets/expression/__docs__/expression.stories.tsx
@@ -26,6 +26,7 @@ type Story = StoryObj<typeof ServerItemRendererWithDebugUI>;
 
 /** This story shows how the expression widget looks when the keypad is
  * configured with _every_ option it supports.  */
+// TODO: use a Renderer wrapper rather than rendering this directly
 export const DesktopKitchenSink = (args: Story["args"]): React.ReactElement => {
     return (
         <div style={{padding: "2rem"}}>
@@ -43,6 +44,7 @@ export const DesktopKitchenSink = (args: Story["args"]): React.ReactElement => {
                 userInput=""
                 trackInteraction={() => {}}
                 widgetId="expression"
+                widgetIndex={0}
                 extraKeys={["x", "y", "z"]}
                 reviewMode={false}
                 answerForms={[

--- a/packages/perseus/src/widgets/group/group.test.tsx
+++ b/packages/perseus/src/widgets/group/group.test.tsx
@@ -287,7 +287,6 @@ describe("group widget", () => {
                     hasNoneOfTheAbove: false,
                     multipleSelect: false,
                     numCorrect: 1,
-                    selectedChoices: [false, false, false, false, true],
                     static: false,
                 },
             },
@@ -329,46 +328,6 @@ describe("group widget", () => {
                     size: "normal",
                     static: false,
                 },
-            },
-            "radio 1": {
-                choices: [
-                    {
-                        id: "0-0-0-0-0",
-                        content: "",
-                        correct: false,
-                        originalIndex: 0,
-                    },
-                    {
-                        id: "1-1-1-1-1",
-                        content: "",
-                        correct: false,
-                        originalIndex: 1,
-                    },
-                    {
-                        id: "2-2-2-2-2",
-                        content: "",
-                        correct: false,
-                        originalIndex: 2,
-                    },
-                    {
-                        id: "3-3-3-3-3",
-                        content: "",
-                        correct: false,
-                        originalIndex: 3,
-                    },
-                    {
-                        id: "4-4-4-4-4",
-                        content: "",
-                        correct: true,
-                        originalIndex: 4,
-                    },
-                ],
-                countChoices: false,
-                deselectEnabled: false,
-                hasNoneOfTheAbove: false,
-                multipleSelect: false,
-                numCorrect: 1,
-                selectedChoices: [false, false, false, false, true],
             },
         });
     });

--- a/packages/perseus/src/widgets/group/group.testdata.ts
+++ b/packages/perseus/src/widgets/group/group.testdata.ts
@@ -152,43 +152,6 @@ export const question1: PerseusRenderer = {
             type: "group",
             version: {major: 0, minor: 0},
         },
-        "radio 1": {
-            graded: true,
-            options: {
-                choices: [
-                    {
-                        id: "0-0-0-0-0",
-                        content: "",
-                        correct: false,
-                    },
-                    {
-                        id: "1-1-1-1-1",
-                        content: "",
-                        correct: false,
-                    },
-                    {
-                        id: "2-2-2-2-2",
-                        content: "",
-                        correct: false,
-                    },
-                    {
-                        id: "3-3-3-3-3",
-                        content: "",
-                        correct: false,
-                    },
-                    {
-                        id: "4-4-4-4-4",
-                        content: "",
-                        correct: true,
-                    },
-                ],
-                multipleSelect: false,
-                randomize: false,
-                numCorrect: 1,
-            },
-            type: "radio",
-            version: {major: 0, minor: 0},
-        },
     },
 };
 

--- a/packages/perseus/src/widgets/passage/__tests__/passage.test.tsx
+++ b/packages/perseus/src/widgets/passage/__tests__/passage.test.tsx
@@ -51,10 +51,12 @@ function renderPassage(
         static: true,
         trackInteraction: () => {},
         widgetId: "passage",
+        widgetIndex: 0,
         reviewMode: false,
     } as const;
 
     const extended = {...base, ...overwrite} as const;
+    // TODO: use a Renderer wrapper rather than rendering this directly
     return render(<PassageWidgetExport.widget {...extended} />);
 }
 

--- a/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
@@ -19,7 +19,7 @@ import {
 } from "./radio.testdata";
 
 import type {APIOptions} from "../../../types";
-import type {PerseusRenderer} from "@khanacademy/perseus-core";
+import type {PerseusRenderer, RadioWidget} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
 
 const selectOption = async (
@@ -938,6 +938,64 @@ describe("Radio Widget", () => {
             // and that correct choice should be Choice B
             expect(correctCount).toBe(1);
             expect(correctChoiceContent).toContain("Choice B");
+        });
+    });
+
+    describe("shuffling", () => {
+        // regression LEMS-297
+        it("shuffles differently for multiple radios in the same exercise", () => {
+            let counter: number = 0;
+            const generateId = () => `${counter++}`;
+            function generateRadio(): RadioWidget {
+                return {
+                    type: "radio",
+                    version: {major: 3, minor: 0},
+                    options: {
+                        choices: [
+                            {
+                                content: "Choice 1",
+                                id: generateId(),
+                            },
+                            {
+                                content: "Choice 2",
+                                id: generateId(),
+                            },
+                            {
+                                content: "Choice 3",
+                                id: generateId(),
+                            },
+                            {
+                                content: "Choice 4",
+                                id: generateId(),
+                            },
+                        ],
+                        randomize: true,
+                    },
+                };
+            }
+            const multipleShuffledRadioQuestion: PerseusRenderer = {
+                content: "[[☃ radio 1]]\n[[☃ radio 2]]",
+                widgets: {
+                    "radio 1": generateRadio(),
+                    "radio 2": generateRadio(),
+                },
+                images: {},
+            };
+
+            const {container} = renderQuestion(multipleShuffledRadioQuestion);
+
+            // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+            const radios = container.querySelectorAll(".perseus-widget-radio");
+
+            expect(radios.length).toBe(2);
+
+            // eslint-disable-next-line testing-library/no-node-access
+            const lis1 = Array.from(radios[0].querySelectorAll("li"));
+            // eslint-disable-next-line testing-library/no-node-access
+            const lis2 = Array.from(radios[1].querySelectorAll("li"));
+
+            const getText = (element) => element.textContent;
+            expect(lis1.map(getText)).not.toEqual(lis2.map(getText));
         });
     });
 });

--- a/packages/perseus/src/widgets/radio/multiple-choice-widget.new.tsx
+++ b/packages/perseus/src/widgets/radio/multiple-choice-widget.new.tsx
@@ -1,14 +1,13 @@
 import * as React from "react";
 import {forwardRef, useImperativeHandle} from "react";
 
+import {usePerseusI18n} from "../../components/i18n-context";
 import Renderer from "../../renderer";
-import {mockStrings} from "../../strings";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/radio/radio-ai-utils";
 
 import MultipleChoiceComponent from "./multiple-choice-component.new";
 import {getChoiceStates, parseNestedWidgets} from "./utils/general-utils";
 
-import type {PerseusStrings} from "../../strings";
 import type {WidgetProps, ChoiceState, Widget} from "../../types";
 import type {RadioPromptJSON} from "../../widget-ai-utils/radio/radio-ai-utils";
 import type {
@@ -46,7 +45,6 @@ export type RenderProps = {
     deselectEnabled?: boolean;
     choices: ReadonlyArray<RadioChoiceWithMetadata>;
     choiceStates?: ReadonlyArray<ChoiceState>;
-    strings?: PerseusStrings;
     editMode?: boolean;
     labelWrap?: boolean;
 };
@@ -87,7 +85,6 @@ const MultipleChoiceWidget = forwardRef<Widget, Props>(
             choiceStates,
             reviewModeRubric,
             questionCompleted,
-            strings = mockStrings,
             static: isStatic,
             apiOptions,
             onChange,
@@ -95,6 +92,8 @@ const MultipleChoiceWidget = forwardRef<Widget, Props>(
             findWidgets,
             reviewMode,
         } = props;
+
+        const {strings} = usePerseusI18n();
 
         // Perseus Widget API methods
         // TODO(LEMS-2994): When we remove the old Radio files, we may need to move some

--- a/packages/perseus/src/widgets/radio/multiple-choice-widget.new.tsx
+++ b/packages/perseus/src/widgets/radio/multiple-choice-widget.new.tsx
@@ -45,13 +45,7 @@ export type RenderProps = {
     countChoices?: boolean;
     deselectEnabled?: boolean;
     choices: ReadonlyArray<RadioChoiceWithMetadata>;
-    // (LEMS-3278) - Remove all references to selectedChoices, as it's not used anywhere.
-    // We're handling selected in the choiceStates array.
-    selectedChoices: ReadonlyArray<PerseusRadioChoice["correct"]>;
     choiceStates?: ReadonlyArray<ChoiceState>;
-    // Deprecated; support for legacy way of handling changes
-    // Adds proptype for prop that is used but was lacking type
-    values?: ReadonlyArray<boolean>;
     strings?: PerseusStrings;
     editMode?: boolean;
     labelWrap?: boolean;
@@ -91,7 +85,6 @@ const MultipleChoiceWidget = forwardRef<Widget, Props>(
             countChoices = false,
             showSolutions = "none",
             choiceStates,
-            values,
             reviewModeRubric,
             questionCompleted,
             strings = mockStrings,
@@ -311,7 +304,6 @@ const MultipleChoiceWidget = forwardRef<Widget, Props>(
                 isStatic,
                 showSolutions,
                 choiceStates,
-                values,
             });
 
             // Build the choice props from the updated choice states

--- a/packages/perseus/src/widgets/radio/radio-component.tsx
+++ b/packages/perseus/src/widgets/radio/radio-component.tsx
@@ -17,23 +17,19 @@ import type {
     ShowSolutions,
     PerseusRadioRubric,
     PerseusRadioUserInput,
+    PerseusRadioWidgetOptions,
 } from "@khanacademy/perseus-core";
 
 // RenderProps is the return type for radio.jsx#transform
-export type RenderProps = {
+export type RenderProps = PerseusRadioWidgetOptions & {
     numCorrect: number;
     hasNoneOfTheAbove?: boolean;
     multipleSelect?: boolean;
     countChoices?: boolean;
     deselectEnabled?: boolean;
     choices: RadioChoiceWithMetadata[];
-    // doesn't seem used? choiceStates includes selected...
-    selectedChoices: PerseusRadioChoice["correct"][];
     showSolutions?: ShowSolutions;
     choiceStates?: ChoiceState[];
-    // Depreciated; support for legacy way of handling changes
-    // Adds proptype for prop that is used but was lacking type
-    values?: boolean[];
 };
 
 export type Props = WidgetProps<
@@ -223,18 +219,6 @@ class Radio extends React.Component<Props> implements Widget {
             }));
         } else if (this.props.choiceStates) {
             choiceStates = this.props.choiceStates;
-        } else if (this.props.values) {
-            // Support legacy choiceStates implementation
-            /* c8 ignore next - props.values is deprecated */
-            choiceStates = this.props.values.map((val) => ({
-                selected: val,
-                crossedOut: false,
-                readOnly: false,
-                highlighted: false,
-                rationaleShown: false,
-                correctnessShown: false,
-                previouslyAnswered: false,
-            }));
         } else {
             choiceStates = choices.map(() => ({
                 selected: false,

--- a/packages/perseus/src/widgets/radio/radio.ff.tsx
+++ b/packages/perseus/src/widgets/radio/radio.ff.tsx
@@ -12,6 +12,7 @@ import {choiceTransform, getUserInputFromSerializedState} from "./util";
 
 import type {RenderProps} from "./radio-component";
 import type {ChoiceState, WidgetProps} from "../../types";
+import type {RadioPromptJSON} from "../../widget-ai-utils/radio/radio-ai-utils";
 
 type Props = WidgetProps<
     RenderProps,
@@ -85,6 +86,10 @@ class Radio extends RadioOld {
         return {
             ...rest,
         };
+    }
+
+    getPromptJSON(): RadioPromptJSON {
+        return this.radioRef.current!.getPromptJSON();
     }
 
     _handleChange(arg: {choiceStates?: ChoiceState[]}) {

--- a/packages/perseus/src/widgets/radio/radio.ff.tsx
+++ b/packages/perseus/src/widgets/radio/radio.ff.tsx
@@ -8,7 +8,7 @@ import _ from "underscore";
 
 import RadioNew from "./multiple-choice-widget.new";
 import RadioOld from "./radio-component";
-import {getUserInputFromSerializedState} from "./util";
+import {choiceTransform, getUserInputFromSerializedState} from "./util";
 
 import type {RenderProps} from "./radio-component";
 import type {ChoiceState, WidgetProps} from "../../types";
@@ -77,7 +77,11 @@ class Radio extends RadioOld {
      * [LEMS-3185] do not trust serializedState/restoreSerializedState
      */
     getSerializedState() {
-        const {userInput: _, ...rest} = this._mergePropsAndState();
+        const {
+            userInput: _,
+            randomize: __,
+            ...rest
+        } = this._mergePropsAndState();
         return {
             ...rest,
         };
@@ -155,10 +159,24 @@ class Radio extends RadioOld {
          * legacy code will understand.
          */
 
+        // randomSeed is problemNum (which changes how we shuffle between exercises)
+        // and widgetIndex (which changes how we shuffle between widgets)
+        const randomSeed =
+            (this.props.problemNum ?? 0) + (this.props.widgetIndex ?? 0);
+        const choices = [
+            ...choiceTransform(
+                this.props.choices,
+                this.props.randomize,
+                this.context.strings,
+                randomSeed,
+            ),
+        ];
+
         return {
             ...this.props,
+            choices,
             choiceStates: this.state.choiceStates?.map((choiceState, index) => {
-                const choice = this.props.choices[index];
+                const choice = choices[index];
                 const selected =
                     this.props.userInput?.selectedChoiceIds.includes(
                         choice.id,

--- a/packages/perseus/src/widgets/radio/radio.ts
+++ b/packages/perseus/src/widgets/radio/radio.ts
@@ -1,117 +1,14 @@
-import {radioLogic, randomizeArrayElements} from "@khanacademy/perseus-core";
+import {radioLogic} from "@khanacademy/perseus-core";
 import _ from "underscore";
 
 import Radio from "./radio.ff";
 import {getUserInputFromSerializedState} from "./util";
 
-import type {RenderProps, RadioChoiceWithMetadata} from "./radio-component";
-import type {PerseusStrings} from "../../strings";
 import type {WidgetExports} from "../../types";
 import type {
     PerseusRadioUserInput,
     PerseusRadioWidgetOptions,
 } from "@khanacademy/perseus-core";
-
-// Transforms the choices for display.
-const _choiceTransform = (
-    widgetOptions: PerseusRadioWidgetOptions,
-    strings: PerseusStrings,
-) => {
-    const _maybeRandomize = function (
-        array: ReadonlyArray<RadioChoiceWithMetadata>,
-    ) {
-        return widgetOptions.randomize ? randomizeArrayElements(array) : array;
-    };
-
-    const _addNoneOfAbove = function (
-        choices: ReadonlyArray<RadioChoiceWithMetadata>,
-    ) {
-        let noneOfTheAbove = null;
-
-        const newChoices = choices.filter((choice, index) => {
-            if (choice.isNoneOfTheAbove) {
-                // @ts-expect-error - TS2322 - Type 'RadioChoiceWithMetadata' is not assignable to type 'null'.
-                noneOfTheAbove = choice;
-                return false;
-            }
-            return true;
-        });
-
-        // Place the "None of the above" options last
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        if (noneOfTheAbove) {
-            newChoices.push(noneOfTheAbove);
-        }
-
-        return newChoices;
-    };
-
-    const enforceOrdering = (
-        choices: ReadonlyArray<RadioChoiceWithMetadata>,
-    ) => {
-        // Represents choices that we automatically re-order if encountered.
-        // Note: these are in the reversed (incorrect) order that we will swap, if
-        // found.
-        // Note 2: these are internationalized when compared later on.
-        const ReversedChoices: ReadonlyArray<[string, string]> = [
-            [strings.false, strings.true],
-            [strings.no, strings.yes],
-        ];
-        const content = choices.map((c) => c.content);
-        if (ReversedChoices.some((reversed) => _.isEqual(content, reversed))) {
-            return [choices[1], choices[0]];
-        }
-        return choices;
-    };
-
-    // Add meta-information to choices
-    const choices: ReadonlyArray<RadioChoiceWithMetadata> =
-        widgetOptions.choices.map((choice, i): RadioChoiceWithMetadata => {
-            return {
-                ...choice,
-                originalIndex: i,
-                correct: Boolean(choice.correct),
-            };
-        });
-
-    // Apply all the transforms. Note that the order we call these is
-    // important!
-    // 3) finally add "None of the above" to the bottom
-    return _addNoneOfAbove(
-        // 2) then (potentially) enforce ordering (eg. False, True becomes
-        //    True, False)
-        enforceOrdering(
-            // 1) we randomize the order first
-            _maybeRandomize(choices),
-        ),
-    );
-};
-
-const transform = (
-    widgetOptions: PerseusRadioWidgetOptions,
-    strings: PerseusStrings,
-): RenderProps => {
-    const choices = _choiceTransform(widgetOptions, strings);
-
-    const {
-        hasNoneOfTheAbove,
-        multipleSelect,
-        countChoices,
-        deselectEnabled,
-        numCorrect,
-    } = widgetOptions;
-
-    return {
-        numCorrect: numCorrect as number,
-        hasNoneOfTheAbove,
-        multipleSelect,
-        countChoices,
-        deselectEnabled,
-        choices,
-        // doesn't seem used? choiceStates includes selected...
-        selectedChoices: _.pluck(choices, "correct"),
-    };
-};
 
 function getStartUserInput(): PerseusRadioUserInput {
     return {
@@ -133,8 +30,6 @@ export default {
     name: "radio",
     displayName: "Radio / Multiple choice",
     widget: Radio,
-    transform,
-    staticTransform: transform,
     getStartUserInput,
     getCorrectUserInput,
     version: radioLogic.version,
@@ -145,6 +40,6 @@ export default {
      * @deprecated - do not use in new code.
      */
     getUserInputFromSerializedState: (serializedState: any) => {
-        return getUserInputFromSerializedState(serializedState, true);
+        return getUserInputFromSerializedState(serializedState);
     },
 } satisfies WidgetExports<typeof Radio>;

--- a/packages/perseus/src/widgets/radio/serialize-radio.test.ts
+++ b/packages/perseus/src/widgets/radio/serialize-radio.test.ts
@@ -47,8 +47,6 @@ const expectedSerializedRadio = {
             originalIndex: 2,
         },
     ],
-    // no idea what this is, it doesn't seem to change...
-    selectedChoices: [false, false, true, false],
     choiceStates: [
         {
             selected: true, // <= note we stash user input
@@ -146,7 +144,6 @@ describe("Radio serialization", () => {
     });
 
     let userEvent: UserEvent;
-    let mathRandomSpy: jest.SpyInstance;
 
     beforeEach(() => {
         userEvent = userEventLib.setup({
@@ -156,20 +153,6 @@ describe("Radio serialization", () => {
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );
-
-        // Mock Math.random to return a deterministic sequence for consistent test results
-        mathRandomSpy = jest.spyOn(Math, "random");
-        let callCount = 0;
-        mathRandomSpy.mockImplementation(() => {
-            // This ensures consistent shuffling behavior in radio widgets
-            const values = [0.3, 0.2, 0.4, 0.1, 0.5, 0.9, 0.8, 0.7, 0.6];
-            return values[callCount++ % values.length];
-        });
-    });
-
-    afterEach(() => {
-        // Restore Math.random to its original implementation
-        mathRandomSpy.mockRestore();
     });
 
     it("should serialize the current state", async () => {

--- a/packages/perseus/src/widgets/radio/util.test.ts
+++ b/packages/perseus/src/widgets/radio/util.test.ts
@@ -1,6 +1,14 @@
 import {mockStrings} from "../../strings";
 
-import {getChoiceLetter} from "./util";
+import {
+    choiceTransform,
+    enforceOrdering,
+    getChoiceLetter,
+    moveNoneOfTheAboveToEnd,
+} from "./util";
+
+import type {RadioChoiceWithMetadata} from "./radio-component";
+import type {PerseusRadioChoice} from "@khanacademy/perseus-core";
 
 describe("getChoiceLetter (in English)", () => {
     it("returns the first 5 letters for most questions", () => {
@@ -18,3 +26,452 @@ describe("getChoiceLetter (in English)", () => {
         }
     });
 });
+
+describe("moveNoneOfTheAboveToEnd", () => {
+    function generateTestChoices(): RadioChoiceWithMetadata[] {
+        return [
+            {
+                content: "Option 1",
+                id: "option-1",
+                originalIndex: 0,
+            },
+            {
+                content: "Option 2",
+                id: "option-2",
+                originalIndex: 1,
+            },
+            {
+                content: "Option 3",
+                id: "option-3",
+                originalIndex: 2,
+            },
+        ];
+    }
+
+    it("moves isNoneOfTheAbove to the end", () => {
+        const input: RadioChoiceWithMetadata[] = generateTestChoices();
+        input[1].isNoneOfTheAbove = true;
+
+        // make sure we don't accidentally break the test
+        expect(input[2].isNoneOfTheAbove).toBeUndefined();
+
+        const rv = moveNoneOfTheAboveToEnd(input);
+
+        expect(rv[2]).toEqual({
+            content: "Option 2",
+            id: "option-2",
+            originalIndex: 1,
+            isNoneOfTheAbove: true,
+        });
+    });
+
+    it("keeps isNoneOfTheAbove at the end", () => {
+        const input: RadioChoiceWithMetadata[] = generateTestChoices();
+        input[2].isNoneOfTheAbove = true;
+
+        // make sure we don't accidentally break the test
+        expect(input[2].isNoneOfTheAbove).not.toBeUndefined();
+
+        const rv = moveNoneOfTheAboveToEnd(input);
+
+        expect(rv[2]).toEqual({
+            content: "Option 3",
+            id: "option-3",
+            originalIndex: 2,
+            isNoneOfTheAbove: true,
+        });
+    });
+
+    it("handles choices without isNoneOfTheAbove", () => {
+        const input: RadioChoiceWithMetadata[] = generateTestChoices();
+
+        // make sure we don't accidentally break the test
+        input.forEach((choice) => {
+            expect(choice.isNoneOfTheAbove).toBeUndefined();
+        });
+
+        const rv = moveNoneOfTheAboveToEnd(input);
+
+        expect(rv).toEqual(input);
+    });
+});
+
+describe("enforceOrdering", () => {
+    it("maintains true/false order", () => {
+        const input: RadioChoiceWithMetadata[] = [
+            {
+                content: "True",
+                id: "option-1",
+                originalIndex: 0,
+            },
+            {
+                content: "False",
+                id: "option-2",
+                originalIndex: 1,
+            },
+        ];
+
+        // make sure we don't accidentally break the test
+        expect(input[0].content).toBe("True");
+        expect(input[1].content).toBe("False");
+
+        const rv = enforceOrdering(input, mockStrings);
+
+        expect(rv[0].content).toBe("True");
+        expect(rv[1].content).toBe("False");
+    });
+
+    it("fixes false/true order", () => {
+        const input: RadioChoiceWithMetadata[] = [
+            {
+                content: "False",
+                id: "option-1",
+                originalIndex: 0,
+            },
+            {
+                content: "True",
+                id: "option-2",
+                originalIndex: 1,
+            },
+        ];
+
+        // make sure we don't accidentally break the test
+        expect(input[0].content).toBe("False");
+        expect(input[1].content).toBe("True");
+
+        const rv = enforceOrdering(input, mockStrings);
+
+        expect(rv[0].content).toBe("True");
+        expect(rv[1].content).toBe("False");
+    });
+
+    it("maintains yes/no order", () => {
+        const input: RadioChoiceWithMetadata[] = [
+            {
+                content: "Yes",
+                id: "option-1",
+                originalIndex: 0,
+            },
+            {
+                content: "No",
+                id: "option-2",
+                originalIndex: 1,
+            },
+        ];
+
+        // make sure we don't accidentally break the test
+        expect(input[0].content).toBe("Yes");
+        expect(input[1].content).toBe("No");
+
+        const rv = enforceOrdering(input, mockStrings);
+
+        expect(rv[0].content).toBe("Yes");
+        expect(rv[1].content).toBe("No");
+    });
+
+    it("fixes no/yes order", () => {
+        const input: RadioChoiceWithMetadata[] = [
+            {
+                content: "No",
+                id: "option-1",
+                originalIndex: 0,
+            },
+            {
+                content: "Yes",
+                id: "option-2",
+                originalIndex: 1,
+            },
+        ];
+
+        // make sure we don't accidentally break the test
+        expect(input[0].content).toBe("No");
+        expect(input[1].content).toBe("Yes");
+
+        const rv = enforceOrdering(input, mockStrings);
+
+        expect(rv[0].content).toBe("Yes");
+        expect(rv[1].content).toBe("No");
+    });
+
+    it("doesn't affect unordered strings", () => {
+        const input: RadioChoiceWithMetadata[] = [
+            {
+                content: "Hello",
+                id: "option-1",
+                originalIndex: 0,
+            },
+            {
+                content: "World",
+                id: "option-2",
+                originalIndex: 1,
+            },
+        ];
+
+        // make sure we don't accidentally break the test
+        expect(input[0].content).toBe("Hello");
+        expect(input[1].content).toBe("World");
+
+        const rv = enforceOrdering(input, mockStrings);
+
+        expect(rv[0].content).toBe("Hello");
+        expect(rv[1].content).toBe("World");
+    });
+});
+
+describe("choiceTransform", () => {
+    it("moves none of the above to the end", () => {
+        const choices: PerseusRadioChoice[] = [
+            {
+                content: "Choice 1",
+                id: "choice-1",
+                isNoneOfTheAbove: true,
+            },
+            {
+                content: "Choice 2",
+                id: "choice-2",
+            },
+        ];
+
+        // test the test data
+        expect(choices[0].isNoneOfTheAbove).toBe(true);
+        expect(choices[1].isNoneOfTheAbove).toBeUndefined();
+
+        const rv = choiceTransform(choices, false, mockStrings, 0);
+
+        expect(rv[0].isNoneOfTheAbove).toBeUndefined();
+        expect(rv[1].isNoneOfTheAbove).toBe(true);
+    });
+
+    it("enforces yes/no ordering", () => {
+        const choices: PerseusRadioChoice[] = [
+            {
+                content: "No",
+                id: "choice-1",
+            },
+            {
+                content: "Yes",
+                id: "choice-2",
+            },
+        ];
+
+        // test the test data
+        expect(choices[0].content).toBe("No");
+        expect(choices[1].content).toBe("Yes");
+
+        const rv = choiceTransform(choices, false, mockStrings, 0);
+
+        expect(rv[0].content).toBe("Yes");
+        expect(rv[1].content).toBe("No");
+    });
+
+    it("shuffles", () => {
+        const choices: PerseusRadioChoice[] = [
+            {
+                content: "Choice 1",
+                id: "choice-1",
+                correct: true,
+            },
+            {
+                content: "Choice 2",
+                id: "choice-2",
+            },
+            {
+                content: "Choice 3",
+                id: "choice-3",
+            },
+            {
+                content: "Choice 4",
+                id: "choice-4",
+            },
+        ];
+
+        expect(choices[0].id).toBe("choice-1");
+        expect(choices[1].id).toBe("choice-2");
+        expect(choices[2].id).toBe("choice-3");
+        expect(choices[3].id).toBe("choice-4");
+
+        const rv = choiceTransform(choices, true, mockStrings, 0);
+
+        expect(rv[0].id).toBe("choice-4");
+        expect(rv[1].id).toBe("choice-2");
+        expect(rv[2].id).toBe("choice-1");
+        expect(rv[3].id).toBe("choice-3");
+    });
+
+    it("populates correct", () => {
+        const choices: PerseusRadioChoice[] = [
+            {
+                content: "Choice 1",
+                id: "choice-1",
+                correct: true,
+            },
+            {
+                content: "Choice 2",
+                id: "choice-2",
+            },
+        ];
+
+        // test the test data
+        expect(choices[0].correct).toBe(true);
+        expect(choices[1].correct).toBeUndefined();
+
+        const rv = choiceTransform(choices, false, mockStrings, 0);
+
+        expect(rv[0].correct).toBe(true);
+        expect(rv[1].correct).toBe(false);
+    });
+
+    it("populates original index", () => {
+        const choices: PerseusRadioChoice[] = [
+            {
+                content: "Choice 1",
+                id: "choice-1",
+            },
+            {
+                content: "Choice 2",
+                id: "choice-2",
+            },
+        ];
+
+        const rv = choiceTransform(choices, false, mockStrings, 0);
+
+        expect(rv[0].originalIndex).toBe(0);
+        expect(rv[1].originalIndex).toBe(1);
+    });
+
+    it("is deterministic", () => {
+        const choices: PerseusRadioChoice[] = [
+            {
+                content: "Choice 1",
+                id: "choice-1",
+                correct: true,
+            },
+            {
+                content: "Choice 2",
+                id: "choice-2",
+            },
+            {
+                content: "Choice 3",
+                id: "choice-3",
+            },
+            {
+                content: "Choice 4",
+                id: "choice-4",
+            },
+        ];
+
+        const rv1 = choiceTransform(choices, true, mockStrings, 0);
+        const rv2 = choiceTransform(choices, true, mockStrings, 0);
+
+        expect(choices).not.toEqual(rv1);
+        expect(choices).not.toEqual(rv2);
+        expect(rv1).toEqual(rv2);
+    });
+
+    it("randomizes differently with different seeds", () => {
+        const choices: PerseusRadioChoice[] = [
+            {
+                content: "Choice 1",
+                id: "choice-1",
+                correct: true,
+            },
+            {
+                content: "Choice 2",
+                id: "choice-2",
+            },
+            {
+                content: "Choice 3",
+                id: "choice-3",
+            },
+            {
+                content: "Choice 4",
+                id: "choice-4",
+            },
+        ];
+
+        const rv1 = choiceTransform(choices, true, mockStrings, 0);
+        const rv2 = choiceTransform(choices, true, mockStrings, 1);
+
+        expect(rv1).not.toEqual(choices);
+        expect(rv2).not.toEqual(choices);
+        expect(rv1).not.toEqual(rv2);
+    });
+});
+
+// describe("shuffleUserInput", () => {
+//     it("shuffles user input", () => {
+//         const choices: RadioChoiceWithMetadata[] = [
+//             {
+//                 id: "3-3-3-3-3",
+//                 content: "Incorrect Choice 3",
+//                 correct: false,
+//                 originalIndex: 3,
+//             },
+//             {
+//                 id: "1-1-1-1-1",
+//                 content: "Incorrect Choice 2",
+//                 correct: false,
+//                 originalIndex: 1,
+//             },
+//             {
+//                 id: "0-0-0-0-0",
+//                 content: "Incorrect Choice 1",
+//                 correct: false,
+//                 originalIndex: 0,
+//             },
+//             {
+//                 id: "2-2-2-2-2",
+//                 content: "Correct Choice",
+//                 correct: true,
+//                 originalIndex: 2,
+//             },
+//         ];
+
+//         const unshuffledUserInput: PerseusRadioUserInput = {
+//             choicesSelected: [true, false, false, false],
+//         };
+
+//         expect(shuffleUserInput(choices, unshuffledUserInput)).toEqual({
+//             choicesSelected: [false, false, true, false],
+//         });
+//     });
+// });
+
+// describe("unshuffleUserInput", () => {
+//     it("unshuffles user input", () => {
+//         const choices: RadioChoiceWithMetadata[] = [
+//             {
+//                 id: "3-3-3-3-3",
+//                 content: "Incorrect Choice 3",
+//                 correct: false,
+//                 originalIndex: 3,
+//             },
+//             {
+//                 id: "1-1-1-1-1",
+//                 content: "Incorrect Choice 2",
+//                 correct: false,
+//                 originalIndex: 1,
+//             },
+//             {
+//                 id: "0-0-0-0-0",
+//                 content: "Incorrect Choice 1",
+//                 correct: false,
+//                 originalIndex: 0,
+//             },
+//             {
+//                 id: "2-2-2-2-2",
+//                 content: "Correct Choice",
+//                 correct: true,
+//                 originalIndex: 2,
+//             },
+//         ];
+
+//         const unshuffledUserInput: PerseusRadioUserInput = {
+//             choicesSelected: [false, false, true, false],
+//         };
+
+//         expect(unshuffleUserInput(choices, unshuffledUserInput)).toEqual({
+//             choicesSelected: [true, false, false, false],
+//         });
+// });
+// });

--- a/packages/perseus/src/widgets/radio/utils/general-utils.test.ts
+++ b/packages/perseus/src/widgets/radio/utils/general-utils.test.ts
@@ -90,26 +90,7 @@ describe("getChoiceStates", () => {
         });
     });
 
-    describe("Case 3: Legacy user selection without submission", () => {
-        it("converts legacy values to choice states", () => {
-            // Arrange
-            const legacyValues = [false, true, false];
-
-            // Act
-            const result = getChoiceStates({
-                choices: mockChoices,
-                values: legacyValues,
-            });
-
-            // Assert
-            expect(result).toHaveLength(3);
-            expect(result[0].selected).toBe(false);
-            expect(result[1].selected).toBe(true);
-            expect(result[2].selected).toBe(false);
-        });
-    });
-
-    describe("Case 4: Initial state", () => {
+    describe("Case 3: Initial state", () => {
         it("returns default unselected choice states", () => {
             // Arrange & Act
             const result = getChoiceStates({

--- a/packages/perseus/src/widgets/radio/utils/general-utils.ts
+++ b/packages/perseus/src/widgets/radio/utils/general-utils.ts
@@ -10,18 +10,16 @@ interface GetChoiceStatesProps {
     isStatic?: boolean | null;
     showSolutions?: ShowSolutions;
     choiceStates?: ReadonlyArray<ChoiceState>;
-    values?: ReadonlyArray<boolean>;
 }
 
 /**
  * Determine the updated choice states for the Radio widget, based on the
- * widget's static / showSolutions states, choiceStates, and values.
+ * widget's static / showSolutions states, and choiceStates.
  *
  * @param choices - The choices for the Radio widget.
  * @param isStatic - Whether the widget is static.
  * @param showSolutions - Whether the widget is in showSolutions mode.
  * @param choiceStates - The choice states for the widget. (The user's current selection states.)
- * @param values - The values for the widget. (Deprecated: The user's current selection states for old content.)
  * @returns The updated choice states for the widget.
  */
 export const getChoiceStates = ({
@@ -29,7 +27,6 @@ export const getChoiceStates = ({
     isStatic,
     showSolutions,
     choiceStates,
-    values,
 }: GetChoiceStatesProps): ReadonlyArray<ChoiceState> => {
     // The default state for a choice state object.
     const defaultState: ChoiceState = {
@@ -61,19 +58,7 @@ export const getChoiceStates = ({
         return choiceStates;
     }
 
-    // Case 3: Legacy user selection without submission
-    // The widget uses the deprecated values property and has
-    // received user input that hasn't been submitted yet.
-    // — In this state, we convert legacy values to choice states.
-    if (values) {
-        /* c8 ignore next - props.values is deprecated */
-        return values.map((val) => ({
-            ...defaultState,
-            selected: val,
-        }));
-    }
-
-    // Case 4: Initial state
+    // Case 3: Initial state
     // The widget is in its pristine state with no user interaction yet
     // — In this state, we return the default, unselected choice states.
     return choices.map(() => ({...defaultState}));


### PR DESCRIPTION
## Summary:
This is a modified copy of this PR: https://github.com/Khan/perseus/pull/2800

I had #2800 ready to go, but there was an urgent need to land #2799 quickly. Unfortunately this caused a lot of merge conflicts but also some shifts around the logic I was working on. I just decided to redo #2800 with a version that worked with the new user input format.

Issue: LEMS-3199

## Test plan:
Nothing should change from the learner's perspective. Unit tests added to make sure there were no major regressions we're trying to support.

---

From the original PR:

> Why this PR exists
>
> We're removing transform and staticTransform to support Answerless/Answerful rendering for the Server Side Scoring project. Now widgets will receive all of their widget options as props.
How this affects Radio
>
> For the most part, Radio's transform was mostly just filtering/passing props. However it also called choiceTransform which does a couple of things:
>
>    It makes sure "None of the above" options were at the end of the choices
>    It enforces correct order of "Yes"/"No" and "True"/"False" questions
>    It shuffles (if randomize is true)
>
> 1 & 2 are deterministic: we can call them over and over again and the output will always be the same. Shuffling was using Math.random though which requires stashing the output of transform because repeat calls would result in different shuffle orders. I believe that we do not want true randomness though:
>
>    In the Teacher Experience we want to be able to show the exact order the learner saw
>    In the future we'll need to be able to sync Khanmigo with the UI and I think we need to do that between the FE and BE
>
> ANYWAY, I made shuffling deterministic. Anakaren told me about the requirement of [LEMS-297](https://khanacademy.atlassian.net/browse/LEMS-297) which means we couldn't just use problemNum as the seed, so I wrote a regression test and made sure to continue support the [LEMS-297](https://khanacademy.atlassian.net/browse/LEMS-297) requirement.

[LEMS-297]: https://khanacademy.atlassian.net/browse/LEMS-297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ