### PR TITLE
Add dated warning for schema changes

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -257,7 +257,8 @@ jobs:
                       pnpm prettier --write ${{ runner.temp }}/schema.d.ts
                   path-to-artifact: ${{ runner.temp }}/schema.d.ts
                   label-name: schema-change
-                  comment-title: 🗄️ Schema Change
+                  # TODO(benchristel): remove the "don't change" message after 2025-11-01.
+                  comment-title: 🗄️ Schema Change (DON'T CHANGE THE SCHEMA BEFORE NOV 1st, 2025 — AX)
 
     check_item_splitting:
         name: Check for item splitting changes

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -257,7 +257,7 @@ jobs:
                       pnpm prettier --write ${{ runner.temp }}/schema.d.ts
                   path-to-artifact: ${{ runner.temp }}/schema.d.ts
                   label-name: schema-change
-                  # TODO(benchristel): remove the "don't change" message after 2025-11-01.
+                  # TODO(LEMS-3516): remove the "don't change" message after 2025-11-01.
                   comment-title: 🗄️ Schema Change (DON'T CHANGE THE SCHEMA BEFORE NOV 1st, 2025 — AX)
 
     check_item_splitting:


### PR DESCRIPTION
We can't make schema changes until November 1st because of AX.

Issue: none

## Test plan:

CI should add a comment with the new title to this PR.