### PR TITLE
[Interactive Graph] Reverted Asymptote/Drag Handle Auto-Blur on Drag End

### DIFF
--- a/.changeset/rich-cameras-shave.md
+++ b/.changeset/rich-cameras-shave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Interactive Graph] Reverted Drag Handle Auto-Blur on Drag End for Logarithm and Exponential interactive graphs

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph-regression.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph-regression.stories.tsx
@@ -530,6 +530,36 @@ export const ShowNoArrows: Story = {
     },
 };
 
+/* Asymptote drag handle regression tests */
+
+export const ExponentialAsymptoteFocused: Story = {
+    args: {
+        question: interactiveGraphQuestionBuilder()
+            .withExponential({asymptote: 3})
+            .build(),
+    },
+    play: async ({canvas}) => {
+        const asymptote = canvas.getByRole("button", {
+            name: /^Horizontal asymptote/,
+        });
+        asymptote.focus();
+    },
+};
+
+export const LogarithmAsymptoteFocused: Story = {
+    args: {
+        question: interactiveGraphQuestionBuilder()
+            .withLogarithm({asymptote: -3})
+            .build(),
+    },
+    play: async ({canvas}) => {
+        const asymptote = canvas.getByRole("button", {
+            name: /^Vertical asymptote/,
+        });
+        asymptote.focus();
+    },
+};
+
 function MafsQuestionRenderer(props: {question: PerseusRenderer}) {
     const {question} = props;
     return (

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-asymptote.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-asymptote.test.tsx
@@ -83,32 +83,6 @@ describe("MovableAsymptote", () => {
         );
     });
 
-    it("blurs the element when a mouse drag ends to clear the focus ring", () => {
-        // Arrange — start with dragging: true
-        useDraggable.mockReturnValue({dragging: true});
-        const {rerender} = render(
-            <Mafs width={200} height={200}>
-                <MovableAsymptote {...defaultProps} />
-            </Mafs>,
-        );
-
-        const group = screen.getByTestId("movable-asymptote");
-        // Simulate that the element received focus during drag
-        group.focus();
-        const blurSpy = jest.spyOn(group, "blur");
-
-        // Act — drag ends
-        useDraggable.mockReturnValue({dragging: false});
-        rerender(
-            <Mafs width={200} height={200}>
-                <MovableAsymptote {...defaultProps} />
-            </Mafs>,
-        );
-
-        // Assert — blur was called to remove the focus ring
-        expect(blurSpy).toHaveBeenCalled();
-    });
-
     it("renders the same structure for vertical orientation", () => {
         // Arrange, Act
         render(

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-asymptote.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-asymptote.tsx
@@ -56,16 +56,6 @@ export function MovableAsymptote(props: Props) {
         constrainKeyboardMovement: constrainKeyboardMovement ?? ((p) => p),
     });
 
-    // When a mouse drag ends, blur the element so the focus ring doesn't
-    // persist after the user releases the mouse and moves away.
-    const wasDragging = React.useRef(false);
-    React.useEffect(() => {
-        if (wasDragging.current && !dragging) {
-            groupRef.current?.blur();
-        }
-        wasDragging.current = dragging;
-    }, [dragging]);
-
     return (
         <g
             ref={groupRef}


### PR DESCRIPTION
## Summary:
- Reverted the auto-blur behavior in `MovableAsymptote` that was added in commit `607c6bc4ed`
- The drag handle now retains focus after dragging, consistent with movable point behavior

## Details

During the logarithm work, a fix was added to `MovableAsymptote` (`movable-asymptote.tsx`) that automatically
blurred the asymptote drag handle when a mouse drag ended. The intent was to prevent the focus ring from
persisting after the user released the mouse and moved away from the line.

**Why it was reverted:** The auto-blur made the drag handle behave differently from movable points in the graph.
Points retain focus after dragging — focus only clears when the user clicks away or navigates away via keyboard.
The asymptote drag handle should follow the same pattern for consistency.

**Current behavior:** After a mouse drag ends, the drag handle retains focus (focus ring remains visible).
Focus is only cleared when the user clicks elsewhere or navigates away via keyboard — matching how movable
points behave across all interactive graph types.

Co-authored by Claude Code (Opus)

Issue: LEMS-4016

## Test plan:
1. Navigate to the Exponential Graph
2. Drag the asymptote and notice that the drag handle has the focused state
3. Hover away from the asymptote and notice it still had the focused state
4. Click another point or anywhere notice it will loose its focused state
5. Also confirm the same behavior when navigating the keyboard
6. Also confirm the same behavior for Logarithm Graph