### PR TITLE
[Radio] Bugfix - Selected choices don't turn blue when in articles

### DIFF
--- a/.changeset/violet-files-accept.md
+++ b/.changeset/violet-files-accept.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Radio] Bugfix - Selected choices don't turn blue when in articles

--- a/packages/perseus/src/widgets/radio/__docs__/multiple-choice-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/multiple-choice-interactions-regression.stories.tsx
@@ -3,6 +3,8 @@ import * as React from "react";
 
 import {getFeatureFlags} from "../../../../../../testing/feature-flags-util";
 import {ServerItemRendererWithDebugUI} from "../../../../../../testing/server-item-renderer-with-debug-ui";
+import {storybookDependenciesV2} from "../../../../../../testing/test-dependencies";
+import ArticleRenderer from "../../../article-renderer";
 import {groupedRadioRationaleQuestion} from "../../graded-group/graded-group.testdata";
 import {
     choicesWithMathFont,
@@ -148,6 +150,36 @@ export const ChoiceTextColorInMultipleSelect = {
         await userEvent.click(choiceToClick);
         choiceToClick.blur();
     },
+};
+
+export const ChoiceTextColorInArticle = (): React.ReactNode => {
+    const question = radioQuestionBuilder()
+        .withContent(
+            "Exceeding reaction chamber thermal limit. We have begun power-supply calibration. Force fields have been established on all turbo lifts and crawlways. Computer, run a level-two diagnostic on warp-drive systems. Antimatter containment positive. Warp drive within normal parameters. I read an ion trail characteristic of a freighter escape pod. The bomb had a molecular-decay detonator. Detecting some unusual fluctuations in subspace frequencies.\n\n" +
+                "We're acquainted with the wormhole phenomenon, but this... Is a remarkable piece of bio-electronic engineering by which I see much of the EM spectrum ranging from heat and infrared through radio waves, et cetera, and forgive me if I've said and listened to this a thousand times. This planet's interior heat provides an abundance of geothermal energy. We need to neutralize the homing signal.\n\n" +
+                "A level-two diagnostic was ordered for what system?\n\n[[☃ radio 1]]",
+        )
+        .addChoice("Antimatter containment")
+        .addChoice("Warp drive", {correct: true})
+        .addChoice("Force fields")
+        .addChoice("Reflector dish")
+        .build();
+    const apiOptions = {flags: getFeatureFlags({"new-radio-widget": true})};
+    return (
+        <ArticleRenderer
+            apiOptions={apiOptions}
+            json={question}
+            useNewStyles
+            dependencies={storybookDependenciesV2}
+        />
+    );
+};
+ChoiceTextColorInArticle.play = async ({canvas}) => {
+    // eslint-disable-next-line testing-library/prefer-screen-queries
+    const choiceToToggle = canvas.getByRole("button", {
+        name: /Warp drive$/,
+    });
+    choiceToToggle.click();
 };
 
 export const FocusSingleSelect = {

--- a/packages/perseus/src/widgets/radio/choice.module.css
+++ b/packages/perseus/src/widgets/radio/choice.module.css
@@ -9,10 +9,11 @@
         line-height: inherit;
     }
 
-    &:global(.perseus-article)
-    .choice:not(.is-correct):has(> button[aria-pressed="true"])
-    :global(.paragraph) {
-        color: var(--wb-semanticColor-core-foreground-instructive-default);
+    &:global(.perseus-article) {
+        .choice:not(.is-correct):has(> button[aria-pressed="true"])
+            :global(.paragraph) {
+            color: var(--wb-semanticColor-core-foreground-instructive-default);
+        }
     }
 }
 

--- a/packages/perseus/src/widgets/radio/choice.module.css
+++ b/packages/perseus/src/widgets/radio/choice.module.css
@@ -8,6 +8,12 @@
         font-weight: inherit;
         line-height: inherit;
     }
+
+    &:global(.perseus-article)
+    .choice:not(.is-correct):has(> button[aria-pressed="true"])
+    :global(.paragraph) {
+        color: var(--wb-semanticColor-core-foreground-instructive-default);
+    }
 }
 
 .choice {


### PR DESCRIPTION
## Summary:
Articles have extra styling that is overly broad, which prevents content in a multiple choice content from turning blue when selected. This PR adds a style rule with higher specificity to override it.

Issue: LEMS-3485

## Test plan: