### PR TITLE
Treat `Infinity` and `-Infinity` as equal when comparing expressions

### DIFF
--- a/packages/kas/src/__tests__/comparing.test.ts
+++ b/packages/kas/src/__tests__/comparing.test.ts
@@ -258,6 +258,14 @@ describe("comparing", () => {
         // This is incorrect, but accurately captures the current behavior
         // See comment in `Expr.compare()` for more details
         expect("(-2)^(n+0.1)").toEqualExpr("(-2)^(n+1.1)");
+
+        // Regression test for a bug where fraction expressions with a
+        // variable in the denominator would sometimes, randomly, compare
+        // different when they should be equal.
+        // See: https://khanacademy.atlassian.net/browse/LEMS-3413
+        for (let i = 0; i < 50; i++) {
+            expect("\\frac{1}{x - 2}").toEqualExpr("\\frac{-1}{2 - x}");
+        }
     });
 
     test("simplify can't yet handle these", () => {

--- a/packages/kas/src/nodes.ts
+++ b/packages/kas/src/nodes.ts
@@ -44,6 +44,10 @@ const isNaN = function (object) {
     return object !== object;
 };
 
+const isInfinite = function (object) {
+    return object === Infinity || object === -Infinity;
+}
+
 // return a random float between min (inclusive) and max (exclusive),
 // not that inclusivity means much, probabilistically, on floats
 const randomFloat = function (min: number, max: number) {
@@ -421,7 +425,10 @@ abstract class Expr {
         var equalNumbers = function (num1: number, num2: number) {
             var delta = getDelta(num1, num2);
             return (
-                num1 === num2 /* needed if either is +/- Infinity */ ||
+                // Treat positive and negative infinity as equal. We want to
+                // consider -1 / 0 equal to 1 / 0 so that 1 / (x - 1) is equal
+                // to -1 / (1 - x) when we guess-and-check with x = 1.
+                isInfinite(num1) && isInfinite(num2) ||
                 (isNaN(num1) && isNaN(num2)) ||
                 delta < Math.pow(10, -TOLERANCE)
             );


### PR DESCRIPTION
## Summary:
We observed that expression widgets where the correct answer is something like

```
\frac{x-3}{x-5}
```

were erroneously being marked incorrect around 5-10% of the time when the user
negated both the numerator and denominator.

The cause is that scoring of expression widgets is nondeterministic.

To determine whether two expressions are equivalent, we pick 12 random values
for each variable in the expression and test whether the the expressions
evaluate to the same value at all of those points.

Most of the time, this approach works, but there can be false positives (answer
scored correct when it is incorrect) as well as false negatives like we’re
seeing in this case.

False negatives can occur in the case of division by zero. For example,
consider the expression `1 / (x - 3)`. This is equivalent to `-1 / (3 - x)` —
the result of multiplying the numerator and denominator by -1. However, our
scoring process would consider these expressions different if `x = 3` is one of
the 12 values chosen:

```
1 / (x - 3) == -1 / (3 - x)

// replace x with zero:
1 / (3 - 3) == -1 / (3 - 3)

1 / 0 == -1 / 0

Infinity == -Infinity

false // !
```

This PR fixes the bug by treating positive and negative infinity as equal when
comparing expressions.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3413

## Test plan:

Deploy to webapp. Watch the logs for the `progress` service. You shouldn't see
any server-side scoring diffs involving fraction expressions.