### PR TITLE
[Radio] Adjust styling to resolve an axe-core incomplete test result

### DIFF
--- a/.changeset/fair-donuts-peel.md
+++ b/.changeset/fair-donuts-peel.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Radio] Adjust styling to resolve an axe-core incomplete test result

--- a/packages/perseus/src/widgets/radio/radio-component.module.css
+++ b/packages/perseus/src/widgets/radio/radio-component.module.css
@@ -25,6 +25,7 @@
     box-sizing: border-box; /* Added here to ensure proper sizing in the editor preview */
     min-width: auto; /* Needed for scrollable view to work */
     padding-inline-end: var(--perseus-multiple-choice-spacing);
+    position: relative;
     /* The following transform will cause a new reference layer for its descendants,
            which we use to position the indicator and the scroll fade in a fixed place while scrolling.
      */


### PR DESCRIPTION
## Summary:
When using the axe-core accessility checker in the content editor screen, axe-core was having trouble determining the color contrarst ratio for the `<legend>` element within the Multiple Choice/Radio widget. This can happen when certain CSS styles are in place that make it difficult to determine background elements (and their color). This PR adds a simple `position: relative` to the containing `<fieldset>` element to aid in determing stacking contexts. There should be no effect on the visible aspects of the widget.

## Test plan:
1. Launch Storybook
1. Navigate to the Editor demo page
1. Add a Radio widget
1. Open the Issues panel
1. Toggle the "Include axe-core scan" button
1. Change one of the answer boxes (to register a change in the preview)
1. Note that there is no error associated with legend (i.e. "Choose 1 answer:")