### PR TITLE
[ Interactive Graph | Vector Graph ] PR1: Type Definitions and Schema

### DIFF
--- a/.changeset/heavy-deers-whisper.md
+++ b/.changeset/heavy-deers-whisper.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-core": minor
+"@khanacademy/perseus-editor": minor
+---
+
+Creation of initial types and stubs for Vector graph

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1110,7 +1110,8 @@ export type PerseusGraphType =
     | PerseusGraphTypeSinusoid
     | PerseusGraphTypeExponential
     | PerseusGraphTypeTangent
-    | PerseusGraphTypeLogarithm;
+    | PerseusGraphTypeLogarithm
+    | PerseusGraphTypeVector;
 
 export type PerseusGraphTypeAngle = {
     type: "angle";
@@ -1277,6 +1278,14 @@ export type PerseusGraphTypeRay = {
     startCoords?: CollinearTuple;
 };
 
+export type PerseusGraphTypeVector = {
+    type: "vector";
+    /** The tail and tip coordinates of the vector: [tail, tip] */
+    coords?: CollinearTuple | null;
+    /** The initial coordinates the graph renders with. */
+    startCoords?: CollinearTuple;
+};
+
 type AbsoluteValueGraphCorrect = {
     type: "absolute-value";
     coords: [Coord, Coord];
@@ -1357,6 +1366,11 @@ type RayGraphCorrect = {
     coords: CollinearTuple;
 };
 
+type VectorGraphCorrect = {
+    type: "vector";
+    coords: CollinearTuple;
+};
+
 export type PerseusGraphCorrectType =
     | AbsoluteValueGraphCorrect
     | AngleGraphCorrect
@@ -1372,7 +1386,8 @@ export type PerseusGraphCorrectType =
     | SinusoidGraphCorrect
     | ExponentialGraphCorrect
     | TangentGraphCorrect
-    | LogarithmGraphCorrect;
+    | LogarithmGraphCorrect
+    | VectorGraphCorrect;
 
 /** Options for the label-image widget. Asks learners to label image parts. */
 export type PerseusLabelImageWidgetOptions = {

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1284,6 +1284,10 @@ export type PerseusGraphTypeVector = {
     coords?: CollinearTuple | null;
     /** The initial coordinates the graph renders with. */
     startCoords?: CollinearTuple;
+    /** How to match the answer.
+     *  "exact" (default) — both tail and tip must match exactly.
+     *  "congruent" — same direction and magnitude, any position. */
+    match?: "exact" | "congruent";
 };
 
 type AbsoluteValueGraphCorrect = {
@@ -1369,6 +1373,10 @@ type RayGraphCorrect = {
 type VectorGraphCorrect = {
     type: "vector";
     coords: CollinearTuple;
+    /** How to match the answer.
+     *  "exact" (default) — both tail and tip must match exactly.
+     *  "congruent" — same direction and magnitude, any position. */
+    match?: "exact" | "congruent";
 };
 
 export type PerseusGraphCorrectType =

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -149,6 +149,12 @@ const parsePerseusGraphTypeLogarithm = object({
     ),
 });
 
+const parsePerseusGraphTypeVector = object({
+    type: constant("vector"),
+    coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
+    startCoords: optional(pair(pairOfNumbers, pairOfNumbers)),
+});
+
 export const parsePerseusGraphType = discriminatedUnionOn("type")
     .withBranch("absolute-value", parsePerseusGraphTypeAbsoluteValue)
     .withBranch("angle", parsePerseusGraphTypeAngle)
@@ -164,7 +170,8 @@ export const parsePerseusGraphType = discriminatedUnionOn("type")
     .withBranch("segment", parsePerseusGraphTypeSegment)
     .withBranch("sinusoid", parsePerseusGraphTypeSinusoid)
     .withBranch("tangent", parsePerseusGraphTypeTangent)
-    .withBranch("logarithm", parsePerseusGraphTypeLogarithm).parser;
+    .withBranch("logarithm", parsePerseusGraphTypeLogarithm)
+    .withBranch("vector", parsePerseusGraphTypeVector).parser;
 
 const parseLockedFigureColor = enumeration(...lockedFigureColorNames);
 

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -153,6 +153,7 @@ const parsePerseusGraphTypeVector = object({
     type: constant("vector"),
     coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
     startCoords: optional(pair(pairOfNumbers, pairOfNumbers)),
+    match: optional(enumeration("exact", "congruent")),
 });
 
 export const parsePerseusGraphType = discriminatedUnionOn("type")

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -573,6 +573,9 @@ function mergeGraphs(
         case "logarithm":
             invariant(b.type === "logarithm");
             return {...a, ...b};
+        case "vector":
+            invariant(b.type === "vector");
+            return {...a, ...b};
         default:
             throw new UnreachableCaseError(a);
     }

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.ts
@@ -300,6 +300,7 @@ export const shouldShowStartCoordsUI = (
         case "sinusoid":
         case "absolute-value":
         case "logarithm":
+        case "vector":
             return true;
         default:
             throw new UnreachableCaseError(graph);

--- a/packages/perseus/src/widget-ai-utils/interactive-graph/interactive-graph-ai-utils.ts
+++ b/packages/perseus/src/widget-ai-utils/interactive-graph/interactive-graph-ai-utils.ts
@@ -328,6 +328,11 @@ const getGraphOptionsForProps = (
                 type: props.userInput.type,
                 startCoords: props.userInput.startCoords,
             };
+        case "vector":
+            return {
+                type: props.userInput.type,
+                startCoords: props.userInput.startCoords,
+            };
         default:
             throw new UnreachableCaseError(type);
     }
@@ -398,6 +403,10 @@ const getUserInput = (userInput: PerseusGraphType): UserInput => {
             return {
                 coords: userInput.coords,
                 asymptote: userInput.asymptote,
+            };
+        case "vector":
+            return {
+                coords: userInput.coords,
             };
         default:
             throw new UnreachableCaseError(type);

--- a/packages/perseus/src/widget-ai-utils/interactive-graph/interactive-graph-ai-utils.ts
+++ b/packages/perseus/src/widget-ai-utils/interactive-graph/interactive-graph-ai-utils.ts
@@ -92,6 +92,11 @@ type LogarithmGraphOptions = {
     startCoords?: {coords: readonly [Coord, Coord]; asymptote: number};
 };
 
+type VectorGraphOptions = {
+    type: "vector";
+    startCoords?: CollinearTuple;
+};
+
 type NoneGraphOptions = Record<string, never>;
 
 type GraphOptions =
@@ -109,7 +114,8 @@ type GraphOptions =
     | SegmentGraphOptions
     | SinusoidGraphOptions
     | TangentGraphOptions
-    | LogarithmGraphOptions;
+    | LogarithmGraphOptions
+    | VectorGraphOptions;
 
 type AngleUserInput = {
     coords?: readonly [Coord, Coord, Coord];
@@ -175,6 +181,10 @@ type TangentUserInput = {
     coords?: readonly Coord[] | null;
 };
 
+type VectorUserInput = {
+    coords?: CollinearTuple | null;
+};
+
 type UserInput =
     | AbsoluteValueUserInput
     | AngleUserInput
@@ -189,7 +199,8 @@ type UserInput =
     | SegmentUserInput
     | SinusoidUserInput
     | TangentUserInput
-    | LogarithmUserInput;
+    | LogarithmUserInput
+    | VectorUserInput;
 
 /**
  * JSON describing an interactive graph widget. Intended for consumption by AI tools.

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.tsx
@@ -616,6 +616,8 @@ class InteractiveGraph extends React.Component<Props, State> {
                 return InteractiveGraph.getTangentEquationString(props);
             case "logarithm":
                 return InteractiveGraph.getLogarithmEquationString(props);
+            case "vector":
+                return "";
             default:
                 throw new UnreachableCaseError(type);
         }

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -780,6 +780,8 @@ const renderGraphElements = (props: {
             return renderTangentGraph(state, dispatch, i18n);
         case "logarithm":
             return renderLogarithmGraph(state, dispatch, i18n);
+        case "vector":
+            throw new Error("Not implemented");
         default:
             throw new UnreachableCaseError(type);
     }

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-state-to-interactive-graph.ts
@@ -117,6 +117,12 @@ export function mafsStateToInteractiveGraph(
                 coords: state.coords,
                 asymptote: state.asymptote,
             };
+        case "vector":
+            invariant(originalGraph.type === "vector");
+            return {
+                ...originalGraph,
+                coords: state.coords,
+            };
         default:
             throw new UnreachableCaseError(state);
     }

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
@@ -153,6 +153,8 @@ export function initializeGraphState(
                 type: graph.type,
                 ...getLogarithmCoords(graph, range, step),
             };
+        case "vector":
+            throw new Error("Not implemented");
         default:
             throw new UnreachableCaseError(graph);
     }

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -316,6 +316,7 @@ function doMovePointInFigure(
         case "tangent":
         case "exponential":
         case "logarithm":
+        case "vector":
             throw new Error(
                 `Don't use movePointInFigure for ${state.type} graphs. Use movePoint instead!`,
             );

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -92,7 +92,7 @@ export interface RayGraphState extends InteractiveGraphStateCommon {
     coords: PairOfPoints;
 }
 
-export interface VectorGraphState extends InteractiveGraphStateCommon {
+interface VectorGraphState extends InteractiveGraphStateCommon {
     type: "vector";
     coords: PairOfPoints;
 }

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -43,7 +43,8 @@ export type InteractiveGraphState =
     | SinusoidGraphState
     | ExponentialGraphState
     | TangentGraphState
-    | LogarithmGraphState;
+    | LogarithmGraphState
+    | VectorGraphState;
 
 export type UnlimitedGraphState = PointGraphState | PolygonGraphState;
 
@@ -88,6 +89,11 @@ export interface PointGraphState extends InteractiveGraphStateCommon {
 
 export interface RayGraphState extends InteractiveGraphStateCommon {
     type: "ray";
+    coords: PairOfPoints;
+}
+
+export interface VectorGraphState extends InteractiveGraphStateCommon {
+    type: "vector";
     coords: PairOfPoints;
 }
 


### PR DESCRIPTION
## Summary

_This PR was created with the help of AI, albeit with heavy oversight and review._

This is part of a series of PRs implementing the vector graph type for the Interactive Graph widget:

▶️ PR1 – type definitions and schema (this PR)
PR2 – state management
PR3 – rendering & accessibility
PR4 – scoring
PR5 – editor support

**Issue:** [LEMS-3971](https://khanacademy.atlassian.net/browse/LEMS-3971)

*   Added type definitions and schema for the vector graph type
*   Added the foundational type scaffolding needed to support a vector graph in the Interactive Graph widget. This is a pure additive change — no runtime behavior is altered and all existing tests continue to pass.

### Changes:

*   data-schema.ts — Adds `PerseusGraphTypeVector` (type: "vector", coords: CollinearTuple | null, startCoords: CollinearTuple) and `VectorGraphCorrect`, and includes both in the `PerseusGraphType` and `PerseusGraphCorrectType` unions. The shape matches `PerseusGraphTypeRay` — two coordinates representing tail and tip.
*   interactive-graph-widget.ts — Adds `parsePerseusGraphTypeVector` and registers it with `parsePerseusGraphType` so the new type round-trips through the parser.
*   types.ts — Adds `VectorGraphState` (type: "vector", coords: PairOfPoints) and adds it to the `InteractiveGraphState` union.
*   Stubs out "vector" cases with `throw new Error("Not implemented")` in `renderGraphElements` (mafs-graph.tsx) and `initializeGraphState` (initialize-graph-state.ts), and returns "" in `getEquationString` (interactive-graph.tsx) to keep TypeScript exhaustiveness errors clear until subsequent PRs fill in the implementation.
*   Adds "vector" to the `mergeGraphs` switch (interactive-graph-editor.tsx) and `shouldShowStartCoordsUI` (util.ts) to satisfy exhaustiveness checks in the editor.
*   Adds "vector" cases in interactive-graph-ai-utils.ts (`getGraphOptionsForProps` and `getUserInput`), mafs-state-to-interactive-graph.ts (serialization), and interactive-graph-reducer.ts (`movePointInFigure` guard) for exhaustiveness.

### Test plan:

*    `pnpm tsc` — no new type errors
*    `pnpm lint` — no lint errors
*    No existing interactive graph tests regress


[LEMS-3971]: https://khanacademy.atlassian.net/browse/LEMS-3971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ