### PR TITLE
[ Interactive Graph | Vector Graph ] PR2: State Management

### DIFF
--- a/.changeset/sixty-guests-punch.md
+++ b/.changeset/sixty-guests-punch.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Implementation of state management logic for new Vector graph

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -383,6 +383,7 @@ export {
     generateIGSegmentGraph,
     generateIGSinusoidGraph,
     generateIGTangentGraph,
+    generateIGVectorGraph,
     generateIGLockedPoint,
     generateIGLockedLine,
     generateIGLockedVector,

--- a/packages/perseus-core/src/utils/generators/interactive-graph-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/interactive-graph-widget-generator.ts
@@ -23,6 +23,7 @@ import type {
     PerseusGraphTypeSegment,
     PerseusGraphTypeSinusoid,
     PerseusGraphTypeTangent,
+    PerseusGraphTypeVector,
     PerseusInteractiveGraphWidgetOptions,
 } from "../../data-schema";
 
@@ -161,6 +162,15 @@ export function generateIGTangentGraph(
 ): PerseusGraphTypeTangent {
     return {
         type: "tangent",
+        ...options,
+    };
+}
+
+export function generateIGVectorGraph(
+    options?: Partial<Omit<PerseusGraphTypeVector, "type">>,
+): PerseusGraphTypeVector {
+    return {
+        type: "vector",
         ...options,
     };
 }

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -150,6 +150,7 @@ export {
     getSegmentCoords,
     getSinusoidCoords,
     getTangentCoords,
+    getVectorCoords,
     getQuadraticCoords,
     getAngleCoords,
 } from "./widgets/interactive-graphs/reducer/initialize-graph-state";

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
@@ -267,6 +267,14 @@ class InteractiveGraphQuestionBuilder {
         return this;
     }
 
+    withVector(options?: {
+        coords?: CollinearTuple;
+        startCoords?: CollinearTuple;
+    }): InteractiveGraphQuestionBuilder {
+        this.interactiveFigureConfig = new VectorGraphConfig(options);
+        return this;
+    }
+
     withCircle(options?: {
         center?: Coord;
         radius?: number;
@@ -742,6 +750,30 @@ class RayGraphConfig implements InteractiveFigureConfig {
 
     graph(): PerseusGraphType {
         return {type: "ray", startCoords: this.startCoords};
+    }
+}
+
+class VectorGraphConfig implements InteractiveFigureConfig {
+    private coords?: CollinearTuple;
+    private startCoords?: CollinearTuple;
+
+    constructor(options?: {
+        coords?: CollinearTuple;
+        startCoords?: CollinearTuple;
+    }) {
+        this.coords = options?.coords;
+        this.startCoords = options?.startCoords;
+    }
+
+    correct(): PerseusGraphType {
+        return {
+            type: "vector",
+            coords: this.coords,
+        };
+    }
+
+    graph(): PerseusGraphType {
+        return {type: "vector", startCoords: this.startCoords};
     }
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -200,18 +200,6 @@ export const rayQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
 export const rayQuestionWithDefaultCorrect: PerseusRenderer =
     interactiveGraphQuestionBuilder().withRay().build();
 
-export const vectorQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
-    .withVector({
-        coords: [
-            [0, 0],
-            [3, 4],
-        ],
-    })
-    .build();
-
-export const vectorQuestionWithDefaultCorrect: PerseusRenderer =
-    interactiveGraphQuestionBuilder().withVector().build();
-
 export const segmentQuestion: PerseusRenderer =
     interactiveGraphQuestionBuilder()
         .withContent(

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -200,15 +200,14 @@ export const rayQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
 export const rayQuestionWithDefaultCorrect: PerseusRenderer =
     interactiveGraphQuestionBuilder().withRay().build();
 
-export const vectorQuestion: PerseusRenderer =
-    interactiveGraphQuestionBuilder()
-        .withVector({
-            coords: [
-                [0, 0],
-                [3, 4],
-            ],
-        })
-        .build();
+export const vectorQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
+    .withVector({
+        coords: [
+            [0, 0],
+            [3, 4],
+        ],
+    })
+    .build();
 
 export const vectorQuestionWithDefaultCorrect: PerseusRenderer =
     interactiveGraphQuestionBuilder().withVector().build();

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -200,6 +200,19 @@ export const rayQuestion: PerseusRenderer = interactiveGraphQuestionBuilder()
 export const rayQuestionWithDefaultCorrect: PerseusRenderer =
     interactiveGraphQuestionBuilder().withRay().build();
 
+export const vectorQuestion: PerseusRenderer =
+    interactiveGraphQuestionBuilder()
+        .withVector({
+            coords: [
+                [0, 0],
+                [3, 4],
+            ],
+        })
+        .build();
+
+export const vectorQuestionWithDefaultCorrect: PerseusRenderer =
+    interactiveGraphQuestionBuilder().withVector().build();
+
 export const segmentQuestion: PerseusRenderer =
     interactiveGraphQuestionBuilder()
         .withContent(

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.test.ts
@@ -641,3 +641,63 @@ describe("initializeGraphState for tangent graphs", () => {
         ]);
     });
 });
+
+describe("initializeGraphState for vector graphs", () => {
+    it("uses the given coords if present", () => {
+        // Arrange, Act
+        const graph = initializeGraphState({
+            ...baseGraphData,
+            graph: {
+                type: "vector",
+                coords: [
+                    [0, 0],
+                    [3, 4],
+                ],
+            },
+        });
+
+        // Assert
+        invariant(graph.type === "vector");
+        expect(graph.coords).toEqual([
+            [0, 0],
+            [3, 4],
+        ]);
+    });
+
+    it("uses startCoords if given and explicit coords are absent", () => {
+        // Arrange, Act
+        const graph = initializeGraphState({
+            ...baseGraphData,
+            graph: {
+                type: "vector",
+                startCoords: [
+                    [1, 2],
+                    [5, 6],
+                ],
+            },
+        });
+
+        // Assert
+        invariant(graph.type === "vector");
+        expect(graph.coords).toEqual([
+            [1, 2],
+            [5, 6],
+        ]);
+    });
+
+    it("uses default coords if neither coords nor startCoords are given", () => {
+        // Arrange, Act
+        const graph = initializeGraphState({
+            ...baseGraphData,
+            graph: {type: "vector"},
+        });
+
+        // Assert
+        invariant(graph.type === "vector");
+        // Default: tail at ~25% of range, tip at ~75% (horizontal vector)
+        expect(graph.coords).toEqual([
+            [-5, 0],
+            [5, 0],
+        ]);
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.test.ts
@@ -694,10 +694,10 @@ describe("initializeGraphState for vector graphs", () => {
 
         // Assert
         invariant(graph.type === "vector");
-        // Default: tail at ~25% of range, tip at ~75% (horizontal vector)
+        // Default: diagonal vector offset from axes
         expect(graph.coords).toEqual([
-            [-5, 0],
-            [5, 0],
+            [-5, 1],
+            [5, 5],
         ]);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.test.ts
@@ -694,10 +694,10 @@ describe("initializeGraphState for vector graphs", () => {
 
         // Assert
         invariant(graph.type === "vector");
-        // Default: diagonal vector offset from axes
+        // Default: 45° diagonal vector in the upper-right area of the graph
         expect(graph.coords).toEqual([
-            [-5, 1],
-            [5, 5],
+            [2, 2],
+            [7, 7],
         ]);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
@@ -328,11 +328,11 @@ export function getVectorCoords(
         return graph.startCoords;
     }
 
-    // Default: diagonal vector in the upper portion of the graph,
-    // offset from axes so it's clearly visible.
+    // Default: 45° diagonal vector in the upper-right area of the graph.
+    // Equal x/y offsets ensure a true 45° angle on a square grid.
     return normalizePoints(range, step, [
-        [0.25, 0.55],
-        [0.75, 0.75],
+        [0.6, 0.6],
+        [0.85, 0.85],
     ]);
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
@@ -328,15 +328,12 @@ export function getVectorCoords(
         return graph.startCoords;
     }
 
-    // Default: tail at ~25% of range, tip at ~75% (horizontal vector)
-    return normalizePoints(
-        range,
-        step,
-        [
-            [0.25, 0.5],
-            [0.75, 0.5],
-        ],
-    );
+    // Default: diagonal vector in the upper portion of the graph,
+    // offset from axes so it's clearly visible.
+    return normalizePoints(range, step, [
+        [0.25, 0.55],
+        [0.75, 0.75],
+    ]);
 }
 
 export function getLinearSystemCoords(

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
@@ -22,6 +22,7 @@ import type {
     PerseusGraphTypeExponential,
     PerseusGraphTypeTangent,
     PerseusGraphTypeLogarithm,
+    PerseusGraphTypeVector,
 } from "@khanacademy/perseus-core";
 import type {Interval} from "mafs";
 
@@ -154,7 +155,11 @@ export function initializeGraphState(
                 ...getLogarithmCoords(graph, range, step),
             };
         case "vector":
-            throw new Error("Not implemented");
+            return {
+                ...shared,
+                type: graph.type,
+                coords: getVectorCoords(graph, range, step),
+            };
         default:
             throw new UnreachableCaseError(graph);
     }
@@ -308,6 +313,30 @@ export function getLineCoords(
     }
 
     return normalizePoints(range, step, defaultLinearCoords[0]);
+}
+
+export function getVectorCoords(
+    graph: PerseusGraphTypeVector,
+    range: [x: Interval, y: Interval],
+    step: [x: number, y: number],
+): PairOfPoints {
+    if (graph.coords) {
+        return graph.coords;
+    }
+
+    if (graph.startCoords) {
+        return graph.startCoords;
+    }
+
+    // Default: tail at ~25% of range, tip at ~75% (horizontal vector)
+    return normalizePoints(
+        range,
+        step,
+        [
+            [0.25, 0.5],
+            [0.75, 0.5],
+        ],
+    );
 }
 
 export function getLinearSystemCoords(

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
@@ -95,6 +95,11 @@ export const actions = {
     tangent: {
         movePoint,
     },
+    vector: {
+        moveTip: (destination: vec.Vector2) => movePoint(1, destination),
+        moveVector: (newStart: vec.Vector2, newEnd: vec.Vector2) =>
+            moveLine(0, newStart, newEnd),
+    },
 };
 
 export const DELETE_INTENT = "delete-intent";

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -12,6 +12,7 @@ import type {
     PolygonGraphState,
     TangentGraphState,
     LogarithmGraphState,
+    VectorGraphState,
 } from "../types";
 import type {GraphRange} from "@khanacademy/perseus-core";
 
@@ -1990,6 +1991,25 @@ function generateLogarithmGraphState(
     };
 }
 
+function generateVectorGraphState(
+    overrides?: Partial<Omit<VectorGraphState, "type">>,
+): VectorGraphState {
+    return {
+        hasBeenInteractedWith: false,
+        type: "vector",
+        range: [
+            [-10, 10],
+            [-10, 10],
+        ],
+        snapStep: [1, 1],
+        coords: [
+            [0, 0],
+            [3, 4],
+        ],
+        ...overrides,
+    };
+}
+
 describe("movePoint on a logarithm graph", () => {
     it("rejects the move when both points would share the same y-coordinate", () => {
         // Arrange — point 0 at y=-3, point 1 at y=-7; trying to move point 0 to y=-7
@@ -2199,5 +2219,113 @@ describe("moveCenter on a logarithm graph (asymptote)", () => {
 
         // Assert — rejected; asymptote stays at 0
         expect(updated.asymptote).toBe(0);
+    });
+});
+
+describe("moveTip on a vector graph", () => {
+    it("moves the tip to the new coordinates", () => {
+        // Arrange
+        const state = generateVectorGraphState();
+
+        // Act
+        const updated = interactiveGraphReducer(
+            state,
+            actions.vector.moveTip([5, 6]),
+        );
+
+        // Assert
+        invariant(updated.type === "vector");
+        expect(updated.coords[1]).toEqual([5, 6]);
+        // Tail should remain unchanged
+        expect(updated.coords[0]).toEqual([0, 0]);
+    });
+
+    it("sets hasBeenInteractedWith after a move", () => {
+        // Arrange
+        const state = generateVectorGraphState({
+            hasBeenInteractedWith: false,
+        });
+
+        // Act
+        const updated = interactiveGraphReducer(
+            state,
+            actions.vector.moveTip([5, 6]),
+        );
+
+        // Assert
+        expect(updated.hasBeenInteractedWith).toBe(true);
+    });
+
+    it("rejects the move when tip would overlap with tail", () => {
+        // Arrange — tail at [0, 0]; trying to move tip to [0, 0]
+        const state = generateVectorGraphState();
+
+        // Act
+        const updated = interactiveGraphReducer(
+            state,
+            actions.vector.moveTip([0, 0]),
+        );
+
+        // Assert — move was rejected; tip stays at original position
+        invariant(updated.type === "vector");
+        expect(updated.coords[1]).toEqual([3, 4]);
+    });
+});
+
+describe("moveVector on a vector graph (body translation)", () => {
+    it("translates both tail and tip by the same delta", () => {
+        // Arrange — default tail [0,0], tip [3,4]; delta [2,1]
+        const state = generateVectorGraphState();
+
+        // Act
+        const updated = interactiveGraphReducer(
+            state,
+            actions.vector.moveVector([2, 1], [5, 5]),
+        );
+
+        // Assert
+        invariant(updated.type === "vector");
+        expect(updated.coords[0]).toEqual([2, 1]);
+        expect(updated.coords[1]).toEqual([5, 5]);
+    });
+
+    it("sets hasBeenInteractedWith after a body drag", () => {
+        // Arrange — default tail [0,0], tip [3,4]; delta [1,1]
+        const state = generateVectorGraphState({
+            hasBeenInteractedWith: false,
+        });
+
+        // Act
+        const updated = interactiveGraphReducer(
+            state,
+            actions.vector.moveVector([1, 1], [4, 5]),
+        );
+
+        // Assert
+        expect(updated.hasBeenInteractedWith).toBe(true);
+    });
+
+    it("constrains the translation so neither point leaves the graph bounds", () => {
+        // Arrange — tail at [0,0], tip at [3,4], range [-10,10]
+        // Try to move by [8, 8] — tip would go to [11, 12] which is out of bounds
+        const state = generateVectorGraphState();
+
+        // Act
+        const updated = interactiveGraphReducer(
+            state,
+            actions.vector.moveVector([8, 8], [11, 12]),
+        );
+
+        // Assert — both points should be within bounds
+        invariant(updated.type === "vector");
+        const [tail, tip] = updated.coords;
+        expect(tail[0]).toBeGreaterThanOrEqual(-10);
+        expect(tail[0]).toBeLessThanOrEqual(10);
+        expect(tail[1]).toBeGreaterThanOrEqual(-10);
+        expect(tail[1]).toBeLessThanOrEqual(10);
+        expect(tip[0]).toBeGreaterThanOrEqual(-10);
+        expect(tip[0]).toBeLessThanOrEqual(10);
+        expect(tip[1]).toBeGreaterThanOrEqual(-10);
+        expect(tip[1]).toBeLessThanOrEqual(10);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -358,7 +358,8 @@ function doMoveLine(
             };
         }
         case "linear":
-        case "ray": {
+        case "ray":
+        case "vector": {
             return {
                 ...state,
                 type: state.type,
@@ -701,6 +702,27 @@ function doMovePoint(
             const newCoords: vec.Vector2[] = [...state.coords];
             newCoords[action.index] = boundDestination;
             if (newCoords[0][X] === newCoords[1][X]) {
+                return state;
+            }
+
+            return {
+                ...state,
+                hasBeenInteractedWith: true,
+                coords: setAtIndex({
+                    array: state.coords,
+                    index: action.index,
+                    newValue: boundDestination,
+                }),
+            };
+        }
+        case "vector": {
+            const boundDestination = boundAndSnapToGrid(
+                action.destination,
+                state,
+            );
+
+            // Reject the move if the tip would overlap with the tail
+            if (vec.dist(boundDestination, state.coords[0]) === 0) {
                 return state;
             }
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-state.ts
@@ -40,6 +40,13 @@ export function getGradableGraph(
         };
     }
 
+    if (state.type === "vector" && initialGraph.type === "vector") {
+        return {
+            ...initialGraph,
+            coords: state.coords,
+        };
+    }
+
     if (state.type === "polygon" && initialGraph.type === "polygon") {
         // Unless the polygon is closed it is not considered score-able.
         if (state.numSides === "unlimited" && !state.closedPolygon) {

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -92,7 +92,7 @@ export interface RayGraphState extends InteractiveGraphStateCommon {
     coords: PairOfPoints;
 }
 
-interface VectorGraphState extends InteractiveGraphStateCommon {
+export interface VectorGraphState extends InteractiveGraphStateCommon {
     type: "vector";
     coords: PairOfPoints;
 }


### PR DESCRIPTION
## Summary

_This PR was created with the help of AI, albeit with heavy oversight and review._

This is part of a series of PRs implementing the vector graph type for the Interactive Graph widget:

PR1 – type definitions and schema
▶️ PR2 – state management (this PR)
PR3 – rendering & accessibility
PR4 – scoring
PR5 – editor support

**Issue:** [LEMS-3971](https://khanacademy.atlassian.net/browse/LEMS-3971)

*   Added state management logic for the vector graph type
*   The graph is now stateful and interactive but not yet visible — rendering still throws "Not implemented" from PR 1's stub. This is a pure additive change — no runtime behavior is altered and all existing tests continue to pass.

### Changes:

*   interactive-graph-action.ts — Adds `vector: { moveTip, moveVector }` to the actions object. `moveTip` dispatches `movePoint(1, destination)` for the tip (the only draggable point). `moveVector` dispatches `moveLine(0, delta)` for body translation.
*   initialize-graph-state.ts — Replaces the PR 1 stub with a real `case "vector"`. Adds and exports `getVectorCoords()` with the standard three-path fallback: explicit coords → startCoords → normalized defaults. Default is a horizontal vector from [-5, 0] to [5, 0].
*   interactive-graph-reducer.ts — Adds vector case in `doMovePoint` (snap to grid, enforce bounds, reject if tip would overlap with tail). Adds `"vector"` to the existing `doMoveLine` case alongside `"linear"` / `"ray"` for body translation.
*   interactive-graph-state.ts — Adds `getGradableGraph()` branch for vector (coords passthrough, same shape as ray).
*   interactive-graph-question-builder.ts — Adds `withVector()` builder method and `VectorGraphConfig` class (matches `RayGraphConfig` pattern).
*   interactive-graph-widget-generator.ts — Adds `generateIGVectorGraph()` generator function (new pattern, replacing builder long-term).
*   perseus-core/src/index.ts — Re-exports `generateIGVectorGraph`.
*   perseus/src/index.ts — Re-exports `getVectorCoords`.
*   interactive-graph.testdata.ts — Adds `vectorQuestion` and `vectorQuestionWithDefaultCorrect` test fixtures.

### Test plan:

*    `pnpm tsc` — no new type errors
*    `pnpm test packages/perseus/src/widgets/interactive-graphs/reducer/` — 143 tests pass, including 9 new vector tests:
     *   3 initialization tests (explicit coords, startCoords fallback, defaults)
     *   3 moveTip tests (basic move, hasBeenInteractedWith, overlap rejection)
     *   3 moveVector tests (body translation, hasBeenInteractedWith, bounds enforcement)
*    No existing interactive graph tests regress


[LEMS-3971]: https://khanacademy.atlassian.net/browse/LEMS-3971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ