### PR TITLE
[Image] | (CX) | Give explore modal launcher a label saying it has description

### DIFF
--- a/.changeset/cuddly-rats-hang.md
+++ b/.changeset/cuddly-rats-hang.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Image] | (CX) | Give explore modal launcher a label saying it has description

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -597,6 +597,7 @@ export type PerseusStrings = {
         point2Y: string;
     }) => string;
     imageExploreButton: string;
+    imageExploreButtonAriaLabel: string;
     imageAlternativeTitle: string;
     imageDescriptionLabel: string;
     imageZoomAriaLabel: string;
@@ -1320,6 +1321,7 @@ export const strings = {
             "Tangent graph with inflection point at %(point1X)s comma %(point1Y)s and control point at %(point2X)s comma %(point2Y)s.",
     },
     imageExploreButton: "Explore image",
+    imageExploreButtonAriaLabel: "Explore image and description",
     imageAlternativeTitle: "Explore image and description",
     imageDescriptionLabel: "Description",
     imageZoomAriaLabel: "Make image bigger.",
@@ -1717,6 +1719,7 @@ export const mockStrings: PerseusStrings = {
     srTangentInteractiveElements: ({point1X, point1Y, point2X, point2Y}) =>
         `Tangent graph with inflection point at ${point1X} comma ${point1Y} and control point at ${point2X} comma ${point2Y}.`,
     imageExploreButton: "Explore image",
+    imageExploreButtonAriaLabel: "Explore image and description",
     imageAlternativeTitle: "Explore image and description",
     imageDescriptionLabel: "Description",
     imageZoomAriaLabel: "Make image bigger.",

--- a/packages/perseus/src/widgets/image/__docs__/image-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/image/__docs__/image-interactions-regression.stories.tsx
@@ -48,7 +48,7 @@ export const LongDescriptionClickedState: Story = {
     },
     play: async ({canvas, userEvent}) => {
         const imageTrigger = canvas.getByRole("button", {
-            name: "Explore image",
+            name: "Explore image and description",
         });
         await userEvent.click(imageTrigger);
     },
@@ -65,7 +65,7 @@ export const LongDescriptionClickedStateWithGraphieImage: Story = {
     },
     play: async ({canvas, userEvent}) => {
         const imageTrigger = canvas.getByRole("button", {
-            name: "Explore image",
+            name: "Explore image and description",
         });
         await userEvent.click(imageTrigger);
     },
@@ -83,7 +83,7 @@ export const LongDescriptionClickedStateWithNoSize: Story = {
     },
     play: async ({canvas, userEvent}) => {
         const imageTrigger = canvas.getByRole("button", {
-            name: "Explore image",
+            name: "Explore image and description",
         });
         await userEvent.click(imageTrigger);
     },
@@ -102,7 +102,7 @@ export const LongDescriptionClickedStateWithNoSizeLargeImage: Story = {
     },
     play: async ({canvas, userEvent}) => {
         const imageTrigger = canvas.getByRole("button", {
-            name: "Explore image",
+            name: "Explore image and description",
         });
         await userEvent.click(imageTrigger);
     },
@@ -117,7 +117,7 @@ export const LongDescriptionClickedStateWithNoSizeLargeSvgImage: Story = {
     },
     play: async ({canvas, userEvent}) => {
         const imageTrigger = canvas.getByRole("button", {
-            name: "Explore image",
+            name: "Explore image and description",
         });
         await userEvent.click(imageTrigger);
     },

--- a/packages/perseus/src/widgets/image/components/explore-image-button.tsx
+++ b/packages/perseus/src/widgets/image/components/explore-image-button.tsx
@@ -14,7 +14,14 @@ export default function ExploreImageButton({hasCaption, onClick}: Props) {
     const context = React.useContext(PerseusI18nContext);
     if (!hasCaption) {
         return (
-            <Button kind="secondary" startIcon={infoIconBold} onClick={onClick}>
+            <Button
+                // Aria-label informs screen reader users that the button
+                // provides access to the long description.
+                aria-label={context.strings.imageExploreButtonAriaLabel}
+                kind="secondary"
+                startIcon={infoIconBold}
+                onClick={onClick}
+            >
                 {context.strings.imageExploreButton}
             </Button>
         );
@@ -22,7 +29,7 @@ export default function ExploreImageButton({hasCaption, onClick}: Props) {
 
     return (
         <IconButton
-            aria-label={context.strings.imageExploreButton}
+            aria-label={context.strings.imageExploreButtonAriaLabel}
             icon={infoIconBold}
             kind="secondary"
             onClick={onClick}

--- a/packages/perseus/src/widgets/image/image.test.ts
+++ b/packages/perseus/src/widgets/image/image.test.ts
@@ -271,7 +271,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
         });
 
         // Assert
-        const button = screen.getByRole("button", {name: "Explore image"});
+        const button = screen.getByRole("button", {
+            name: "Explore image and description",
+        });
         expect(button).toBeVisible();
         expect(button).toHaveTextContent("Explore image");
     });
@@ -298,9 +300,14 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
         });
 
         // Assert
-        const iconButton = screen.getByRole("button", {name: "Explore image"});
+        const iconButton = screen.getByRole("button", {
+            name: "Explore image and description",
+        });
         expect(iconButton).toBeVisible();
-        expect(iconButton).toHaveAttribute("aria-label", "Explore image");
+        expect(iconButton).toHaveAttribute(
+            "aria-label",
+            "Explore image and description",
+        );
         expect(iconButton).not.toHaveTextContent("Explore image");
     });
 
@@ -324,7 +331,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
         });
 
         //  Act
-        const button = screen.getByRole("button", {name: "Explore image"});
+        const button = screen.getByRole("button", {
+            name: "Explore image and description",
+        });
         await userEvent.click(button);
 
         // Assert
@@ -352,7 +361,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
         });
 
         //  Act
-        const button = screen.getByRole("button", {name: "Explore image"});
+        const button = screen.getByRole("button", {
+            name: "Explore image and description",
+        });
         await userEvent.click(button);
 
         // Assert
@@ -381,7 +392,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
         });
 
         //  Act
-        const button = screen.getByRole("button", {name: "Explore image"});
+        const button = screen.getByRole("button", {
+            name: "Explore image and description",
+        });
         await userEvent.click(button);
 
         // Assert
@@ -413,7 +426,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
         });
 
         //  Act
-        const button = screen.getByRole("button", {name: "Explore image"});
+        const button = screen.getByRole("button", {
+            name: "Explore image and description",
+        });
         await userEvent.click(button);
 
         // Assert
@@ -442,7 +457,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
         });
 
         //  Act - open the modal, check for zoom button
-        const button = screen.getByRole("button", {name: "Explore image"});
+        const button = screen.getByRole("button", {
+            name: "Explore image and description",
+        });
         await userEvent.click(button);
         const withinDialog = within(screen.getByRole("dialog"));
         const zoomButton = withinDialog.queryByRole("button", {
@@ -703,7 +720,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
 
             // Assert
             expect(
-                screen.queryByRole("button", {name: "Explore image"}),
+                screen.queryByRole("button", {
+                    name: "Explore image and description",
+                }),
             ).not.toBeInTheDocument();
         });
 
@@ -767,7 +786,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
                 screen.queryByText("widget caption"),
             ).not.toBeInTheDocument();
             expect(
-                screen.queryByRole("button", {name: "Explore image"}),
+                screen.queryByRole("button", {
+                    name: "Explore image and description",
+                }),
             ).not.toBeInTheDocument();
 
             // Decorative images have role="presentation" due to empty alt text
@@ -806,7 +827,9 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
             expect(screen.getByText("widget title")).toBeVisible();
             expect(screen.getByText("widget caption")).toBeVisible();
             expect(
-                screen.getByRole("button", {name: "Explore image"}),
+                screen.getByRole("button", {
+                    name: "Explore image and description",
+                }),
             ).toBeVisible();
             expect(screen.getByAltText("widget alt text")).toBeVisible();
         });


### PR DESCRIPTION
## Summary:
Right now, the label for the explore image modal launcher button is "Explore image,"
but that doesn't make it clear to screen reader users that the explore image modal
will also contain the long description for the image.

To make this more clear, use the aria label "Explore image and description"

Issue: https://khanacademy.atlassian.net/browse/LEMS-4045

## Test plan:
`pnpm jest packages/perseus/src/widgets/image/image.test.ts`

Storybook
- Open `/?path=/story/widgets-image-widget-demo--image`
- Turn on a screen reader
- Navigate to the explore image launcher button
- Confirm it says "Explore image and description"

| Before | After |
| --- | --- |
| <img width="676" height="588" alt="Screenshot 2026-04-20 at 4 03 41 PM" src="https://github.com/user-attachments/assets/fbc28b4e-8585-4f4a-9980-14d967ba5604" /> | <img width="706" height="583" alt="Screenshot 2026-04-20 at 3 51 10 PM" src="https://github.com/user-attachments/assets/c3c5ee6d-5633-43fb-9799-b906213251d9" /> |
