### PR TITLE
[Radio] Bugfix - Borders next to correct choices should not show

### DIFF
--- a/.changeset/shy-cats-cheat.md
+++ b/.changeset/shy-cats-cheat.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Radio] Bugfix - Borders next to correct choices should not show

--- a/packages/perseus/src/widgets/radio/__docs__/multiple-choice-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/multiple-choice-initial-state-regression.stories.tsx
@@ -23,7 +23,7 @@ type Story = StoryObj<typeof RadioQuestionRenderer>;
  */
 
 export default {
-    title: "Widgets/RadioNew/Visual Regression Tests/Static",
+    title: "Widgets/RadioNew/Visual Regression Tests/Initial State",
     component: RadioQuestionRenderer,
     tags: ["!dev"],
     parameters: {

--- a/packages/perseus/src/widgets/radio/__docs__/multiple-choice-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/multiple-choice-interactions-regression.stories.tsx
@@ -27,7 +27,7 @@ type StoryArgs = {
 >;
 
 export default {
-    title: "Widgets/RadioNew/Visual Regression Tests/Interactive",
+    title: "Widgets/RadioNew/Visual Regression Tests/Interactions",
     component: ServerItemRendererWithDebugUI,
     tags: ["!autodocs"],
     parameters: {

--- a/packages/perseus/src/widgets/radio/__docs__/multiple-choice-static-regression.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/multiple-choice-static-regression.stories.tsx
@@ -84,8 +84,10 @@ export const SingleSelectShowSolutions: Story = {
     args: {
         item: generateTestPerseusItem({
             question: radioQuestionBuilder()
-                .addChoice("Choice 1", {correct: true})
-                .addChoice("Choice 2")
+                .addChoice("Choice 1")
+                // Leaving the correct choice in the second position to test that
+                //     the first choice still has a top border.
+                .addChoice("Choice 2", {correct: true})
                 .addChoice("Choice 3")
                 .addChoice("Choice 4")
                 .build(),
@@ -245,8 +247,11 @@ export const MultiSelectShowSolutions: Story = {
         item: generateTestPerseusItem({
             question: radioQuestionBuilder()
                 .addChoice("Choice 1", {correct: true})
-                .addChoice("Choice 2", {correct: true})
-                .addChoice("Choice 3")
+                // Tests that borders between separate correct answers are hidden properly
+                .addChoice("Choice 2")
+                .addChoice("Choice 3", {correct: true})
+                // Leaving the last choice as not correct to test that there is still a bottom border
+                // (i.e. the removal of the border only affects the top of the choice, not the whole choice.)
                 .addChoice("Choice 4")
                 .withMultipleSelect(true)
                 .build(),

--- a/packages/perseus/src/widgets/radio/choice.module.css
+++ b/packages/perseus/src/widgets/radio/choice.module.css
@@ -140,6 +140,26 @@
     cursor: default;
 }
 
+/* Don't show borders for choices that come after a correct choice.
+   Here, the "choices that come after" is defined by the sibling selector:
+        + :not(.is-correct)
+   However, we only want to affect the top border of the sibling,
+     which is in the :before pseudo-element:
+        + :not(.is-correct):before
+*/
+.is-correct + :not(.is-correct):before {
+    --perseus-multiple-choice-divider-width: 0;
+}
+
+/* Don't show borders for choices that come before a correct choice.
+   Here, we want to affect the siblings "that come before", so we use :has().
+   This reads as "apply to any element that 'has' a sibling that 'is-correct'".
+   It also only applies the style change to the :after pseudo-element (the bottom border).
+*/
+:not(.is-correct):has(+ .is-correct):after {
+    --perseus-multiple-choice-divider-width: 0;
+}
+
 /**************
  LEGACY STYLING
  **************/


### PR DESCRIPTION
## Summary:
The choice borders next to a correct choice (when in review mode) should not be visible as it is distracting. This PR adjusts the styling to account for these situations.

Issue: LEMS-3456

## Test plan:
1. Open Storybook (use the link in this PR)
2. View the regression stories that "show solutions"
   - Single Select: Widgets => RadioNew => Visual Regression Tests => Initial State => Single Select Show Solutions
   - Multiple Select: Widgets => RadioNew => Visual Regression Tests => Initial State => Multiple Select Show Solutions
3. Notice that the horizontal borders between choices is not visible above and below choices that are marked correct

## Affected UI:
### Before
<img width="246" height="331" alt="Screenshot 2025-10-02 at 3 10 51 PM" src="https://github.com/user-attachments/assets/5f7443b2-b070-4059-8f72-dbc69566e404" />

### After
<img width="267" height="324" alt="Screenshot 2025-10-02 at 3 12 25 PM" src="https://github.com/user-attachments/assets/ac18c8b4-cca6-4b8d-b64f-cf9424dd9666" />
