### PR TITLE
[ Interactive Graph | Vector Graph ] PR5: Editor Support

### DIFF
--- a/.changeset/fast-points-complain.md
+++ b/.changeset/fast-points-complain.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Creation of new Vector Graph Editor

--- a/packages/perseus-editor/src/__testdata__/interactive-graph-question-builder.ts
+++ b/packages/perseus-editor/src/__testdata__/interactive-graph-question-builder.ts
@@ -302,6 +302,14 @@ class InteractiveGraphQuestionBuilder {
         return this;
     }
 
+    withVector(options?: {
+        coords?: CollinearTuple;
+        startCoords?: CollinearTuple;
+    }): InteractiveGraphQuestionBuilder {
+        this.interactiveFigureConfig = new VectorGraphConfig(options);
+        return this;
+    }
+
     withPolygon(
         snapTo?: SnapTo,
         options?: {
@@ -839,6 +847,30 @@ class ExponentialGraphConfig implements InteractiveFigureConfig {
                     ? {coords: this.startCoords, asymptote: this.startAsymptote}
                     : undefined,
         };
+    }
+}
+
+class VectorGraphConfig implements InteractiveFigureConfig {
+    private coords?: CollinearTuple;
+    private startCoords?: CollinearTuple;
+
+    constructor(options?: {
+        coords?: CollinearTuple;
+        startCoords?: CollinearTuple;
+    }) {
+        this.coords = options?.coords;
+        this.startCoords = options?.startCoords;
+    }
+
+    correct(): PerseusGraphType {
+        return {
+            type: "vector",
+            coords: this.coords,
+        };
+    }
+
+    graph(): PerseusGraphType {
+        return {type: "vector", startCoords: this.startCoords};
     }
 }
 

--- a/packages/perseus-editor/src/__testdata__/interactive-graph-question-builder.ts
+++ b/packages/perseus-editor/src/__testdata__/interactive-graph-question-builder.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 // Duplicated from packages/perseus/src/widgets/interactive-graphs/interactive-graph-question-builder.ts
 // This is to have similar test data for packages/perseus-editor
 

--- a/packages/perseus-editor/src/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus-editor/src/__testdata__/interactive-graph.testdata.ts
@@ -157,6 +157,9 @@ export const sinusoidMinimalQuestion: PerseusRenderer =
 export const exponentialMinimalQuestion: PerseusRenderer =
     interactiveGraphQuestionBuilder().withExponential().build();
 
+export const vectorMinimalQuestion: PerseusRenderer =
+    interactiveGraphQuestionBuilder().withVector().build();
+
 export const segmentWithLockedFigures: PerseusRenderer =
     interactiveGraphQuestionBuilder()
         .addLockedPointAt(-7, -7, {labels: [{text: "A"}], ariaLabel: "Point A"})

--- a/packages/perseus-editor/src/widgets/__docs__/interactive-graph-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__docs__/interactive-graph-editor.stories.tsx
@@ -27,6 +27,7 @@ import {
     segmentWithLockedFigures,
     segmentWithStartingCoordsQuestion,
     exponentialMinimalQuestion,
+    vectorMinimalQuestion,
     sinusoidMinimalQuestion,
     sinusoidWithStartingCoordsAndPiTicksQuestion,
     unlimitedPolygonWithCorrectAnswerQuestion,
@@ -119,6 +120,10 @@ export const InteractiveGraphExponential = (): React.ReactElement => {
     return (
         <EditorPageWithStorybookPreview question={exponentialMinimalQuestion} />
     );
+};
+
+export const InteractiveGraphVector = (): React.ReactElement => {
+    return <EditorPageWithStorybookPreview question={vectorMinimalQuestion} />;
 };
 
 export const InteractiveGraphSinusoid = (): React.ReactElement => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
@@ -68,9 +68,7 @@ const GraphTypeSelector = (props: GraphTypeSelectorProps) => {
             <OptionItem value="polygon" label="Polygon" />
             <OptionItem value="segment" label="Line Segment(s)" />
             <OptionItem value="ray" label="Ray" />
-            {showVector && (
-                <OptionItem value="vector" label="Vector" />
-            )}
+            {showVector && <OptionItem value="vector" label="Vector" />}
             <OptionItem value="angle" label="Angle" />
         </SingleSelect>
     );

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
@@ -34,6 +34,11 @@ const GraphTypeSelector = (props: GraphTypeSelectorProps) => {
         "interactive-graph-logarithm",
     );
 
+    const showVector = isFeatureOn(
+        {apiOptions: props.apiOptions},
+        "interactive-graph-vector",
+    );
+
     return (
         <SingleSelect
             selectedValue={props.graphType}
@@ -63,6 +68,9 @@ const GraphTypeSelector = (props: GraphTypeSelectorProps) => {
             <OptionItem value="polygon" label="Polygon" />
             <OptionItem value="segment" label="Line Segment(s)" />
             <OptionItem value="ray" label="Ray" />
+            {showVector && (
+                <OptionItem value="vector" label="Vector" />
+            )}
             <OptionItem value="angle" label="Angle" />
         </SingleSelect>
     );

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/vector-answer-options.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/vector-answer-options.tsx
@@ -1,0 +1,53 @@
+import {components} from "@khanacademy/perseus";
+import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
+import * as React from "react";
+import invariant from "tiny-invariant";
+
+import styles from "../interactive-graph-editor.module.css";
+import LabeledRow from "../locked-figures/labeled-row";
+
+import type {Props as EditorProps} from "../interactive-graph-editor";
+import type {PerseusGraphTypeVector} from "@khanacademy/perseus-core";
+
+const {InfoTip} = components;
+
+interface Props {
+    correct: PerseusGraphTypeVector;
+    onChange: (props: Partial<EditorProps>) => void;
+}
+
+export default function VectorAnswerOptions({correct, onChange}: Props) {
+    return (
+        <LabeledRow label="Student answer must">
+            <SingleSelect
+                selectedValue={correct.match || "exact"}
+                onChange={(newValue) => {
+                    invariant(
+                        correct.type === "vector",
+                        `Expected graph type to be vector, but got ${correct.type}`,
+                    );
+                    onChange({
+                        correct: {
+                            ...correct,
+                            match: newValue as PerseusGraphTypeVector["match"],
+                        },
+                    });
+                }}
+                // Never uses placeholder, always has value
+                placeholder=""
+                className={styles.singleSelectShort}
+            >
+                <OptionItem value="exact" label="match exactly" />
+                <OptionItem value="congruent" label="be congruent" />
+            </SingleSelect>
+            <InfoTip>
+                <p>
+                    Congruency requires only that the vector has the same
+                    direction and magnitude. An exact match implies
+                    congruency, but also requires that the tail and tip
+                    are in the same position on the grid.
+                </p>
+            </InfoTip>
+        </LabeledRow>
+    );
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/vector-answer-options.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/vector-answer-options.tsx
@@ -43,9 +43,9 @@ export default function VectorAnswerOptions({correct, onChange}: Props) {
             <InfoTip>
                 <p>
                     Congruency requires only that the vector has the same
-                    direction and magnitude. An exact match implies
-                    congruency, but also requires that the tail and tip
-                    are in the same position on the grid.
+                    direction and magnitude. An exact match implies congruency,
+                    but also requires that the tail and tip are in the same
+                    position on the grid.
                 </p>
             </InfoTip>
         </LabeledRow>

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -32,6 +32,7 @@ import InteractiveGraphSettings from "./components/interactive-graph-settings";
 import InteractiveGraphSRTree from "./components/interactive-graph-sr-tree";
 import PolygonAnswerOptions from "./components/polygon-answer-options";
 import SegmentCountSelector from "./components/segment-count-selector";
+import VectorAnswerOptions from "./components/vector-answer-options";
 import LabeledRow from "./locked-figures/labeled-row";
 import LockedFiguresSection from "./locked-figures/locked-figures-section";
 import StartCoordsSettings from "./start-coords/start-coords-settings";
@@ -454,6 +455,12 @@ class InteractiveGraphEditor extends React.Component<Props> {
                             <PolygonAnswerOptions
                                 correct={this.props.correct}
                                 graph={this.props.graph}
+                                onChange={this.props.onChange}
+                            />
+                        )}
+                        {this.props.correct?.type === "vector" && (
+                            <VectorAnswerOptions
+                                correct={this.props.correct}
                                 onChange={this.props.onChange}
                             />
                         )}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
@@ -11,6 +11,7 @@ import {
     getSegmentCoords,
     getSinusoidCoords,
     getTangentCoords,
+    getVectorCoords,
 } from "@khanacademy/perseus";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -136,6 +137,15 @@ const StartCoordsSettingsInner = (props: Props) => {
             return (
                 <StartCoordsLogarithm
                     startCoords={currentLogarithmCoords}
+                    onChange={onChange}
+                />
+            );
+        }
+        case "vector": {
+            const vectorCoords = getVectorCoords(props, range, step);
+            return (
+                <StartCoordsLine
+                    startCoords={vectorCoords}
                     onChange={onChange}
                 />
             );

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/types.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/types.ts
@@ -14,7 +14,8 @@ type GraphTypesThatHaveStartCoords =
     | {type: "sinusoid"}
     | {type: "exponential"}
     | {type: "logarithm"}
-    | {type: "tangent"};
+    | {type: "tangent"}
+    | {type: "vector"};
 
 export type StartCoords = Extract<
     PerseusGraphType,

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/util.ts
@@ -13,6 +13,7 @@ import {
     getSegmentCoords,
     getSinusoidCoords,
     getTangentCoords,
+    getVectorCoords,
 } from "@khanacademy/perseus";
 import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 
@@ -43,6 +44,12 @@ export function getDefaultGraphStartCoords(
         case "linear":
         case "ray":
             return getLineCoords(
+                {...graph, startCoords: undefined},
+                range,
+                step,
+            );
+        case "vector":
+            return getVectorCoords(
                 {...graph, startCoords: undefined},
                 range,
                 step,


### PR DESCRIPTION
## Summary

_This PR was created with the help of AI, albeit with heavy oversight and review._

This is part of a series of PRs implementing the vector graph type for the Interactive Graph widget:

PR1 – type definitions and schema
PR2 – state management
PR3 – rendering & accessibility
PR4 – scoring
▶️ PR5 – editor support (this PR)

**Issue:** [LEMS-3971](https://khanacademy.atlassian.net/browse/LEMS-3971)

*   Surfaces the vector graph type in the content-creator UI. Once landed and the feature flag is enabled, content creators can author vector graph exercises.

### Changes:

*   graph-type-selector.tsx — Adds "Vector" option to the graph type dropdown, gated behind `interactive-graph-vector` feature flag.
*   start-coords/types.ts — Adds `{type: "vector"}` to `GraphTypesThatHaveStartCoords` union.
*   start-coords/util.ts — Imports `getVectorCoords` and adds `case "vector"` in `getDefaultGraphStartCoords`.
*   start-coords/start-coords-settings.tsx — Adds `case "vector"` dispatching to `<StartCoordsLine>` (reuses the existing component since vector has the same `CollinearTuple` shape as ray/linear).
*   interactive-graph-question-builder.ts — Adds `withVector()` builder method and `VectorGraphConfig` class to the editor's test data builder.
*   __testdata__/interactive-graph.testdata.ts — Adds `vectorMinimalQuestion` test fixture for the editor story.
*   interactive-graph-editor.stories.tsx — Adds `InteractiveGraphVector` editor Storybook story.

### Design decisions:

*   **No editor validation for overlapping start coords** — Consistent with ray, linear, and segment which also don't validate for overlapping points in the editor. The reducer already rejects moves that would cause overlap during interaction.
*   **Reuses `StartCoordsLine`** — Vector's `CollinearTuple` start coords shape matches ray/linear, so no custom start coords component is needed (unlike exponential which has an asymptote field).

### Test plan:

*    `pnpm tsc` — no new type errors
*    `pnpm lint` — no lint errors
*    Verified in Storybook: editor correctly shows vector graph type when feature flag is enabled, start coords UI works
*    No existing tests regress


[LEMS-3971]: https://khanacademy.atlassian.net/browse/LEMS-3971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ