### PR TITLE
Narrow preview-bridge linterContext to only used values

### DIFF
--- a/.changeset/swift-bridges-narrow.md
+++ b/.changeset/swift-bridges-narrow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": major
+---
+
+Narrow the type of `linterContext` on the preview-bridge message types to just `contentType` and `highlightLint` (removing `paths` and corresponding `contentPaths` prop from `EditorPage`, `ArticleEditor`, and `HintEditor`). The receiving side already builds the rest of the linter context via `pushContextStack`. 

--- a/packages/perseus-editor/src/preview/message-types.ts
+++ b/packages/perseus-editor/src/preview/message-types.ts
@@ -9,17 +9,17 @@ import type {
     PerseusArticle,
     PerseusItem,
 } from "@khanacademy/perseus-core";
-import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
 /**
  * The subset of `LinterContextProps` that's meaningful to send across the
  * preview bridge. The receiver wraps this in `pushContextStack(...)` before
  * passing it to the renderer, which fills in the `stack`.
  */
-type PreviewLinterContext = Pick<
-    LinterContextProps,
-    "contentType" | "highlightLint"
->;
+// TODO(jeremy): Remove this type and inline it into the messages that use it.
+type PreviewLinterContext = {
+    contentType: string;
+    highlightLint: boolean;
+};
 
 /**
  * Constant identifier for all Perseus preview messages

--- a/packages/perseus-editor/src/preview/message-types.ts
+++ b/packages/perseus-editor/src/preview/message-types.ts
@@ -12,6 +12,16 @@ import type {
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
 /**
+ * The subset of `LinterContextProps` that's meaningful to send across the
+ * preview bridge. The receiver wraps this in `pushContextStack(...)` before
+ * passing it to the renderer, which fills in the `stack`.
+ */
+type PreviewLinterContext = Pick<
+    LinterContextProps,
+    "contentType" | "highlightLint"
+>;
+
+/**
  * Constant identifier for all Perseus preview messages
  */
 export const PREVIEW_MESSAGE_SOURCE = "perseus-preview" as const;
@@ -31,7 +41,7 @@ export type QuestionPreviewData = {
     apiOptions: APIOptions;
     initialHintsVisible: number;
     device: DeviceType;
-    linterContext: LinterContextProps;
+    linterContext: PreviewLinterContext;
     reviewMode?: boolean;
     legacyPerseusLint?: ReadonlyArray<string>;
     problemNum?: number;
@@ -44,7 +54,7 @@ export type HintPreviewData = {
     hint: Hint;
     pos: number;
     apiOptions: APIOptions;
-    linterContext: LinterContextProps;
+    linterContext: PreviewLinterContext;
 };
 
 /**
@@ -53,7 +63,7 @@ export type HintPreviewData = {
 export type ArticlePreviewData = {
     apiOptions: APIOptions;
     json: PerseusArticle;
-    linterContext: LinterContextProps;
+    linterContext: PreviewLinterContext;
     legacyPerseusLint?: ReadonlyArray<string>;
 };
 

--- a/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
+++ b/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
@@ -46,7 +46,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
-                    stack: [],
                 },
             };
 
@@ -89,7 +88,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
-                    stack: [],
                 },
             };
 
@@ -119,7 +117,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
-                    stack: [],
                 },
             };
 
@@ -149,7 +146,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
-                    stack: [],
                 },
             };
 
@@ -182,7 +178,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
-                    stack: [],
                 },
             };
 
@@ -205,7 +200,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "article",
                     highlightLint: false,
-                    stack: [],
                 },
             };
 
@@ -235,7 +229,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "article",
                     highlightLint: false,
-                    stack: [],
                 },
             };
 
@@ -261,7 +254,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "article",
                     highlightLint: false,
-                    stack: [],
                 },
             };
             const section2: ArticlePreviewData = {
@@ -273,7 +265,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "article",
                     highlightLint: false,
-                    stack: [],
                 },
             };
 
@@ -312,7 +303,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "article",
                     highlightLint: false,
-                    stack: [],
                 },
             };
 
@@ -334,7 +324,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "article",
                     highlightLint: false,
-                    stack: [],
                 },
             };
             const section2: ArticlePreviewData = {
@@ -344,7 +333,6 @@ describe("sanitizePreviewData", () => {
                 linterContext: {
                     contentType: "article",
                     highlightLint: false,
-                    stack: [],
                 },
             };
 
@@ -395,7 +383,6 @@ describe("sanitizePreviewData", () => {
                                 linterContext: {
                                     contentType: "exercise",
                                     highlightLint: false,
-                                    stack: [],
                                 },
                             },
                         };
@@ -410,7 +397,6 @@ describe("sanitizePreviewData", () => {
                                 linterContext: {
                                     contentType: "exercise",
                                     highlightLint: false,
-                                    stack: [],
                                 },
                             },
                         };
@@ -430,7 +416,6 @@ describe("sanitizePreviewData", () => {
                                 linterContext: {
                                     contentType: "article",
                                     highlightLint: false,
-                                    stack: [],
                                 },
                             },
                         };
@@ -451,7 +436,6 @@ describe("sanitizePreviewData", () => {
                                     linterContext: {
                                         contentType: "article",
                                         highlightLint: false,
-                                        stack: [],
                                     },
                                 },
                             ],

--- a/packages/perseus-editor/src/preview/use-preview-controller.test.ts
+++ b/packages/perseus-editor/src/preview/use-preview-controller.test.ts
@@ -557,7 +557,6 @@ describe("usePreviewController", () => {
                     linterContext: {
                         contentType: "exercise",
                         highlightLint: false,
-                        stack: [],
                     },
                 },
             };
@@ -599,7 +598,6 @@ describe("usePreviewController", () => {
                         linterContext: {
                             contentType: "article",
                             highlightLint: false,
-                            stack: [],
                         },
                     },
                     {
@@ -612,7 +610,6 @@ describe("usePreviewController", () => {
                         linterContext: {
                             contentType: "article",
                             highlightLint: false,
-                            stack: [],
                         },
                     },
                 ],
@@ -667,7 +664,6 @@ function createQuestionPreview(overrides?: {
             linterContext: {
                 contentType: "exercise",
                 highlightLint: false,
-                stack: [],
             },
         },
     };

--- a/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
+++ b/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
@@ -161,7 +161,6 @@ describe("usePreviewPresenter", () => {
                     linterContext: {
                         contentType: "exercise",
                         highlightLint: false,
-                        stack: [],
                     },
                 },
             };
@@ -196,7 +195,6 @@ describe("usePreviewPresenter", () => {
                     linterContext: {
                         contentType: "exercise",
                         highlightLint: false,
-                        stack: [],
                     },
                 },
             };
@@ -232,7 +230,6 @@ describe("usePreviewPresenter", () => {
                     linterContext: {
                         contentType: "article",
                         highlightLint: false,
-                        stack: [],
                     },
                 },
             };
@@ -263,7 +260,6 @@ describe("usePreviewPresenter", () => {
                         linterContext: {
                             contentType: "article",
                             highlightLint: false,
-                            stack: [],
                         },
                     },
                     {
@@ -272,7 +268,6 @@ describe("usePreviewPresenter", () => {
                         linterContext: {
                             contentType: "article",
                             highlightLint: false,
-                            stack: [],
                         },
                     },
                 ],
@@ -346,7 +341,6 @@ describe("usePreviewPresenter", () => {
                     linterContext: {
                         contentType: "exercise",
                         highlightLint: false,
-                        stack: [],
                     },
                 },
             };
@@ -371,7 +365,6 @@ describe("usePreviewPresenter", () => {
                     linterContext: {
                         contentType: "exercise",
                         highlightLint: false,
-                        stack: [],
                     },
                 },
             };
@@ -634,7 +627,6 @@ describe("usePreviewPresenter", () => {
                     linterContext: {
                         contentType: "exercise",
                         highlightLint: false,
-                        stack: [],
                     },
                 },
             };
@@ -689,7 +681,6 @@ describe("usePreviewPresenter", () => {
                         linterContext: {
                             contentType: "exercise",
                             highlightLint: false,
-                            stack: [],
                         },
                     },
                 },
@@ -702,7 +693,6 @@ describe("usePreviewPresenter", () => {
                         linterContext: {
                             contentType: "exercise",
                             highlightLint: false,
-                            stack: [],
                         },
                     },
                 },
@@ -714,7 +704,6 @@ describe("usePreviewPresenter", () => {
                         linterContext: {
                             contentType: "article",
                             highlightLint: false,
-                            stack: [],
                         },
                     },
                 },

--- a/packages/perseus/src/__docs__/server-item-renderer.stories.tsx
+++ b/packages/perseus/src/__docs__/server-item-renderer.stories.tsx
@@ -1,3 +1,4 @@
+import {View} from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
 import {useState} from "react";
 import {action} from "storybook/actions";
@@ -19,6 +20,20 @@ import type {Meta, StoryObj} from "@storybook/react-vite";
 const meta: Meta = {
     title: "Renderers/Server Item Renderer",
     component: ServerItemRendererWithDebugUI,
+    decorators: [
+        (Story) => {
+            return (
+                // The <Lint> components `hoverTarget` style currently uses an
+                // absolutely positioned element that has {right: -40}, which
+                // effectively moves it outside the components bounding box. We
+                // add a margin right here so we can actually see the linter
+                // warnings in any of these stories!
+                <View style={{marginRight: "40px"}}>
+                    <Story />
+                </View>
+            );
+        },
+    ],
     args: {
         title: "Server Item Renderer",
     },


### PR DESCRIPTION
## Summary:

Following after #3568 which removed some dead code around preview and linter context, I found more things we can trim. 

The preview-bridge message types in `packages/perseus-editor/src/preview/message-types.ts` had linterContext typed as the full `LinterContextProps`, which includes `contentType`, `highlightLint`, and `stack`. In practice, the editors only ever set `contentType` and `highlightLint`; `stack` is built up entirely on the receiver side by `pushContextStack()` calls as the renderer tree descends. The type was wider than the data being sent and makes it confusing to understand.

This PR narrows `linterContext` on the three `*PreviewData` shapes to a local `PreviewLinterContext` which is built using the `LinterContextProps` type to reflect reality. There is no runtime change: the editors already only populated those two fields, and `pushContextStack` already tolerates a missing stack. 

Issue: LEMS-4083

## Test plan:

`pnpm typecheck`
`pnpm test`

Run storybook and check through the various editor pages to ensure the preview still loads.  Add a 1st-level heading (which is a linter violation) to the **Question** area (`# Hello`) and then toggle the "Style Warnings" button (bottom-right corner of the page with the eyeball icon). You should see the lint warning disappear. 