### PR TITLE
[ig-scorer] Break out Ray

### DIFF
--- a/.changeset/silver-cobras-explain.md
+++ b/.changeset/silver-cobras-explain.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-score": patch
+---
+
+Copy ray scoring into score-ray.ts

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-ray.test.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-ray.test.ts
@@ -1,0 +1,90 @@
+import {scoreRay} from "./score-ray";
+
+import type {PerseusGraphTypeRay} from "@khanacademy/perseus-core";
+
+describe("scoreRay", () => {
+    it("returns invalid score when missing user input coords", () => {
+        const userInput: PerseusGraphTypeRay = {type: "ray"};
+        const rubric: PerseusGraphTypeRay = {
+            type: "ray",
+            coords: [
+                [0, 0],
+                [1, 1],
+            ],
+        };
+
+        expect(scoreRay(userInput, rubric)).toHaveInvalidInput();
+    });
+
+    it("returns invalid score when missing rubric coords", () => {
+        const userInput: PerseusGraphTypeRay = {
+            type: "ray",
+            coords: [
+                [0, 0],
+                [1, 1],
+            ],
+        };
+        const rubric: PerseusGraphTypeRay = {type: "ray"};
+
+        expect(scoreRay(userInput, rubric)).toHaveInvalidInput();
+    });
+
+    it("returns correct score when start matches and direction point is collinear", () => {
+        // Ray from (0,0) toward (1,1); guess uses a different direction point
+        // on the same ray (2,2 is collinear with origin toward (1,1)).
+        const userInput: PerseusGraphTypeRay = {
+            type: "ray",
+            coords: [
+                [0, 0],
+                [2, 2],
+            ],
+        };
+        const rubric: PerseusGraphTypeRay = {
+            type: "ray",
+            coords: [
+                [0, 0],
+                [1, 1],
+            ],
+        };
+
+        expect(scoreRay(userInput, rubric)).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("returns incorrect score when start point does not match", () => {
+        const userInput: PerseusGraphTypeRay = {
+            type: "ray",
+            coords: [
+                [1, 0],
+                [2, 1],
+            ],
+        };
+        const rubric: PerseusGraphTypeRay = {
+            type: "ray",
+            coords: [
+                [0, 0],
+                [1, 1],
+            ],
+        };
+
+        expect(scoreRay(userInput, rubric)).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("returns incorrect score when direction is not collinear with correct ray", () => {
+        const userInput: PerseusGraphTypeRay = {
+            type: "ray",
+            coords: [
+                [0, 0],
+                [1, 2],
+            ],
+        };
+        const rubric: PerseusGraphTypeRay = {
+            type: "ray",
+            coords: [
+                [0, 0],
+                [1, 1],
+            ],
+        };
+
+        expect(scoreRay(userInput, rubric)).toHaveBeenAnsweredIncorrectly();
+    });
+});

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-ray.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-ray.ts
@@ -1,0 +1,29 @@
+import {geometry} from "@khanacademy/kmath";
+import {approximateDeepEqual} from "@khanacademy/perseus-core";
+
+const {collinear} = geometry;
+
+import type {PerseusGraphTypeRay, PerseusScore} from "@khanacademy/perseus-core";
+
+export function scoreRay(
+    userInput: PerseusGraphTypeRay,
+    rubric: PerseusGraphTypeRay,
+): PerseusScore {
+    if (!userInput.coords || !rubric.coords) {
+        return {type: "invalid", message: null};
+    }
+
+    const guess = userInput.coords;
+    const correct = rubric.coords;
+
+    const isCorrect =
+        approximateDeepEqual(guess[0], correct[0]) &&
+        collinear(correct[0], correct[1], guess[1]);
+
+    return {
+        type: "points",
+        earned: isCorrect ? 1 : 0,
+        total: 1,
+        message: null,
+    };
+}

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-ray.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-ray.ts
@@ -3,7 +3,10 @@ import {approximateDeepEqual} from "@khanacademy/perseus-core";
 
 const {collinear} = geometry;
 
-import type {PerseusGraphTypeRay, PerseusScore} from "@khanacademy/perseus-core";
+import type {
+    PerseusGraphTypeRay,
+    PerseusScore,
+} from "@khanacademy/perseus-core";
 
 export function scoreRay(
     userInput: PerseusGraphTypeRay,


### PR DESCRIPTION
## Summary:

This PR: split out Ray scorer.

PR stack:
- Linear: #3542
- LinearSystem: #3549
- 📈 Ray: #3552
- Segment: #3553
- Circle: #3554
- Point: #3555
- Vector: #3556
- Polygon: #3557
- Angle: #3558
- Quadratic: #3559
- Sinusoid: #3560
- Tangent: #3561
- AbsoluteValue: #3562
- Exponential: #3563
- Logarithm: #3564
- Refactor scorer function: #3565

---

## About these PRs

This stack of PRs is just about splitting the `scoreInteractiveGraph` function into sub-scorers. Originally the function was a giant 400+ lines-of-code function that handled all scoring for IG. In the end the main function is shrunk down to a little over 100 lines-of-code.

Goals:

- Split out the functionality of each sub-scorer as directly as possible **while avoiding changes to the sub-scorer as much as possible.**
- Avoid changing original functionality.
- Set up testing for each sub-scorer so that they have focused tests.
- Do this in a way that's as easy to review as possible.

How this was accomplished:

- Used Claude to get near 100% test coverage of the original `scoreInteractiveGraph` function (see #3565)
- Used Claude to generate a PR plan (see #3542)
- Went through each sub-scorer and copied the functionality from `scoreInteractiveGraph` without modifying `scoreInteractiveGraph`, while also adding test coverage
- In the last PR (#3565), I had Claude update `scoreInteractiveGraph` to use the sub-scorers.
- Ran all tests and everything passes!

This provided a high level of confidence in the changes (because of the test coverage) and made the PRs easier to review (most are additive and easy to compare to original functionality).