### PR TITLE
[ig-scorer] Break out Vector

### DIFF
--- a/.changeset/yellow-mangos-learn.md
+++ b/.changeset/yellow-mangos-learn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-score": patch
+---
+
+Copy vector scoring into score-vector.ts

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-vector.test.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-vector.test.ts
@@ -1,0 +1,113 @@
+import {scoreVector} from "./score-vector";
+
+import type {PerseusGraphTypeVector} from "@khanacademy/perseus-core";
+
+describe("scoreVector", () => {
+    it("returns invalid when user input has no coords", () => {
+        const userInput: PerseusGraphTypeVector = {type: "vector"};
+        const rubric: PerseusGraphTypeVector = {
+            type: "vector",
+            coords: [
+                [0, 0],
+                [1, 1],
+            ],
+        };
+
+        expect(scoreVector(userInput, rubric)).toHaveInvalidInput();
+    });
+
+    it("returns invalid when rubric has no coords", () => {
+        const userInput: PerseusGraphTypeVector = {
+            type: "vector",
+            coords: [
+                [0, 0],
+                [1, 1],
+            ],
+        };
+        const rubric: PerseusGraphTypeVector = {type: "vector"};
+
+        expect(scoreVector(userInput, rubric)).toHaveInvalidInput();
+    });
+
+    it("returns correct for exact match with same tail and tip", () => {
+        const userInput: PerseusGraphTypeVector = {
+            type: "vector",
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
+        };
+        const rubric: PerseusGraphTypeVector = {
+            type: "vector",
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
+        };
+
+        expect(scoreVector(userInput, rubric)).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("returns incorrect for exact match when positions differ", () => {
+        const userInput: PerseusGraphTypeVector = {
+            type: "vector",
+            coords: [
+                [0, 0],
+                [2, 2],
+            ],
+        };
+        const rubric: PerseusGraphTypeVector = {
+            type: "vector",
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
+        };
+
+        expect(scoreVector(userInput, rubric)).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("returns correct for congruent match when delta is the same", () => {
+        // guess: tail (2,3), tip (4,5) → delta [2,2]
+        // rubric: tail (0,0), tip (2,2) → delta [2,2]
+        const userInput: PerseusGraphTypeVector = {
+            type: "vector",
+            coords: [
+                [2, 3],
+                [4, 5],
+            ],
+        };
+        const rubric: PerseusGraphTypeVector = {
+            type: "vector",
+            match: "congruent",
+            coords: [
+                [0, 0],
+                [2, 2],
+            ],
+        };
+
+        expect(scoreVector(userInput, rubric)).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("returns incorrect for congruent match when delta differs", () => {
+        // guess: tail (0,0), tip (1,2) → delta [1,2]
+        // rubric: tail (0,0), tip (2,2) → delta [2,2]
+        const userInput: PerseusGraphTypeVector = {
+            type: "vector",
+            coords: [
+                [0, 0],
+                [1, 2],
+            ],
+        };
+        const rubric: PerseusGraphTypeVector = {
+            type: "vector",
+            match: "congruent",
+            coords: [
+                [0, 0],
+                [2, 2],
+            ],
+        };
+
+        expect(scoreVector(userInput, rubric)).toHaveBeenAnsweredIncorrectly();
+    });
+});

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-vector.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-vector.ts
@@ -1,0 +1,45 @@
+import {approximateDeepEqual} from "@khanacademy/perseus-core";
+
+import type {
+    PerseusGraphTypeVector,
+    PerseusScore,
+} from "@khanacademy/perseus-core";
+
+export function scoreVector(
+    userInput: PerseusGraphTypeVector,
+    rubric: PerseusGraphTypeVector,
+): PerseusScore {
+    if (!userInput.coords || !rubric.coords) {
+        return {type: "invalid", message: null};
+    }
+
+    const guess = userInput.coords;
+    const correct = rubric.coords;
+
+    let match: boolean;
+    if (rubric.match === "congruent") {
+        // Congruent: same direction and magnitude, any position.
+        // Compare the component form ⟨dx, dy⟩ of each vector.
+        const guessDelta = [
+            guess[1][0] - guess[0][0],
+            guess[1][1] - guess[0][1],
+        ];
+        const correctDelta = [
+            correct[1][0] - correct[0][0],
+            correct[1][1] - correct[0][1],
+        ];
+        match = approximateDeepEqual(guessDelta, correctDelta);
+    } else {
+        // Exact (default): both tail and tip must match.
+        match =
+            approximateDeepEqual(guess[0], correct[0]) &&
+            approximateDeepEqual(guess[1], correct[1]);
+    }
+
+    return {
+        type: "points",
+        earned: match ? 1 : 0,
+        total: 1,
+        message: null,
+    };
+}


### PR DESCRIPTION
## Summary:

This PR: split out Vector scorer.

PR stack:
- Linear: #3542
- LinearSystem: #3549
- Ray: #3552
- Segment: #3553
- Circle: #3554
- Point: #3555
- 📈 Vector: #3556
- Polygon: #3557
- Angle: #3558
- Quadratic: #3559
- Sinusoid: #3560
- Tangent: #3561
- AbsoluteValue: #3562
- Exponential: #3563
- Logarithm: #3564
- Refactor scorer function: #3565

---

## About these PRs

This stack of PRs is just about splitting the `scoreInteractiveGraph` function into sub-scorers. Originally the function was a giant 400+ lines-of-code function that handled all scoring for IG. In the end the main function is shrunk down to a little over 100 lines-of-code.

Goals:

- Split out the functionality of each sub-scorer as directly as possible **while avoiding changes to the sub-scorer as much as possible.**
- Avoid changing original functionality.
- Set up testing for each sub-scorer so that they have focused tests.
- Do this in a way that's as easy to review as possible.

How this was accomplished:

- Used Claude to get near 100% test coverage of the original `scoreInteractiveGraph` function (see #3565)
- Used Claude to generate a PR plan (see #3542)
- Went through each sub-scorer and copied the functionality from `scoreInteractiveGraph` without modifying `scoreInteractiveGraph`, while also adding test coverage
- In the last PR (#3565), I had Claude update `scoreInteractiveGraph` to use the sub-scorers.
- Ran all tests and everything passes!

This provided a high level of confidence in the changes (because of the test coverage) and made the PRs easier to review (most are additive and easy to compare to original functionality).