### PR TITLE
[ig-scorer] Break out Sinusoid

### DIFF
--- a/.changeset/long-meals-occur.md
+++ b/.changeset/long-meals-occur.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-score": patch
+---
+
+Copy sinusoid scoring into score-sinusoid.ts

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-sinusoid.test.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-sinusoid.test.ts
@@ -1,0 +1,105 @@
+import {scoreSinusoid} from "./score-sinusoid";
+
+import type {PerseusGraphTypeSinusoid} from "@khanacademy/perseus-core";
+
+describe("scoreSinusoid", () => {
+    it("returns invalid score when missing user coords", () => {
+        const userInput: PerseusGraphTypeSinusoid = {
+            type: "sinusoid",
+        };
+        const rubric: PerseusGraphTypeSinusoid = {
+            type: "sinusoid",
+            coords: [
+                [0, 0],
+                [1, 1],
+            ],
+        };
+
+        const score = scoreSinusoid(userInput, rubric);
+
+        expect(score).toHaveInvalidInput();
+    });
+
+    it("returns invalid score when missing rubric coords", () => {
+        const userInput: PerseusGraphTypeSinusoid = {
+            type: "sinusoid",
+            coords: [
+                [0, 0],
+                [1, 1],
+            ],
+        };
+        const rubric: PerseusGraphTypeSinusoid = {
+            type: "sinusoid",
+        };
+
+        const score = scoreSinusoid(userInput, rubric);
+
+        expect(score).toHaveInvalidInput();
+    });
+
+    it("returns correct score when sinusoid coefficients match", () => {
+        const userInput: PerseusGraphTypeSinusoid = {
+            type: "sinusoid",
+            coords: [
+                [0, 0],
+                [1, 1],
+            ],
+        };
+        const rubric: PerseusGraphTypeSinusoid = {
+            type: "sinusoid",
+            coords: [
+                [0, 0],
+                [1, 1],
+            ],
+        };
+
+        const score = scoreSinusoid(userInput, rubric);
+
+        expect(score).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("returns incorrect score when sinusoid coefficients do not match", () => {
+        const userInput: PerseusGraphTypeSinusoid = {
+            type: "sinusoid",
+            // amplitude 2, different from rubric
+            coords: [
+                [0, 0],
+                [1, 2],
+            ],
+        };
+        const rubric: PerseusGraphTypeSinusoid = {
+            type: "sinusoid",
+            coords: [
+                [0, 0],
+                [1, 1],
+            ],
+        };
+
+        const score = scoreSinusoid(userInput, rubric);
+
+        expect(score).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("returns correct score for canonically equivalent phase-shifted sinusoids", () => {
+        // [[0,0],[1,1]] → phase=0; [[4,0],[5,1]] → phase=2π → canonical phase=0
+        // Both represent the same underlying sine curve.
+        const userInput: PerseusGraphTypeSinusoid = {
+            type: "sinusoid",
+            coords: [
+                [4, 0],
+                [5, 1],
+            ],
+        };
+        const rubric: PerseusGraphTypeSinusoid = {
+            type: "sinusoid",
+            coords: [
+                [0, 0],
+                [1, 1],
+            ],
+        };
+
+        const score = scoreSinusoid(userInput, rubric);
+
+        expect(score).toHaveBeenAnsweredCorrectly();
+    });
+});

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-sinusoid.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-sinusoid.ts
@@ -1,0 +1,34 @@
+import {coefficients, geometry} from "@khanacademy/kmath";
+import {approximateDeepEqual} from "@khanacademy/perseus-core";
+
+const {getSinusoidCoefficients} = coefficients;
+const {canonicalSineCoefficients} = geometry;
+
+import type {
+    PerseusGraphTypeSinusoid,
+    PerseusScore,
+} from "@khanacademy/perseus-core";
+
+export function scoreSinusoid(
+    userInput: PerseusGraphTypeSinusoid,
+    rubric: PerseusGraphTypeSinusoid,
+): PerseusScore {
+    if (!userInput.coords || !rubric.coords) {
+        return {type: "invalid", message: null};
+    }
+
+    const guessCoeffs = getSinusoidCoefficients(userInput.coords);
+    const correctCoeffs = getSinusoidCoefficients(rubric.coords);
+    const canonicalGuessCoeffs = canonicalSineCoefficients(guessCoeffs);
+    const canonicalCorrectCoeffs = canonicalSineCoefficients(correctCoeffs);
+    const isCorrect = approximateDeepEqual(
+        canonicalGuessCoeffs,
+        canonicalCorrectCoeffs,
+    );
+    return {
+        type: "points",
+        earned: isCorrect ? 1 : 0,
+        total: 1,
+        message: null,
+    };
+}


### PR DESCRIPTION
## Summary:

This PR: split out Sinusoid scorer.

PR stack:
- Linear: #3542
- LinearSystem: #3549
- Ray: #3552
- Segment: #3553
- Circle: #3554
- Point: #3555
- Vector: #3556
- Polygon: #3557
- Angle: #3558
- Quadratic: #3559
- 📈 Sinusoid: #3560
- Tangent: #3561
- AbsoluteValue: #3562
- Exponential: #3563
- Logarithm: #3564
- Refactor scorer function: #3565

---

## About these PRs

This stack of PRs is just about splitting the `scoreInteractiveGraph` function into sub-scorers. Originally the function was a giant 400+ lines-of-code function that handled all scoring for IG. In the end the main function is shrunk down to a little over 100 lines-of-code.

Goals:

- Split out the functionality of each sub-scorer as directly as possible **while avoiding changes to the sub-scorer as much as possible.**
- Avoid changing original functionality.
- Set up testing for each sub-scorer so that they have focused tests.
- Do this in a way that's as easy to review as possible.

How this was accomplished:

- Used Claude to get near 100% test coverage of the original `scoreInteractiveGraph` function (see #3565)
- Used Claude to generate a PR plan (see #3542)
- Went through each sub-scorer and copied the functionality from `scoreInteractiveGraph` without modifying `scoreInteractiveGraph`, while also adding test coverage
- In the last PR (#3565), I had Claude update `scoreInteractiveGraph` to use the sub-scorers.
- Ran all tests and everything passes!

This provided a high level of confidence in the changes (because of the test coverage) and made the PRs easier to review (most are additive and easy to compare to original functionality).