### PR TITLE
Add Storybook MCP addon for AI-assisted UI development

### DIFF
--- a/.changeset/spotty-trains-rescue.md
+++ b/.changeset/spotty-trains-rescue.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Add Storybook MCP addon for AI-assisted UI development

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -114,6 +114,7 @@ const config: StorybookConfig = {
         "@storybook/addon-a11y",
         "@storybook/addon-docs",
         "@storybook/addon-links",
+        "@storybook/addon-mcp",
     ],
     // This framework automatically reads the vite.config.ts in the root dir
     // https://www.npmjs.com/package/@storybook/builder-vite#customize-vite-config

--- a/.storybook/storybook-mcp-guide.md
+++ b/.storybook/storybook-mcp-guide.md
@@ -56,7 +56,7 @@ When writing or modifying UI components, Claude Code now has two tools it can us
 
 - **Storybook must be running** on port 6006 for the MCP tools to work. If it's not running, Claude Code will still function normally — it just won't have access to the Storybook tools.
 - **This is local only.** The MCP server registration is per-developer and doesn't affect CI, builds, or other developers.
-- **It doesn't replace testing.** Continue using `pnpm test` for unit tests, Cypress for interaction tests, and the a11y addon for accessibility checks. The MCP tools help the AI write *better* code and stories — they don't run tests.
+- **It doesn't replace testing.** AI assistants should write tests for any feature they implement, not just stories. Continue using `pnpm test` for unit tests, Cypress for interaction tests, and the a11y addon for accessibility checks. The MCP tools help the AI write *better* code and stories — they don't run tests.
 
 ---
 

--- a/.storybook/storybook-mcp-guide.md
+++ b/.storybook/storybook-mcp-guide.md
@@ -107,8 +107,8 @@ MCP (Model Context Protocol) is a standard way for AI assistants to connect to e
 **The flow:**
 1. You give Claude Code a prompt (e.g., "Create stories for the dropdown widget")
 2. Claude Code calls the MCP tools on the running Storybook server
-3. Storybook returns project-specific conventions and story metadata
-4. Claude Code writes the code and gives you a preview URL
+3. Storybook returns story authoring guidelines and live preview URLs
+4. Claude Code writes the code following those guidelines and shares the preview URL
 5. You click the link to verify the result in your browser
 
 ### What happens without MCP vs. with MCP
@@ -167,7 +167,7 @@ In `.mdx` files, add the `tags` prop to the `<Meta>` component:
 
 Perseus has specific patterns that are easy to get wrong:
 - **Widget generators** in `packages/perseus-core/src/utils/generators` should be used for test data — not hand-rolled props
-- **Stories live in `__docs__/` directories** within each widget/component folder, not in a central location
+- **New stories go in `__docs__/` directories** within each widget/component folder. Some older stories are colocated directly (e.g., `matrix/matrix.stories.tsx`) but haven't been migrated yet.
 - **The widget data schema is versioned and strict** — inventing props that don't exist will cause type errors or runtime failures
 - There are **~60+ existing story files** across widgets, editors, components, and math-input with established conventions
 

--- a/.storybook/storybook-mcp-guide.md
+++ b/.storybook/storybook-mcp-guide.md
@@ -1,0 +1,183 @@
+# Using Storybook MCP in Perseus
+
+## What is it?
+
+`@storybook/addon-mcp` connects Claude Code (or other AI coding assistants) directly to your running Storybook instance. Instead of the AI guessing at component APIs and story patterns, it can query your actual Storybook for real documentation and generate live preview URLs to verify its work visually.
+
+## What's already done
+
+The addon is installed and configured in the repo — no code changes needed on your end.
+
+## One-time setup (per developer)
+
+### 1. Start Storybook
+
+```bash
+pnpm storybook
+```
+
+### 2. Register the MCP server with Claude Code
+
+```bash
+claude mcp add storybook-mcp --transport http http://localhost:6006/mcp --scope project
+```
+
+This only needs to be done once, and creates the file `.mcp.json`. It saves the connection to your local Claude Code project settings (not committed to git).
+
+### 3. Verify it's connected
+
+```bash
+claude mcp list
+```
+
+You should see:
+
+```
+storybook-mcp: http://localhost:6006/mcp (HTTP) - Connected
+```
+
+## How it helps day-to-day
+
+When writing or modifying UI components, Claude Code now has two tools it can use:
+
+| Tool                               | What it does                                                       | When it's useful                                   |
+| ---------------------------------- | ------------------------------------------------------------------ | -------------------------------------------------- |
+| `get-storybook-story-instructions` | Returns story authoring guidelines specific to our Storybook setup | Before creating or editing any `.stories.tsx` file  |
+| `preview-stories`                  | Returns live Storybook URLs for specific stories                   | After making UI changes, to visually verify results |
+
+### Example prompts that benefit from MCP
+
+- "Create stories for the new widget I just built"
+- "Add a story showing the error state for numeric-input"
+- "Update the expression widget stories to cover the mobile keypad"
+- "Show me what the radio widget looks like in its selected state"
+
+## Important notes
+
+- **Storybook must be running** on port 6006 for the MCP tools to work. If it's not running, Claude Code will still function normally — it just won't have access to the Storybook tools.
+- **This is local only.** The MCP server registration is per-developer and doesn't affect CI, builds, or other developers.
+- **It doesn't replace testing.** Continue using `pnpm test` for unit tests, Cypress for interaction tests, and the a11y addon for accessibility checks. The MCP tools help the AI write *better* code and stories — they don't run tests.
+
+---
+
+## Understanding how this works
+
+### What is MCP?
+
+MCP (Model Context Protocol) is a standard way for AI assistants to connect to external tools and data sources. Think of it like an API, but specifically designed for AI assistants to call. When Claude Code has an MCP connection to Storybook, it can ask Storybook questions about your components instead of relying only on reading source files.
+
+### How the pieces connect
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  Your Machine                                                  │
+│                                                                │
+│  ┌──────────┐    prompt     ┌─────────────┐                    │
+│  │          │ ─────────────>│             │                    │
+│  │Developer │    response   │ Claude Code │                    │
+│  │          │ <─────────────│   (CLI)     │                    │
+│  └──────────┘               └──────┬──────┘                    │
+│       │                            │                           │
+│       │                            │ MCP calls                 │
+│       │ clicks                     │ (get-storybook-story-     │
+│       │ preview                    │  instructions,            │
+│       │ link                       │  preview-stories)         │
+│       │                            │                           │
+│       │                     ┌──────▼──────┐                    │
+│       │                     │  Storybook  │                    │
+│       │                     │ Dev Server  │                    │
+│       │                     │ :6006       │                    │
+│       │                     │             │                    │
+│       │                     │ ┌─────────┐ │                    │
+│       │                     │ │addon-mcp│ │                    │
+│       │                     │ │ /mcp    │ │                    │
+│       │                     │ └─────────┘ │                    │
+│       │                     └──────┬──────┘                    │
+│       │                            │                           │
+│       │                            │ reads                     │
+│       │                            │                           │
+│       │                     ┌──────▼──────┐                    │
+│       └────────────────────>│  Stories &  │                    │
+│         views in browser    │ Components  │                    │
+│                             │ (Perseus)   │                    │
+│                             └─────────────┘                    │
+└────────────────────────────────────────────────────────────────┘
+```
+
+**The flow:**
+1. You give Claude Code a prompt (e.g., "Create stories for the dropdown widget")
+2. Claude Code calls the MCP tools on the running Storybook server
+3. Storybook returns project-specific conventions and story metadata
+4. Claude Code writes the code and gives you a preview URL
+5. You click the link to verify the result in your browser
+
+### What happens without MCP vs. with MCP
+
+**Without MCP**, when you ask Claude Code to write a story for a widget:
+1. It reads your source files to understand the component
+2. It guesses at story patterns based on its general Storybook knowledge
+3. It might use outdated import paths (e.g., `@storybook/test` instead of `storybook/test`)
+4. It might hand-write widget props instead of using our generators
+5. You manually navigate to Storybook to check if the result looks right
+
+**With MCP**, the same request goes like this:
+1. Claude Code calls `get-storybook-story-instructions` to learn this project's specific conventions
+2. It reads your source files to understand the component
+3. It writes the story following the correct patterns, imports, and data conventions
+4. It calls `preview-stories` and gives you a direct link like `http://localhost:6006/?path=/story/widgets-radio--default`
+5. You click the link and immediately see the result
+
+### The component manifest and `!manifest` tag
+
+The addon builds a **component manifest** — a structured index of all your
+components and their stories. This is what powers the MCP docs tools, letting
+AI assistants discover what components exist and how they're used.
+
+Not everything in Storybook is a component. Documentation pages, visual
+regression tests, and dev utilities would pollute the manifest with entries
+that aren't actual components. The `!manifest` tag excludes them.
+
+**When to add `!manifest` to a story:**
+
+| Story type | Example | Needs `!manifest`? |
+| --- | --- | --- |
+| Documentation/overview pages | Introduction, Getting Started, a11y docs | Yes |
+| Visual regression test stories | `*-regression.stories.tsx` for Chromatic | Yes |
+| Dev utilities | `preview.stories.tsx` | Yes |
+| Actual widget/component stories | `dropdown.stories.tsx` | No |
+| Internal sub-component stories | `choice-indicator.stories.tsx` | No |
+
+**How to add it:**
+
+In `.stories.tsx` files, add `"!manifest"` to the existing tags array:
+```typescript
+export default {
+    title: "Widgets/Definition/Visual Regression Tests/Initial State",
+    tags: ["!dev", "!manifest"],
+    // ...
+};
+```
+
+In `.mdx` files, add the `tags` prop to the `<Meta>` component:
+```mdx
+<Meta title="Widgets/Definition/Accessibility" tags={["!manifest"]} />
+```
+
+### Why does Perseus benefit from this?
+
+Perseus has specific patterns that are easy to get wrong:
+- **Widget generators** in `packages/perseus-core/src/utils/generators` should be used for test data — not hand-rolled props
+- **Stories live in `__docs__/` directories** within each widget/component folder, not in a central location
+- **The widget data schema is versioned and strict** — inventing props that don't exist will cause type errors or runtime failures
+- There are **~60+ existing story files** across widgets, editors, components, and math-input with established conventions
+
+The MCP connection gives Claude Code direct access to these conventions so it follows them correctly on the first try, rather than requiring you to review and correct its output.
+
+### What you don't need to change about how you work
+
+- You still write and review code the same way
+- You still run `pnpm test`, lint, and type-check before submitting PRs
+- You still use Storybook in your browser for visual development
+- The MCP addon is invisible if you're not using an AI assistant — it adds no overhead to Storybook's normal behavior
+
+The only new step is the one-time `claude mcp add` command in the setup section above. After that, Claude Code uses the tools automatically when they're relevant.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,17 +193,21 @@ claude mcp add storybook-mcp --transport http http://localhost:6006/mcp --scope 
 | `preview-stories`                   | Get live Storybook URLs to visually verify stories   |
 
 ### Workflow for UI work
-1. Call `get-storybook-story-instructions` to get the latest story authoring guidelines
-2. Write or modify the component and its stories
-3. Call `preview-stories` to get the live Storybook URLs and visually verify each story state
+1. Call `get-storybook-story-instructions` once per session — the guidelines
+   don't change between calls, so there's no need to re-fetch them.
+2. Write or modify the component and its stories.
+3. Call `preview-stories` only after finishing changes, not speculatively
+   during exploration.
+4. Prefer MCP tool calls over crawling raw source files — reading story
+   conventions via MCP is cheaper than navigating through source directories.
 
 ### Perseus-specific rules
 - **Never invent widget props.** Perseus widgets have a strict versioned data
   schema. Always verify against documented stories before using any prop.
 - **Use widget generators for test data.** All widget test data must come from
   `packages/perseus-core/src/utils/generators` — never hand-roll it.
-- **Check for existing stories first.** Stories live in `__docs__/` directories
-  throughout the packages (widgets, components, editors, math-input) — avoid
+- **Check for existing stories first.** New stories go in `__docs__/` directories.
+  Some older stories are colocated directly but haven't been migrated yet — avoid
   duplicating what's already there.
 - **Every new component needs stories** covering each key visual state.
 - **Add `!manifest` to non-component stories.** Documentation pages, visual

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,6 +170,47 @@ describe("WidgetComponent", () => {
 - Avoid unnecessary re-renders in widget hierarchies
 - Profile performance with React DevTools
 
+## Storybook MCP — AI-Assisted UI Development
+
+A Storybook MCP server runs as part of the local dev server via `@storybook/addon-mcp`.
+Before doing any widget, component, or UI work in this repo, use the Storybook MCP tools
+to ground your work in the actual codebase.
+
+### Setup (first time)
+Make sure Storybook is running:
+```bash
+pnpm storybook
+```
+Then register the MCP server with Claude Code:
+```bash
+claude mcp add storybook-mcp --transport http http://localhost:6006/mcp --scope project
+```
+
+### Available MCP tools
+| Tool                                | Purpose                                              |
+| ----------------------------------- | ---------------------------------------------------- |
+| `get-storybook-story-instructions`  | Get story authoring guidelines for this project      |
+| `preview-stories`                   | Get live Storybook URLs to visually verify stories   |
+
+### Workflow for UI work
+1. Call `get-storybook-story-instructions` to get the latest story authoring guidelines
+2. Write or modify the component and its stories
+3. Call `preview-stories` to get the live Storybook URLs and visually verify each story state
+
+### Perseus-specific rules
+- **Never invent widget props.** Perseus widgets have a strict versioned data
+  schema. Always verify against documented stories before using any prop.
+- **Use widget generators for test data.** All widget test data must come from
+  `packages/perseus-core/src/utils/generators` — never hand-roll it.
+- **Check for existing stories first.** Stories live in `__docs__/` directories
+  throughout the packages (widgets, components, editors, math-input) — avoid
+  duplicating what's already there.
+- **Every new component needs stories** covering each key visual state.
+- **Add `!manifest` to non-component stories.** Documentation pages, visual
+  regression tests (`*-regression.stories.tsx`), a11y docs, and dev utilities
+  should include `"!manifest"` in their tags to keep them out of the component
+  manifest. Actual widget/component stories should NOT have this tag.
+
 ## Debugging Tips
 
 ### Storybook Development

--- a/__docs__/api.mdx
+++ b/__docs__/api.mdx
@@ -4,6 +4,7 @@ import {Markdown, Meta} from "@storybook/addon-docs/blocks";
 
 <Meta
     title="API Documentation"
+    tags={["!manifest"]}
     parameters={{docs: {toc: {headingSelector: "h2, h3"}}}}
 />
 

--- a/__docs__/getting-started.mdx
+++ b/__docs__/getting-started.mdx
@@ -2,6 +2,7 @@ import {Meta} from "@storybook/addon-docs/blocks";
 
 <Meta
     title="Getting Started"
+    tags={["!manifest"]}
     parameters={{docs: {toc: {headingSelector: "h2, h3"}}}}
 />
 

--- a/__docs__/introduction.mdx
+++ b/__docs__/introduction.mdx
@@ -4,6 +4,7 @@ import {graphExample} from "./sample-data";
 
 <Meta
     title="Introduction"
+    tags={["!manifest"]}
     parameters={{docs: {toc: {headingSelector: "h2, h3"}}}}
 />
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "@storybook/addon-a11y": "10.3.1",
         "@storybook/addon-docs": "10.3.1",
         "@storybook/addon-links": "10.3.1",
-        "@storybook/addon-mcp": "^0.6.0",
+        "@storybook/addon-mcp": "0.6.0",
         "@storybook/react-vite": "10.3.1",
         "@swc-node/register": "^1.10.10",
         "@swc/core": "1.11.13",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
         "@storybook/addon-a11y": "10.3.1",
         "@storybook/addon-docs": "10.3.1",
         "@storybook/addon-links": "10.3.1",
+        "@storybook/addon-mcp": "^0.6.0",
         "@storybook/react-vite": "10.3.1",
         "@swc-node/register": "^1.10.10",
         "@swc/core": "1.11.13",

--- a/packages/perseus-editor/src/__docs__/article-editor-initial-state-regression.stories.tsx
+++ b/packages/perseus-editor/src/__docs__/article-editor-initial-state-regression.stories.tsx
@@ -16,7 +16,7 @@ registerAllWidgetsAndEditorsForTesting();
 export default {
     title: "Editors/ArticleEditor/Visual Regression Tests",
     component: ArticleEditor,
-    tags: ["!autodocs"],
+    tags: ["!autodocs", "!manifest"],
     parameters: {
         docs: {
             description: {

--- a/packages/perseus-editor/src/__docs__/editor-page-initial-state-regression.stories.tsx
+++ b/packages/perseus-editor/src/__docs__/editor-page-initial-state-regression.stories.tsx
@@ -11,7 +11,7 @@ registerAllWidgetsAndEditorsForTesting();
 
 export default {
     title: "Editors/EditorPage/Visual Regression Tests",
-    tags: ["!dev"],
+    tags: ["!dev", "!manifest"],
     parameters: {
         docs: {
             description: {

--- a/packages/perseus-editor/src/testing/preview.stories.tsx
+++ b/packages/perseus-editor/src/testing/preview.stories.tsx
@@ -8,7 +8,7 @@ const meta: Meta = {
     // 👇 Disable auto-generated documentation for this component. This
     // component supports preview in dev mode and isn't meant to be used as a
     // story by itself..
-    tags: ["!autodocs"],
+    tags: ["!autodocs", "!manifest"],
 };
 export default meta;
 

--- a/packages/perseus/src/__docs__/renderers-overview.mdx
+++ b/packages/perseus/src/__docs__/renderers-overview.mdx
@@ -1,6 +1,6 @@
 import {Markdown, Meta} from "@storybook/addon-docs/blocks";
 
-<Meta title="Renderers/Overview" />
+<Meta title="Renderers/Overview" tags={["!manifest"]} />
 
 # Perseus Renderers Overview
 

--- a/packages/perseus/src/widgets/definition/__docs__/a11y.mdx
+++ b/packages/perseus/src/widgets/definition/__docs__/a11y.mdx
@@ -1,6 +1,6 @@
 import {Meta} from "@storybook/addon-docs/blocks";
 
-<Meta title="Widgets/Definition/Accessibility" />
+<Meta title="Widgets/Definition/Accessibility" tags={["!manifest"]} />
 
 # Definition Accessibility
 

--- a/packages/perseus/src/widgets/definition/__docs__/definition-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/definition/__docs__/definition-initial-state-regression.stories.tsx
@@ -18,7 +18,7 @@ type Story = StoryObj<typeof ServerItemRendererWithDebugUI>;
 export default {
     title: "Widgets/Definition/Visual Regression Tests/Initial State",
     component: ServerItemRendererWithDebugUI,
-    tags: ["!dev"],
+    tags: ["!dev", "!manifest"],
     parameters: {
         docs: {
             description: {

--- a/packages/perseus/src/widgets/definition/__docs__/definition-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/definition/__docs__/definition-interactions-regression.stories.tsx
@@ -9,7 +9,7 @@ import type {Meta} from "@storybook/react-vite";
 const meta: Meta = {
     title: "Widgets/Definition/Visual Regression Tests/Interactions",
     component: ServerItemRendererWithDebugUI,
-    tags: ["!autodocs"],
+    tags: ["!autodocs", "!manifest"],
     parameters: {
         docs: {
             description: {

--- a/packages/perseus/src/widgets/dropdown/__docs__/a11y.mdx
+++ b/packages/perseus/src/widgets/dropdown/__docs__/a11y.mdx
@@ -1,6 +1,6 @@
 import {Meta} from "@storybook/addon-docs/blocks";
 
-<Meta title="Widgets/Dropdown/Accessibility" />
+<Meta title="Widgets/Dropdown/Accessibility" tags={["!manifest"]} />
 
 # Dropdown Accessibility
 

--- a/packages/perseus/src/widgets/dropdown/__docs__/dropdown.initial-state.stories.tsx
+++ b/packages/perseus/src/widgets/dropdown/__docs__/dropdown.initial-state.stories.tsx
@@ -28,7 +28,7 @@ type Story = StoryObj<typeof DropdownQuestionRenderer>;
 export default {
     title: "Widgets/Dropdown/Visual Regression Tests/Initial State",
     component: DropdownQuestionRenderer,
-    tags: ["!dev"],
+    tags: ["!dev", "!manifest"],
     parameters: {
         docs: {
             description: {

--- a/packages/perseus/src/widgets/dropdown/__docs__/dropdown.interactions.stories.tsx
+++ b/packages/perseus/src/widgets/dropdown/__docs__/dropdown.interactions.stories.tsx
@@ -18,7 +18,7 @@ import type {Meta} from "@storybook/react-vite";
  */
 export default {
     title: "Widgets/Dropdown/Visual Regression Tests/Interactions",
-    tags: ["!autodocs"],
+    tags: ["!autodocs", "!manifest"],
     parameters: {
         docs: {
             description: {

--- a/packages/perseus/src/widgets/explanation/__docs__/a11y.mdx
+++ b/packages/perseus/src/widgets/explanation/__docs__/a11y.mdx
@@ -1,6 +1,6 @@
 import {Meta} from "@storybook/addon-docs/blocks";
 
-<Meta title="Widgets/Explanation/Accessibility" />
+<Meta title="Widgets/Explanation/Accessibility" tags={["!manifest"]} />
 
 # Explanation Accessibility
 

--- a/packages/perseus/src/widgets/explanation/__docs__/explanation-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/explanation/__docs__/explanation-initial-state-regression.stories.tsx
@@ -13,7 +13,7 @@ import type {Meta, StoryObj} from "@storybook/react-vite";
 const meta: Meta = {
     title: "Widgets/Explanation/Visual Regression Tests/Initial State",
     component: ServerItemRendererWithDebugUI,
-    tags: ["!dev"],
+    tags: ["!dev", "!manifest"],
     parameters: {
         docs: {
             description: {

--- a/packages/perseus/src/widgets/explanation/__docs__/explanation-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/explanation/__docs__/explanation-interactions-regression.stories.tsx
@@ -9,7 +9,7 @@ import type {Meta} from "@storybook/react-vite";
 const meta: Meta = {
     title: "Widgets/Explanation/Visual Regression Tests/Interactions",
     component: ServerItemRendererWithDebugUI,
-    tags: ["!autodocs"],
+    tags: ["!autodocs", "!manifest"],
     parameters: {
         docs: {
             description: {

--- a/packages/perseus/src/widgets/expression/__docs__/a11y.mdx
+++ b/packages/perseus/src/widgets/expression/__docs__/a11y.mdx
@@ -1,6 +1,6 @@
 import {Meta} from "@storybook/addon-docs/blocks";
 
-<Meta title="Widgets/Expression/Accessibility" />
+<Meta title="Widgets/Expression/Accessibility" tags={["!manifest"]} />
 
 # Expression Accessibility
 

--- a/packages/perseus/src/widgets/free-response/__docs__/free-response-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/free-response/__docs__/free-response-initial-state-regression.stories.tsx
@@ -10,7 +10,7 @@ const FreeResponseWidget = getWidget("free-response")!;
 const meta: Meta<typeof FreeResponseWidget> = {
     title: "Widgets/Free Response/Visual Regression Tests/Initial State",
     component: FreeResponseWidget,
-    tags: ["!autodocs"],
+    tags: ["!autodocs", "!manifest"],
     parameters: {
         docs: {
             description: {

--- a/packages/perseus/src/widgets/free-response/__docs__/free-response-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/free-response/__docs__/free-response-interactions-regression.stories.tsx
@@ -10,7 +10,7 @@ const FreeResponseWidget = getWidget("free-response")!;
 const meta: Meta = {
     title: "Widgets/Free Response/Visual Regression Tests/Interactions",
     component: FreeResponseWidget,
-    tags: ["!autodocs"],
+    tags: ["!autodocs", "!manifest"],
     parameters: {
         docs: {
             description: {

--- a/packages/perseus/src/widgets/image/__docs__/image-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/image/__docs__/image-initial-state-regression.stories.tsx
@@ -41,6 +41,7 @@ const articleContent = `But in other cases, an object may experience a centripet
 const meta: Meta<typeof ImageWidget> = {
     title: "Widgets/Image/Visual Regression Tests",
     component: ImageWidget,
+    tags: ["!manifest"],
     parameters: {
         docs: {
             description: {

--- a/packages/perseus/src/widgets/image/__docs__/image-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/image/__docs__/image-interactions-regression.stories.tsx
@@ -22,7 +22,7 @@ const earthMoonImageCaption =
 const meta: Meta = {
     title: "Widgets/Image/Visual Regression Tests/Interactions",
     component: ImageWidget,
-    tags: ["!autodocs"],
+    tags: ["!autodocs", "!manifest"],
     parameters: {
         docs: {
             description: {

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/a11y.mdx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/a11y.mdx
@@ -1,6 +1,6 @@
 import {Meta} from "@storybook/addon-docs/blocks";
 
-<Meta title="Widgets/Interactive Graph/Accessibility" />
+<Meta title="Widgets/Interactive Graph/Accessibility" tags={["!manifest"]} />
 
 # Interactive Graph Accessibility
 

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph-asymptote-regression.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph-asymptote-regression.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta<typeof MafsQuestionRenderer> = {
     component: MafsQuestionRenderer,
     // !autodocs: shows individual stories in sidebar without a Docs page
     // (matches radio interactions pattern)
-    tags: ["!autodocs"],
+    tags: ["!autodocs", "!manifest"],
     parameters: {
         chromatic: {disableSnapshot: false},
     },

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph-regression.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph-regression.stories.tsx
@@ -30,7 +30,7 @@ type Story = StoryObj<typeof MafsQuestionRenderer>;
 const meta: Meta<typeof MafsQuestionRenderer> = {
     title: "Widgets/Interactive Graph/Visual Regression Tests",
     component: MafsQuestionRenderer,
-    tags: ["!dev"],
+    tags: ["!dev", "!manifest"],
     parameters: {
         chromatic: {disableSnapshot: false},
     },

--- a/packages/perseus/src/widgets/label-image/__docs__/label-image-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/label-image/__docs__/label-image-initial-state-regression.stories.tsx
@@ -10,7 +10,7 @@ const LabelImageWidget = getWidget("label-image")!;
 const meta: Meta<typeof LabelImageWidget> = {
     title: "Widgets/Label Image/Visual Regression Tests/Initial State",
     component: LabelImageWidget,
-    tags: ["!autodocs"],
+    tags: ["!autodocs", "!manifest"],
     parameters: {
         docs: {
             description: {

--- a/packages/perseus/src/widgets/label-image/__docs__/label-image-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/label-image/__docs__/label-image-interactions-regression.stories.tsx
@@ -12,7 +12,7 @@ const LabelImageWidget = getWidget("label-image")!;
 const meta: Meta<typeof LabelImageWidget> = {
     title: "Widgets/Label Image/Visual Regression Tests/Interactions",
     component: LabelImageWidget,
-    tags: ["!autodocs"],
+    tags: ["!autodocs", "!manifest"],
     parameters: {
         chromatic: {disableSnapshot: false, modes: themeModes},
     },

--- a/packages/perseus/src/widgets/numeric-input/__docs__/a11y.mdx
+++ b/packages/perseus/src/widgets/numeric-input/__docs__/a11y.mdx
@@ -1,6 +1,6 @@
 import {Meta} from "@storybook/addon-docs/blocks";
 
-<Meta title="Widgets/Numeric Input/Accessibility" />
+<Meta title="Widgets/Numeric Input/Accessibility" tags={["!manifest"]} />
 
 # Numeric Input Accessibility
 

--- a/packages/perseus/src/widgets/numeric-input/__docs__/numeric-input-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/numeric-input/__docs__/numeric-input-initial-state-regression.stories.tsx
@@ -10,7 +10,7 @@ const NumericInputWidget = getWidget("numeric-input")!;
 const meta: Meta<typeof NumericInputWidget> = {
     title: "Widgets/Numeric Input/Visual Regression Tests/Initial State",
     component: NumericInputWidget,
-    tags: ["!autodocs"],
+    tags: ["!autodocs", "!manifest"],
     parameters: {
         docs: {
             description: {

--- a/packages/perseus/src/widgets/numeric-input/__docs__/numeric-input-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/numeric-input/__docs__/numeric-input-interactions-regression.stories.tsx
@@ -10,7 +10,7 @@ const NumericInputWidget = getWidget("numeric-input")!;
 const meta: Meta<typeof NumericInputWidget> = {
     title: "Widgets/Numeric Input/Visual Regression Tests/Interactions",
     component: NumericInputWidget,
-    tags: ["!autodocs"],
+    tags: ["!autodocs", "!manifest"],
     parameters: {
         docs: {
             description: {

--- a/packages/perseus/src/widgets/radio/__docs__/a11y.mdx
+++ b/packages/perseus/src/widgets/radio/__docs__/a11y.mdx
@@ -1,6 +1,6 @@
 import {Meta} from "@storybook/addon-docs/blocks";
 
-<Meta title="Widgets/Radio/Accessibility" />
+<Meta title="Widgets/Radio/Accessibility" tags={["!manifest"]} />
 
 # Radio Widget Accessibility
 

--- a/packages/perseus/src/widgets/radio/__docs__/multiple-choice-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/multiple-choice-initial-state-regression.stories.tsx
@@ -32,7 +32,7 @@ type Story = StoryObj<typeof RadioQuestionRenderer>;
 export default {
     title: "Widgets/Radio/Visual Regression Tests/Initial State",
     component: RadioQuestionRenderer,
-    tags: ["!dev"],
+    tags: ["!dev", "!manifest"],
     parameters: {
         docs: {
             description: {

--- a/packages/perseus/src/widgets/radio/__docs__/multiple-choice-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/multiple-choice-interactions-regression.stories.tsx
@@ -30,7 +30,7 @@ type StoryArgs = {
 export default {
     title: "Widgets/Radio/Visual Regression Tests/Interactions",
     component: ServerItemRendererWithDebugUI,
-    tags: ["!autodocs"],
+    tags: ["!autodocs", "!manifest"],
     parameters: {
         docs: {
             description: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -220,7 +220,7 @@ importers:
         specifier: 10.3.1
         version: 10.3.1(react@18.2.0)(storybook@10.3.1(@testing-library/dom@10.3.1)(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
       '@storybook/addon-mcp':
-        specifier: ^0.6.0
+        specifier: 0.6.0
         version: 0.6.0(storybook@10.3.1(@testing-library/dom@10.3.1)(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: 10.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       '@storybook/addon-links':
         specifier: 10.3.1
         version: 10.3.1(react@18.2.0)(storybook@10.3.1(@testing-library/dom@10.3.1)(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))
+      '@storybook/addon-mcp':
+        specifier: ^0.6.0
+        version: 0.6.0(storybook@10.3.1(@testing-library/dom@10.3.1)(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: 10.3.1
         version: 10.3.1(esbuild@0.24.0)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@4.37.0)(storybook@10.3.1(@testing-library/dom@10.3.1)(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)(vite@5.4.0(@types/node@20.17.6)(less@4.2.0)(sass@1.89.2)(stylus@0.62.0)(terser@5.46.1))(webpack@5.97.1(@swc/core@1.11.13(@swc/helpers@0.5.17))(esbuild@0.24.0))
@@ -2988,6 +2991,9 @@ packages:
     engines: {node: '>=8.10'}
     hasBin: true
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@storybook/addon-a11y@10.3.1':
     resolution: {integrity: sha512-6mbrvFgBx5A6vn4Gt44m8KFvrBOhr+AvNvI8LFutWrW3/lJhvnVCz2wTTDausgSRPJdsW67wWgZCFhsLEUinqQ==}
     peerDependencies:
@@ -3005,6 +3011,15 @@ packages:
       storybook: ^10.3.1
     peerDependenciesMeta:
       react:
+        optional: true
+
+  '@storybook/addon-mcp@0.6.0':
+    resolution: {integrity: sha512-E79m2S7ik9wiF1AnI49fwbLQkrD03PicIZpCdeFhbbB19MF4tKFKyaQtbT3f6eaAP4EP2+COLDVLCQ7B3rGF4w==}
+    peerDependencies:
+      '@storybook/addon-vitest': ^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0
+      storybook: ^0.0.0-0 || ^9.1.16 || ^10.0.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0
+    peerDependenciesMeta:
+      '@storybook/addon-vitest':
         optional: true
 
   '@storybook/builder-vite@10.3.1':
@@ -3039,6 +3054,9 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@storybook/mcp@0.7.0':
+    resolution: {integrity: sha512-Pr4E61tM5e7aDzqgNOL/Ylw8CGdb+BIDGOf3vbmFfkR8ZnXjPxaV/vhTEsiXynnIpjQWCzySCxOU1icxZsgjrA==}
 
   '@storybook/react-dom-shim@10.3.1':
     resolution: {integrity: sha512-X337d639Bw9ej8vIi29bxgRsHcrFHhux1gMSmDifYjBRhTUXE3/OeDtoEl6ZV5Pgc5BAabUF5L2cl0mb428BYQ==}
@@ -3225,6 +3243,26 @@ packages:
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
+
+  '@tmcp/adapter-valibot@0.1.5':
+    resolution: {integrity: sha512-9P2wrVYPngemNK0UvPb/opC722/jfd09QxXmme1TRp/wPsl98vpSk/MXt24BCMqBRv4Dvs0xxJH4KHDcjXW52Q==}
+    peerDependencies:
+      tmcp: ^1.17.0
+      valibot: ^1.1.0
+
+  '@tmcp/session-manager@0.2.1':
+    resolution: {integrity: sha512-DOGy9LfufXCy1wfpGHZ6qPSDQtRnTVwOb71+41ffovTqzLMZlK3iLK/LIsekHxIiku+iIAUiqEKN+DHbqEm8IA==}
+    peerDependencies:
+      tmcp: ^1.16.3
+
+  '@tmcp/transport-http@0.8.5':
+    resolution: {integrity: sha512-qQLqiCTtbxtTSswqOn/782df7O57RxI/yLUtCDQ++kHEhbmDUc8glmmtGJ3mrb7yPSPoM5VF2Pc2Q5cA6quzLA==}
+    peerDependencies:
+      '@tmcp/auth': ^0.3.3 || ^0.4.0
+      tmcp: ^1.18.0
+    peerDependenciesMeta:
+      '@tmcp/auth':
+        optional: true
 
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
@@ -3696,6 +3734,11 @@ packages:
     resolution: {integrity: sha512-3zc+Ve99z4usVP6l9knYVbVnZgfqhKah7sIG+PS2w+vpig2v2OLct05vs+ZXMzwxdNCMka8B+8WlOo0z6Pn6DA==}
     peerDependencies:
       react: '>= 16.8.0'
+
+  '@valibot/to-json-schema@1.6.0':
+    resolution: {integrity: sha512-d6rYyK5KVa2XdqamWgZ4/Nr+cXhxjy7lmpe6Iajw15J/jmU+gyxl2IEd1Otg1d7Rl3gOQL5reulnSypzBtYy1A==}
+    peerDependencies:
+      valibot: ^1.3.0
 
   '@vitejs/plugin-react-swc@3.8.1':
     resolution: {integrity: sha512-aEUPCckHDcFyxpwFm0AIkbtv6PpUp3xTb9wYGFjtABynXjCYKkWoxX0AOK9NT9XCrdk6mBBUOeHQS+RKdcNO1A==}
@@ -5287,6 +5330,9 @@ packages:
     deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   esm@3.2.25:
     resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
     engines: {node: '>=6'}
@@ -6628,6 +6674,9 @@ packages:
     resolution: {integrity: sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
+  json-rpc-2.0@1.7.1:
+    resolution: {integrity: sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -7493,6 +7542,9 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  picoquery@2.5.0:
+    resolution: {integrity: sha512-j1kgOFxtaCyoFCkpoYG2Oj3OdGakadO7HZ7o5CqyRazlmBekKhbDoUnNnXASE07xSY4nDImWZkrZv7toSxMi/g==}
 
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -8500,6 +8552,9 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  sqids@0.3.0:
+    resolution: {integrity: sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==}
+
   sshpk@1.17.0:
     resolution: {integrity: sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==}
     engines: {node: '>=0.10.0'}
@@ -8770,6 +8825,9 @@ packages:
   tinyspy@4.0.4:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
+
+  tmcp@1.19.3:
+    resolution: {integrity: sha512-plz/TLKNFrdfQN32LjCTN6ULy6pynfGPgHcU7KGCI5dBrxQ9Mub99SmcYuzxEkLjJooQuOD3gosSwZEl1htOtw==}
 
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
@@ -9066,6 +9124,9 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  uri-template-matcher@1.1.2:
+    resolution: {integrity: sha512-uZc1h12jdO3m/R77SfTEOuo6VbMhgWznaawKpBjRGSJb7i91x5PgI37NQJtG+Cerxkk0yr1pylBY2qG1kQ+aEQ==}
+
   urix@0.1.0:
     resolution: {integrity: sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==}
     deprecated: Please see https://github.com/lydell/urix#deprecated
@@ -9130,6 +9191,14 @@ packages:
   v8-to-istanbul@9.0.1:
     resolution: {integrity: sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==}
     engines: {node: '>=10.12.0'}
+
+  valibot@1.2.0:
+    resolution: {integrity: sha512-mm1rxUsmOxzrwnX5arGS+U4T25RdvpPjPN4yR0u9pUBov9+zGVtO84tif1eY4r6zWxVxu3KzIyknJy3rxfRZZg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
@@ -12087,6 +12156,8 @@ snapshots:
       ignore: 5.3.2
       p-map: 4.0.0
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@storybook/addon-a11y@10.3.1(storybook@10.3.1(@testing-library/dom@10.3.1)(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
       '@storybook/global': 5.0.0
@@ -12116,6 +12187,19 @@ snapshots:
       storybook: 10.3.1(@testing-library/dom@10.3.1)(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     optionalDependencies:
       react: 18.2.0
+
+  '@storybook/addon-mcp@0.6.0(storybook@10.3.1(@testing-library/dom@10.3.1)(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(typescript@5.9.3)':
+    dependencies:
+      '@storybook/mcp': 0.7.0(typescript@5.9.3)
+      '@tmcp/adapter-valibot': 0.1.5(tmcp@1.19.3(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))
+      '@tmcp/transport-http': 0.8.5(tmcp@1.19.3(typescript@5.9.3))
+      picoquery: 2.5.0
+      storybook: 10.3.1(@testing-library/dom@10.3.1)(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      tmcp: 1.19.3(typescript@5.9.3)
+      valibot: 1.2.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@tmcp/auth'
+      - typescript
 
   '@storybook/builder-vite@10.3.1(esbuild@0.24.0)(rollup@4.37.0)(storybook@10.3.1(@testing-library/dom@10.3.1)(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(vite@5.4.0(@types/node@20.17.6)(less@4.2.0)(sass@1.89.2)(stylus@0.62.0)(terser@5.46.1))(webpack@5.97.1(@swc/core@1.11.13(@swc/helpers@0.5.17))(esbuild@0.24.0))':
     dependencies:
@@ -12149,6 +12233,16 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@storybook/mcp@0.7.0(typescript@5.9.3)':
+    dependencies:
+      '@tmcp/adapter-valibot': 0.1.5(tmcp@1.19.3(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))
+      '@tmcp/transport-http': 0.8.5(tmcp@1.19.3(typescript@5.9.3))
+      tmcp: 1.19.3(typescript@5.9.3)
+      valibot: 1.2.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@tmcp/auth'
+      - typescript
 
   '@storybook/react-dom-shim@10.3.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(storybook@10.3.1(@testing-library/dom@10.3.1)(prettier@3.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))':
     dependencies:
@@ -12339,6 +12433,23 @@ snapshots:
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.3.1)':
     dependencies:
       '@testing-library/dom': 10.3.1
+
+  '@tmcp/adapter-valibot@0.1.5(tmcp@1.19.3(typescript@5.9.3))(valibot@1.2.0(typescript@5.9.3))':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@valibot/to-json-schema': 1.6.0(valibot@1.2.0(typescript@5.9.3))
+      tmcp: 1.19.3(typescript@5.9.3)
+      valibot: 1.2.0(typescript@5.9.3)
+
+  '@tmcp/session-manager@0.2.1(tmcp@1.19.3(typescript@5.9.3))':
+    dependencies:
+      tmcp: 1.19.3(typescript@5.9.3)
+
+  '@tmcp/transport-http@0.8.5(tmcp@1.19.3(typescript@5.9.3))':
+    dependencies:
+      '@tmcp/session-manager': 0.2.1(tmcp@1.19.3(typescript@5.9.3))
+      esm-env: 1.2.2
+      tmcp: 1.19.3(typescript@5.9.3)
 
   '@tootallnate/once@2.0.0': {}
 
@@ -12851,6 +12962,10 @@ snapshots:
     dependencies:
       '@use-gesture/core': 10.3.0
       react: 18.2.0
+
+  '@valibot/to-json-schema@1.6.0(valibot@1.2.0(typescript@5.9.3))':
+    dependencies:
+      valibot: 1.2.0(typescript@5.9.3)
 
   '@vitejs/plugin-react-swc@3.8.1(@swc/helpers@0.5.17)(vite@5.4.0(@types/node@20.17.6)(less@4.2.0)(sass@1.89.2)(stylus@0.62.0)(terser@5.46.1))':
     dependencies:
@@ -14844,6 +14959,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  esm-env@1.2.2: {}
+
   esm@3.2.25: {}
 
   espree@9.6.1:
@@ -16558,6 +16675,8 @@ snapshots:
 
   json-parse-even-better-errors@3.0.2: {}
 
+  json-rpc-2.0@1.7.1: {}
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -17555,6 +17674,8 @@ snapshots:
   picomatch@4.0.2: {}
 
   picomatch@4.0.3: {}
+
+  picoquery@2.5.0: {}
 
   pify@2.3.0: {}
 
@@ -18715,6 +18836,8 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  sqids@0.3.0: {}
+
   sshpk@1.17.0:
     dependencies:
       asn1: 0.2.6
@@ -19024,6 +19147,16 @@ snapshots:
   tinyrainbow@2.0.0: {}
 
   tinyspy@4.0.4: {}
+
+  tmcp@1.19.3(typescript@5.9.3):
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      json-rpc-2.0: 1.7.1
+      sqids: 0.3.0
+      uri-template-matcher: 1.1.2
+      valibot: 1.2.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
 
   tmp@0.0.33:
     dependencies:
@@ -19383,6 +19516,8 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  uri-template-matcher@1.1.2: {}
+
   urix@0.1.0: {}
 
   url-parse@1.5.10:
@@ -19432,6 +19567,10 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 1.9.0
+
+  valibot@1.2.0(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   validate-npm-package-license@3.0.4:
     dependencies:


### PR DESCRIPTION
## Summary:
- Adds `@storybook/addon-mcp` (v0.6.0) to enable AI coding assistants (like Claude Code) to connect directly to our running Storybook instance
- Adds `!manifest` tags to 27 non-component stories (regression tests, documentation pages, a11y docs, dev utilities) to keep the component manifest clean
- Adds a developer guide at `.storybook/storybook-mcp-guide.md` explaining what the addon does, how to set it up, and how it works
- Updates `CLAUDE.md` with Storybook MCP workflow and `!manifest` tagging rules

## What is this?

`@storybook/addon-mcp` runs an MCP (Model Context Protocol) server inside the Storybook dev server. This lets AI assistants query Storybook for project-specific story authoring conventions and generate live preview URLs to verify their work visually — instead of guessing at patterns from source files alone.

**Available tools:**
| Tool | Purpose |
|------|---------|
| `get-storybook-story-instructions` | Returns story authoring guidelines specific to our setup |
| `preview-stories` | Returns live Storybook URLs for specific stories |

## Why?

Perseus has specific story patterns (widget generators, `__docs__/` directories, strict versioned data schema) that are easy to get wrong without context. This addon gives AI assistants direct access to those conventions so they follow them correctly on the first try.

## Changes

### New files
- `.storybook/storybook-mcp-guide.md` — Developer guide covering setup, usage, architecture, and `!manifest` tagging

### Configuration
- `package.json` — Added `@storybook/addon-mcp: ^0.6.0` to devDependencies
- `.storybook/main.ts` — Registered `@storybook/addon-mcp` in addons array
- `CLAUDE.md` — Added Storybook MCP section with workflow and Perseus-specific rules

### `!manifest` tags (27 files)
Added `!manifest` to exclude non-component entries from the component manifest:

- **Root documentation MDX** (4): introduction, getting-started, api, renderers-overview
- **Accessibility docs MDX** (7): a11y.mdx for definition, dropdown, explanation, expression, interactive-graph, numeric-input, radio
- **Visual regression stories** (15): all `*-regression.stories.tsx` across definition, dropdown, explanation, free-response, image, interactive-graph, label-image, numeric-input, radio, article-editor, editor-page
- **Dev utility** (1): `preview.stories.tsx`

Actual widget/component stories and internal sub-component stories were intentionally left without `!manifest` — they belong in the manifest.

## Setup (per developer, one-time)

```bash
pnpm storybook
claude mcp add storybook-mcp --transport http http://localhost:6006/mcp --scope project
```
Co-authored by Claude Code

Issue: LEMS-XXXX

## Test plan

- [ ] Run `pnpm storybook` and verify Storybook starts without errors
- [ ] Open `http://localhost:6006/mcp` in a browser and verify the MCP server status page loads
- [ ] Run `claude mcp list` and verify `storybook-mcp` shows as connected
- [ ] Verify regression stories and documentation pages still render correctly in Storybook (the `!manifest` tag doesn't affect rendering)
- [ ] Run `pnpm tsc` — type-check passes