### PR TITLE
Mark exported editor component's `serialize()` functions as deprecated

### DIFF
--- a/.changeset/famous-cycles-obey.md
+++ b/.changeset/famous-cycles-obey.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Deprecate `serialize()` function on EditorPage, ArticleEditor, and Editor components - use `onChange` prop instead!

--- a/packages/perseus-editor/src/article-editor.tsx
+++ b/packages/perseus-editor/src/article-editor.tsx
@@ -460,6 +460,11 @@ export default class ArticleEditor extends React.Component<Props, State> {
         });
     }
 
+    /**
+     * Returns the current version of the edited {@see {@link PerseusArticle}}.
+     *
+     * @deprecated Use the {@see {@link Props.onChange}} prop instead.
+     */
     serialize(): PerseusArticle {
         if (this.props.mode === "edit") {
             return this._sections().map((section, i) => {

--- a/packages/perseus-editor/src/article-editor.tsx
+++ b/packages/perseus-editor/src/article-editor.tsx
@@ -461,9 +461,9 @@ export default class ArticleEditor extends React.Component<Props, State> {
     }
 
     /**
-     * Returns the current version of the edited {@see {@link PerseusArticle}}.
+     * Returns the current version of the edited {@link PerseusArticle}.
      *
-     * @deprecated Use the {@see {@link Props.onChange}} prop instead.
+     * @deprecated Use the {@link Props.onChange} prop instead.
      */
     serialize(): PerseusArticle {
         if (this.props.mode === "edit") {

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -254,6 +254,11 @@ class EditorPage extends React.Component<Props, State> {
         return issues1.concat(issues2);
     }
 
+    /**
+     * Returns the current version of the edited {@see {@link PerseusItem}}.
+     *
+     * @deprecated Use the {@see {@link Props.onChange}} prop instead.
+     */
     serialize(): PerseusItem {
         if (this.props.jsonMode) {
             return this.state.json;

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -255,9 +255,9 @@ class EditorPage extends React.Component<Props, State> {
     }
 
     /**
-     * Returns the current version of the edited {@see {@link PerseusItem}}.
+     * Returns the current version of the edited {@link PerseusItem}.
      *
-     * @deprecated Use the {@see {@link Props.onChange}} prop instead.
+     * @deprecated Use the {@link Props.onChange} prop instead.
      */
     serialize(): PerseusItem {
         if (this.props.jsonMode) {

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -854,6 +854,11 @@ class Editor extends React.Component<Props, State> {
         }
     };
 
+    /**
+     * Returns the current version of the edited {@see {@link PerseusRenderer}}.
+     *
+     * @deprecated Use the {@see {@link Props.onChange}} prop instead.
+     */
     serialize(): PerseusRenderer {
         // need to serialize the widgets since the state might not be
         // completely represented in props. ahem //transformer// (and

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -855,9 +855,9 @@ class Editor extends React.Component<Props, State> {
     };
 
     /**
-     * Returns the current version of the edited {@see {@link PerseusRenderer}}.
+     * Returns the current version of the edited {@link PerseusRenderer}.
      *
-     * @deprecated Use the {@see {@link Props.onChange}} prop instead.
+     * @deprecated Use the {@link Props.onChange} prop instead.
      */
     serialize(): PerseusRenderer {
         // need to serialize the widgets since the state might not be

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -133,6 +133,9 @@ type Props = Readonly<{
     warnNoWidgets: boolean;
     widgetIsOpen?: boolean;
     imageUploader?: ImageUploader;
+    /**
+     * asdf
+     */
     // eslint-disable-next-line import/no-deprecated
     onChange: ChangeHandler;
 }>;
@@ -857,7 +860,7 @@ class Editor extends React.Component<Props, State> {
     /**
      * Returns the current version of the edited {@link PerseusRenderer}.
      *
-     * @deprecated Use the {@link Props.onChange} prop instead.
+     * @deprecated Use the `Props.onChange` prop instead.
      */
     serialize(): PerseusRenderer {
         // need to serialize the widgets since the state might not be

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -133,9 +133,6 @@ type Props = Readonly<{
     warnNoWidgets: boolean;
     widgetIsOpen?: boolean;
     imageUploader?: ImageUploader;
-    /**
-     * asdf
-     */
     // eslint-disable-next-line import/no-deprecated
     onChange: ChangeHandler;
 }>;


### PR DESCRIPTION
## Summary:

We've been working for a while to get rid of the `.serialize()` functions on the exported editor components. This is a legacy function that returns the current state of the edited item. However, a more React way is to provide that via a callback prop. We already have that prop in `onChange`. 

As of today (May 2026) no clients that use Perseus editors are using serialize anymore, so we can deprecate it and shortly delete it!

Issue: LEMS-4073

## Test plan:

:eyes: