### PR TITLE
[Preview NG] Export preview system hooks from @khanacademy/perseus-editor

### DIFF
--- a/.changeset/warm-clouds-drift.md
+++ b/.changeset/warm-clouds-drift.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Export preview system hooks and types from @khanacademy/perseus-editor

--- a/packages/perseus-editor/src/index.ts
+++ b/packages/perseus-editor/src/index.ts
@@ -11,6 +11,10 @@ export {default as IframeContentRenderer} from "./iframe-content-renderer";
 export {default as ContentPreview} from "./content-preview";
 export type {Issue} from "./components/issues-panel";
 
+// Preview system hooks and utilities
+export {usePreviewController} from "./preview/use-preview-controller";
+export {usePreviewPresenter} from "./preview/use-preview-presenter";
+
 import "./styles/perseus-editor.css";
 
 // eslint-disable-next-line import/order


### PR DESCRIPTION
## Summary:

*This PR is part of a series building a typed, hook-based preview system for the Perseus editor. The new system replaces the untyped `window.iframeDataStore` + raw `postMessage(string)` communication with structured, validated message passing via `usePreviewController` and `usePreviewPresenter` hooks. The new system is being built alongside the old one — no existing behavior changes until the final PR in the series flips the switch.*

Previous PRs in this series:
- #3464
- #3467
- #3474
- #3492
- #3495

---

Exports `usePreviewController` and `usePreviewPresenter` from the `@khanacademy/perseus-editor` package so they can be consumed by the frontend repo and other consumers. This is a small wiring PR — it adds four lines to the package's main `index.ts`.

Purely additive — no existing behavior is changed.

Issue: LEMS-3741

## Test plan:

`pnpm tsc` and `pnpm knip` both pass. No new tests needed — the hooks are already fully tested in #3495.