### PR TITLE
Fix release workflow network sandboxing for sigstore

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,7 +81,8 @@ jobs:
               with:
                   conf-files: .github/npm-extra-domains.conf
                   # hooks.slack.com: Slack webhook for publish success/failure notifications
-                  extra-domains: hooks.slack.com
+                  # fulcio.sigstore.dev,rekor.sigstore.dev: signing certificates are stored here
+                  extra-domains: hooks.slack.com, fulcio.sigstore.dev rekor.sigstore.dev
 
             - name: Install & cache node_modules
               uses: ./.github/actions/shared-node-cache


### PR DESCRIPTION
## Summary                      

Our last release [failed](https://khanacademy.slack.com/archives/C01AZ9H8TTQ/p1776104191564179) because the `release` job couldn't reach sigstore's servers (`fulcio.sigstore.dev` and `rekor.sigstore.dev`) to sign the npm packages. We'd already fixed this for the `publish_snapshot` job but missed the `release` job.                                                                                                            
                                                                                                                              
This adds those same domains to the release job's network allowlist so provenance signing can complete successfully.        
                                                                                                                            
Issue: <none>
                                          
## Test plan
  - Once this lands, we need to re-trigger a release (either the automatic push-to-main trigger will handle it, or we can   
  manually dispatch with `gh workflow run publish.yml --ref main -f run_type=release`)
  - Confirm the publish succeeds and packages show up on npm with provenance