### PR TITLE
Remove unused default value for polygon points

### DIFF
--- a/.changeset/bright-planes-bake.md
+++ b/.changeset/bright-planes-bake.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: remove unused default value for polygon graph point coordinates

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -101,12 +101,8 @@ const PolygonGraph = (props: Props) => {
     } = graphConfig;
     const [[left, top]] = useTransformVectorsToPixels([x[0], y[1]]);
 
-    // TODO(benchristel): can the default set of points be removed here? I don't
-    // think coords can be null.
-    const points = coords ?? [[0, 0]];
-
     // Logic to build the dragging experience. Primarily used by Limited Polygon.
-    const dragReferencePoint = points[0];
+    const dragReferencePoint = coords[0];
     const constrain: KeyboardMovementConstraint =
         getKeyboardMovementConstraintForPolygon(snapStep, snapTo);
 
@@ -157,7 +153,7 @@ const PolygonGraph = (props: Props) => {
         left,
         top,
         dragging,
-        points,
+        points: coords,
         hovered,
         setHovered,
         focusVisible,


### PR DESCRIPTION
## Summary:
This fixes a TODO comment. `coords` can't be null or undefined here.

Issue: none

## Test plan:

CI checks should pass.