### PR TITLE
chore(kmath): remove underscore dependency and replace with native JS

### DIFF
--- a/.changeset/remove-legacy-deps-from-kmath.md
+++ b/.changeset/remove-legacy-deps-from-kmath.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/kmath": patch
+---
+
+Remove `underscore` and `jquery` as peer and dev dependencies. All usages have been replaced with native JavaScript equivalents.

--- a/.changeset/remove-underscore-from-kmath.md
+++ b/.changeset/remove-underscore-from-kmath.md
@@ -1,5 +1,0 @@
----
-"@khanacademy/kmath": patch
----
-
-Remove `underscore` as a peer and dev dependency. All usages have been replaced with native JavaScript equivalents.

--- a/.changeset/remove-underscore-from-kmath.md
+++ b/.changeset/remove-underscore-from-kmath.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/kmath": patch
+---
+
+Remove `underscore` as a peer and dev dependency. All usages have been replaced with native JavaScript equivalents.

--- a/packages/kmath/package.json
+++ b/packages/kmath/package.json
@@ -33,6 +33,6 @@
     },
     "keywords": [],
     "khan": {
-        "catalogHash": "d7663955f3310f2b"
+        "catalogHash": "e3b0c44298fc1c14"
     }
 }

--- a/packages/kmath/package.json
+++ b/packages/kmath/package.json
@@ -30,12 +30,10 @@
     },
     "devDependencies": {
         "jquery": "catalog:devDeps",
-        "perseus-build-settings": "workspace:*",
-        "underscore": "catalog:devDeps"
+        "perseus-build-settings": "workspace:*"
     },
     "peerDependencies": {
-        "jquery": "catalog:peerDeps",
-        "underscore": "catalog:peerDeps"
+        "jquery": "catalog:peerDeps"
     },
     "keywords": [],
     "khan": {

--- a/packages/kmath/package.json
+++ b/packages/kmath/package.json
@@ -29,11 +29,7 @@
         "@khanacademy/perseus-utils": "workspace:*"
     },
     "devDependencies": {
-        "jquery": "catalog:devDeps",
         "perseus-build-settings": "workspace:*"
-    },
-    "peerDependencies": {
-        "jquery": "catalog:peerDeps"
     },
     "keywords": [],
     "khan": {

--- a/packages/kmath/src/geometry.ts
+++ b/packages/kmath/src/geometry.ts
@@ -7,7 +7,6 @@ import {
     approximateEqual,
     type Coord,
 } from "@khanacademy/perseus-core";
-import _ from "underscore";
 
 import {sum} from "./math";
 import * as knumber from "./number";
@@ -63,7 +62,7 @@ export function intersects(ab: Line, cd: Line): boolean {
         [cd[0], cd[1], ab[1]] as const,
     ];
 
-    const orientations = _.map(triplets, function (triplet) {
+    const orientations = triplets.map(function (triplet) {
         return sign(ccw(...triplet));
     });
 
@@ -111,10 +110,11 @@ export function polygonSidesIntersect(vertices: Coord[]): boolean {
     return false;
 }
 
-export function vector(a, b) {
-    return _.map(_.zip(a, b), function (pair) {
-        return pair[0] - pair[1];
-    });
+export function vector(
+    a: ReadonlyArray<number>,
+    b: ReadonlyArray<number>,
+): number[] {
+    return a.map((val, i) => val - b[i]);
 }
 
 export function reverseVector(vector: Coord): Coord {
@@ -125,43 +125,29 @@ export function reverseVector(vector: Coord): Coord {
 // path (assuming a closed loop, where the last point connects back to the
 // first).
 export function clockwise(points: Coord[]): boolean {
-    const segments = _.zip(points, points.slice(1).concat(points.slice(0, 1)));
-    const areas = _.map(segments, function (segment) {
-        const p1 = segment[0];
-        const p2 = segment[1];
+    const rotated = points.slice(1).concat(points.slice(0, 1));
+    const areas = points.map(function (p1, i) {
+        const p2 = rotated[i];
         return (p2[0] - p1[0]) * (p2[1] + p1[1]);
     });
     return sum(areas) > 0;
 }
 
-export function magnitude(v: ReadonlyArray<Coord>): number {
-    return Math.sqrt(
-        _.reduce(
-            v,
-            function (memo, el) {
-                // @ts-expect-error - TS2345 - Argument of type 'Coord' is not assignable to parameter of type 'number'.
-                return memo + Math.pow(el, 2);
-            },
-            0,
-        ),
-    );
+export function magnitude(v: ReadonlyArray<number>): number {
+    return Math.sqrt(v.reduce((memo, el) => memo + el * el, 0));
 }
 
-function dotProduct(a: Coord, b: Coord): number {
-    return _.reduce(
-        _.zip(a, b),
-        function (memo, pair) {
-            return memo + pair[0] * pair[1];
-        },
-        0,
-    );
+function dotProduct(
+    a: ReadonlyArray<number>,
+    b: ReadonlyArray<number>,
+): number {
+    return a.reduce((memo, val, i) => memo + val * b[i], 0);
 }
 
 function sideLengths(coords: ReadonlyArray<Coord>): ReadonlyArray<number> {
-    const segments = _.zip(coords, rotate(coords));
-    return segments.map(function (segment) {
-        // @ts-expect-error - TS2345 - Argument of type 'number[]' is not assignable to parameter of type 'readonly Coord[]'. | TS2556 - A spread argument must either have a tuple type or be passed to a rest parameter.
-        return magnitude(vector(...segment));
+    const rotated = rotate(coords);
+    return coords.map(function (coord, i) {
+        return magnitude(vector(coord, rotated[i]));
     });
 }
 
@@ -169,27 +155,21 @@ function sideLengths(coords: ReadonlyArray<Coord>): ReadonlyArray<number> {
 export function angleMeasures(
     coords: ReadonlyArray<Coord>,
 ): ReadonlyArray<number> {
-    const triplets = _.zip(rotate(coords, -1), coords, rotate(coords, 1));
+    const prev = rotate(coords, -1);
+    const next = rotate(coords, 1);
 
-    const offsets = _.map(triplets, function (triplet) {
+    const offsets = coords.map(function (coord, i) {
+        const triplet = [prev[i], coord, next[i]] as const;
         const p = vector(triplet[1], triplet[0]);
         const q = vector(triplet[2], triplet[1]);
-        // @ts-expect-error - TS2345 - Argument of type 'number[]' is not assignable to parameter of type 'Coord'. | TS2345 - Argument of type 'number[]' is not assignable to parameter of type 'readonly Coord[]'. | TS2345 - Argument of type 'number[]' is not assignable to parameter of type 'readonly Coord[]'.
         const raw = Math.acos(dotProduct(p, q) / (magnitude(p) * magnitude(q)));
-        // @ts-expect-error - TS2556 - A spread argument must either have a tuple type or be passed to a rest parameter.
         return sign(ccw(...triplet)) > 0 ? raw : -raw;
     });
 
-    const sum = _.reduce(
-        offsets,
-        function (memo, arg) {
-            return memo + arg;
-        },
-        0,
-    );
+    const offsetSum = offsets.reduce((memo, arg) => memo + arg, 0);
 
-    return _.map(offsets, function (offset) {
-        return sum > 0 ? Math.PI - offset : Math.PI + offset;
+    return offsets.map(function (offset) {
+        return offsetSum > 0 ? Math.PI - offset : Math.PI + offset;
     });
 }
 
@@ -231,17 +211,19 @@ export function similar(
         sides = rotate(sides, i);
 
         if (approximateDeepEqual(angles1, angles)) {
-            const sidePairs = _.zip(sides1, sides);
+            const sidePairs = sides1.map(
+                (s, idx) => [s, sides[idx]] as [number, number],
+            );
 
-            const factors = _.map(sidePairs, function (pair) {
+            const factors = sidePairs.map(function (pair) {
                 return pair[0] / pair[1];
             });
 
-            const same = _.all(factors, function (factor) {
+            const same = factors.every(function (factor) {
                 return approximateEqual(factors[0], factor);
             });
 
-            const congruentEnough = _.all(sidePairs, function (pair) {
+            const congruentEnough = sidePairs.every(function (pair) {
                 return knumber.equal(pair[0], pair[1], tolerance);
             });
 

--- a/packages/kmath/src/math.ts
+++ b/packages/kmath/src/math.ts
@@ -1,5 +1,3 @@
-import $ from "jquery";
-
 import * as knumber from "./number";
 
 import type {MathFormat} from "@khanacademy/perseus-core";
@@ -76,9 +74,8 @@ const KhanMath = {
         }
         if (n < 101) {
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-            return !!$.grep(KhanMath.primes, function (p, i) {
-                return Math.abs(p - n) <= 0.5;
-            }).length;
+            return !!KhanMath.primes.filter((p) => Math.abs(p - n) <= 0.5)
+                .length;
         }
         if (n <= 1 || (n > 2 && n % 2 === 0)) {
             return false;
@@ -103,10 +100,10 @@ const KhanMath = {
         const maxf = Math.sqrt(number);
         for (let f = 2; f <= maxf; f++) {
             if (number % f === 0) {
-                return $.merge(
-                    KhanMath.getPrimeFactorization(f),
-                    KhanMath.getPrimeFactorization(number / f),
-                );
+                return [
+                    ...KhanMath.getPrimeFactorization(f),
+                    ...KhanMath.getPrimeFactorization(number / f),
+                ];
             }
         }
     },
@@ -203,7 +200,7 @@ const KhanMath = {
     // Note: purposively more inclusive than answer-types' predicate.forms
     // That is, it is not necessarily true that interpreted input are numeric
     getNumericFormat: function (text: string): MathFormat | null | undefined {
-        text = $.trim(text);
+        text = text.trim();
         text = text.replace(/\u2212/, "-").replace(/([+-])\s+/g, "$1");
         if (text.match(/^[+-]?\d+$/)) {
             return "integer";

--- a/packages/kmath/src/math.ts
+++ b/packages/kmath/src/math.ts
@@ -1,5 +1,4 @@
 import $ from "jquery";
-import _ from "underscore";
 
 import * as knumber from "./number";
 
@@ -256,7 +255,10 @@ const KhanMath = {
             }
         }
 
-        if (_(["proper", "improper", "mixed", "fraction"]).contains(format)) {
+        if (
+            format != null &&
+            ["proper", "improper", "mixed", "fraction"].includes(format)
+        ) {
             const fraction = knumber.toFraction(number);
             const numerator = Math.abs(fraction[0]);
             const denominator = fraction[1];

--- a/packages/kmath/src/number.ts
+++ b/packages/kmath/src/number.ts
@@ -3,17 +3,15 @@
  * A number is a js-number, e.g. 5.12
  */
 
-import _ from "underscore";
-
 export const DEFAULT_TOLERANCE = 1e-9;
 
 export function is(x: any): boolean {
-    return _.isNumber(x) && !_.isNaN(x);
+    return typeof x === "number" && !Number.isNaN(x);
 }
 
 export function equal(x: number, y: number, tolerance?: number): boolean {
     // Checking for undefined makes this function behave nicely
-    // with vectors of different lengths that are _.zip'd together
+    // when called with vectors of different lengths
     if (x == null || y == null) {
         return x === y;
     }

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
@@ -612,7 +612,6 @@ export const getAngleCoords = (params: {
 
     defaultCoords = normalizePoints(range, step, defaultCoords, true);
 
-    // @ts-expect-error - TS2345 - Argument of type 'number[]' is not assignable to parameter of type 'readonly Coord[]'. | TS2556 - A spread argument must either have a tuple type or be passed to a rest parameter.
     const radius = magnitude(vector(...defaultCoords));
 
     // We're adding a placeholder for the third point to appease ts and so that we

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -1359,7 +1359,6 @@ export function calculateAngleSnap(
     }
 
     const knownSide = magnitude(
-        // @ts-expect-error - TS2345 - Argument of type 'number[]' is not assignable to parameter of type 'readonly Coord[]'.
         vector(coordsCopy[rel(-1)], coordsCopy[rel(1)]),
     );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -506,9 +506,6 @@ importers:
       perseus-build-settings:
         specifier: workspace:*
         version: link:../../config/build
-      underscore:
-        specifier: catalog:devDeps
-        version: 1.4.4
 
   packages/math-input:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -500,9 +500,6 @@ importers:
         specifier: workspace:*
         version: link:../perseus-utils
     devDependencies:
-      jquery:
-        specifier: catalog:devDeps
-        version: 2.1.1
       perseus-build-settings:
         specifier: workspace:*
         version: link:../../config/build


### PR DESCRIPTION
## Summary:
Replaces all underscore usages in kmath with native Array methods and
built-in JS equivalents, removing the package from devDependencies and peerDependencies.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
                                                                                                                                       
  Changes                                                                                                                              
                                                                                                                                      
  - Removed underscore from devDependencies and peerDependencies in package.json                                                       
  - Replaced all _ usages with native JS equivalents:
    - _.map / _.reduce / _.all → Array.map / Array.reduce / Array.every                                                                
    - _.zip → index-based mapping (avoids the [T | undefined, T | undefined] typing issues _.zip introduced)                           
    - _.isNumber / _.isNaN → typeof x === "number" / Number.isNaN                                                                      
    - _.contains → Array.includes                                                                                                      
  - Fixed several pre-existing @ts-expect-error suppressions that were artifacts of underscore's weak types — these are now clean      
                                                                                                                                       
  Testing                                                
                                                                                                                                       
  Existing test suite covers the changed functions. No behavioral changes intended.