### PR TITLE
[Interactive Graph] Fix Asymptote Line Thickness on Keyboard Focus for exponential and logarithm

### DIFF
--- a/.changeset/polite-cooks-sip.md
+++ b/.changeset/polite-cooks-sip.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Interactive Graph: Fix Asymptote Line Thickness on Keyboard Focus for exponential and logarithm

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph-asymptote-regression.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph-asymptote-regression.stories.tsx
@@ -64,6 +64,8 @@ export const ExponentialDragHandleDefault: Story = {
 
 // Focused state: the drag handle pill shows the focus ring and
 // active state (larger pill with grip dots) above the curve line.
+// The asymptote line itself should also be thick (4px) on keyboard
+// focus, matching the hover/drag behavior.
 export const ExponentialDragHandleFocused: Story = {
     args: {
         question: interactiveGraphQuestionBuilder()
@@ -174,6 +176,8 @@ export const LogarithmDragHandleDefault: Story = {
 
 // Focused state: the drag handle pill shows the focus ring and
 // active state (larger pill with grip dots) above the curve line.
+// The asymptote line itself should also be thick (4px) on keyboard
+// focus, matching the hover/drag behavior.
 export const LogarithmDragHandleFocused: Story = {
     args: {
         question: interactiveGraphQuestionBuilder()

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/notes/logarithm.md
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/notes/logarithm.md
@@ -366,6 +366,14 @@ The drag handle retains focus after a mouse drag ends — it does not auto-blur.
 how movable points behave across all interactive graph types. Focus clears only when the user
 clicks elsewhere or navigates away via keyboard.
 
+### Asymptote line thickness on keyboard focus (LEMS-4038)
+
+The asymptote line must be thick (4px) when focused via keyboard, matching the hover and drag
+behavior. The CSS rule in `mafs-styles.css` uses `.MafsView .movable-line:focus-visible` to
+activate `--movable-line-stroke-weight-active`. Without this, keyboard users see the drag handle
+in its active state (larger pill with grip dots) but the line itself stays at the default 2px,
+creating an inconsistent visual state. This applies to both logarithm and exponential graphs.
+
 ### Visual regression stories for drag handle states
 
 A dedicated stories file (`interactive-graph-asymptote-regression.stories.tsx`) covers all drag

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/notes/logarithm.md
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/notes/logarithm.md
@@ -8,8 +8,7 @@ as context for future development and Claude Code sessions.
 
 - **Ticket:** [LEMS-3950](https://khanacademy.atlassian.net/browse/LEMS-3950)
 - **POC:** https://github.com/Khan/perseus/pull/3322
-- **POC branch:** `LEMS-3950/poc-logarithm-interactive-graph`
-- **Technical notes commit:** 7e377d631900c46f5d6d4b993d1d9238a942575a
+- **Technical research revision:** [7e377d631900c46f5d6d4b993d1d9238a942575a](https://github.com/Khan/perseus/blob/7e377d631900c46f5d6d4b993d1d9238a942575a/packages/perseus/src/widgets/interactive-graphs/__docs__/notes/logarithm.md)
 
 ## Architecture Overview
 
@@ -86,6 +85,11 @@ exponential graph.
   - **Focus ring** (keyboard focus only): rounded outline around the handle (not the full line)
 - The drag handle retains focus after a mouse drag ends, matching movable point behavior.
   Focus clears only when the user clicks elsewhere or navigates away via keyboard.
+- The asymptote line is thick (4px) when hovered, focused via keyboard, or being dragged.
+  This is driven by the CSS variable `--movable-line-stroke-weight` on the parent
+  `.movable-line` element, activated via `:hover`, `:focus-visible`, and `.movable-dragging`
+  selectors in `mafs-styles.css`. The same behavior applies to all `movable-line` elements
+  (including `MovableLine` in other graph types).
 
 ### Asymptote Drag Behavior
 
@@ -348,33 +352,7 @@ The Grapher widget has a complete logarithm implementation that served as the ma
 - `packages/perseus/src/widgets/grapher/grapher.testdata.ts` (lines 162–214) — `logarithmQuestion`
   test data (`y = 4 * log_2(x + 6) - 7`, asymptote `x = -6`).
 
-## Implementation Notes
-
-These notes capture non-obvious decisions made during implementation that are important
-context for future changes.
-
-### SVG rendering order matters for the drag handle (LEMS-4037)
-
-The curve (`Plot.OfX`) must render before `MovableAsymptote` in the JSX so the drag handle
-appears above the curve in SVG stacking order. If the order is reversed, the curve's SVG
-path will visually cover the drag handle, making it appear unclickable when the curve passes
-through the handle area. This applies to both logarithm and exponential graphs.
-
-### Drag handle focus behavior (LEMS-4016)
-
-The drag handle retains focus after a mouse drag ends — it does not auto-blur. This matches
-how movable points behave across all interactive graph types. Focus clears only when the user
-clicks elsewhere or navigates away via keyboard.
-
-### Asymptote line thickness on keyboard focus (LEMS-4038)
-
-The asymptote line must be thick (4px) when focused via keyboard, matching the hover and drag
-behavior. The CSS rule in `mafs-styles.css` uses `.MafsView .movable-line:focus-visible` to
-activate `--movable-line-stroke-weight-active`. Without this, keyboard users see the drag handle
-in its active state (larger pill with grip dots) but the line itself stays at the default 2px,
-creating an inconsistent visual state. This applies to both logarithm and exponential graphs.
-
-### Visual regression stories for drag handle states
+## Visual Regression Testing
 
 A dedicated stories file (`interactive-graph-asymptote-regression.stories.tsx`) covers all drag
 handle visual states for both logarithm and exponential graphs. Located at

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -46,6 +46,7 @@
 }
 
 .MafsView .movable-line:hover,
+.MafsView .movable-line:focus-visible,
 .movable-dragging {
     --movable-line-stroke-weight: var(--movable-line-stroke-weight-active);
 }


### PR DESCRIPTION
## Summary:
- Add `:focus-visible` CSS rule so the asymptote line is thick (4px) when focused via keyboard
- Update visual regression story comments to document the expected line thickness on focus

Issue: LEMS-4038

## Test plan:
1. Navigate to exponential graph
2. Use the keyboard to navigate to the asymptote and notice that the border is thick indicating an active state
3. Use the mouse to drag the asymptote and notice that the border is still thick indicating an active state
4. Navigate to the logarithm graph
5. Use the keyboard to navigate to the asymptote and notice that the border is thick indicating an active state
6. Use the mouse to drag the asymptote and notice that the border is still thick indicating an active state