### PR TITLE
Remove customKeypad from input-number props

### DIFF
--- a/.changeset/brown-coins-pay.md
+++ b/.changeset/brown-coins-pay.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+The unused `customKeypad` option for the input-number widget has been removed. Callers should continue to use `apiOptions.customKeypad` instead.

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -2173,7 +2173,6 @@ export type PerseusInputNumberWidgetOptions = {
     simplify: "required" | "optional" | "enforced";
     size: "normal" | "small";
     value: string | number;
-    customKeypad?: boolean;
 };
 
 /** Options for the molecule-renderer widget. Renders a molecule via SMILES. */

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/input-number-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/input-number-widget.ts
@@ -49,6 +49,5 @@ export const parseInputNumberWidget = parseWidget(
             union(number).or(string).or(booleanToString).parser,
             () => 0,
         ),
-        customKeypad: optional(boolean),
     }),
 );

--- a/packages/perseus-core/src/widgets/input-number/input-number-util.ts
+++ b/packages/perseus-core/src/widgets/input-number/input-number-util.ts
@@ -6,13 +6,7 @@ import type {PerseusInputNumberWidgetOptions} from "../../data-schema";
  */
 type InputNumberPublicWidgetOptions = Pick<
     PerseusInputNumberWidgetOptions,
-    | "answerType"
-    | "inexact"
-    | "maxError"
-    | "rightAlign"
-    | "simplify"
-    | "size"
-    | "customKeypad"
+    "answerType" | "inexact" | "maxError" | "rightAlign" | "simplify" | "size"
 >;
 
 /**


### PR DESCRIPTION
## Summary:
This prop wasn't used. The input-number widget uses `apiOptions.customKeypad`
instead.

Issue: none

## Test plan:

CI checks should pass.