### PR TITLE
(wip) [Color - NAW] Refactor Image widget to use semantic fonts and colors

### DIFF
--- a/.storybook/modes.ts
+++ b/.storybook/modes.ts
@@ -1,0 +1,36 @@
+export const allModes = {
+    // Responsive modes
+    small: {
+        viewport: "small",
+    },
+    medium: {
+        viewport: "medium",
+    },
+    large: {
+        viewport: "large",
+    },
+    chromebook: {
+        viewport: "chromebook",
+    },
+    // Theming
+    themeDefault: {
+        theme: "default",
+    },
+    themeThunderBlocks: {
+        theme: "thunderblocks",
+    },
+    // NOTE: This will go away when we fully remove the light variants.
+    dark: {
+        background: "darkBlue",
+    },
+    // Accessibility
+    "themeDefault rtl": {
+        theme: "default",
+        direction: "rtl",
+    },
+};
+
+export const themeModes = {
+    default: allModes.themeDefault,
+    thunderblocks: allModes.themeThunderBlocks,
+};

--- a/packages/perseus/src/widgets/image/__docs__/image-interaction-regression.stories.tsx
+++ b/packages/perseus/src/widgets/image/__docs__/image-interaction-regression.stories.tsx
@@ -1,0 +1,100 @@
+import {themeModes} from "../../../../../../.storybook/modes";
+import {ServerItemRendererWithDebugUI} from "../../../../../../testing/server-item-renderer-with-debug-ui";
+import {earthMoonImage} from "../utils";
+
+import type {Meta} from "@storybook/react-vite";
+import {earthMoonImageCaption, rendererDecorator} from "../image.testdata";
+
+const meta: Meta = {
+    title: "Widgets/Image/Visual Regression Tests/Interactions",
+    component: ServerItemRendererWithDebugUI,
+    tags: ["!autodocs"],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    "Regression tests for the Image widget that DO need some sort of interaction to test, which will be used with Chromatic. Stories are displayed on their own page.",
+            },
+        },
+        chromatic: {disableSnapshot: false, modes: themeModes},
+    },
+};
+
+export default meta;
+
+export const FocusedState = {
+    decorators: [rendererDecorator],
+    args: {
+        backgroundImage: earthMoonImage,
+        alt: "Earth and Moon",
+        longDescription:
+            "This is a *very* long description of the earth and moon.",
+        title: "Earth and Moon",
+        caption: earthMoonImageCaption,
+    },
+    play: async ({canvas, userEvent}) => {
+        // eslint-disable-next-line testing-library/prefer-screen-queries
+        const imageTrigger = canvas.getByRole("button", {
+            name: "Earth and Moon",
+        });
+        imageTrigger.focus();
+    },
+};
+
+export const LongDescriptionFocusedState = {
+    decorators: [rendererDecorator],
+    args: {
+        backgroundImage: earthMoonImage,
+        alt: "Earth and Moon",
+        longDescription:
+            "This is a *very* long description of the earth and moon.",
+        title: "Earth and Moon",
+        caption: earthMoonImageCaption,
+    },
+    play: async ({canvas, userEvent}) => {
+        // eslint-disable-next-line testing-library/prefer-screen-queries
+        const imageTrigger = canvas.getByRole("button", {
+            name: "Explore image",
+        });
+        imageTrigger.focus();
+    },
+};
+
+export const LongDescriptionClickedState = {
+    decorators: [rendererDecorator],
+    args: {
+        backgroundImage: earthMoonImage,
+        alt: "Earth and Moon",
+        longDescription:
+            "This is a *very* long description of the earth and moon.",
+        title: "Earth and Moon",
+        caption: earthMoonImageCaption,
+    },
+    play: async ({canvas, userEvent}) => {
+        // eslint-disable-next-line testing-library/prefer-screen-queries
+        const imageTrigger = canvas.getByRole("button", {
+            name: "Explore image",
+        });
+        await userEvent.click(imageTrigger);
+    },
+};
+
+export const LongDescriptionClickedImageFocusedState = {
+    decorators: [rendererDecorator],
+    args: {
+        backgroundImage: earthMoonImage,
+        alt: "Earth and Moon",
+        longDescription:
+            "This is a *very* long description of the earth and moon.",
+        title: "Earth and Moon",
+        caption: earthMoonImageCaption,
+    },
+    play: async ({canvas, userEvent}) => {
+        // eslint-disable-next-line testing-library/prefer-screen-queries
+        const descriptionTrigger = canvas.getByRole("button", {
+            name: "Explore image",
+        });
+        await userEvent.click(descriptionTrigger);
+        await userEvent.tab();
+    },
+};

--- a/packages/perseus/src/widgets/image/__docs__/image-interaction-regression.stories.tsx
+++ b/packages/perseus/src/widgets/image/__docs__/image-interaction-regression.stories.tsx
@@ -1,9 +1,9 @@
 import {themeModes} from "../../../../../../.storybook/modes";
 import {ServerItemRendererWithDebugUI} from "../../../../../../testing/server-item-renderer-with-debug-ui";
+import {earthMoonImageCaption, rendererDecorator} from "../image.testdata";
 import {earthMoonImage} from "../utils";
 
 import type {Meta} from "@storybook/react-vite";
-import {earthMoonImageCaption, rendererDecorator} from "../image.testdata";
 
 const meta: Meta = {
     title: "Widgets/Image/Visual Regression Tests/Interactions",

--- a/packages/perseus/src/widgets/image/__docs__/image-static-regression.stories.tsx
+++ b/packages/perseus/src/widgets/image/__docs__/image-static-regression.stories.tsx
@@ -1,63 +1,37 @@
-import {
-    generateTestPerseusRenderer,
-    generateImageOptions,
-    generateImageWidget,
-} from "@khanacademy/perseus-core";
 import * as React from "react";
 
-import {getFeatureFlags} from "../../../../../../testing/feature-flags-util";
-import {ApiOptions} from "../../../perseus-api";
-import Renderer from "../../../renderer";
-import {mockStrings} from "../../../strings";
-import UserInputManager from "../../../user-input-manager";
+import {themeModes} from "../../../../../../.storybook/modes";
 import {getWidget} from "../../../widgets";
 import {
-    mobileDecorator,
     articleDecorator,
     mobileArticleDecorator,
+    mobileDecorator,
     rtlDecorator,
 } from "../../__testutils__/story-decorators";
 import {earthMoonImage, frescoImage, monasteryImage} from "../utils";
-
-import type {PerseusRenderer} from "@khanacademy/perseus-core";
 import type {Meta, StoryObj} from "@storybook/react-vite";
+import {earthMoonImageCaption, rendererDecorator} from "../image.testdata";
 
 const ImageWidget = getWidget("image")!;
 
 type Story = StoryObj<typeof ImageWidget>;
 
-const earthMoonImageCaption =
-    "The Moon above Earth's horizon, captured by the International Space Station, [NASA](https://images.nasa.gov/details/iss071e515452)";
 const frescsoLongDescription =
     "In the apse, or semicircular recess, The Offer of the Casa Madre to Victory (L’Offerta della Casa Madre alla Vittoria) fresco recalls medieval apse decorative schemes with Christ surrounded by saints to whom the Church is dedicated. Santagata replaced Mary with a triumphant and wingless figure representing Victory, and he replaced saints with sentries. The charismatic wounded veteran Carlo Delcroix, who became the AMNIG president, is depicted presenting a model of the Casa Madre to Victory (not unlike the medieval patron Enrico Scrovegni, who offered the Arena chapel he commissioned to the Virgin Mary).\n\nThis image has some stuff in it. *Here is some italic text.* **Here is some bold text.**";
 
 const articleContent = `But in other cases, an object may experience a centripetal force for an extended time and complete *repeated* revolutions. An example of this type of motion is an astronomical object in **orbit**.\n\n[[☃ image 1]]\n\nLet's explore some of the language and relationships involved in orbital motion.`;
 
-// Breaking this out instead of using it globally, so that the
-// right-to-left story can wrap the ImageQuestionRenderer with the
-// right-to-left wrapper.
-const rendererDecorator = (_, {args, parameters}) => {
-    return (
-        <ImageQuestionRenderer
-            question={generateTestPerseusRenderer({
-                content: parameters?.content ?? "[[☃ image 1]]",
-                widgets: {
-                    "image 1": generateImageWidget({
-                        options: generateImageOptions({
-                            ...args,
-                        }),
-                    }),
-                },
-            })}
-        />
-    );
-};
-
 const meta: Meta<typeof ImageWidget> = {
     title: "Widgets/Image/Visual Regression Tests",
     component: ImageWidget,
     parameters: {
-        chromatic: {disableSnapshot: false},
+        docs: {
+            description: {
+                component:
+                    "Regression tests for the Image widget that do NOT need any interactions to test, which will be used with Chromatic. Stories are all displayed on one page.",
+            },
+        },
+        chromatic: {disableSnapshot: false, modes: themeModes},
     },
 };
 export default meta;
@@ -269,26 +243,3 @@ export const RightToLeftImageMobile: Story = {
         backgroundImage: frescoImage,
     },
 };
-
-function ImageQuestionRenderer(props: {question: PerseusRenderer}) {
-    const {question} = props;
-    return (
-        <UserInputManager widgets={question.widgets} problemNum={0}>
-            {({userInput, handleUserInput, initializeUserInput}) => (
-                <Renderer
-                    userInput={userInput}
-                    handleUserInput={handleUserInput}
-                    initializeUserInput={initializeUserInput}
-                    strings={mockStrings}
-                    content={question.content}
-                    widgets={question.widgets}
-                    images={question.images}
-                    apiOptions={{
-                        ...ApiOptions.defaults,
-                        flags: getFeatureFlags({"image-widget-upgrade": true}),
-                    }}
-                />
-            )}
-        </UserInputManager>
-    );
-}

--- a/packages/perseus/src/widgets/image/__docs__/image-static-regression.stories.tsx
+++ b/packages/perseus/src/widgets/image/__docs__/image-static-regression.stories.tsx
@@ -8,9 +8,10 @@ import {
     mobileDecorator,
     rtlDecorator,
 } from "../../__testutils__/story-decorators";
-import {earthMoonImage, frescoImage, monasteryImage} from "../utils";
-import type {Meta, StoryObj} from "@storybook/react-vite";
 import {earthMoonImageCaption, rendererDecorator} from "../image.testdata";
+import {earthMoonImage, frescoImage, monasteryImage} from "../utils";
+
+import type {Meta, StoryObj} from "@storybook/react-vite";
 
 const ImageWidget = getWidget("image")!;
 

--- a/packages/perseus/src/widgets/image/image.testdata.tsx
+++ b/packages/perseus/src/widgets/image/image.testdata.tsx
@@ -4,9 +4,9 @@ import {
     generateTestPerseusRenderer,
     type PerseusRenderer,
 } from "@khanacademy/perseus-core";
+import {getFeatureFlags} from "perseus/testing/feature-flags-util";
 import * as React from "react";
 
-import {getFeatureFlags} from "../../../../../testing/feature-flags-util";
 import {ApiOptions} from "../../perseus-api";
 import Renderer from "../../renderer";
 import {mockStrings} from "../../strings";

--- a/packages/perseus/src/widgets/image/image.testdata.tsx
+++ b/packages/perseus/src/widgets/image/image.testdata.tsx
@@ -1,8 +1,16 @@
 import {
-    generateTestPerseusRenderer,
     generateImageOptions,
     generateImageWidget,
+    generateTestPerseusRenderer,
+    type PerseusRenderer,
 } from "@khanacademy/perseus-core";
+import * as React from "react";
+
+import {getFeatureFlags} from "../../../../../testing/feature-flags-util";
+import {ApiOptions} from "../../perseus-api";
+import Renderer from "../../renderer";
+import {mockStrings} from "../../strings";
+import UserInputManager from "../../user-input-manager";
 
 export const question = generateTestPerseusRenderer({
     content:
@@ -42,3 +50,49 @@ export const questionWithZoom = generateTestPerseusRenderer({
         }),
     },
 });
+
+export const earthMoonImageCaption =
+    "The Moon above Earth's horizon, captured by the International Space Station, [NASA](https://images.nasa.gov/details/iss071e515452)";
+
+export function ImageQuestionRenderer(props: {question: PerseusRenderer}) {
+    const {question} = props;
+    return (
+        <UserInputManager widgets={question.widgets} problemNum={0}>
+            {({userInput, handleUserInput, initializeUserInput}) => (
+                <Renderer
+                    userInput={userInput}
+                    handleUserInput={handleUserInput}
+                    initializeUserInput={initializeUserInput}
+                    strings={mockStrings}
+                    content={question.content}
+                    widgets={question.widgets}
+                    images={question.images}
+                    apiOptions={{
+                        ...ApiOptions.defaults,
+                        flags: getFeatureFlags({"image-widget-upgrade": true}),
+                    }}
+                />
+            )}
+        </UserInputManager>
+    );
+}
+
+// Breaking this out instead of using it globally, so that the
+// right-to-left story can wrap the ImageQuestionRenderer with the
+// right-to-left wrapper.
+export const rendererDecorator = (_, {args, parameters}) => {
+    return (
+        <ImageQuestionRenderer
+            question={generateTestPerseusRenderer({
+                content: parameters?.content ?? "[[☃ image 1]]",
+                widgets: {
+                    "image 1": generateImageWidget({
+                        options: generateImageOptions({
+                            ...args,
+                        }),
+                    }),
+                },
+            })}
+        />
+    );
+};


### PR DESCRIPTION
## Summary:
To allow theming with Perseus, we are updating a number of key widgets to use WonderBlocks semantic colors and font styling. This work updates the Image widget with semantic color tokens and semantic font tokens.

Issue: LEMS-3490

## Test plan:
- Manually check changes using Storybook theme button
- Add Chromatic visual regression tests and confirm update is as intended
- Confirm all checks pass
- Will be QE tested