### PR TITLE
Fix release workflow network config for sigstore domains

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,7 +82,7 @@ jobs:
                   conf-files: .github/npm-extra-domains.conf
                   # hooks.slack.com: Slack webhook for publish success/failure notifications
                   # fulcio.sigstore.dev,rekor.sigstore.dev: signing certificates are stored here
-                  extra-domains: hooks.slack.com, fulcio.sigstore.dev rekor.sigstore.dev
+                  extra-domains: hooks.slack.com fulcio.sigstore.dev rekor.sigstore.dev
 
             - name: Install & cache node_modules
               uses: ./.github/actions/shared-node-cache


### PR DESCRIPTION
## Summary:

The last fix for the release failed because I used a comma to separate the extra domains instead of a space. This broke the action and caused the release to fail. 

This PR just removes the comma and leave the space. 

Issue: <none>

## Test plan:

 - After merging, trigger a release (the push-to-main trigger should handle it, or manually via `gh workflow run publish.yml --ref main -f run_type=release`)
  - Confirm the publish succeeds and packages show up on npm with provenance  