### PR TITLE
Fix TypeScript suppressions tagged with LEMS-2656

### DIFF
--- a/.changeset/chilled-starfishes-camp.md
+++ b/.changeset/chilled-starfishes-camp.md
@@ -1,0 +1,8 @@
+---
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Internal: Fix typescript error suppressions.

--- a/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
+++ b/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
@@ -10,7 +10,6 @@ import {getKeyTranslator} from "../key-handlers/key-translator";
 
 import type {MathFieldInterface} from "../input/mathquill-types";
 import type {KeypadKey} from "@khanacademy/perseus-core";
-import type MathQuill from "mathquill";
 
 import Keypad from "./index";
 

--- a/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
+++ b/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
@@ -12,6 +12,7 @@ import type {MathFieldInterface} from "../input/mathquill-types";
 import type {KeypadKey} from "@khanacademy/perseus-core";
 
 import Keypad from "./index";
+import type MathQuill from "mathquill";
 
 export default {
     title: "Math Input/Components/v2 Keypad With Mathquill",
@@ -32,13 +33,15 @@ export function V2KeypadWithMathquill() {
                 mathFieldWrapperRef.current,
                 "en",
                 mockStrings,
-                // TODO(LEMS-2656): remove TS suppression
-                // @ts-expect-error: Type 'EditableMathQuill' is not assignable to type 'MathFieldInterface'.
                 (baseConfig) => ({
                     ...baseConfig,
                     handlers: {
-                        edit: (_mathField: MathFieldInterface) => {
-                            setCursorContext(getCursorContext(_mathField));
+                        edit: (_mathField) => {
+                            // Cast to MathFieldInterface to get the types for
+                            // the cursor() and controller() methods, which
+                            // exist but aren't part of the published
+                            // MathQuill API.
+                            setCursorContext(getCursorContext(_mathField as MathFieldInterface));
                         },
                     },
                 }),

--- a/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
+++ b/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
@@ -10,9 +10,9 @@ import {getKeyTranslator} from "../key-handlers/key-translator";
 
 import type {MathFieldInterface} from "../input/mathquill-types";
 import type {KeypadKey} from "@khanacademy/perseus-core";
+import type MathQuill from "mathquill";
 
 import Keypad from "./index";
-import type MathQuill from "mathquill";
 
 export default {
     title: "Math Input/Components/v2 Keypad With Mathquill",
@@ -41,7 +41,11 @@ export function V2KeypadWithMathquill() {
                             // the cursor() and controller() methods, which
                             // exist but aren't part of the published
                             // MathQuill API.
-                            setCursorContext(getCursorContext(_mathField as MathFieldInterface));
+                            setCursorContext(
+                                getCursorContext(
+                                    _mathField as MathFieldInterface,
+                                ),
+                            );
                         },
                     },
                 }),

--- a/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
+++ b/packages/math-input/src/components/keypad/keypad-mathquill.stories.tsx
@@ -36,12 +36,13 @@ export function V2KeypadWithMathquill() {
                     ...baseConfig,
                     handlers: {
                         edit: (_mathField) => {
-                            // Cast to MathFieldInterface to get the types for
-                            // the cursor() and controller() methods, which
-                            // exist but aren't part of the published
-                            // MathQuill API.
                             setCursorContext(
                                 getCursorContext(
+                                    // Cast to MathFieldInterface to get the types for
+                                    // the cursor() and controller() methods, which
+                                    // exist but aren't part of the published
+                                    // MathQuill API.
+                                    // eslint-disable-next-line no-restricted-syntax
                                     _mathField as MathFieldInterface,
                                 ),
                             );

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -63,6 +63,8 @@ export {
     type ParseFailureDetail,
 } from "./parse-perseus-json";
 /** @hidden */
+export {parseLockedFigureColor} from "./parse-perseus-json/perseus-parsers/interactive-graph-widget";
+/** @hidden */
 export {interactiveGraphTypeParser} from "./parse-perseus-json/perseus-parsers/interactive-graph-widget";
 /** @hidden */
 export {parse} from "./parse-perseus-json/parse";

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -65,7 +65,7 @@ export {
 /** @hidden */
 export {
     parseLockedFigureColor,
-    parseLockedFigureFillType,
+    parseLockedFigureFillStyle,
     parseLockedLabelSize,
     parseLockedLineKind,
 } from "./parse-perseus-json/perseus-parsers/interactive-graph-widget";

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -67,6 +67,7 @@ export {
     parseLockedFigureColor,
     parseLockedFigureFillType,
     parseLockedLabelSize,
+    parseLockedLineKind,
 } from "./parse-perseus-json/perseus-parsers/interactive-graph-widget";
 /** @hidden */
 export {interactiveGraphTypeParser} from "./parse-perseus-json/perseus-parsers/interactive-graph-widget";

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -66,6 +66,7 @@ export {
 export {
     parseLockedFigureColor,
     parseLockedFigureFillType,
+    parseLockedLabelSize,
 } from "./parse-perseus-json/perseus-parsers/interactive-graph-widget";
 /** @hidden */
 export {interactiveGraphTypeParser} from "./parse-perseus-json/perseus-parsers/interactive-graph-widget";

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -62,6 +62,10 @@ export {
     parseAndMigratePerseusRenderer,
     type ParseFailureDetail,
 } from "./parse-perseus-json";
+/** @hidden */
+export {interactiveGraphTypeParser} from "./parse-perseus-json/perseus-parsers/interactive-graph-widget";
+/** @hidden */
+export {parse} from "./parse-perseus-json/parse";
 
 export {isSuccess, isFailure} from "./parse-perseus-json/result";
 export {

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -63,7 +63,10 @@ export {
     type ParseFailureDetail,
 } from "./parse-perseus-json";
 /** @hidden */
-export {parseLockedFigureColor} from "./parse-perseus-json/perseus-parsers/interactive-graph-widget";
+export {
+    parseLockedFigureColor,
+    parseLockedFigureFillType,
+} from "./parse-perseus-json/perseus-parsers/interactive-graph-widget";
 /** @hidden */
 export {interactiveGraphTypeParser} from "./parse-perseus-json/perseus-parsers/interactive-graph-widget";
 /** @hidden */

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -70,7 +70,7 @@ export {
     parseLockedLineKind,
 } from "./parse-perseus-json/perseus-parsers/interactive-graph-widget";
 /** @hidden */
-export {interactiveGraphTypeParser} from "./parse-perseus-json/perseus-parsers/interactive-graph-widget";
+export {parseInteractiveGraphType} from "./parse-perseus-json/perseus-parsers/interactive-graph-widget";
 /** @hidden */
 export {parse} from "./parse-perseus-json/parse";
 

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -209,9 +209,11 @@ const parseLockedPointType = object({
     ariaLabel: optional(string),
 });
 
+export const parseLockedLineKind = enumeration("line", "ray", "segment");
+
 const parseLockedLineType = object({
     type: constant("line"),
-    kind: enumeration("line", "ray", "segment"),
+    kind: parseLockedLineKind,
     points: pair(parseLockedPointType, parseLockedPointType),
     color: parseLockedFigureColor,
     lineStyle: parseLockedLineStyle,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -176,7 +176,7 @@ export const parsePerseusGraphType = discriminatedUnionOn("type")
 
 export const parseLockedFigureColor = enumeration(...lockedFigureColorNames);
 
-const parseLockedFigureFillType = enumeration(
+export const parseLockedFigureFillType = enumeration(
     "none",
     "white",
     "translucent",

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -176,7 +176,7 @@ export const parsePerseusGraphType = discriminatedUnionOn("type")
 
 export const parseLockedFigureColor = enumeration(...lockedFigureColorNames);
 
-export const parseLockedFigureFillType = enumeration(
+export const parseLockedFigureFillStyle = enumeration(
     "none",
     "white",
     "translucent",
@@ -239,7 +239,7 @@ const parseLockedEllipseType = object({
     radius: pairOfNumbers,
     angle: number,
     color: parseLockedFigureColor,
-    fillStyle: parseLockedFigureFillType,
+    fillStyle: parseLockedFigureFillStyle,
     strokeStyle: parseLockedLineStyle,
     weight: parseStrokeWeight,
     labels: defaulted(array(parseLockedLabelType), () => []),
@@ -251,7 +251,7 @@ const parseLockedPolygonType = object({
     points: array(pairOfNumbers),
     color: parseLockedFigureColor,
     showVertices: boolean,
-    fillStyle: parseLockedFigureFillType,
+    fillStyle: parseLockedFigureFillStyle,
     strokeStyle: parseLockedLineStyle,
     weight: parseStrokeWeight,
     labels: defaulted(array(parseLockedLabelType), () => []),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -190,12 +190,14 @@ const parseStrokeWeight = defaulted(
     () => "medium" as const,
 );
 
+export const parseLockedLabelSize = enumeration("small", "medium", "large");
+
 const parseLockedLabelType = object({
     type: constant("label"),
     coord: pairOfNumbers,
     text: string,
     color: parseLockedFigureColor,
-    size: enumeration("small", "medium", "large"),
+    size: parseLockedLabelSize,
 });
 
 const parseLockedPointType = object({

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -174,7 +174,7 @@ export const parsePerseusGraphType = discriminatedUnionOn("type")
     .withBranch("logarithm", parsePerseusGraphTypeLogarithm)
     .withBranch("vector", parsePerseusGraphTypeVector).parser;
 
-const parseLockedFigureColor = enumeration(...lockedFigureColorNames);
+export const parseLockedFigureColor = enumeration(...lockedFigureColorNames);
 
 const parseLockedFigureFillType = enumeration(
     "none",

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -370,5 +370,4 @@ export const interactiveGraphTypeParser = union(constant("angle"))
     .or(constant("absolute-value"))
     .or(constant("tangent"))
     .or(constant("logarithm"))
-    .or(constant("vector"))
-    .parser;
+    .or(constant("vector")).parser;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -357,19 +357,21 @@ export const parseInteractiveGraphWidget = parseWidget(
 /**
  * A parser that accepts the type field of an interactive graph.
  */
-export const interactiveGraphTypeParser = union(constant("angle"))
-    .or(constant("circle"))
-    .or(constant("linear"))
-    .or(constant("linear-system"))
-    .or(constant("none"))
-    .or(constant("point"))
-    .or(constant("polygon"))
-    .or(constant("quadratic"))
-    .or(constant("ray"))
-    .or(constant("segment"))
-    .or(constant("sinusoid"))
-    .or(constant("exponential"))
-    .or(constant("absolute-value"))
-    .or(constant("tangent"))
-    .or(constant("logarithm"))
-    .or(constant("vector")).parser;
+export const interactiveGraphTypeParser = enumeration(
+    "angle",
+    "circle",
+    "linear",
+    "linear-system",
+    "none",
+    "point",
+    "polygon",
+    "quadratic",
+    "ray",
+    "segment",
+    "sinusoid",
+    "exponential",
+    "absolute-value",
+    "tangent",
+    "logarithm",
+    "vector",
+);

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -351,3 +351,24 @@ export const parseInteractiveGraphWidget = parseWidget(
         fullGraphAriaDescription: optional(string),
     }),
 );
+
+/**
+ * A parser that accepts the type field of an interactive graph.
+ */
+export const interactiveGraphTypeParser = union(constant("angle"))
+    .or(constant("circle"))
+    .or(constant("linear"))
+    .or(constant("linear-system"))
+    .or(constant("none"))
+    .or(constant("point"))
+    .or(constant("polygon"))
+    .or(constant("quadratic"))
+    .or(constant("ray"))
+    .or(constant("segment"))
+    .or(constant("sinusoid"))
+    .or(constant("exponential"))
+    .or(constant("absolute-value"))
+    .or(constant("tangent"))
+    .or(constant("logarithm"))
+    .or(constant("vector"))
+    .parser;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -359,7 +359,7 @@ export const parseInteractiveGraphWidget = parseWidget(
 /**
  * A parser that accepts the type field of an interactive graph.
  */
-export const interactiveGraphTypeParser = enumeration(
+export const parseInteractiveGraphType = enumeration(
     "angle",
     "circle",
     "linear",

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.typetest.ts
@@ -4,11 +4,11 @@ import {ctx} from "../general-purpose-parsers/test-helpers";
 import {assertSuccess} from "../result";
 
 import {
-    interactiveGraphTypeParser,
+    parseInteractiveGraphType,
     parseInteractiveGraphWidget,
 } from "./interactive-graph-widget";
 
-import type {InteractiveGraphWidget} from "../../data-schema";
+import type {InteractiveGraphWidget, PerseusGraphType} from "../../data-schema";
 import type {ParseResult} from "../parser-types";
 
 describe("the InteractiveGraphWidget parser", () => {
@@ -19,12 +19,10 @@ describe("the InteractiveGraphWidget parser", () => {
     });
 });
 
-describe("interactiveGraphTypeParser", () => {
+describe("parseInteractiveGraphType", () => {
     it("should return the same type as the type field of an interactive graph", () => {
-        const result = interactiveGraphTypeParser("", ctx());
+        const result = parseInteractiveGraphType("", ctx());
         assertSuccess(result);
-        expect(result.value).type.toBe<
-            InteractiveGraphWidget["options"]["graph"]["type"]
-        >();
+        expect(result.value).type.toBe<PerseusGraphType["type"]>();
     });
 });

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.typetest.ts
@@ -1,9 +1,12 @@
 import {describe, it, expect} from "tstyche";
 
 import {ctx} from "../general-purpose-parsers/test-helpers";
-
-import {interactiveGraphTypeParser, parseInteractiveGraphWidget} from "./interactive-graph-widget";
 import {assertSuccess} from "../result";
+
+import {
+    interactiveGraphTypeParser,
+    parseInteractiveGraphWidget,
+} from "./interactive-graph-widget";
 
 import type {InteractiveGraphWidget} from "../../data-schema";
 import type {ParseResult} from "../parser-types";
@@ -20,6 +23,8 @@ describe("interactiveGraphTypeParser", () => {
     it("should return the same type as the type field of an interactive graph", () => {
         const result = interactiveGraphTypeParser("", ctx());
         assertSuccess(result);
-        expect(result.value).type.toBe<InteractiveGraphWidget["options"]["graph"]["type"]>();
-    })
-})
+        expect(result.value).type.toBe<
+            InteractiveGraphWidget["options"]["graph"]["type"]
+        >();
+    });
+});

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.typetest.ts
@@ -2,7 +2,8 @@ import {describe, it, expect} from "tstyche";
 
 import {ctx} from "../general-purpose-parsers/test-helpers";
 
-import {parseInteractiveGraphWidget} from "./interactive-graph-widget";
+import {interactiveGraphTypeParser, parseInteractiveGraphWidget} from "./interactive-graph-widget";
+import {assertSuccess} from "../result";
 
 import type {InteractiveGraphWidget} from "../../data-schema";
 import type {ParseResult} from "../parser-types";
@@ -14,3 +15,11 @@ describe("the InteractiveGraphWidget parser", () => {
         >();
     });
 });
+
+describe("interactiveGraphTypeParser", () => {
+    it("should return the same type as the type field of an interactive graph", () => {
+        const result = interactiveGraphTypeParser("", ctx());
+        assertSuccess(result);
+        expect(result.value).type.toBe<InteractiveGraphWidget["options"]["graph"]["type"]>();
+    })
+})

--- a/packages/perseus-editor/src/components/typed-single-select.tsx
+++ b/packages/perseus-editor/src/components/typed-single-select.tsx
@@ -1,0 +1,53 @@
+import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
+import * as React from "react";
+
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
+
+/**
+ * An object representing the options of a `<select>` element in HTML.
+ * Each property key in the object is a `value` of an option, and each
+ * property value is the text that appears in the `<select>` dropdown. If a
+ * property value is falsey, the corresponding option is hidden from the
+ * dropdown.
+ */
+type SelectOptions<ValueT extends string> = Record<
+    ValueT,
+    string | null | undefined | false
+>;
+
+interface OwnProps<ValueT extends string> {
+    options: SelectOptions<ValueT>;
+    selectedValue?: NoInfer<ValueT> | null | undefined;
+    onChange: (selectedValue: NoInfer<ValueT>) => void;
+}
+
+export type Props<ValueT extends string> = OwnProps<ValueT> &
+    Omit<PropsFor<typeof SingleSelect>, keyof OwnProps<string>>;
+
+/**
+ * A typesafe version of Wonder Blocks' `SingleSelect` component. Use this
+ * when you need a `SingleSelect` to choose among the branches of a union
+ * type like `"foo" | "bar" | "baz"`.
+ */
+export function TypedSingleSelect<ValueT extends string>(props: Props<ValueT>) {
+    return (
+        <SingleSelect
+            {...props}
+            // eslint-disable-next-line no-restricted-syntax
+            onChange={props.onChange as (selectedValue: string) => void}
+        >
+            {Object.entries(props.options).map(([key, value]) => {
+                if (value) {
+                    return (
+                        <OptionItem
+                            key={key}
+                            value={key}
+                            label={String(value)}
+                        />
+                    );
+                }
+                return null;
+            })}
+        </SingleSelect>
+    );
+}

--- a/packages/perseus-editor/src/components/typed-single-select.tsx
+++ b/packages/perseus-editor/src/components/typed-single-select.tsx
@@ -6,9 +6,8 @@ import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 /**
  * An object representing the options of a `<select>` element in HTML.
  * Each property key in the object is a `value` of an option, and each
- * property value is the text that appears in the `<select>` dropdown. If a
- * property value is falsey, the corresponding option is hidden from the
- * dropdown.
+ * property value is the text of that option in the dropdown. If a property
+ * value is falsey, the corresponding option is hidden from the dropdown.
  */
 type SelectOptions<ValueT extends string> = Record<
     ValueT,

--- a/packages/perseus-editor/src/widgets/interaction-editor/mathquill-input.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/mathquill-input.tsx
@@ -31,8 +31,6 @@ export default function MathquillInput(props: Props) {
                 mathFieldWrapperRef.current,
                 locale,
                 strings,
-                // TODO(LEMS-2656): remove TS suppression
-                // @ts-expect-error: Types of parameters 'mathField' and 'mq' are incompatible. Type 'EditableMathQuill | BaseMathQuill' is not assignable to type 'MathFieldInterface'.
                 (baseConfig) => ({
                     ...baseConfig,
                     handlers: {
@@ -51,12 +49,15 @@ export default function MathquillInput(props: Props) {
                                 props.onChange(value);
                             }
                         },
-                        upOutOf: (mathField: MathFieldInterface) => {
+                        upOutOf: (mathField) => {
                             // This handler is called when the user presses the up
                             // arrow key, but there is nowhere in the expression to go
                             // up to (no numerator or exponent). For ease of use,
                             // interpret this as an attempt to create an exponent.
-                            mathField.typedText("^");
+
+                            // This cast is needed because `BaseMathQuill`
+                            // doesn't have the typedText method.
+                            (mathField as MathFieldInterface).typedText("^");
                         },
                     },
                 }),

--- a/packages/perseus-editor/src/widgets/interaction-editor/mathquill-input.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/mathquill-input.tsx
@@ -57,6 +57,7 @@ export default function MathquillInput(props: Props) {
 
                             // This cast is needed because `BaseMathQuill`
                             // doesn't have the typedText method.
+                            // eslint-disable-next-line no-restricted-syntax
                             (mathField as MathFieldInterface).typedText("^");
                         },
                     },

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
@@ -1,5 +1,5 @@
 import {
-    interactiveGraphTypeParser,
+    parseInteractiveGraphType,
     isFailure,
     isFeatureOn,
     parse,
@@ -30,7 +30,7 @@ const GraphTypeSelector = (props: GraphTypeSelectorProps) => {
         <SingleSelect
             selectedValue={props.graphType}
             onChange={(value) => {
-                const parsedType = parse(value, interactiveGraphTypeParser);
+                const parsedType = parse(value, parseInteractiveGraphType);
                 if (isFailure(parsedType)) {
                     throw new Error(parsedType.detail);
                 }

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
@@ -1,13 +1,9 @@
-import {
-    parseInteractiveGraphType,
-    isFailure,
-    isFeatureOn,
-    parse,
-} from "@khanacademy/perseus-core";
-import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
+import {isFeatureOn} from "@khanacademy/perseus-core";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
+
+import {TypedSingleSelect} from "../../../components/typed-single-select";
 
 import type {APIOptionsWithDefaults} from "@khanacademy/perseus";
 import type {PerseusGraphType} from "@khanacademy/perseus-core";
@@ -27,35 +23,30 @@ const GraphTypeSelector = (props: GraphTypeSelectorProps) => {
     );
 
     return (
-        <SingleSelect
-            selectedValue={props.graphType}
-            onChange={(value) => {
-                const parsedType = parse(value, parseInteractiveGraphType);
-                if (isFailure(parsedType)) {
-                    throw new Error(parsedType.detail);
-                }
-                props.onChange(parsedType.value);
+        <TypedSingleSelect
+            options={{
+                "absolute-value": "Absolute value",
+                none: "None",
+                linear: "Linear function",
+                quadratic: "Quadratic function",
+                sinusoid: "Sinusoid function",
+                exponential: "Exponential function",
+                tangent: "Tangent function",
+                logarithm: "Logarithm function",
+                circle: "Circle",
+                point: "Point(s)",
+                "linear-system": "Linear System",
+                polygon: "Polygon",
+                segment: "Line Segment(s)",
+                ray: "Ray",
+                vector: showVector && "Vector",
+                angle: "Angle",
             }}
+            selectedValue={props.graphType}
+            onChange={props.onChange}
             placeholder="Select an answer type"
             style={styles.singleSelectShort}
-        >
-            <OptionItem value="absolute-value" label="Absolute value" />
-            <OptionItem value="none" label="None" />
-            <OptionItem value="linear" label="Linear function" />
-            <OptionItem value="quadratic" label="Quadratic function" />
-            <OptionItem value="sinusoid" label="Sinusoid function" />
-            <OptionItem value="exponential" label="Exponential function" />
-            <OptionItem value="tangent" label="Tangent function" />
-            <OptionItem value="logarithm" label="Logarithm function" />
-            <OptionItem value="circle" label="Circle" />
-            <OptionItem value="point" label="Point(s)" />
-            <OptionItem value="linear-system" label="Linear System" />
-            <OptionItem value="polygon" label="Polygon" />
-            <OptionItem value="segment" label="Line Segment(s)" />
-            <OptionItem value="ray" label="Ray" />
-            {showVector && <OptionItem value="vector" label="Vector" />}
-            <OptionItem value="angle" label="Angle" />
-        </SingleSelect>
+        />
     );
 };
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
@@ -1,10 +1,16 @@
-import {interactiveGraphTypeParser, isFailure, isFeatureOn, parse, PerseusGraphType} from "@khanacademy/perseus-core";
+import {
+    interactiveGraphTypeParser,
+    isFailure,
+    isFeatureOn,
+    parse,
+} from "@khanacademy/perseus-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
-import {APIOptionsWithDefaults} from "@khanacademy/perseus";
+import type {APIOptionsWithDefaults} from "@khanacademy/perseus";
+import type {PerseusGraphType} from "@khanacademy/perseus-core";
 
 type GraphTypeSelectorProps = {
     graphType: PerseusGraphType["type"];

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
@@ -1,14 +1,14 @@
-import {isFeatureOn} from "@khanacademy/perseus-core";
+import {interactiveGraphTypeParser, isFailure, isFeatureOn, parse, PerseusGraphType} from "@khanacademy/perseus-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
-import type {APIOptionsWithDefaults} from "@khanacademy/perseus";
+import {APIOptionsWithDefaults} from "@khanacademy/perseus";
 
 type GraphTypeSelectorProps = {
-    graphType: string;
-    onChange: (newGraphType: string) => void;
+    graphType: PerseusGraphType["type"];
+    onChange: (newGraphType: PerseusGraphType["type"]) => void;
     // TODO(LEMS-3976): clean up feature flag
     apiOptions: APIOptionsWithDefaults;
 };
@@ -23,7 +23,13 @@ const GraphTypeSelector = (props: GraphTypeSelectorProps) => {
     return (
         <SingleSelect
             selectedValue={props.graphType}
-            onChange={props.onChange}
+            onChange={(value) => {
+                const parsedType = parse(value, interactiveGraphTypeParser);
+                if (isFailure(parsedType)) {
+                    throw new Error(parsedType.detail);
+                }
+                props.onChange(parsedType.value);
+            }}
             placeholder="Select an answer type"
             style={styles.singleSelectShort}
         >

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-settings.tsx
@@ -54,7 +54,7 @@ type Props = {
     /**
      * The labels for the x and y axes.
      */
-    labels: ReadonlyArray<string>;
+    labels: string[];
     /**
      * Specifies the location of the labels on the graph.  default: "onAxis".
      * - "onAxis": Labels are positioned on the axis at the right (x) and top (y) of the graph.

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -39,11 +39,8 @@ import StartCoordsSettings from "./start-coords/start-coords-settings";
 import {getStartCoords, shouldShowStartCoordsUI} from "./start-coords/util";
 
 import type {APIOptionsWithDefaults} from "@khanacademy/perseus";
-import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 const InteractiveGraph = InteractiveGraphWidget.widget;
-
-type InteractiveGraphProps = PropsFor<typeof InteractiveGraph>;
 
 type Range = [min: number, max: number];
 
@@ -223,8 +220,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
             _.extend(json, {
                 graph: {
                     type: correct.type,
-                    startCoords:
-                        this.props.graph && getStartCoords(this.props.graph),
+                    startCoords: getStartCoords(this.props.graph),
                 },
                 correct: correct,
             });

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -423,14 +423,12 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                     this.props.graph?.type ??
                                     InteractiveGraph.defaultProps.userInput.type
                                 }
-                                onChange={
-                                    ((type: PerseusGraphType["type"]) => {
-                                        this.props.onChange({
-                                            graph: {type},
-                                            correct: {type},
-                                        });
-                                    })
-                                }
+                                onChange={(type: PerseusGraphType["type"]) => {
+                                    this.props.onChange({
+                                        graph: {type},
+                                        correct: {type},
+                                    });
+                                }}
                                 // TODO(LEMS-3976): clean up feature flag
                                 apiOptions={this.props.apiOptions}
                             />

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -53,7 +53,7 @@ export type Props = {
     /**
      * The labels for the x and y axes.
      */
-    labels: ReadonlyArray<string>;
+    labels: string[];
     /**
      * Specifies the location of the labels on the graph.  default: "onAxis".
      * - "onAxis": Labels are positioned on the axis at the right (x) and top (y) of the graph.
@@ -125,10 +125,10 @@ export type Props = {
     correct: PerseusGraphType;
     /**
      * The locked figures to display in the graph area.
-     * Locked figures are graph elements (points, lines, line segmeents,
+     * Locked figures are graph elements (points, lines, line segments,
      * etc.) that are locked in place and not interactive.
      */
-    lockedFigures?: Array<LockedFigure>;
+    lockedFigures: Array<LockedFigure>;
     // Aria-label for the full graph area. Short title for the graph.
     fullGraphAriaLabel?: string;
     // Aria-description for the graph area. Longer description of the graph.
@@ -140,7 +140,7 @@ export type Props = {
     /**
      * The graph to display in the graph area.
      */
-    graph: InteractiveGraphProps["userInput"];
+    graph: PerseusGraphType;
     onChange: (props: Partial<Props>) => void;
     // Whether the graph has been set to static mode.
     // Graphs in static mode are not interactive, and their coords are
@@ -366,13 +366,8 @@ class InteractiveGraphEditor extends React.Component<Props> {
                 static: this.props.apiOptions?.editingDisabled ?? false,
                 trackInteraction: function () {},
                 userInput: correct,
-                handleUserInput: (
-                    newGraph: InteractiveGraphProps["userInput"],
-                ) => {
+                handleUserInput: (newGraph: PerseusGraphType) => {
                     let correct = this.props.correct;
-                    // TODO(benchristel): can we improve the type of onChange
-                    // so this invariant isn't necessary?
-                    invariant(newGraph != null);
                     if (correct.type === newGraph.type) {
                         correct = mergeGraphs(correct, newGraph);
                     } else {
@@ -389,10 +384,20 @@ class InteractiveGraphEditor extends React.Component<Props> {
             graph = (
                 // There are a bunch of props that renderer.jsx passes to widgets via
                 // getWidgetProps() and widget-container.jsx that the editors don't
-                // bother passing.
-                // @ts-expect-error - TS2769 - No overload matches this call.
+                // bother passing. We pass `undefined` for these props and
+                // cast to `any`.
                 <InteractiveGraph
                     {...graphProps}
+                    graph={undefined as any}
+                    widgetId={undefined as any}
+                    widgetIndex={undefined as any}
+                    alignment={undefined}
+                    problemNum={undefined}
+                    onFocus={undefined as any}
+                    onBlur={undefined as any}
+                    findWidgets={undefined as any}
+                    reviewMode={undefined as any}
+                    linterContext={undefined as any}
                     containerSizeClass={sizeClass}
                     apiOptions={{
                         ...this.props.apiOptions,
@@ -418,17 +423,13 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                     this.props.graph?.type ??
                                     InteractiveGraph.defaultProps.userInput.type
                                 }
-                                // TODO(LEMS-2656): remove TS suppression
                                 onChange={
-                                    // eslint-disable-next-line no-restricted-syntax
-                                    ((
-                                        type: Required<InteractiveGraphProps>["userInput"]["type"],
-                                    ) => {
+                                    ((type: PerseusGraphType["type"]) => {
                                         this.props.onChange({
                                             graph: {type},
                                             correct: {type},
                                         });
-                                    }) as any
+                                    })
                                 }
                                 // TODO(LEMS-3976): clean up feature flag
                                 apiOptions={this.props.apiOptions}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -384,15 +384,23 @@ class InteractiveGraphEditor extends React.Component<Props> {
                 // cast to `any`.
                 <InteractiveGraph
                     {...graphProps}
+                    // eslint-disable-next-line no-restricted-syntax
                     graph={undefined as any}
+                    // eslint-disable-next-line no-restricted-syntax
                     widgetId={undefined as any}
+                    // eslint-disable-next-line no-restricted-syntax
                     widgetIndex={undefined as any}
                     alignment={undefined}
                     problemNum={undefined}
+                    // eslint-disable-next-line no-restricted-syntax
                     onFocus={undefined as any}
+                    // eslint-disable-next-line no-restricted-syntax
                     onBlur={undefined as any}
+                    // eslint-disable-next-line no-restricted-syntax
                     findWidgets={undefined as any}
+                    // eslint-disable-next-line no-restricted-syntax
                     reviewMode={undefined as any}
+                    // eslint-disable-next-line no-restricted-syntax
                     linterContext={undefined as any}
                     containerSizeClass={sizeClass}
                     apiOptions={{

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/color-select.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/color-select.tsx
@@ -1,4 +1,9 @@
-import {lockedFigureColors} from "@khanacademy/perseus-core";
+import {
+    lockedFigureColors,
+    parseLockedFigureColor,
+    parse,
+    isFailure,
+} from "@khanacademy/perseus-core";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
@@ -31,9 +36,16 @@ const ColorSelect = (props: Props) => {
                 <Strut size={spacing.xxSmall_6} />
                 <SingleSelect
                     selectedValue={selectedValue}
-                    // TODO(LEMS-2656): remove TS suppression
-                    // eslint-disable-next-line no-restricted-syntax
-                    onChange={onChange as any}
+                    onChange={(value) => {
+                        const parsedColor = parse(
+                            value,
+                            parseLockedFigureColor,
+                        );
+                        if (isFailure(parsedColor)) {
+                            throw new Error(parsedColor.detail);
+                        }
+                        onChange(parsedColor.value);
+                    }}
                     // Placeholder is required, but never gets used.
                     placeholder=""
                 >

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.tsx
@@ -5,7 +5,7 @@ import {
     isFailure,
     lockedFigureFillStyles,
     parse,
-    parseLockedFigureFillType,
+    parseLockedFigureFillStyle,
 } from "@khanacademy/perseus-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -237,7 +237,7 @@ const LockedEllipseSettings = (props: Props) => {
                         onChange={(value) => {
                             const parsedFillStyle = parse(
                                 value,
-                                parseLockedFigureFillType,
+                                parseLockedFigureFillStyle,
                             );
                             if (isFailure(parsedFillStyle)) {
                                 throw new Error(parsedFillStyle.detail);

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.tsx
@@ -2,7 +2,10 @@ import {angles} from "@khanacademy/kmath";
 import {components} from "@khanacademy/perseus";
 import {
     getDefaultFigureForType,
+    isFailure,
     lockedFigureFillStyles,
+    parse,
+    parseLockedFigureFillType,
 } from "@khanacademy/perseus-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -38,7 +41,6 @@ import {
 import type {LockedFigureSettingsCommonProps} from "./locked-figure-settings";
 import type {
     Coord,
-    LockedFigureFillType,
     LockedEllipseType,
     LockedFigureColor,
     LockedLabelType,
@@ -232,12 +234,16 @@ const LockedEllipseSettings = (props: Props) => {
                     <Strut size={spacing.xxSmall_6} />
                     <SingleSelect
                         selectedValue={fillStyle}
-                        // TODO(LEMS-2656): remove TS suppression
-                        onChange={
-                            // eslint-disable-next-line no-restricted-syntax
-                            ((value: LockedFigureFillType) =>
-                                onChangeProps({fillStyle: value})) as any
-                        }
+                        onChange={(value) => {
+                            const parsedFillStyle = parse(
+                                value,
+                                parseLockedFigureFillType,
+                            );
+                            if (isFailure(parsedFillStyle)) {
+                                throw new Error(parsedFillStyle.detail);
+                            }
+                            onChangeProps({fillStyle: parsedFillStyle.value});
+                        }}
                         // Placeholder is required, but never gets used.
                         placeholder=""
                     >

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-label-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-label-settings.tsx
@@ -7,8 +7,11 @@
  */
 import {components} from "@khanacademy/perseus";
 import {
+    isFailure,
     lockedFigureColors,
     type LockedLabelType,
+    parse,
+    parseLockedLabelSize,
 } from "@khanacademy/perseus-core";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
@@ -166,14 +169,16 @@ export default function LockedLabelSettings(props: Props) {
                     <Strut size={spacing.xSmall_8} />
                     <SingleSelect
                         selectedValue={size}
-                        // TODO(LEMS-2656): remove TS suppression
-                        onChange={
-                            // eslint-disable-next-line no-restricted-syntax
-                            ((newValue: "small" | "medium" | "large") =>
-                                onChangeProps({
-                                    size: newValue,
-                                })) as any
-                        }
+                        onChange={(newValue) => {
+                            const parsedSize = parse(
+                                newValue,
+                                parseLockedLabelSize,
+                            );
+                            if (isFailure(parsedSize)) {
+                                throw new Error(parsedSize.detail);
+                            }
+                            onChangeProps({size: parsedSize.value});
+                        }}
                         // Placeholder is required, but never gets used since
                         // we have a label for the select.
                         placeholder=""

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.tsx
@@ -5,7 +5,12 @@
  * Used in the interactive graph editor's locked figures section.
  */
 import {vector as kvector} from "@khanacademy/kmath";
-import {getDefaultFigureForType} from "@khanacademy/perseus-core";
+import {
+    getDefaultFigureForType,
+    isFailure,
+    parse,
+    parseLockedLineKind,
+} from "@khanacademy/perseus-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
@@ -236,12 +241,13 @@ const LockedLineSettings = (props: Props) => {
                 <Strut size={spacing.xxxSmall_4} />
                 <SingleSelect
                     selectedValue={kind}
-                    // TODO(LEMS-2656): remove TS suppression
-                    onChange={
-                        // eslint-disable-next-line no-restricted-syntax
-                        ((value: "line" | "segment" | "ray") =>
-                            onChangeProps({kind: value})) as any
-                    }
+                    onChange={(value) => {
+                        const parsedKind = parse(value, parseLockedLineKind);
+                        if (isFailure(parsedKind)) {
+                            throw new Error(parsedKind.detail);
+                        }
+                        onChangeProps({kind: parsedKind.value});
+                    }}
                     // Placeholder is required, but never gets used.
                     placeholder=""
                 >

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
@@ -2,10 +2,12 @@ import {
     getDefaultFigureForType,
     lockedFigureFillStyles,
     type Coord,
-    type LockedFigureFillType,
     type LockedPolygonType,
     type LockedFigureColor,
     type LockedLabelType,
+    parseLockedFigureFillStyle,
+    parse,
+    isFailure,
 } from "@khanacademy/perseus-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -209,12 +211,16 @@ const LockedPolygonSettings = (props: Props) => {
                     <Strut size={spacing.xxSmall_6} />
                     <SingleSelect
                         selectedValue={fillStyle}
-                        // TODO(LEMS-2656): remove TS suppression
-                        onChange={
-                            // eslint-disable-next-line no-restricted-syntax
-                            ((value: LockedFigureFillType) =>
-                                onChangeProps({fillStyle: value})) as any
-                        }
+                        onChange={(value) => {
+                            const parsedFillStyle = parse(
+                                value,
+                                parseLockedFigureFillStyle,
+                            );
+                            if (isFailure(parsedFillStyle)) {
+                                throw new Error(parsedFillStyle.detail);
+                            }
+                            onChangeProps({fillStyle: parsedFillStyle.value});
+                        }}
                         // Placeholder is required, but never gets used.
                         placeholder=""
                     >

--- a/packages/perseus/src/components/graphie-classes.ts
+++ b/packages/perseus/src/components/graphie-classes.ts
@@ -128,7 +128,6 @@ const createSimpleClass = function (addFunction: any): any {
         },
 
         remove: function () {
-            // @ts-expect-error - TS2554 - Expected 3 arguments, but got 2.
             nestedMap(this._elements, (elem) => {
                 if (elem) {
                     elem.remove();
@@ -139,7 +138,6 @@ const createSimpleClass = function (addFunction: any): any {
         },
 
         toFront: function () {
-            // @ts-expect-error - TS2554 - Expected 3 arguments, but got 2.
             nestedMap(this._elements, (elem) => {
                 if (_.isFunction(elem.toFront)) {
                     elem.toFront();

--- a/packages/perseus/src/components/graphie.tsx
+++ b/packages/perseus/src/components/graphie.tsx
@@ -232,7 +232,6 @@ class Graphie extends React.Component<Props> {
         this._movables = {};
     };
 
-    // @ts-expect-error - TS2322 - Type '(children: readonly any[], options: any) => ReactElement<any, string | JSXElementConstructor<any>> | readonly ReactElement<any, string | JSXElementConstructor<any>>[]' is not assignable to type '(children: readonly any[], arg2: any) => ReactElement<any, string | JSXElementConstructor<any>>'.
     _renderMovables: (
         children: ReadonlyArray<any>,
         arg2: {
@@ -279,7 +278,6 @@ class Graphie extends React.Component<Props> {
         // elements occurring afterwards. If this happens, we set
         // `areMovablesOutOfOrder` to true:
         let areMovablesOutOfOrder = false;
-        // @ts-expect-error - TS2554 - Expected 3 arguments, but got 2.
         return nestedMap(children, (childDescriptor) => {
             if (!childDescriptor) {
                 // Still increment the key to avoid cascading key changes

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -192,12 +192,11 @@ class InnerMathInput extends React.Component<InnerProps, State> {
                 this.__mathFieldWrapperRef,
                 locale,
                 this.props.mathInputStrings,
-                // TODO(LEMS-2656): remove TS suppression
-                // @ts-expect-error: Type 'EditableMathQuill' is not assignable to type 'MathFieldInterface'.
                 (baseConfig) => ({
                     ...baseConfig,
                     handlers: {
-                        edit: debounce((mathField: MathFieldInterface) => {
+                        edit: debounce((mathQuill) => {
+                            const mathField = mathQuill as MathFieldInterface;
                             // This handler is guaranteed to be called on change, but
                             // unlike React it sometimes generates false positives.
                             // One of these is on initialization (with an empty string
@@ -251,12 +250,15 @@ class InnerMathInput extends React.Component<InnerProps, State> {
                                 $(this.__mathFieldWrapperRef).submit();
                             }
                         },
-                        upOutOf: (mathField: MathFieldInterface) => {
+                        upOutOf: (mathField) => {
                             // This handler is called when the user presses the up
                             // arrow key, but there is nowhere in the expression to go
                             // up to (no numerator or exponent). For ease of use,
                             // interpret this as an attempt to create an exponent.
-                            mathField.typedText("^");
+
+                            // BaseMathQuill doesn't have a typedText method,
+                            // so we have to cast here.
+                            (mathField as MathFieldInterface).typedText("^");
                         },
                     },
                 }),

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -196,6 +196,7 @@ class InnerMathInput extends React.Component<InnerProps, State> {
                     ...baseConfig,
                     handlers: {
                         edit: debounce((mathQuill) => {
+                            // eslint-disable-next-line no-restricted-syntax
                             const mathField = mathQuill as MathFieldInterface;
                             // This handler is guaranteed to be called on change, but
                             // unlike React it sometimes generates false positives.
@@ -258,6 +259,7 @@ class InnerMathInput extends React.Component<InnerProps, State> {
 
                             // BaseMathQuill doesn't have a typedText method,
                             // so we have to cast here.
+                            // eslint-disable-next-line no-restricted-syntax
                             (mathField as MathFieldInterface).typedText("^");
                         },
                     },

--- a/packages/perseus/src/util.ts
+++ b/packages/perseus/src/util.ts
@@ -49,21 +49,18 @@ type TouchHandlers = {
 
 let supportsPassive = false;
 
+type NestedArray<T> = ReadonlyArray<T | NestedArray<T>>
+
 const nestedMap = function <T, M>(
-    children: T | ReadonlyArray<T>,
+    children: T | NestedArray<T>,
     func: (arg1: T) => M,
-    context: unknown,
-): M | ReadonlyArray<M> {
+): M | NestedArray<M> {
     if (Array.isArray(children)) {
-        // @ts-expect-error - TS2322 - Type '(M | readonly M[])[]' is not assignable to type 'M | readonly M[]'.
         return _.map(children, function (child) {
-            // @ts-expect-error - TS2554 - Expected 3 arguments, but got 2.
             return nestedMap(child, func);
         });
     }
-    // TODO(LEMS-2656): remove TS suppression
-    // @ts-expect-error: T | ReadonlyArray<T> is not assignable to T
-    return func.call(context, children);
+    return func(children as T);
 };
 
 /**

--- a/packages/perseus/src/util.ts
+++ b/packages/perseus/src/util.ts
@@ -49,7 +49,7 @@ type TouchHandlers = {
 
 let supportsPassive = false;
 
-type NestedArray<T> = ReadonlyArray<T | NestedArray<T>>
+type NestedArray<T> = ReadonlyArray<T | NestedArray<T>>;
 
 const nestedMap = function <T, M>(
     children: T | NestedArray<T>,

--- a/packages/perseus/src/util.ts
+++ b/packages/perseus/src/util.ts
@@ -60,6 +60,7 @@ const nestedMap = function <T, M>(
             return nestedMap(child, func);
         });
     }
+    // eslint-disable-next-line no-restricted-syntax
     return func(children as T);
 };
 

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -395,9 +395,7 @@ function getStartUserInput(): PerseusExpressionUserInput {
 function getOneCorrectAnswerFromRubric(
     rubric: PerseusExpressionRubric,
 ): string | null | undefined {
-    // TODO(LEMS-2656): remove TS suppression
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-    const correctAnswers = (rubric.answerForms || []).filter(
+    const correctAnswers = rubric.answerForms.filter(
         (answerForm) => answerForm.considered === "correct",
     );
     if (correctAnswers.length === 0) {

--- a/packages/perseus/src/widgets/input-number/input-number.tsx
+++ b/packages/perseus/src/widgets/input-number/input-number.tsx
@@ -131,17 +131,13 @@ class InputNumber extends React.Component<Props> implements Widget {
         return true;
     };
 
-    // TODO(LEMS-2656): remove TS suppression
-    // @ts-expect-error: Type 'FocusPath' is not assignable to type 'Path'.
-    focusInputPath: (arg1: Path) => void = (inputPath) => {
+    focusInputPath: () => void = () => {
         // eslint-disable-next-line react/no-string-refs
         // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'ReactInstance'.
         this.refs.input.focus();
     };
 
-    // TODO(LEMS-2656): remove TS suppression
-    // @ts-expect-error: Type 'FocusPath' is not assignable to type 'Path'.
-    blurInputPath: (arg1: Path) => void = (inputPath) => {
+    blurInputPath: () => void = () => {
         // eslint-disable-next-line react/no-string-refs
         // @ts-expect-error - TS2339 - Property 'blur' does not exist on type 'ReactInstance'.
         if (typeof this.refs.input?.blur === "function") {

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.tsx
@@ -119,6 +119,7 @@ type InteractiveGraphProps = {
     /**
      * The type of graph
      */
+    // TODO(benchristel): it seems like `graph` is not used. Remove it?
     graph: PerseusGraphType;
     /**
      * The correct answer for this widget.


### PR DESCRIPTION
## Summary:
We turned on `strictFunctionTypes` in TS back in 2024, which revealed a bunch
of type errors. This PR fixes the ones that still remain.

Issue: LEMS-2656

## Test plan:

CI checks should pass.