### PR TITLE
Use pure markdown to parse instead of regex

### DIFF
--- a/packages/perseus-editor/src/widgets/__docs__/image-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__docs__/image-editor.stories.tsx
@@ -7,6 +7,7 @@ import {
 import * as React from "react";
 
 import {getFeatureFlags} from "../../../../../testing/feature-flags-util";
+import {earthMoonImage} from "../../../../perseus/src/widgets/image/utils";
 import EditorPageWithStorybookPreview from "../../__docs__/editor-page-with-storybook-preview";
 import {registerAllWidgetsAndEditorsForTesting} from "../../util/register-all-widgets-and-editors-for-testing";
 import ImageEditor from "../image-editor/image-editor";
@@ -15,7 +16,7 @@ import type {Meta, StoryObj} from "@storybook/react-vite";
 
 const PROD_EDITOR_WIDTH = 330;
 
-const withinEditorPageDecorator = (_, {args}) => {
+const withinEditorPageDecorator = (_, {args, parameters}) => {
     return (
         <div style={{width: PROD_EDITOR_WIDTH}}>
             <EditorPageWithStorybookPreview
@@ -26,7 +27,7 @@ const withinEditorPageDecorator = (_, {args}) => {
                     }),
                 }}
                 question={generateTestPerseusRenderer({
-                    content: "[[☃ image 1]]",
+                    content: parameters.content || "[[☃ image 1]]",
                     widgets: {
                         "image 1": generateImageWidget({
                             options: generateImageOptions({
@@ -46,7 +47,6 @@ registerAllWidgetsAndEditorsForTesting();
 const meta: Meta = {
     title: "Widgets/Image/Editor Demo",
     component: ImageEditor,
-    tags: ["!dev"],
     argTypes: {
         labels: {
             control: false,
@@ -90,13 +90,23 @@ export const Populated: Story = {
     name: "Populated (Within Editor Page)",
     decorators: [withinEditorPageDecorator],
     args: {
-        backgroundImage: {
-            url: "https://cdn.kastatic.org/ka-content-images/61831c1329dbc32036d7dd0d03e06e7e2c622718.jpg",
-            width: 400,
-            height: 225,
-        },
+        backgroundImage: earthMoonImage,
         alt: "The moon showing behind the Earth in space.",
         caption: "Captured via XYZ Telescope",
         title: "The Moon",
+    },
+};
+
+export const WithMarkdownImage: Story = {
+    name: "With Markdown Image (Within Editor Page)",
+    decorators: [withinEditorPageDecorator],
+    args: {
+        backgroundImage: earthMoonImage,
+        alt: "The moon showing behind the Earth in space.",
+        caption: "Captured via XYZ Telescope",
+        title: "The Moon",
+    },
+    parameters: {
+        content: `[[☃ image 1]]\n\n![earth and moon](${earthMoonImage.url})`,
     },
 };

--- a/packages/perseus-linter/src/rules/all-rules.ts
+++ b/packages/perseus-linter/src/rules/all-rules.ts
@@ -14,6 +14,7 @@ import HeadingSentenceCase from "./heading-sentence-case";
 import HeadingTitleCase from "./heading-title-case";
 import ImageAltText from "./image-alt-text";
 import ImageInTable from "./image-in-table";
+import ImageMarkdown from "./image-markdown";
 import ImageSpacesAroundUrls from "./image-spaces-around-urls";
 import ImageUrlEmpty from "./image-url-empty";
 import ImageWidget from "./image-widget";
@@ -47,6 +48,7 @@ export default [
     HeadingSentenceCase,
     HeadingTitleCase,
     ImageAltText,
+    ImageMarkdown,
     ImageInTable,
     LinkClickHere,
     LongParagraph,

--- a/packages/perseus-linter/src/rules/image-markdown.test.ts
+++ b/packages/perseus-linter/src/rules/image-markdown.test.ts
@@ -1,0 +1,40 @@
+import {expectWarning, expectPass} from "../__tests__/test-utils";
+
+import imageMarkdownRule from "./image-markdown";
+
+describe("image-alt-text", () => {
+    // All markdown images (format ![alt](url)) should result in a warning
+    expectWarning(imageMarkdownRule, [
+        "![]()",
+        "![](  )",
+        "![](\n)",
+        "![]('something')",
+        "![]()",
+        "![ ]()",
+        "![\n]()",
+        "![](http://google.com/)",
+        '![](http://google.com/ "title")',
+        "![ ](http://google.com/)",
+        "![ \t\n ](http://google.com/)",
+        "![blah](http://google.com/)",
+    ]);
+
+    // Text that does not contain markdown images should pass
+    expectPass(imageMarkdownRule, [
+        "!",
+        "![",
+        "![]",
+        "![](",
+        "[]()",
+        "]()",
+        "()",
+        ")",
+        "![alt-text](http://google.com", // No ending paren
+        '![alternative text](http://google.com/ "title"', // No ending paren
+        "![alt alt alt][url-ref]", // No parens
+        "![][url-ref]", // No parens
+        "!()[]", // Wrong order
+        "[]()", // link markdown, not image
+        "[link text](http://google.com)", // link markdown, not image
+    ]);
+});

--- a/packages/perseus-linter/src/rules/image-markdown.test.ts
+++ b/packages/perseus-linter/src/rules/image-markdown.test.ts
@@ -2,8 +2,9 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 
 import imageMarkdownRule from "./image-markdown";
 
-describe("image-alt-text", () => {
+describe("image-markdown", () => {
     // All markdown images (format ![alt](url)) should result in a warning
+    // when NOT inside a widget
     expectWarning(imageMarkdownRule, [
         "![]()",
         "![](  )",
@@ -37,4 +38,36 @@ describe("image-alt-text", () => {
         "[]()", // link markdown, not image
         "[link text](http://google.com)", // link markdown, not image
     ]);
+
+    // Markdown images should pass when inside a widget (e.g., Radio widget)
+    expectPass(
+        imageMarkdownRule,
+        [
+            "![](http://google.com/)",
+            "![alt text](http://example.com/image.png)",
+            "![]()",
+            "![ ](http://google.com/)",
+            "![blah](http://google.com/)",
+        ],
+        {
+            stack: ["root", "paragraph", "widget", "text", "image"],
+        },
+    );
+
+    // Additional test to ensure stack checking works correctly
+    expectPass(imageMarkdownRule, ["![test image](http://test.com/img.jpg)"], {
+        stack: ["widget", "image"],
+    });
+
+    expectPass(imageMarkdownRule, ["![test image](http://test.com/img.jpg)"], {
+        stack: ["widget"],
+    });
+
+    expectWarning(
+        imageMarkdownRule,
+        ["![test image](http://test.com/img.jpg)"],
+        {
+            stack: ["image"],
+        },
+    );
 });

--- a/packages/perseus-linter/src/rules/image-markdown.test.ts
+++ b/packages/perseus-linter/src/rules/image-markdown.test.ts
@@ -18,6 +18,8 @@ describe("image-markdown", () => {
         "![ ](http://google.com/)",
         "![ \t\n ](http://google.com/)",
         "![blah](http://google.com/)",
+        "![alt alt alt][url-ref]", // Reference image
+        "![][url-ref]", // Reference image
     ]);
 
     // Text that does not contain markdown images should pass
@@ -32,11 +34,10 @@ describe("image-markdown", () => {
         ")",
         "![alt-text](http://google.com", // No ending paren
         '![alternative text](http://google.com/ "title"', // No ending paren
-        "![alt alt alt][url-ref]", // No parens
-        "![][url-ref]", // No parens
         "!()[]", // Wrong order
         "[]()", // link markdown, not image
         "[link text](http://google.com)", // link markdown, not image
+        "![][", // Incomplete reference image
     ]);
 
     // Markdown images should pass when inside a widget (e.g., Radio widget)

--- a/packages/perseus-linter/src/rules/image-markdown.ts
+++ b/packages/perseus-linter/src/rules/image-markdown.ts
@@ -5,6 +5,12 @@ export default Rule.makeRule({
     severity: Rule.Severity.WARNING,
     selector: "image",
     lint: function (state, content, nodes, match, context) {
+        console.log("state", state);
+        console.log("content", content);
+        console.log("nodes", nodes);
+        console.log("match", match);
+        console.log("context", context);
+
         // Discourage using markdown images
         //
         // Regex for ![alt](image url):
@@ -14,6 +20,10 @@ export default Rule.makeRule({
         //   \( start of image url
         //   [^\)]* any characters except )
         //   \) end of link
+        //
+        // By confirming the markdown is inside the content paragraph, we can
+        // avoid flagging images within other widgets (e.g. Radio) that still
+        // have to use markdown.
         //
         // NOTE: Can't use PerseusMarkdown.parse() to identify the markdown
         // image because it would try to access 'allWidgets' before
@@ -25,3 +35,5 @@ Please use the Image widget instead.`;
         }
     },
 }) as Rule;
+
+// STOP!!!!! THIS DOESN'T STOP FLAGGING STUFF WITHIN RADIO WIDGETS

--- a/packages/perseus-linter/src/rules/image-markdown.ts
+++ b/packages/perseus-linter/src/rules/image-markdown.ts
@@ -5,13 +5,12 @@ export default Rule.makeRule({
     severity: Rule.Severity.WARNING,
     selector: "image",
     lint: function (state, content, nodes, match, context) {
-        console.log("state", state);
-        console.log("content", content);
-        console.log("nodes", nodes);
-        console.log("match", match);
-        console.log("context", context);
+        // Check if we're inside a widget - if so, allow markdown images.
+        if (context?.stack && context.stack.includes("widget")) {
+            return;
+        }
 
-        // Discourage using markdown images
+        // Discourage using markdown images in main content
         //
         // Regex for ![alt](image url):
         //   ![ start of image image regex/alt
@@ -20,10 +19,6 @@ export default Rule.makeRule({
         //   \( start of image url
         //   [^\)]* any characters except )
         //   \) end of link
-        //
-        // By confirming the markdown is inside the content paragraph, we can
-        // avoid flagging images within other widgets (e.g. Radio) that still
-        // have to use markdown.
         //
         // NOTE: Can't use PerseusMarkdown.parse() to identify the markdown
         // image because it would try to access 'allWidgets' before
@@ -35,5 +30,3 @@ Please use the Image widget instead.`;
         }
     },
 }) as Rule;
-
-// STOP!!!!! THIS DOESN'T STOP FLAGGING STUFF WITHIN RADIO WIDGETS

--- a/packages/perseus-linter/src/rules/image-markdown.ts
+++ b/packages/perseus-linter/src/rules/image-markdown.ts
@@ -1,0 +1,27 @@
+import Rule from "../rule";
+
+export default Rule.makeRule({
+    name: "image-markdown",
+    severity: Rule.Severity.WARNING,
+    selector: "image",
+    lint: function (state, content, nodes, match, context) {
+        // Discourage using markdown images
+        //
+        // Regex for ![alt](image url):
+        //   ![ start of image image regex/alt
+        //   [^\]]* any characters except ]
+        //   \] end of image marker
+        //   \( start of image url
+        //   [^\)]* any characters except )
+        //   \) end of link
+        //
+        // NOTE: Can't use PerseusMarkdown.parse() to identify the markdown
+        // image because it would try to access 'allWidgets' before
+        // initialization, causing an error.
+        if (context?.content.match(/!\[[^\]]*\]\([^)]*\)/)) {
+            return `No inline markdown images:
+Markdown images (![alt](url) format) are not recommended.
+Please use the Image widget instead.`;
+        }
+    },
+}) as Rule;

--- a/packages/perseus-linter/src/rules/image-widget.ts
+++ b/packages/perseus-linter/src/rules/image-widget.ts
@@ -42,24 +42,5 @@ Add a description in the "Alt Text" box of the image widget.`;
 for accessibility, all images should have descriptive alt text.
 This image's alt text is only ${alt.trim().length} characters long.`;
         }
-
-        // Discourage using markdown images
-        //
-        // Regex for ![alt](image url):
-        //   ![ start of image image regex/alt
-        //   [^\]]* any characters except ]
-        //   \] end of image marker
-        //   \( start of image url
-        //   [^\)]* any characters except )
-        //   \) end of link
-        //
-        // NOTE: Can't use PerseusMarkdown.parse() to identify the markdown
-        // image because it would try to access 'allWidgets' before
-        // initialization, causing an error.
-        if (context.content.match(/!\[[^\]]*\]\([^)]*\)/)) {
-            return `No inline markdown images:
-Markdown images (![alt](url) format) are not recommended.
-Please use the Image widget instead.`;
-        }
     },
 }) as Rule;

--- a/packages/perseus-linter/src/rules/image-widget.ts
+++ b/packages/perseus-linter/src/rules/image-widget.ts
@@ -42,5 +42,24 @@ Add a description in the "Alt Text" box of the image widget.`;
 for accessibility, all images should have descriptive alt text.
 This image's alt text is only ${alt.trim().length} characters long.`;
         }
+
+        // Discourage using markdown images
+        //
+        // Regex for ![alt](image url):
+        //   ![ start of image image regex/alt
+        //   [^\]]* any characters except ]
+        //   \] end of image marker
+        //   \( start of image url
+        //   [^\)]* any characters except )
+        //   \) end of link
+        //
+        // NOTE: Can't use PerseusMarkdown.parse() to identify the markdown
+        // image because it would try to access 'allWidgets' before
+        // initialization, causing an error.
+        if (context.content.match(/!\[[^\]]*\]\([^)]*\)/)) {
+            return `No inline markdown images:
+Markdown images (![alt](url) format) are not recommended.
+Please use the Image widget instead.`;
+        }
     },
 }) as Rule;


### PR DESCRIPTION
## Summary:
Created a new Perseus linter rule so that the editor has a warning when markdown
images are used.

Bonus - added a new story for the Image widget editor that shows this lint error.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3568

## Test plan:
`pnpm jest packages/perseus-linter/src/rules/image-markdown.test.ts`

Storybook
`/?path=/story/widgets-image-editor-demo--with-markdown-image-linter-warning`