### PR TITLE
[ig-scorer] Break out Circle

### DIFF
--- a/.changeset/fresh-toes-rescue.md
+++ b/.changeset/fresh-toes-rescue.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-score": patch
+---
+
+Copy circle scoring into score-circle.ts

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-circle.test.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-circle.test.ts
@@ -1,0 +1,100 @@
+import {scoreCircle} from "./score-circle";
+
+import type {PerseusGraphTypeCircle} from "@khanacademy/perseus-core";
+
+describe("scoreCircle", () => {
+    it("returns invalid when user input has no center", () => {
+        const userInput: PerseusGraphTypeCircle = {type: "circle", radius: 5};
+        const rubric: PerseusGraphTypeCircle = {
+            type: "circle",
+            center: [0, 0],
+            radius: 5,
+        };
+
+        expect(scoreCircle(userInput, rubric)).toHaveInvalidInput();
+    });
+
+    it("returns invalid when user input has no radius", () => {
+        const userInput: PerseusGraphTypeCircle = {
+            type: "circle",
+            center: [0, 0],
+        };
+        const rubric: PerseusGraphTypeCircle = {
+            type: "circle",
+            center: [0, 0],
+            radius: 5,
+        };
+
+        expect(scoreCircle(userInput, rubric)).toHaveInvalidInput();
+    });
+
+    it("returns invalid when rubric has no center", () => {
+        const userInput: PerseusGraphTypeCircle = {
+            type: "circle",
+            center: [0, 0],
+            radius: 5,
+        };
+        const rubric: PerseusGraphTypeCircle = {type: "circle", radius: 5};
+
+        expect(scoreCircle(userInput, rubric)).toHaveInvalidInput();
+    });
+
+    it("returns invalid when rubric has no radius", () => {
+        const userInput: PerseusGraphTypeCircle = {
+            type: "circle",
+            center: [0, 0],
+            radius: 5,
+        };
+        const rubric: PerseusGraphTypeCircle = {
+            type: "circle",
+            center: [0, 0],
+        };
+
+        expect(scoreCircle(userInput, rubric)).toHaveInvalidInput();
+    });
+
+    it("returns correct when center and radius match", () => {
+        const userInput: PerseusGraphTypeCircle = {
+            type: "circle",
+            center: [2, 3],
+            radius: 4,
+        };
+        const rubric: PerseusGraphTypeCircle = {
+            type: "circle",
+            center: [2, 3],
+            radius: 4,
+        };
+
+        expect(scoreCircle(userInput, rubric)).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("returns incorrect when center does not match", () => {
+        const userInput: PerseusGraphTypeCircle = {
+            type: "circle",
+            center: [1, 1],
+            radius: 4,
+        };
+        const rubric: PerseusGraphTypeCircle = {
+            type: "circle",
+            center: [2, 3],
+            radius: 4,
+        };
+
+        expect(scoreCircle(userInput, rubric)).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("returns incorrect when radius does not match", () => {
+        const userInput: PerseusGraphTypeCircle = {
+            type: "circle",
+            center: [2, 3],
+            radius: 7,
+        };
+        const rubric: PerseusGraphTypeCircle = {
+            type: "circle",
+            center: [2, 3],
+            radius: 4,
+        };
+
+        expect(scoreCircle(userInput, rubric)).toHaveBeenAnsweredIncorrectly();
+    });
+});

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-circle.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-circle.ts
@@ -1,0 +1,34 @@
+import {
+    approximateDeepEqual,
+    approximateEqual,
+} from "@khanacademy/perseus-core";
+
+import type {
+    PerseusGraphTypeCircle,
+    PerseusScore,
+} from "@khanacademy/perseus-core";
+
+export function scoreCircle(
+    userInput: PerseusGraphTypeCircle,
+    rubric: PerseusGraphTypeCircle,
+): PerseusScore {
+    if (
+        userInput.center == null ||
+        userInput.radius == null ||
+        rubric.center == null ||
+        rubric.radius == null
+    ) {
+        return {type: "invalid", message: null};
+    }
+
+    const isCorrect =
+        approximateDeepEqual(userInput.center, rubric.center) &&
+        approximateEqual(userInput.radius, rubric.radius);
+
+    return {
+        type: "points",
+        earned: isCorrect ? 1 : 0,
+        total: 1,
+        message: null,
+    };
+}


### PR DESCRIPTION
## Summary:

This PR: split out Circle scorer.

PR stack:
- Linear: #3542
- LinearSystem: #3549
- Ray: #3552
- Segment: #3553
- 📈 Circle: #3554
- Point: #3555
- Vector: #3556
- Polygon: #3557
- Angle: #3558
- Quadratic: #3559
- Sinusoid: #3560
- Tangent: #3561
- AbsoluteValue: #3562
- Exponential: #3563
- Logarithm: #3564
- Refactor scorer function: #3565

---

## About these PRs

This stack of PRs is just about splitting the `scoreInteractiveGraph` function into sub-scorers. Originally the function was a giant 400+ lines-of-code function that handled all scoring for IG. In the end the main function is shrunk down to a little over 100 lines-of-code.

Goals:

- Split out the functionality of each sub-scorer as directly as possible **while avoiding changes to the sub-scorer as much as possible.**
- Avoid changing original functionality.
- Set up testing for each sub-scorer so that they have focused tests.
- Do this in a way that's as easy to review as possible.

How this was accomplished:

- Used Claude to get near 100% test coverage of the original `scoreInteractiveGraph` function (see #3565)
- Used Claude to generate a PR plan (see #3542)
- Went through each sub-scorer and copied the functionality from `scoreInteractiveGraph` without modifying `scoreInteractiveGraph`, while also adding test coverage
- In the last PR (#3565), I had Claude update `scoreInteractiveGraph` to use the sub-scorers.
- Ran all tests and everything passes!

This provided a high level of confidence in the changes (because of the test coverage) and made the PRs easier to review (most are additive and easy to compare to original functionality).