### PR TITLE
docs(changeset): Ensure the default coords for Exponential and Logarithm are slightly further away from the asymptote.

### DIFF
--- a/.changeset/bright-dogs-own.md
+++ b/.changeset/bright-dogs-own.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Ensure the default coords for Exponential and Logarithm are slightly further away from the asymptote.

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.test.ts
@@ -516,7 +516,7 @@ describe("initializeGraphState for exponential graphs", () => {
         // Assert
         invariant(graph.type === "exponential");
         expect(graph.coords).toEqual([
-            [0, 1],
+            [0, 2],
             [5, 5],
         ]);
         expect(graph.asymptote).toBe(0);
@@ -582,7 +582,7 @@ describe("initializeGraphState for logarithm graphs", () => {
         // Assert
         invariant(graph.type === "logarithm");
         expect(graph.coords).toEqual([
-            [1, 1],
+            [2, 1],
             [5, 5],
         ]);
         expect(graph.asymptote).toBe(0);

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
@@ -499,10 +499,12 @@ export function getExponentialCoords(
         };
     }
 
-    // Default: two points above the x-axis, matching the Grapher widget defaults.
-    // [0.5, 0.55] normalizes to just above y=0 (≈1 step up in a [-10,10] range).
+    // Default: two points above the x-axis. The closest point sits a few
+    // steps above the asymptote so it doesn't visually overlap the
+    // asymptote drag handle. [0.5, 0.6] normalizes to (0, 2) in a [-10,10]
+    // range.
     let defaultCoords: [Coord, Coord] = [
-        [0.5, 0.55],
+        [0.5, 0.6],
         [0.75, 0.75],
     ];
     defaultCoords = normalizePoints(range, step, defaultCoords, true);
@@ -532,9 +534,12 @@ export function getLogarithmCoords(
 
     // Default coords as normalized fractions of the graph range. After
     // normalization with the default asymptote at x=0, both points will
-    // be to the right of the asymptote.
+    // be to the right of the asymptote. The closest point sits a few
+    // steps from the asymptote so it doesn't visually overlap the
+    // asymptote drag handle. [0.6, 0.55] normalizes to (2, 1) in a
+    // [-10,10] range.
     let defaultCoords: [Coord, Coord] = [
-        [0.55, 0.55],
+        [0.6, 0.55],
         [0.75, 0.75],
     ];
     defaultCoords = normalizePoints(range, step, defaultCoords, true);


### PR DESCRIPTION
## Summary:
This PR simply updates our default coordinates for Exponential and Logarithm graphs slightly, in order to ensure that the point does not start too close to the asymptote drag handle. 

Issue: LEMS-4054

## Test plan:
- tests pass 
- manual testing 