### PR TITLE
Revert "[Radio] Fix iOS mobile hover issue when use is dragging the screen left or right"

### DIFF
--- a/.changeset/flat-moles-drop.md
+++ b/.changeset/flat-moles-drop.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Revert fix for iOS mobile hover issue when use is dragging the screen left or right

--- a/packages/perseus/src/widgets/radio/choice-indicator.module.css
+++ b/packages/perseus/src/widgets/radio/choice-indicator.module.css
@@ -35,6 +35,9 @@
        and apply the ring when the parent is hovered.
    The exception to this is when the indicator is showing correctness
        (i.e. has the classes .is-correct or .is-wrong).
+   Mobile known inconsistent behavior on hover effect when scrolling left-to-right/up-and-down:
+       - Android doesn't show the outline during tap-dragging gestures, only when user taps the choice.
+       - iOS shows the outline during tap-dragging gestures.
  */
 .base:hover,
 .base:focus,

--- a/packages/perseus/src/widgets/radio/choice-indicator.module.css
+++ b/packages/perseus/src/widgets/radio/choice-indicator.module.css
@@ -29,24 +29,18 @@
     }
 }
 
-/* Show outline on focus, and when the choice container is hovered on devices with hover capability.
+/* Show outline on hover, focus, and when the choice container is hovered.
    Since we don't have a reference to the container's class name,
        we grab the parent element with :has(> .base)
        and apply the ring when the parent is hovered.
    The exception to this is when the indicator is showing correctness
        (i.e. has the classes .is-correct or .is-wrong).
  */
-.base:focus {
+.base:hover,
+.base:focus,
+:has(> .base):hover .base:not(:where(.is-correct, .is-wrong)) {
     outline-offset: var(--wb-sizing-size_020);
     outline-width: var(--wb-sizing-size_020);
-}
-
-@media (hover: hover) {
-    .base:hover,
-    :has(> .base):hover .base:not(:where(.is-correct, .is-wrong)) {
-        outline-offset: var(--wb-sizing-size_020);
-        outline-width: var(--wb-sizing-size_020);
-    }
 }
 
 /* button is checked */
@@ -81,11 +75,9 @@
     cursor: default;
 }
 
-@media (hover: hover) {
-    .is-correct:hover,
-    .is-wrong:hover {
-        outline: none;
-    }
+.is-correct:hover,
+.is-wrong:hover {
+    outline: none;
 }
 
 .is-correct[aria-pressed="true"] {

--- a/packages/perseus/src/widgets/radio/choice.module.css
+++ b/packages/perseus/src/widgets/radio/choice.module.css
@@ -106,6 +106,9 @@
       - the choice is in review mode AND
          - the choice is incorrect AND
          - the choice indicator has focus
+   Mobile known inconsistent behavior on hover effect when scrolling left-to-right/up-and-down:
+      - Android doesn't show the enhanced divider during tap-dragging gestures, only when user taps the choice.
+      - iOS shows the enhanced divider during tap-dragging gestures.
  */
 .choice:not(.is-correct):focus-within,
 .choice:not(.is-correct, .is-wrong):hover {

--- a/packages/perseus/src/widgets/radio/choice.module.css
+++ b/packages/perseus/src/widgets/radio/choice.module.css
@@ -33,10 +33,8 @@
     width: 100%;
 }
 
-@media (hover: hover) {
-    .choice:hover {
-        cursor: pointer;
-    }
+.choice:hover {
+    cursor: pointer;
 }
 
 .choice:not(.is-correct):has(> button[aria-pressed="true"]) {
@@ -90,16 +88,11 @@
     );
 }
 
+.choice:hover:after,
 .choice:focus-within:after,
+.choice:hover:before,
 .choice:focus-within:before {
     z-index: 10; /* Ensure the divider is above the adjacent choice dividers */
-}
-
-@media (hover: hover) {
-    .choice:hover:after,
-    .choice:hover:before {
-        z-index: 10; /* Ensure the divider is above the adjacent choice dividers */
-    }
 }
 
 /* The first choice option needs additional space for the border */
@@ -114,20 +107,12 @@
          - the choice is incorrect AND
          - the choice indicator has focus
  */
-.choice:not(.is-correct):focus-within {
+.choice:not(.is-correct):focus-within,
+.choice:not(.is-correct, .is-wrong):hover {
     --perseus-multiple-choice-divider-width: var(--wb-border-width-medium);
     --perseus-multiple-choice-divider-color: var(
         --wb-semanticColor-core-border-neutral-default
     );
-}
-
-@media (hover: hover) {
-    .choice:not(.is-correct, .is-wrong):hover {
-        --perseus-multiple-choice-divider-width: var(--wb-border-width-medium);
-        --perseus-multiple-choice-divider-color: var(
-            --wb-semanticColor-core-border-neutral-default
-        );
-    }
 }
 
 /***********
@@ -147,11 +132,9 @@
     color: var(--wb-semanticColor-core-foreground-neutral-subtle);
 }
 
-@media (hover: hover) {
-    .is-correct:hover,
-    .is-wrong:hover {
-        cursor: default;
-    }
+.is-correct:hover,
+.is-wrong:hover {
+    cursor: default;
 }
 
 /**************


### PR DESCRIPTION
Reverts Khan/perseus#2859

Decision: Feedback from QA, it's valuable and better experience to have the visual feedback when user selects a choice, having the horizontal outlines when we have a choice selected. Having the slight visual bug on iOS when tap-dragging to keep that UI outline on both Android and iOS.


Issue: LEMS-3467