### PR TITLE
[Radio] Bugfix - Additional space needed between choice text and rationale

### DIFF
--- a/.changeset/loud-planets-rescue.md
+++ b/.changeset/loud-planets-rescue.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Radio] Bugfix - Additional space needed between choice text and rationale

--- a/packages/perseus/src/widgets/radio/__docs__/multiple-choice-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/multiple-choice-initial-state-regression.stories.tsx
@@ -119,6 +119,15 @@ export const SingleSelectWithPassageRef: Story = {
     },
 };
 
+export const SingleSelectWithRationale = {
+    args: {
+        item: generateTestPerseusItem({
+            question: questionWithPassage,
+        }),
+        showSolutions: "all",
+    },
+};
+
 export const SingleSelectWithImages: Story = {
     args: {
         item: generateTestPerseusItem({

--- a/packages/perseus/src/widgets/radio/multiple-choice.module.css
+++ b/packages/perseus/src/widgets/radio/multiple-choice.module.css
@@ -84,7 +84,7 @@
 .content {
     display: flex;
     flex-direction: column;
-    gap: calc(var(--perseus-multiple-choice-indicator-font-size) / 4);
+    gap: var(--wb-sizing-size_080);
     margin-inline-start: var(--perseus-multiple-choice-content-margin);
     position: relative; /* Needed to enable the z-index to work */
     z-index: -1; /* Ensures that the content is below the indicator and scroll fade */


### PR DESCRIPTION
## Summary:
Additional space is needed between the choice content and the rationale for that choice. This is being done instead of indenting the rationale, per design.

Issue: LEMS-3455

## Test plan:
1. Open Storyboook (use the link from this PR)
2. Open a story that has rationale
   - For instance: Widgets => RadioNew => Visual Regression Tests => Initial State => Single Select With Rationale
3. Notice the small amount of additional space between the content and rationale