### PR TITLE
[ Interactive Graph | Vector Graph ] PR4: Scoring

### DIFF
--- a/.changeset/lazy-bats-complain.md
+++ b/.changeset/lazy-bats-complain.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-score": minor
+---
+
+Added ability to score Vector Interactive Graphs

--- a/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.test.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.test.ts
@@ -1149,3 +1149,102 @@ describe("InteractiveGraph scoring on a vector question", () => {
         expect(result).toHaveBeenAnsweredIncorrectly();
     });
 });
+
+const vectorCongruentRubric: PerseusInteractiveGraphRubric = {
+    graph: {type: "vector"},
+    correct: {
+        type: "vector",
+        coords: [
+            [0, 0],
+            [3, 4],
+        ],
+        match: "congruent",
+    },
+};
+
+describe("InteractiveGraph scoring on a vector question with congruent matching", () => {
+    it("marks a translated vector as correct when match is congruent", () => {
+        // Arrange — same direction ⟨3, 4⟩ but different position
+        const guess: PerseusGraphType = {
+            type: "vector",
+            coords: [
+                [2, 1],
+                [5, 5],
+            ],
+        };
+
+        // Act
+        const result = scoreInteractiveGraph(guess, vectorCongruentRubric);
+
+        // Assert
+        expect(result).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("marks exact position as correct when match is congruent", () => {
+        // Arrange — same position as rubric
+        const guess: PerseusGraphType = {
+            type: "vector",
+            coords: [
+                [0, 0],
+                [3, 4],
+            ],
+        };
+
+        // Act
+        const result = scoreInteractiveGraph(guess, vectorCongruentRubric);
+
+        // Assert
+        expect(result).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("marks wrong direction as incorrect when match is congruent", () => {
+        // Arrange — same magnitude but different direction
+        const guess: PerseusGraphType = {
+            type: "vector",
+            coords: [
+                [0, 0],
+                [4, 3],
+            ],
+        };
+
+        // Act
+        const result = scoreInteractiveGraph(guess, vectorCongruentRubric);
+
+        // Assert
+        expect(result).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("marks opposite direction as incorrect when match is congruent", () => {
+        // Arrange — reversed direction ⟨-3, -4⟩
+        const guess: PerseusGraphType = {
+            type: "vector",
+            coords: [
+                [3, 4],
+                [0, 0],
+            ],
+        };
+
+        // Act
+        const result = scoreInteractiveGraph(guess, vectorCongruentRubric);
+
+        // Assert
+        expect(result).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("marks wrong magnitude as incorrect when match is congruent", () => {
+        // Arrange — same direction but different length ⟨6, 8⟩
+        const guess: PerseusGraphType = {
+            type: "vector",
+            coords: [
+                [0, 0],
+                [6, 8],
+            ],
+        };
+
+        // Act
+        const result = scoreInteractiveGraph(guess, vectorCongruentRubric);
+
+        // Assert
+        expect(result).toHaveBeenAnsweredIncorrectly();
+    });
+});

--- a/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.test.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.test.ts
@@ -1048,3 +1048,104 @@ describe("InteractiveGraph scoring on a tangent question", () => {
         expect(result).toHaveBeenAnsweredCorrectly();
     });
 });
+
+const vectorRubric: PerseusInteractiveGraphRubric = {
+    graph: {type: "vector"},
+    correct: {
+        type: "vector",
+        coords: [
+            [0, 0],
+            [3, 4],
+        ],
+    },
+};
+
+describe("InteractiveGraph scoring on a vector question", () => {
+    it("marks the answer invalid if guess is undefined", () => {
+        // Arrange, Act
+        const result = scoreInteractiveGraph(undefined, vectorRubric);
+
+        // Assert
+        expect(result).toHaveInvalidInput();
+    });
+
+    it("marks the answer invalid if coords are missing", () => {
+        // Arrange
+        const guess: PerseusGraphType = {type: "vector"};
+
+        // Act
+        const result = scoreInteractiveGraph(guess, vectorRubric);
+
+        // Assert
+        expect(result).toHaveInvalidInput();
+    });
+
+    it("marks a correct answer as correct", () => {
+        // Arrange
+        const guess: PerseusGraphType = {
+            type: "vector",
+            coords: [
+                [0, 0],
+                [3, 4],
+            ],
+        };
+
+        // Act
+        const result = scoreInteractiveGraph(guess, vectorRubric);
+
+        // Assert
+        expect(result).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("marks a wrong tail as incorrect", () => {
+        // Arrange — correct tip but wrong tail
+        const guess: PerseusGraphType = {
+            type: "vector",
+            coords: [
+                [1, 1],
+                [3, 4],
+            ],
+        };
+
+        // Act
+        const result = scoreInteractiveGraph(guess, vectorRubric);
+
+        // Assert
+        expect(result).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("marks a wrong tip as incorrect", () => {
+        // Arrange — correct tail but wrong tip
+        const guess: PerseusGraphType = {
+            type: "vector",
+            coords: [
+                [0, 0],
+                [4, 5],
+            ],
+        };
+
+        // Act
+        const result = scoreInteractiveGraph(guess, vectorRubric);
+
+        // Assert
+        expect(result).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("marks swapped tail and tip as incorrect", () => {
+        // Arrange — coords are reversed (tip at tail position, tail at tip)
+        // Unlike ray, vector scoring is order-sensitive
+        const guess: PerseusGraphType = {
+            type: "vector",
+            coords: [
+                [3, 4],
+                [0, 0],
+            ],
+        };
+
+        // Act
+        const result = scoreInteractiveGraph(guess, vectorRubric);
+
+        // Assert
+        expect(result).toHaveBeenAnsweredIncorrectly();
+    });
+});

--- a/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.ts
@@ -431,18 +431,30 @@ function scoreInteractiveGraph(
             userInput.coords != null &&
             rubric.correct.coords != null
         ) {
-            // Vector scoring: both tail and tip must match exactly.
-            // Order matters — coords[0] is tail, coords[1] is tip.
-            if (
-                approximateDeepEqual(
-                    userInput.coords[0],
-                    rubric.correct.coords[0],
-                ) &&
-                approximateDeepEqual(
-                    userInput.coords[1],
-                    rubric.correct.coords[1],
-                )
-            ) {
+            const guess = userInput.coords;
+            const correct = rubric.correct.coords;
+
+            let match: boolean;
+            if (rubric.correct.match === "congruent") {
+                // Congruent: same direction and magnitude, any position.
+                // Compare the component form ⟨dx, dy⟩ of each vector.
+                const guessDelta: Coord = [
+                    guess[1][0] - guess[0][0],
+                    guess[1][1] - guess[0][1],
+                ];
+                const correctDelta: Coord = [
+                    correct[1][0] - correct[0][0],
+                    correct[1][1] - correct[0][1],
+                ];
+                match = approximateDeepEqual(guessDelta, correctDelta);
+            } else {
+                // Exact (default): both tail and tip must match exactly.
+                match =
+                    approximateDeepEqual(guess[0], correct[0]) &&
+                    approximateDeepEqual(guess[1], correct[1]);
+            }
+
+            if (match) {
                 return {
                     type: "points",
                     earned: 1,

--- a/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.ts
@@ -425,6 +425,31 @@ function scoreInteractiveGraph(
                     message: null,
                 };
             }
+        } else if (
+            userInput.type === "vector" &&
+            rubric.correct.type === "vector" &&
+            userInput.coords != null &&
+            rubric.correct.coords != null
+        ) {
+            // Vector scoring: both tail and tip must match exactly.
+            // Order matters — coords[0] is tail, coords[1] is tip.
+            if (
+                approximateDeepEqual(
+                    userInput.coords[0],
+                    rubric.correct.coords[0],
+                ) &&
+                approximateDeepEqual(
+                    userInput.coords[1],
+                    rubric.correct.coords[1],
+                )
+            ) {
+                return {
+                    type: "points",
+                    earned: 1,
+                    total: 1,
+                    message: null,
+                };
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

_This PR was created with the help of AI, albeit with heavy oversight and review._

This is part of a series of PRs implementing the vector graph type for the Interactive Graph widget:

PR1 – type definitions and schema
PR2 – state management
PR3 – rendering & accessibility
▶️ PR4 – scoring (this PR)
PR5 – editor support

**Issue:** [LEMS-3971](https://khanacademy.atlassian.net/browse/LEMS-3971)

*   Added scoring logic for the vector graph type. The graph is now gradeable.

### Changes:

*   score-interactive-graph.ts — Adds vector scoring branch. Both tail (`coords[0]`) and tip (`coords[1]`) must match exactly via `approximateDeepEqual`. Unlike ray (which uses `collinear` for the second point), vector scoring is order-sensitive — swapping tail and tip is incorrect.
*   score-interactive-graph.test.ts — 6 new tests: undefined guess (invalid), missing coords (invalid), correct answer, wrong tail (incorrect), wrong tip (incorrect), swapped tail and tip (incorrect).

### Test plan:

*    `pnpm tsc` — no new type errors
*    `pnpm test packages/perseus-score/src/widgets/interactive-graph/` — 44 tests pass, including 6 new vector scoring tests
*    No existing scoring tests regress


[LEMS-3971]: https://khanacademy.atlassian.net/browse/LEMS-3971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ