### PR TITLE
[Image] | (a11y) | Add aria-describedby to Explore Image modal

### DIFF
--- a/.changeset/giant-donkeys-wink.md
+++ b/.changeset/giant-donkeys-wink.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Image] | (a11y) | Add aria-describedby to Explore Image modal

--- a/packages/perseus/src/widgets/image/components/explore-image-modal-content.tsx
+++ b/packages/perseus/src/widgets/image/components/explore-image-modal-content.tsx
@@ -16,7 +16,12 @@ import type {CommonImageProps, ZoomProps, GifProps} from "./image-info-area";
 
 const MODAL_HEIGHT = 568;
 
-type Props = CommonImageProps & ZoomProps & GifProps;
+type Props = CommonImageProps &
+    ZoomProps &
+    GifProps & {
+        captionId: string;
+        longDescId: string;
+    };
 
 export default function ExploreImageModalContent({
     backgroundImage,
@@ -30,6 +35,8 @@ export default function ExploreImageModalContent({
     labels,
     range,
     zoomSize,
+    captionId,
+    longDescId,
 }: Props) {
     const [isGifPlaying, setIsGifPlaying] = React.useState(false);
     const context = React.useContext(PerseusI18nContext);
@@ -146,7 +153,10 @@ export default function ExploreImageModalContent({
                 )}
 
                 {caption && (
-                    <div className={styles.modalCaptionContainer}>
+                    <div
+                        id={captionId}
+                        className={styles.modalCaptionContainer}
+                    >
                         {/* Use Renderer so that the caption can support markdown and TeX. */}
                         <Renderer
                             content={caption}
@@ -165,12 +175,14 @@ export default function ExploreImageModalContent({
                     {context.strings.imageDescriptionLabel}
                 </Heading>
                 {/* Use Renderer so that the description can support markdown and TeX. */}
-                <Renderer
-                    content={longDescription}
-                    apiOptions={apiOptions}
-                    linterContext={linterContext}
-                    strings={context.strings}
-                />
+                <div id={longDescId}>
+                    <Renderer
+                        content={longDescription}
+                        apiOptions={apiOptions}
+                        linterContext={linterContext}
+                        strings={context.strings}
+                    />
+                </div>
             </div>
         </div>
     );

--- a/packages/perseus/src/widgets/image/components/explore-image-modal.test.tsx
+++ b/packages/perseus/src/widgets/image/components/explore-image-modal.test.tsx
@@ -234,6 +234,38 @@ describe("ExploreImageModal", () => {
         expect(screen.getByText("widget long description")).toBeInTheDocument();
     });
 
+    it("sets the describedby to short and long description IDs if there is a caption", () => {
+        // Arrange, Act
+        renderModal({
+            ...defaultProps,
+            backgroundImage: earthMoonImage,
+            caption: "widget caption",
+        });
+
+        // Assert
+        const dialog = screen.getByRole("dialog");
+        // Regex for "uniqueId-caption uniqueId-long-desc"
+        expect(dialog.getAttribute("aria-describedby")).toMatch(
+            /^:r\w+:-caption :r\w+:-long-desc$/,
+        );
+    });
+
+    it("sets the describedby to long description ID if there is no caption", () => {
+        // Arrange, Act
+        renderModal({
+            ...defaultProps,
+            backgroundImage: earthMoonImage,
+            longDescription: "widget long description",
+        });
+
+        // Assert
+        const dialog = screen.getByRole("dialog");
+        const ariaDescribedBy = dialog.getAttribute("aria-describedby");
+        // Regex for "uniqueId-long-desc"
+        expect(ariaDescribedBy).toMatch(/^:r\w+:-long-desc$/);
+        expect(ariaDescribedBy).not.toMatch(/caption/);
+    });
+
     describe("gif controls", () => {
         it("should render gif controls if the image is a gif", () => {
             // Arrange, Act

--- a/packages/perseus/src/widgets/image/components/explore-image-modal.tsx
+++ b/packages/perseus/src/widgets/image/components/explore-image-modal.tsx
@@ -14,6 +14,9 @@ type Props = CommonImageProps & ZoomProps & GifProps;
 
 export const ExploreImageModal = (props: Props) => {
     const context = React.useContext(PerseusI18nContext);
+    const uniqueId = React.useId();
+    const captionId = `${uniqueId}-caption`;
+    const longDescId = `${uniqueId}-long-desc`;
 
     const titleText = props.title || context.strings.imageAlternativeTitle;
     const title = (
@@ -39,7 +42,16 @@ export const ExploreImageModal = (props: Props) => {
         >
             <FlexibleDialog
                 title={title}
-                content={<ExploreImageModalContent {...props} />}
+                content={
+                    <ExploreImageModalContent
+                        {...props}
+                        captionId={captionId}
+                        longDescId={longDescId}
+                    />
+                }
+                aria-describedby={
+                    props.caption ? `${captionId} ${longDescId}` : longDescId
+                }
                 styles={{
                     root: wbStyles.root,
                 }}


### PR DESCRIPTION
## Summary:
The internal audit pointed out that we're missing aria-describedby on the Explore Image modal.
In order to follow best practices, I'm adding that here.

As per the suggestion in the ticket, I'm adding both caption and description IDs if the
caption is present. If there is no caption, then it's just the description ID.

NOTE: This change is not possible to test in VoiceOver since it has a behavior discrepancy -
it will be the same as before adding the aria-describedby. We should be able to see a
difference when using NVDA though. 

Update: I confirmed that it reads the describedby content before the close button when using
NVDA on my personal Windows machine!

Issue: https://khanacademy.atlassian.net/browse/LEMS-4046

## Test plan:
`pnpm jest packages/perseus/src/widgets/image/components/explore-image-modal.test.tsx`

Storybook
- Go to `/?path=/story/widgets-image-widget-demo--image`
- Open the Elements tab in dev tools
- Confirm that the `role="dialog"` element has `aria-describedby` that points to the
  caption and description IDs.

| Before | After |
| --- | --- |
| <img width="436" height="92" alt="Screenshot 2026-04-16 at 2 10 32 PM" src="https://github.com/user-attachments/assets/e077459c-c749-4f1d-8619-5dd8196b2cc0" /> | <img width="449" height="119" alt="Screenshot 2026-04-16 at 2 10 23 PM" src="https://github.com/user-attachments/assets/e638297a-df3e-4234-a982-071c58bb4ef4" /> |
