### PR TITLE
Revert "Resolving the cursor jumping in the Editor bug  (#2976)"

### DIFF
--- a/.changeset/mean-moles-poke.md
+++ b/.changeset/mean-moles-poke.md
@@ -1,5 +1,0 @@
----
-"@khanacademy/perseus-editor": minor
----
-
-Resolving a long-standing Perseus Editor cursor jumping bug by removing the debounce on changes in the Editor and moving it upstream.

--- a/.changeset/tough-deers-rescue.md
+++ b/.changeset/tough-deers-rescue.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Reverting Editor Cursor Bouncing Fix

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -162,6 +162,7 @@ type State = {
 // eslint-disable-next-line react/no-unsafe
 class Editor extends React.Component<Props, State> {
     lastUserValue: string | null | undefined;
+    deferredChange: any | null | undefined;
     widgetIds: any | null | undefined;
 
     underlay = React.createRef<HTMLDivElement>();
@@ -248,6 +249,12 @@ class Editor extends React.Component<Props, State> {
         if (this.props.content !== prevProps.content) {
             this._sizeImages(this.props);
         }
+    }
+
+    componentWillUnmount() {
+        // TODO(jeff, CP-3128): Use Wonder Blocks Timing API.
+        // eslint-disable-next-line no-restricted-syntax
+        clearTimeout(this.deferredChange);
     }
 
     getWidgetEditor(
@@ -434,11 +441,17 @@ class Editor extends React.Component<Props, State> {
     handleChange: (e: React.SyntheticEvent<HTMLTextAreaElement>) => void = (
         e: React.SyntheticEvent<HTMLTextAreaElement>,
     ) => {
-        const newValue = e.currentTarget.value;
-        this.setState({textAreaValue: newValue});
-        if (newValue !== this.props.content) {
-            this.props.onChange({content: newValue});
-        }
+        // TODO(jeff, CP-3128): Use Wonder Blocks Timing API.
+        // eslint-disable-next-line no-restricted-syntax
+        clearTimeout(this.deferredChange);
+        this.setState({textAreaValue: e.currentTarget.value});
+        // TODO(jeff, CP-3128): Use Wonder Blocks Timing API.
+        // eslint-disable-next-line no-restricted-syntax
+        this.deferredChange = setTimeout(() => {
+            if (this.state.textAreaValue !== this.props.content) {
+                this.props.onChange({content: this.state.textAreaValue});
+            }
+        }, this.props.apiOptions.editorChangeDelay);
     };
 
     _handleKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void = (


### PR DESCRIPTION
## Summary:
This reverts commit 9f9bb2327634a0fc21970fce4ac085a0d8e9a235, AKA the work that removed the Perseus-side debouncing. This is due to some issues with specific inputs in various widget editors experiencing a worsening of the issue, as they do not have a local state. 

## Test plan:
- tests pass 
- manual testing upstream