### PR TITLE
Definition style update based on Figma designs

### DIFF
--- a/.changeset/lovely-pants-add.md
+++ b/.changeset/lovely-pants-add.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Definition style update based on Figma designs

--- a/packages/perseus/src/widgets/definition/definition.tsx
+++ b/packages/perseus/src/widgets/definition/definition.tsx
@@ -98,7 +98,7 @@ const styles = {
         color: semanticColor.core.foreground.neutral.strong,
         fontSize: font.body.size.medium,
         fontWeight: font.weight.medium,
-        lineHeight: font.body.lineHeight.large,
+        lineHeight: font.body.lineHeight.medium,
     },
 } as const;
 


### PR DESCRIPTION
## Summary:
Small update based on design feedback. Definition was previously using the `font.body.lineHeight.large`,  but after a Figma design was created, we decided the `medium` size provided a better experience.

Clicked Story Update
<img width="1212" height="345" alt="image" src="https://github.com/user-attachments/assets/98e72a4e-9394-42bc-940a-ee4f82b2594c" />


## Test plan:
- Confirm checks pass
- Check manually in Storybook