### PR TITLE
[Color - NAW] Refactor Definiition widget to use semantic colors

### DIFF
--- a/.storybook/modes.ts
+++ b/.storybook/modes.ts
@@ -1,0 +1,36 @@
+export const allModes = {
+    // Responsive modes
+    small: {
+        viewport: "small",
+    },
+    medium: {
+        viewport: "medium",
+    },
+    large: {
+        viewport: "large",
+    },
+    chromebook: {
+        viewport: "chromebook",
+    },
+    // Theming
+    themeDefault: {
+        theme: "default",
+    },
+    themeThunderBlocks: {
+        theme: "thunderblocks",
+    },
+    // NOTE: This will go away when we fully remove the light variants.
+    dark: {
+        background: "darkBlue",
+    },
+    // Accessibility
+    "themeDefault rtl": {
+        theme: "default",
+        direction: "rtl",
+    },
+};
+
+export const themeModes = {
+    default: allModes.themeDefault,
+    thunderblocks: allModes.themeThunderBlocks,
+};

--- a/packages/perseus/src/widgets/definition/__docs__/definition-interaction-regression.stories.tsx
+++ b/packages/perseus/src/widgets/definition/__docs__/definition-interaction-regression.stories.tsx
@@ -1,9 +1,10 @@
-import type {PerseusItem} from "@khanacademy/perseus-core";
 import {generateTestPerseusItem} from "@khanacademy/perseus-core";
 import * as React from "react";
 
 import {ServerItemRendererWithDebugUI} from "../../../../../../testing/server-item-renderer-with-debug-ui";
 import {question} from "../definition.testdata";
+
+import type {PerseusItem} from "@khanacademy/perseus-core";
 import type {Meta} from "@storybook/react-vite";
 
 type StoryArgs = {

--- a/packages/perseus/src/widgets/definition/__docs__/definition-interaction-regression.stories.tsx
+++ b/packages/perseus/src/widgets/definition/__docs__/definition-interaction-regression.stories.tsx
@@ -1,0 +1,96 @@
+import type {PerseusItem} from "@khanacademy/perseus-core";
+import {generateTestPerseusItem} from "@khanacademy/perseus-core";
+import * as React from "react";
+
+import {ServerItemRendererWithDebugUI} from "../../../../../../testing/server-item-renderer-with-debug-ui";
+import {question} from "../definition.testdata";
+import type {Meta} from "@storybook/react-vite";
+
+type StoryArgs = {
+    // Story Option
+    item: PerseusItem;
+    // Definition Options
+    static: boolean;
+    // Testing Options
+    startAnswerless: boolean;
+} & Pick<
+    React.ComponentProps<typeof ServerItemRendererWithDebugUI>,
+    "reviewMode" | "showSolutions"
+>;
+
+export default {
+    title: "Widgets/Definition/Visual Regression Tests/Interactive",
+    component: ServerItemRendererWithDebugUI,
+    tags: ["!autodocs"],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    "Regression tests for the definition widget that DO need some sort of interaction to test, which will be used with Chromatic. Stories are displayed on their own page.",
+            },
+        },
+        chromatic: {disableSnapshot: false},
+    },
+    args: {
+        static: false,
+        startAnswerless: false,
+        reviewMode: false,
+        showSolutions: "none",
+        item: generateTestPerseusItem({
+            question,
+        }),
+    } satisfies StoryArgs,
+    argTypes: {
+        showSolutions: {
+            options: ["none", "all", "selected"],
+            control: {
+                type: "select",
+            },
+        },
+    },
+    render: (args: StoryArgs) => (
+        <ServerItemRendererWithDebugUI
+            item={applyStoryArgs(args)}
+            reviewMode={args.reviewMode}
+            showSolutions={args.showSolutions}
+            startAnswerless={args.startAnswerless}
+        />
+    ),
+} satisfies Meta<StoryArgs>;
+
+const applyStoryArgs = (args: StoryArgs): PerseusItem => {
+    const storyItem = {
+        ...args.item,
+        question: {
+            ...args.item.question,
+            widgets: {},
+        },
+    };
+    for (const [widgetId, widget] of Object.entries(
+        args.item.question.widgets,
+    )) {
+        storyItem.question.widgets[widgetId] = {...widget, static: args.static};
+    }
+
+    return storyItem;
+};
+
+export const FocusedState = {
+    play: async ({canvas}) => {
+        // eslint-disable-next-line testing-library/prefer-screen-queries
+        const definitionTrigger = canvas.getByRole("button", {
+            name: "the Pequots",
+        });
+        definitionTrigger.focus();
+    },
+};
+
+export const ClickedState = {
+    play: async ({canvas, userEvent}) => {
+        // eslint-disable-next-line testing-library/prefer-screen-queries
+        const definitionTrigger = canvas.getByRole("button", {
+            name: "the Pequots",
+        });
+        await userEvent.click(definitionTrigger);
+    },
+};

--- a/packages/perseus/src/widgets/definition/__docs__/definition-static-regression.stories.tsx
+++ b/packages/perseus/src/widgets/definition/__docs__/definition-static-regression.stories.tsx
@@ -1,12 +1,13 @@
 import {generateTestPerseusItem} from "@khanacademy/perseus-core";
 import * as React from "react";
-import {storybookDependenciesV2} from "../../../../../../testing/test-dependencies";
-import type {StoryObj} from "@storybook/react-vite";
-import {article, question} from "../definition.testdata";
-import ArticleRenderer from "../../../article-renderer";
-import {ServerItemRendererWithDebugUI} from "../../../../../../testing/server-item-renderer-with-debug-ui";
-import {themeModes} from "../../../../../../.storybook/modes";
 
+import {themeModes} from "../../../../../../.storybook/modes";
+import {ServerItemRendererWithDebugUI} from "../../../../../../testing/server-item-renderer-with-debug-ui";
+import {storybookDependenciesV2} from "../../../../../../testing/test-dependencies";
+import ArticleRenderer from "../../../article-renderer";
+import {article, question} from "../definition.testdata";
+
+import type {StoryObj} from "@storybook/react-vite";
 
 type Story = StoryObj<typeof ServerItemRendererWithDebugUI>;
 

--- a/packages/perseus/src/widgets/definition/__docs__/definition-static-regression.stories.tsx
+++ b/packages/perseus/src/widgets/definition/__docs__/definition-static-regression.stories.tsx
@@ -1,0 +1,46 @@
+import {generateTestPerseusItem} from "@khanacademy/perseus-core";
+import * as React from "react";
+import {storybookDependenciesV2} from "../../../../../../testing/test-dependencies";
+import type {StoryObj} from "@storybook/react-vite";
+import {article, question} from "../definition.testdata";
+import ArticleRenderer from "../../../article-renderer";
+import {ServerItemRendererWithDebugUI} from "../../../../../../testing/server-item-renderer-with-debug-ui";
+import {themeModes} from "../../../../../../.storybook/modes";
+
+
+type Story = StoryObj<typeof ServerItemRendererWithDebugUI>;
+
+/**
+ * This is a visual regression story for the definition widget.
+ */
+
+export default {
+    title: "Widgets/Definition/Visual Regression Tests/Static",
+    component: ServerItemRendererWithDebugUI,
+    tags: ["!dev"],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    "Regression tests for the definition widget that do NOT need any interactions to test, which will be used with Chromatic. Stories are all displayed on one page.",
+            },
+        },
+        chromatic: {disableSnapshot: false, modes: themeModes},
+    },
+};
+
+export const Exercise: Story = {
+    args: {
+        item: generateTestPerseusItem({question}),
+    },
+};
+
+export const Article = (): React.ReactNode => {
+    return (
+        <ArticleRenderer
+            json={article}
+            useNewStyles
+            dependencies={storybookDependenciesV2}
+        />
+    );
+};


### PR DESCRIPTION
## Summary:
To allow theming with Perseus, we are updating a number of key widgets to use WonderBlocks semantic colors. This work updates the Definition widget with semantic color tokens.

Issue: LEMS-3492

## Test plan:
- Manually check changes using Storybook theme button
- Add regression tests and confirm update is as intended
- Confirm all checks pass
- Will be QE tested