### PR TITLE
docs(changeset): Allow the asymptote to be placed between points. Also allow for points to be on asymptote line so long as they don't overlap with the drag handle.

### DIFF
--- a/.changeset/light-teachers-compare.md
+++ b/.changeset/light-teachers-compare.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Allow the asymptote to be placed between points. Also allow for points to be on asymptote line so long as they don't overlap with the drag handle.

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/notes/exponential.md
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/notes/exponential.md
@@ -1,0 +1,411 @@
+# Exponential Graph — Technical Reference
+
+Technical specification for the exponential graph type in the Interactive Graph widget.
+This document defines expected behavior, architecture, and design decisions. It is intended
+as context for future development and Claude Code sessions.
+
+## Traceability
+
+- **Ticket:** [LEMS-3711](https://khanacademy.atlassian.net/browse/LEMS-3711)
+
+## Architecture Overview
+
+### File Map
+
+| File | Purpose |
+|------|---------|
+| `graphs/exponential.tsx` | Main rendering component: curve, asymptote, points, SR descriptions |
+| `graphs/components/movable-asymptote.tsx` | Reusable draggable asymptote line (shared with logarithm) |
+| `graphs/components/asymptote-drag-handle.tsx` | Pill-shaped SVG drag handle (shared with logarithm) |
+| `reducer/interactive-graph-reducer.ts` | `doMovePoint` and `doMoveCenter` cases for exponential |
+| `reducer/initialize-graph-state.ts` | `getExponentialCoords()` — default coords and asymptote |
+| `reducer/interactive-graph-state.ts` | `getGradableGraph` serialization for exponential |
+| `mafs-state-to-interactive-graph.ts` | Exponential state → persisted data conversion |
+| `types.ts` | `ExponentialGraphState` (coords + asymptote + snapStep) |
+| `interactive-graph.tsx` | `getExponentialEquationString()`, `defaultExponentialCoords()` |
+| `interactive-graph-question-builder.ts` | `withExponential()` test helper |
+| `interactive-graph.testdata.ts` | `exponentialQuestion` fixture |
+| `@khanacademy/kmath` `coefficients.ts` | `getExponentialCoefficients()` — shared math utility |
+| `@khanacademy/perseus-core` `data-schema.ts` | `PerseusGraphTypeExponential`, `ExponentialGraphCorrect` |
+| `@khanacademy/perseus-score` `score-interactive-graph.ts` | Exponential scoring block |
+| `@khanacademy/perseus-editor` `start-coords-exponential.tsx` | Editor start coords UI |
+| `__docs__/interactive-graph-asymptote-regression.stories.tsx` | Drag handle visual regression stories (shared with logarithm) |
+
+### Data Flow
+
+```
+User interaction (drag/keyboard)
+  → Dispatch action (movePoint / moveCenter)
+  → Reducer applies constraints, updates ExponentialGraphState
+  → ExponentialGraph component re-renders:
+      1. Computes coefficients from coords + asymptote (getExponentialCoefficients)
+      2. Renders Plot.OfX with y-padding NaN cutoff
+      3. Renders MovableAsymptote with drag handle
+      4. Renders MovablePoints
+  → On submit: getGradableGraph extracts coords + asymptote
+  → Scoring: coefficient comparison via approximateDeepEqual
+```
+
+## Expected Behavior
+
+### Curve Rendering
+
+- The curve renders `f(x) = a * e^(b*x) + c` using a single `<Plot.OfX>`.
+- The curve is drawn across the full x-domain `[xMin, xMax]` — exponential is defined
+  everywhere, so no domain restriction is needed.
+- The curve approaches the horizontal asymptote as `x → ±∞`. The `Plot.OfX` callback
+  applies a **y-padding NaN cutoff** so that y-values far outside the visible range stop
+  the SVG path (see [Curve-Asymptote Visual Continuity](#curve-asymptote-visual-continuity)).
+- The curve never visually touches or intersects the asymptote: as `x → ±∞` the curve
+  exits horizontally off the left/right edges of the visible area while y converges on
+  the asymptote.
+- When the asymptote sits between the two points (or a point lies exactly on the asymptote),
+  no exponential fits — `getExponentialCoefficients` returns `undefined` and the
+  `<Plot.OfX>` is not rendered. The asymptote and points remain fully interactive in this
+  state, so the user can recover by dragging anything back to a valid configuration.
+- The curve updates in real time as points or asymptote are dragged.
+
+### SVG Rendering Order
+
+The `MovableAsymptote` component wraps both the asymptote lines and the drag handle. The
+curve is rendered as `children` of `MovableAsymptote`, which places it between the lines
+and the handle in the SVG DOM. This gives the following back-to-front stacking:
+
+1. **Asymptote lines** (white backing + dashed blue) — bottom layer
+2. **Curve** (`Plot.OfX`, rendered as `MovableAsymptote` children) — above the lines
+3. **Drag handle** (`AsymptoteDragHandle`) — above the curve
+4. **Movable points** (`MovablePoint`) — top layer
+
+This order ensures two things: (a) the curve is visible where it approaches the asymptote
+(not hidden behind the white backing line), and (b) the drag handle is always visually
+above the curve line. The curve has `pointerEvents: "none"` so it does not intercept
+mouse/touch events meant for the asymptote's hit target underneath. The same ordering
+applies to the logarithm graph.
+
+### Asymptote Rendering
+
+- The asymptote is a full-width horizontal **dashed** line using `MovableAsymptote` with `orientation="horizontal"`.
+- The line is rendered as two stacked SVG lines: a solid white backing line (so dashes are
+  visible on grid lines and axes) and a dashed blue line on top with rounded ends (`stroke-linecap: round`).
+- **Resting state**: stroke weight 2px, dash length 6, gap 8.
+- **Hover/focus/drag state**: stroke weight 4px, dash length 8, gap 12.
+- These are controlled by CSS variables `--movable-asymptote-stroke-weight`,
+  `--movable-asymptote-dash-length`, and `--movable-asymptote-dash-gap` in `mafs-styles.css`,
+  activated via `:hover`, `:focus-visible`, and `.movable-dragging` selectors.
+- The entire line is draggable (not just the handle) via a transparent 44px-tall SVG hit target.
+- A pill-shaped drag handle (`AsymptoteDragHandle`) is rendered at the midpoint:
+  - **Active state** (hovered, focused, or dragging): 22px × 12px pill with 6 white grip dots (3×2 grid)
+  - **Inactive state** (default): 16px × 6px pill, no grip dots
+  - **Focus ring** (keyboard focus only): rounded outline around the handle (not the full line)
+- The drag handle retains focus after a mouse drag ends, matching movable point behavior.
+  Focus clears only when the user clicks elsewhere or navigates away via keyboard.
+
+### Asymptote Drag Behavior
+
+- The asymptote is constrained to vertical movement only (X component ignored).
+- The asymptote snaps to the grid.
+- The asymptote may be dragged to any y-position, including between the two curve points.
+  When between the points (i.e. one point above and one below), no valid exponential fits
+  and the curve disappears (the asymptote and points remain interactive).
+- The asymptote cannot land such that its drag handle (a pill at the x-midpoint of the range,
+  on the asymptote line) would overlap a curve point's coord. This guarantees the handle is
+  always grabbable. Built from `getAsymptoteHandleCoord("horizontal", range, asymptote)`.
+
+### Point Behavior
+
+- Two movable control points define the curve shape along with the asymptote.
+- Points may be placed anywhere within the graph range, including on or across the asymptote.
+  Configurations that produce no fit (point on asymptote, or points on opposite sides) are
+  allowed — they simply produce no curve.
+- Both points must have **different x-values** (same x makes coefficient `b` undefined).
+  Unlike logarithm, same y-values are *allowed* — only same x is degenerate for exponential.
+- The only forbidden landing position is the exact coord of the asymptote drag handle (so
+  the handle stays grabbable).
+- Invalid moves are rejected gracefully (no crash, no invalid state).
+
+### Keyboard Navigation
+
+- **Points:** Arrow keys move by snap step. The shared `getAsymptoteGraphKeyboardConstraint`
+  helper applies an `isValidPosition()` predicate that rejects same-x collisions with the
+  other point and rejects landing on the asymptote drag handle's coord. If a step lands on
+  a forbidden position, the constraint retries up to 3 snap steps in the same direction. If
+  no valid position exists within 3 steps, the point stays in place.
+- **Asymptote:** Arrow keys move vertically by snap step. `skipAsymptoteKeyboardOverPoint`
+  snaps the proposed point to the grid (required by `useDraggable`'s function-form
+  constraint), then if the snapped position would put the handle on a point's coord, it
+  steps further in the direction of travel until it finds a valid position (up to 3 extra
+  snap steps).
+
+### Scoring
+
+- Coefficients `{a, b, c}` are computed for both user answer and rubric using
+  `getExponentialCoefficients()`.
+- Comparison uses `approximateDeepEqual` on `[a, b, c]` arrays of the coefficients.
+- No canonical normalization needed (exponential has no periodic equivalences).
+- Two different sets of control points that produce the same curve score as correct.
+- Returns `invalid` if coords or asymptote are missing, or coefficient computation fails.
+
+### Accessibility
+
+- `aria-label` on the graph container (`srExponentialGraph`).
+- Localized labels for each point (`srExponentialPoint1`, `srExponentialPoint2`).
+- Localized asymptote label (`srExponentialAsymptote`) with keyboard navigation instructions.
+- Graph description (`srExponentialDescription`) with point and asymptote positions.
+- Interactive elements description (`srExponentialInteractiveElements`).
+- `aria-live="polite"` on the asymptote announces position changes to screen readers.
+- All number values use `srFormatNumber` for locale-appropriate formatting.
+
+### Editor
+
+- "Exponential function" appears in the graph type selector, gated by the
+  `interactive-graph-exponent` feature flag (note: the flag name is `-exponent`, not
+  `-exponential`).
+- `StartCoordsExponential` component provides: two coordinate pair inputs, a single number
+  input for asymptote y-position, and equation display showing `y = a * e^(b*x) + c`.
+- CSS module styling (`start-coords-exponential.module.css`), not Aphrodite.
+
+### Mobile
+
+- All interactions (drag points, drag asymptote) work via touch.
+- The 44px transparent hit target on the asymptote ensures adequate touch target size.
+
+## Mathematical Model
+
+### Formula
+
+```
+f(x) = a * e^(b * x) + c
+```
+
+Where `[a, b, c]` are 3 coefficients derived from 2 movable points and 1 horizontal asymptote.
+The asymptote y-value *is* the `c` coefficient — no extra computation needed for `c`.
+
+### Coefficient Computation
+
+Direct (no flipping/inversion). Given `p1 = [x1, y1]`, `p2 = [x2, y2]`, asymptote y = `c`:
+
+1. `c = asymptote` (the asymptote y-value is the c coefficient directly)
+2. `b = ln((y1 - c) / (y2 - c)) / (x1 - x2)`
+3. `a = (y1 - c) / e^(b * x1)`
+
+### When `getExponentialCoefficients` returns `undefined`
+
+These are the cases where no exponential fits and the renderer skips `<Plot.OfX>`. The widget
+allows the user to enter these states (asymptote between points is intentionally allowed) —
+they just produce no curve.
+
+- Same x-coordinate on both points (makes `b` undefined: division by zero in the exponent formula)
+- A point lying exactly on the asymptote (`y1 === c` or `y2 === c` makes the ratio `0` or `∞`)
+- Points on opposite sides of the asymptote (`(y1 - c) / (y2 - c) <= 0`, so `ln(ratio)` is undefined)
+- Non-finite or zero `a`/`b`
+
+### Domain
+
+The exponential function is defined for all real `x`. `Plot.OfX` is given no `domain` prop,
+so it samples across the full visible x-range.
+
+### Curve-Asymptote Visual Continuity
+
+The curve uses a **y-padding NaN cutoff** to terminate the SVG path when y escapes the
+visible range. In `exponential.tsx`:
+
+```typescript
+const yPadding = (yMax - yMin) * 4;
+// inside Plot.OfX y={(x) => ...}:
+if (y < yMin - yPadding || y > yMax + yPadding) {
+    return NaN;
+}
+```
+
+A `NaN` return tells Mafs to break the SVG path at that x — the curve simply ends.
+
+**Why this works for exponential:**
+The exponential curve approaches its asymptote **horizontally** — `x` extends to ±∞ while
+`y` converges on the asymptote value. The curve exits the visible area off the left/right
+edges. The y-padding cutoff just controls how far vertically the curve extends (away from
+the asymptote) before being clipped, which is robust for all coefficient values.
+
+**Why exponential doesn't need a dynamic domain offset (like logarithm does):**
+Logarithm approaches its vertical asymptote vertically (y → ±∞ as x nears the asymptote),
+so a y-padding cutoff would end the SVG path *near the asymptote itself*, causing visible
+discontinuity for flatter curves. Exponential avoids that problem entirely because the
+curve exits horizontally, not vertically. See logarithm.md for the dynamic-offset approach
+used there.
+
+## State Management
+
+### `ExponentialGraphState`
+
+```typescript
+interface ExponentialGraphState {
+    type: "exponential";
+    coords: [Coord, Coord];    // Two curve control points
+    asymptote: number;          // Y-value of the horizontal asymptote
+    snapStep: vec.Vector2;
+    range: [Interval, Interval];
+    hasBeenInteractedWith: boolean;
+}
+```
+
+### Actions
+
+Reuses existing action creators (no new action types):
+- `actions.exponential.movePoint(index, destination)` → `MOVE_POINT`
+- `actions.exponential.moveCenter(newPoint)` → `MOVE_CENTER`
+
+### Reducer: `doMovePoint`
+
+1. Snap destination to grid, bound to range.
+2. Reject if both points would have the same x-value (degenerate coefficient computation).
+3. Reject if the destination overlaps the asymptote drag handle's coord (so the handle stays
+   grabbable). Handle coord is computed via `getAsymptoteHandleCoord("horizontal", range, asymptote)`.
+
+Note: same y-values are *not* rejected for exponential (unlike logarithm).
+
+### Reducer: `doMoveCenter`
+
+1. Extract Y component only (vertical movement) and snap to grid.
+2. Reject if the snapped position equals the current asymptote (no-op).
+3. Reject if the new asymptote's drag handle would land on a point's coord. Future handle
+   coord is computed via `getAsymptoteHandleCoord("horizontal", range, newY)`.
+
+### Defaults
+
+`getExponentialCoords()` returns default coords using normalized fractions `[0.5, 0.55]` and
+`[0.75, 0.75]` (matching Grapher widget defaults), with the default asymptote at `y = 0`
+(the x-axis). Both default points sit above the asymptote so the curve renders immediately.
+
+## Decisions Log
+
+Numbered decisions with rationale for future context.
+
+1. **Explicit asymptote dragging** — The asymptote is user-movable (matching Grapher behavior)
+   rather than derived from the control points. Gives content creators full control.
+
+2. **Asymptote y-value is stored as a `number`, not a coord pair** — `asymptote: number`
+   = the `c` coefficient directly. This eliminates stale x-coordinates and simplifies all
+   downstream code (kmath, scoring, serialization).
+
+3. **Reuse `moveCenter` action** — Instead of a new `moveAsymptote` action type, reuses the
+   existing `MOVE_CENTER` action (also used by circle and logarithm graphs). Keeps the action
+   surface small.
+
+4. **Single `Plot.OfX` with full domain** — Exponential is defined everywhere, so no domain
+   restriction is needed. The y-padding NaN cutoff handles visual continuity.
+
+5. **Conditional curve rendering when no valid fit** — When the asymptote sits between the
+   two points (or shares a y-value with one), `getExponentialCoefficients` returns `undefined`
+   and `<Plot.OfX>` is skipped. The asymptote and points stay interactive so the user can
+   recover by moving them.
+
+6. **Direct coefficient comparison for scoring** — No canonical normalization needed because
+   exponential has no periodic equivalences. `approximateDeepEqual` on `[a, b, c]` suffices.
+
+7. **Asymptote-between-points is allowed at runtime, rejected by the editor** — The runtime
+   reducer lets the user drag the asymptote anywhere, including between the two control
+   points; when it's between them no exponential fits and the curve simply disappears
+   (the asymptote and points stay interactive). The editor's start-coords validator, however,
+   rejects this state for *initial* coords (see `interactive-graph-editor.tsx` `validate()`
+   block) — content can only be authored with a valid configuration, but the learner can
+   transiently enter the no-fit state while interacting.
+
+8. **Same-x rejected; same-y allowed** — Only same x-values make the coefficient computation
+   degenerate (`b = ln(ratio) / 0`). Same y-values are geometrically valid for exponential
+   (e.g. two points equally distant from the asymptote on different sides — though that
+   produces no fit for a different reason). This differs from logarithm, where both same-x
+   and same-y are rejected at the reducer level.
+
+9. **Full-line draggable asymptote** — Uses `useDraggable` + `SVGLine` pattern from `MovableLine`,
+   making the entire line interactive. A pill-shaped handle provides visual affordance.
+
+10. **Y-padding NaN cutoff for curve termination** — Uses a fixed `4 × (yMax - yMin)` padding
+    multiplier. This works for exponential because the curve exits horizontally off the
+    visible area; the y-padding only controls how far vertically the SVG path extends. A
+    dynamic domain offset (used by logarithm) is unnecessary here.
+    See [Curve-Asymptote Visual Continuity](#curve-asymptote-visual-continuity).
+
+11. **Localized focus ring on drag handle** — Focus ring appears around the drag handle pill
+    (not the full asymptote line), consistent with how movable points display focus.
+
+12. **Point-on-handle is the only forbidden overlap** — Points can sit anywhere within the
+    graph range; the only constraint is that a point's coord cannot equal the asymptote
+    drag handle's coord (a single point in graph-space at the midpoint of the x-range, on
+    the asymptote y-value). This keeps the handle grabbable while letting the rest of the
+    graph be a valid landing surface for points. The same rule mirrors in reverse for
+    asymptote moves.
+
+13. **Bounded keyboard skip retry** — Both the point-keyboard predicate and the asymptote
+    keyboard constraint cap their direction-of-travel skip at 3 snap steps. With at most 2
+    curve points blocking, 3 is always sufficient to find a valid position; if none is
+    found, the element stays put.
+
+14. **Drag handle retains focus after drag** — Matches movable point behavior. Focus clears
+    only when the user clicks elsewhere or navigates away via keyboard.
+
+15. **Curve renders between asymptote lines and drag handle** — `Plot.OfX` is rendered as
+    `children` of `MovableAsymptote`, placing it between the asymptote lines (white backing +
+    dashed blue) and the drag handle in the SVG DOM. This ensures the curve is visible where
+    it approaches the asymptote (not hidden behind the white backing line) while keeping the
+    drag handle visually above the curve. The curve has `pointerEvents: "none"` so it does
+    not intercept events meant for the asymptote's hit target underneath.
+
+16. **CSS modules (not Aphrodite)** — All component styling uses `.module.css` files with class
+    names, following the project convention.
+
+## Comparison with Other Graph Types
+
+### vs. Logarithm
+
+| Aspect | Exponential | Logarithm |
+|--------|-------------|-----------|
+| Formula | `a * e^(b*x) + c` | `a * ln(b*x + c)` |
+| Asymptote | Horizontal (y-value) | Vertical (x-value) |
+| Asymptote movement | Vertical only | Horizontal only |
+| Drag handle orientation | Horizontal | Vertical |
+| Point degeneracy | Same x-values rejected | Same x-values **and** same y-values rejected |
+| No-curve-fits state | Asymptote between point y-values, or point on asymptote | Asymptote between point x-values, or point on asymptote |
+| Coefficient computation | Direct from points + asymptote | Inverse of exponential (flip coords, compute, invert) |
+| Curve continuity approach | Y-padding NaN cutoff | Dynamic domain offset |
+| Domain | Full `[xMin, xMax]` | Restricted to one side of the asymptote |
+
+### vs. Tangent
+
+| Aspect | Tangent | Exponential |
+|--------|---------|-------------|
+| Formula | `a * tan(b*x - c) + d` | `a * e^(b*x) + c` |
+| Coefficients | 4 | 3 |
+| Interactive elements | 2 points | 2 points + 1 draggable asymptote |
+| Asymptotes | Multiple (periodic, computed) | Single horizontal (user-movable) |
+| Domain restriction | Undefined at each asymptote | Defined everywhere |
+| Rendering | Segment splitting (multiple `Plot.OfX`) | Single `Plot.OfX` with NaN cutoff |
+| Canonical normalization | Yes | No |
+
+### vs. Sinusoid
+
+| Aspect | Sinusoid | Exponential |
+|--------|----------|-------------|
+| Control points | 2 points | 2 points + 1 asymptote |
+| Asymptotes | None | Single horizontal (draggable) |
+| Domain | All real numbers | All real numbers |
+| Reducer actions | `movePoint` | `movePoint` + `moveCenter` |
+
+## Legacy Reference: Grapher Widget
+
+The Grapher widget has a complete exponential implementation that served as the mathematical
+reference:
+
+- `packages/perseus-core/src/utils/grapher-util.ts` — `Exponential` object with coefficient
+  computation, evaluation, equation string, asymptote constraints, and default coordinates.
+- `packages/perseus-core/src/utils/grapher-types.ts` — `ExponentialType` extends
+  `SharedGrapherType` and `AsymptoticGraphsType`.
+- `packages/perseus-core/src/data-schema.ts` — Grapher `exponential` answer type.
+- `packages/perseus/src/widgets/grapher/grapher.testdata.ts` — `exponentialQuestion` test data.
+
+## Visual Regression Testing
+
+A dedicated stories file (`interactive-graph-asymptote-regression.stories.tsx`) covers all drag
+handle visual states for both exponential and logarithm graphs. Located at
+"Widgets/Interactive Graph/Visual Regression Tests/Asymptote Drag Handle" in Storybook.
+Stories use `play` functions to programmatically focus elements, making states visible in both
+the Storybook UI and Chromatic snapshots. Follows the radio widget interaction regression pattern
+(`tags: ["!autodocs"]`).

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/notes/logarithm.md
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/notes/logarithm.md
@@ -64,8 +64,10 @@ User interaction (drag/keyboard)
   (which uses a y-padding NaN cutoff), logarithm relies on the domain offset because the
   curve exits the visible area **vertically** — a y-padding cutoff would end the SVG path
   near the asymptote, causing a visible discontinuity for flatter curves.
-- During transient invalid states (e.g. mid-drag), `coeffRef` provides the last valid
-  coefficients so the curve doesn't break.
+- When the asymptote sits between the two points, no logarithm fits — `getLogarithmCoefficients`
+  returns `undefined` and the `<Plot.OfX>` is not rendered. The asymptote and points remain
+  fully interactive in this state, so the user can recover by dragging anything back to a
+  valid configuration.
 - The curve updates in real time as points or asymptote are dragged.
 
 ### SVG Rendering Order
@@ -107,33 +109,34 @@ applies to the exponential graph.
 
 - The asymptote is constrained to horizontal movement only (Y component ignored).
 - The asymptote snaps to the grid.
-- The asymptote cannot land on either point's x-coordinate.
-- **Snap-through logic:** When the asymptote would land between or on the curve points, it
-  snaps past all points to the other side (one `snapStep` beyond the nearest extreme point
-  in the drag direction).
-- **Direction detection:** Uses the requested mouse position relative to the midpoint between
-  the two curve points (prevents oscillation/flicker from state changes between frames).
-- When the asymptote crosses to the other side of both points, the curve flips direction.
+- The asymptote may be dragged to any x-position, including between the two curve points.
+  When between the points, no valid logarithm fits and the curve disappears (the asymptote
+  and points remain interactive).
+- The asymptote cannot land such that its drag handle (a pill at the y-midpoint of the range,
+  on the asymptote line) would overlap a curve point's coord. This guarantees the handle is
+  always grabbable. Built from `getAsymptoteHandleCoord("vertical", range, asymptote)`.
 
 ### Point Behavior
 
 - Two movable control points define the curve shape along with the asymptote.
-- Points cannot be placed on the asymptote line (`point.x !== asymptoteX`).
-- Both points must have different y-values (prevents degenerate coefficient computation).
-- **Cross-asymptote reflection:** When a point is dragged across the asymptote, the other
-  point is automatically reflected across (`reflectedX = 2 * asymptoteX - otherX`) so both
-  points end up on the same side. A post-reflection guard rejects the move if the reflected
-  point would share the same x-coordinate as the moved point.
+- Points may be placed anywhere along the asymptote line. The only forbidden position is the
+  exact coord of the asymptote drag handle (so the handle stays grabbable).
+- Both points must have different x-values and different y-values (either case is degenerate
+  for the coefficient computation).
 - Invalid moves are rejected gracefully (no crash, no invalid state).
 
 ### Keyboard Navigation
 
-- **Points:** Arrow keys move by snap step. A unified `isValidPosition()` check enforces
-  asymptote and same-y rules with bounded retry (max 3 steps in the move direction). If no
-  valid position exists within 3 steps, the point stays in place.
-- **Asymptote:** Arrow keys move horizontally by snap step. `constrainAsymptoteKeyboard()`
-  applies the same snap-through logic as mouse drag — when the snapped position would land
-  between or on points, it snaps past all points using the midpoint heuristic.
+- **Points:** Arrow keys move by snap step. The shared `getAsymptoteGraphKeyboardConstraint`
+  helper applies an `isValidPosition()` predicate that rejects same-x or same-y collisions
+  with the other point and rejects landing on the asymptote drag handle's coord. If a step
+  lands on a forbidden position, the constraint retries up to 3 snap steps in the same
+  direction. If no valid position exists within 3 steps, the point stays in place.
+- **Asymptote:** Arrow keys move horizontally by snap step. `skipAsymptoteKeyboardOverPoint`
+  snaps the proposed point to the grid (required by `useDraggable`'s function-form
+  constraint), then if the snapped position would put the handle on a point's coord, it
+  steps further in the direction of travel until it finds a valid position (up to 3 extra
+  snap steps).
 
 ### Scoring
 
@@ -159,8 +162,6 @@ applies to the exponential graph.
 - "Logarithm function" appears in the graph type selector, gated by `interactive-graph-logarithm` feature flag.
 - `StartCoordsLogarithm` component provides: two coordinate pair inputs, a single number
   input for asymptote x-position, and equation display showing `y = a * ln(b*x + c)`.
-- Start asymptote validation: the asymptote x-value cannot fall between or on the x-coordinates
-  of the curve's start points (mirrors exponential's y-axis validation but for x-axis).
 - CSS module styling (not Aphrodite), following `start-coords-exponential.module.css` pattern.
 
 ### Mobile
@@ -190,7 +191,11 @@ Where `[a, b, c]` are 3 coefficients derived from 2 movable points and 1 vertica
     - `b = 1 / aExp`
     - `c = -cExp / aExp`
 
-### Validation Guards (returns `undefined` for invalid inputs)
+### When `getLogarithmCoefficients` returns `undefined`
+
+These are the cases where no logarithm fits and the renderer skips `<Plot.OfX>`. The widget
+allows the user to enter these states (asymptote between points is intentionally allowed) —
+they just produce no curve.
 
 - Same y-coordinate on both points (makes `bExp` undefined)
 - A point lying on the asymptote
@@ -273,17 +278,17 @@ Reuses existing action creators (no new action types):
 ### Reducer: `doMovePoint`
 
 1. Snap destination to grid, bound to range.
-2. Reject if point lands on asymptote x-coordinate.
-3. Reject if both points would have the same y-value.
-4. If point crosses asymptote: reflect the other point across (`reflectedX = 2 * asymptoteX - otherX`).
-5. Post-reflection guard: reject if reflected point collides with moved point's x-coordinate.
+2. Reject if both points would have the same x-value (degenerate coefficient computation).
+3. Reject if both points would have the same y-value (degenerate coefficient computation).
+4. Reject if the destination overlaps the asymptote drag handle's coord (so the handle stays
+   grabbable). Handle coord is computed via `getAsymptoteHandleCoord("vertical", range, asymptote)`.
 
 ### Reducer: `doMoveCenter`
 
-1. Extract X component only (horizontal movement).
-2. Snap to grid.
-3. If new position is between or on the curve points: snap past all points to the other side.
-4. Direction determined by comparing requested position to midpoint between curve points.
+1. Extract X component only (horizontal movement) and snap to grid.
+2. Reject if the snapped position equals the current asymptote (no-op).
+3. Reject if the new asymptote's drag handle would land on a point's coord. Future handle
+   coord is computed via `getAsymptoteHandleCoord("vertical", range, newX)`.
 
 ### Defaults
 
@@ -306,14 +311,20 @@ Numbered decisions with rationale for future context.
    for multiple periodic asymptotes), logarithm has one asymptote and the function is defined on
    only one side. No discontinuity workaround needed.
 
-4. **Ref-based coefficient caching** — `coeffRef` stores last valid coefficients as fallback
-   during transient invalid states. Same pattern as tangent and sinusoid.
+4. **Conditional curve rendering when no valid fit** — When the asymptote sits between the
+   two points (or shares a coord with one), `getLogarithmCoefficients` returns `undefined`
+   and `<Plot.OfX>` is skipped. The asymptote and points stay interactive so the user can
+   recover by moving them. This replaces an earlier ref-based caching approach that would
+   keep showing a stale curve in invalid states.
 
 5. **Direct coefficient comparison for scoring** — No canonical normalization needed because
    logarithm has no periodic equivalences. `approximateDeepEqual` on `{a, b, c}` suffices.
 
-6. **Midpoint-based snap-through** — Snap direction uses the midpoint between curve points
-   (not the previous asymptote position) to prevent oscillation when state changes between frames.
+6. **Asymptote-between-points is allowed** — The asymptote can be dragged anywhere along its
+   axis, including between the two control points. Content authors requested this state
+   because it improves the usability of authoring questions about the asymptote. When the
+   asymptote is between the points there is no real exponential/logarithm fit, so the curve
+   simply disappears.
 
 7. **Full-line draggable asymptote** — Uses `useDraggable` + `SVGLine` pattern from `MovableLine`,
    making the entire line interactive. A pill-shaped handle provides visual affordance.
@@ -328,13 +339,17 @@ Numbered decisions with rationale for future context.
 9. **Localized focus ring on drag handle** — Focus ring appears around the drag handle pill
    (not the full asymptote line), consistent with how movable points display focus.
 
-10. **Point cross-asymptote reflection** — When a point crosses the asymptote, the other point
-    is reflected to the same side. Matches Grapher behavior. Replaced the earlier approach of
-    rejecting cross-asymptote moves.
+10. **Point-on-handle is the only forbidden overlap** — Points can sit anywhere along the
+    asymptote line; the only constraint is that a point's coord cannot equal the asymptote
+    drag handle's coord (a single point in graph-space at the midpoint of the y-range, on
+    the asymptote x-value). This keeps the handle grabbable while letting the rest of the
+    asymptote line be a valid landing surface for points. The same rule mirrors in reverse
+    for asymptote moves.
 
-11. **Bounded keyboard constraint retry** — Unified `isValidPosition()` check inside a bounded
-    loop (max 3 steps). Prevents infinite-loop risk and ensures the point stays put if no valid
-    position exists.
+11. **Bounded keyboard skip retry** — Both the point-keyboard predicate and the asymptote
+    keyboard constraint cap their direction-of-travel skip at 3 snap steps. With at most 2
+    curve points blocking, 3 is always sufficient to find a valid position; if none is
+    found, the element stays put.
 
 12. **Drag handle retains focus after drag** — Matches movable point behavior. Auto-blur on drag
     end was implemented and reverted for consistency (see Post-Implementation Fixes).
@@ -371,8 +386,8 @@ Numbered decisions with rationale for future context.
 | Asymptote | Horizontal (y-value) | Vertical (x-value) |
 | Asymptote movement | Vertical only | Horizontal only |
 | Drag handle orientation | Horizontal | Vertical |
-| Point constraint | Same x-values rejected | Same y-values rejected |
-| Cross-asymptote reflection | Y-axis reflection | X-axis reflection |
+| Point degeneracy | Same x-values rejected | Same x-values **and** same y-values rejected |
+| No-curve-fits state | Asymptote between point y-values | Asymptote between point x-values |
 | Coefficient relationship | Inverse of logarithm | Inverse of exponential |
 
 ### vs. Sinusoid

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/exponential.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/exponential.test.tsx
@@ -6,10 +6,7 @@ import {testDependencies} from "../../../testing/test-dependencies";
 import {MafsGraph} from "../mafs-graph";
 import {getBaseMafsGraphPropsForTests} from "../utils";
 
-import {
-    constrainAsymptoteKeyboard,
-    getExponentialKeyboardConstraint,
-} from "./exponential";
+import {getExponentialKeyboardConstraint} from "./exponential";
 
 import type {InteractiveGraphState} from "../types";
 import type {vec} from "mafs";
@@ -154,6 +151,35 @@ describe("Exponential graph screen reader", () => {
         );
     });
 
+    it("renders without crashing when the asymptote sits between the curve points", () => {
+        // Arrange, Act — asymptote y=4 sits between points at y=3 and y=6.
+        // There is no exponential curve that fits, so the Plot.OfX is skipped.
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseExponentialState,
+                    coords: [
+                        [0, 3],
+                        [1, 6],
+                    ],
+                    asymptote: 4,
+                }}
+            />,
+        );
+
+        // Assert — asymptote + both points still rendered
+        expect(
+            screen.getByRole("button", {name: /Horizontal asymptote/}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: /Point 1/}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: /Point 2/}),
+        ).toBeInTheDocument();
+    });
+
     it("describes the interactive elements for the graph", () => {
         // Arrange, Act
         render(
@@ -219,10 +245,12 @@ describe("getExponentialKeyboardConstraint", () => {
         expect(constraint.up).toEqual([0, 4]);
     });
 
-    it("skips positions on the asymptote when moving down", () => {
-        // Arrange — point at y=2, asymptote at y=1: moving down would hit y=1 then y=0
+    it("allows moving down onto the asymptote line", () => {
+        // Arrange — point 0 at (-1, 2), asymptote at y=1. Moving down used
+        // to skip past y=1; asymptote crossings are now allowed so the
+        // point lands on the asymptote line (off the drag handle's x).
         const nearAsymptoteCoords: [vec.Vector2, vec.Vector2] = [
-            [0, 2],
+            [-1, 2],
             [2, 6],
         ];
 
@@ -235,8 +263,30 @@ describe("getExponentialKeyboardConstraint", () => {
             range,
         );
 
-        // Assert — skips y=1 (asymptote) and lands on y=0
-        expect(constraint.down).toEqual([0, 0]);
+        // Assert
+        expect(constraint.down).toEqual([-1, 1]);
+    });
+
+    it("skips the position that would land on the asymptote drag handle", () => {
+        // Arrange — handle coord is (midX=0, asymptote=2). Point 0 at (0, 3)
+        // moving down to (0, 2) would land on the handle and is skipped;
+        // the next step (0, 1) is valid.
+        const onHandleCoords: [vec.Vector2, vec.Vector2] = [
+            [0, 3],
+            [2, 6],
+        ];
+
+        // Act
+        const constraint = getExponentialKeyboardConstraint(
+            onHandleCoords,
+            2,
+            snapStep,
+            0,
+            range,
+        );
+
+        // Assert
+        expect(constraint.down).toEqual([0, 1]);
     });
 
     it("skips positions that share x-coordinate with the other point when moving right", () => {
@@ -260,12 +310,9 @@ describe("getExponentialKeyboardConstraint", () => {
     });
 
     it("rejects positions where the clamped coord collides with the other point's x", () => {
-        // Arrange — points at [9,3] and [8,6], asymptote at 1.
-        // Moving point 0 right: x=10 clamps to 9 (inset max),
-        // which equals otherPoint[X]=... wait, otherPoint is point 1.
-        // Actually let's use: point 0 at [8,3], point 1 at [9,6].
-        // Moving right: x=9 shares x with point 1 (skip).
-        // x=10 clamps to 9 (same as point 1). All further clamp to 9.
+        // Arrange — point 0 at x=8, point 1 at x=9 (graph edge).
+        // Moving right: x=9 shares x with point 1, x=10 clamps to 9.
+        // No valid right move — falls back to original position.
         const edgeCoords: [vec.Vector2, vec.Vector2] = [
             [8, 3],
             [9, 6],
@@ -280,100 +327,7 @@ describe("getExponentialKeyboardConstraint", () => {
             range,
         );
 
-        // Assert — no valid right move, falls back to original position
+        // Assert
         expect(constraint.right).toEqual([8, 3]);
-    });
-
-    it("stays put when all upward positions would cause a clamped reflection collision", () => {
-        // Arrange — asymptote at y=8, points at [3,7] and [1,4].
-        // Moving point 0 up: y=8 is the asymptote (skip), y=9 crosses
-        // the asymptote so reflectedY = 2*8-4 = 12, which clamps to 9
-        // (yMax - snapStep). clampedReflectedY(9) === clampedY(9). Skip.
-        // y=10 clamps to 9 too. No valid upward position.
-        const edgeCoords: [vec.Vector2, vec.Vector2] = [
-            [3, 7],
-            [1, 4],
-        ];
-
-        // Act
-        const constraint = getExponentialKeyboardConstraint(
-            edgeCoords,
-            8,
-            snapStep,
-            0,
-            range,
-        );
-
-        // Assert — no valid up move, falls back to original position
-        expect(constraint.up).toEqual([3, 7]);
-    });
-
-    it("skips positions where the clamped asymptote check catches out-of-bounds coord", () => {
-        // Arrange — asymptote at y=9 (one step from edge).
-        // Point 0 at [3,8], moving up: y=9 is asymptote (skip).
-        // y=10 clamps to 9 which also equals asymptote. Skip.
-        // No valid upward position.
-        const edgeCoords: [vec.Vector2, vec.Vector2] = [
-            [3, 8],
-            [1, 6],
-        ];
-
-        // Act
-        const constraint = getExponentialKeyboardConstraint(
-            edgeCoords,
-            9,
-            snapStep,
-            0,
-            range,
-        );
-
-        // Assert — no valid up move
-        expect(constraint.up).toEqual([3, 8]);
-    });
-});
-
-describe("constrainAsymptoteKeyboard", () => {
-    const snapStep: vec.Vector2 = [1, 1];
-
-    it("allows the asymptote to move freely when not between or on the curve points", () => {
-        // Arrange — points at y=3 and y=6, asymptote moving to y=1 (below both)
-        const coords: [vec.Vector2, vec.Vector2] = [
-            [0, 3],
-            [2, 6],
-        ];
-
-        // Act
-        const result = constrainAsymptoteKeyboard([0, 1], coords, snapStep);
-
-        // Assert — y=1 is valid (below both points)
-        expect(result).toEqual([0, 1]);
-    });
-
-    it("snaps the asymptote below both points when it would land between them", () => {
-        // Arrange — points at y=2 and y=6, asymptote trying to land at y=4 (between)
-        const coords: [vec.Vector2, vec.Vector2] = [
-            [0, 2],
-            [2, 6],
-        ];
-
-        // Act
-        const result = constrainAsymptoteKeyboard([0, 4], coords, snapStep);
-
-        // Assert — snapped to one step below the lower point (y=2-1=1) or above upper (y=6+1=7)
-        expect(result[1] < 2 || result[1] > 6).toBe(true);
-    });
-
-    it("skips a y-value exactly equal to a curve point", () => {
-        // Arrange — points at y=2 and y=6, asymptote trying to land exactly at y=2
-        const coords: [vec.Vector2, vec.Vector2] = [
-            [0, 2],
-            [2, 6],
-        ];
-
-        // Act
-        const result = constrainAsymptoteKeyboard([0, 2], coords, snapStep);
-
-        // Assert — must not land exactly on y=2
-        expect(result[1]).not.toBe(2);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/exponential.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/exponential.tsx
@@ -1,7 +1,4 @@
-import {
-    coefficients as kmathCoefficients,
-    type ExponentialCoefficient,
-} from "@khanacademy/kmath";
+import {coefficients as kmathCoefficients} from "@khanacademy/kmath";
 import {Plot} from "mafs";
 import * as React from "react";
 
@@ -21,7 +18,8 @@ import {srFormatNumber} from "./screenreader-text";
 import {useTransformVectorsToPixels} from "./use-transform";
 import {
     getAsymptoteGraphKeyboardConstraint,
-    constrainAsymptoteKeyboardMovement,
+    getAsymptoteHandleCoord,
+    skipAsymptoteKeyboardOverPoint,
 } from "./utils";
 
 import type {
@@ -30,6 +28,7 @@ import type {
     Dispatch,
     InteractiveGraphElementSuite,
 } from "../types";
+import type {ExponentialCoefficient} from "@khanacademy/kmath";
 import type {Coord} from "@khanacademy/perseus-core";
 import type {Interval, vec} from "mafs";
 
@@ -57,17 +56,10 @@ function ExponentialGraph(props: ExponentialGraphProps) {
 
     const {coords, asymptote, snapStep} = graphState;
 
-    // Cache last valid coefficients so the graph doesn't break during
-    // transient invalid states (e.g. mid-drag where points share an x-value).
-    const coeffRef = React.useRef<ExponentialCoefficient>({
-        a: 1,
-        b: 1,
-        c: 0,
-    });
+    // When the asymptote sits between the two points there is no valid
+    // exponential that fits — coeffs will be undefined, and we skip
+    // rendering the curve below.
     const coeffs = getExponentialCoefficients(coords, asymptote);
-    if (coeffs !== undefined) {
-        coeffRef.current = coeffs;
-    }
 
     const asymptoteY = asymptote;
     const yMin = range[1][0];
@@ -86,13 +78,12 @@ function ExponentialGraph(props: ExponentialGraphProps) {
     // The asymptote is a full-width horizontal line.
     const asymptoteLeft: vec.Vector2 = [range[0][0], asymptoteY];
     const asymptoteRight: vec.Vector2 = [range[0][1], asymptoteY];
-    const asymptoteMidX = (range[0][0] + range[0][1]) / 2;
-    const asymptoteMid: vec.Vector2 = [asymptoteMidX, asymptoteY];
+    const handleCoord = getAsymptoteHandleCoord("horizontal", range, asymptote);
 
     const [leftPx, rightPx, midPx] = useTransformVectorsToPixels(
         asymptoteLeft,
         asymptoteRight,
-        asymptoteMid,
+        handleCoord,
     );
 
     return (
@@ -101,30 +92,39 @@ function ExponentialGraph(props: ExponentialGraphProps) {
                 start={leftPx}
                 end={rightPx}
                 mid={midPx}
-                point={asymptoteLeft}
+                point={handleCoord}
                 onMove={(newPoint) =>
                     dispatch(actions.exponential.moveCenter(newPoint))
                 }
                 constrainKeyboardMovement={(p) =>
-                    constrainAsymptoteKeyboard(p, coords, snapStep)
+                    skipAsymptoteKeyboardOverPoint(
+                        p,
+                        asymptote,
+                        coords,
+                        handleCoord,
+                        snapStep,
+                        "horizontal",
+                    )
                 }
                 orientation="horizontal"
                 ariaLabel={srExponentialAsymptote}
             >
-                <Plot.OfX
-                    y={(x) => {
-                        const y = computeExponential(x, coeffRef.current);
-                        if (y < yMin - yPadding || y > yMax + yPadding) {
-                            return NaN;
-                        }
-                        return y;
-                    }}
-                    color={interactiveColor}
-                    svgPathProps={{
-                        "aria-hidden": true,
-                        style: {pointerEvents: "none"},
-                    }}
-                />
+                {coeffs !== undefined && (
+                    <Plot.OfX
+                        y={(x) => {
+                            const y = computeExponential(x, coeffs);
+                            if (y < yMin - yPadding || y > yMax + yPadding) {
+                                return NaN;
+                            }
+                            return y;
+                        }}
+                        color={interactiveColor}
+                        svgPathProps={{
+                            "aria-hidden": true,
+                            style: {pointerEvents: "none"},
+                        }}
+                    />
+                )}
             </MovableAsymptote>
             {coords.map((coord, i) => (
                 <MovablePoint
@@ -153,13 +153,6 @@ function ExponentialGraph(props: ExponentialGraphProps) {
     );
 }
 
-export const constrainAsymptoteKeyboard = (
-    p: vec.Vector2,
-    coords: ReadonlyArray<Coord>,
-    snapStep: vec.Vector2,
-): vec.Vector2 =>
-    constrainAsymptoteKeyboardMovement(p, coords, snapStep, "horizontal");
-
 export const getExponentialKeyboardConstraint = (
     coords: ReadonlyArray<Coord>,
     asymptote: number,
@@ -173,7 +166,7 @@ export const getExponentialKeyboardConstraint = (
     right: vec.Vector2;
 } => {
     const otherPoint = coords[1 - pointIndex];
-    const asymptoteY = asymptote;
+    const handleCoord = getAsymptoteHandleCoord("horizontal", range, asymptote);
 
     return getAsymptoteGraphKeyboardConstraint(
         coords,
@@ -191,33 +184,13 @@ export const getExponentialKeyboardConstraint = (
             const clampedX = clamped[X];
             const clampedY = clamped[Y];
 
-            // Point cannot land on the horizontal asymptote
-            if (coord[Y] === asymptoteY || clampedY === asymptoteY) {
-                return false;
-            }
             // Both points must have different x-values
             if (coord[X] === otherPoint[X] || clampedX === otherPoint[X]) {
                 return false;
             }
-            // When the move crosses the asymptote, the reducer will
-            // reflect the other point. Check that the reflected Y
-            // doesn't collide with the proposed coord's Y.
-            const currentPoint = coords[pointIndex];
-            const currentSide = currentPoint[Y] > asymptoteY;
-            const proposedSide = coord[Y] > asymptoteY;
-            if (currentSide !== proposedSide) {
-                const reflectedY = 2 * asymptoteY - otherPoint[Y];
-                const clampedReflectedY = snap(
-                    snapStep,
-                    bound({snapStep, range, point: [0, reflectedY]}),
-                )[Y];
-                if (
-                    reflectedY === coord[Y] ||
-                    clampedReflectedY === coord[Y] ||
-                    clampedReflectedY === clampedY
-                ) {
-                    return false;
-                }
+            // Point cannot overlap the asymptote's drag handle
+            if (clampedX === handleCoord[X] && clampedY === handleCoord[Y]) {
+                return false;
             }
             return true;
         },

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/logarithm.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/logarithm.test.tsx
@@ -6,10 +6,7 @@ import {testDependencies} from "../../../testing/test-dependencies";
 import {MafsGraph} from "../mafs-graph";
 import {getBaseMafsGraphPropsForTests} from "../utils";
 
-import {
-    constrainAsymptoteKeyboard,
-    getLogarithmKeyboardConstraint,
-} from "./logarithm";
+import {getLogarithmKeyboardConstraint} from "./logarithm";
 
 import type {InteractiveGraphState} from "../types";
 import type {vec} from "mafs";
@@ -154,6 +151,31 @@ describe("Logarithm graph screen reader", () => {
         );
     });
 
+    it("renders without crashing when the asymptote sits between the curve points", () => {
+        // Arrange, Act — asymptote x=-4.5 sits between points at x=-4 and x=-5.
+        // There is no logarithm curve that fits, so the Plot.OfX is skipped.
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseLogarithmState,
+                    asymptote: -4.5,
+                }}
+            />,
+        );
+
+        // Assert — asymptote + both points still rendered
+        expect(
+            screen.getByRole("button", {name: /Vertical asymptote/}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: /Point 1/}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: /Point 2/}),
+        ).toBeInTheDocument();
+    });
+
     it("describes the interactive elements for the graph", () => {
         // Arrange, Act
         render(
@@ -219,8 +241,10 @@ describe("getLogarithmKeyboardConstraint", () => {
         expect(constraint.up).toEqual([-4, -2]);
     });
 
-    it("skips positions on the asymptote when moving left", () => {
-        // Arrange — point at x=-5, asymptote at x=-6: moving left would hit x=-6 then x=-7
+    it("allows moving onto the asymptote line", () => {
+        // Arrange — point 0 at (-5, -3), asymptote at x=-6. Moving left used
+        // to skip past x=-6; asymptote crossings are now allowed so the
+        // point lands on the asymptote line (off the drag handle's y).
         const nearAsymptoteCoords: [vec.Vector2, vec.Vector2] = [
             [-5, -3],
             [-4, -7],
@@ -235,8 +259,30 @@ describe("getLogarithmKeyboardConstraint", () => {
             range,
         );
 
-        // Assert — skips x=-6 (asymptote) and lands on x=-7
-        expect(constraint.left).toEqual([-7, -3]);
+        // Assert
+        expect(constraint.left).toEqual([-6, -3]);
+    });
+
+    it("skips the position that would land on the asymptote drag handle", () => {
+        // Arrange — handle coord is (asymptote=-4, midY=0). Point 0 at (-4, 1)
+        // moving down to (-4, 0) would land on the handle and is skipped;
+        // the next step (-4, -1) is valid.
+        const onHandleCoords: [vec.Vector2, vec.Vector2] = [
+            [-4, 1],
+            [-5, -7],
+        ];
+
+        // Act
+        const constraint = getLogarithmKeyboardConstraint(
+            onHandleCoords,
+            -4,
+            snapStep,
+            0,
+            range,
+        );
+
+        // Assert
+        expect(constraint.down).toEqual([-4, -1]);
     });
 
     it("skips positions that share y-coordinate with the other point when moving down", () => {
@@ -275,41 +321,12 @@ describe("getLogarithmKeyboardConstraint", () => {
             range,
         );
 
-        // Assert — skips x=-5 (same x as point 1), x=-6 (asymptote),
-        // and x=-7 (reflected other point would collide), lands on x=-8
-        expect(constraint.left).toEqual([-8, -3]);
-    });
-
-    it("stays put when all rightward positions would cause a clamped collision", () => {
-        // Arrange — asymptote at x=8, points at [7,3] and [4,1].
-        // Moving point 0 right: x=8 is the asymptote, x=9 crosses the
-        // asymptote so reflectedX = 2*8-4 = 12 which clamps to 9
-        // (same as clamped coord), and x>=10 all clamp to 9 as well.
-        // No valid rightward position exists, so the point stays put.
-        const edgeCoords: [vec.Vector2, vec.Vector2] = [
-            [7, 3],
-            [4, 1],
-        ];
-        const edgeRange: [vec.Vector2, vec.Vector2] = [
-            [-10, 10],
-            [-10, 10],
-        ];
-
-        // Act
-        const constraint = getLogarithmKeyboardConstraint(
-            edgeCoords,
-            8,
-            snapStep,
-            0,
-            edgeRange,
-        );
-
-        // Assert — no valid right move, falls back to original position
-        expect(constraint.right).toEqual([7, 3]);
+        // Assert — skips x=-5 (same x as point 1) and lands on x=-6
+        expect(constraint.left).toEqual([-6, -3]);
     });
 
     it("rejects positions where the clamped coord collides with the other point", () => {
-        // Arrange — points at [8,3] and [9,1], asymptote at -5.
+        // Arrange — points at [8,3] and [9,1].
         // Moving point 0 right: x=9 shares x with otherPoint (skip).
         // x=10 clamps to 9 (inset max), which also equals otherPoint[X].
         // All further attempts clamp to 9 too. Point stays put.
@@ -325,7 +342,7 @@ describe("getLogarithmKeyboardConstraint", () => {
         // Act
         const constraint = getLogarithmKeyboardConstraint(
             edgeCoords,
-            -5,
+            asymptote,
             snapStep,
             0,
             edgeRange,
@@ -333,51 +350,5 @@ describe("getLogarithmKeyboardConstraint", () => {
 
         // Assert — no valid right move, falls back to original position
         expect(constraint.right).toEqual([8, 3]);
-    });
-});
-
-describe("constrainAsymptoteKeyboard", () => {
-    const snapStep: vec.Vector2 = [1, 1];
-
-    it("allows the asymptote to move freely when not between or on the curve points", () => {
-        // Arrange — points at x=-4 and x=-5, asymptote moving to x=-7 (left of both)
-        const coords: [vec.Vector2, vec.Vector2] = [
-            [-4, -3],
-            [-5, -7],
-        ];
-
-        // Act
-        const result = constrainAsymptoteKeyboard([-7, 0], coords, snapStep);
-
-        // Assert — x=-7 is valid (left of both points)
-        expect(result).toEqual([-7, 0]);
-    });
-
-    it("snaps the asymptote past both points when it would land between them", () => {
-        // Arrange — points at x=-4 and x=-2, asymptote trying to land at x=-3 (between)
-        const coords: [vec.Vector2, vec.Vector2] = [
-            [-4, -3],
-            [-2, -7],
-        ];
-
-        // Act
-        const result = constrainAsymptoteKeyboard([-3, 0], coords, snapStep);
-
-        // Assert — snapped to one step past the points
-        expect(result[0] < -4 || result[0] > -2).toBe(true);
-    });
-
-    it("skips an x-value exactly equal to a curve point", () => {
-        // Arrange — points at x=-4 and x=-2, asymptote trying to land exactly at x=-4
-        const coords: [vec.Vector2, vec.Vector2] = [
-            [-4, -3],
-            [-2, -7],
-        ];
-
-        // Act
-        const result = constrainAsymptoteKeyboard([-4, 0], coords, snapStep);
-
-        // Assert — must not land exactly on x=-4
-        expect(result[0]).not.toBe(-4);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/logarithm.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/logarithm.tsx
@@ -1,7 +1,4 @@
-import {
-    coefficients as kmathCoefficients,
-    type LogarithmCoefficient,
-} from "@khanacademy/kmath";
+import {coefficients as kmathCoefficients} from "@khanacademy/kmath";
 import {Plot} from "mafs";
 import * as React from "react";
 
@@ -21,7 +18,8 @@ import {srFormatNumber} from "./screenreader-text";
 import {useTransformVectorsToPixels} from "./use-transform";
 import {
     getAsymptoteGraphKeyboardConstraint,
-    constrainAsymptoteKeyboardMovement,
+    getAsymptoteHandleCoord,
+    skipAsymptoteKeyboardOverPoint,
 } from "./utils";
 
 import type {
@@ -30,6 +28,7 @@ import type {
     Dispatch,
     InteractiveGraphElementSuite,
 } from "../types";
+import type {LogarithmCoefficient} from "@khanacademy/kmath";
 import type {Coord} from "@khanacademy/perseus-core";
 import type {Interval, vec} from "mafs";
 
@@ -57,47 +56,16 @@ function LogarithmGraph(props: LogarithmGraphProps) {
 
     const {coords, asymptote, snapStep} = graphState;
 
-    // Cache last valid coefficients so the graph doesn't break during
-    // transient invalid states (e.g. mid-drag where points share a y-value).
-    const coeffRef = React.useRef<LogarithmCoefficient>({
-        a: 1,
-        b: 1,
-        c: 0,
-    });
+    // When the asymptote sits between the two points there is no valid
+    // logarithm that fits — coeffs will be undefined, and we skip
+    // rendering the curve below.
     const coeffs = getLogarithmCoefficients(coords, asymptote);
-    if (coeffs !== undefined) {
-        coeffRef.current = coeffs;
-    }
 
     const asymptoteX = asymptote;
     const xMin = range[0][0];
     const xMax = range[0][1];
     const yMin = range[1][0];
     const yMax = range[1][1];
-
-    // Determine which side of the asymptote the points are on
-    const pointsRightOfAsymptote = coords[0][X] > asymptoteX;
-
-    // Compute the domain boundary dynamically so the curve always
-    // starts off-screen. Unlike exponential (which uses a y-padding
-    // NaN cutoff because the curve exits horizontally), the logarithm
-    // curve exits vertically — y → ±∞ as x → asymptote. A y-padding
-    // cutoff would end the SVG path near the asymptote, causing a
-    // visible discontinuity. Instead, we solve for the x where the
-    // curve reaches a y-value safely beyond the visible range, so the
-    // SVG path begins off-screen for any coefficient values.
-    //
-    // For f(x) = a * ln(b*x + c), solving y = targetY for x:
-    //   x = (e^(targetY / a) - c) / b
-    const offScreenMargin = 2; // graph units beyond visible edge
-    const {a, b, c} = coeffRef.current;
-    // Near the asymptote, y → -∞ if a > 0, or +∞ if a < 0
-    const targetY = a > 0 ? yMin - offScreenMargin : yMax + offScreenMargin;
-    const computedX = (Math.exp(targetY / a) - c) / b;
-    const computedOffset = Math.abs(computedX - asymptoteX);
-    // Use the computed offset if valid, otherwise fall back to 1e-8
-    const domainOffset =
-        isFinite(computedOffset) && computedOffset > 0 ? computedOffset : 1e-8;
 
     // Aria strings
     const {
@@ -111,13 +79,12 @@ function LogarithmGraph(props: LogarithmGraphProps) {
     // The asymptote is a full-height vertical line.
     const asymptoteBottom: vec.Vector2 = [asymptoteX, yMin];
     const asymptoteTop: vec.Vector2 = [asymptoteX, yMax];
-    const asymptoteMidY = (yMin + yMax) / 2;
-    const asymptoteMid: vec.Vector2 = [asymptoteX, asymptoteMidY];
+    const handleCoord = getAsymptoteHandleCoord("vertical", range, asymptote);
 
     const [bottomPx, topPx, midPx] = useTransformVectorsToPixels(
         asymptoteBottom,
         asymptoteTop,
-        asymptoteMid,
+        handleCoord,
     );
 
     return (
@@ -126,29 +93,34 @@ function LogarithmGraph(props: LogarithmGraphProps) {
                 start={bottomPx}
                 end={topPx}
                 mid={midPx}
-                point={asymptoteMid}
+                point={handleCoord}
                 onMove={(newPoint) =>
                     dispatch(actions.logarithm.moveCenter(newPoint))
                 }
                 constrainKeyboardMovement={(p) =>
-                    constrainAsymptoteKeyboard(p, coords, snapStep)
+                    skipAsymptoteKeyboardOverPoint(
+                        p,
+                        asymptote,
+                        coords,
+                        handleCoord,
+                        snapStep,
+                        "vertical",
+                    )
                 }
                 orientation="vertical"
                 ariaLabel={srLogarithmAsymptote}
             >
-                <Plot.OfX
-                    y={(x) => computeLogarithm(coeffRef.current, x)}
-                    color={interactiveColor}
-                    svgPathProps={{
-                        "aria-hidden": true,
-                        style: {pointerEvents: "none"},
-                    }}
-                    domain={
-                        pointsRightOfAsymptote
-                            ? [asymptoteX + domainOffset, xMax]
-                            : [xMin, asymptoteX - domainOffset]
-                    }
-                />
+                {coeffs !== undefined &&
+                    renderLogarithmCurve({
+                        coeffs,
+                        coords,
+                        asymptoteX,
+                        xMin,
+                        xMax,
+                        yMin,
+                        yMax,
+                        interactiveColor,
+                    })}
             </MovableAsymptote>
             {coords.map((coord, i) => (
                 <MovablePoint
@@ -175,13 +147,6 @@ function LogarithmGraph(props: LogarithmGraphProps) {
     );
 }
 
-export const constrainAsymptoteKeyboard = (
-    p: vec.Vector2,
-    coords: ReadonlyArray<Coord>,
-    snapStep: vec.Vector2,
-): vec.Vector2 =>
-    constrainAsymptoteKeyboardMovement(p, coords, snapStep, "vertical");
-
 export const getLogarithmKeyboardConstraint = (
     coords: ReadonlyArray<Coord>,
     asymptote: number,
@@ -195,7 +160,7 @@ export const getLogarithmKeyboardConstraint = (
     right: vec.Vector2;
 } => {
     const otherPoint = coords[1 - pointIndex];
-    const asymptoteX = asymptote;
+    const handleCoord = getAsymptoteHandleCoord("vertical", range, asymptote);
 
     return getAsymptoteGraphKeyboardConstraint(
         coords,
@@ -213,10 +178,6 @@ export const getLogarithmKeyboardConstraint = (
             const clampedX = clamped[X];
             const clampedY = clamped[Y];
 
-            // Point cannot land on the vertical asymptote
-            if (coord[X] === asymptoteX || clampedX === asymptoteX) {
-                return false;
-            }
             // Both points must have different x-values
             // (same x makes the coefficient computation degenerate)
             if (coord[X] === otherPoint[X] || clampedX === otherPoint[X]) {
@@ -226,25 +187,9 @@ export const getLogarithmKeyboardConstraint = (
             if (coord[Y] === otherPoint[Y] || clampedY === otherPoint[Y]) {
                 return false;
             }
-            // When the move crosses the asymptote, the reducer will
-            // reflect the other point. Check that the reflected X
-            // doesn't collide with the proposed coord's X.
-            const currentPoint = coords[pointIndex];
-            const currentSide = currentPoint[X] > asymptoteX;
-            const proposedSide = coord[X] > asymptoteX;
-            if (currentSide !== proposedSide) {
-                const reflectedX = 2 * asymptoteX - otherPoint[X];
-                const clampedReflectedX = snap(
-                    snapStep,
-                    bound({snapStep, range, point: [reflectedX, 0]}),
-                )[X];
-                if (
-                    reflectedX === coord[X] ||
-                    clampedReflectedX === coord[X] ||
-                    clampedReflectedX === clampedX
-                ) {
-                    return false;
-                }
+            // Point cannot overlap the asymptote's drag handle
+            if (clampedX === handleCoord[X] && clampedY === handleCoord[Y]) {
+                return false;
             }
             return true;
         },
@@ -263,6 +208,63 @@ const computeLogarithm = function (
     }
     return a * Math.log(arg);
 };
+
+// Compute the domain boundary so the curve starts off-screen. Unlike
+// exponential (which uses a y-padding NaN cutoff because the curve exits
+// horizontally), the logarithm curve exits vertically — y → ±∞ as x →
+// asymptote. A y-padding cutoff would end the SVG path near the asymptote,
+// causing a visible discontinuity. Instead, we solve for the x where the
+// curve reaches a y-value safely beyond the visible range, so the SVG
+// path begins off-screen for any coefficient values.
+//
+// For f(x) = a * ln(b*x + c), solving y = targetY for x:
+//   x = (e^(targetY / a) - c) / b
+function renderLogarithmCurve({
+    coeffs,
+    coords,
+    asymptoteX,
+    xMin,
+    xMax,
+    yMin,
+    yMax,
+    interactiveColor,
+}: {
+    coeffs: LogarithmCoefficient;
+    coords: ReadonlyArray<Coord>;
+    asymptoteX: number;
+    xMin: number;
+    xMax: number;
+    yMin: number;
+    yMax: number;
+    interactiveColor: string | undefined;
+}): React.ReactNode {
+    const offScreenMargin = 2; // graph units beyond visible edge
+    const {a, b, c} = coeffs;
+    // Near the asymptote, y → -∞ if a > 0, or +∞ if a < 0
+    const targetY = a > 0 ? yMin - offScreenMargin : yMax + offScreenMargin;
+    const computedX = (Math.exp(targetY / a) - c) / b;
+    const computedOffset = Math.abs(computedX - asymptoteX);
+    // Use the computed offset if valid, otherwise fall back to 1e-8
+    const domainOffset =
+        isFinite(computedOffset) && computedOffset > 0 ? computedOffset : 1e-8;
+    const pointsRightOfAsymptote = coords[0][X] > asymptoteX;
+
+    return (
+        <Plot.OfX
+            y={(x) => computeLogarithm(coeffs, x)}
+            color={interactiveColor}
+            svgPathProps={{
+                "aria-hidden": true,
+                style: {pointerEvents: "none"},
+            }}
+            domain={
+                pointsRightOfAsymptote
+                    ? [asymptoteX + domainOffset, xMax]
+                    : [xMin, asymptoteX - domainOffset]
+            }
+        />
+    );
+}
 
 function getLogarithmDescription(
     state: LogarithmGraphState,

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.test.ts
@@ -4,8 +4,10 @@ import {
     getIntersectionOfRayWithBox,
     getArrayWithoutDuplicates,
     getAngleFromPoints,
+    getAsymptoteHandleCoord,
     getSideLengthsFromPoints,
     calculateScaledRadius,
+    skipAsymptoteKeyboardOverPoint,
 } from "./utils";
 
 import type {Coord} from "@khanacademy/perseus-core";
@@ -381,4 +383,213 @@ describe("calculateScaledRadius", () => {
             expect(radius).toEqual(expected);
         },
     );
+});
+
+describe("getAsymptoteHandleCoord", () => {
+    const symmetricRange: [Interval, Interval] = [
+        [-10, 10],
+        [-10, 10],
+    ];
+
+    it("places a horizontal asymptote's handle at the x-range midpoint at the asymptote's y", () => {
+        // Arrange, Act
+        const result = getAsymptoteHandleCoord("horizontal", symmetricRange, 3);
+
+        // Assert — midX = 0, handle at (0, 3)
+        expect(result).toEqual([0, 3]);
+    });
+
+    it("places a vertical asymptote's handle at the asymptote's x at the y-range midpoint", () => {
+        // Arrange, Act
+        const result = getAsymptoteHandleCoord("vertical", symmetricRange, -4);
+
+        // Assert — midY = 0, handle at (-4, 0)
+        expect(result).toEqual([-4, 0]);
+    });
+
+    it("returns a non-integer midpoint for an asymmetric horizontal range", () => {
+        // Arrange — range [-5, 4] has midX = -0.5
+        const range: [Interval, Interval] = [
+            [-5, 4],
+            [-5, 5],
+        ];
+
+        // Act
+        const result = getAsymptoteHandleCoord("horizontal", range, 0);
+
+        // Assert
+        expect(result).toEqual([-0.5, 0]);
+    });
+
+    it("returns a non-integer midpoint for an asymmetric vertical range", () => {
+        // Arrange — range [-5, 4] has midY = -0.5
+        const range: [Interval, Interval] = [
+            [-5, 5],
+            [-5, 4],
+        ];
+
+        // Act
+        const result = getAsymptoteHandleCoord("vertical", range, 0);
+
+        // Assert
+        expect(result).toEqual([0, -0.5]);
+    });
+});
+
+describe("skipAsymptoteKeyboardOverPoint", () => {
+    const snapStep: vec.Vector2 = [1, 1];
+
+    it("passes a horizontal asymptote through unchanged when no point blocks the step", () => {
+        // Arrange — handle is at (midX=0, asymptote=0); proposed y=1 is
+        // not occupied by any point at x=0
+        const coords: ReadonlyArray<Coord> = [
+            [2, 5],
+            [-2, -5],
+        ];
+
+        // Act
+        const result = skipAsymptoteKeyboardOverPoint(
+            [0, 1],
+            0,
+            coords,
+            [0, 0],
+            snapStep,
+            "horizontal",
+        );
+
+        // Assert
+        expect(result).toEqual([0, 1]);
+    });
+
+    it("skips a horizontal asymptote past a blocking point in the direction of travel", () => {
+        // Arrange — handle at x=0 moving up; point at (0, 1) blocks y=1,
+        // so the asymptote should jump to y=2.
+        const coords: ReadonlyArray<Coord> = [
+            [0, 1],
+            [2, -3],
+        ];
+
+        // Act
+        const result = skipAsymptoteKeyboardOverPoint(
+            [0, 1],
+            0,
+            coords,
+            [0, 0],
+            snapStep,
+            "horizontal",
+        );
+
+        // Assert
+        expect(result).toEqual([0, 2]);
+    });
+
+    it("skips a horizontal asymptote past multiple consecutive blocking points", () => {
+        // Arrange — handle at x=0 moving up from y=0; points at (0,1) and
+        // (0,2) both block. Asymptote should jump to y=3.
+        const coords: ReadonlyArray<Coord> = [
+            [0, 1],
+            [0, 2],
+        ];
+
+        // Act
+        const result = skipAsymptoteKeyboardOverPoint(
+            [0, 1],
+            0,
+            coords,
+            [0, 0],
+            snapStep,
+            "horizontal",
+        );
+
+        // Assert
+        expect(result).toEqual([0, 3]);
+    });
+
+    it("skips a vertical asymptote past a blocking point in the direction of travel", () => {
+        // Arrange — handle at y=0 moving right; point at (1, 0) blocks x=1,
+        // so the asymptote should jump to x=2.
+        const coords: ReadonlyArray<Coord> = [
+            [1, 0],
+            [-3, 2],
+        ];
+
+        // Act
+        const result = skipAsymptoteKeyboardOverPoint(
+            [1, 0],
+            0,
+            coords,
+            [0, 0],
+            snapStep,
+            "vertical",
+        );
+
+        // Assert
+        expect(result).toEqual([2, 0]);
+    });
+
+    it("returns the proposed position when direction is zero", () => {
+        // Arrange — proposed equals current asymptote (no delta); nothing to skip
+        const coords: ReadonlyArray<Coord> = [
+            [0, 0],
+            [2, 3],
+        ];
+
+        // Act
+        const result = skipAsymptoteKeyboardOverPoint(
+            [0, 0],
+            0,
+            coords,
+            [0, 0],
+            snapStep,
+            "horizontal",
+        );
+
+        // Assert
+        expect(result).toEqual([0, 0]);
+    });
+
+    it("snaps a sub-grid proposed position to the nearest grid point", () => {
+        // Arrange — useDraggable's function-form constraint receives
+        // continuous (non-snap-aligned) test points and expects the
+        // returned point to be snap-aligned. A proposed y=0.2 must snap
+        // back to y=0 so useDraggable keeps iterating.
+        const coords: ReadonlyArray<Coord> = [
+            [2, 5],
+            [-2, -5],
+        ];
+
+        // Act
+        const result = skipAsymptoteKeyboardOverPoint(
+            [0, 0.2],
+            0,
+            coords,
+            [0, 0],
+            snapStep,
+            "horizontal",
+        );
+
+        // Assert
+        expect(result).toEqual([0, 0]);
+    });
+
+    it("advances the horizontal asymptote to the next grid point once the proposed position crosses the halfway mark", () => {
+        // Arrange — proposed y=0.6 snaps up to y=1, past the midpoint
+        const coords: ReadonlyArray<Coord> = [
+            [2, 5],
+            [-2, -5],
+        ];
+
+        // Act
+        const result = skipAsymptoteKeyboardOverPoint(
+            [0, 0.6],
+            0,
+            coords,
+            [0, 0],
+            snapStep,
+            "horizontal",
+        );
+
+        // Assert
+        expect(result).toEqual([0, 1]);
+    });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts
@@ -435,44 +435,61 @@ export function getAsymptoteGraphKeyboardConstraint(
 }
 
 /**
- * Shared keyboard constraint for asymptote movement (exponential, logarithm).
- * When the next snapped position would land between or on the curve points,
- * snaps past all of them in the direction of travel using a midpoint heuristic.
- *
- * @param orientation - "horizontal" for exponential (asymptote moves on Y-axis),
- *   "vertical" for logarithm (asymptote moves on X-axis).
+ * Position of the asymptote's drag handle in graph-space. For a horizontal
+ * asymptote (exponential), this sits at the midpoint of the x-range on
+ * the asymptote's y-value. For a vertical asymptote (logarithm), it sits
+ * on the asymptote's x-value at the midpoint of the y-range.
  */
-export function constrainAsymptoteKeyboardMovement(
-    p: vec.Vector2,
+export function getAsymptoteHandleCoord(
+    orientation: "horizontal" | "vertical",
+    range: [Interval, Interval],
+    asymptote: number,
+): vec.Vector2 {
+    if (orientation === "horizontal") {
+        const midX = (range[0][0] + range[0][1]) / 2;
+        return [midX, asymptote];
+    }
+    const midY = (range[1][0] + range[1][1]) / 2;
+    return [asymptote, midY];
+}
+
+/**
+ * Keyboard snap + skip for the asymptote drag handle. `useDraggable`'s
+ * function-form constraint expects the returned point to be snap-aligned;
+ * it searches along the direction of travel until the returned point is
+ * far enough from the current asymptote to register as a move. After
+ * snapping, if the proposed position would put the handle on one of the
+ * curve points, we step further in the direction of travel until we find
+ * a valid position (up to 3 attempts).
+ */
+export function skipAsymptoteKeyboardOverPoint(
+    proposed: vec.Vector2,
+    currentAsymptote: number,
     coords: ReadonlyArray<Coord>,
+    handleCoord: vec.Vector2,
     snapStep: vec.Vector2,
     orientation: "horizontal" | "vertical",
 ): vec.Vector2 {
-    const snapped = snap(snapStep, p);
+    const snapped = snap(snapStep, proposed);
+    const moveAxis = orientation === "horizontal" ? 1 : 0;
+    const pinAxis = orientation === "horizontal" ? 0 : 1;
+    const step = snapStep[moveAxis];
+    const dir = Math.sign(snapped[moveAxis] - currentAsymptote);
+    if (dir === 0) {
+        return snapped;
+    }
 
-    // Select the axis: horizontal asymptote constrains on Y, vertical on X
-    const axis = orientation === "horizontal" ? 1 : 0;
-    const otherAxis = orientation === "horizontal" ? 0 : 1;
-    let newVal = snapped[axis];
-    const step = snapStep[axis];
+    const pinValue = handleCoord[pinAxis];
+    const isForbidden = (v: number) =>
+        coords.some((c) => c[pinAxis] === pinValue && c[moveAxis] === v);
 
-    const maxVal = Math.max(coords[0][axis], coords[1][axis]);
-    const minVal = Math.min(coords[0][axis], coords[1][axis]);
-
-    const allGreater = coords[0][axis] > newVal && coords[1][axis] > newVal;
-    const allLesser = coords[0][axis] < newVal && coords[1][axis] < newVal;
-
-    if (!allGreater && !allLesser) {
-        const midpoint = (maxVal + minVal) / 2;
-        if (newVal >= midpoint) {
-            newVal = maxVal + step;
-        } else {
-            newVal = minVal - step;
-        }
+    let value = snapped[moveAxis];
+    for (let i = 0; i < 3 && isForbidden(value); i++) {
+        value += dir * step;
     }
 
     const result: vec.Vector2 = [0, 0];
-    result[axis] = newVal;
-    result[otherAxis] = snapped[otherAxis];
+    result[moveAxis] = value;
+    result[pinAxis] = snapped[pinAxis];
     return result;
 }

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -1960,8 +1960,10 @@ describe("movePoint on an exponential graph", () => {
         expect(updated.coords[0]).toEqual([0, 3]);
     });
 
-    it("rejects the move when the point would land on the asymptote", () => {
-        // Arrange — asymptote at y=1; trying to move point 0 to y=1
+    it("allows the point to land on the asymptote", () => {
+        // Arrange — asymptote at y=1; moving point 0 to y=1 used to be rejected
+        // but is now allowed. The curve disappears because no exponential fits
+        // a point on its own horizontal asymptote.
         const state = generateExponentialGraphState();
 
         // Act
@@ -1970,9 +1972,46 @@ describe("movePoint on an exponential graph", () => {
             actions.exponential.movePoint(0, [-1, 1]),
         );
 
+        // Assert
+        invariant(updated.type === "exponential");
+        expect(updated.coords[0]).toEqual([-1, 1]);
+    });
+
+    it("allows the point to cross the asymptote without reflecting the other point", () => {
+        // Arrange — asymptote at y=1, points at y=3 and y=6 (both above).
+        // Moving point 0 below the asymptote used to reflect point 1; it is
+        // now allowed and the curve disappears.
+        const state = generateExponentialGraphState();
+        const originalOtherPoint = state.coords[1];
+
+        // Act
+        const updated = interactiveGraphReducer(
+            state,
+            actions.exponential.movePoint(0, [-1, -5]),
+        );
+
+        // Assert
+        invariant(updated.type === "exponential");
+        expect(updated.coords[0]).toEqual([-1, -5]);
+        expect(updated.coords[1]).toEqual(originalOtherPoint);
+    });
+
+    it("rejects the move when the point would overlap the asymptote drag handle", () => {
+        // Arrange — range is [-10,10] so midX=0; asymptote=1. The handle is
+        // at (0, 1). Moving point 0 onto that coord must be rejected so the
+        // user can always grab the handle.
+        const state = generateExponentialGraphState();
+
+        // Act
+        const updated = interactiveGraphReducer(
+            state,
+            actions.exponential.movePoint(0, [0, 1]),
+        );
+
         // Assert — move was rejected
         invariant(updated.type === "exponential");
         expect(updated.coords[0]).toEqual([0, 3]);
+        expect(updated.hasBeenInteractedWith).toBe(false);
     });
 });
 
@@ -1992,8 +2031,10 @@ describe("moveCenter on an exponential graph (asymptote)", () => {
         expect(updated.asymptote).toBe(-2);
     });
 
-    it("rejects the move when the asymptote would land between the curve points", () => {
-        // Arrange — curve points at y=3 and y=6; trying to move asymptote to y=4 (between them)
+    it("allows the asymptote to move between the curve points", () => {
+        // Arrange — curve points at y=3 and y=6. Moving the asymptote to y=4
+        // (between them) used to snap-through to y=2; it is now allowed and
+        // the curve disappears.
         const state = generateExponentialGraphState({
             coords: [
                 [0, 3],
@@ -2008,8 +2049,30 @@ describe("moveCenter on an exponential graph (asymptote)", () => {
         );
         invariant(updated.type === "exponential");
 
-        // Assert — y=4 < midpoint(4.5), so snaps to bottomMost - stepY = 3 - 1 = 2
-        expect(updated.asymptote).toBe(2);
+        // Assert
+        expect(updated.asymptote).toBe(4);
+    });
+
+    it("rejects the move when the asymptote drag handle would overlap a point", () => {
+        // Arrange — range [-10,10] so midX=0. Point 0 sits at (0, 5), so
+        // moving the asymptote to y=5 would place its handle on the point.
+        const state = generateExponentialGraphState({
+            coords: [
+                [0, 5],
+                [2, 8],
+            ],
+            asymptote: 1,
+        });
+
+        // Act
+        const updated = interactiveGraphReducer(
+            state,
+            actions.exponential.moveCenter([0, 5]),
+        );
+        invariant(updated.type === "exponential");
+
+        // Assert — move was rejected; asymptote stays at 1
+        expect(updated.asymptote).toBe(1);
     });
 
     it("ignores the x component and only moves the asymptote vertically", () => {
@@ -2105,8 +2168,10 @@ describe("movePoint on a logarithm graph", () => {
         expect(updated.hasBeenInteractedWith).toBe(false);
     });
 
-    it("rejects the move when point would land on the asymptote", () => {
-        // Arrange — asymptote at x=-6; trying to move point 0 to x=-6
+    it("allows the point to land on the asymptote", () => {
+        // Arrange — asymptote at x=-6; moving point 0 to x=-6 used to be
+        // rejected but is now allowed. The curve disappears because no
+        // logarithm fits a point on its own vertical asymptote.
         const state = generateLogarithmGraphState();
 
         // Act
@@ -2115,28 +2180,28 @@ describe("movePoint on a logarithm graph", () => {
             actions.logarithm.movePoint(0, [-6, -2]),
         );
 
-        // Assert — move was rejected
+        // Assert
         invariant(updated.type === "logarithm");
-        expect(updated.coords[0]).toEqual([-4, -3]);
-        expect(updated.hasBeenInteractedWith).toBe(false);
+        expect(updated.coords[0]).toEqual([-6, -2]);
     });
 
-    it("reflects the other point when a point crosses the asymptote", () => {
-        // Arrange — asymptote at x=-6, points at (-4, -3) and (-5, -7)
-        // Both points are to the right of the asymptote.
+    it("allows the point to cross the asymptote without reflecting the other point", () => {
+        // Arrange — asymptote at x=-6, points at (-4, -3) and (-5, -7),
+        // both to the right. Moving point 0 across the asymptote used to
+        // reflect point 1; it is now allowed and the curve disappears.
         const state = generateLogarithmGraphState();
+        const originalOtherPoint = state.coords[1];
 
-        // Act — move point 0 to x=-8 (left of asymptote at x=-6)
+        // Act
         const updated = interactiveGraphReducer(
             state,
             actions.logarithm.movePoint(0, [-8, -3]),
         );
 
-        // Assert — point 0 moved, point 1 reflected across asymptote:
-        // reflectedX = 2 * (-6) - (-5) = -12 + 5 = -7
+        // Assert
         invariant(updated.type === "logarithm");
         expect(updated.coords[0]).toEqual([-8, -3]);
-        expect(updated.coords[1]).toEqual([-7, -7]);
+        expect(updated.coords[1]).toEqual(originalOtherPoint);
     });
 
     it("allows a valid move", () => {
@@ -2154,47 +2219,20 @@ describe("movePoint on a logarithm graph", () => {
         expect(updated.coords[0]).toEqual([-3, -2]);
     });
 
-    it("rejects cross-asymptote move when reflection would cause same-x collision", () => {
-        // Arrange — asymptote=-6, coords=[(-4,-3), (-5,-7)], snapStep=[1,1]
-        // Moving point 0 to (-7,-3) crosses the asymptote.
-        // reflectedX = 2*(-6) - (-5) = -7, so both points would be at x=-7.
+    it("rejects the move when the point would overlap the asymptote drag handle", () => {
+        // Arrange — range is [-10,10] so midY=0; asymptote=-6. The handle
+        // is at (-6, 0). Moving point 0 onto that coord must be rejected.
         const state = generateLogarithmGraphState();
 
         // Act
         const updated = interactiveGraphReducer(
             state,
-            actions.logarithm.movePoint(0, [-7, -3]),
+            actions.logarithm.movePoint(0, [-6, 0]),
         );
 
-        // Assert — move was rejected; state is unchanged
+        // Assert — move was rejected
         invariant(updated.type === "logarithm");
         expect(updated.coords[0]).toEqual([-4, -3]);
-        expect(updated.coords[1]).toEqual([-5, -7]);
-        expect(updated.hasBeenInteractedWith).toBe(false);
-    });
-
-    it("rejects cross-asymptote move when reflected point snaps to the asymptote x-coordinate", () => {
-        // Arrange — asymptote=-6, non-grid-aligned point at x=-5.6.
-        // Moving point 0 to (-8,-3) crosses the asymptote.
-        // reflectedX = 2*(-6) - (-5.6) = -6.4, which snaps to -6
-        // (the asymptote). This must be rejected.
-        const state = generateLogarithmGraphState({
-            coords: [
-                [-4, -3],
-                [-5.6, -7],
-            ],
-        });
-
-        // Act
-        const updated = interactiveGraphReducer(
-            state,
-            actions.logarithm.movePoint(0, [-8, -3]),
-        );
-
-        // Assert — move was rejected; state is unchanged
-        invariant(updated.type === "logarithm");
-        expect(updated.coords[0]).toEqual([-4, -3]);
-        expect(updated.coords[1]).toEqual([-5.6, -7]);
         expect(updated.hasBeenInteractedWith).toBe(false);
     });
 });
@@ -2215,9 +2253,10 @@ describe("moveCenter on a logarithm graph (asymptote)", () => {
         expect(updated.asymptote).toBe(-8);
     });
 
-    it("snaps past the curve points when the asymptote is dragged between them", () => {
-        // Arrange — curve points at x=-4 and x=-5; trying to move asymptote
-        // between them. boundAndSnapToGrid snaps destination to x=-4.
+    it("allows the asymptote to move between the curve points", () => {
+        // Arrange — curve points at x=-4 and x=-5. Moving the asymptote
+        // between them used to snap-through to x=-3; it is now allowed
+        // and the curve disappears.
         const state = generateLogarithmGraphState({
             coords: [
                 [-4, -3],
@@ -2225,8 +2264,7 @@ describe("moveCenter on a logarithm graph (asymptote)", () => {
             ],
         });
 
-        // Act — destination snaps to x=-4, which is on a point. Since
-        // -4 >= midpoint(-4.5), snap-through pushes to rightMost + step = -3.
+        // Act — destination snaps to x=-4
         const updated = interactiveGraphReducer(
             state,
             actions.logarithm.moveCenter([-4.4, 0]),
@@ -2234,7 +2272,29 @@ describe("moveCenter on a logarithm graph (asymptote)", () => {
         invariant(updated.type === "logarithm");
 
         // Assert
-        expect(updated.asymptote).toBe(-3);
+        expect(updated.asymptote).toBe(-4);
+    });
+
+    it("rejects the move when the asymptote drag handle would overlap a point", () => {
+        // Arrange — range [-10,10] so midY=0. Point 0 sits at (3, 0), so
+        // moving the asymptote to x=3 would place its handle on the point.
+        const state = generateLogarithmGraphState({
+            coords: [
+                [3, 0],
+                [5, 2],
+            ],
+            asymptote: -6,
+        });
+
+        // Act
+        const updated = interactiveGraphReducer(
+            state,
+            actions.logarithm.moveCenter([3, 0]),
+        );
+        invariant(updated.type === "logarithm");
+
+        // Assert — move was rejected; asymptote stays at -6
+        expect(updated.asymptote).toBe(-6);
     });
 
     it("ignores the y component and only moves the asymptote horizontally", () => {
@@ -2250,32 +2310,6 @@ describe("moveCenter on a logarithm graph (asymptote)", () => {
 
         // Assert — asymptote moves to x=-8 regardless of the y passed
         expect(updated.asymptote).toBe(-8);
-    });
-
-    it("rejects the move when asymptote would still be between the two points after snap-through", () => {
-        // Arrange — points at x=8 and x=10. When the asymptote is dragged
-        // to x=9 (between them), midpoint=(8+10)/2=9. Since 9 >= 9,
-        // snap-through pushes to rightMost + step = 10 + 1 = 11. Clamping
-        // to inset bounds [-9, 9] gives 9. The stillAllRight/stillAllLeft
-        // check rejects because 8 < 9 < 10 — the asymptote would still
-        // be between the two points.
-        const state = generateLogarithmGraphState({
-            coords: [
-                [8, -3],
-                [10, -7],
-            ],
-            asymptote: 0,
-        });
-
-        // Act
-        const updated = interactiveGraphReducer(
-            state,
-            actions.logarithm.moveCenter([9, 0]),
-        );
-        invariant(updated.type === "logarithm");
-
-        // Assert — rejected; asymptote stays at 0
-        expect(updated.asymptote).toBe(0);
     });
 });
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -10,7 +10,10 @@ import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 import {vec} from "mafs";
 import _ from "underscore";
 
-import {getArrayWithoutDuplicates} from "../graphs/utils";
+import {
+    getArrayWithoutDuplicates,
+    getAsymptoteHandleCoord,
+} from "../graphs/utils";
 import {clamp, clampToBox, inset, snap, X, Y} from "../math";
 import {bound, boundToEdge, isUnlimitedGraphState} from "../utils";
 
@@ -548,48 +551,22 @@ function doMovePoint(
             const newCoords: vec.Vector2[] = [...state.coords];
             newCoords[action.index] = boundDestination;
 
-            const asymptoteY = state.asymptote;
-
-            // Point cannot land on the asymptote
-            if (boundDestination[Y] === asymptoteY) {
-                return state;
-            }
-
             // Both points must have different x-values (makes b undefined if same)
             if (newCoords[0][X] === newCoords[1][X]) {
                 return state;
             }
 
-            // If the moved point crosses the asymptote, reflect the other
-            // point across it so the entire curve moves to the new side.
-            // This matches Grapher behavior where dragging past the asymptote
-            // relocates the whole curve. Mirrors the logarithm reducer.
-            const otherIndex = 1 - action.index;
-            const otherPoint = state.coords[otherIndex];
-            const movedSide = boundDestination[Y] > asymptoteY;
-            const otherSide = otherPoint[Y] > asymptoteY;
-
-            if (movedSide !== otherSide) {
-                const reflectedY = 2 * asymptoteY - otherPoint[Y];
-                const updatedCoords: [vec.Vector2, vec.Vector2] = [
-                    ...state.coords,
-                ];
-                updatedCoords[action.index] = boundDestination;
-                updatedCoords[otherIndex] = boundAndSnapToGrid(
-                    [otherPoint[X], reflectedY],
-                    state,
-                );
-
-                // Both points at the same x is invalid for an exponential
-                if (updatedCoords[0][X] === updatedCoords[1][X]) {
-                    return state;
-                }
-
-                return {
-                    ...state,
-                    hasBeenInteractedWith: true,
-                    coords: updatedCoords,
-                };
+            // Point cannot overlap the asymptote's drag handle.
+            const expHandle = getAsymptoteHandleCoord(
+                "horizontal",
+                state.range,
+                state.asymptote,
+            );
+            if (
+                boundDestination[X] === expHandle[X] &&
+                boundDestination[Y] === expHandle[Y]
+            ) {
+                return state;
             }
 
             return {
@@ -610,13 +587,6 @@ function doMovePoint(
             const newCoords: vec.Vector2[] = [...state.coords];
             newCoords[action.index] = boundDestination;
 
-            const asymptoteX = state.asymptote;
-
-            // Point cannot land on the asymptote
-            if (boundDestination[X] === asymptoteX) {
-                return state;
-            }
-
             // Both points must have different x-values
             // (same x makes the logarithm coefficient computation degenerate)
             if (newCoords[0][X] === newCoords[1][X]) {
@@ -629,42 +599,17 @@ function doMovePoint(
                 return state;
             }
 
-            // If the moved point crosses the asymptote, reflect the other
-            // point across it so the entire curve moves to the new side.
-            const otherIndex = 1 - action.index;
-            const otherPoint = state.coords[otherIndex];
-            const movedSide = boundDestination[X] > asymptoteX;
-            const otherSide = otherPoint[X] > asymptoteX;
-
-            if (movedSide !== otherSide) {
-                const reflectedX = 2 * asymptoteX - otherPoint[X];
-                const updatedCoords: [vec.Vector2, vec.Vector2] = [
-                    ...state.coords,
-                ];
-                updatedCoords[action.index] = boundDestination;
-                updatedCoords[otherIndex] = boundAndSnapToGrid(
-                    [reflectedX, otherPoint[Y]],
-                    state,
-                );
-
-                // Reflected point cannot land on the asymptote
-                if (updatedCoords[otherIndex][X] === asymptoteX) {
-                    return state;
-                }
-
-                // Both points at the same x or y is invalid for a logarithm
-                if (
-                    updatedCoords[0][X] === updatedCoords[1][X] ||
-                    updatedCoords[0][Y] === updatedCoords[1][Y]
-                ) {
-                    return state;
-                }
-
-                return {
-                    ...state,
-                    hasBeenInteractedWith: true,
-                    coords: updatedCoords,
-                };
+            // Point cannot overlap the asymptote's drag handle.
+            const logHandle = getAsymptoteHandleCoord(
+                "vertical",
+                state.range,
+                state.asymptote,
+            );
+            if (
+                boundDestination[X] === logHandle[X] &&
+                boundDestination[Y] === logHandle[Y]
+            ) {
+                return state;
             }
 
             return {
@@ -825,44 +770,25 @@ function doMoveCenter(
         }
         case "exponential": {
             // Move the asymptote vertically only
-            let newY = boundAndSnapToGrid(action.destination, state)[Y];
-            const coords = state.coords;
-            const stepY = state.snapStep[Y];
-
-            // Both points must stay on the same side of the new asymptote position
-            const allAbove = coords[0][Y] > newY && coords[1][Y] > newY;
-            const allBelow = coords[0][Y] < newY && coords[1][Y] < newY;
-
-            if (!allAbove && !allBelow) {
-                // Asymptote would end up between or on the points.
-                // Snap to whichever valid side the user is dragging toward.
-                const topMost = Math.max(coords[0][Y], coords[1][Y]);
-                const bottomMost = Math.min(coords[0][Y], coords[1][Y]);
-                const midpoint = (topMost + bottomMost) / 2;
-
-                newY = newY >= midpoint ? topMost + stepY : bottomMost - stepY;
-                // Clamp to the snap-inset bounds (not raw range) so the
-                // asymptote can't be pushed to the graph edge where no
-                // point can be placed on the other side.
-                const insetY = inset(state.snapStep, state.range)[1];
-                newY = clamp(newY, insetY[0], insetY[1]);
-
-                // After clamping, the asymptote may have ended up back
-                // between or on the points. If so, reject the move.
-                const stillAllAbove =
-                    coords[0][Y] > newY && coords[1][Y] > newY;
-                const stillAllBelow =
-                    coords[0][Y] < newY && coords[1][Y] < newY;
-                if (!stillAllAbove && !stillAllBelow) {
-                    return state;
-                }
-            }
-
-            // Final safety: asymptote must not land exactly on either point
-            if (newY === coords[0][Y] || newY === coords[1][Y]) {
+            const newY = boundAndSnapToGrid(action.destination, state)[Y];
+            if (newY === state.asymptote) {
                 return state;
             }
-
+            // Reject if the asymptote's drag handle would land on a point.
+            const expFutureHandle = getAsymptoteHandleCoord(
+                "horizontal",
+                state.range,
+                newY,
+            );
+            if (
+                state.coords.some(
+                    (c) =>
+                        c[X] === expFutureHandle[X] &&
+                        c[Y] === expFutureHandle[Y],
+                )
+            ) {
+                return state;
+            }
             return {
                 ...state,
                 hasBeenInteractedWith: true,
@@ -871,42 +797,25 @@ function doMoveCenter(
         }
         case "logarithm": {
             // Move the asymptote horizontally only
-            let newX = boundAndSnapToGrid(action.destination, state)[X];
-            const coords = state.coords;
-            const stepX = state.snapStep[X];
-
-            // Both points must stay on the same side of the new asymptote position
-            const allRight = coords[0][X] > newX && coords[1][X] > newX;
-            const allLeft = coords[0][X] < newX && coords[1][X] < newX;
-
-            if (!allRight && !allLeft) {
-                // Asymptote would end up between or on the points.
-                // Snap to whichever valid side the user is dragging toward.
-                const rightMost = Math.max(coords[0][X], coords[1][X]);
-                const leftMost = Math.min(coords[0][X], coords[1][X]);
-                const midpoint = (rightMost + leftMost) / 2;
-
-                newX = newX >= midpoint ? rightMost + stepX : leftMost - stepX;
-                // Clamp to the snap-inset bounds (not raw range) so the
-                // asymptote can't be pushed to the graph edge where no
-                // point can be placed on the other side.
-                const insetX = inset(state.snapStep, state.range)[0];
-                newX = clamp(newX, insetX[0], insetX[1]);
-
-                // After clamping, the asymptote may have ended up back
-                // between or on the points. If so, reject the move.
-                const stillAllRight =
-                    coords[0][X] > newX && coords[1][X] > newX;
-                const stillAllLeft = coords[0][X] < newX && coords[1][X] < newX;
-                if (!stillAllRight && !stillAllLeft) {
-                    return state;
-                }
-            }
-
+            const newX = boundAndSnapToGrid(action.destination, state)[X];
             if (newX === state.asymptote) {
                 return state;
             }
-
+            // Reject if the asymptote's drag handle would land on a point.
+            const logFutureHandle = getAsymptoteHandleCoord(
+                "vertical",
+                state.range,
+                newX,
+            );
+            if (
+                state.coords.some(
+                    (c) =>
+                        c[X] === logFutureHandle[X] &&
+                        c[Y] === logFutureHandle[Y],
+                )
+            ) {
+                return state;
+            }
             return {
                 ...state,
                 hasBeenInteractedWith: true,


### PR DESCRIPTION
## Summary:
The old Grapher Tangent / Exponential graphs used to allow users to place the asymptote in-between the points (an “invalid” location). When we implemented these graphs in Interactive Graph, the team actually thought that this was a “glitch state” that needed to be resolved. 

This PR creates the logic to mimic the functionality from Grapher in order to allow users to place points between or on the asymptote line so long as it does not overlap with the drag handle. 

Issue: LEMS-4055

## Test plan:
- tests pass