### PR TITLE
[Image] Update copy of recalculate button in editor

### DIFF
--- a/.changeset/red-stingrays-return.md
+++ b/.changeset/red-stingrays-return.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Image] Update copy of recalculate button in editor

--- a/packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx
@@ -905,7 +905,7 @@ describe("image editor", () => {
                 name: "Scaled Height",
             });
             const resetToOriginalSizeButton = screen.getByRole("button", {
-                name: "Recalculate original size",
+                name: "Recalculate natural size",
             });
             expect(scaleField).toBeInTheDocument();
             expect(scaleField).toHaveValue(1);
@@ -1045,7 +1045,7 @@ describe("image editor", () => {
             },
         );
 
-        it("should call onChange with original image size when recalculate original size is clicked", async () => {
+        it("should call onChange with original image size when Recalculate natural size is clicked", async () => {
             // Arrange
             const onChangeMock = jest.fn();
             render(
@@ -1062,7 +1062,7 @@ describe("image editor", () => {
 
             // Act
             const resetToOriginalSizeButton = screen.getByRole("button", {
-                name: "Recalculate original size",
+                name: "Recalculate natural size",
             });
             await userEvent.click(resetToOriginalSizeButton);
 
@@ -1085,7 +1085,7 @@ describe("image editor", () => {
 
             // Act
             const resetToOriginalSizeButton = screen.getByRole("button", {
-                name: "Recalculate original size",
+                name: "Recalculate natural size",
             });
             await userEvent.click(resetToOriginalSizeButton);
 
@@ -1121,7 +1121,7 @@ describe("image editor", () => {
                 name: "Scaled Height",
             });
             const resetToOriginalSizeButton = screen.getByRole("button", {
-                name: "Recalculate original size",
+                name: "Recalculate natural size",
             });
             expect(scaleField).toBeInTheDocument();
             expect(scaledWidthField).toBeInTheDocument();
@@ -1174,7 +1174,7 @@ describe("image editor", () => {
                 name: "Scaled Height",
             });
             const resetToOriginalSizeButton = screen.queryByRole("button", {
-                name: "Recalculate original size",
+                name: "Recalculate natural size",
             });
             expect(scaleField).not.toBeInTheDocument();
             expect(scaledWidthField).not.toBeInTheDocument();

--- a/packages/perseus-editor/src/widgets/image-editor/components/image-scale-input.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/components/image-scale-input.tsx
@@ -102,7 +102,7 @@ export default function ImageScaleInput({
     return (
         <div className={styles.dimensionsContainer}>
             <BodyMonospace>
-                Dimensions: {width} x {height}
+                Natural size: {width} x {height}
             </BodyMonospace>
             <Button
                 kind="tertiary"
@@ -110,7 +110,7 @@ export default function ImageScaleInput({
                 startIcon={arrowCounterClockwise}
                 onClick={handleResetToOriginalSize}
             >
-                Recalculate original size
+                Recalculate natural size
             </Button>
 
             {hasLargeDimensions && (


### PR DESCRIPTION
## Summary:
"Recalculate original size" was a bit ambiguous, and could imply that it would
set the scale to 1, which is incorrect To make this clearer, I'm updating it to
say "Natural size" and "Recalculate natural size" for more clarity.

Issue: none

## Test plan:
`pnpm jest packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx`

Storybook
- `/?path=/story/editors-editorpage--with-all-flags`
- Add image widget
- Paste a URL (example: `https://cdn.kastatic.org/ka-content-images/61831c1329dbc32036d7dd0d03e06e7e2c622718.jpg`)
- Confirm that the copy is updated

| Before | After |
| --- | --- |
| <img width="350" height="617" alt="Screenshot 2026-04-28 at 10 42 06 AM" src="https://github.com/user-attachments/assets/e58b8220-23ee-4056-9eb4-04015e5bfad5" /> | <img width="350" height="618" alt="Screenshot 2026-04-28 at 10 37 51 AM" src="https://github.com/user-attachments/assets/708812d6-9aad-40fb-a86a-a06eb243f028" /> |


