### PR TITLE
[Interactive Graph] Fix interactive graph x-axis label overlapping with content below

### DIFF
--- a/.changeset/metal-experts-mate.md
+++ b/.changeset/metal-experts-mate.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix interactive graph x-axis label overlapping with content below when y-range starts at 0 or higher

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`Interactive Graph A none-type graph renders predictably: first render 1
             class="default_xu2jcg mafs-graph-container"
           >
             <div
-              class="default_xu2jcg-o_O-inlineStyles_1t4cnlh mafs-graph"
+              class="default_xu2jcg-o_O-inlineStyles_11rziql mafs-graph"
               tabindex="0"
             >
               <div
@@ -1104,7 +1104,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
           >
             <div
               aria-describedby="interactive-graph-interactive-elements-description-:r2: instructions-:r2:"
-              class="default_xu2jcg-o_O-inlineStyles_1t4cnlh mafs-graph"
+              class="default_xu2jcg-o_O-inlineStyles_11rziql mafs-graph"
               tabindex="0"
             >
               <div
@@ -1550,7 +1550,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
           >
             <div
               aria-describedby="interactive-graph-interactive-elements-description-:rc: instructions-:rc:"
-              class="default_xu2jcg-o_O-inlineStyles_1t4cnlh mafs-graph"
+              class="default_xu2jcg-o_O-inlineStyles_11rziql mafs-graph"
               tabindex="0"
             >
               <div
@@ -2002,7 +2002,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
           >
             <div
               aria-describedby="interactive-graph-interactive-elements-description-:rl: unlimited-graph-keyboard-prompt-:rl: instructions-:rl:"
-              class="default_xu2jcg-o_O-inlineStyles_1t4cnlh mafs-graph"
+              class="default_xu2jcg-o_O-inlineStyles_11rziql mafs-graph"
               tabindex="0"
             >
               <div
@@ -2262,7 +2262,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
           >
             <div
               aria-describedby="unlimited-graph-keyboard-prompt-:rr: instructions-:rr:"
-              class="default_xu2jcg-o_O-inlineStyles_1t4cnlh mafs-graph"
+              class="default_xu2jcg-o_O-inlineStyles_11rziql mafs-graph"
               tabindex="0"
             >
               <div
@@ -2500,7 +2500,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
           >
             <div
               aria-describedby="interactive-graph-interactive-elements-description-:r4: instructions-:r4:"
-              class="default_xu2jcg-o_O-inlineStyles_1t4cnlh mafs-graph"
+              class="default_xu2jcg-o_O-inlineStyles_11rziql mafs-graph"
               tabindex="0"
             >
               <div
@@ -2919,7 +2919,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
           >
             <div
               aria-describedby="interactive-graph-interactive-elements-description-:re: instructions-:re:"
-              class="default_xu2jcg-o_O-inlineStyles_1t4cnlh mafs-graph"
+              class="default_xu2jcg-o_O-inlineStyles_11rziql mafs-graph"
               tabindex="0"
             >
               <div
@@ -3371,7 +3371,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
           >
             <div
               aria-describedby="interactive-graph-interactive-elements-description-:rm: instructions-:rm:"
-              class="default_xu2jcg-o_O-inlineStyles_1t4cnlh mafs-graph"
+              class="default_xu2jcg-o_O-inlineStyles_11rziql mafs-graph"
               tabindex="0"
             >
               <div
@@ -3738,7 +3738,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
           >
             <div
               aria-describedby="interactive-graph-interactive-elements-description-:rt: instructions-:rt:"
-              class="default_xu2jcg-o_O-inlineStyles_1t4cnlh mafs-graph"
+              class="default_xu2jcg-o_O-inlineStyles_11rziql mafs-graph"
               tabindex="0"
             >
               <div

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.test.ts
@@ -1,6 +1,7 @@
 import {
     clampLabelPosition,
     fontSize,
+    getGraphBottomMargin,
     getLabelPosition,
     getLabelTransform,
 } from "./utils";
@@ -228,5 +229,57 @@ describe("clampLabelPosition", () => {
         const expected = [-fontSize * 1.5, -fontSize * 2];
 
         expect(clampLabelPosition(labelPosition, graphInfo)).toEqual(expected);
+    });
+});
+
+describe("getGraphBottomMargin", () => {
+    it("returns the base margin when the x-axis label is within the graph area", () => {
+        // Label Y = 200 (center of a 400px graph), well within bounds
+        expect(getGraphBottomMargin(200, 400, true, true)).toBe(30);
+    });
+
+    it("returns the base margin when y-range starts at 0 (onAxis, small overflow)", () => {
+        // For range [0, N], onAxis label is at Y = height (400).
+        // Overflow = 400 + fontSize - 400 = 14, result = max(30, 14) = 30
+        // The 30px base margin already covers this small overflow.
+        expect(getGraphBottomMargin(400, 400, true, true)).toBe(30);
+    });
+
+    it("returns increased margin for wholly positive y-range (onAxis, clamped label)", () => {
+        // For range [6, 15] onAxis, the label is clamped to
+        // Y = height + fontSize * 1.25 = 417.5
+        // Overflow = 417.5 + 14 - 400 = 31.5, result = max(30, 31.5) = 31.5
+        // The margin just clears the label; the paragraph's own 22px top
+        // margin then provides the visual gap.
+        const clampedY = 400 + fontSize * 1.25;
+        const overflow = clampedY + fontSize - 400;
+        expect(getGraphBottomMargin(clampedY, 400, true, true)).toBe(overflow);
+    });
+
+    it("returns increased margin for alongEdge labels with y-range starting at 0", () => {
+        // For alongEdge with yMin >= 0, the label is at Y = height + 3 * fontSize = 442
+        // Overflow = 442 + 14 - 400 = 56, result = max(30, 56) = 56
+        const alongEdgeY = 400 + 3 * fontSize;
+        const overflow = alongEdgeY + fontSize - 400;
+        expect(getGraphBottomMargin(alongEdgeY, 400, true, true)).toBe(
+            overflow,
+        );
+    });
+
+    it("returns the base margin when there is no x-axis label", () => {
+        // Even with a label position below the graph, no x-axis label
+        // means no extra margin needed
+        expect(getGraphBottomMargin(500, 400, false, true)).toBe(30);
+    });
+
+    it("returns the base margin when axis labels are not shown", () => {
+        // Even with a label position below the graph, if labels
+        // aren't shown (markings = "none"), no extra margin needed
+        expect(getGraphBottomMargin(500, 400, true, false)).toBe(30);
+    });
+
+    it("returns the base margin for negative y-range where label is within bounds", () => {
+        // For range [-10, 10], the label Y = 200 (well within the 400px graph)
+        expect(getGraphBottomMargin(200, 400, true, true)).toBe(30);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/utils.ts
@@ -181,6 +181,38 @@ export const getLabelPosition = (
 
     return [xLabel, yLabel];
 };
+/**
+ * Calculate the bottom margin needed for the graph container to prevent the
+ * x-axis label from overlapping with content below the graph.
+ *
+ * When the y-range starts at or above 0, the x-axis label can extend below
+ * the graph content area. This function calculates the extra margin needed.
+ * Exported for testing purposes.
+ */
+export const getGraphBottomMargin = (
+    xAxisLabelLocationY: number,
+    graphHeight: number,
+    hasXAxisLabel: boolean,
+    showsAxisLabels: boolean,
+): number => {
+    const baseMargin = 30;
+    if (!showsAxisLabels || !hasXAxisLabel) {
+        return baseMargin;
+    }
+    // The label is vertically centered at xAxisLabelLocationY (via CSS
+    // transform: translate(_, -50%)), so its bottom edge is at approximately
+    // xAxisLabelLocationY + labelHeight/2. We use fontSize (14px) as a
+    // conservative overestimate of labelHeight/2 to ensure the margin
+    // covers the label with a small buffer.
+    const xLabelBottomOverflow = Math.max(
+        0,
+        xAxisLabelLocationY + fontSize - graphHeight,
+    );
+    // Ensure the graph's bottom margin is large enough to prevent
+    // the overflowing label from overlapping with adjacent content.
+    return Math.max(baseMargin, xLabelBottomOverflow);
+};
+
 // Determines whether to show the label for the given tick
 // Currently, the only condition is to hide the label at -tickStep
 // on the y-axis when the y-axis is within the graph bounds

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/utils.ts
@@ -187,7 +187,6 @@ export const getLabelPosition = (
  *
  * When the y-range starts at or above 0, the x-axis label can extend below
  * the graph content area. This function calculates the extra margin needed.
- * Exported for testing purposes.
  */
 export const getGraphBottomMargin = (
     xAxisLabelLocationY: number,

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -27,6 +27,7 @@ import {LegacyGrid} from "./backgrounds/legacy-grid";
 import {
     fontSize,
     fontSizeYAxisLabelMultiplier,
+    getGraphBottomMargin,
     getLabelPosition,
 } from "./backgrounds/utils";
 import GraphLockedLabelsLayer from "./graph-locked-labels-layer";
@@ -198,6 +199,19 @@ export const MafsGraph = (props: MafsGraphProps) => {
     const marginWithExtraOffset =
         -1 * (yAxisLabelLocation[X] - marginLabelDiff);
 
+    // When the y-range starts at or above 0, the x-axis label can extend
+    // below the graph content area. We dynamically increase the bottom
+    // margin to prevent the label from overlapping with content below.
+    const showsAxisLabels =
+        props.markings === "graph" || props.markings === "axes";
+    const hasXAxisLabel = !!(labels[0] && labels[0].trim());
+    const graphMarginBottom = getGraphBottomMargin(
+        xAxisLabelLocation[Y],
+        height,
+        hasXAxisLabel,
+        showsAxisLabels,
+    );
+
     return (
         <GraphConfigContext.Provider
             value={{
@@ -235,7 +249,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                         marginLeft: needsExtraMargin
                             ? `${marginWithExtraOffset}px`
                             : `${GRAPH_LEFT_MARGIN}px`,
-                        marginBottom: "30px",
+                        marginBottom: graphMarginBottom,
                         pointerEvents: props.static ? "none" : "auto",
                         userSelect: "none",
                         width,


### PR DESCRIPTION
## Summary:
- When the y-range starts at 0 or higher (e.g., `[0, 19]`), the x-axis label extends below the graph content area and overlaps with text rendered after the widget.
- The graph container had a hardcoded `marginBottom: 30px` that didn't account for label overflow.
- The fix dynamically calculates the bottom margin to clear the overflowing label, so adjacent content (paragraphs, other widgets) retains its natural spacing without overlap.

## Root Cause
The x-axis label is absolutely positioned at the end of the x-axis. When `yMin >= 0`, the x-axis sits at or near the bottom edge of the graph, pushing the label below the graph's content box. The fixed 30px margin was not enough to cover the overflow, especially for:
- **onAxis labels** with wholly positive y-ranges (label clamped to `height + fontSize * 1.25`)
- **alongEdge labels** with `yMin >= 0` (label offset by `fontSize * 3` below the graph)

## Changes

`packages/perseus/src/widgets/interactive-graphs/backgrounds/utils.ts`
- Added `getGraphBottomMargin()` — calculates the bottom margin needed to clear the x-axis label overflow so it doesn't overlap with adjacent content.

`packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx`
- Replaced the hardcoded `marginBottom: "30px"` with a dynamic value from `getGraphBottomMargin()`
- The calculation considers: label pixel position, graph height, whether labels are shown, and whether there is x-axis label text

`packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-labels.test.ts`
- Added 7 tests for `getGraphBottomMargin()` covering: normal range, yMin=0 (onAxis), wholly positive range (onAxis clamped), alongEdge with yMin=0, no label text, labels hidden, and negative range

`packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap`
- Updated 9 snapshots (CSS class hash changed due to the style value now being dynamic)

## Effective margins by scenario

| Scenario | Label overflow | Graph margin | Visual gap below label |
|---|---|---|---|
| Default [-10,10], onAxis | 0px | 30px | 30px+ (label inside graph) |
| yMin=0 [0,19], onAxis | 14px | 30px | ~22px |
| Wholly positive [6,15], onAxis | 31.5px | 31.5px | ~22px |
| yMin=0, alongEdge | 56px | 56px | ~22px |

Co-authored by Claude Code (Opus)
Issue: LEMS-3921

## Test plan

Use the content below:
```
Caleb measured the height of the snow in his yard before a winter storm began. 

The graph shows the snow height, in centimeters, during a winter storm.

[[☃ interactive-graph 1]]

**Write an equation that represents the height of the snow, $H$, in centimeters, after $t$ hours.**

$H=$ [[☃ expression 1]]
```

- [x] All 44 interactive-graph test suites pass (1111 tests)
- [x] No lint errors
- [x] No new type errors
- [ ] Verify in Storybook with y-range `[0, 19]` and x-label `$\text{Time (hours)}$`
- [ ] Verify with y-range `[-1, 19]` (workaround case) still looks correct
- [ ] Verify with wholly positive y-range like `[5, 15]`
- [ ] Verify with `alongEdge` label location
- [ ] Verify default range `[-10, 10]` is unchanged
- [ ] Verify graph with no x-axis label text is unchanged