### PR TITLE
Remove FixedToResponsive from SVGImage

### DIFF
--- a/.changeset/clever-glasses-lie.md
+++ b/.changeset/clever-glasses-lie.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Remove FixedToResponsive from images

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -346,35 +346,6 @@ describe("renderer", () => {
             },
         );
 
-        it("should wrap image to be responsive if not in table and dimensions provided", () => {
-            // Arrange
-            const question = {
-                content:
-                    "One image with dimensions that isn't in a table.\n\n" +
-                    "![This image has dimensions](https://ka-perseus-images.s3.amazonaws.com/29e9aa32de3731b09e245e416cbf4e3fb2e89b58.svg)",
-                images: {
-                    "https://ka-perseus-images.s3.amazonaws.com/29e9aa32de3731b09e245e416cbf4e3fb2e89b58.svg":
-                        {height: 410, width: 420},
-                },
-                widgets: {},
-            } as const;
-            renderQuestion(question);
-
-            // Act
-            markImagesAsLoaded();
-
-            // Assert
-            const imageNodes = screen.queryAllByAltText(
-                "This image has dimensions",
-            );
-            expect(imageNodes).toHaveLength(1);
-
-            // eslint-disable-next-line testing-library/no-node-access
-            expect(imageNodes[0].parentElement).toHaveClass(
-                "fixed-to-responsive",
-            );
-        });
-
         it("should not wrap image to be responsive if not in table and no dimensions provided", () => {
             // Arrange
             const question = {
@@ -401,36 +372,6 @@ describe("renderer", () => {
             expect(imageNodes[0].parentElement).not.toHaveClass(
                 "fixed-to-responsive",
             );
-        });
-
-        it("should add dimensions to wrapper, if provided", () => {
-            // Arrange
-            const question = {
-                content:
-                    "One image with dimensions.\n\n" +
-                    "![This image has dimensions](https://ka-perseus-images.s3.amazonaws.com/29e9aa32de3731b09e245e416cbf4e3fb2e89b58.svg)",
-                images: {
-                    "https://ka-perseus-images.s3.amazonaws.com/29e9aa32de3731b09e245e416cbf4e3fb2e89b58.svg":
-                        {height: 410, width: 420},
-                },
-                widgets: {},
-            } as const;
-            renderQuestion(question);
-
-            // Act
-            markImagesAsLoaded();
-
-            // Assert
-            expect(
-                screen.queryAllByAltText("This image has dimensions"),
-            ).toHaveLength(1);
-
-            const wrapperStyle = getComputedStyle(
-                // @ts-expect-error - TS2345 - Argument of type 'HTMLElement | null' is not assignable to parameter of type 'Element'.
-                screen.getByAltText("This image has dimensions").parentElement, // eslint-disable-line testing-library/no-node-access
-            );
-            expect(wrapperStyle.maxWidth).toBe("420px");
-            expect(wrapperStyle.maxHeight).toBe("410px");
         });
 
         it("should not add dimensions to wrapper, if not provided", () => {

--- a/packages/perseus/src/components/image-loader.tsx
+++ b/packages/perseus/src/components/image-loader.tsx
@@ -158,6 +158,12 @@ class ImageLoader extends React.Component<Props, State> {
                 onKeyUp={onKeyUp}
                 onKeyDown={onKeyDown}
                 {...imgProps}
+                style={
+                    imgProps.style ?? {
+                        width: "100%",
+                        height: "100%",
+                    }
+                }
             />
         );
     };

--- a/packages/perseus/src/components/svg-image.tsx
+++ b/packages/perseus/src/components/svg-image.tsx
@@ -12,7 +12,6 @@ import Util from "../util";
 import {loadGraphie} from "../util/graphie-utils";
 import * as Zoom from "../zoom";
 
-import FixedToResponsive from "./fixed-to-responsive";
 import Graphie from "./graphie";
 import ImageLoader from "./image-loader";
 
@@ -23,12 +22,6 @@ import type {Alignment, Size} from "@khanacademy/perseus-core";
 
 // Minimum image width to make an image appear as zoomable.
 const ZOOMABLE_THRESHOLD = 700;
-
-function isImageProbablyPhotograph(imageUrl) {
-    // TODO(david): Do an inventory to refine this heuristic. For example, what
-    //     % of .png images are illustrations?
-    return /\.(jpg|jpeg)$/i.test(imageUrl);
-}
 
 function defaultPreloader(dimensions: Dimensions) {
     return (
@@ -483,16 +476,7 @@ class SvgImage extends React.Component<Props, State> {
                 imageProps.onClick = this._handleZoomClick;
 
                 return (
-                    <FixedToResponsive
-                        className={wrapperClasses}
-                        width={width}
-                        height={height}
-                        constrainHeight={this.props.constrainHeight}
-                        allowFullBleed={
-                            this.props.allowFullBleed &&
-                            isImageProbablyPhotograph(imageSrc)
-                        }
-                    >
+                    <div className={wrapperClasses}>
                         <ImageLoader
                             src={imageSrc}
                             imgProps={imageProps}
@@ -500,7 +484,7 @@ class SvgImage extends React.Component<Props, State> {
                             onUpdate={this.handleUpdate}
                         />
                         {extraGraphie}
-                    </FixedToResponsive>
+                    </div>
                 );
             }
             imageProps.style = dimensions;
@@ -559,12 +543,7 @@ class SvgImage extends React.Component<Props, State> {
 
         if (responsive) {
             return (
-                <FixedToResponsive
-                    className="svg-image"
-                    width={width}
-                    height={height}
-                    constrainHeight={this.props.constrainHeight}
-                >
+                <div className="svg-image">
                     <ImageLoader
                         src={imageUrl}
                         onLoad={this.onImageLoad}
@@ -574,7 +553,7 @@ class SvgImage extends React.Component<Props, State> {
                     />
                     {graphie}
                     {extraGraphie}
-                </FixedToResponsive>
+                </div>
             );
         }
         imageProps.style = dimensions;

--- a/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
+++ b/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
@@ -333,12 +333,8 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
         class="paragraph"
       >
         <div
-          class="fixed-to-responsive svg-image"
-          style="max-width: 220px; max-height: 223px;"
+          class="svg-image"
         >
-          <div
-            style="padding-bottom: 101.36%;"
-          />
           <span
             style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
           >
@@ -382,12 +378,8 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
         class="paragraph"
       >
         <div
-          class="fixed-to-responsive svg-image"
-          style="max-width: 244px; max-height: 223px;"
+          class="svg-image"
         >
-          <div
-            style="padding-bottom: 91.39%;"
-          />
           <span
             style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
           >
@@ -840,12 +832,8 @@ exports[`categorizer widget should snapshot: first render 1`] = `
         class="paragraph"
       >
         <div
-          class="fixed-to-responsive svg-image"
-          style="max-width: 220px; max-height: 223px;"
+          class="svg-image"
         >
-          <div
-            style="padding-bottom: 101.36%;"
-          />
           <span
             style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
           >
@@ -889,12 +877,8 @@ exports[`categorizer widget should snapshot: first render 1`] = `
         class="paragraph"
       >
         <div
-          class="fixed-to-responsive svg-image"
-          style="max-width: 244px; max-height: 223px;"
+          class="svg-image"
         >
-          <div
-            style="padding-bottom: 91.39%;"
-          />
           <span
             style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
           >

--- a/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
+++ b/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
@@ -1368,12 +1368,8 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                 style="width: 400px; height: 400px;"
               >
                 <div
-                  class="fixed-to-responsive svg-image"
-                  style="max-width: 400px; max-height: 400px;"
+                  class="svg-image"
                 >
-                  <div
-                    style="padding-bottom: 100%;"
-                  />
                   <span
                     style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
                   >

--- a/packages/perseus/src/widgets/group/__snapshots__/group.test.tsx.snap
+++ b/packages/perseus/src/widgets/group/__snapshots__/group.test.tsx.snap
@@ -22,12 +22,8 @@ exports[`group widget should snapshot: initial render 1`] = `
               class="paragraph"
             >
               <div
-                class="fixed-to-responsive svg-image"
-                style="max-width: 428px; max-height: 480px;"
+                class="svg-image"
               >
-                <div
-                  style="padding-bottom: 112.14999999999999%;"
-                />
                 <span
                   style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
                 >
@@ -841,12 +837,8 @@ exports[`group widget should snapshot: initial render 1`] = `
                             style="max-width: 380px;"
                           >
                             <div
-                              class="fixed-to-responsive svg-image"
-                              style="max-width: 380px; max-height: 80px;"
+                              class="svg-image"
                             >
-                              <div
-                                style="padding-bottom: 21.05%;"
-                              />
                               <span
                                 style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
                               >

--- a/packages/perseus/src/widgets/image/__snapshots__/image.test.ts.snap
+++ b/packages/perseus/src/widgets/image/__snapshots__/image.test.ts.snap
@@ -47,12 +47,8 @@ exports[`image widget - isMobile(false) should snapshot: first render 1`] = `
                     </div>
                   </div>
                   <div
-                    class="fixed-to-responsive svg-image"
-                    style="max-width: 420px; max-height: 345px;"
+                    class="svg-image"
                   >
-                    <div
-                      style="padding-bottom: 82.14%;"
-                    />
                     <span
                       style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
                     >
@@ -228,12 +224,8 @@ exports[`image widget - isMobile(true) should snapshot: first render 1`] = `
                     </div>
                   </div>
                   <div
-                    class="fixed-to-responsive svg-image"
-                    style="max-width: 420px; max-height: 345px;"
+                    class="svg-image"
                   >
-                    <div
-                      style="padding-bottom: 82.14%;"
-                    />
                     <span
                       style="top: 0px; left: 0px; width: 100%; height: 100%; position: absolute; min-width: 20px; display: flex; justify-content: center; align-content: center;"
                     >


### PR DESCRIPTION
## Summary:
There's a bug that's causing image widgets to render super weirdly when they're in a "grouped question" drawer.

This is actually two separate issues:
- way too much spacing, causing the image to shift below the visible spacing
- width is going over 100% of the container space

Fixing them here by removing the `<FixedToResponsive>` from `<SVGImage>`, and constraining `<ImageLoader>` to 100% width and height when dimensions are not provided.

Issue: none

## Test plan:
Load these changes into local frontend dev server and check the following two paths:
- `/ela/8th-grade-reading-and-vocabulary/x435b1de09a877dd7:to-your-health-long-passage-practice/x435b1de09a877dd7:reading-argumentative-texts-to-your-health/e/athletes-and-mental-health`
- `/ela/8th-grade-reading-and-vocabulary/x435b1de09a877dd7:to-your-health-long-passage-practice/x435b1de09a877dd7:reading-argumentative-texts-to-your-health/e/how-not-to-die`

## Screenshots:

| Before | After |
| --- | --- |
| <img width="389" height="680" alt="Screenshot 2025-09-12 at 4 10 08 PM" src="https://github.com/user-attachments/assets/bfc34166-5bca-477b-923c-ac6dbc8bd7b7" /> | <img width="386" height="678" alt="Screenshot 2025-09-12 at 4 10 19 PM" src="https://github.com/user-attachments/assets/237305eb-6019-4375-b2a3-c0ebd3b568b9" /> |
| <img width="386" height="677" alt="Screenshot 2025-09-12 at 4 10 41 PM" src="https://github.com/user-attachments/assets/6abeddc5-a9e8-4df9-ac60-a2237a2c3539" /> | <img width="386" height="682" alt="Screenshot 2025-09-12 at 4 10 46 PM" src="https://github.com/user-attachments/assets/b5598b39-ab5d-4442-ab1a-45c4ee305ba4" /> |


