### PR TITLE
[Image] | (CX) | Add a warning for large images

### DIFF
--- a/.changeset/itchy-students-repair.md
+++ b/.changeset/itchy-students-repair.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Image] | (CX) | Add warning for large images

--- a/packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx
@@ -8,7 +8,10 @@ import {act, render, screen, fireEvent} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
-import {earthMoonImage} from "../../../../perseus/src/widgets/image/utils";
+import {
+    earthMoonImage,
+    frescoImage,
+} from "../../../../perseus/src/widgets/image/utils";
 import {getFeatureFlags} from "../../testing/feature-flags-util";
 import {mockImageLoading} from "../../testing/image-loader-utils";
 import {
@@ -222,6 +225,54 @@ describe("image editor", () => {
 
         // Assert
         expect(screen.getByText(nonKhanImageWarning)).toBeInTheDocument();
+    });
+
+    it("should render warning for large image", () => {
+        // Arrange, Act
+        render(
+            <ImageEditorWithDependencies
+                apiOptions={{
+                    ...apiOptions,
+                    flags: getFeatureFlags({
+                        "image-widget-upgrade-scale": true,
+                    }),
+                }}
+                // frescoImage is very large (1698 x 955)
+                backgroundImage={frescoImage}
+                onChange={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByText(
+                "Large images may cause slow performance for learners. Please use a max size of 1024 x 1024.",
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it("should note render warning for smaller image", () => {
+        // Arrange, Act
+        render(
+            <ImageEditorWithDependencies
+                apiOptions={{
+                    ...apiOptions,
+                    flags: getFeatureFlags({
+                        "image-widget-upgrade-scale": true,
+                    }),
+                }}
+                // earthMoonImage is small (400 x 225)
+                backgroundImage={earthMoonImage}
+                onChange={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.queryByText(
+                "Large images may cause slow performance for learners. Please use a max size of 1024 x 1024.",
+            ),
+        ).not.toBeInTheDocument();
     });
 
     it("should render preview image with alt text", () => {

--- a/packages/perseus-editor/src/widgets/image-editor/components/image-scale-input.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/components/image-scale-input.tsx
@@ -116,7 +116,7 @@ export default function ImageScaleInput({
             {hasLargeDimensions && (
                 <Banner
                     kind="warning"
-                    text="Large images may cause slow performance for learners. Please use a max size of 1024x1024."
+                    text="Large images may cause slow performance for learners. Please use a max size of 1024 x 1024."
                 />
             )}
 

--- a/packages/perseus-editor/src/widgets/image-editor/components/image-scale-input.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/components/image-scale-input.tsx
@@ -116,7 +116,7 @@ export default function ImageScaleInput({
             {hasLargeDimensions && (
                 <Banner
                     kind="warning"
-                    text="This image has large dimensions and may cause slowed performance."
+                    text="Large images may cause slow performance for learners. Please use a max size of 1024x1024."
                 />
             )}
 

--- a/packages/perseus-editor/src/widgets/image-editor/components/image-scale-input.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/components/image-scale-input.tsx
@@ -13,7 +13,8 @@ import {wbFieldStyles} from "../utils";
 import type {Props as ImageEditorProps} from "../image-editor";
 import type {PerseusImageBackground} from "@khanacademy/perseus-core";
 
-const LARGE_DIMENSION_THRESHOLD = 1024;
+// 1024 * 1024 = 1,048,576
+const LARGE_DIMENSION_THRESHOLD = 1048576;
 
 interface Props {
     backgroundImage: PerseusImageBackground;
@@ -96,8 +97,7 @@ export default function ImageScaleInput({
         });
     }
 
-    const hasLargeDimensions =
-        width > LARGE_DIMENSION_THRESHOLD || height > LARGE_DIMENSION_THRESHOLD;
+    const hasLargeDimensions = width * height > LARGE_DIMENSION_THRESHOLD;
 
     return (
         <div className={styles.dimensionsContainer}>

--- a/packages/perseus-editor/src/widgets/image-editor/components/image-scale-input.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/components/image-scale-input.tsx
@@ -1,4 +1,5 @@
 import {Util} from "@khanacademy/perseus";
+import Banner from "@khanacademy/wonder-blocks-banner";
 import Button from "@khanacademy/wonder-blocks-button";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
 import {BodyMonospace} from "@khanacademy/wonder-blocks-typography";
@@ -11,6 +12,8 @@ import {wbFieldStyles} from "../utils";
 
 import type {Props as ImageEditorProps} from "../image-editor";
 import type {PerseusImageBackground} from "@khanacademy/perseus-core";
+
+const LARGE_DIMENSION_THRESHOLD = 1024;
 
 interface Props {
     backgroundImage: PerseusImageBackground;
@@ -93,6 +96,9 @@ export default function ImageScaleInput({
         });
     }
 
+    const hasLargeDimensions =
+        width > LARGE_DIMENSION_THRESHOLD || height > LARGE_DIMENSION_THRESHOLD;
+
     return (
         <div className={styles.dimensionsContainer}>
             <BodyMonospace>
@@ -106,6 +112,13 @@ export default function ImageScaleInput({
             >
                 Recalculate original size
             </Button>
+
+            {hasLargeDimensions && (
+                <Banner
+                    kind="warning"
+                    text="This image has large dimensions and may cause slowed performance."
+                />
+            )}
 
             <div className={styles.horizontalLine} />
 


### PR DESCRIPTION
## Summary:
If an image is too large, it can cause slowdowns in both the editor and for our learners.

Add a warning here to let the content authors know if that's the case.

Issue: https://khanacademy.atlassian.net/browse/LEMS-4050

## Test plan:
`pnpm jest packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx`

Storybook
- Go to `/?path=/story/editors-editorpage--with-all-flags`
- Add an image widget
- Use a large image (example: `https://cdn.kastatic.org/ka-perseus-images/01f44d5b73290da6bec97c75a5316fb05ab61f12.jpg`)
- Confirm that a warning shows up about the image being too large
- Use a small image (example: `https://cdn.kastatic.org/ka-content-images/61831c1329dbc32036d7dd0d03e06e7e2c622718.jpg`)
- Confirm that the warning does not show up

| Before | After |
| --- | --- |
| <img width="361" height="619" alt="Screenshot 2026-04-16 at 2 37 47 PM" src="https://github.com/user-attachments/assets/de4ff518-6d2d-4e92-8285-8668d8e237ff" /> | <img width="360" height="706" alt="Screenshot 2026-04-16 at 2 37 52 PM" src="https://github.com/user-attachments/assets/5f606002-e7b8-4367-a8ca-d4309d8498b1" /> |
