### PR TITLE
[Preview NG] Add PreviewWithIframe component

### DIFF
--- a/.changeset/bold-mountains-rise.md
+++ b/.changeset/bold-mountains-rise.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Add `PreviewWithIframe` (to replace legacy `IframeContentRenderer`), a new functional component that uses the typed `usePreviewController` postMessage protocol.

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -92,7 +92,6 @@ describe("PreviewWithIframe", () => {
             data: {
                 item: {
                     question: {content: "Q", widgets: {}, images: {}},
-                    answerArea: {calculator: false} as any,
                     hints: [],
                 },
                 apiOptions: {},
@@ -124,7 +123,6 @@ describe("PreviewWithIframe", () => {
             data: {
                 item: {
                     question: {content: "Q", widgets: {}, images: {}},
-                    answerArea: {calculator: false} as any,
                     hints: [],
                 },
                 apiOptions: {},

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -36,58 +36,37 @@ describe("PreviewWithIframe", () => {
         expect(iframe).toBeInTheDocument();
         expect(iframe).toHaveAttribute("src", "/preview");
     });
+    it.each([true, false])(
+        "sets data-mobile attribute isMobile is set",
+        (isMobile: boolean) => {
+            render(
+                <PreviewWithIframe
+                    url="/preview"
+                    isMobile={isMobile}
+                    seamless={false}
+                />,
+            );
 
-    it("sets data-mobile to 'true' when isMobile is true", () => {
-        render(
-            <PreviewWithIframe
-                url="/preview"
-                isMobile={true}
-                seamless={false}
-            />,
-        );
+            const iframe = screen.getByTitle(/perseus-preview/);
+            expect(iframe.dataset.mobile).toBe(isMobile.toString());
+        },
+    );
 
-        const iframe = screen.getByTitle(/perseus-preview/);
-        expect(iframe.dataset.mobile).toBe("true");
-    });
+    it.each([true, false])(
+        "sets data-lint-gutter attribute when seamless is provided",
+        (seamless: boolean) => {
+            render(
+                <PreviewWithIframe
+                    url="/preview"
+                    isMobile={false}
+                    seamless={seamless}
+                />,
+            );
 
-    it("sets data-mobile to 'false' when isMobile is false", () => {
-        render(
-            <PreviewWithIframe
-                url="/preview"
-                isMobile={false}
-                seamless={false}
-            />,
-        );
-
-        const iframe = screen.getByTitle(/perseus-preview/);
-        expect(iframe.dataset.mobile).toBe("false");
-    });
-
-    it("sets data-lint-gutter to 'true' when seamless is true", () => {
-        render(
-            <PreviewWithIframe
-                url="/preview"
-                isMobile={false}
-                seamless={true}
-            />,
-        );
-
-        const iframe = screen.getByTitle(/perseus-preview/);
-        expect(iframe.dataset.lintGutter).toBe("true");
-    });
-
-    it("sets data-lint-gutter to 'false' when seamless is false", () => {
-        render(
-            <PreviewWithIframe
-                url="/preview"
-                isMobile={false}
-                seamless={false}
-            />,
-        );
-
-        const iframe = screen.getByTitle(/perseus-preview/);
-        expect(iframe.dataset.lintGutter).toBe("false");
-    });
+            const iframe = screen.getByTitle(/perseus-preview/);
+            expect(iframe.dataset.lintGutter).toBe(seamless.toString());
+        },
+    );
 
     it("delegates sendNewData to usePreviewController's sendData via ref", () => {
         const ref = React.createRef<PreviewWithIframeRef>();
@@ -115,7 +94,6 @@ describe("PreviewWithIframe", () => {
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
-                    paths: [],
                     stack: [],
                 },
             },

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -153,31 +153,4 @@ describe("PreviewWithIframe", () => {
         const div = screen.getByTestId("preview-with-iframe-container");
         expect(div.style.height).toBe("500px");
     });
-
-    it("assigns unique iframe IDs across instances", () => {
-        const {unmount} = render(
-            <PreviewWithIframe
-                url="/preview"
-                isMobile={false}
-                seamless={false}
-            />,
-        );
-
-        const iframe1 = screen.getByTitle(/perseus-preview/);
-        const id1 = iframe1.dataset.id;
-        unmount();
-
-        render(
-            <PreviewWithIframe
-                url="/preview"
-                isMobile={false}
-                seamless={false}
-            />,
-        );
-
-        const iframe2 = screen.getByTitle(/perseus-preview/);
-        const id2 = iframe2.dataset.id;
-
-        expect(id1).not.toBe(id2);
-    });
 });

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -86,7 +86,7 @@ describe("PreviewWithIframe", () => {
         },
     );
 
-    it("sends content using usePreviewController's sendData", () => {
+    it("sends data again when the content prop changes", () => {
         const data: PreviewContent = {
             type: "question",
             data: {

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -1,10 +1,11 @@
+import {ApiOptions} from "@khanacademy/perseus";
 import {render, screen} from "@testing-library/react";
 import * as React from "react";
 
 import PreviewWithIframe from "./preview-with-iframe";
+import {clone} from "./testing/object-utils";
 
 import type {PreviewContent} from "./preview/message-types";
-import type {PreviewWithIframeRef} from "./preview-with-iframe";
 
 const mockSendData = jest.fn();
 let mockHeight: number | null = null;
@@ -15,6 +16,21 @@ jest.mock("./preview/use-preview-controller", () => ({
         height: mockHeight,
     }),
 }));
+
+function buildArticleContent(): PreviewContent {
+    return {
+        type: "article",
+        data: {
+            apiOptions: ApiOptions.defaults,
+            json: {content: "Hello", widgets: {}, images: {}},
+            linterContext: {
+                contentType: "article",
+                highlightLint: false,
+                stack: [],
+            },
+        },
+    };
+}
 
 describe("PreviewWithIframe", () => {
     beforeEach(() => {
@@ -27,6 +43,7 @@ describe("PreviewWithIframe", () => {
                 url="/preview"
                 isMobile={false}
                 seamless={false}
+                content={buildArticleContent()}
             />,
         );
 
@@ -43,6 +60,7 @@ describe("PreviewWithIframe", () => {
                     url="/preview"
                     isMobile={isMobile}
                     seamless={false}
+                    content={buildArticleContent()}
                 />,
             );
 
@@ -59,6 +77,7 @@ describe("PreviewWithIframe", () => {
                     url="/preview"
                     isMobile={false}
                     seamless={seamless}
+                    content={buildArticleContent()}
                 />,
             );
 
@@ -67,18 +86,7 @@ describe("PreviewWithIframe", () => {
         },
     );
 
-    it("delegates sendNewData to usePreviewController's sendData via ref", () => {
-        const ref = React.createRef<PreviewWithIframeRef>();
-
-        render(
-            <PreviewWithIframe
-                ref={ref}
-                url="/preview"
-                isMobile={false}
-                seamless={false}
-            />,
-        );
-
+    it("sends content using usePreviewController's sendData", () => {
         const data: PreviewContent = {
             type: "question",
             data: {
@@ -98,10 +106,61 @@ describe("PreviewWithIframe", () => {
             },
         };
 
-        invariant(ref.current);
-        ref.current.sendNewData(data);
+        render(
+            <PreviewWithIframe
+                url="/preview"
+                isMobile={false}
+                seamless={false}
+                content={data}
+            />,
+        );
 
         expect(mockSendData).toHaveBeenCalledWith(data);
+    });
+
+    it("sends content using usePreviewController's sendData", () => {
+        const content: PreviewContent = {
+            type: "question",
+            data: {
+                item: {
+                    question: {content: "Q", widgets: {}, images: {}},
+                    answerArea: {calculator: false} as any,
+                    hints: [],
+                },
+                apiOptions: {},
+                device: "desktop",
+                initialHintsVisible: 0,
+                linterContext: {
+                    contentType: "exercise",
+                    highlightLint: false,
+                    stack: [],
+                },
+            },
+        };
+
+        const {rerender} = render(
+            <PreviewWithIframe
+                url="/preview"
+                isMobile={false}
+                seamless={false}
+                content={content}
+            />,
+        );
+
+        const modifiedContent = clone(content);
+        modifiedContent.data.item.question.content = "Abc";
+
+        // Act
+        rerender(
+            <PreviewWithIframe
+                url="/preview"
+                isMobile={false}
+                seamless={false}
+                content={modifiedContent}
+            />,
+        );
+
+        expect(mockSendData).toHaveBeenCalledWith(modifiedContent);
     });
 
     it("sets container height to '100%' when seamless is false", () => {
@@ -110,6 +169,7 @@ describe("PreviewWithIframe", () => {
                 url="/preview"
                 isMobile={false}
                 seamless={false}
+                content={buildArticleContent()}
             />,
         );
 
@@ -125,6 +185,7 @@ describe("PreviewWithIframe", () => {
                 url="/preview"
                 isMobile={false}
                 seamless={true}
+                content={buildArticleContent()}
             />,
         );
 

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -6,7 +6,6 @@ import PreviewWithIframe from "./preview-with-iframe";
 import type {PreviewContent} from "./preview/message-types";
 import type {PreviewWithIframeRef} from "./preview-with-iframe";
 
-// Mock usePreviewController so we can control its behavior
 const mockSendData = jest.fn();
 let mockHeight: number | null = null;
 
@@ -90,6 +89,7 @@ describe("PreviewWithIframe", () => {
                 },
                 apiOptions: {},
                 device: "desktop",
+                initialHintsVisible: 0,
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -98,7 +98,8 @@ describe("PreviewWithIframe", () => {
             },
         };
 
-        ref.current?.sendNewData(data);
+        invariant(ref.current);
+        ref.current.sendNewData(data);
 
         expect(mockSendData).toHaveBeenCalledWith(data);
     });

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -89,7 +89,6 @@ describe("PreviewWithIframe", () => {
                     hints: [],
                 },
                 apiOptions: {},
-                initialHintsVisible: 0,
                 device: "desktop",
                 linterContext: {
                     contentType: "exercise",

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -1,0 +1,183 @@
+import {render, screen} from "@testing-library/react";
+import * as React from "react";
+
+import PreviewWithIframe from "./preview-with-iframe";
+
+import type {PreviewContent} from "./preview/message-types";
+import type {PreviewWithIframeRef} from "./preview-with-iframe";
+
+// Mock usePreviewController so we can control its behavior
+const mockSendData = jest.fn();
+let mockHeight: number | null = null;
+
+jest.mock("./preview/use-preview-controller", () => ({
+    usePreviewController: () => ({
+        sendData: mockSendData,
+        height: mockHeight,
+    }),
+}));
+
+describe("PreviewWithIframe", () => {
+    beforeEach(() => {
+        mockSendData.mockClear();
+        mockHeight = null;
+    });
+
+    it("renders an iframe with the given URL", () => {
+        render(
+            <PreviewWithIframe
+                url="/preview"
+                isMobile={false}
+                seamless={false}
+            />,
+        );
+
+        const iframe = screen.getByTitle(/perseus-preview/);
+        expect(iframe).toBeInTheDocument();
+        expect(iframe).toHaveAttribute("src", "/preview");
+    });
+
+    it("sets data-mobile to 'true' when isMobile is true", () => {
+        render(
+            <PreviewWithIframe
+                url="/preview"
+                isMobile={true}
+                seamless={false}
+            />,
+        );
+
+        const iframe = screen.getByTitle(/perseus-preview/);
+        expect(iframe.dataset.mobile).toBe("true");
+    });
+
+    it("sets data-mobile to 'false' when isMobile is false", () => {
+        render(
+            <PreviewWithIframe
+                url="/preview"
+                isMobile={false}
+                seamless={false}
+            />,
+        );
+
+        const iframe = screen.getByTitle(/perseus-preview/);
+        expect(iframe.dataset.mobile).toBe("false");
+    });
+
+    it("sets data-lint-gutter to 'true' when seamless is true", () => {
+        render(
+            <PreviewWithIframe
+                url="/preview"
+                isMobile={false}
+                seamless={true}
+            />,
+        );
+
+        const iframe = screen.getByTitle(/perseus-preview/);
+        expect(iframe.dataset.lintGutter).toBe("true");
+    });
+
+    it("sets data-lint-gutter to 'false' when seamless is false", () => {
+        render(
+            <PreviewWithIframe
+                url="/preview"
+                isMobile={false}
+                seamless={false}
+            />,
+        );
+
+        const iframe = screen.getByTitle(/perseus-preview/);
+        expect(iframe.dataset.lintGutter).toBe("false");
+    });
+
+    it("delegates sendNewData to usePreviewController's sendData via ref", () => {
+        const ref = React.createRef<PreviewWithIframeRef>();
+
+        render(
+            <PreviewWithIframe
+                ref={ref}
+                url="/preview"
+                isMobile={false}
+                seamless={false}
+            />,
+        );
+
+        const data: PreviewContent = {
+            type: "question",
+            data: {
+                item: {
+                    question: {content: "Q", widgets: {}, images: {}},
+                    answerArea: {calculator: false} as any,
+                    hints: [],
+                },
+                apiOptions: {},
+                initialHintsVisible: 0,
+                device: "desktop",
+                linterContext: {
+                    contentType: "exercise",
+                    highlightLint: false,
+                    paths: [],
+                    stack: [],
+                },
+            },
+        };
+
+        ref.current?.sendNewData(data);
+
+        expect(mockSendData).toHaveBeenCalledWith(data);
+    });
+
+    it("sets container height to '100%' when seamless is false", () => {
+        render(
+            <PreviewWithIframe
+                url="/preview"
+                isMobile={false}
+                seamless={false}
+            />,
+        );
+
+        const div = screen.getByTestId("preview-with-iframe-container");
+        expect(div.style.height).toBe("100%");
+    });
+
+    it("sets container height from usePreviewController when seamless is true", () => {
+        mockHeight = 500;
+
+        render(
+            <PreviewWithIframe
+                url="/preview"
+                isMobile={false}
+                seamless={true}
+            />,
+        );
+
+        const div = screen.getByTestId("preview-with-iframe-container");
+        expect(div.style.height).toBe("500px");
+    });
+
+    it("assigns unique iframe IDs across instances", () => {
+        const {unmount} = render(
+            <PreviewWithIframe
+                url="/preview"
+                isMobile={false}
+                seamless={false}
+            />,
+        );
+
+        const iframe1 = screen.getByTitle(/perseus-preview/);
+        const id1 = iframe1.dataset.id;
+        unmount();
+
+        render(
+            <PreviewWithIframe
+                url="/preview"
+                isMobile={false}
+                seamless={false}
+            />,
+        );
+
+        const iframe2 = screen.getByTitle(/perseus-preview/);
+        const id2 = iframe2.dataset.id;
+
+        expect(id1).not.toBe(id2);
+    });
+});

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -26,7 +26,6 @@ function buildArticleContent(): PreviewContent {
             linterContext: {
                 contentType: "article",
                 highlightLint: false,
-                stack: [],
             },
         },
     };
@@ -100,7 +99,6 @@ describe("PreviewWithIframe", () => {
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
-                    stack: [],
                 },
             },
         };
@@ -131,7 +129,6 @@ describe("PreviewWithIframe", () => {
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
-                    stack: [],
                 },
             },
         };

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -19,7 +19,6 @@ jest.mock("./preview/use-preview-controller", () => ({
 
 describe("PreviewWithIframe", () => {
     beforeEach(() => {
-        mockSendData.mockClear();
         mockHeight = null;
     });
 
@@ -36,6 +35,7 @@ describe("PreviewWithIframe", () => {
         expect(iframe).toBeInTheDocument();
         expect(iframe).toHaveAttribute("src", "/preview");
     });
+
     it.each([true, false])(
         "sets data-mobile attribute isMobile is set",
         (isMobile: boolean) => {

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -36,7 +36,7 @@ describe("PreviewWithIframe", () => {
     });
 
     it.each([true, false])(
-        "sets data-mobile attribute isMobile is set",
+        "sets data-mobile attribute when isMobile is: %s",
         (isMobile: boolean) => {
             render(
                 <PreviewWithIframe
@@ -52,7 +52,7 @@ describe("PreviewWithIframe", () => {
     );
 
     it.each([true, false])(
-        "sets data-lint-gutter attribute when seamless is provided",
+        "sets data-lint-gutter attribute when seamless is: %s",
         (seamless: boolean) => {
             render(
                 <PreviewWithIframe

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -113,8 +113,8 @@ describe("PreviewWithIframe", () => {
             />,
         );
 
-        const div = screen.getByTestId("preview-with-iframe-container");
-        expect(div.style.height).toBe("100%");
+        const container = screen.getByTitle(/perseus-preview/);
+        expect(container.style.height).toBe("100%");
     });
 
     it("sets container height from usePreviewController when seamless is true", () => {
@@ -128,7 +128,7 @@ describe("PreviewWithIframe", () => {
             />,
         );
 
-        const div = screen.getByTestId("preview-with-iframe-container");
-        expect(div.style.height).toBe("500px");
+        const container = screen.getByTitle(/perseus-preview/);
+        expect(container.style.height).toBe("500px");
     });
 });

--- a/packages/perseus-editor/src/preview-with-iframe.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.tsx
@@ -36,7 +36,6 @@ export type PreviewWithIframeRef = {
 
 const PreviewWithIframe = React.forwardRef<PreviewWithIframeRef, Props>(
     (props, ref) => {
-        const containerRef = React.useRef<HTMLDivElement>(null);
         const iframeRef = React.useRef<HTMLIFrameElement>(null);
 
         const {sendData, height} = usePreviewController(iframeRef);
@@ -61,24 +60,18 @@ const PreviewWithIframe = React.forwardRef<PreviewWithIframeRef, Props>(
         }
 
         return (
-            <div
-                ref={containerRef}
-                data-testid="preview-with-iframe-container"
+            <iframe
+                ref={iframeRef}
+                title={`perseus-preview`}
+                data-mobile={props.isMobile ? "true" : "false"}
+                // The seamless prop is the same as the "nochrome" prop that
+                // gets passed to DeviceFramer. If it is set, then we're going
+                // to be displaying editor previews and want to leave some room
+                // for lint indicators in the right margin.
+                data-lint-gutter={props.seamless ? "true" : "false"}
                 style={{width: "100%", height: containerHeight}}
-            >
-                <iframe
-                    ref={iframeRef}
-                    title={`perseus-preview`}
-                    data-mobile={props.isMobile ? "true" : "false"}
-                    // The seamless prop is the same as the "nochrome" prop that
-                    // gets passed to DeviceFramer. If it is set, then we're going
-                    // to be displaying editor previews and want to leave some room
-                    // for lint indicators in the right margin.
-                    data-lint-gutter={props.seamless ? "true" : "false"}
-                    style={{width: "100%", height: "100%"}}
-                    src={props.url}
-                />
-            </div>
+                src={props.url}
+            />
         );
     },
 );

--- a/packages/perseus-editor/src/preview-with-iframe.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.tsx
@@ -39,19 +39,6 @@ const PreviewWithIframe = React.forwardRef<PreviewWithIframeRef, Props>(
 
         const {sendData, height} = usePreviewController(iframeRef);
 
-        // Update container height based on iframe content height
-        React.useEffect(() => {
-            if (!containerRef.current) {
-                return;
-            }
-
-            if (!props.seamless) {
-                containerRef.current.style.height = "100%";
-            } else if (height !== null) {
-                containerRef.current.style.height = `${height}px`;
-            }
-        }, [height, props.seamless]);
-
         // Expose sendNewData method via ref
         React.useImperativeHandle(
             ref,
@@ -63,11 +50,19 @@ const PreviewWithIframe = React.forwardRef<PreviewWithIframeRef, Props>(
             [sendData],
         );
 
+        // Update container height based on iframe content height
+        let containerHeight = "100%";
+        if (!props.seamless) {
+            containerHeight = "100%";
+        } else if (height !== null) {
+            containerHeight = `${height}px`;
+        }
+
         return (
             <div
                 ref={containerRef}
                 data-testid="preview-with-iframe-container"
-                style={{width: "100%", height: "100%"}}
+                style={{width: "100%", height: containerHeight}}
             >
                 <iframe
                     ref={iframeRef}

--- a/packages/perseus-editor/src/preview-with-iframe.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import {isEqual} from "underscore";
 
 import {usePreviewController} from "./preview/use-preview-controller";
 
@@ -46,6 +47,11 @@ function PreviewWithIframe(props: Props) {
 
     const {sendData, height} = usePreviewController(iframeRef);
 
+    // NOTE: The `props.content` is an object and will trigger a re-render of
+    // this component any time its identity changes (regardless of whether it
+    // _actually_ changed). This matches previous behavior from the old
+    // IframeContentRenderer. If performance becomes an issue, we can look at
+    // using React.memo() on this component or some other performance fix.
     React.useEffect(() => {
         sendData(props.content);
     }, [sendData, props.content]);

--- a/packages/perseus-editor/src/preview-with-iframe.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.tsx
@@ -51,13 +51,10 @@ const PreviewWithIframe = React.forwardRef<PreviewWithIframeRef, Props>(
             [sendData],
         );
 
-        // Update container height based on iframe content height
-        let containerHeight = "100%";
-        if (!props.seamless) {
-            containerHeight = "100%";
-        } else if (height !== null) {
-            containerHeight = `${height}px`;
-        }
+        // Update container height based on iframe content height if we're in
+        // seamless mode.
+        const containerHeight =
+            props.seamless && height != null ? `${height}px` : "100%";
 
         return (
             <iframe

--- a/packages/perseus-editor/src/preview-with-iframe.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.tsx
@@ -1,16 +1,18 @@
 /**
- * Displays the given content in an iframe, isolating it from the parent page.
+ * Displays content in an iframe, isolating it from the parent page and
+ * triggering rendering mobile, if needed.
  *
  * To simulate the environment of content rendered by itself, content previews
- * are rendered inside iframes, where components such as the math keypad work
- * because the body of the document is not the body of the editor. To make this
- * work, this component renders an iframe and communicates with it via the
- * structured `usePreviewController` postMessage protocol.
+ * are rendered inside iframes, where components such as the math keypad and
+ * mobile breakpoints based on media queries work (because the body of the
+ * document is not the body of the editor. To make this work, this component
+ * renders an iframe and communicates with it via the `usePreviewController`
+ * hook and its use of postMessage.
  *
- * This is the new preview iframe component, intended to replace
- * `IframeContentRenderer` once all editors have migrated. It exists alongside
- * the legacy component so that consumers (e.g. khan/frontend's devadmin) can
- * keep using `IframeContentRenderer` until the atomic flip ships.
+ * This is the new preview iframe component, replaces `IframeContentRenderer`
+ * once all editors have migrated. It exists alongside the legacy component so
+ * that consumers can keep using `IframeContentRenderer` until they are all
+ * ported over.
  */
 import * as React from "react";
 

--- a/packages/perseus-editor/src/preview-with-iframe.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.tsx
@@ -1,19 +1,3 @@
-/**
- * Displays content in an iframe, isolating it from the parent page and
- * triggering rendering mobile, if needed.
- *
- * To simulate the environment of content rendered by itself, content previews
- * are rendered inside iframes, where components such as the math keypad and
- * mobile breakpoints based on media queries work (because the body of the
- * document is not the body of the editor. To make this work, this component
- * renders an iframe and communicates with it via the `usePreviewController`
- * hook and its use of postMessage.
- *
- * This is the new preview iframe component, replaces `IframeContentRenderer`
- * once all editors have migrated. It exists alongside the legacy component so
- * that consumers can keep using `IframeContentRenderer` until they are all
- * ported over.
- */
 import * as React from "react";
 
 import {usePreviewController} from "./preview/use-preview-controller";
@@ -34,50 +18,58 @@ type Props = {
      * prevent scrolling inside the iframe.
      */
     seamless: boolean;
+
+    /**
+     * The content to render in the preview area.
+     */
+    content: PreviewContent;
 };
 
-export type PreviewWithIframeRef = {
-    sendNewData: (data: PreviewContent) => void;
-};
+/**
+ * Displays content in an iframe, isolating it from the parent page and
+ * switches to rendering for mobile, if needed.
+ *
+ * To simulate the environment of content rendered by itself, content previews
+ * are rendered inside iframes, where components such as the math keypad and
+ * mobile breakpoints based on media queries work (because the body of the
+ * document is not the body of the editor). To make this work, this component
+ * renders an iframe and communicates with it via the
+ * {@link usePreviewController} hook and its use of postMessage.
+ *
+ * This is the new preview iframe component, replacing `IframeContentRenderer`
+ * once all editors have migrated. It exists alongside the legacy component so
+ * that consumers can keep using `IframeContentRenderer` until they are all
+ * ported over.
+ */
+function PreviewWithIframe(props: Props) {
+    const iframeRef = React.useRef<HTMLIFrameElement>(null);
 
-const PreviewWithIframe = React.forwardRef<PreviewWithIframeRef, Props>(
-    (props, ref) => {
-        const iframeRef = React.useRef<HTMLIFrameElement>(null);
+    const {sendData, height} = usePreviewController(iframeRef);
 
-        const {sendData, height} = usePreviewController(iframeRef);
+    React.useEffect(() => {
+        sendData(props.content);
+    }, [sendData, props.content]);
 
-        // Expose sendNewData method via ref
-        React.useImperativeHandle(
-            ref,
-            () => ({
-                sendNewData: (data: PreviewContent) => {
-                    sendData(data);
-                },
-            }),
-            [sendData],
-        );
+    // Update container height based on iframe content height if we're in
+    // seamless mode.
+    const containerHeight =
+        props.seamless && height != null ? `${height}px` : "100%";
 
-        // Update container height based on iframe content height if we're in
-        // seamless mode.
-        const containerHeight =
-            props.seamless && height != null ? `${height}px` : "100%";
-
-        return (
-            <iframe
-                ref={iframeRef}
-                title={`perseus-preview`}
-                data-mobile={String(props.isMobile)}
-                // The seamless prop is the same as the "nochrome" prop that
-                // gets passed to DeviceFramer. If it is set, then we're going
-                // to be displaying editor previews and want to leave some room
-                // for lint indicators in the right margin.
-                data-lint-gutter={String(props.seamless)}
-                style={{width: "100%", height: containerHeight}}
-                src={props.url}
-            />
-        );
-    },
-);
+    return (
+        <iframe
+            ref={iframeRef}
+            title={`perseus-preview`}
+            data-mobile={String(props.isMobile)}
+            // The seamless prop is the same as the "nochrome" prop that
+            // gets passed to DeviceFramer. If it is set, then we're going
+            // to be displaying editor previews and want to leave some room
+            // for lint indicators in the right margin.
+            data-lint-gutter={String(props.seamless)}
+            style={{width: "100%", height: containerHeight}}
+            src={props.url}
+        />
+    );
+}
 
 PreviewWithIframe.displayName = "PreviewWithIframe";
 

--- a/packages/perseus-editor/src/preview-with-iframe.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.tsx
@@ -1,0 +1,96 @@
+/**
+ * Displays the given content in an iframe, isolating it from the parent page.
+ *
+ * To simulate the environment of content rendered by itself, content previews
+ * are rendered inside iframes, where components such as the math keypad work
+ * because the body of the document is not the body of the editor. To make this
+ * work, this component renders an iframe and communicates with it via the
+ * structured `usePreviewController` postMessage protocol.
+ *
+ * This is the new preview iframe component, intended to replace
+ * `IframeContentRenderer` once all editors have migrated. It exists alongside
+ * the legacy component so that consumers (e.g. khan/frontend's devadmin) can
+ * keep using `IframeContentRenderer` until the atomic flip ships.
+ */
+import * as React from "react";
+
+import {usePreviewController} from "./preview/use-preview-controller";
+
+import type {PreviewContent} from "./preview/message-types";
+
+let nextIframeID = 0;
+
+type Props = {
+    // The URL that the iframe should load
+    url: string;
+    // Whether the iframe should be displaying in mobile mode
+    isMobile: boolean;
+    // Whether to make the iframe's height match its content's height,
+    // used to prevent scrolling inside the iframe.
+    seamless: boolean;
+};
+
+export type PreviewWithIframeRef = {
+    sendNewData: (data: PreviewContent) => void;
+};
+
+const PreviewWithIframe = React.forwardRef<PreviewWithIframeRef, Props>(
+    (props, ref) => {
+        const containerRef = React.useRef<HTMLDivElement>(null);
+        const iframeRef = React.useRef<HTMLIFrameElement>(null);
+        // ID is for debugging/logging, not routing (which uses event.source)
+        const [iframeId] = React.useState(() => String(nextIframeID++));
+
+        const {sendData, height} = usePreviewController(iframeRef);
+
+        // Update container height based on iframe content height
+        React.useEffect(() => {
+            if (!containerRef.current) {
+                return;
+            }
+
+            if (!props.seamless) {
+                containerRef.current.style.height = "100%";
+            } else if (height !== null) {
+                containerRef.current.style.height = `${height}px`;
+            }
+        }, [height, props.seamless]);
+
+        // Expose sendNewData method via ref
+        React.useImperativeHandle(
+            ref,
+            () => ({
+                sendNewData: (data: PreviewContent) => {
+                    sendData(data);
+                },
+            }),
+            [sendData],
+        );
+
+        return (
+            <div
+                ref={containerRef}
+                data-testid="preview-with-iframe-container"
+                style={{width: "100%", height: "100%"}}
+            >
+                <iframe
+                    ref={iframeRef}
+                    title={`perseus-preview-${iframeId}`}
+                    data-id={iframeId}
+                    data-mobile={props.isMobile ? "true" : "false"}
+                    // The seamless prop is the same as the "nochrome" prop that
+                    // gets passed to DeviceFramer. If it is set, then we're going
+                    // to be displaying editor previews and want to leave some room
+                    // for lint indicators in the right margin.
+                    data-lint-gutter={props.seamless ? "true" : "false"}
+                    style={{width: "100%", height: "100%"}}
+                    src={props.url}
+                />
+            </div>
+        );
+    },
+);
+
+PreviewWithIframe.displayName = "PreviewWithIframe";
+
+export default PreviewWithIframe;

--- a/packages/perseus-editor/src/preview-with-iframe.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import {isEqual} from "underscore";
 
 import {usePreviewController} from "./preview/use-preview-controller";
 

--- a/packages/perseus-editor/src/preview-with-iframe.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.tsx
@@ -21,12 +21,18 @@ import {usePreviewController} from "./preview/use-preview-controller";
 import type {PreviewContent} from "./preview/message-types";
 
 type Props = {
-    // The URL that the iframe should load
+    /**
+     * The URL that the iframe should load
+     */
     url: string;
-    // Whether the iframe should be displaying in mobile mode
+    /**
+     * Whether the iframe should be displaying in mobile mode
+     */
     isMobile: boolean;
-    // Whether to make the iframe's height match its content's height,
-    // used to prevent scrolling inside the iframe.
+    /**
+     * Whether to make the iframe's height match its content's height, used to
+     * prevent scrolling inside the iframe.
+     */
     seamless: boolean;
 };
 
@@ -60,12 +66,12 @@ const PreviewWithIframe = React.forwardRef<PreviewWithIframeRef, Props>(
             <iframe
                 ref={iframeRef}
                 title={`perseus-preview`}
-                data-mobile={props.isMobile ? "true" : "false"}
+                data-mobile={String(props.isMobile)}
                 // The seamless prop is the same as the "nochrome" prop that
                 // gets passed to DeviceFramer. If it is set, then we're going
                 // to be displaying editor previews and want to leave some room
                 // for lint indicators in the right margin.
-                data-lint-gutter={props.seamless ? "true" : "false"}
+                data-lint-gutter={String(props.seamless)}
                 style={{width: "100%", height: containerHeight}}
                 src={props.url}
             />

--- a/packages/perseus-editor/src/preview-with-iframe.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.tsx
@@ -18,8 +18,6 @@ import {usePreviewController} from "./preview/use-preview-controller";
 
 import type {PreviewContent} from "./preview/message-types";
 
-let nextIframeID = 0;
-
 type Props = {
     // The URL that the iframe should load
     url: string;
@@ -38,8 +36,6 @@ const PreviewWithIframe = React.forwardRef<PreviewWithIframeRef, Props>(
     (props, ref) => {
         const containerRef = React.useRef<HTMLDivElement>(null);
         const iframeRef = React.useRef<HTMLIFrameElement>(null);
-        // ID is for debugging/logging, not routing (which uses event.source)
-        const [iframeId] = React.useState(() => String(nextIframeID++));
 
         const {sendData, height} = usePreviewController(iframeRef);
 
@@ -75,8 +71,7 @@ const PreviewWithIframe = React.forwardRef<PreviewWithIframeRef, Props>(
             >
                 <iframe
                     ref={iframeRef}
-                    title={`perseus-preview-${iframeId}`}
-                    data-id={iframeId}
+                    title={`perseus-preview`}
                     data-mobile={props.isMobile ? "true" : "false"}
                     // The seamless prop is the same as the "nochrome" prop that
                     // gets passed to DeviceFramer. If it is set, then we're going


### PR DESCRIPTION
## Summary:

*This PR is part of a series building a typed, hook-based preview system for the Perseus editor. The new system replaces the untyped `window.iframeDataStore` + raw `postMessage(string)` communication with structured, validated message passing via `usePreviewController` and `usePreviewPresenter` hooks. The new system is being built alongside the old one — no existing behavior changes until the final PR in the series flips the switch.*

Previous PRs in this series:
- #3464
- #3467
- #3474
- #3492
- #3495
- #3499

---

Adds `PreviewWithIframe`, a new editor-side component that wraps a content preview iframe and communicates with it through `usePreviewController` and the typed postMessage protocol introduced earlier in this series (#3474, #3492, #3495, #3499). It's a component that the editor can use without needing to manage the iframe and controller hook directly. 

This PR is purely additive. It introduces a "spiritual successor" to the legacy `IframeContentRenderer`. No editor or preview page yet uses `PreviewWithIframe`; that flip happens in the next branch in the series, where the storybook preview page and all four editors switch over together. 

I chose to fork rather than rewrite `IframeContentRenderer` in place because `khan/frontend`'s devadmin imports the legacy component directly — rewriting in place would have required coordinating each Perseus PR with a frontend version bump. The fork lets the early Perseus PRs in this series land independently, and the legacy component will be deleted in a later cleanup pass once nothing imports it.

The long-term goal is to drop the iframe entirely once browser support for CSS `@container` queries reaches our floor; the `With*` suffix leaves room for a sibling `PreviewWithDiv` without renaming this one.

Issue: LEMS-3741

## Test plan:

- [x] `pnpm tsc`  - clean
- [x] `pnpm lint` - clean for the new files
- [x] `pnpm test`