### PR TITLE
[Interactive graph] Fix polygon angles' shape and size

### DIFF
--- a/.changeset/fluffy-mirrors-jog.md
+++ b/.changeset/fluffy-mirrors-jog.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Interactive graph] Fix polygon angles' shape and size

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -2603,10 +2603,11 @@ exports[`Interactive Graph question Should render user input predictably: with u
                           >
                             <path
                               aria-hidden="true"
-                              d="M 1.8 2 L 1.8 2.3 M 1.8 2.3 L 1.5 2.3"
+                              d="M 1.92 2 L 1.92 2.42 M 1.92 2.42 L 1.5 2.42"
                               data-testid="angle-indicators__right-angle"
                               fill="none"
-                              stroke-width="0.02"
+                              stroke-width="1"
+                              vector-effect="non-scaling-stroke"
                             />
                           </g>
                           <polygon

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.test.ts
@@ -2,7 +2,7 @@ import {angles} from "@khanacademy/kmath";
 
 import {
     shouldDrawArcOutside,
-    shouldDrawArcOutsidePolygon,
+    isConcavePolygonVertex,
 } from "./angle-indicators";
 
 import type {Coord, CollinearTuple} from "@khanacademy/perseus-core";
@@ -146,7 +146,7 @@ describe("shouldDrawArcOutsidePolygon", () => {
                 clockwiseConcaveCoords[nextIndex],
             ] satisfies [vec.Vector2, vec.Vector2];
 
-            expect(shouldDrawArcOutsidePolygon(vertex, endPoints)).toBe(
+            expect(isConcavePolygonVertex(vertex, endPoints)).toBe(
                 isOutside,
             );
         },

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.test.ts
@@ -1,9 +1,6 @@
 import {angles} from "@khanacademy/kmath";
 
-import {
-    shouldDrawArcOutside,
-    isConcavePolygonVertex,
-} from "./angle-indicators";
+import {shouldDrawArcOutside, isConcavePolygonVertex} from "./angle-indicators";
 
 import type {Coord, CollinearTuple} from "@khanacademy/perseus-core";
 import type {vec, Interval} from "mafs";
@@ -146,9 +143,7 @@ describe("shouldDrawArcOutsidePolygon", () => {
                 clockwiseConcaveCoords[nextIndex],
             ] satisfies [vec.Vector2, vec.Vector2];
 
-            expect(isConcavePolygonVertex(vertex, endPoints)).toBe(
-                isOutside,
-            );
+            expect(isConcavePolygonVertex(vertex, endPoints)).toBe(isOutside);
         },
     );
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.tsx
@@ -97,16 +97,15 @@ export const PolygonAngle = ({
     }
 
     // Note: Need to pass in endpoints in a clockwise order for the cross product.
-    const isOutside = shouldDrawArcOutsidePolygon(centerPoint, endPoints);
+    const isConcave = isConcavePolygonVertex(centerPoint, endPoints);
 
-    const largeArcFlag = isOutside ? 1 : 0;
-    const sweepFlag = isOutside ? 1 : 0;
+    const largeArcFlag = isConcave ? 1 : 0;
 
-    const arc = `M ${x1} ${y1} A ${radius} ${radius} 0 ${largeArcFlag} ${sweepFlag} ${x2} ${y2}`;
+    const arc = `M ${x1} ${y1} A ${radius} ${radius} 0 ${largeArcFlag} ${1} ${x2} ${y2}`;
 
     let angleInDegrees = angle * (180 / Math.PI);
     // If we have triggered "largArcFlag", the angle should be greater than 180
-    if (isOutside) {
+    if (isConcave) {
         angleInDegrees = 360 - angleInDegrees;
     }
 
@@ -133,7 +132,7 @@ export const PolygonAngle = ({
                 </filter>
             </defs>
 
-            {!isOutside && isRightPolygonAngle(angle) ? (
+            {!isConcave && isRightPolygonAngle(angle) ? (
                 <RightAngleSquare
                     start={[x1, y1]}
                     vertex={[x2, y2]}
@@ -383,7 +382,7 @@ const isEven = (n: number) => n % 2 === 0;
  * if the endpoints are clockwise itself - this has to be checked by the
  * caller. This is because of edge cases involving concave polygons.
  */
-export function shouldDrawArcOutsidePolygon(
+export function isConcavePolygonVertex(
     centerPoint: vec.Vector2,
     clockwiseEndpoints: [vec.Vector2, vec.Vector2],
 ) {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/angle-indicators.tsx
@@ -8,7 +8,6 @@ import useGraphConfig from "../../reducer/use-graph-config";
 import {
     getIntersectionOfRayWithBox as getRangeIntersectionVertex,
     calculateScaledRadius,
-    calculateScaledStrokeWidth,
 } from "../utils";
 
 import {MafsCssTransformWrapper} from "./css-transform-wrapper";
@@ -87,7 +86,7 @@ export const PolygonAngle = ({
 
     const largeArcFlag = isConcave ? 1 : 0;
 
-    const arc = `M ${x1} ${y1} A ${radius} ${radius} 0 ${largeArcFlag} ${1} ${x2} ${y2}`;
+    const arc = `M ${x1} ${y1} A ${radius} ${radius} 0 ${largeArcFlag} 1 ${x2} ${y2}`;
 
     let angleInDegrees = angle * (180 / Math.PI);
     // If we have triggered "largArcFlag", the angle should be greater than 180
@@ -184,8 +183,8 @@ export const Angle = ({
     const a = vec.dist(vertex, point1);
     const b = vec.dist(vertex, point2);
 
-    // Set the radius of the arc to scale with the graph range
-    const radius = calculateScaledRadius(range);
+    // Set the radius of the arc
+    const radius = 2;
 
     // Calculate the end points of the arc
     const y1 = centerY + ((startY - centerY) / a) * radius;
@@ -282,32 +281,29 @@ const RightAngleSquare = ({
     vertex: vec.Vector2;
     end: vec.Vector2;
     className?: string;
-}) => {
-    const {range} = useGraphConfig();
-    const strokeWidth = calculateScaledStrokeWidth(range);
-    return (
-        <MafsCssTransformWrapper>
-            <path
-                // Use aria-hidden to hide the line from screen readers
-                // so it doesn't read as "image" with no context.
-                // The elements using this should have their own aria-labels,
-                // so this is okay.
-                aria-hidden={true}
-                d={`M ${x1} ${y1} L ${x3} ${y3} M ${x3} ${y3} L ${x2} ${y2}`}
-                strokeWidth={strokeWidth}
-                fill="none"
-                className={className}
-                data-testid="angle-indicators__right-angle"
-            />
-        </MafsCssTransformWrapper>
-    );
-};
+}) => (
+    <MafsCssTransformWrapper>
+        <path
+            // Use aria-hidden to hide the line from screen readers
+            // so it doesn't read as "image" with no context.
+            // The elements using this should have their own aria-labels,
+            // so this is okay.
+            aria-hidden={true}
+            d={`M ${x1} ${y1} L ${x3} ${y3} M ${x3} ${y3} L ${x2} ${y2}`}
+            strokeWidth={1}
+            fill="none"
+            className={className}
+            data-testid="angle-indicators__right-angle"
+            // Stop the stroke from being invisible with different ranges or
+            // stretching awkwardly when the x range and y range are different.
+            vectorEffect="non-scaling-stroke"
+        />
+    </MafsCssTransformWrapper>
+);
 
 // We're conditionally adding the class name here so that we can style the arc differently
 // based on whether it's an angle or a polygon angle
 const Arc = ({arc, className}: {arc: string; className?: string}) => {
-    const {range} = useGraphConfig();
-    const strokeWidth = calculateScaledStrokeWidth(range);
     return (
         <MafsCssTransformWrapper>
             <path
@@ -317,10 +313,13 @@ const Arc = ({arc, className}: {arc: string; className?: string}) => {
                 // so this is okay.
                 aria-hidden={true}
                 d={arc}
-                strokeWidth={strokeWidth}
+                strokeWidth={1}
                 fill="none"
                 className={className}
                 data-testid="angle-indicators__arc"
+                // Stop the stroke from being invisible with different ranges or
+                // stretching awkwardly when the x range and y range are different.
+                vectorEffect="non-scaling-stroke"
             />
         </MafsCssTransformWrapper>
     );

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.test.ts
@@ -5,6 +5,7 @@ import {
     getArrayWithoutDuplicates,
     getAngleFromPoints,
     getSideLengthsFromPoints,
+    calculateScaledRadius,
 } from "./utils";
 
 import type {Coord} from "@khanacademy/perseus-core";
@@ -358,6 +359,26 @@ describe("getSideLengthsFromPoints", () => {
 
             const result = getSideLengthsFromPoints(trianglePoints, index);
             expect(result).toEqual(sideLengths);
+        },
+    );
+});
+
+describe("calculateScaledRadius", () => {
+    test.each`
+        xMin   | xMax  | yMin   | yMax  | expected
+        ${-1}  | ${1}  | ${-1}  | ${1}  | ${0.12}
+        ${-10} | ${10} | ${-10} | ${10} | ${1.2}
+        ${-1}  | ${1}  | ${-10} | ${10} | ${0.12}
+        ${-10} | ${10} | ${-1}  | ${1}  | ${0.12}
+        ${-2}  | ${10} | ${-10} | ${2}  | ${0.72}
+    `(
+        "returns correct radius for range [$xMin, $xMax], [$yMin, $yMax]",
+        ({xMin, xMax, yMin, yMax, expected}) => {
+            const radius = calculateScaledRadius([
+                [xMin, xMax],
+                [yMin, yMax],
+            ]);
+            expect(radius).toEqual(expected);
         },
     );
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -361,33 +361,21 @@ export function getPolygonSideString(
 
 /**
  * Calculate an appropriate radius for angle arcs based on the graph range.
- * The radius scales with the range so it's visible at all zoom levels.
+ * The radius scales with the range so it's visible at all graph sizes.
  */
 export function calculateScaledRadius(range: [Interval, Interval]): number {
     const [[xMin, xMax], [yMin, yMax]] = range;
     const xSpan = xMax - xMin;
     const ySpan = yMax - yMin;
 
-    // Use the smaller span to ensure the arc fits well in both dimensions
+    // Use the smaller span to make sure the arc fits in both dimensions,
+    // although ideally they'd be the same for geometry anyway.
     const minSpan = Math.min(xSpan, ySpan);
 
-    // Scale the radius proportionally to the range, with a reasonable scaling factor
-    // This ensures the arc is always visible but not too large
-    // 8% of the graph size seems to work well for this.
-    return minSpan * 0.08; // 8% of the smaller dimension
-}
-
-/**
- * Calculate an appropriate stroke width for angle arcs based on the graph range.
- * The stroke width scales with the range so it's visible at all zoom levels.
- */
-export function calculateScaledStrokeWidth(
-    range: [Interval, Interval],
-): number {
-    const [[xMin, xMax], [yMin, yMax]] = range;
-    const xSpan = xMax - xMin;
-    const ySpan = yMax - yMin;
-
-    const minSpan = Math.min(xSpan, ySpan);
-    return minSpan * 0.005;
+    // Scale the radius proportionally to the range.
+    // Ended up using 0.06 because:
+    // - Setting this higher would bring the angle labels closer to the
+    //   center, and may risk them overlapping in the default state.
+    // - Setting this lower would make the arc too small to be visible.
+    return minSpan * 0.06;
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -358,3 +358,36 @@ export function getPolygonSideString(
               length: srFormatNumber(sideLength, locale, 1),
           });
 }
+
+/**
+ * Calculate an appropriate radius for angle arcs based on the graph range.
+ * The radius scales with the range so it's visible at all zoom levels.
+ */
+export function calculateScaledRadius(range: [Interval, Interval]): number {
+    const [[xMin, xMax], [yMin, yMax]] = range;
+    const xSpan = xMax - xMin;
+    const ySpan = yMax - yMin;
+
+    // Use the smaller span to ensure the arc fits well in both dimensions
+    const minSpan = Math.min(xSpan, ySpan);
+
+    // Scale the radius proportionally to the range, with a reasonable scaling factor
+    // This ensures the arc is always visible but not too large
+    // 8% of the graph size seems to work well for this.
+    return minSpan * 0.08; // 8% of the smaller dimension
+}
+
+/**
+ * Calculate an appropriate stroke width for angle arcs based on the graph range.
+ * The stroke width scales with the range so it's visible at all zoom levels.
+ */
+export function calculateScaledStrokeWidth(
+    range: [Interval, Interval],
+): number {
+    const [[xMin, xMax], [yMin, yMax]] = range;
+    const xSpan = xMax - xMin;
+    const ySpan = yMax - yMin;
+
+    const minSpan = Math.min(xSpan, ySpan);
+    return minSpan * 0.005;
+}


### PR DESCRIPTION
## Summary:
There were some issues with polygon angles. Fixing them here:
- Scale the arc radius so that the angles markers are visible with large ranges.
- Use `vectorEffect="non-scaling-stroke"` so the stroke doesn't warp with the range.
- Rename `shouldDrawArcOutsidePolygon` to `isConcavePolygonVertex` for clarity.
- Update the arc path so that it doesn't incorrectly draw angles outside.

Issue: https://khanacademy.atlassian.net/browse/LEMS-2907

## Test plan:
`pnpm jest packages/perseus/src/widgets/interactive-graphs/graphs/utils.test.ts`

Storybook
`/?path=/docs/widgets-interactive-graph-editor-demo--docs#interactive-graph-polygon`