### PR TITLE
Give `nodeWarnings` a real type instead of `any[]`

### DIFF
--- a/.changeset/chilled-nails-type.md
+++ b/.changeset/chilled-nails-type.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-linter": patch
+---
+
+Internal: improve type safety.

--- a/packages/perseus-linter/src/rule.ts
+++ b/packages/perseus-linter/src/rule.ts
@@ -152,7 +152,7 @@ export type LinterWarning = {
     start: number;
     end: number;
     target?: string;
-    severity?: number;
+    severity: number;
     metadata?: Record<string, any>;
 };
 
@@ -346,6 +346,7 @@ export default class Rule {
             // a rule was failing.
             return {
                 rule: "lint-rule-failure",
+                severity: this.severity,
                 message: `Exception in rule ${this.name}: ${e.message}
 Stack trace:
 ${e.stack}`,

--- a/packages/perseus-linter/src/run-linter.ts
+++ b/packages/perseus-linter/src/run-linter.ts
@@ -211,8 +211,8 @@ export function runLinter(
                 const content = node.content; // Text nodes have content
                 const warning = nodeWarnings[0]; // There is only one warning.
                 // These are the lint boundaries within the content
-                const start = warning.start || 0;
-                const end = warning.end || content.length;
+                const start = warning.start;
+                const end = warning.end;
                 const prefix = content.substring(0, start);
                 const lint = content.substring(start, end);
                 const suffix = content.substring(end);

--- a/packages/perseus-linter/src/run-linter.ts
+++ b/packages/perseus-linter/src/run-linter.ts
@@ -66,14 +66,14 @@ export function runLinter(
     // issue too. But using JavaScript has its own downsides: there is
     // risk that the linter JavaScript would interfere with
     // widget-related Javascript.
-    let tableWarnings: Array<LinterWarning> = [];
+    let tableWarnings: LinterWarning[] = [];
     let insideTable = false;
 
     // Traverse through the nodes of the parse tree. At each node, loop
     // through the array of lint rules and check whether there is a
     // lint violation at that node.
     tt.traverse((node, state, content) => {
-        const nodeWarnings: Array<any> = [];
+        const nodeWarnings: LinterWarning[] = [];
 
         // If our rule is only designed to be tested against a particular
         // content type and we're not in that content type, we don't need to


### PR DESCRIPTION
## Summary:
I told Claude to fix a TODO of its choice. It tried to get rid of an `any` type
in the linter... and bungled it.  As I was trying to fix up the result, I
discovered this lower-hanging fruit.

Issue: none

## Test plan:

Lint errors should still appear in the editor.