### PR TITLE
Delete `ServerItemRenderer.getUserInputLegacy()`

### DIFF
--- a/.changeset/short-games-behave.md
+++ b/.changeset/short-games-behave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": major
+---
+
+Remove the deprecated `getUserInputLegacy()` method of `ServerItemRenderer`. Callers should use `getUserInput()` instead.

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -37,7 +37,6 @@ import type {
     ShowSolutions,
     KeypadContextRendererInterface,
     RendererInterface,
-    UserInput,
     UserInputMap,
 } from "@khanacademy/perseus-core";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
@@ -280,19 +279,6 @@ export class ServerItemRenderer
 
     getPromptJSON(): RendererPromptJSON {
         return this.questionRenderer.getPromptJSON();
-    }
-
-    /**
-     * Returns an array of the widget `.getUserInput()` results
-     *
-     * TODO: can we remove this? Seems to be just for backwards
-     * compatibility with old Perseus Chrome logging
-     * @deprecated use getUserInput
-     */
-    getUserInputLegacy(): UserInput[] {
-        const userInputMap = this.questionRenderer.getUserInputMap();
-        const widgetIds = this.questionRenderer.getWidgetIds();
-        return widgetIds.map((id) => userInputMap[id]);
     }
 
     /**

--- a/testing/item-renderer-hooks.tsx
+++ b/testing/item-renderer-hooks.tsx
@@ -100,11 +100,11 @@ export const useItemRenderer = (
             "en",
         );
 
+        const widgetIds = renderer.getWidgetIds();
+        const userInputArray = widgetIds.map((id) => userInput[id]);
+
         // Continue to include an empty guess for the now defunct answer area.
-        const maxCompatGuess: [UserInput[], []] = [
-            renderer.getUserInputLegacy(),
-            [],
-        ];
+        const maxCompatGuess: [UserInput[], []] = [userInputArray, []];
 
         const keScore = keScoreFromPerseusScore(
             score,


### PR DESCRIPTION
## Summary:
This method was deprecated, and is no longer used by any callers within Khan
Academy.

Issue: LEMS-2523

## Test plan:

CI should be green.