### PR TITLE
Remove unused paths field from LinterContextProps and contentPaths prop from editors

### DIFF
--- a/.changeset/quiet-paths-vanish.md
+++ b/.changeset/quiet-paths-vanish.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-linter": major
+"@khanacademy/perseus-editor": major
+---
+
+Remove unused `paths` field from `LinterContextProps` and the corresponding `contentPaths` prop from `EditorPage`, `ArticleEditor`, and `HintEditor`. The field was never read by any linter rule or renderer.

--- a/packages/perseus-editor/src/__docs__/content-preview.stories.tsx
+++ b/packages/perseus-editor/src/__docs__/content-preview.stories.tsx
@@ -73,7 +73,6 @@ export const WithLintErrors: Story = {
             contentType: "exercise",
             highlightLint: true,
             stack: [],
-            paths: [],
         },
         question: withLintErrors,
     },

--- a/packages/perseus-editor/src/article-editor.tsx
+++ b/packages/perseus-editor/src/article-editor.tsx
@@ -51,7 +51,6 @@ type RendererProps = {
 };
 
 type DefaultProps = {
-    contentPaths?: ReadonlyArray<string>;
     json: PerseusArticle;
     mode: "diff" | "edit" | "json" | "preview";
     screen: "phone" | "tablet" | "desktop";
@@ -77,7 +76,6 @@ type State = {
 
 export default class ArticleEditor extends React.Component<Props, State> {
     static defaultProps: DefaultProps = {
-        contentPaths: [],
         // NOTE(Jeremy):
         json: [{} as any],
         mode: "edit",
@@ -191,7 +189,6 @@ export default class ArticleEditor extends React.Component<Props, State> {
             linterContext: {
                 contentType: "article",
                 highlightLint: this.state.highlightLint,
-                paths: this.props.contentPaths,
             },
             // @ts-expect-error - TS2339 - Property 'getSaveWarnings' does not exist on type 'ReactInstance'.
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -48,8 +48,6 @@ type Props = {
     additionalTemplates?: Record<string, string>;
     apiOptions?: APIOptions;
     answerArea: PerseusAnswerArea; // related to the question,
-    // TODO(CP-4838): Should this be a required prop?
-    contentPaths?: ReadonlyArray<string>;
     dependencies: PerseusDependenciesV2;
     /** "Power user" mode. Shows the raw JSON of the question. */
     developerMode: boolean;
@@ -232,8 +230,6 @@ class EditorPage extends React.Component<Props, State> {
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: this.state.highlightLint,
-                    // TODO(CP-4838): is it okay to use [] as a default?
-                    paths: this.props.contentPaths || [],
                 },
                 reviewMode: true,
                 legacyPerseusLint: this.itemEditor.current?.getSaveWarnings(),

--- a/packages/perseus-editor/src/hint-editor.tsx
+++ b/packages/perseus-editor/src/hint-editor.tsx
@@ -187,7 +187,6 @@ type CombinedHintEditorProps = {
     isFirst: boolean;
     hint: Hint;
     pos: number; // position,
-    contentPaths: ReadonlyArray<string>;
     // URL of the route to show on initial load of the preview frames.
     previewURL: string;
     onMove: (direction: number) => unknown;
@@ -224,7 +223,6 @@ class CombinedHintEditor extends React.Component<CombinedHintEditorProps> {
                 linterContext: {
                     contentType: "hint",
                     highlightLint: this.props.highlightLint,
-                    paths: this.props.contentPaths,
                 },
             },
         });
@@ -417,8 +415,6 @@ class CombinedHintsEditor extends React.Component<CombinedHintsEditorProps> {
                             highlightLint={this.props.highlightLint}
                             // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                             previewURL={this.props.previewURL}
-                            // TODO(CP-4838): what should be passed here?
-                            contentPaths={[]}
                             // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                             widgetIsOpen={this.props.widgetIsOpen}
                         />

--- a/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
+++ b/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
@@ -46,7 +46,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
-                    paths: [],
                     stack: [],
                 },
             };
@@ -89,7 +88,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
-                    paths: [],
                     stack: [],
                 },
             };
@@ -120,7 +118,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
-                    paths: [],
                     stack: [],
                 },
             };
@@ -151,7 +148,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
-                    paths: [],
                     stack: [],
                 },
             };
@@ -184,7 +180,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
-                    paths: [],
                     stack: [],
                 },
             };
@@ -208,7 +203,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "article",
                     highlightLint: false,
-                    paths: [],
                     stack: [],
                 },
             };
@@ -238,7 +232,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "article",
                     highlightLint: false,
-                    paths: [],
                     stack: [],
                 },
             };
@@ -265,7 +258,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "article",
                     highlightLint: false,
-                    paths: [],
                     stack: [],
                 },
             };
@@ -278,7 +270,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "article",
                     highlightLint: false,
-                    paths: [],
                     stack: [],
                 },
             };
@@ -318,7 +309,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "article",
                     highlightLint: false,
-                    paths: [],
                     stack: [],
                 },
             };
@@ -341,7 +331,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "article",
                     highlightLint: false,
-                    paths: [],
                     stack: [],
                 },
             };
@@ -351,7 +340,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "article",
                     highlightLint: false,
-                    paths: [],
                     stack: [],
                 },
             };
@@ -403,7 +391,6 @@ describe("sanitizePreviewData", () => {
                                 linterContext: {
                                     contentType: "exercise",
                                     highlightLint: false,
-                                    paths: [],
                                     stack: [],
                                 },
                             },
@@ -419,7 +406,6 @@ describe("sanitizePreviewData", () => {
                                 linterContext: {
                                     contentType: "exercise",
                                     highlightLint: false,
-                                    paths: [],
                                     stack: [],
                                 },
                             },
@@ -440,7 +426,6 @@ describe("sanitizePreviewData", () => {
                                 linterContext: {
                                     contentType: "article",
                                     highlightLint: false,
-                                    paths: [],
                                     stack: [],
                                 },
                             },
@@ -462,7 +447,6 @@ describe("sanitizePreviewData", () => {
                                     linterContext: {
                                         contentType: "article",
                                         highlightLint: false,
-                                        paths: [],
                                         stack: [],
                                     },
                                 },

--- a/packages/perseus-linter/src/proptypes.ts
+++ b/packages/perseus-linter/src/proptypes.ts
@@ -3,6 +3,5 @@ import type {LinterContextProps} from "./types";
 export const linterContextDefault: LinterContextProps = {
     contentType: "",
     highlightLint: false,
-    paths: [],
     stack: [],
 };

--- a/packages/perseus-linter/src/types.ts
+++ b/packages/perseus-linter/src/types.ts
@@ -5,7 +5,6 @@
 export type LinterContextProps = {
     contentType: string;
     highlightLint: boolean;
-    paths: ReadonlyArray<string>;
     stack: ReadonlyArray<string>;
     // additional properties can be added to the context by widgets
 };

--- a/packages/perseus/src/__docs__/server-item-renderer.stories.tsx
+++ b/packages/perseus/src/__docs__/server-item-renderer.stories.tsx
@@ -51,7 +51,6 @@ export const WithLintingError: Story = {
         linterContext: {
             contentType: "",
             highlightLint: true,
-            paths: [],
             stack: [],
         },
     },
@@ -162,7 +161,6 @@ export const Interactive = () => {
                                 linterContext={{
                                     contentType: "",
                                     highlightLint: true,
-                                    paths: [],
                                     stack: [],
                                 }}
                             />

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -144,8 +144,6 @@ describe("renderer", () => {
             linterContext: {
                 contentType: "exercise",
                 highlightLint: true,
-                // TODO(CP-4838): is it okay to use [] as a default?
-                paths: [],
                 stack: [],
             },
         } as const;

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -501,7 +501,6 @@ describe("server item renderer", () => {
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
-                    paths: [],
                     stack: [],
                 },
             });
@@ -519,7 +518,6 @@ describe("server item renderer", () => {
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: true,
-                    paths: [],
                     stack: [],
                 },
             });

--- a/packages/perseus/src/widgets/image/components/explore-image-modal.test.tsx
+++ b/packages/perseus/src/widgets/image/components/explore-image-modal.test.tsx
@@ -48,7 +48,6 @@ const defaultProps = {
     linterContext: {
         contentType: "",
         highlightLint: false,
-        paths: [],
         stack: ["widget"],
     },
     apiOptions: ApiOptions.defaults,

--- a/packages/perseus/src/widgets/radio/__tests__/radio-widget.test.tsx
+++ b/packages/perseus/src/widgets/radio/__tests__/radio-widget.test.tsx
@@ -48,7 +48,6 @@ const baseChoiceStates = [
 const baseLinterContext: LinterContextProps = {
     contentType: "radio",
     highlightLint: false,
-    paths: [],
     stack: [],
 };
 

--- a/packages/perseus/src/widgets/radio/radio-widget.tsx
+++ b/packages/perseus/src/widgets/radio/radio-widget.tsx
@@ -186,7 +186,6 @@ const RadioWidget = forwardRef<RadioWidgetHandle, Props>(
             const linterContext: LinterContextProps = {
                 contentType: "radio",
                 highlightLint: false,
-                paths: [],
                 stack: [],
             };
 


### PR DESCRIPTION
## Summary:

While working with Ben today on some preview-related refactoring, we started asking what some of the LinterContext values were for. Well, turns out `paths` is completely unused. A few places set it, but no code looks at it, so we can remove it. 
This propogates out to the `contentPaths` props on the `ArticleEditor`, `EditorPage`, and `HintEditor` components. `contentPaths` is used to set up `paths` on linter contexts, but no client passes it down, and because `paths` is dead, there's no point leaving the prop here.

Issue: LEMS-4083 

## Test plan:

`pnpm test`
`pnpm typecheck`

Run storybook and make sure the previews for EditorPage work!