### PR TITLE
Remove orphaned widgets from PerseusRenderers when parsing

### DIFF
--- a/.changeset/fast-guests-hope.md
+++ b/.changeset/fast-guests-hope.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": minor
+---
+
+Widgets that are "orphaned" (i.e. not referenced in the content string of their parent Renderer) are now removed during parsing.

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-renderer.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-renderer.test.ts
@@ -1,0 +1,55 @@
+import {PerseusRenderer} from "@khanacademy/perseus-core";
+import {parsePerseusRenderer} from "./perseus-renderer";
+import {assertSuccess} from "../result";
+import {ctx} from "../general-purpose-parsers/test-helpers";
+
+describe("parsePerseusRenderer", () => {
+    it("removes an orphaned widget", () => {
+        const renderer: PerseusRenderer = {
+            content: "",
+            images: {},
+            widgets: {
+                "radio 1": {
+                    type: "radio",
+                    version: {major: 3, minor: 0},
+                    options: {
+                        choices: [{
+                            id: "1",
+                            content: "A",
+                        }],
+                    },
+                },
+            },
+        }
+
+        const result = parsePerseusRenderer(renderer, ctx());
+        assertSuccess(result)
+
+        // Assert: the radio widget is removed because it's not referenced.
+        expect(result.value.widgets).toEqual({});
+    });
+
+    it("keeps widgets that are referenced in the `content`", () => {
+        const renderer: PerseusRenderer = {
+            content: "[[☃ radio 1]]",
+            images: {},
+            widgets: {
+                "radio 1": {
+                    type: "radio",
+                    version: {major: 3, minor: 0},
+                    options: {
+                        choices: [{
+                            id: "1",
+                            content: "A",
+                        }],
+                    },
+                },
+            },
+        }
+
+        const result = parsePerseusRenderer(renderer, ctx());
+        assertSuccess(result)
+
+        expect(result.value.widgets).toHaveProperty("radio 1");
+    })
+})

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-renderer.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-renderer.test.ts
@@ -1,7 +1,9 @@
-import {PerseusRenderer} from "@khanacademy/perseus-core";
-import {parsePerseusRenderer} from "./perseus-renderer";
-import {assertSuccess} from "../result";
 import {ctx} from "../general-purpose-parsers/test-helpers";
+import {assertSuccess} from "../result";
+
+import {parsePerseusRenderer} from "./perseus-renderer";
+
+import type {PerseusRenderer} from "../../data-schema";
 
 describe("parsePerseusRenderer", () => {
     it("removes an orphaned widget", () => {
@@ -13,17 +15,19 @@ describe("parsePerseusRenderer", () => {
                     type: "radio",
                     version: {major: 3, minor: 0},
                     options: {
-                        choices: [{
-                            id: "1",
-                            content: "A",
-                        }],
+                        choices: [
+                            {
+                                id: "1",
+                                content: "A",
+                            },
+                        ],
                     },
                 },
             },
-        }
+        };
 
         const result = parsePerseusRenderer(renderer, ctx());
-        assertSuccess(result)
+        assertSuccess(result);
 
         // Assert: the radio widget is removed because it's not referenced.
         expect(result.value.widgets).toEqual({});
@@ -38,18 +42,20 @@ describe("parsePerseusRenderer", () => {
                     type: "radio",
                     version: {major: 3, minor: 0},
                     options: {
-                        choices: [{
-                            id: "1",
-                            content: "A",
-                        }],
+                        choices: [
+                            {
+                                id: "1",
+                                content: "A",
+                            },
+                        ],
                     },
                 },
             },
-        }
+        };
 
         const result = parsePerseusRenderer(renderer, ctx());
-        assertSuccess(result)
+        assertSuccess(result);
 
         expect(result.value.widgets).toHaveProperty("radio 1");
-    })
-})
+    });
+});

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-renderer.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-renderer.ts
@@ -1,4 +1,5 @@
-import {any, object, string} from "../general-purpose-parsers";
+import {any, object, pipeParsers, string} from "../general-purpose-parsers";
+import {convert} from "../general-purpose-parsers/convert";
 import {defaulted} from "../general-purpose-parsers/defaulted";
 
 import {parseImages} from "./images-map";
@@ -7,27 +8,33 @@ import {parseWidgetsMap} from "./widgets-map";
 import type {PerseusRenderer} from "../../data-schema";
 import type {Parser} from "../parser-types";
 
-export const parsePerseusRenderer: Parser<PerseusRenderer> = defaulted(
-    object({
-        // TODO(benchristel): content is also defaulted to empty string in
-        // renderer.tsx. See if we can remove one default or the other.
-        content: defaulted(string, () => ""),
-        // This module has an import cycle with parseWidgetsMap, because the
-        // `group` widget can contain another renderer.
-        // The anonymous function below ensures that we don't try to access
-        // parseWidgetsMap before it's defined.
-        widgets: defaulted(
-            (rawVal, ctx) => parseWidgetsMap(rawVal, ctx),
-            () => ({}),
-        ),
-        images: parseImages,
-        // deprecated
-        metadata: any,
-    }),
-    // Default value
-    () => ({
-        content: "",
-        widgets: {},
-        images: {},
-    }),
-);
+const parseRenderer = object({
+    // TODO(benchristel): content is also defaulted to empty string in
+    // renderer.tsx. See if we can remove one default or the other.
+    content: defaulted(string, () => ""),
+    // This module has an import cycle with parseWidgetsMap, because the
+    // `group` widget can contain another renderer.
+    // The anonymous function below ensures that we don't try to access
+    // parseWidgetsMap before it's defined.
+    widgets: defaulted(
+        (rawVal, ctx) => parseWidgetsMap(rawVal, ctx),
+        () => ({}),
+    ),
+    images: parseImages,
+    // deprecated
+    metadata: any,
+});
+
+const createDefaultRenderer = () => ({
+    content: "",
+    widgets: {},
+    images: {},
+});
+
+function removeOrphanedWidgets(renderer: PerseusRenderer): PerseusRenderer {
+    return renderer;
+}
+
+export const parsePerseusRenderer: Parser<PerseusRenderer> = pipeParsers(
+    defaulted(parseRenderer, createDefaultRenderer),
+).then(convert(removeOrphanedWidgets)).parser;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-renderer.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-renderer.ts
@@ -1,3 +1,5 @@
+import {getWidgetIdsFromContent} from "../../utils/widget-id-utils";
+
 import {any, object, pipeParsers, string} from "../general-purpose-parsers";
 import {convert} from "../general-purpose-parsers/convert";
 import {defaulted} from "../general-purpose-parsers/defaulted";
@@ -7,7 +9,6 @@ import {parseWidgetsMap} from "./widgets-map";
 
 import type {PerseusRenderer, PerseusWidgetsMap} from "../../data-schema";
 import type {Parser} from "../parser-types";
-import {getWidgetIdsFromContent} from "@khanacademy/perseus-core";
 
 const parseRenderer = object({
     // TODO(benchristel): content is also defaulted to empty string in
@@ -33,11 +34,11 @@ const createDefaultRenderer = () => ({
 });
 
 function removeOrphanedWidgets(renderer: PerseusRenderer): PerseusRenderer {
-    const referencedWidgetIds = getWidgetIdsFromContent(renderer.content)
+    const referencedWidgetIds = getWidgetIdsFromContent(renderer.content);
 
-    const referencedWidgets: PerseusWidgetsMap = {}
+    const referencedWidgets: PerseusWidgetsMap = {};
     for (const id of referencedWidgetIds) {
-        referencedWidgets[id] = renderer.widgets[id]
+        referencedWidgets[id] = renderer.widgets[id];
     }
 
     return {

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-renderer.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-renderer.ts
@@ -1,5 +1,4 @@
 import {getWidgetIdsFromContent} from "../../utils/widget-id-utils";
-
 import {any, object, pipeParsers, string} from "../general-purpose-parsers";
 import {convert} from "../general-purpose-parsers/convert";
 import {defaulted} from "../general-purpose-parsers/defaulted";

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-renderer.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/perseus-renderer.ts
@@ -5,8 +5,9 @@ import {defaulted} from "../general-purpose-parsers/defaulted";
 import {parseImages} from "./images-map";
 import {parseWidgetsMap} from "./widgets-map";
 
-import type {PerseusRenderer} from "../../data-schema";
+import type {PerseusRenderer, PerseusWidgetsMap} from "../../data-schema";
 import type {Parser} from "../parser-types";
+import {getWidgetIdsFromContent} from "@khanacademy/perseus-core";
 
 const parseRenderer = object({
     // TODO(benchristel): content is also defaulted to empty string in
@@ -32,7 +33,17 @@ const createDefaultRenderer = () => ({
 });
 
 function removeOrphanedWidgets(renderer: PerseusRenderer): PerseusRenderer {
-    return renderer;
+    const referencedWidgetIds = getWidgetIdsFromContent(renderer.content)
+
+    const referencedWidgets: PerseusWidgetsMap = {}
+    for (const id of referencedWidgetIds) {
+        referencedWidgets[id] = renderer.widgets[id]
+    }
+
+    return {
+        ...renderer,
+        widgets: referencedWidgets,
+    };
 }
 
 export const parsePerseusRenderer: Parser<PerseusRenderer> = pipeParsers(


### PR DESCRIPTION
Perseus renderers sometimes contain entries in the `widgets` map that
are not referenced in the `content` string. I'm not sure if this
happens due to a bug in the editors, or because people are manually
editing the JSON.

In any case, these unused widgets are confusing to humans and LLMs
alike. This PR removes them during parsing.

Issue: LEMS-3983

## Test plan:

Verify there are no regressions in the editor related to:

- cut/copy and paste of content including widgets
- undoing (with ctrl+Z) a change that deletes or adds a widget