### PR TITLE
[ig-scorer] Break out Polygon

### DIFF
--- a/.changeset/thin-impalas-melt.md
+++ b/.changeset/thin-impalas-melt.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-score": patch
+---
+
+Copy polygon scoring into score-polygon.ts

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-polygon.test.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-polygon.test.ts
@@ -1,0 +1,239 @@
+import {scorePolygon} from "./score-polygon";
+
+import type {PerseusGraphTypePolygon} from "@khanacademy/perseus-core";
+
+describe("scorePolygon", () => {
+    it("returns invalid when user input has no coords", () => {
+        const userInput: PerseusGraphTypePolygon = {type: "polygon"};
+        const rubric: PerseusGraphTypePolygon = {
+            type: "polygon",
+            coords: [
+                [0, 0],
+                [2, 0],
+                [0, 2],
+            ],
+        };
+
+        expect(scorePolygon(userInput, rubric)).toHaveInvalidInput();
+    });
+
+    it("returns invalid when rubric has no coords", () => {
+        const userInput: PerseusGraphTypePolygon = {
+            type: "polygon",
+            coords: [
+                [0, 0],
+                [2, 0],
+                [0, 2],
+            ],
+        };
+        const rubric: PerseusGraphTypePolygon = {type: "polygon"};
+
+        expect(scorePolygon(userInput, rubric)).toHaveInvalidInput();
+    });
+
+    it("returns correct for similar match when polygon is scaled", () => {
+        // Same right-isosceles triangle scaled 2x — same angles, proportional sides.
+        const userInput: PerseusGraphTypePolygon = {
+            type: "polygon",
+            coords: [
+                [0, 0],
+                [4, 0],
+                [0, 4],
+            ],
+        };
+        const rubric: PerseusGraphTypePolygon = {
+            type: "polygon",
+            match: "similar",
+            coords: [
+                [0, 0],
+                [2, 0],
+                [0, 2],
+            ],
+        };
+
+        expect(scorePolygon(userInput, rubric)).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("returns incorrect for similar match when polygons have different angles", () => {
+        // A right-isosceles triangle vs a 30-60-90-like triangle — different angles.
+        const userInput: PerseusGraphTypePolygon = {
+            type: "polygon",
+            coords: [
+                [0, 0],
+                [2, 0],
+                [0, 1],
+            ],
+        };
+        const rubric: PerseusGraphTypePolygon = {
+            type: "polygon",
+            match: "similar",
+            coords: [
+                [0, 0],
+                [2, 0],
+                [0, 2],
+            ],
+        };
+
+        expect(scorePolygon(userInput, rubric)).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("returns correct for congruent match when polygons are the same size", () => {
+        const userInput: PerseusGraphTypePolygon = {
+            type: "polygon",
+            coords: [
+                [0, 0],
+                [2, 0],
+                [0, 2],
+            ],
+        };
+        const rubric: PerseusGraphTypePolygon = {
+            type: "polygon",
+            match: "congruent",
+            coords: [
+                [0, 0],
+                [2, 0],
+                [0, 2],
+            ],
+        };
+
+        expect(scorePolygon(userInput, rubric)).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("returns incorrect for congruent match when polygon is scaled", () => {
+        // Similar shape but 2x scale — angles match but sides do not.
+        const userInput: PerseusGraphTypePolygon = {
+            type: "polygon",
+            coords: [
+                [0, 0],
+                [4, 0],
+                [0, 4],
+            ],
+        };
+        const rubric: PerseusGraphTypePolygon = {
+            type: "polygon",
+            match: "congruent",
+            coords: [
+                [0, 0],
+                [2, 0],
+                [0, 2],
+            ],
+        };
+
+        expect(scorePolygon(userInput, rubric)).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("returns correct for approx match when sides are within 0.1", () => {
+        // Legs differ by 0.05 — within the 0.1 approx tolerance.
+        const userInput: PerseusGraphTypePolygon = {
+            type: "polygon",
+            coords: [
+                [0, 0],
+                [2.05, 0],
+                [0, 2.05],
+            ],
+        };
+        const rubric: PerseusGraphTypePolygon = {
+            type: "polygon",
+            match: "approx",
+            coords: [
+                [0, 0],
+                [2, 0],
+                [0, 2],
+            ],
+        };
+
+        expect(scorePolygon(userInput, rubric)).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("returns incorrect for approx match when sides differ by more than 0.1", () => {
+        // Legs differ by 0.2 — exceeds the 0.1 approx tolerance.
+        const userInput: PerseusGraphTypePolygon = {
+            type: "polygon",
+            coords: [
+                [0, 0],
+                [2.2, 0],
+                [0, 2.2],
+            ],
+        };
+        const rubric: PerseusGraphTypePolygon = {
+            type: "polygon",
+            match: "approx",
+            coords: [
+                [0, 0],
+                [2, 0],
+                [0, 2],
+            ],
+        };
+
+        expect(scorePolygon(userInput, rubric)).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("returns correct for exact match when vertices are in the same order", () => {
+        const userInput: PerseusGraphTypePolygon = {
+            type: "polygon",
+            coords: [
+                [0, 0],
+                [1, 0],
+                [1, 1],
+                [0, 1],
+            ],
+        };
+        const rubric: PerseusGraphTypePolygon = {
+            type: "polygon",
+            coords: [
+                [0, 0],
+                [1, 0],
+                [1, 1],
+                [0, 1],
+            ],
+        };
+
+        expect(scorePolygon(userInput, rubric)).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("returns correct for exact match when vertices are in a different order", () => {
+        const userInput: PerseusGraphTypePolygon = {
+            type: "polygon",
+            coords: [
+                [1, 0],
+                [0, 0],
+                [0, 1],
+                [1, 1],
+            ],
+        };
+        const rubric: PerseusGraphTypePolygon = {
+            type: "polygon",
+            coords: [
+                [0, 0],
+                [1, 0],
+                [1, 1],
+                [0, 1],
+            ],
+        };
+
+        expect(scorePolygon(userInput, rubric)).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("returns incorrect for exact match when polygon does not match", () => {
+        const userInput: PerseusGraphTypePolygon = {
+            type: "polygon",
+            coords: [
+                [0, 0],
+                [2, 0],
+                [2, 2],
+                [0, 2],
+            ],
+        };
+        const rubric: PerseusGraphTypePolygon = {
+            type: "polygon",
+            coords: [
+                [0, 0],
+                [1, 0],
+                [1, 1],
+                [0, 1],
+            ],
+        };
+
+        expect(scorePolygon(userInput, rubric)).toHaveBeenAnsweredIncorrectly();
+    });
+});

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-polygon.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-polygon.ts
@@ -1,0 +1,42 @@
+import {number as knumber, geometry} from "@khanacademy/kmath";
+import {approximateDeepEqual} from "@khanacademy/perseus-core";
+
+const {similar} = geometry;
+
+import type {
+    PerseusGraphTypePolygon,
+    PerseusScore,
+} from "@khanacademy/perseus-core";
+
+export function scorePolygon(
+    userInput: PerseusGraphTypePolygon,
+    rubric: PerseusGraphTypePolygon,
+): PerseusScore {
+    if (!userInput.coords || !rubric.coords) {
+        return {type: "invalid", message: null};
+    }
+
+    const guess = userInput.coords.slice();
+    const correct = rubric.coords.slice();
+
+    let match: boolean;
+    if (rubric.match === "similar") {
+        match = similar(guess, correct, Number.POSITIVE_INFINITY);
+    } else if (rubric.match === "congruent") {
+        match = similar(guess, correct, knumber.DEFAULT_TOLERANCE);
+    } else if (rubric.match === "approx") {
+        match = similar(guess, correct, 0.1);
+    } else {
+        /* exact */
+        guess.sort();
+        correct.sort();
+        match = approximateDeepEqual(guess, correct);
+    }
+
+    return {
+        type: "points",
+        earned: match ? 1 : 0,
+        total: 1,
+        message: null,
+    };
+}


### PR DESCRIPTION
## Summary:

This PR: split out Polygon scorer.

PR stack:
- Linear: #3542
- LinearSystem: #3549
- Ray: #3552
- Segment: #3553
- Circle: #3554
- Point: #3555
- Vector: #3556
- 📈 Polygon: #3557
- Angle: #3558
- Quadratic: #3559
- Sinusoid: #3560
- Tangent: #3561
- AbsoluteValue: #3562
- Exponential: #3563
- Logarithm: #3564
- Refactor scorer function: #3565

---

## About these PRs

This stack of PRs is just about splitting the `scoreInteractiveGraph` function into sub-scorers. Originally the function was a giant 400+ lines-of-code function that handled all scoring for IG. In the end the main function is shrunk down to a little over 100 lines-of-code.

Goals:

- Split out the functionality of each sub-scorer as directly as possible **while avoiding changes to the sub-scorer as much as possible.**
- Avoid changing original functionality.
- Set up testing for each sub-scorer so that they have focused tests.
- Do this in a way that's as easy to review as possible.

How this was accomplished:

- Used Claude to get near 100% test coverage of the original `scoreInteractiveGraph` function (see #3565)
- Used Claude to generate a PR plan (see #3542)
- Went through each sub-scorer and copied the functionality from `scoreInteractiveGraph` without modifying `scoreInteractiveGraph`, while also adding test coverage
- In the last PR (#3565), I had Claude update `scoreInteractiveGraph` to use the sub-scorers.
- Ran all tests and everything passes!

This provided a high level of confidence in the changes (because of the test coverage) and made the PRs easier to review (most are additive and easy to compare to original functionality).