### PR TITLE
Make `angleOffsetDeg` nullable

### DIFF
--- a/.changeset/fair-humans-yell.md
+++ b/.changeset/fair-humans-yell.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-core": patch
+---
+
+Make angleOffsetDeg nullable

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1120,7 +1120,7 @@ export type PerseusGraphTypeAngle = {
     /** Allow Reflex Angles if an "angle" type. default: true */
     allowReflexAngles?: boolean;
     /** The angle offset in degrees if an "angle" type. default: 0 */
-    angleOffsetDeg?: number;
+    angleOffsetDeg: number;
     /** Snap to degree increments if an "angle" type. default: 1 */
     snapDegrees?: number;
     /** How to match the answer. If missing, defaults to exact matching. */

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1120,7 +1120,7 @@ export type PerseusGraphTypeAngle = {
     /** Allow Reflex Angles if an "angle" type. default: true */
     allowReflexAngles?: boolean;
     /** The angle offset in degrees if an "angle" type. default: 0 */
-    angleOffsetDeg: number;
+    angleOffsetDeg?: number | null;
     /** Snap to degree increments if an "angle" type. default: 1 */
     snapDegrees?: number;
     /** How to match the answer. If missing, defaults to exact matching. */

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -30,7 +30,7 @@ const parsePerseusGraphTypeAngle = object({
     type: constant("angle"),
     showAngles: optional(boolean),
     allowReflexAngles: optional(boolean),
-    angleOffsetDeg: optional(number),
+    angleOffsetDeg: defaulted(number, () => 0),
     snapDegrees: optional(number),
     match: optional(constant("congruent")),
     coords: optional(trio(pairOfNumbers, pairOfNumbers, pairOfNumbers)),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -30,7 +30,7 @@ const parsePerseusGraphTypeAngle = object({
     type: constant("angle"),
     showAngles: optional(boolean),
     allowReflexAngles: optional(boolean),
-    angleOffsetDeg: defaulted(number, () => 0),
+    angleOffsetDeg: optional(nullable(number)),
     snapDegrees: optional(number),
     match: optional(constant("congruent")),
     coords: optional(trio(pairOfNumbers, pairOfNumbers, pairOfNumbers)),

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -6273,6 +6273,235 @@ Next, we'll look at some other representations of functions!",
 }
 `;
 
+exports[`parseAndMigratePerseusItem given interactive-graph-angle-offset-deg-null.ts returns the same result as before 1`] = `
+{
+  "answerArea": {
+    "calculator": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTimeToPayOff": false,
+    "financialCalculatorTotalAmount": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+  },
+  "hints": [],
+  "question": {
+    "content": "**Construct a $130^\\circ$ angle.**
+
+[[☃ interactive-graph 1]]
+
+
+",
+    "images": {
+      "https://ka-perseus-images.s3.amazonaws.com/02564832cdaa56aa507437df41dd13e1fefbe595.png": {
+        "height": 160,
+        "width": 398,
+      },
+      "https://ka-perseus-images.s3.amazonaws.com/37521922ea42bbbf67622075e1ea51e095f37479.png": {
+        "height": 291,
+        "width": 401,
+      },
+    },
+    "widgets": {
+      "interactive-graph 1": {
+        "alignment": "default",
+        "graded": true,
+        "options": {
+          "backgroundImage": {
+            "bottom": 0,
+            "left": 0,
+            "scale": 1,
+            "url": null,
+          },
+          "correct": {
+            "allowReflexAngles": false,
+            "angleOffsetDeg": 0,
+            "coords": [
+              [
+                6.322005947128351,
+                -9,
+              ],
+              [
+                0,
+                -9,
+              ],
+              [
+                -4.937270536554472,
+                -3.1159901004516657,
+              ],
+            ],
+            "match": "congruent",
+            "showAngles": false,
+            "snapDegrees": 5,
+            "type": "angle",
+          },
+          "graph": {
+            "allowReflexAngles": false,
+            "angleOffsetDeg": 0,
+            "showAngles": false,
+            "snapDegrees": 5,
+            "startCoords": [
+              [
+                7,
+                -9,
+              ],
+              [
+                0,
+                -9,
+              ],
+              [
+                7,
+                -7.60585899672032,
+              ],
+            ],
+            "type": "angle",
+          },
+          "labelLocation": "onAxis",
+          "labels": [
+            "x",
+            "y",
+          ],
+          "lockedFigures": [],
+          "markings": "none",
+          "range": [
+            [
+              -10,
+              10,
+            ],
+            [
+              -10,
+              10,
+            ],
+          ],
+          "showAxisArrows": {
+            "xMax": true,
+            "xMin": true,
+            "yMax": true,
+            "yMin": true,
+          },
+          "showProtractor": true,
+          "showTooltips": false,
+          "step": [
+            1,
+            1,
+          ],
+        },
+        "static": false,
+        "type": "interactive-graph",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`parseAndMigratePerseusItem given interactive-graph-angle-offset-deg-null.ts returns the same result as before with answer information removed 1`] = `
+{
+  "answerArea": {
+    "calculator": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTimeToPayOff": false,
+    "financialCalculatorTotalAmount": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+  },
+  "hints": [],
+  "question": {
+    "content": "**Construct a $130^\\circ$ angle.**
+
+[[☃ interactive-graph 1]]
+
+
+",
+    "images": {
+      "https://ka-perseus-images.s3.amazonaws.com/02564832cdaa56aa507437df41dd13e1fefbe595.png": {
+        "height": 160,
+        "width": 398,
+      },
+      "https://ka-perseus-images.s3.amazonaws.com/37521922ea42bbbf67622075e1ea51e095f37479.png": {
+        "height": 291,
+        "width": 401,
+      },
+    },
+    "widgets": {
+      "interactive-graph 1": {
+        "alignment": "default",
+        "graded": true,
+        "options": {
+          "backgroundImage": {
+            "bottom": 0,
+            "left": 0,
+            "scale": 1,
+            "url": null,
+          },
+          "correct": {
+            "type": "linear",
+          },
+          "graph": {
+            "allowReflexAngles": false,
+            "angleOffsetDeg": 0,
+            "showAngles": false,
+            "snapDegrees": 5,
+            "startCoords": [
+              [
+                7,
+                -9,
+              ],
+              [
+                0,
+                -9,
+              ],
+              [
+                7,
+                -7.60585899672032,
+              ],
+            ],
+            "type": "angle",
+          },
+          "labelLocation": "onAxis",
+          "labels": [
+            "x",
+            "y",
+          ],
+          "lockedFigures": [],
+          "markings": "none",
+          "range": [
+            [
+              -10,
+              10,
+            ],
+            [
+              -10,
+              10,
+            ],
+          ],
+          "showAxisArrows": {
+            "xMax": true,
+            "xMin": true,
+            "yMax": true,
+            "yMin": true,
+          },
+          "showProtractor": true,
+          "showTooltips": false,
+          "step": [
+            1,
+            1,
+          ],
+        },
+        "static": false,
+        "type": "interactive-graph",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`parseAndMigratePerseusItem given interactive-graph-backgroundImage-with-empty-string-coordinates.ts returns the same result as before 1`] = `
 {
   "answerArea": {
@@ -20448,6 +20677,7 @@ exports[`parseAndMigrateUserInputMap given the data from input-number.ts returns
 exports[`parseAndMigrateUserInputMap given the data from interactive-graph.ts returns the same result as before 1`] = `
 {
   "interactive-graph 1": {
+    "angleOffsetDeg": 0,
     "type": "angle",
   },
   "interactive-graph 10": {

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -6314,7 +6314,7 @@ exports[`parseAndMigratePerseusItem given interactive-graph-angle-offset-deg-nul
           },
           "correct": {
             "allowReflexAngles": false,
-            "angleOffsetDeg": 0,
+            "angleOffsetDeg": null,
             "coords": [
               [
                 6.322005947128351,
@@ -6336,7 +6336,7 @@ exports[`parseAndMigratePerseusItem given interactive-graph-angle-offset-deg-nul
           },
           "graph": {
             "allowReflexAngles": false,
-            "angleOffsetDeg": 0,
+            "angleOffsetDeg": null,
             "showAngles": false,
             "snapDegrees": 5,
             "startCoords": [
@@ -6441,7 +6441,7 @@ exports[`parseAndMigratePerseusItem given interactive-graph-angle-offset-deg-nul
           },
           "graph": {
             "allowReflexAngles": false,
-            "angleOffsetDeg": 0,
+            "angleOffsetDeg": null,
             "showAngles": false,
             "snapDegrees": 5,
             "startCoords": [
@@ -20677,7 +20677,6 @@ exports[`parseAndMigrateUserInputMap given the data from input-number.ts returns
 exports[`parseAndMigrateUserInputMap given the data from interactive-graph.ts returns the same result as before 1`] = `
 {
   "interactive-graph 1": {
-    "angleOffsetDeg": 0,
     "type": "angle",
   },
   "interactive-graph 10": {

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/interactive-graph-angle-offset-deg-null.ts
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/interactive-graph-angle-offset-deg-null.ts
@@ -1,0 +1,98 @@
+// WARNING: Do not change or delete this file! If you do, Perseus might become
+// unable to parse the current data format, which will break clients.
+// If you need to add more regression tests, add a new file to this directory.
+export default {
+    question: {
+        content:
+            "**Construct a $130^\\circ$ angle.**\n\n[[☃ interactive-graph 1]]\n\n\n",
+        images: {
+            "https://ka-perseus-images.s3.amazonaws.com/02564832cdaa56aa507437df41dd13e1fefbe595.png":
+                {
+                    height: 160,
+                    width: 398,
+                },
+            "https://ka-perseus-images.s3.amazonaws.com/37521922ea42bbbf67622075e1ea51e095f37479.png":
+                {
+                    height: 291,
+                    width: 401,
+                },
+        },
+        widgets: {
+            "interactive-graph 1": {
+                type: "interactive-graph",
+                alignment: "default",
+                static: false,
+                graded: true,
+                options: {
+                    step: [1, 1],
+                    backgroundImage: {
+                        bottom: 0,
+                        left: 0,
+                        scale: 1,
+                        url: null,
+                    },
+                    markings: "none",
+                    labels: ["x", "y"],
+                    labelLocation: "onAxis",
+                    showProtractor: true,
+                    showTooltips: false,
+                    range: [
+                        [-10, 10],
+                        [-10, 10],
+                    ],
+                    showAxisArrows: {
+                        xMin: true,
+                        xMax: true,
+                        yMin: true,
+                        yMax: true,
+                    },
+                    lockedFigures: [],
+                    graph: {
+                        type: "angle",
+                        startCoords: [
+                            [7, -9],
+                            [0, -9],
+                            [7, -7.60585899672032],
+                        ],
+                        allowReflexAngles: false,
+                        angleOffsetDeg: null,
+                        showAngles: false,
+                        snapDegrees: 5,
+                    },
+                    correct: {
+                        coords: [
+                            [6.322005947128351, -9],
+                            [0, -9],
+                            [-4.937270536554472, -3.1159901004516657],
+                        ],
+                        match: "congruent",
+                        showAngles: false,
+                        snapDegrees: 5,
+                        type: "angle",
+                        hasBeenInteractedWith: true,
+                        range: [
+                            [-10, 10],
+                            [-10, 10],
+                        ],
+                        snapStep: [0.5, 0.5],
+                        angleOffsetDeg: null,
+                        allowReflexAngles: false,
+                    },
+                },
+                version: {
+                    major: 0,
+                    minor: 0,
+                },
+            },
+        },
+    },
+    answerArea: {
+        calculator: false,
+        financialCalculatorMonthlyPayment: false,
+        financialCalculatorTotalAmount: false,
+        financialCalculatorTimeToPayOff: false,
+        periodicTable: false,
+        periodicTableWithKey: false,
+    },
+    hints: [],
+};

--- a/packages/perseus/src/widget-ai-utils/interactive-graph/interactive-graph-ai-utils.ts
+++ b/packages/perseus/src/widget-ai-utils/interactive-graph/interactive-graph-ai-utils.ts
@@ -10,7 +10,7 @@ type CollinearTuple = readonly [Coord, Coord];
 
 type AngleGraphOptions = {
     type: "angle";
-    angleOffsetDegrees: number | undefined;
+    angleOffsetDegrees?: number | null;
     startCoords?: readonly [Coord, Coord, Coord];
 };
 
@@ -113,7 +113,7 @@ type GraphOptions =
 
 type AngleUserInput = {
     coords?: readonly [Coord, Coord, Coord];
-    angleOffsetDegrees?: number;
+    angleOffsetDegrees?: number | null;
 };
 
 type CircleUserInput = {

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
@@ -127,7 +127,7 @@ export function initializeGraphState(
                 type: graph.type,
                 showAngles: Boolean(graph.showAngles),
                 coords: getAngleCoords({graph, range, step}),
-                angleOffsetDeg: Number(graph.angleOffsetDeg),
+                angleOffsetDeg: graph.angleOffsetDeg,
                 allowReflexAngles: Boolean(graph.allowReflexAngles),
                 snapDegrees: Number(graph.snapDegrees),
             };

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
@@ -127,7 +127,7 @@ export function initializeGraphState(
                 type: graph.type,
                 showAngles: Boolean(graph.showAngles),
                 coords: getAngleCoords({graph, range, step}),
-                angleOffsetDeg: graph.angleOffsetDeg,
+                angleOffsetDeg: graph.angleOffsetDeg ?? 0,
                 allowReflexAngles: Boolean(graph.allowReflexAngles),
                 snapDegrees: Number(graph.snapDegrees),
             };

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -1136,7 +1136,7 @@ function boundAndSnapAngleEndPoints(
         range: [Interval, Interval];
         coords: Coord[];
         snapDegrees?: number;
-        angleOffsetDeg?: number;
+        angleOffsetDeg?: number | null;
         snapStep: vec.Vector2;
     },
     index: number,

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -158,7 +158,7 @@ export interface AngleGraphState extends InteractiveGraphStateCommon {
     // Allow Reflex Angles if an "angle" type.  default: false
     allowReflexAngles?: boolean;
     // The angle offset in degrees if an "angle" type. default: 0
-    angleOffsetDeg?: number;
+    angleOffsetDeg?: number | null;
     // Snap to degree increments if an "angle" type. default: 1
     snapDegrees?: number;
     // must have 3 coords - ie [Coord, Coord, Coord]


### PR DESCRIPTION
## Summary:
We received `angleOffsetDeg: null` which made the parser made. This PR allows the parser to accept null for `angleOffsetDeg`.

See: https://khanacademy.slack.com/archives/CJDRXTGQ7/p1777927558183819

I don't really understand `angleOffsetDeg`. It doesn't get set directly in the editor and it seems to default to 0 everywhere that it's used: `The angle offset in degrees if an "angle" type. default: 0`. Somehow content was created where it was `null` but that's considered invalid by the parser, which is why we got this report from CP.

The proposed solution is to let `angleOffsetDeg` be `null` in the parser.