### PR TITLE
[ig-scorer] Break out Angle

### DIFF
--- a/.changeset/early-wolves-run.md
+++ b/.changeset/early-wolves-run.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-score": patch
+---
+
+Copy angle scoring into score-angle.ts

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-angle.test.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-angle.test.ts
@@ -1,0 +1,176 @@
+import {scoreAngle} from "./score-angle";
+
+import type {PerseusGraphTypeAngle} from "@khanacademy/perseus-core";
+
+describe("scoreAngle", () => {
+    it("returns invalid when user input has no coords", () => {
+        const userInput: PerseusGraphTypeAngle = {type: "angle"};
+        const rubric: PerseusGraphTypeAngle = {
+            type: "angle",
+            coords: [
+                [-5, 0],
+                [0, 0],
+                [5, 5],
+            ],
+        };
+
+        expect(scoreAngle(userInput, rubric)).toHaveInvalidInput();
+    });
+
+    it("returns correct for congruent match when angles have the same measure", () => {
+        // Both are 90-degree angles at the origin; guess arms are 2 units, rubric arms are 1 unit.
+        const userInput: PerseusGraphTypeAngle = {
+            type: "angle",
+            coords: [
+                [2, 0],
+                [0, 0],
+                [0, 2],
+            ],
+        };
+        const rubric: PerseusGraphTypeAngle = {
+            type: "angle",
+            match: "congruent",
+            coords: [
+                [1, 0],
+                [0, 0],
+                [0, 1],
+            ],
+        };
+
+        expect(scoreAngle(userInput, rubric)).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("returns incorrect for congruent match when angles have different measures", () => {
+        // guess is a 45-degree angle; rubric is a 90-degree angle.
+        const userInput: PerseusGraphTypeAngle = {
+            type: "angle",
+            coords: [
+                [1, 0],
+                [0, 0],
+                [1, 1],
+            ],
+        };
+        const rubric: PerseusGraphTypeAngle = {
+            type: "angle",
+            match: "congruent",
+            coords: [
+                [1, 0],
+                [0, 0],
+                [0, 1],
+            ],
+        };
+
+        expect(scoreAngle(userInput, rubric)).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("returns correct for exact match when vertex matches and arms are collinear with correct rays", () => {
+        // guess arms are twice as long but collinear with the correct rays.
+        const userInput: PerseusGraphTypeAngle = {
+            type: "angle",
+            coords: [
+                [2, 0],
+                [0, 0],
+                [0, 2],
+            ],
+        };
+        const rubric: PerseusGraphTypeAngle = {
+            type: "angle",
+            coords: [
+                [1, 0],
+                [0, 0],
+                [0, 1],
+            ],
+        };
+
+        expect(scoreAngle(userInput, rubric)).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("returns incorrect for exact match when vertex does not match", () => {
+        const userInput: PerseusGraphTypeAngle = {
+            type: "angle",
+            coords: [
+                [2, 0],
+                [1, 0],
+                [1, 2],
+            ],
+        };
+        const rubric: PerseusGraphTypeAngle = {
+            type: "angle",
+            coords: [
+                [1, 0],
+                [0, 0],
+                [0, 1],
+            ],
+        };
+
+        expect(scoreAngle(userInput, rubric)).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("returns incorrect for exact match when arms are not collinear with correct rays", () => {
+        const userInput: PerseusGraphTypeAngle = {
+            type: "angle",
+            coords: [
+                [1, 0],
+                [0, 0],
+                [1, 2],
+            ],
+        };
+        const rubric: PerseusGraphTypeAngle = {
+            type: "angle",
+            coords: [
+                [1, 0],
+                [0, 0],
+                [0, 1],
+            ],
+        };
+
+        expect(scoreAngle(userInput, rubric)).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("reverses coords and returns correct when angle is clockwise and allowReflexAngles is false", () => {
+        // guess coords are in clockwise order (reflex direction); with allowReflexAngles false,
+        // they are reversed before scoring and then match the rubric's reversed ordering.
+        const userInput: PerseusGraphTypeAngle = {
+            type: "angle",
+            coords: [
+                [-5, 0],
+                [0, 0],
+                [5, 5],
+            ],
+        };
+        const rubric: PerseusGraphTypeAngle = {
+            type: "angle",
+            allowReflexAngles: false,
+            coords: [
+                [5, 5],
+                [0, 0],
+                [-5, 0],
+            ],
+        };
+
+        expect(scoreAngle(userInput, rubric)).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("does not reverse coords when allowReflexAngles is true, even for clockwise angles", () => {
+        // coords are in clockwise order but allowReflexAngles allows it, so no reversal.
+        const userInput: PerseusGraphTypeAngle = {
+            type: "angle",
+            coords: [
+                [5, 0],
+                [0, 0],
+                [-5, -5],
+            ],
+        };
+        const rubric: PerseusGraphTypeAngle = {
+            type: "angle",
+            allowReflexAngles: true,
+            coords: [
+                [5, 0],
+                [0, 0],
+                [-5, -5],
+            ],
+        };
+
+        expect(scoreAngle(userInput, rubric)).toHaveBeenAnsweredCorrectly();
+    });
+});

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-angle.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-angle.ts
@@ -1,0 +1,61 @@
+import {geometry, angles} from "@khanacademy/kmath";
+import {
+    approximateDeepEqual,
+    approximateEqual,
+} from "@khanacademy/perseus-core";
+
+const {collinear, clockwise} = geometry;
+const {getClockwiseAngle} = angles;
+
+import type {
+    Coord,
+    PerseusGraphTypeAngle,
+    PerseusScore,
+} from "@khanacademy/perseus-core";
+
+export function scoreAngle(
+    userInput: PerseusGraphTypeAngle,
+    rubric: PerseusGraphTypeAngle,
+): PerseusScore {
+    const coords = userInput.coords;
+    const correct = rubric.coords;
+    const allowReflexAngles = rubric.allowReflexAngles;
+
+    // While the angle graph should always have 3 points, our types
+    // technically allow for null values. We'll check for that here.
+    // TODO: (LEMS-2857) We would like to update the type of coords
+    // to be non-nullable, as the graph should always have 3 points.
+    if (!coords) {
+        return {type: "invalid", message: null};
+    }
+
+    const areClockwise = clockwise([coords[0], coords[2], coords[1]]);
+    const shouldReverseCoords = areClockwise && !allowReflexAngles;
+    const guess = shouldReverseCoords
+        ? (coords.slice().reverse() as [Coord, Coord, Coord])
+        : coords;
+
+    let match: boolean;
+    if (rubric.match === "congruent") {
+        const guessAngle = getClockwiseAngle(guess, allowReflexAngles);
+        const correctAngle = correct
+            ? getClockwiseAngle(correct, allowReflexAngles)
+            : null;
+        match =
+            correctAngle !== null && approximateEqual(guessAngle, correctAngle);
+    } else {
+        /* exact */
+        match =
+            correct != null &&
+            approximateDeepEqual(guess[1], correct[1]) &&
+            collinear(correct[1], correct[0], guess[0]) &&
+            collinear(correct[1], correct[2], guess[2]);
+    }
+
+    return {
+        type: "points",
+        earned: match ? 1 : 0,
+        total: 1,
+        message: null,
+    };
+}


### PR DESCRIPTION
## Summary:

This PR: split out Angle scorer.

PR stack:
- Linear: #3542
- LinearSystem: #3549
- Ray: #3552
- Segment: #3553
- Circle: #3554
- Point: #3555
- Vector: #3556
- Polygon: #3557
- 📈 Angle: #3558
- Quadratic: #3559
- Sinusoid: #3560
- Tangent: #3561
- AbsoluteValue: #3562
- Exponential: #3563
- Logarithm: #3564
- Refactor scorer function: #3565

---

## About these PRs

This stack of PRs is just about splitting the `scoreInteractiveGraph` function into sub-scorers. Originally the function was a giant 400+ lines-of-code function that handled all scoring for IG. In the end the main function is shrunk down to a little over 100 lines-of-code.

Goals:

- Split out the functionality of each sub-scorer as directly as possible **while avoiding changes to the sub-scorer as much as possible.**
- Avoid changing original functionality.
- Set up testing for each sub-scorer so that they have focused tests.
- Do this in a way that's as easy to review as possible.

How this was accomplished:

- Used Claude to get near 100% test coverage of the original `scoreInteractiveGraph` function (see #3565)
- Used Claude to generate a PR plan (see #3542)
- Went through each sub-scorer and copied the functionality from `scoreInteractiveGraph` without modifying `scoreInteractiveGraph`, while also adding test coverage
- In the last PR (#3565), I had Claude update `scoreInteractiveGraph` to use the sub-scorers.
- Ran all tests and everything passes!

This provided a high level of confidence in the changes (because of the test coverage) and made the PRs easier to review (most are additive and easy to compare to original functionality).