### PR TITLE
Fix image widget sizing within grouped questions

### DIFF
--- a/.changeset/swift-dancers-join.md
+++ b/.changeset/swift-dancers-join.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix image sizing within grouped questions

--- a/packages/perseus/src/components/fixed-to-responsive.tsx
+++ b/packages/perseus/src/components/fixed-to-responsive.tsx
@@ -29,14 +29,14 @@ type Props = {
     allowFullBleed?: boolean;
     // This is used to determine if the spacer should be rendered. The spacer
     // can cause a disruptive amount of space for Image widgets in certain cases.
-    removeSpacer?: boolean;
+    renderSpacer?: boolean;
 };
 
 type DefaultProps = {
     className: Props["className"];
     constrainHeight: Props["constrainHeight"];
     allowFullBleed: Props["allowFullBleed"];
-    removeSpacer: Props["removeSpacer"];
+    renderSpacer: Props["renderSpacer"];
 };
 
 type State = {
@@ -51,7 +51,7 @@ class FixedToResponsive extends React.Component<Props, State> {
         className: "",
         constrainHeight: false,
         allowFullBleed: false,
-        removeSpacer: false,
+        renderSpacer: true,
     };
 
     state: State = {
@@ -147,7 +147,7 @@ class FixedToResponsive extends React.Component<Props, State> {
 
         const container = (
             <div className={className} style={style}>
-                {!this.props.removeSpacer && spacer}
+                {this.props.renderSpacer && spacer}
                 {this.props.children}
             </div>
         );

--- a/packages/perseus/src/components/fixed-to-responsive.tsx
+++ b/packages/perseus/src/components/fixed-to-responsive.tsx
@@ -27,6 +27,9 @@ type Props = {
     className?: string;
     constrainHeight?: boolean;
     allowFullBleed?: boolean;
+    // Check if the component is within an Image widget. This is used to
+    // determine if the spacer should be rendered. The spacer causes
+    // a disruptive amount of space for Image widgets in certain cases.
     withinImageWidget?: boolean;
 };
 
@@ -117,8 +120,6 @@ class FixedToResponsive extends React.Component<Props, State> {
         );
 
         let {width, height} = this.props;
-        // eslint-disable-next-line no-console
-        console.log("within image widget", this.props.withinImageWidget);
 
         // Constrain height to be at most 2/3 viewport height, maintaining
         // aspect ratio.
@@ -144,6 +145,7 @@ class FixedToResponsive extends React.Component<Props, State> {
 
         const container = (
             <div className={className} style={style}>
+                {/* The spacer is only for the non-Image widgets (i.e. Video) */}
                 {!this.props.withinImageWidget && spacer}
                 {this.props.children}
             </div>

--- a/packages/perseus/src/components/fixed-to-responsive.tsx
+++ b/packages/perseus/src/components/fixed-to-responsive.tsx
@@ -110,6 +110,8 @@ class FixedToResponsive extends React.Component<Props, State> {
         // the width of the containing block, so:
         //     (fixed height / fixed width) * display width = display height
         // Based on http://refills.bourbon.io/components/#video && medium.com
+        // TODO(LEMS-3549): Remove spacer once we figure out the best way
+        // to approach spacing with modern recommended practices.
         const spacer = (
             <div
                 style={{
@@ -145,7 +147,6 @@ class FixedToResponsive extends React.Component<Props, State> {
 
         const container = (
             <div className={className} style={style}>
-                {/* The spacer is only for the non-Image widgets (i.e. Video) */}
                 {!this.props.removeSpacer && spacer}
                 {this.props.children}
             </div>

--- a/packages/perseus/src/components/fixed-to-responsive.tsx
+++ b/packages/perseus/src/components/fixed-to-responsive.tsx
@@ -27,12 +27,14 @@ type Props = {
     className?: string;
     constrainHeight?: boolean;
     allowFullBleed?: boolean;
+    withinImageWidget?: boolean;
 };
 
 type DefaultProps = {
     className: Props["className"];
     constrainHeight: Props["constrainHeight"];
     allowFullBleed: Props["allowFullBleed"];
+    withinImageWidget: Props["withinImageWidget"];
 };
 
 type State = {
@@ -47,6 +49,7 @@ class FixedToResponsive extends React.Component<Props, State> {
         className: "",
         constrainHeight: false,
         allowFullBleed: false,
+        withinImageWidget: false,
     };
 
     state: State = {
@@ -140,7 +143,7 @@ class FixedToResponsive extends React.Component<Props, State> {
 
         const container = (
             <div className={className} style={style}>
-                {spacer}
+                {!this.props.withinImageWidget && spacer}
                 {this.props.children}
             </div>
         );

--- a/packages/perseus/src/components/fixed-to-responsive.tsx
+++ b/packages/perseus/src/components/fixed-to-responsive.tsx
@@ -28,7 +28,8 @@ type Props = {
     constrainHeight?: boolean;
     allowFullBleed?: boolean;
     // This is used to determine if the spacer should be rendered. The spacer
-    // can cause a disruptive amount of space for Image widgets in certain cases.
+    // can cause a disruptive amount of space for Image widgets in certain
+    // cases (e.g. mobile Image widget within Grouped questions).
     renderSpacer?: boolean;
 };
 

--- a/packages/perseus/src/components/fixed-to-responsive.tsx
+++ b/packages/perseus/src/components/fixed-to-responsive.tsx
@@ -114,7 +114,8 @@ class FixedToResponsive extends React.Component<Props, State> {
         const spacer = (
             <div
                 style={{
-                    paddingBottom: ((1 / aspectRatio) * 100).toFixed(4) + "%",
+                    // @ts-expect-error - TS2362 - The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
+                    paddingBottom: (1 / aspectRatio).toFixed(4) * 100 + "%",
                 }}
             />
         );

--- a/packages/perseus/src/components/fixed-to-responsive.tsx
+++ b/packages/perseus/src/components/fixed-to-responsive.tsx
@@ -111,13 +111,14 @@ class FixedToResponsive extends React.Component<Props, State> {
         const spacer = (
             <div
                 style={{
-                    // @ts-expect-error - TS2362 - The left-hand side of an arithmetic operation must be of type 'any', 'number', 'bigint' or an enum type.
-                    paddingBottom: (1 / aspectRatio).toFixed(4) * 100 + "%",
+                    paddingBottom: ((1 / aspectRatio) * 100).toFixed(4) + "%",
                 }}
             />
         );
 
         let {width, height} = this.props;
+        // eslint-disable-next-line no-console
+        console.log("within image widget", this.props.withinImageWidget);
 
         // Constrain height to be at most 2/3 viewport height, maintaining
         // aspect ratio.

--- a/packages/perseus/src/components/fixed-to-responsive.tsx
+++ b/packages/perseus/src/components/fixed-to-responsive.tsx
@@ -27,17 +27,16 @@ type Props = {
     className?: string;
     constrainHeight?: boolean;
     allowFullBleed?: boolean;
-    // Check if the component is within an Image widget. This is used to
-    // determine if the spacer should be rendered. The spacer causes
-    // a disruptive amount of space for Image widgets in certain cases.
-    withinImageWidget?: boolean;
+    // This is used to determine if the spacer should be rendered. The spacer
+    // can cause a disruptive amount of space for Image widgets in certain cases.
+    removeSpacer?: boolean;
 };
 
 type DefaultProps = {
     className: Props["className"];
     constrainHeight: Props["constrainHeight"];
     allowFullBleed: Props["allowFullBleed"];
-    withinImageWidget: Props["withinImageWidget"];
+    removeSpacer: Props["removeSpacer"];
 };
 
 type State = {
@@ -52,7 +51,7 @@ class FixedToResponsive extends React.Component<Props, State> {
         className: "",
         constrainHeight: false,
         allowFullBleed: false,
-        withinImageWidget: false,
+        removeSpacer: false,
     };
 
     state: State = {
@@ -147,7 +146,7 @@ class FixedToResponsive extends React.Component<Props, State> {
         const container = (
             <div className={className} style={style}>
                 {/* The spacer is only for the non-Image widgets (i.e. Video) */}
-                {!this.props.withinImageWidget && spacer}
+                {!this.props.removeSpacer && spacer}
                 {this.props.children}
             </div>
         );

--- a/packages/perseus/src/components/image-loader.tsx
+++ b/packages/perseus/src/components/image-loader.tsx
@@ -157,6 +157,8 @@ class ImageLoader extends React.Component<Props, State> {
                 src={staticUrl(src)}
                 onKeyUp={onKeyUp}
                 onKeyDown={onKeyDown}
+                width={imgProps.style?.width ?? "100%"}
+                height={imgProps.style?.height ?? "100%"}
                 {...imgProps}
             />
         );

--- a/packages/perseus/src/components/image-loader.tsx
+++ b/packages/perseus/src/components/image-loader.tsx
@@ -157,8 +157,14 @@ class ImageLoader extends React.Component<Props, State> {
                 src={staticUrl(src)}
                 onKeyUp={onKeyUp}
                 onKeyDown={onKeyDown}
-                width={imgProps.style?.width ?? "100%"}
-                height={imgProps.style?.height ?? "100%"}
+                // Stop the image size from being larger than 100%
+                // when width and height are not explicitly provided.
+                style={
+                    imgProps.style ?? {
+                        width: "100%",
+                        height: "100%",
+                    }
+                }
                 {...imgProps}
             />
         );

--- a/packages/perseus/src/components/svg-image.tsx
+++ b/packages/perseus/src/components/svg-image.tsx
@@ -101,7 +101,11 @@ type Props = {
      * If not, it defaults to a no-op.
      */
     setAssetStatus: (assetKey: string, loaded: boolean) => void;
-    withinImageWidget?: boolean;
+    /**
+     * This is used to determine if the spacer should be rendered. The spacer
+     * can cause a disruptive amount of space for Image widgets in certain cases.
+     */
+    removeSpacer?: boolean;
 };
 
 type DefaultProps = {
@@ -112,7 +116,7 @@ type DefaultProps = {
     setAssetStatus: NonNullable<Props["setAssetStatus"]>;
     src: NonNullable<Props["src"]>;
     zoomToFullSizeOnMobile: NonNullable<Props["zoomToFullSizeOnMobile"]>;
-    withinImageWidget: NonNullable<Props["withinImageWidget"]>;
+    removeSpacer: NonNullable<Props["removeSpacer"]>;
 };
 
 type Label = {
@@ -155,7 +159,7 @@ class SvgImage extends React.Component<Props, State> {
         scale: 1,
         zoomToFullSizeOnMobile: false,
         setAssetStatus: (src: string, status: boolean) => {},
-        withinImageWidget: false,
+        removeSpacer: false,
     };
 
     constructor(props: Props) {
@@ -495,7 +499,7 @@ class SvgImage extends React.Component<Props, State> {
                             this.props.allowFullBleed &&
                             isImageProbablyPhotograph(imageSrc)
                         }
-                        withinImageWidget={this.props.withinImageWidget}
+                        removeSpacer={this.props.removeSpacer}
                     >
                         <ImageLoader
                             src={imageSrc}
@@ -568,7 +572,7 @@ class SvgImage extends React.Component<Props, State> {
                     width={width}
                     height={height}
                     constrainHeight={this.props.constrainHeight}
-                    withinImageWidget={this.props.withinImageWidget}
+                    removeSpacer={this.props.removeSpacer}
                 >
                     <ImageLoader
                         src={imageUrl}

--- a/packages/perseus/src/components/svg-image.tsx
+++ b/packages/perseus/src/components/svg-image.tsx
@@ -105,7 +105,7 @@ type Props = {
      * This is used to determine if the spacer should be rendered. The spacer
      * can cause a disruptive amount of space for Image widgets in certain cases.
      */
-    removeSpacer?: boolean;
+    renderSpacer?: boolean;
 };
 
 type DefaultProps = {
@@ -116,7 +116,7 @@ type DefaultProps = {
     setAssetStatus: NonNullable<Props["setAssetStatus"]>;
     src: NonNullable<Props["src"]>;
     zoomToFullSizeOnMobile: NonNullable<Props["zoomToFullSizeOnMobile"]>;
-    removeSpacer: NonNullable<Props["removeSpacer"]>;
+    renderSpacer: NonNullable<Props["renderSpacer"]>;
 };
 
 type Label = {
@@ -159,7 +159,7 @@ class SvgImage extends React.Component<Props, State> {
         scale: 1,
         zoomToFullSizeOnMobile: false,
         setAssetStatus: (src: string, status: boolean) => {},
-        removeSpacer: false,
+        renderSpacer: false,
     };
 
     constructor(props: Props) {
@@ -499,7 +499,7 @@ class SvgImage extends React.Component<Props, State> {
                             this.props.allowFullBleed &&
                             isImageProbablyPhotograph(imageSrc)
                         }
-                        removeSpacer={this.props.removeSpacer}
+                        renderSpacer={this.props.renderSpacer}
                     >
                         <ImageLoader
                             src={imageSrc}
@@ -572,7 +572,7 @@ class SvgImage extends React.Component<Props, State> {
                     width={width}
                     height={height}
                     constrainHeight={this.props.constrainHeight}
-                    removeSpacer={this.props.removeSpacer}
+                    renderSpacer={this.props.renderSpacer}
                 >
                     <ImageLoader
                         src={imageUrl}

--- a/packages/perseus/src/components/svg-image.tsx
+++ b/packages/perseus/src/components/svg-image.tsx
@@ -159,7 +159,7 @@ class SvgImage extends React.Component<Props, State> {
         scale: 1,
         zoomToFullSizeOnMobile: false,
         setAssetStatus: (src: string, status: boolean) => {},
-        renderSpacer: false,
+        renderSpacer: true,
     };
 
     constructor(props: Props) {

--- a/packages/perseus/src/components/svg-image.tsx
+++ b/packages/perseus/src/components/svg-image.tsx
@@ -101,6 +101,7 @@ type Props = {
      * If not, it defaults to a no-op.
      */
     setAssetStatus: (assetKey: string, loaded: boolean) => void;
+    withinImageWidget?: boolean;
 };
 
 type DefaultProps = {
@@ -111,6 +112,7 @@ type DefaultProps = {
     setAssetStatus: NonNullable<Props["setAssetStatus"]>;
     src: NonNullable<Props["src"]>;
     zoomToFullSizeOnMobile: NonNullable<Props["zoomToFullSizeOnMobile"]>;
+    withinImageWidget: NonNullable<Props["withinImageWidget"]>;
 };
 
 type Label = {
@@ -153,6 +155,7 @@ class SvgImage extends React.Component<Props, State> {
         scale: 1,
         zoomToFullSizeOnMobile: false,
         setAssetStatus: (src: string, status: boolean) => {},
+        withinImageWidget: false,
     };
 
     constructor(props: Props) {
@@ -492,6 +495,7 @@ class SvgImage extends React.Component<Props, State> {
                             this.props.allowFullBleed &&
                             isImageProbablyPhotograph(imageSrc)
                         }
+                        withinImageWidget={this.props.withinImageWidget}
                     >
                         <ImageLoader
                             src={imageSrc}
@@ -564,6 +568,7 @@ class SvgImage extends React.Component<Props, State> {
                     width={width}
                     height={height}
                     constrainHeight={this.props.constrainHeight}
+                    withinImageWidget={this.props.withinImageWidget}
                 >
                     <ImageLoader
                         src={imageUrl}

--- a/packages/perseus/src/widgets/group/__snapshots__/group.test.tsx.snap
+++ b/packages/perseus/src/widgets/group/__snapshots__/group.test.tsx.snap
@@ -844,9 +844,6 @@ exports[`group widget should snapshot: initial render 1`] = `
                               class="fixed-to-responsive svg-image"
                               style="max-width: 380px; max-height: 80px;"
                             >
-                              <div
-                                style="padding-bottom: 21.05%;"
-                              />
                               <span
                                 style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
                               >

--- a/packages/perseus/src/widgets/image/__snapshots__/image.test.ts.snap
+++ b/packages/perseus/src/widgets/image/__snapshots__/image.test.ts.snap
@@ -50,9 +50,6 @@ exports[`image widget - isMobile(false) should snapshot: first render 1`] = `
                     class="fixed-to-responsive svg-image"
                     style="max-width: 420px; max-height: 345px;"
                   >
-                    <div
-                      style="padding-bottom: 82.14%;"
-                    />
                     <span
                       style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
                     >
@@ -231,9 +228,6 @@ exports[`image widget - isMobile(true) should snapshot: first render 1`] = `
                     class="fixed-to-responsive svg-image"
                     style="max-width: 420px; max-height: 345px;"
                   >
-                    <div
-                      style="padding-bottom: 82.14%;"
-                    />
                     <span
                       style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
                     >

--- a/packages/perseus/src/widgets/image/image.tsx
+++ b/packages/perseus/src/widgets/image/image.tsx
@@ -70,7 +70,7 @@ export const ImageComponent = (props: ImageWidgetProps) => {
                         constrainHeight={apiOptions.isMobile}
                         allowFullBleed={apiOptions.isMobile}
                         setAssetStatus={setAssetStatus}
-                        removeSpacer={true}
+                        renderSpacer={false}
                     />
                 )}
             </AssetContext.Consumer>

--- a/packages/perseus/src/widgets/image/image.tsx
+++ b/packages/perseus/src/widgets/image/image.tsx
@@ -70,6 +70,7 @@ export const ImageComponent = (props: ImageWidgetProps) => {
                         constrainHeight={apiOptions.isMobile}
                         allowFullBleed={apiOptions.isMobile}
                         setAssetStatus={setAssetStatus}
+                        withinImageWidget={true}
                     />
                 )}
             </AssetContext.Consumer>

--- a/packages/perseus/src/widgets/image/image.tsx
+++ b/packages/perseus/src/widgets/image/image.tsx
@@ -70,7 +70,7 @@ export const ImageComponent = (props: ImageWidgetProps) => {
                         constrainHeight={apiOptions.isMobile}
                         allowFullBleed={apiOptions.isMobile}
                         setAssetStatus={setAssetStatus}
-                        withinImageWidget={true}
+                        removeSpacer={true}
                     />
                 )}
             </AssetContext.Consumer>


### PR DESCRIPTION
## Summary:
There's a bug that's causing image widgets to render super weirdly when they're in a "grouped question" drawer.

This is actually two separate issues:
- way too much spacing, causing the image to shift below the visible spacing
- width is going over 100% of the container space

Fixing them here by removing the spacer in `<FixedToResponsive>` when rendered within an Image widget, and constraining `<ImageLoader>` to 100% width and height when dimensions are not provided.

Issue: none

## Test plan:
Load these changes into local frontend dev server and check the following two paths:
- `/ela/8th-grade-reading-and-vocabulary/x435b1de09a877dd7:to-your-health-long-passage-practice/x435b1de09a877dd7:reading-argumentative-texts-to-your-health/e/athletes-and-mental-health`
- `/ela/8th-grade-reading-and-vocabulary/x435b1de09a877dd7:to-your-health-long-passage-practice/x435b1de09a877dd7:reading-argumentative-texts-to-your-health/e/how-not-to-die`

## Screenshots:

| Before | After |
| --- | --- |
| <img width="389" height="680" alt="Screenshot 2025-09-12 at 4 10 08 PM" src="https://github.com/user-attachments/assets/bfc34166-5bca-477b-923c-ac6dbc8bd7b7" /> | <img width="386" height="678" alt="Screenshot 2025-09-12 at 4 10 19 PM" src="https://github.com/user-attachments/assets/237305eb-6019-4375-b2a3-c0ebd3b568b9" /> |
| <img width="386" height="677" alt="Screenshot 2025-09-12 at 4 10 41 PM" src="https://github.com/user-attachments/assets/6abeddc5-a9e8-4df9-ac60-a2237a2c3539" /> | <img width="386" height="682" alt="Screenshot 2025-09-12 at 4 10 46 PM" src="https://github.com/user-attachments/assets/b5598b39-ab5d-4442-ab1a-45c4ee305ba4" /> |


