### PR TITLE
[Preview NG] Add functions to sanitize objects for sending to Preview

### DIFF
--- a/.changeset/swift-birds-fly.md
+++ b/.changeset/swift-birds-fly.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Add preview data sanitizer to strip non-serializable values before postMessage

--- a/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
+++ b/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
@@ -305,13 +305,9 @@ describe("sanitizePreviewData", () => {
             if (result.type === "article-all") {
                 expect(result.data).toHaveLength(2);
                 expect(result.data[0].apiOptions.readOnly).toBe(true);
-                expect(
-                    result.data[0].apiOptions.onFocusChange,
-                ).toBeUndefined();
+                expect(result.data[0].apiOptions.onFocusChange).toBeUndefined();
                 expect(result.data[1].apiOptions.readOnly).toBe(false);
-                expect(
-                    result.data[1].apiOptions.onFocusChange,
-                ).toBeUndefined();
+                expect(result.data[1].apiOptions.onFocusChange).toBeUndefined();
             }
         });
 
@@ -385,9 +381,7 @@ describe("sanitizePreviewData", () => {
             expect(result.type).toBe("article-all");
             if (result.type === "article-all") {
                 expect(result.data).toHaveLength(2);
-                expect(
-                    result.data[0].apiOptions.onFocusChange,
-                ).toBeUndefined();
+                expect(result.data[0].apiOptions.onFocusChange).toBeUndefined();
                 // Section with null apiOptions should be unchanged
                 expect(result.data[1].apiOptions).toBeNull();
             }

--- a/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
+++ b/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
@@ -1,4 +1,5 @@
 import {getDefaultAnswerArea} from "@khanacademy/perseus-core";
+import invariant from "tiny-invariant";
 
 import {sanitizePreviewData} from "./preview-data-sanitizer";
 
@@ -57,28 +58,22 @@ describe("sanitizePreviewData", () => {
 
             const result = sanitizePreviewData(previewContent);
 
-            expect(result.type).toBe("question");
-            if (result.type === "question") {
-                // Serializable options should remain
-                expect(result.data.apiOptions.readOnly).toBe(true);
-                expect(result.data.apiOptions.isMobile).toBe(false);
-                expect(result.data.apiOptions.customKeypad).toBe(true);
+            invariant(result.type === "question");
+            // Serializable options should remain
+            expect(result.data.apiOptions.readOnly).toBe(true);
+            expect(result.data.apiOptions.isMobile).toBe(false);
+            expect(result.data.apiOptions.customKeypad).toBe(true);
 
-                // Non-serializable functions should be removed
-                expect(result.data.apiOptions.onFocusChange).toBeUndefined();
-                expect(
-                    result.data.apiOptions.answerableCallback,
-                ).toBeUndefined();
-                expect(result.data.apiOptions.getAnotherHint).toBeUndefined();
-                expect(
-                    result.data.apiOptions.interactionCallback,
-                ).toBeUndefined();
-                expect(result.data.apiOptions.trackInteraction).toBeUndefined();
+            // Non-serializable functions should be removed
+            expect(result.data.apiOptions.onFocusChange).toBeUndefined();
+            expect(result.data.apiOptions.answerableCallback).toBeUndefined();
+            expect(result.data.apiOptions.getAnotherHint).toBeUndefined();
+            expect(result.data.apiOptions.interactionCallback).toBeUndefined();
+            expect(result.data.apiOptions.trackInteraction).toBeUndefined();
 
-                // Other properties should remain unchanged
-                expect(result.data.item).toBe(questionData.item);
-                expect(result.data.initialHintsVisible).toBe(0);
-            }
+            // Other properties should remain unchanged
+            expect(result.data.item).toBe(questionData.item);
+            expect(result.data.initialHintsVisible).toBe(0);
         });
 
         it("handles question data with null apiOptions", () => {
@@ -106,7 +101,7 @@ describe("sanitizePreviewData", () => {
 
             const result = sanitizePreviewData(previewContent);
 
-            expect(result.type).toBe("question");
+            invariant(result.type === "question");
             // Should return unchanged when apiOptions is null
             expect(result).toEqual(previewContent);
         });
@@ -168,19 +163,17 @@ describe("sanitizePreviewData", () => {
 
             const result = sanitizePreviewData(previewContent);
 
-            expect(result.type).toBe("hint");
-            if (result.type === "hint") {
-                // Serializable options should remain
-                expect(result.data.apiOptions.readOnly).toBe(true);
+            invariant(result.type === "hint");
+            // Serializable options should remain
+            expect(result.data.apiOptions.readOnly).toBe(true);
 
-                // Non-serializable functions should be removed
-                expect(result.data.apiOptions.onFocusChange).toBeUndefined();
-                expect(result.data.apiOptions.trackInteraction).toBeUndefined();
+            // Non-serializable functions should be removed
+            expect(result.data.apiOptions.onFocusChange).toBeUndefined();
+            expect(result.data.apiOptions.trackInteraction).toBeUndefined();
 
-                // Other properties should remain unchanged
-                expect(result.data.hint).toBe(hintData.hint);
-                expect(result.data.pos).toBe(0);
-            }
+            // Other properties should remain unchanged
+            expect(result.data.hint).toBe(hintData.hint);
+            expect(result.data.pos).toBe(0);
         });
 
         it("handles hint data with null apiOptions", () => {
@@ -227,19 +220,15 @@ describe("sanitizePreviewData", () => {
 
             const result = sanitizePreviewData(previewContent);
 
-            expect(result.type).toBe("article");
-            if (result.type === "article") {
-                // Serializable options should remain
-                expect(result.data.apiOptions.customKeypad).toBe(true);
+            invariant(result.type === "article");
+            // Serializable options should remain
+            expect(result.data.apiOptions.customKeypad).toBe(true);
 
-                // Non-serializable functions should be removed
-                expect(
-                    result.data.apiOptions.interactionCallback,
-                ).toBeUndefined();
+            // Non-serializable functions should be removed
+            expect(result.data.apiOptions.interactionCallback).toBeUndefined();
 
-                // Other properties should remain unchanged
-                expect(result.data.json).toBe(articleData.json);
-            }
+            // Other properties should remain unchanged
+            expect(result.data.json).toBe(articleData.json);
         });
 
         it("handles article data with null apiOptions", () => {
@@ -301,14 +290,12 @@ describe("sanitizePreviewData", () => {
 
             const result = sanitizePreviewData(previewContent);
 
-            expect(result.type).toBe("article-all");
-            if (result.type === "article-all") {
-                expect(result.data).toHaveLength(2);
-                expect(result.data[0].apiOptions.readOnly).toBe(true);
-                expect(result.data[0].apiOptions.onFocusChange).toBeUndefined();
-                expect(result.data[1].apiOptions.readOnly).toBe(false);
-                expect(result.data[1].apiOptions.onFocusChange).toBeUndefined();
-            }
+            invariant(result.type === "article-all");
+            expect(result.data).toHaveLength(2);
+            expect(result.data[0].apiOptions.readOnly).toBe(true);
+            expect(result.data[0].apiOptions.onFocusChange).toBeUndefined();
+            expect(result.data[1].apiOptions.readOnly).toBe(false);
+            expect(result.data[1].apiOptions.onFocusChange).toBeUndefined();
         });
 
         it("handles empty article-all array", () => {
@@ -319,10 +306,8 @@ describe("sanitizePreviewData", () => {
 
             const result = sanitizePreviewData(previewContent);
 
-            expect(result.type).toBe("article-all");
-            if (result.type === "article-all") {
-                expect(result.data).toHaveLength(0);
-            }
+            invariant(result.type === "article-all");
+            expect(result.data).toHaveLength(0);
         });
 
         it("does not mutate original article-all data", () => {
@@ -378,13 +363,11 @@ describe("sanitizePreviewData", () => {
 
             const result = sanitizePreviewData(previewContent);
 
-            expect(result.type).toBe("article-all");
-            if (result.type === "article-all") {
-                expect(result.data).toHaveLength(2);
-                expect(result.data[0].apiOptions.onFocusChange).toBeUndefined();
-                // Section with null apiOptions should be unchanged
-                expect(result.data[1].apiOptions).toBeNull();
-            }
+            invariant(result.type === "article-all");
+            expect(result.data).toHaveLength(2);
+            expect(result.data[0].apiOptions.onFocusChange).toBeUndefined();
+            // Section with null apiOptions should be unchanged
+            expect(result.data[1].apiOptions).toBeNull();
         });
     });
 

--- a/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
+++ b/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
@@ -1,0 +1,502 @@
+import {getDefaultAnswerArea} from "@khanacademy/perseus-core";
+
+import {sanitizePreviewData} from "./preview-data-sanitizer";
+
+import type {
+    ArticlePreviewData,
+    HintPreviewData,
+    PreviewContent,
+    QuestionPreviewData,
+} from "./message-types";
+import type {APIOptions} from "@khanacademy/perseus";
+
+// Mock API options with both serializable and non-serializable properties
+function createMockApiOptions(): APIOptions {
+    return {
+        // Serializable options
+        readOnly: true,
+        isMobile: false,
+        customKeypad: true,
+        // Non-serializable function callbacks (should be removed)
+        onFocusChange: jest.fn(),
+        answerableCallback: jest.fn(),
+        getAnotherHint: jest.fn(),
+        interactionCallback: jest.fn(),
+        trackInteraction: jest.fn(),
+    };
+}
+
+describe("sanitizePreviewData", () => {
+    describe("question preview data", () => {
+        it("sanitizes apiOptions in question data", () => {
+            const questionData: QuestionPreviewData = {
+                item: {
+                    question: {
+                        content: "What is 2+2?",
+                        widgets: {},
+                        images: {},
+                    },
+                    answerArea: getDefaultAnswerArea(),
+                    hints: [],
+                },
+                apiOptions: createMockApiOptions(),
+                initialHintsVisible: 0,
+                device: "phone",
+                linterContext: {
+                    contentType: "exercise",
+                    highlightLint: false,
+                    paths: [],
+                    stack: [],
+                },
+            };
+
+            const previewContent: PreviewContent = {
+                type: "question",
+                data: questionData,
+            };
+
+            const result = sanitizePreviewData(previewContent);
+
+            expect(result.type).toBe("question");
+            if (result.type === "question") {
+                // Serializable options should remain
+                expect(result.data.apiOptions.readOnly).toBe(true);
+                expect(result.data.apiOptions.isMobile).toBe(false);
+                expect(result.data.apiOptions.customKeypad).toBe(true);
+
+                // Non-serializable functions should be removed
+                expect(result.data.apiOptions.onFocusChange).toBeUndefined();
+                expect(
+                    result.data.apiOptions.answerableCallback,
+                ).toBeUndefined();
+                expect(result.data.apiOptions.getAnotherHint).toBeUndefined();
+                expect(
+                    result.data.apiOptions.interactionCallback,
+                ).toBeUndefined();
+                expect(result.data.apiOptions.trackInteraction).toBeUndefined();
+
+                // Other properties should remain unchanged
+                expect(result.data.item).toBe(questionData.item);
+                expect(result.data.initialHintsVisible).toBe(0);
+            }
+        });
+
+        it("handles question data with null apiOptions", () => {
+            const questionData: QuestionPreviewData = {
+                item: {
+                    question: {content: "Test", widgets: {}, images: {}},
+                    answerArea: getDefaultAnswerArea(),
+                    hints: [],
+                },
+                apiOptions: null as any,
+                initialHintsVisible: 0,
+                device: "phone",
+                linterContext: {
+                    contentType: "exercise",
+                    highlightLint: false,
+                    paths: [],
+                    stack: [],
+                },
+            };
+
+            const previewContent: PreviewContent = {
+                type: "question",
+                data: questionData,
+            };
+
+            const result = sanitizePreviewData(previewContent);
+
+            expect(result.type).toBe("question");
+            // Should return unchanged when apiOptions is null
+            expect(result).toEqual(previewContent);
+        });
+
+        it("does not mutate original question data", () => {
+            const apiOptions = createMockApiOptions();
+            const questionData: QuestionPreviewData = {
+                item: {
+                    question: {content: "Test", widgets: {}, images: {}},
+                    answerArea: getDefaultAnswerArea(),
+                    hints: [],
+                },
+                apiOptions,
+                initialHintsVisible: 0,
+                device: "phone",
+                linterContext: {
+                    contentType: "exercise",
+                    highlightLint: false,
+                    paths: [],
+                    stack: [],
+                },
+            };
+
+            const previewContent: PreviewContent = {
+                type: "question",
+                data: questionData,
+            };
+
+            sanitizePreviewData(previewContent);
+
+            // Original should still have functions
+            expect(apiOptions.onFocusChange).toBeDefined();
+            expect(apiOptions.answerableCallback).toBeDefined();
+        });
+    });
+
+    describe("hint preview data", () => {
+        it("sanitizes apiOptions in hint data", () => {
+            const hintData: HintPreviewData = {
+                hint: {
+                    content: "Try thinking about...",
+                    widgets: {},
+                    images: {},
+                },
+                pos: 0,
+                apiOptions: createMockApiOptions(),
+                linterContext: {
+                    contentType: "exercise",
+                    highlightLint: false,
+                    paths: [],
+                    stack: [],
+                },
+            };
+
+            const previewContent: PreviewContent = {
+                type: "hint",
+                data: hintData,
+            };
+
+            const result = sanitizePreviewData(previewContent);
+
+            expect(result.type).toBe("hint");
+            if (result.type === "hint") {
+                // Serializable options should remain
+                expect(result.data.apiOptions.readOnly).toBe(true);
+
+                // Non-serializable functions should be removed
+                expect(result.data.apiOptions.onFocusChange).toBeUndefined();
+                expect(result.data.apiOptions.trackInteraction).toBeUndefined();
+
+                // Other properties should remain unchanged
+                expect(result.data.hint).toBe(hintData.hint);
+                expect(result.data.pos).toBe(0);
+            }
+        });
+
+        it("handles hint data with null apiOptions", () => {
+            const hintData: HintPreviewData = {
+                hint: {content: "Hint", widgets: {}, images: {}},
+                pos: 1,
+                apiOptions: null as any,
+                linterContext: {
+                    contentType: "exercise",
+                    highlightLint: false,
+                    paths: [],
+                    stack: [],
+                },
+            };
+
+            const previewContent: PreviewContent = {
+                type: "hint",
+                data: hintData,
+            };
+
+            const result = sanitizePreviewData(previewContent);
+
+            expect(result).toEqual(previewContent);
+        });
+    });
+
+    describe("article preview data", () => {
+        it("sanitizes apiOptions in article data", () => {
+            const articleData: ArticlePreviewData = {
+                json: [{content: "# Article Title", widgets: {}, images: {}}],
+                apiOptions: createMockApiOptions(),
+                linterContext: {
+                    contentType: "article",
+                    highlightLint: false,
+                    paths: [],
+                    stack: [],
+                },
+            };
+
+            const previewContent: PreviewContent = {
+                type: "article",
+                data: articleData,
+            };
+
+            const result = sanitizePreviewData(previewContent);
+
+            expect(result.type).toBe("article");
+            if (result.type === "article") {
+                // Serializable options should remain
+                expect(result.data.apiOptions.customKeypad).toBe(true);
+
+                // Non-serializable functions should be removed
+                expect(
+                    result.data.apiOptions.interactionCallback,
+                ).toBeUndefined();
+
+                // Other properties should remain unchanged
+                expect(result.data.json).toBe(articleData.json);
+            }
+        });
+
+        it("handles article data with null apiOptions", () => {
+            const articleData: ArticlePreviewData = {
+                json: [{content: "Content", widgets: {}, images: {}}],
+                apiOptions: null as any,
+                linterContext: {
+                    contentType: "article",
+                    highlightLint: false,
+                    paths: [],
+                    stack: [],
+                },
+            };
+
+            const previewContent: PreviewContent = {
+                type: "article",
+                data: articleData,
+            };
+
+            const result = sanitizePreviewData(previewContent);
+
+            expect(result).toEqual(previewContent);
+        });
+    });
+
+    // NOTE: The article-all type currently uses ArticlePreviewData[] where
+    // each section carries its own apiOptions. This will be simplified to a
+    // single apiOptions when we restructure the preview data types.
+    describe("article-all preview data", () => {
+        it("sanitizes apiOptions in all article sections", () => {
+            const section1: ArticlePreviewData = {
+                json: [{content: "Section 1", widgets: {}, images: {}}],
+                apiOptions: createMockApiOptions(),
+                linterContext: {
+                    contentType: "article",
+                    highlightLint: false,
+                    paths: [],
+                    stack: [],
+                },
+            };
+            const section2: ArticlePreviewData = {
+                json: [{content: "Section 2", widgets: {}, images: {}}],
+                apiOptions: {
+                    ...createMockApiOptions(),
+                    readOnly: false,
+                },
+                linterContext: {
+                    contentType: "article",
+                    highlightLint: false,
+                    paths: [],
+                    stack: [],
+                },
+            };
+
+            const previewContent: PreviewContent = {
+                type: "article-all",
+                data: [section1, section2],
+            };
+
+            const result = sanitizePreviewData(previewContent);
+
+            expect(result.type).toBe("article-all");
+            if (result.type === "article-all") {
+                expect(result.data).toHaveLength(2);
+                expect(result.data[0].apiOptions.readOnly).toBe(true);
+                expect(
+                    result.data[0].apiOptions.onFocusChange,
+                ).toBeUndefined();
+                expect(result.data[1].apiOptions.readOnly).toBe(false);
+                expect(
+                    result.data[1].apiOptions.onFocusChange,
+                ).toBeUndefined();
+            }
+        });
+
+        it("handles empty article-all array", () => {
+            const previewContent: PreviewContent = {
+                type: "article-all",
+                data: [],
+            };
+
+            const result = sanitizePreviewData(previewContent);
+
+            expect(result.type).toBe("article-all");
+            if (result.type === "article-all") {
+                expect(result.data).toHaveLength(0);
+            }
+        });
+
+        it("does not mutate original article-all data", () => {
+            const apiOptions = createMockApiOptions();
+            const section: ArticlePreviewData = {
+                json: [{content: "Section 1", widgets: {}, images: {}}],
+                apiOptions,
+                linterContext: {
+                    contentType: "article",
+                    highlightLint: false,
+                    paths: [],
+                    stack: [],
+                },
+            };
+
+            const previewContent: PreviewContent = {
+                type: "article-all",
+                data: [section],
+            };
+
+            sanitizePreviewData(previewContent);
+
+            // Original should still have functions
+            expect(apiOptions.onFocusChange).toBeDefined();
+        });
+
+        it("handles sections with null apiOptions", () => {
+            const section1: ArticlePreviewData = {
+                json: [{content: "Section 1", widgets: {}, images: {}}],
+                apiOptions: createMockApiOptions(),
+                linterContext: {
+                    contentType: "article",
+                    highlightLint: false,
+                    paths: [],
+                    stack: [],
+                },
+            };
+            const section2: ArticlePreviewData = {
+                json: [{content: "Section 2", widgets: {}, images: {}}],
+                apiOptions: null as any,
+                linterContext: {
+                    contentType: "article",
+                    highlightLint: false,
+                    paths: [],
+                    stack: [],
+                },
+            };
+
+            const previewContent: PreviewContent = {
+                type: "article-all",
+                data: [section1, section2],
+            };
+
+            const result = sanitizePreviewData(previewContent);
+
+            expect(result.type).toBe("article-all");
+            if (result.type === "article-all") {
+                expect(result.data).toHaveLength(2);
+                expect(
+                    result.data[0].apiOptions.onFocusChange,
+                ).toBeUndefined();
+                // Section with null apiOptions should be unchanged
+                expect(result.data[1].apiOptions).toBeNull();
+            }
+        });
+    });
+
+    describe("edge cases", () => {
+        it("preserves data structure for all content types", () => {
+            const types: PreviewContent["type"][] = [
+                "question",
+                "hint",
+                "article",
+                "article-all",
+            ];
+
+            types.forEach((type) => {
+                let previewContent: PreviewContent;
+
+                switch (type) {
+                    case "question":
+                        previewContent = {
+                            type: "question",
+                            data: {
+                                item: {
+                                    question: {
+                                        content: "Q",
+                                        widgets: {},
+                                        images: {},
+                                    },
+                                    answerArea: getDefaultAnswerArea(),
+                                    hints: [],
+                                },
+                                apiOptions: {},
+                                initialHintsVisible: 0,
+                                device: "phone",
+                                linterContext: {
+                                    contentType: "exercise",
+                                    highlightLint: false,
+                                    paths: [],
+                                    stack: [],
+                                },
+                            },
+                        };
+                        break;
+                    case "hint":
+                        previewContent = {
+                            type: "hint",
+                            data: {
+                                hint: {content: "H", widgets: {}, images: {}},
+                                pos: 0,
+                                apiOptions: {},
+                                linterContext: {
+                                    contentType: "exercise",
+                                    highlightLint: false,
+                                    paths: [],
+                                    stack: [],
+                                },
+                            },
+                        };
+                        break;
+                    case "article":
+                        previewContent = {
+                            type: "article",
+                            data: {
+                                json: [
+                                    {
+                                        content: "A",
+                                        widgets: {},
+                                        images: {},
+                                    },
+                                ],
+                                apiOptions: {},
+                                linterContext: {
+                                    contentType: "article",
+                                    highlightLint: false,
+                                    paths: [],
+                                    stack: [],
+                                },
+                            },
+                        };
+                        break;
+                    case "article-all":
+                        previewContent = {
+                            type: "article-all",
+                            data: [
+                                {
+                                    json: [
+                                        {
+                                            content: "Paragraph A",
+                                            widgets: {},
+                                            images: {},
+                                        },
+                                    ],
+                                    apiOptions: {},
+                                    linterContext: {
+                                        contentType: "article",
+                                        highlightLint: false,
+                                        paths: [],
+                                        stack: [],
+                                    },
+                                },
+                            ],
+                        };
+                        break;
+                }
+
+                const result = sanitizePreviewData(previewContent);
+                expect(result.type).toBe(type);
+            });
+        });
+    });
+});

--- a/packages/perseus-editor/src/preview/preview-data-sanitizer.ts
+++ b/packages/perseus-editor/src/preview/preview-data-sanitizer.ts
@@ -1,0 +1,48 @@
+import {sanitizeApiOptions} from "./sanitize-api-options";
+
+import type {PreviewContent} from "./message-types";
+
+/**
+ * Sanitizes preview content by removing non-serializable functions and React
+ * components from apiOptions before sending via postMessage.
+ *
+ * NOTE: The article-all case currently sanitizes apiOptions on each section
+ * individually because the current type is ArticlePreviewData[] (each section
+ * carries its own apiOptions). This will be simplified to a single apiOptions
+ * when we restructure the preview data types.
+ */
+export function sanitizePreviewData(
+    /** Preview content to sanitize */
+    content: PreviewContent,
+): PreviewContent {
+    if (
+        (content.type === "question" ||
+            content.type === "hint" ||
+            content.type === "article") &&
+        content.data.apiOptions != null
+    ) {
+        return {
+            ...content,
+            data: {
+                ...content.data,
+                apiOptions: sanitizeApiOptions(content.data.apiOptions),
+            },
+        } as PreviewContent;
+    }
+
+    if (content.type === "article-all") {
+        return {
+            ...content,
+            data: content.data.map((section) =>
+                section.apiOptions != null
+                    ? {
+                          ...section,
+                          apiOptions: sanitizeApiOptions(section.apiOptions),
+                      }
+                    : section,
+            ),
+        } as PreviewContent;
+    }
+
+    return content;
+}

--- a/packages/perseus-editor/src/preview/sanitize-api-options.ts
+++ b/packages/perseus-editor/src/preview/sanitize-api-options.ts
@@ -1,0 +1,39 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import React from "react";
+
+import type {APIOptions} from "@khanacademy/perseus";
+
+/**
+ * Removes non-serializable functions and React components from APIOptions
+ * before sending via postMessage.
+ *
+ * All function callbacks and React components are removed as they cannot be
+ * cloned by the structured clone algorithm used by postMessage.
+ *
+ * Serializable options (booleans, strings, numbers) are preserved.
+ */
+export function sanitizeApiOptions(
+    apiOptions: APIOptions,
+): Partial<APIOptions> | null {
+    if (apiOptions == null) {
+        return null;
+    }
+
+    const {
+        onFocusChange: _,
+        answerableCallback: __,
+        getAnotherHint: ___,
+        interactionCallback: ____,
+        imagePreloader: _____,
+        trackInteraction: ______,
+        setDrawingAreaAvailable: ________,
+        baseElements: _________,
+        nativeKeypadProxy: __________,
+        // Remove React nodes (placeholders)
+        imagePlaceholder: ___________,
+        widgetPlaceholder: ____________,
+        ...serializableOptions
+    } = apiOptions;
+
+    return serializableOptions;
+}


### PR DESCRIPTION
## Summary:

_This PR is part of a series building a typed, hook-based preview system for the Perseus editor. The new system replaces the untyped window.iframeDataStore + raw postMessage(string) communication with structured, validated message passing via usePreviewHost and usePreviewClient hooks. The new system is being built alongside the old one — no existing behaviour changes until the final PR in the series flips the switch._

* https://github.com/Khan/perseus/pull/3464
* https://github.com/Khan/perseus/pull/3467 
* https://github.com/Khan/perseus/pull/3474

---

Adds `sanitizeApiOptions()` and `sanitizePreviewData()` which strip non-serializable values (function callbacks, React components) from preview data before it's sent via `postMessage`. The structured clone algorithm used by `postMessage` can't handle functions, so they need to be removed before sending.                                                               
                                                                                                                            
`sanitizeApiOptions()` destructures `APIOptions` to remove known non-serializable fields (`onFocusChange`, `trackInteraction`, `imagePreloader`, `nativeKeypadProxy`, placeholder components, etc.) and returns only the serializable remainder.                                                                                                                  
                                                                      
`sanitizePreviewData()` wraps this for all preview content types — question, hint, article, and article-all. The article-all case currently sanitizes per-section since each `ArticlePreviewData` carries its own `apiOptions`; this will be simplified when we restructure the preview data types in a later PR.
                                                                      
Purely additive — no existing behaviour is changed.                                                                          
                                                                                                                            
**Depends on:** #3474

Issue: LEMS-3741
                 
## Test plan:                           
                                                                                                                            
`pnpm test`