### PR TITLE
docs(changeset): Ensure that Ray and Linear points cannot overlap

### DIFF
--- a/.changeset/witty-ladybugs-attend.md
+++ b/.changeset/witty-ladybugs-attend.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Ensure that Ray and Linear points cannot overlap

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -244,6 +244,62 @@ describe("movePointInFigure", () => {
         ]);
     });
 
+    it("does not allow moving the endpoints of a linear graph to the same location", () => {
+        const state: InteractiveGraphState = {
+            hasBeenInteractedWith: false,
+            type: "linear",
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [1, 1],
+            coords: [
+                [1, 1],
+                [2, 2],
+            ],
+        };
+
+        const updated = interactiveGraphReducer(
+            state,
+            actions.linear.movePoint(0, [2, 2]),
+        );
+
+        invariant(updated.type === "linear");
+        expect(updated.hasBeenInteractedWith).toBe(false);
+        expect(updated.coords).toEqual([
+            [1, 1],
+            [2, 2],
+        ]);
+    });
+
+    it("does not allow moving the endpoints of a ray to the same location", () => {
+        const state: InteractiveGraphState = {
+            hasBeenInteractedWith: false,
+            type: "ray",
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [1, 1],
+            coords: [
+                [1, 1],
+                [2, 2],
+            ],
+        };
+
+        const updated = interactiveGraphReducer(
+            state,
+            actions.ray.movePoint(0, [2, 2]),
+        );
+
+        invariant(updated.type === "ray");
+        expect(updated.hasBeenInteractedWith).toBe(false);
+        expect(updated.coords).toEqual([
+            [1, 1],
+            [2, 2],
+        ]);
+    });
+
     it("does not allow moving the endpoints of a sinusoid to the same x location", () => {
         const state: InteractiveGraphState = {
             ...baseSinusoidGraphState,

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -296,6 +296,10 @@ function doMovePointInFigure(
                 newValue: boundAndSnapToGrid(action.destination, state),
             });
 
+            if (coordsOverlap(newCoords)) {
+                return state;
+            }
+
             return {
                 ...state,
                 hasBeenInteractedWith: true,


### PR DESCRIPTION
## Summary:
This PR simply ensures that the points in the Ray or Linear graphs cannot overlap. 

Note: This will have a conflict with another PR I have, as I had to split apart the reducer logic for Ray and Linear. I'll resolve that manually when I land these tickets. 

Issue: LEMS-4020

## Test plan:
- tests pass 
- manual testing 