### PR TITLE
[ig-scorer] Break out Logarithm

### DIFF
--- a/.changeset/chilly-pugs-relate.md
+++ b/.changeset/chilly-pugs-relate.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-score": patch
+---
+
+Copy logarithm scoring into score-logarithm.ts

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-logarithm.test.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-logarithm.test.ts
@@ -1,0 +1,135 @@
+import {scoreLogarithm} from "./score-logarithm";
+
+import type {PerseusGraphTypeLogarithm} from "@khanacademy/perseus-core";
+
+describe("scoreLogarithm", () => {
+    it("returns invalid score when missing user coords", () => {
+        const userInput: PerseusGraphTypeLogarithm = {
+            type: "logarithm",
+            asymptote: 3,
+        };
+        const rubric: PerseusGraphTypeLogarithm = {
+            type: "logarithm",
+            coords: [
+                [5, 0],
+                [11, 1],
+            ],
+            asymptote: 3,
+        };
+
+        const score = scoreLogarithm(userInput, rubric);
+
+        expect(score).toHaveInvalidInput();
+    });
+
+    it("returns invalid score when missing user asymptote", () => {
+        const userInput: PerseusGraphTypeLogarithm = {
+            type: "logarithm",
+            coords: [
+                [5, 0],
+                [11, 1],
+            ],
+        };
+        const rubric: PerseusGraphTypeLogarithm = {
+            type: "logarithm",
+            coords: [
+                [5, 0],
+                [11, 1],
+            ],
+            asymptote: 3,
+        };
+
+        const score = scoreLogarithm(userInput, rubric);
+
+        expect(score).toHaveInvalidInput();
+    });
+
+    it("returns invalid score when missing rubric coords", () => {
+        const userInput: PerseusGraphTypeLogarithm = {
+            type: "logarithm",
+            coords: [
+                [5, 0],
+                [11, 1],
+            ],
+            asymptote: 3,
+        };
+        const rubric: PerseusGraphTypeLogarithm = {
+            type: "logarithm",
+            asymptote: 3,
+        };
+
+        const score = scoreLogarithm(userInput, rubric);
+
+        expect(score).toHaveInvalidInput();
+    });
+
+    it("returns invalid score when missing rubric asymptote", () => {
+        const userInput: PerseusGraphTypeLogarithm = {
+            type: "logarithm",
+            coords: [
+                [5, 0],
+                [11, 1],
+            ],
+            asymptote: 3,
+        };
+        const rubric: PerseusGraphTypeLogarithm = {
+            type: "logarithm",
+            coords: [
+                [5, 0],
+                [11, 1],
+            ],
+        };
+
+        const score = scoreLogarithm(userInput, rubric);
+
+        expect(score).toHaveInvalidInput();
+    });
+
+    it("returns correct score when logarithm coefficients match", () => {
+        // Inverse of f(x) = 2·e^x + 3; asymptote at x=3, coords [5,0] and [11,1]
+        const userInput: PerseusGraphTypeLogarithm = {
+            type: "logarithm",
+            coords: [
+                [5, 0],
+                [11, 1],
+            ],
+            asymptote: 3,
+        };
+        const rubric: PerseusGraphTypeLogarithm = {
+            type: "logarithm",
+            coords: [
+                [5, 0],
+                [11, 1],
+            ],
+            asymptote: 3,
+        };
+
+        const score = scoreLogarithm(userInput, rubric);
+
+        expect(score).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("returns incorrect score when logarithm coefficients do not match", () => {
+        // Different curve: asymptote at x=0, coords [4,0] and [1,1]
+        const userInput: PerseusGraphTypeLogarithm = {
+            type: "logarithm",
+            coords: [
+                [4, 0],
+                [1, 1],
+            ],
+            asymptote: 0,
+        };
+        const rubric: PerseusGraphTypeLogarithm = {
+            type: "logarithm",
+            coords: [
+                [5, 0],
+                [11, 1],
+            ],
+            asymptote: 3,
+        };
+
+        const score = scoreLogarithm(userInput, rubric);
+
+        expect(score).toHaveBeenAnsweredIncorrectly();
+    });
+});

--- a/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-logarithm.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/sub-scorers/score-logarithm.ts
@@ -1,0 +1,45 @@
+import {coefficients} from "@khanacademy/kmath";
+import {approximateDeepEqual} from "@khanacademy/perseus-core";
+
+const {getLogarithmCoefficients} = coefficients;
+
+import type {
+    PerseusGraphTypeLogarithm,
+    PerseusScore,
+} from "@khanacademy/perseus-core";
+
+export function scoreLogarithm(
+    userInput: PerseusGraphTypeLogarithm,
+    rubric: PerseusGraphTypeLogarithm,
+): PerseusScore {
+    if (
+        !userInput.coords ||
+        userInput.asymptote == null ||
+        !rubric.coords ||
+        rubric.asymptote == null
+    ) {
+        return {type: "invalid", message: null};
+    }
+
+    const guessCoeffs = getLogarithmCoefficients(
+        userInput.coords,
+        userInput.asymptote,
+    );
+    const correctCoeffs = getLogarithmCoefficients(
+        rubric.coords,
+        rubric.asymptote,
+    );
+    const isCorrect =
+        guessCoeffs != null &&
+        correctCoeffs != null &&
+        approximateDeepEqual(
+            [guessCoeffs.a, guessCoeffs.b, guessCoeffs.c],
+            [correctCoeffs.a, correctCoeffs.b, correctCoeffs.c],
+        );
+    return {
+        type: "points",
+        earned: isCorrect ? 1 : 0,
+        total: 1,
+        message: null,
+    };
+}


### PR DESCRIPTION
## Summary:

This PR: split out Logarithm scorer.

PR stack:
- Linear: #3542
- LinearSystem: #3549
- Ray: #3552
- Segment: #3553
- Circle: #3554
- Point: #3555
- Vector: #3556
- Polygon: #3557
- Angle: #3558
- Quadratic: #3559
- Sinusoid: #3560
- Tangent: #3561
- AbsoluteValue: #3562
- Exponential: #3563
- 📈 Logarithm: #3564
- Refactor scorer function: #3565

---

## About these PRs

This stack of PRs is just about splitting the `scoreInteractiveGraph` function into sub-scorers. Originally the function was a giant 400+ lines-of-code function that handled all scoring for IG. In the end the main function is shrunk down to a little over 100 lines-of-code.

Goals:

- Split out the functionality of each sub-scorer as directly as possible **while avoiding changes to the sub-scorer as much as possible.**
- Avoid changing original functionality.
- Set up testing for each sub-scorer so that they have focused tests.
- Do this in a way that's as easy to review as possible.

How this was accomplished:

- Used Claude to get near 100% test coverage of the original `scoreInteractiveGraph` function (see #3565)
- Used Claude to generate a PR plan (see #3542)
- Went through each sub-scorer and copied the functionality from `scoreInteractiveGraph` without modifying `scoreInteractiveGraph`, while also adding test coverage
- In the last PR (#3565), I had Claude update `scoreInteractiveGraph` to use the sub-scorers.
- Ran all tests and everything passes!

This provided a high level of confidence in the changes (because of the test coverage) and made the PRs easier to review (most are additive and easy to compare to original functionality).