### PR TITLE
[Preview NG] Migrate storybook preview page to usePreviewPresenter hook

### DIFF
--- a/.changeset/happy-rivers-flow.md
+++ b/.changeset/happy-rivers-flow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Migrate storybook preview page from iframeDataStore to usePreviewPresenter hook

--- a/packages/perseus-editor/src/testing/preview/exercise-preview-page.tsx
+++ b/packages/perseus-editor/src/testing/preview/exercise-preview-page.tsx
@@ -1,116 +1,75 @@
-/* eslint-disable import/no-relative-packages, import/order */
 import {View} from "@khanacademy/wonder-blocks-core";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
-import {PreviewRenderer} from "./preview-renderer";
+import {usePreviewPresenter} from "../../preview/use-preview-presenter";
 
-import type {PreviewContent} from "../../preview/message-types";
+import {PreviewRenderer} from "./preview-renderer";
 
 /**
  * Loads the exercise preview frame
  *
  * This is loaded inside the iframe, where it sets up the ExercisePreviewFrame
  * component that handles all communication between the iframe and its parent.
+ *
+ * Uses the usePreviewPresenter hook to receive content data from the parent
+ * window and report height changes back via structured postMessage protocol.
  */
 const ExercisePreviewPage = () => {
-    const [previewData, setPreviewData] = React.useState<PreviewContent | null>(
-        null,
-    );
-    const [iframeId, setIframeId] = React.useState<string | null>(null);
+    const {data, reportHeight} = usePreviewPresenter();
     const containerRef = React.useRef<HTMLDivElement>(null);
+    const lastHeightRef = React.useRef<number | null>(null);
 
-    // Read iframe configuration from dataset attributes
+    // Handle body overflow for article-all type (allows scrolling)
     React.useEffect(() => {
-        const iframe = window.frameElement as HTMLIFrameElement | null;
-        if (iframe?.dataset.id) {
-            setIframeId(iframe.dataset.id);
-        }
-    }, []);
-
-    // Listen for data from parent
-    React.useEffect(() => {
-        const handleMessage = (event: MessageEvent) => {
-            // For now, we receive the iframe ID and look up data in parent's iframeDataStore
-            if (
-                typeof event.data === "string" ||
-                typeof event.data === "number"
-            ) {
-                const id = String(event.data);
-                // Access parent's iframeDataStore
-                try {
-                    // @ts-expect-error - accessing parent window's custom property
-                    const data = window.parent.iframeDataStore?.[id];
-                    if (data) {
-                        setPreviewData(data);
-                    }
-                } catch (e) {
-                    // Cross-origin access might fail in some cases
-                    // Silently ignore - this is expected in cross-origin scenarios
-                    // eslint-disable-next-line no-console
-                    console.error("Error accessing iframeDataStore", e);
-                }
-            }
-        };
-
-        window.addEventListener("message", handleMessage);
-
-        // Request initial data
-        if (iframeId) {
-            window.parent.postMessage(iframeId, "*");
+        if (data?.type === "article-all") {
+            document.body.style.overflow = "scroll";
+        } else {
+            document.body.style.overflow = "hidden";
         }
 
         return () => {
-            window.removeEventListener("message", handleMessage);
+            document.body.style.overflow = "hidden";
         };
-    }, [iframeId]);
+    }, [data?.type]);
 
     // Send height updates to parent
     React.useEffect(() => {
-        if (!iframeId || !containerRef.current) {
+        if (!containerRef.current) {
             return;
         }
 
         const sendHeightUpdate = () => {
             const height = containerRef.current?.scrollHeight;
-            if (height) {
+            if (height && height !== lastHeightRef.current) {
+                lastHeightRef.current = height;
+
                 // NOTE(Jeremy) I'm not sure where this comes from but it's how
                 // production does it.
                 const bottomMargin = 30;
 
-                window.parent.postMessage(
-                    {
-                        id: iframeId,
-                        height: height + bottomMargin,
-                    },
-                    "*",
-                );
+                reportHeight(height + bottomMargin);
             }
         };
 
         // Send initial height
         sendHeightUpdate();
 
-        // Poll for height changes (to capture animations, etc.)
-        const interval = setInterval(sendHeightUpdate, 500);
-
         // Also send on resize
         let resizeObserver: ResizeObserver | undefined;
         const container = containerRef.current;
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        if (container) {
+        if (container != null) {
             resizeObserver = new ResizeObserver(sendHeightUpdate);
             resizeObserver.observe(container);
         }
 
         return () => {
-            clearInterval(interval);
             resizeObserver?.disconnect();
         };
-    }, [iframeId, previewData]);
+    }, [data, reportHeight]);
 
-    if (!previewData) {
+    if (!data) {
         return (
             <View style={styles.loading}>
                 <div>Loading preview...</div>
@@ -120,7 +79,7 @@ const ExercisePreviewPage = () => {
 
     return (
         <div ref={containerRef}>
-            <PreviewRenderer data={previewData} />
+            <PreviewRenderer data={data} />
         </div>
     );
 };

--- a/packages/perseus-editor/src/testing/preview/exercise-preview-page.tsx
+++ b/packages/perseus-editor/src/testing/preview/exercise-preview-page.tsx
@@ -28,10 +28,6 @@ const ExercisePreviewPage = () => {
         } else {
             document.body.style.overflow = "hidden";
         }
-
-        return () => {
-            document.body.style.overflow = "hidden";
-        };
     }, [data?.type]);
 
     // Send height updates to parent


### PR DESCRIPTION
## Summary:

*This PR is part of a series building a typed, hook-based preview system for the Perseus editor. The new system replaces the untyped `window.iframeDataStore` + raw `postMessage(string)` communication with structured, validated message passing via `usePreviewController` and `usePreviewPresenter` hooks. The new system is being built alongside the old one — no existing behavior changes until the final PR in the series flips the switch.*

Previous PRs in this series:
- #3464
- #3467
- #3474
- #3492
- #3495
- #3499

---

Migrates `exercise-preview-page.tsx` (the Storybook preview iframe content page) from the legacy `window.iframeDataStore` protocol to the new `usePreviewPresenter` hook. This replaces manual `postMessage` event listeners and `iframeDataStore` lookups with the typed hook API, and swaps `setInterval` polling for height with a `ResizeObserver` that only reports when height actually changes.

This is the first file in the series that modifies existing code rather than adding new files. The preview page only runs inside an iframe — when rendered standalone it shows "Loading preview..." via the hook's iframe validation.

Issue: LEMS-3741

## Test plan:

`pnpm tsc` passes. The preview page is tested via Storybook — load any EditorPage or ArticleEditor story and verify the preview pane renders content and resizes correctly.