### PR TITLE
[ig-scorer] Break out Point

### DIFF
--- a/.changeset/flat-pets-deny.md
+++ b/.changeset/flat-pets-deny.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-score": patch
+---
+
+Copy point scoring into score-point.ts

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-point.test.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-point.test.ts
@@ -1,0 +1,78 @@
+import {scorePoint} from "./score-point";
+
+import type {PerseusGraphTypePoint} from "@khanacademy/perseus-core";
+
+describe("scorePoint", () => {
+    it("returns invalid when user input has no coords", () => {
+        const userInput: PerseusGraphTypePoint = {type: "point"};
+        const rubric: PerseusGraphTypePoint = {
+            type: "point",
+            coords: [[1, 2]],
+        };
+
+        expect(scorePoint(userInput, rubric)).toHaveInvalidInput();
+    });
+
+    it("throws when rubric has null coords", () => {
+        const userInput: PerseusGraphTypePoint = {
+            type: "point",
+            coords: [[1, 2]],
+        };
+        const rubric: PerseusGraphTypePoint = {type: "point", coords: null};
+
+        expect(() => scorePoint(userInput, rubric)).toThrow(
+            "Point graph rubric has null coords",
+        );
+    });
+
+    it("returns correct when coords match in the same order", () => {
+        const userInput: PerseusGraphTypePoint = {
+            type: "point",
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
+        };
+        const rubric: PerseusGraphTypePoint = {
+            type: "point",
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
+        };
+
+        expect(scorePoint(userInput, rubric)).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("returns correct when coords match in different order", () => {
+        const userInput: PerseusGraphTypePoint = {
+            type: "point",
+            coords: [
+                [3, 4],
+                [1, 2],
+            ],
+        };
+        const rubric: PerseusGraphTypePoint = {
+            type: "point",
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
+        };
+
+        expect(scorePoint(userInput, rubric)).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("returns incorrect when coords do not match", () => {
+        const userInput: PerseusGraphTypePoint = {
+            type: "point",
+            coords: [[5, 6]],
+        };
+        const rubric: PerseusGraphTypePoint = {
+            type: "point",
+            coords: [[1, 2]],
+        };
+
+        expect(scorePoint(userInput, rubric)).toHaveBeenAnsweredIncorrectly();
+    });
+});

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-point.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-point.ts
@@ -1,6 +1,9 @@
 import {approximateDeepEqual} from "@khanacademy/perseus-core";
 
-import type {PerseusGraphTypePoint, PerseusScore} from "@khanacademy/perseus-core";
+import type {
+    PerseusGraphTypePoint,
+    PerseusScore,
+} from "@khanacademy/perseus-core";
 
 export function scorePoint(
     userInput: PerseusGraphTypePoint,

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-point.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-point.ts
@@ -1,0 +1,34 @@
+import {approximateDeepEqual} from "@khanacademy/perseus-core";
+
+import type {PerseusGraphTypePoint, PerseusScore} from "@khanacademy/perseus-core";
+
+export function scorePoint(
+    userInput: PerseusGraphTypePoint,
+    rubric: PerseusGraphTypePoint,
+): PerseusScore {
+    if (!userInput.coords) {
+        return {type: "invalid", message: null};
+    }
+
+    if (rubric.coords == null) {
+        throw new Error("Point graph rubric has null coords");
+    }
+
+    const guess = userInput.coords.slice();
+    const correct = rubric.coords.slice();
+    // Everything's already rounded so we shouldn't need to do an
+    // eq() comparison but _.isEqual(0, -0) is false, so we'll use
+    // eq() anyway. The sort should be fine because it'll stringify
+    // it and -0 converted to a string is "0"
+    // TODO(benchristel): once we drop support for Safari 15, use
+    // toSorted here to avoid mutating the input arrays!
+    guess.sort();
+    correct.sort();
+
+    return {
+        type: "points",
+        earned: approximateDeepEqual(guess, correct) ? 1 : 0,
+        total: 1,
+        message: null,
+    };
+}


### PR DESCRIPTION
## Summary:

This PR: split out Point scorer.

PR stack:
- Linear: #3542
- LinearSystem: #3549
- Ray: #3552
- Segment: #3553
- Circle: #3554
- 📈 Point: #3555
- Vector: #3556
- Polygon: #3557
- Angle: #3558
- Quadratic: #3559
- Sinusoid: #3560
- Tangent: #3561
- AbsoluteValue: #3562
- Exponential: #3563
- Logarithm: #3564
- Refactor scorer function: #3565

---

## About these PRs

This stack of PRs is just about splitting the `scoreInteractiveGraph` function into sub-scorers. Originally the function was a giant 400+ lines-of-code function that handled all scoring for IG. In the end the main function is shrunk down to a little over 100 lines-of-code.

Goals:

- Split out the functionality of each sub-scorer as directly as possible **while avoiding changes to the sub-scorer as much as possible.**
- Avoid changing original functionality.
- Set up testing for each sub-scorer so that they have focused tests.
- Do this in a way that's as easy to review as possible.

How this was accomplished:

- Used Claude to get near 100% test coverage of the original `scoreInteractiveGraph` function (see #3565)
- Used Claude to generate a PR plan (see #3542)
- Went through each sub-scorer and copied the functionality from `scoreInteractiveGraph` without modifying `scoreInteractiveGraph`, while also adding test coverage
- In the last PR (#3565), I had Claude update `scoreInteractiveGraph` to use the sub-scorers.
- Ran all tests and everything passes!

This provided a high level of confidence in the changes (because of the test coverage) and made the PRs easier to review (most are additive and easy to compare to original functionality).