### PR TITLE
Test that the ItemDiff component will render an image diff

### DIFF
--- a/.changeset/fifty-buttons-join.md
+++ b/.changeset/fifty-buttons-join.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Adding tests for ItemDiff component

--- a/packages/perseus-editor/src/__tests__/editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/editor.test.tsx
@@ -3,6 +3,7 @@ import {act, render, screen, waitFor} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
+import {mockImageLoading} from "../../../../testing/image-loader-utils";
 import {
     testDependencies,
     testDependenciesV2,
@@ -89,31 +90,15 @@ describe("Editor", () => {
 
     test("clicking on the widget editor should open it", async () => {
         // Arrange
-        const images: Array<Record<any, any>> = [];
-        const originalImage = window.Image;
         // The editor preview uses SvgImage, which uses ImageLoader.
         // We need to mock the image loading in ImageLoader for it to render.
-        // Mock HTML Image so we can trigger onLoad callbacks and see full
-        // image rendering.
-        // @ts-expect-error - TS2322 - Type 'Mock<Record<string, any>, [], any>' is not assignable to type 'new (width?: number | undefined, height?: number | undefined) => HTMLImageElement'.
-        window.Image = jest.fn(() => {
-            const img: Record<string, any> = {};
-            images.push(img);
-            return img;
-        });
+        const unmockImageLoading = mockImageLoading();
 
         render(<Harnessed />);
 
         // Act
         const widgetDisclosure = screen.getByText("image 1");
         await userEvent.click(widgetDisclosure);
-
-        // Trigger the image load
-        images.forEach((img) => {
-            if (img?.onload) {
-                act(() => img.onload());
-            }
-        });
 
         // Assert
         const previewImage = screen.getByAltText(/Preview:/);
@@ -125,7 +110,7 @@ describe("Editor", () => {
         );
 
         // Cleanup
-        window.Image = originalImage;
+        unmockImageLoading();
     });
 
     it("should update values", async () => {

--- a/packages/perseus-editor/src/diffs/__tests__/item-diff.test.tsx
+++ b/packages/perseus-editor/src/diffs/__tests__/item-diff.test.tsx
@@ -1,0 +1,111 @@
+import {Dependencies} from "@khanacademy/perseus";
+import {
+    generateImageOptions,
+    generateImageWidget,
+    generateTestPerseusItem,
+    generateTestPerseusRenderer,
+    getDefaultAnswerArea,
+    type PerseusItem,
+} from "@khanacademy/perseus-core";
+import {act, render, screen} from "@testing-library/react";
+import * as React from "react";
+
+import {mockImageLoading} from "../../../../../testing/image-loader-utils";
+import {
+    testDependencies,
+    testDependenciesV2,
+} from "../../../../../testing/test-dependencies";
+import {registerAllWidgetsAndEditorsForTesting} from "../../util/register-all-widgets-and-editors-for-testing";
+import ItemDiff from "../item-diff";
+
+describe("ItemDiff", () => {
+    let unmockImageLoading: () => void;
+
+    beforeAll(() => {
+        registerAllWidgetsAndEditorsForTesting();
+    });
+
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+        unmockImageLoading = mockImageLoading();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        unmockImageLoading();
+    });
+
+    it("renders an image widget in the diff view", () => {
+        // Arrange
+
+        const beforeItem: PerseusItem = generateTestPerseusItem({
+            question: generateTestPerseusRenderer({
+                content: "[[☃ image 1]]",
+                widgets: {
+                    "image 1": generateImageWidget({
+                        options: generateImageOptions({
+                            title: "Original Image",
+                            caption: "This is the original image",
+                            alt: "Original image description",
+                            backgroundImage: {
+                                url: "https://example.com/original-image.jpg",
+                                width: 400,
+                                height: 300,
+                            },
+                        }),
+                    }),
+                },
+            }),
+            answerArea: getDefaultAnswerArea(),
+            hints: [],
+        });
+
+        const afterItem: PerseusItem = generateTestPerseusItem({
+            question: generateTestPerseusRenderer({
+                content: "[[☃ image 1]]",
+                widgets: {
+                    "image 1": generateImageWidget({
+                        options: generateImageOptions({
+                            title: "Updated Image",
+                            caption: "This is the updated image",
+                            alt: "Updated image description",
+                            backgroundImage: {
+                                url: "https://example.com/updated-image.jpg",
+                                width: 500,
+                                height: 400,
+                            },
+                        }),
+                    }),
+                },
+            }),
+            answerArea: getDefaultAnswerArea(),
+            hints: [],
+        });
+
+        // Act
+        render(
+            <ItemDiff
+                before={beforeItem as any}
+                after={afterItem as any}
+                dependencies={testDependenciesV2}
+            />,
+        );
+
+        // Wait for the next tick to allow setTimeout to execute
+        act(() => {
+            jest.runAllTimers();
+        });
+
+        // Assert
+        expect(screen.getByText('"Updated Image"')).toBeInTheDocument();
+        expect(
+            screen.getByText('"This is the updated image"'),
+        ).toBeInTheDocument();
+
+        expect(
+            screen.getByText('"https://example.com/updated-image.jpg"'),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx
@@ -698,7 +698,7 @@ describe("image editor", () => {
         it("should render when feature flag is enabled", () => {
             // Arrange & Act
             render(
-                <ImageEditor
+                <ImageEditorWithDependencies
                     apiOptions={apiOptions}
                     backgroundImage={earthMoonImage}
                     onChange={() => {}}
@@ -715,7 +715,7 @@ describe("image editor", () => {
         it("should not render feature flag is disabled", () => {
             // Arrange & Act
             render(
-                <ImageEditor
+                <ImageEditorWithDependencies
                     apiOptions={{
                         ...ApiOptions.defaults,
                         flags: getFeatureFlags({"image-widget-upgrade": false}),
@@ -737,7 +737,7 @@ describe("image editor", () => {
         it("should render when decorative is true", () => {
             // Arrange & Act
             render(
-                <ImageEditor
+                <ImageEditorWithDependencies
                     apiOptions={apiOptions}
                     backgroundImage={earthMoonImage}
                     decorative={true}
@@ -757,7 +757,7 @@ describe("image editor", () => {
             // Arrange
             const onChangeMock = jest.fn();
             render(
-                <ImageEditor
+                <ImageEditorWithDependencies
                     apiOptions={apiOptions}
                     backgroundImage={earthMoonImage}
                     onChange={onChangeMock}

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -8,6 +8,7 @@ import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
 import {testWidgetIdExtraction} from "../../../../testing/extract-widget-ids-contract-tests";
+import {mockImageLoading} from "../../../../testing/image-loader-utils";
 import {clone} from "../../../../testing/object-utils";
 import {testDependencies} from "../../../../testing/test-dependencies";
 import {
@@ -285,40 +286,15 @@ describe("renderer", () => {
     });
 
     describe("rendering", () => {
-        const images: Array<Record<any, any>> = [];
-        let originalImage;
+        let unmockImageLoading: () => void;
 
         beforeEach(() => {
-            originalImage = window.Image;
-            // Mock HTML Image so we can trigger onLoad callbacks and see full
-            // image rendering.
-            // @ts-expect-error - TS2322 - Type 'Mock<Record<string, any>, [], any>' is not assignable to type 'new (width?: number | undefined, height?: number | undefined) => HTMLImageElement'.
-            window.Image = jest.fn(() => {
-                const img: Record<string, any> = {};
-                images.push(img);
-                return img;
-            });
+            unmockImageLoading = mockImageLoading();
         });
 
         afterEach(() => {
-            window.Image = originalImage;
+            unmockImageLoading();
         });
-
-        // Tells the image loader 1, or all, of our images loaded
-        const markImagesAsLoaded = (imageIndex?: number) => {
-            if (imageIndex != null) {
-                const img = images[imageIndex];
-                if (img?.onload) {
-                    act(() => img.onload());
-                }
-            } else {
-                images.forEach((i) => {
-                    if (i?.onload) {
-                        act(() => i.onload());
-                    }
-                });
-            }
-        };
 
         it.each([true, false])(
             "should render a table when isMobile: %s",
@@ -360,7 +336,9 @@ describe("renderer", () => {
             renderQuestion(question);
 
             // Act
-            markImagesAsLoaded();
+            act(() => {
+                jest.runAllTimers();
+            });
 
             // Assert
             const imageNodes = screen.queryAllByAltText(
@@ -386,7 +364,9 @@ describe("renderer", () => {
             renderQuestion(question);
 
             // Act
-            markImagesAsLoaded();
+            act(() => {
+                jest.runAllTimers();
+            });
 
             // Assert
             const imageNodes = screen.queryAllByAltText(
@@ -417,7 +397,9 @@ describe("renderer", () => {
             renderQuestion(question);
 
             // Act
-            markImagesAsLoaded();
+            act(() => {
+                jest.runAllTimers();
+            });
 
             // Assert
             expect(
@@ -444,7 +426,9 @@ describe("renderer", () => {
             renderQuestion(question);
 
             // Act
-            markImagesAsLoaded();
+            act(() => {
+                jest.runAllTimers();
+            });
 
             // Assert
             expect(screen.queryAllByAltText("This image doesn't")).toHaveLength(
@@ -478,7 +462,9 @@ describe("renderer", () => {
             renderQuestion(question);
 
             // Act
-            markImagesAsLoaded();
+            act(() => {
+                jest.runAllTimers();
+            });
 
             // Assert
             const imageNodes = screen.queryAllByAltText(

--- a/packages/perseus/src/widgets/image/image.test.ts
+++ b/packages/perseus/src/widgets/image/image.test.ts
@@ -7,6 +7,7 @@ import {act, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 
 import {getFeatureFlags} from "../../../../../testing/feature-flags-util";
+import {mockImageLoading} from "../../../../../testing/image-loader-utils";
 import {testDependencies} from "../../../../../testing/test-dependencies";
 import * as Dependencies from "../../dependencies";
 import {scorePerseusItemTesting} from "../../util/test-utils";
@@ -20,13 +21,12 @@ import type {UserEvent} from "@testing-library/user-event";
 
 describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
     let userEvent: UserEvent;
+    let unmockImageLoading: () => void;
 
     const apiOptions: APIOptions = {
         isMobile,
         flags: getFeatureFlags({"image-widget-upgrade": true}),
     };
-    const images: HTMLImageElement[] = [];
-    let originalImage;
 
     beforeEach(() => {
         userEvent = userEventLib.setup({
@@ -36,37 +36,12 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
             testDependencies,
         );
 
-        // Mock window.Image for ImageLoader
-        originalImage = window.Image;
-        window.Image = jest.fn(() => {
-            const img = {} as HTMLImageElement;
-            images.push(img);
-            return img;
-        });
-
-        // Mocked for loading graphie in svg-image
-        global.fetch = jest.fn(() =>
-            Promise.resolve({
-                text: () => "",
-                ok: true,
-            }),
-        ) as jest.Mock;
+        unmockImageLoading = mockImageLoading();
     });
 
     afterEach(() => {
-        window.Image = originalImage;
+        unmockImageLoading();
     });
-
-    // Helper to simulate image loading completion
-    const markImagesAsLoaded = () => {
-        act(() => {
-            images.forEach((img) => {
-                if (img?.onload) {
-                    img.onload(new Event("load"));
-                }
-            });
-        });
-    };
 
     it("should snapshot", () => {
         // Arrange
@@ -127,7 +102,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
 
         // Act
         renderQuestion(imageQuestion, apiOptions);
-        markImagesAsLoaded(); // Simulate image loading completion
+        act(() => {
+            jest.runAllTimers();
+        });
 
         // Assert
         expect(screen.getByRole("figure")).toBeVisible();
@@ -149,7 +126,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
 
         // Act
         renderQuestion(imageQuestion, apiOptions);
-        markImagesAsLoaded(); // Simulate image loading completion
+        act(() => {
+            jest.runAllTimers();
+        });
 
         // Assert
         expect(screen.getByAltText("widget alt")).toBeVisible();
@@ -171,7 +150,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
 
         // Act
         renderQuestion(imageQuestion, apiOptions);
-        markImagesAsLoaded(); // Simulate image loading completion
+        act(() => {
+            jest.runAllTimers();
+        });
 
         // Assert
         expect(screen.getByText("widget title")).toBeVisible();
@@ -193,7 +174,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
 
         // Act
         renderQuestion(imageQuestion, apiOptions);
-        markImagesAsLoaded(); // Simulate image loading completion
+        act(() => {
+            jest.runAllTimers();
+        });
 
         // Assert
         expect(screen.getByText("widget caption")).toBeVisible();
@@ -215,7 +198,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
 
         // Act
         renderQuestion(imageQuestion, apiOptions);
-        markImagesAsLoaded(); // Simulate image loading completion
+        act(() => {
+            jest.runAllTimers();
+        });
 
         // Assert
         const button = screen.getByRole("button", {name: "Explore image"});
@@ -240,7 +225,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
 
         // Act
         renderQuestion(imageQuestion, apiOptions);
-        markImagesAsLoaded(); // Simulate image loading completion
+        act(() => {
+            jest.runAllTimers();
+        });
 
         // Assert
         const iconButton = screen.getByRole("button", {name: "Explore image"});
@@ -264,7 +251,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
         });
 
         renderQuestion(imageQuestion, apiOptions);
-        markImagesAsLoaded(); // Simulate image loading completion
+        act(() => {
+            jest.runAllTimers();
+        });
 
         //  Act
         const button = screen.getByRole("button", {name: "Explore image"});
@@ -290,7 +279,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
         });
 
         renderQuestion(imageQuestion, apiOptions);
-        markImagesAsLoaded(); // Simulate image loading completion
+        act(() => {
+            jest.runAllTimers();
+        });
 
         //  Act
         const button = screen.getByRole("button", {name: "Explore image"});
@@ -317,7 +308,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
         });
 
         renderQuestion(imageQuestion, apiOptions);
-        markImagesAsLoaded(); // Simulate image loading completion
+        act(() => {
+            jest.runAllTimers();
+        });
 
         //  Act
         const button = screen.getByRole("button", {name: "Explore image"});
@@ -347,7 +340,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
         });
 
         renderQuestion(imageQuestion, apiOptions);
-        markImagesAsLoaded(); // Simulate image loading completion
+        act(() => {
+            jest.runAllTimers();
+        });
 
         //  Act
         const button = screen.getByRole("button", {name: "Explore image"});
@@ -380,7 +375,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
             };
 
             renderQuestion(imageQuestion, apiOptionsWithFeatureFlag);
-            markImagesAsLoaded(); // Simulate image loading completion
+            act(() => {
+                jest.runAllTimers();
+            });
 
             // Assert
             const button = screen.getByRole("button", {name: "Explore image"});
@@ -409,7 +406,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
             };
 
             renderQuestion(imageQuestion, apiOptionsWithFeatureFlag);
-            markImagesAsLoaded(); // Simulate image loading completion
+            act(() => {
+                jest.runAllTimers();
+            });
 
             // Assert
             const iconButton = screen.getByRole("button", {
@@ -440,7 +439,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
             };
 
             renderQuestion(imageQuestion, apiOptionsWithFeatureFlag);
-            markImagesAsLoaded(); // Simulate image loading completion
+            act(() => {
+                jest.runAllTimers();
+            });
 
             // Assert
             const button = screen.queryByRole("button", {
@@ -470,7 +471,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
             };
 
             renderQuestion(imageQuestion, apiOptionsWithFeatureFlag);
-            markImagesAsLoaded(); // Simulate image loading completion
+            act(() => {
+                jest.runAllTimers();
+            });
 
             // Assert
             const iconButton = screen.queryByRole("button", {
@@ -498,7 +501,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
 
             // Act
             renderQuestion(imageQuestion, apiOptions);
-            markImagesAsLoaded();
+            act(() => {
+                jest.runAllTimers();
+            });
 
             // Assert
             expect(screen.queryByText("widget title")).not.toBeInTheDocument();
@@ -521,7 +526,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
 
             // Act
             renderQuestion(imageQuestion, apiOptions);
-            markImagesAsLoaded();
+            act(() => {
+                jest.runAllTimers();
+            });
 
             // Assert
             expect(
@@ -546,7 +553,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
 
             // Act
             renderQuestion(imageQuestion, apiOptions);
-            markImagesAsLoaded();
+            act(() => {
+                jest.runAllTimers();
+            });
 
             // Assert
             expect(
@@ -571,7 +580,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
 
             // Act
             renderQuestion(imageQuestion, apiOptions);
-            markImagesAsLoaded();
+            act(() => {
+                jest.runAllTimers();
+            });
 
             // Assert
             const image = screen.getByRole("button");
@@ -601,7 +612,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
 
             // Act
             renderQuestion(imageQuestion, apiOptions);
-            markImagesAsLoaded();
+            act(() => {
+                jest.runAllTimers();
+            });
 
             // Assert
             expect(screen.queryByText("widget title")).not.toBeInTheDocument();
@@ -639,7 +652,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
 
             // Act
             renderQuestion(imageQuestion, apiOptions);
-            markImagesAsLoaded();
+            act(() => {
+                jest.runAllTimers();
+            });
 
             // Assert
             expect(screen.getByText("widget title")).toBeVisible();

--- a/testing/image-loader-utils.ts
+++ b/testing/image-loader-utils.ts
@@ -18,18 +18,11 @@ export const mockImageLoading = () => {
                 });
             }
         }, 0);
+
         return img;
     });
 
     window.Image = mockImage as any;
-
-    // Mock fetch for loading graphie in svg-image
-    global.fetch = jest.fn(() =>
-        Promise.resolve({
-            text: () => "",
-            ok: true,
-        }),
-    ) as jest.Mock;
 
     return () => {
         window.Image = originalImage;

--- a/testing/image-loader-utils.ts
+++ b/testing/image-loader-utils.ts
@@ -19,6 +19,13 @@ export const mockImageLoading = () => {
             }
         }, 0);
 
+        global.fetch = jest.fn((url) => {
+            return Promise.resolve({
+                text: () => Promise.resolve(""),
+                ok: true,
+            });
+        }) as jest.Mock;
+
         return img;
     });
 

--- a/testing/image-loader-utils.ts
+++ b/testing/image-loader-utils.ts
@@ -1,0 +1,37 @@
+import {act} from "@testing-library/react";
+
+/**
+ * Mocks image loading done by the ImageLoader component to immediately trigger
+ * the load event.
+ * @returns A function to unmock the image loading
+ */
+export const mockImageLoading = () => {
+    const originalImage = window.Image;
+
+    const mockImage = jest.fn(() => {
+        const img = {} as HTMLImageElement;
+        // Immediately trigger onload using setTimeout to ensure it happens after render
+        setTimeout(() => {
+            if (img.onload) {
+                act(() => {
+                    img.onload!(new Event("load"));
+                });
+            }
+        }, 0);
+        return img;
+    });
+
+    window.Image = mockImage as any;
+
+    // Mock fetch for loading graphie in svg-image
+    global.fetch = jest.fn(() =>
+        Promise.resolve({
+            text: () => "",
+            ok: true,
+        }),
+    ) as jest.Mock;
+
+    return () => {
+        window.Image = originalImage;
+    };
+};


### PR DESCRIPTION
## Summary:
Adds a test to make sure the ItemDiff component will correctly render and load an Image.
A change to the dependencies API caused a regression last week, and this test would have caught it.
Unfortunately in order to ensure it catches the regression, some tricky image loading mocking has to be done.

## Test plan:
- Ensure the tests pass