### PR TITLE
[Interactive Graph] Remove some feature flags related to Interactive Graph Phase 2 (absolute value, tangent, logarithm, and exponent)

### DIFF
--- a/.changeset/lemon-trains-rest.md
+++ b/.changeset/lemon-trains-rest.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Remove some feature flags related to Interactive Graph Phase 2 (absolute value, tangent, logarithm, and exponent)

--- a/packages/perseus-core/src/feature-flags.ts
+++ b/packages/perseus-core/src/feature-flags.ts
@@ -13,10 +13,6 @@ const PerseusFeatureFlags = [
     "new-radio-widget", // TODO(LEMS-2994): clean up feature flag
     "image-widget-upgrade-gif-controls", // TODO(LEMS-3914): clean up feature flag
     "image-widget-upgrade-scale", // TODO(LEMS-3912): clean up feature flag
-    "interactive-graph-absolute-value", // TODO(LEMS-3976): clean up feature flag
-    "interactive-graph-tangent", // TODO(LEMS-3976): clean up feature flag
-    "interactive-graph-logarithm", // TODO(LEMS-3976): clean up feature flag
-    "interactive-graph-exponent", // TODO(LEMS-3976): clean up feature flag
     "interactive-graph-vector", // TODO(LEMS-3976): clean up feature flag
     "interactive-graph-not-scored", // TODO(LEMS-3976): clean up feature flag
 ] as const;

--- a/packages/perseus-editor/src/testing/feature-flags-util.ts
+++ b/packages/perseus-editor/src/testing/feature-flags-util.ts
@@ -6,10 +6,6 @@ const DEFAULT_FEATURE_FLAGS = {
     "new-radio-widget": false,
     "image-widget-upgrade-gif-controls": false,
     "image-widget-upgrade-scale": false,
-    "interactive-graph-absolute-value": false,
-    "interactive-graph-tangent": false,
-    "interactive-graph-logarithm": false,
-    "interactive-graph-exponent": false,
     "interactive-graph-vector": false,
     "interactive-graph-not-scored": false,
     // ...add new flags here

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
@@ -15,26 +15,6 @@ type GraphTypeSelectorProps = {
 
 const GraphTypeSelector = (props: GraphTypeSelectorProps) => {
     // TODO(LEMS-3976): clean up feature flag
-    const showExponential = isFeatureOn(
-        {apiOptions: props.apiOptions},
-        "interactive-graph-exponent",
-    );
-
-    const showAbsoluteValue = isFeatureOn(
-        {apiOptions: props.apiOptions},
-        "interactive-graph-absolute-value",
-    );
-
-    const showTangent = isFeatureOn(
-        {apiOptions: props.apiOptions},
-        "interactive-graph-tangent",
-    );
-
-    const showLogarithm = isFeatureOn(
-        {apiOptions: props.apiOptions},
-        "interactive-graph-logarithm",
-    );
-
     const showVector = isFeatureOn(
         {apiOptions: props.apiOptions},
         "interactive-graph-vector",
@@ -47,22 +27,14 @@ const GraphTypeSelector = (props: GraphTypeSelectorProps) => {
             placeholder="Select an answer type"
             style={styles.singleSelectShort}
         >
-            {showAbsoluteValue && (
-                <OptionItem value="absolute-value" label="Absolute value" />
-            )}
+            <OptionItem value="absolute-value" label="Absolute value" />
             <OptionItem value="none" label="None" />
             <OptionItem value="linear" label="Linear function" />
             <OptionItem value="quadratic" label="Quadratic function" />
             <OptionItem value="sinusoid" label="Sinusoid function" />
-            {showExponential && (
-                <OptionItem value="exponential" label="Exponential function" />
-            )}
-            {showTangent && (
-                <OptionItem value="tangent" label="Tangent function" />
-            )}
-            {showLogarithm && (
-                <OptionItem value="logarithm" label="Logarithm function" />
-            )}
+            <OptionItem value="exponential" label="Exponential function" />
+            <OptionItem value="tangent" label="Tangent function" />
+            <OptionItem value="logarithm" label="Logarithm function" />
             <OptionItem value="circle" label="Circle" />
             <OptionItem value="point" label="Point(s)" />
             <OptionItem value="linear-system" label="Linear System" />

--- a/packages/perseus/src/testing/feature-flags-util.ts
+++ b/packages/perseus/src/testing/feature-flags-util.ts
@@ -6,10 +6,6 @@ const DEFAULT_FEATURE_FLAGS = {
     "new-radio-widget": false,
     "image-widget-upgrade-gif-controls": false,
     "image-widget-upgrade-scale": false,
-    "interactive-graph-absolute-value": false,
-    "interactive-graph-tangent": false,
-    "interactive-graph-logarithm": false,
-    "interactive-graph-exponent": false,
     "interactive-graph-vector": false,
     "interactive-graph-not-scored": false,
     // ...add new flags here


### PR DESCRIPTION
## Summary:
Remove some feature flags related to Interactive Graph Phase 2 (absolute value, tangent, logarithm, and exponent)
Note: other feature flags will be done on a separate PR after the play test.

Issue: LEMS-3976

## Test plan: