### PR TITLE
[Image] | (CX) | Remove "math in caption" linter error

### DIFF
--- a/.changeset/great-houses-wonder.md
+++ b/.changeset/great-houses-wonder.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-linter": patch
+---
+
+[Image] | (CX) | Remove "math in caption" linter error

--- a/packages/perseus-linter/src/rules/image-widget.test.ts
+++ b/packages/perseus-linter/src/rules/image-widget.test.ts
@@ -33,40 +33,4 @@ describe("image-widget", () => {
             },
         },
     });
-
-    // Warn for image widget with math in its caption
-    expectWarning(imageWidgetRule, "[[☃ image 1]]", {
-        widgets: {
-            "image 1": {
-                options: {
-                    alt: "1234567890",
-                    caption: "Test: $x$",
-                },
-            },
-        },
-    });
-
-    // Pass for image widget with caption and no math
-    expectPass(imageWidgetRule, "[[☃ image 1]]", {
-        widgets: {
-            "image 1": {
-                options: {
-                    alt: "1234567890",
-                    caption: "Test: x",
-                },
-            },
-        },
-    });
-
-    // Pass for image widget with escaped dollar in its caption
-    expectPass(imageWidgetRule, "[[☃ image 1]]", {
-        widgets: {
-            "image 1": {
-                options: {
-                    alt: "1234567890",
-                    caption: "Test: \\$10",
-                },
-            },
-        },
-    });
 });

--- a/packages/perseus-linter/src/rules/image-widget.ts
+++ b/packages/perseus-linter/src/rules/image-widget.ts
@@ -42,11 +42,5 @@ Add a description in the "Alt Text" box of the image widget.`;
 for accessibility, all images should have descriptive alt text.
 This image's alt text is only ${alt.trim().length} characters long.`;
         }
-
-        // Make sure there is no math in the caption
-        if (widget.options.caption && widget.options.caption.match(/[^\\]\$/)) {
-            return `No math in image captions:
-Don't include math expressions in image captions.`;
-        }
     },
 }) as Rule;


### PR DESCRIPTION
## Summary:

There's a linter error that shows up if there is TeX in an image caption:

> No math in image captions: Don't include math expressions in image captions.

This was likely added before we had adequate i18n support for math expressions, but this is no longer the case. It should be safe to remove this linter warning now.

Issue: none

## Test plan:
`pnpm jest packages/perseus-linter/src/rules/image-widget.test.ts`

Storybook
`/?path=/docs/widgets-image-editor-demo--docs#populated-within-editor-page`

| Before | After |
| ----- | ----- |
| <img width="534" height="503" alt="Screenshot 2025-09-29 at 1 50 24 PM" src="https://github.com/user-attachments/assets/13a258c3-30bf-41a8-8ff8-1d2aa68d2c65" /> | <img width="499" height="449" alt="Screenshot 2025-09-29 at 1 50 33 PM" src="https://github.com/user-attachments/assets/95c76280-c263-4b7d-ad12-d789bd1eba21" /> |