### PR TITLE
Require dependencies as a prop for HintRenderer

### DIFF
--- a/.changeset/brave-boxes-rule.md
+++ b/.changeset/brave-boxes-rule.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": major
+---
+
+Require dependencies as a prop for HintRenderer

--- a/packages/perseus/src/__docs__/hints-renderer.stories.tsx
+++ b/packages/perseus/src/__docs__/hints-renderer.stories.tsx
@@ -1,6 +1,7 @@
 import {View} from "@khanacademy/wonder-blocks-core";
 import React from "react";
 
+import {storybookDependenciesV2} from "../../../../testing/test-dependencies";
 import HintsRenderer from "../hints-renderer";
 import {ApiOptions} from "../perseus-api";
 import {interactiveGraphQuestionBuilder} from "../widgets/interactive-graphs/interactive-graph-question-builder";
@@ -35,6 +36,7 @@ type Story = StoryObj<typeof HintsRenderer>;
 
 export const Interactive: Story = {
     args: {
+        dependencies: storybookDependenciesV2,
         hints: [
             {
                 content: "this is hint 1",
@@ -61,6 +63,7 @@ export const Interactive: Story = {
 export const WithAllInteractiveGraphs: Story = {
     args: {
         apiOptions: defaultApiOptions,
+        dependencies: storybookDependenciesV2,
         hints: [
             {
                 ...interactiveGraphQuestionBuilder().withAngle().build(),

--- a/packages/perseus/src/hint-renderer.tsx
+++ b/packages/perseus/src/hint-renderer.tsx
@@ -4,12 +4,13 @@ import classnames from "classnames";
 import * as React from "react";
 
 import {PerseusI18nContext} from "./components/i18n-context";
+import {DependenciesContext} from "./dependencies";
 import Renderer from "./renderer";
 import {baseUnitPx, hintBorderWidth, kaGreen, gray97} from "./styles/constants";
 import mediaQueries from "./styles/media-queries";
 import UserInputManager from "./user-input-manager";
 
-import type {SharedRendererProps} from "./types";
+import type {PerseusDependenciesV2, SharedRendererProps} from "./types";
 
 type Props = SharedRendererProps & {
     className?: string;
@@ -19,6 +20,7 @@ type Props = SharedRendererProps & {
     pos: number;
     totalHints?: number;
     findExternalWidgets?: any;
+    dependencies: PerseusDependenciesV2;
 };
 
 type DefaultProps = {
@@ -78,46 +80,56 @@ class HintRenderer extends React.Component<Props> {
         } as const;
 
         return (
-            // @ts-expect-error - TS2322 - Type 'string' is not assignable to type 'number | undefined'.
-            <div className={classNames} tabIndex="-1">
-                {!apiOptions.isMobile && (
-                    <span className="perseus-sr-only">
-                        {this.context.strings.hintPos({pos: pos + 1})}
-                    </span>
-                )}
-                {!apiOptions.isMobile && totalHints != null && pos != null && (
-                    <span
-                        className="perseus-hint-label"
-                        style={{
-                            display: "block",
-                            color: apiOptions.hintProgressColor,
-                        }}
-                    >
-                        {`${pos + 1} / ${totalHints}`}
-                    </span>
-                )}
-
-                <UserInputManager widgets={hint.widgets} problemNum={0}>
-                    {({userInput, handleUserInput, initializeUserInput}) => (
-                        <Renderer
-                            ref={this.rendererRef}
-                            userInput={userInput}
-                            handleUserInput={handleUserInput}
-                            initializeUserInput={initializeUserInput}
-                            widgets={hint.widgets}
-                            content={hint.content || ""}
-                            images={hint.images}
-                            apiOptions={rendererApiOptions}
-                            findExternalWidgets={this.props.findExternalWidgets}
-                            linterContext={PerseusLinter.pushContextStack(
-                                this.props.linterContext,
-                                "hint",
-                            )}
-                            strings={this.context.strings}
-                        />
+            <DependenciesContext.Provider value={this.props.dependencies}>
+                {/* @ts-expect-error - TS2322 - Type 'string' is not assignable to type 'number | undefined'. */}
+                <div className={classNames} tabIndex="-1">
+                    {!apiOptions.isMobile && (
+                        <span className="perseus-sr-only">
+                            {this.context.strings.hintPos({pos: pos + 1})}
+                        </span>
                     )}
-                </UserInputManager>
-            </div>
+                    {!apiOptions.isMobile &&
+                        totalHints != null &&
+                        pos != null && (
+                            <span
+                                className="perseus-hint-label"
+                                style={{
+                                    display: "block",
+                                    color: apiOptions.hintProgressColor,
+                                }}
+                            >
+                                {`${pos + 1} / ${totalHints}`}
+                            </span>
+                        )}
+
+                    <UserInputManager widgets={hint.widgets} problemNum={0}>
+                        {({
+                            userInput,
+                            handleUserInput,
+                            initializeUserInput,
+                        }) => (
+                            <Renderer
+                                ref={this.rendererRef}
+                                userInput={userInput}
+                                handleUserInput={handleUserInput}
+                                initializeUserInput={initializeUserInput}
+                                widgets={hint.widgets}
+                                content={hint.content || ""}
+                                images={hint.images}
+                                apiOptions={rendererApiOptions}
+                                findExternalWidgets={
+                                    this.props.findExternalWidgets
+                                }
+                                linterContext={PerseusLinter.pushContextStack(
+                                    this.props.linterContext,
+                                    "hint",
+                                )}
+                                strings={this.context.strings}
+                            />
+                        )}
+                    </UserInputManager>
+                </div>
+            </DependenciesContext.Provider>
         );
     }
 }

--- a/packages/perseus/src/hints-renderer.tsx
+++ b/packages/perseus/src/hints-renderer.tsx
@@ -20,7 +20,7 @@ import sharedStyles from "./styles/shared";
 import Util from "./util";
 
 import type Renderer from "./renderer";
-import type {APIOptionsWithDefaults} from "./types";
+import type {APIOptionsWithDefaults, PerseusDependenciesV2} from "./types";
 import type {Hint} from "@khanacademy/perseus-core";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
@@ -28,6 +28,7 @@ type Props = PropsFor<typeof Renderer> & {
     className?: string;
     hints: ReadonlyArray<Hint>;
     hintsVisible?: number;
+    dependencies: PerseusDependenciesV2;
 };
 
 type DefaultProps = {
@@ -155,6 +156,7 @@ class HintsRenderer extends React.Component<Props, State> {
 
             const renderer = (
                 <HintRenderer
+                    dependencies={this.props.dependencies}
                     lastHint={lastHint}
                     lastRendered={lastRendered}
                     hint={hint}

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -469,6 +469,7 @@ export class ServerItemRenderer
 
         const hintsRenderer = (
             <HintsRenderer
+                dependencies={this.props.dependencies}
                 hints={this.props.item.hints}
                 hintsVisible={this.props.hintsVisible}
                 apiOptions={apiOptions}


### PR DESCRIPTION
## Summary:
Turns out that HintRenderer is also rendered outside of any other renderer in the frontend app.
This means that it also needs to have `dependencies` as a prop so it can provide it via React context.

## Test plan:
- Ensure tests pass
- Open a frontend PR to update the HintRenderer props and ensure the hint editor works in devadmin