### PR TITLE
[ig-scorer] Break out LinearSystem

### DIFF
--- a/.changeset/mean-badgers-judge.md
+++ b/.changeset/mean-badgers-judge.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-score": patch
+---
+
+Copy linear system scoring into score-linear-system.ts

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-linear-system.test.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-linear-system.test.ts
@@ -1,0 +1,146 @@
+import {scoreLinearSystem} from "./score-linear-system";
+
+import type {PerseusGraphTypeLinearSystem} from "@khanacademy/perseus-core";
+
+describe("scoreLinearSystem", () => {
+    it("returns invalid score when user input coords are missing", () => {
+        const userInput: PerseusGraphTypeLinearSystem = {
+            type: "linear-system",
+        };
+        const rubric: PerseusGraphTypeLinearSystem = {
+            type: "linear-system",
+            coords: [
+                [
+                    [-1, -1],
+                    [1, 1],
+                ],
+                [
+                    [-1, 1],
+                    [1, -1],
+                ],
+            ],
+        };
+
+        expect(scoreLinearSystem(userInput, rubric)).toHaveInvalidInput();
+    });
+
+    it("returns invalid score when rubric coords are missing", () => {
+        const userInput: PerseusGraphTypeLinearSystem = {
+            type: "linear-system",
+            coords: [
+                [
+                    [-1, -1],
+                    [1, 1],
+                ],
+                [
+                    [-1, 1],
+                    [1, -1],
+                ],
+            ],
+        };
+        const rubric: PerseusGraphTypeLinearSystem = {
+            type: "linear-system",
+        };
+
+        expect(scoreLinearSystem(userInput, rubric)).toHaveInvalidInput();
+    });
+
+    it("returns correct score when lines match in the same order", () => {
+        const userInput: PerseusGraphTypeLinearSystem = {
+            type: "linear-system",
+            coords: [
+                [
+                    [-1, -1],
+                    [1, 1],
+                ],
+                [
+                    [-1, 1],
+                    [1, -1],
+                ],
+            ],
+        };
+        const rubric: PerseusGraphTypeLinearSystem = {
+            type: "linear-system",
+            coords: [
+                [
+                    [-1, -1],
+                    [1, 1],
+                ],
+                [
+                    [-1, 1],
+                    [1, -1],
+                ],
+            ],
+        };
+
+        expect(
+            scoreLinearSystem(userInput, rubric),
+        ).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("returns correct score when lines match in swapped order", () => {
+        const userInput: PerseusGraphTypeLinearSystem = {
+            type: "linear-system",
+            coords: [
+                [
+                    [-1, 1],
+                    [1, -1],
+                ],
+                [
+                    [-1, -1],
+                    [1, 1],
+                ],
+            ],
+        };
+        const rubric: PerseusGraphTypeLinearSystem = {
+            type: "linear-system",
+            coords: [
+                [
+                    [-1, -1],
+                    [1, 1],
+                ],
+                [
+                    [-1, 1],
+                    [1, -1],
+                ],
+            ],
+        };
+
+        expect(
+            scoreLinearSystem(userInput, rubric),
+        ).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("returns incorrect score when lines do not match", () => {
+        const userInput: PerseusGraphTypeLinearSystem = {
+            type: "linear-system",
+            coords: [
+                [
+                    [0, 0],
+                    [1, 2],
+                ],
+                [
+                    [0, 0],
+                    [2, 1],
+                ],
+            ],
+        };
+        const rubric: PerseusGraphTypeLinearSystem = {
+            type: "linear-system",
+            coords: [
+                [
+                    [-1, -1],
+                    [1, 1],
+                ],
+                [
+                    [-1, 1],
+                    [1, -1],
+                ],
+            ],
+        };
+
+        expect(
+            scoreLinearSystem(userInput, rubric),
+        ).toHaveBeenAnsweredIncorrectly();
+    });
+});

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-linear-system.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-linear-system.ts
@@ -1,0 +1,37 @@
+import {geometry} from "@khanacademy/kmath";
+
+const {collinear} = geometry;
+
+import type {
+    PerseusGraphTypeLinearSystem,
+    PerseusScore,
+} from "@khanacademy/perseus-core";
+
+export function scoreLinearSystem(
+    userInput: PerseusGraphTypeLinearSystem,
+    rubric: PerseusGraphTypeLinearSystem,
+): PerseusScore {
+    if (!userInput.coords || !rubric.coords) {
+        return {type: "invalid", message: null};
+    }
+
+    const guess = userInput.coords;
+    const correct = rubric.coords;
+
+    const isCorrect =
+        (collinear(correct[0][0], correct[0][1], guess[0][0]) &&
+            collinear(correct[0][0], correct[0][1], guess[0][1]) &&
+            collinear(correct[1][0], correct[1][1], guess[1][0]) &&
+            collinear(correct[1][0], correct[1][1], guess[1][1])) ||
+        (collinear(correct[0][0], correct[0][1], guess[1][0]) &&
+            collinear(correct[0][0], correct[0][1], guess[1][1]) &&
+            collinear(correct[1][0], correct[1][1], guess[0][0]) &&
+            collinear(correct[1][0], correct[1][1], guess[0][1]));
+
+    return {
+        type: "points",
+        earned: isCorrect ? 1 : 0,
+        total: 1,
+        message: null,
+    };
+}


### PR DESCRIPTION
## Summary:

This PR: split out LinearSystem scorer.

PR stack:
- Linear: #3542
- 📈 LinearSystem: #3549
- Ray: #3552
- Segment: #3553
- Circle: #3554
- Point: #3555
- Vector: #3556
- Polygon: #3557
- Angle: #3558
- Quadratic: #3559
- Sinusoid: #3560
- Tangent: #3561
- AbsoluteValue: #3562
- Exponential: #3563
- Logarithm: #3564
- Refactor scorer function: #3565

---

## About these PRs

This stack of PRs is just about splitting the `scoreInteractiveGraph` function into sub-scorers. Originally the function was a giant 400+ lines-of-code function that handled all scoring for IG. In the end the main function is shrunk down to a little over 100 lines-of-code.

Goals:

- Split out the functionality of each sub-scorer as directly as possible **while avoiding changes to the sub-scorer as much as possible.**
- Avoid changing original functionality.
- Set up testing for each sub-scorer so that they have focused tests.
- Do this in a way that's as easy to review as possible.

How this was accomplished:

- Used Claude to get near 100% test coverage of the original `scoreInteractiveGraph` function (see #3565)
- Used Claude to generate a PR plan (see #3542)
- Went through each sub-scorer and copied the functionality from `scoreInteractiveGraph` without modifying `scoreInteractiveGraph`, while also adding test coverage
- In the last PR (#3565), I had Claude update `scoreInteractiveGraph` to use the sub-scorers.
- Ran all tests and everything passes!

This provided a high level of confidence in the changes (because of the test coverage) and made the PRs easier to review (most are additive and easy to compare to original functionality).