### PR TITLE
[ig-scorer] Break out Segment

### DIFF
--- a/.changeset/stupid-news-rhyme.md
+++ b/.changeset/stupid-news-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-score": patch
+---
+
+Copy segment scoring into score-segment.ts

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-segment.test.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-segment.test.ts
@@ -1,0 +1,114 @@
+import {scoreSegment} from "./score-segment";
+
+import type {PerseusGraphTypeSegment} from "@khanacademy/perseus-core";
+
+describe("scoreSegment", () => {
+    it("returns invalid when user input has no coords", () => {
+        const userInput: PerseusGraphTypeSegment = {type: "segment"};
+        const rubric: PerseusGraphTypeSegment = {
+            type: "segment",
+            coords: [
+                [
+                    [0, 0],
+                    [1, 1],
+                ],
+            ],
+        };
+
+        expect(scoreSegment(userInput, rubric)).toHaveInvalidInput();
+    });
+
+    it("returns invalid when rubric has no coords", () => {
+        const userInput: PerseusGraphTypeSegment = {
+            type: "segment",
+            coords: [
+                [
+                    [0, 0],
+                    [1, 1],
+                ],
+            ],
+        };
+        const rubric: PerseusGraphTypeSegment = {type: "segment"};
+
+        expect(scoreSegment(userInput, rubric)).toHaveInvalidInput();
+    });
+
+    it("returns correct when segment endpoints are in reversed order", () => {
+        // Same segment, but the user placed the endpoints in the opposite order.
+        const userInput: PerseusGraphTypeSegment = {
+            type: "segment",
+            coords: [
+                [
+                    [3, 4],
+                    [1, 2],
+                ],
+            ],
+        };
+        const rubric: PerseusGraphTypeSegment = {
+            type: "segment",
+            coords: [
+                [
+                    [1, 2],
+                    [3, 4],
+                ],
+            ],
+        };
+
+        expect(scoreSegment(userInput, rubric)).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("returns correct when multiple segments are in a different order", () => {
+        // Two segments given in opposite order from the rubric.
+        const userInput: PerseusGraphTypeSegment = {
+            type: "segment",
+            coords: [
+                [
+                    [5, 6],
+                    [7, 8],
+                ],
+                [
+                    [1, 2],
+                    [3, 4],
+                ],
+            ],
+        };
+        const rubric: PerseusGraphTypeSegment = {
+            type: "segment",
+            coords: [
+                [
+                    [1, 2],
+                    [3, 4],
+                ],
+                [
+                    [5, 6],
+                    [7, 8],
+                ],
+            ],
+        };
+
+        expect(scoreSegment(userInput, rubric)).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("returns incorrect when segment does not match rubric", () => {
+        const userInput: PerseusGraphTypeSegment = {
+            type: "segment",
+            coords: [
+                [
+                    [0, 0],
+                    [1, 1],
+                ],
+            ],
+        };
+        const rubric: PerseusGraphTypeSegment = {
+            type: "segment",
+            coords: [
+                [
+                    [0, 0],
+                    [2, 2],
+                ],
+            ],
+        };
+
+        expect(scoreSegment(userInput, rubric)).toHaveBeenAnsweredIncorrectly();
+    });
+});

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-segment.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-segment.ts
@@ -1,0 +1,28 @@
+import {approximateDeepEqual, deepClone} from "@khanacademy/perseus-core";
+import _ from "underscore";
+
+import type {
+    PerseusGraphTypeSegment,
+    PerseusScore,
+} from "@khanacademy/perseus-core";
+
+export function scoreSegment(
+    userInput: PerseusGraphTypeSegment,
+    rubric: PerseusGraphTypeSegment,
+): PerseusScore {
+    if (!userInput.coords || !rubric.coords) {
+        return {type: "invalid", message: null};
+    }
+
+    let guess = deepClone(userInput.coords);
+    let correct = deepClone(rubric.coords);
+    guess = _.invoke(guess, "sort").sort();
+    correct = _.invoke(correct, "sort").sort();
+
+    return {
+        type: "points",
+        earned: approximateDeepEqual(guess, correct) ? 1 : 0,
+        total: 1,
+        message: null,
+    };
+}


### PR DESCRIPTION
## Summary:

This PR: split out Segment scorer.

PR stack:
- Linear: #3542
- LinearSystem: #3549
- Ray: #3552
- 📈 Segment: #3553
- Circle: #3554
- Point: #3555
- Vector: #3556
- Polygon: #3557
- Angle: #3558
- Quadratic: #3559
- Sinusoid: #3560
- Tangent: #3561
- AbsoluteValue: #3562
- Exponential: #3563
- Logarithm: #3564
- Refactor scorer function: #3565

---

## About these PRs

This stack of PRs is just about splitting the `scoreInteractiveGraph` function into sub-scorers. Originally the function was a giant 400+ lines-of-code function that handled all scoring for IG. In the end the main function is shrunk down to a little over 100 lines-of-code.

Goals:

- Split out the functionality of each sub-scorer as directly as possible **while avoiding changes to the sub-scorer as much as possible.**
- Avoid changing original functionality.
- Set up testing for each sub-scorer so that they have focused tests.
- Do this in a way that's as easy to review as possible.

How this was accomplished:

- Used Claude to get near 100% test coverage of the original `scoreInteractiveGraph` function (see #3565)
- Used Claude to generate a PR plan (see #3542)
- Went through each sub-scorer and copied the functionality from `scoreInteractiveGraph` without modifying `scoreInteractiveGraph`, while also adding test coverage
- In the last PR (#3565), I had Claude update `scoreInteractiveGraph` to use the sub-scorers.
- Ran all tests and everything passes!

This provided a high level of confidence in the changes (because of the test coverage) and made the PRs easier to review (most are additive and easy to compare to original functionality).