### PR TITLE
[Preview NG] Migrate Perseus to the new preview system

### DIFF
--- a/.changeset/bright-cats-leap.md
+++ b/.changeset/bright-cats-leap.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-editor": major
+---
+
+Migrate Perseus to use the new preview system (`PreviewWithIframe` and
+`usePreviewController`).

--- a/.changeset/clever-doves-fly.md
+++ b/.changeset/clever-doves-fly.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": major
+---
+
+Replace deprecated `Changeable.ChangeableProps` / `ChangeHandler` with concrete typed `onChange` signatures on `Editor` and `ArticleEditor`. 

--- a/.changeset/happy-rivers-flow.md
+++ b/.changeset/happy-rivers-flow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Migrate storybook preview page from iframeDataStore to usePreviewPresenter hook

--- a/.changeset/happy-rivers-flow.md
+++ b/.changeset/happy-rivers-flow.md
@@ -1,5 +1,0 @@
----
-"@khanacademy/perseus-editor": patch
----
-
-Migrate storybook preview page from iframeDataStore to usePreviewPresenter hook

--- a/packages/perseus-editor/src/__tests__/hint-editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/hint-editor.test.tsx
@@ -21,7 +21,11 @@ describe("CombinedHintsEditor", () => {
 
     it("should render", () => {
         render(
-            <CombinedHintsEditor deviceType="phone" previewURL="about:blank" />,
+            <CombinedHintsEditor
+                deviceType="phone"
+                previewURL="about:blank"
+                highlightLint={false}
+            />,
         );
     });
 
@@ -32,6 +36,7 @@ describe("CombinedHintsEditor", () => {
             <CombinedHintsEditor
                 deviceType="phone"
                 previewURL="about:blank"
+                highlightLint={false}
                 hints={[
                     {content: "You know this one!", widgets: {}, images: {}},
                     {content: "Ok, the answer is 3", widgets: {}, images: {}},
@@ -54,6 +59,7 @@ describe("CombinedHintsEditor", () => {
             <CombinedHintsEditor
                 deviceType="phone"
                 previewURL="about:blank"
+                highlightLint={false}
                 hints={[
                     {content: "You know this one!", widgets: {}, images: {}},
                     {content: "Ok, the answer is 3", widgets: {}, images: {}},
@@ -77,6 +83,7 @@ describe("CombinedHintsEditor", () => {
             <CombinedHintsEditor
                 deviceType="phone"
                 previewURL="about:blank"
+                highlightLint={false}
                 hints={[
                     {content: "You know this one!", widgets: {}, images: {}},
                     {content: "Ok, the answer is 3", widgets: {}, images: {}},
@@ -100,6 +107,7 @@ describe("CombinedHintsEditor", () => {
                 deviceType="phone"
                 previewURL="about:blank"
                 apiOptions={{editingDisabled: true}}
+                highlightLint={false}
                 hints={[
                     {content: "You know this one!", widgets: {}, images: {}},
                 ]}

--- a/packages/perseus-editor/src/article-editor.tsx
+++ b/packages/perseus-editor/src/article-editor.tsx
@@ -32,7 +32,6 @@ import PreviewWithIframe from "./preview-with-iframe";
 import {detectTexErrors} from "./util/tex-error-detector";
 
 import type {Issue} from "./components/issues-panel";
-import type {PreviewWithIframeRef} from "./preview-with-iframe";
 import type {
     APIOptions,
     ImageUploader,
@@ -81,12 +80,8 @@ export default class ArticleEditor extends React.Component<Props, State> {
         issues: [],
     };
 
-    // Store refs for preview iframes (keyed by section index or "all")
-    private frameRefs: Record<string, PreviewWithIframeRef | null> = {};
-
     componentDidMount() {
         this._updateIssues();
-        this._updatePreviewFrames();
     }
 
     componentDidUpdate(prevProps: Props) {
@@ -94,8 +89,6 @@ export default class ArticleEditor extends React.Component<Props, State> {
         if (prevProps.json !== this.props.json) {
             this._updateIssues();
         }
-
-        this._updatePreviewFrames();
     }
 
     /**
@@ -103,13 +96,7 @@ export default class ArticleEditor extends React.Component<Props, State> {
      * Helper function to be used with componentDidMount and componentDidUpdate.
      */
     _updateIssues() {
-        // Get sections array
-        const sections: PerseusArticle =
-            this.props.json instanceof Array
-                ? this.props.json
-                : [this.props.json];
-
-        const issues = sections.map((section) => {
+        const issues = this._sections().map((section) => {
             const parsed = PerseusMarkdown.parse(section.content ?? "", {});
             const linterContext = {
                 content: section.content,
@@ -144,30 +131,6 @@ export default class ArticleEditor extends React.Component<Props, State> {
         });
 
         this.setState({issues});
-    }
-
-    _updatePreviewFrames() {
-        if (this.props.mode === "preview") {
-            const frameAll = this.frameRefs["all"];
-            if (frameAll) {
-                frameAll.sendNewData({
-                    type: "article-all",
-                    data: this._sections().map((section, i) =>
-                        this._previewDataForSection(section, i),
-                    ),
-                });
-            }
-        } else if (this.props.mode === "edit") {
-            this._sections().forEach((section, i) => {
-                const frame = this.frameRefs[String(i)];
-                if (frame) {
-                    frame.sendNewData({
-                        type: "article",
-                        data: this._previewDataForSection(section, i),
-                    });
-                }
-            });
-        }
     }
 
     _previewDataForSection(section: PerseusRenderer, sectionIndex: number) {
@@ -218,6 +181,7 @@ export default class ArticleEditor extends React.Component<Props, State> {
 
         const sections = this._sections();
         const editingDisabled = this.props.apiOptions?.editingDisabled ?? false;
+        const isMobile = this._isMobilePreview();
 
         return (
             <div className="perseus-editor-table">
@@ -309,7 +273,24 @@ export default class ArticleEditor extends React.Component<Props, State> {
                                 </div>
 
                                 <div className="editor-preview">
-                                    {this._renderIframePreview(i, true)}
+                                    <DeviceFramer
+                                        deviceType={this.props.screen}
+                                        nochrome={true}
+                                    >
+                                        <PreviewWithIframe
+                                            key={`${String(i)}-${this.props.screen}`}
+                                            isMobile={isMobile}
+                                            seamless={true}
+                                            url={this.props.previewURL}
+                                            content={{
+                                                type: "article" as const,
+                                                data: this._previewDataForSection(
+                                                    section,
+                                                    i,
+                                                ),
+                                            }}
+                                        />
+                                    </DeviceFramer>
                                 </div>
                             </fieldset>
                         </div>,
@@ -361,32 +342,23 @@ export default class ArticleEditor extends React.Component<Props, State> {
         );
     }
 
-    _renderIframePreview(
-        i: number | string,
-        nochrome: boolean,
-    ): React.ReactElement<any> {
-        const isMobile =
-            this.props.screen === "phone" || this.props.screen === "tablet";
-
-        return (
-            <DeviceFramer deviceType={this.props.screen} nochrome={nochrome}>
-                <PreviewWithIframe
-                    ref={(node) => {
-                        this.frameRefs[String(i)] = node;
-                    }}
-                    key={this.props.screen}
-                    isMobile={isMobile}
-                    seamless={nochrome}
-                    url={this.props.previewURL}
-                />
-            </DeviceFramer>
-        );
-    }
-
     _renderPreviewMode(): React.ReactElement<React.ComponentProps<"div">> {
         return (
             <div className="standalone-preview">
-                {this._renderIframePreview("all", false)}
+                <DeviceFramer deviceType={this.props.screen} nochrome={false}>
+                    <PreviewWithIframe
+                        key={`all-${this.props.screen}`}
+                        isMobile={this._isMobilePreview()}
+                        seamless={false}
+                        url={this.props.previewURL}
+                        content={{
+                            type: "article-all" as const,
+                            data: this._sections().map((section, idx) =>
+                                this._previewDataForSection(section, idx),
+                            ),
+                        }}
+                    />
+                </DeviceFramer>
             </div>
         );
     }
@@ -403,6 +375,10 @@ export default class ArticleEditor extends React.Component<Props, State> {
         sections[i] = {...sections[i], ...newProps};
         this.props.onChange({json: sections});
     };
+
+    private _isMobilePreview() {
+        return this.props.screen === "phone" || this.props.screen === "tablet";
+    }
 
     _handleMoveSectionEarlier(i: number) {
         if (i === 0) {

--- a/packages/perseus-editor/src/article-editor.tsx
+++ b/packages/perseus-editor/src/article-editor.tsx
@@ -433,20 +433,24 @@ export default class ArticleEditor extends React.Component<Props, State> {
     _handleAddSectionAfter(i: number) {
         // We do a full serialization here because we
         // might be copying widgets:
-        const sections = {...this.serialize()};
+        const clonedArticle = this.serialize();
+        // Articles are (annoyingly) either a single PerseusRenderer _or_ an
+        // array of them! Would be nice for the article to always be an array!
+        const sections =
+            clonedArticle instanceof Array ? clonedArticle : [clonedArticle];
+
         // Here we do magic to allow you to copy-paste
         // things from the previous section into the new
         // section while preserving widgets.
         // To enable this, we preserve the widgets
         // object for the new section, but wipe out
         // the content.
-        const newSection =
-            i >= 0
-                ? {
-                      widgets: sections[i].widgets,
-                  }
-                : {};
-        // @ts-expect-error - TS2339 - Property 'splice' does not exist on type 'PerseusArticle'.
+        const newSection = {
+            content: "",
+            images: {},
+            widgets: i >= 0 ? sections[i].widgets : {},
+        };
+
         sections.splice(i + 1, 0, newSection);
         this.props.onChange({
             json: sections,

--- a/packages/perseus-editor/src/article-editor.tsx
+++ b/packages/perseus-editor/src/article-editor.tsx
@@ -21,18 +21,18 @@ import arrowCircleUpIcon from "@phosphor-icons/core/bold/arrow-circle-up-bold.sv
 import plusIcon from "@phosphor-icons/core/bold/plus-bold.svg";
 import trashIcon from "@phosphor-icons/core/bold/trash-bold.svg";
 import * as React from "react";
-import _ from "underscore";
 
 import DeviceFramer from "./components/device-framer";
 import IssuesPanel from "./components/issues-panel";
 import JsonEditor from "./components/json-editor";
 import SectionControlButton from "./components/section-control-button";
 import Editor from "./editor";
-import IframeContentRenderer from "./iframe-content-renderer";
 import {WARNINGS} from "./messages";
+import PreviewWithIframe from "./preview-with-iframe";
 import {detectTexErrors} from "./util/tex-error-detector";
 
 import type {Issue} from "./components/issues-panel";
+import type {PreviewWithIframeRef} from "./preview-with-iframe";
 import type {
     APIOptions,
     ImageUploader,
@@ -50,6 +50,7 @@ type DefaultProps = {
         i: number,
     ) => React.ReactElement<React.ComponentProps<"span">>;
 };
+
 type Props = DefaultProps & {
     apiOptions?: APIOptions;
     dependencies: PerseusDependenciesV2;
@@ -69,9 +70,7 @@ type State = {
 
 export default class ArticleEditor extends React.Component<Props, State> {
     static defaultProps: DefaultProps = {
-        // NOTE(Jeremy):
-        // eslint-disable-next-line no-restricted-syntax
-        json: [{} as any],
+        json: [{content: "", widgets: {}, images: {}}],
         mode: "edit",
         screen: "desktop",
         sectionImageUploadGenerator: () => <span />,
@@ -81,6 +80,9 @@ export default class ArticleEditor extends React.Component<Props, State> {
         highlightLint: true,
         issues: [],
     };
+
+    // Store refs for preview iframes (keyed by section index or "all")
+    private frameRefs: Record<string, PreviewWithIframeRef | null> = {};
 
     componentDidMount() {
         this._updateIssues();
@@ -146,47 +148,54 @@ export default class ArticleEditor extends React.Component<Props, State> {
 
     _updatePreviewFrames() {
         if (this.props.mode === "preview") {
-            // eslint-disable-next-line react/no-string-refs
-            // @ts-expect-error - TS2339 - Property 'sendNewData' does not exist on type 'ReactInstance'.
-            this.refs["frame-all"].sendNewData({
-                type: "article-all",
-                data: this._sections().map((section, i) => {
-                    return this._apiOptionsForSection(section, i);
-                }),
-            });
+            const frameAll = this.frameRefs["all"];
+            if (frameAll) {
+                frameAll.sendNewData({
+                    type: "article-all",
+                    data: this._sections().map((section, i) =>
+                        this._previewDataForSection(section, i),
+                    ),
+                });
+            }
         } else if (this.props.mode === "edit") {
             this._sections().forEach((section, i) => {
-                // eslint-disable-next-line react/no-string-refs
-                // @ts-expect-error - TS2339 - Property 'sendNewData' does not exist on type 'ReactInstance'.
-                this.refs["frame-" + i].sendNewData({
-                    type: "article",
-                    data: this._apiOptionsForSection(section, i),
-                });
+                const frame = this.frameRefs[String(i)];
+                if (frame) {
+                    frame.sendNewData({
+                        type: "article",
+                        data: this._previewDataForSection(section, i),
+                    });
+                }
             });
         }
     }
 
-    _apiOptionsForSection(section: PerseusRenderer, sectionIndex: number): any {
+    _previewDataForSection(section: PerseusRenderer, sectionIndex: number) {
         // eslint-disable-next-line react/no-string-refs
         const editor = this.refs[`editor${sectionIndex}`];
-        return {
-            apiOptions: {
-                ...ApiOptions.defaults,
-                ...this.props.apiOptions,
 
-                // Alignment options are always available in article
-                // editors
-                showAlignmentOptions: true,
-                isArticle: true,
-            },
+        return {
+            apiOptions: this._apiOptionsForPreview(),
             json: section,
             linterContext: {
                 contentType: "article",
                 highlightLint: this.state.highlightLint,
+                stack: [],
             },
             // @ts-expect-error - TS2339 - Property 'getSaveWarnings' does not exist on type 'ReactInstance'.
-            // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-            legacyPerseusLint: editor ? editor.getSaveWarnings() : [],
+            legacyPerseusLint: editor?.getSaveWarnings() ?? [],
+        };
+    }
+
+    _apiOptionsForPreview(): APIOptions {
+        return {
+            ...ApiOptions.defaults,
+            ...this.props.apiOptions,
+
+            // Alignment options are always available in article
+            // editors
+            showAlignmentOptions: true,
+            isArticle: true,
         };
     }
 
@@ -361,11 +370,12 @@ export default class ArticleEditor extends React.Component<Props, State> {
 
         return (
             <DeviceFramer deviceType={this.props.screen} nochrome={nochrome}>
-                <IframeContentRenderer
-                    ref={"frame-" + i}
+                <PreviewWithIframe
+                    ref={(node) => {
+                        this.frameRefs[String(i)] = node;
+                    }}
                     key={this.props.screen}
-                    datasetKey="mobile"
-                    datasetValue={isMobile}
+                    isMobile={isMobile}
                     seamless={nochrome}
                     url={this.props.previewURL}
                 />
@@ -423,7 +433,7 @@ export default class ArticleEditor extends React.Component<Props, State> {
     _handleAddSectionAfter(i: number) {
         // We do a full serialization here because we
         // might be copying widgets:
-        const sections = _.clone(this.serialize());
+        const sections = {...this.serialize()};
         // Here we do magic to allow you to copy-paste
         // things from the previous section into the new
         // section while preserving widgets.

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -145,7 +145,7 @@ class EditorPage extends React.Component<Props, State> {
         // NOTE: It is required to delay the preview update until after the
         // current frame, to allow for ItemEditor to render its widgets.
         // This then enables to serialize the widgets properties correctly,
-        // in order to send data to the preview iframe (IframeContentRenderer).
+        // in order to send data to the preview iframe (PreviewWithIframe).
         // Otherwise, widgets will render in an "empty" state in the preview.
         // TODO(jeff, CP-3128): Use Wonder Blocks Timing API
         // eslint-disable-next-line no-restricted-syntax

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -81,6 +81,9 @@ type Props = {
      * with the content that aren't linted/detected by Perseus itself.
      */
     issues?: Issue[];
+    /** The problem number, used for deterministic random seeding in the
+     * preview. */
+    problemNum?: number;
 };
 
 type DefaultProps = {
@@ -98,8 +101,6 @@ type State = {
 };
 
 class EditorPage extends React.Component<Props, State> {
-    _isMounted: boolean;
-
     itemEditor = React.createRef<ItemEditor>();
     hintsEditor = React.createRef<CombinedHintsEditor>();
 
@@ -119,16 +120,6 @@ class EditorPage extends React.Component<Props, State> {
             highlightLint: true,
             widgetsAreOpen: this.props.widgetsAreOpen ?? true,
         };
-
-        this._isMounted = false;
-    }
-
-    componentDidMount() {
-        // NOTE(scottgrant): This is a hack to remove the deprecated call to
-        // this.isMounted() but is still considered an anti-pattern.
-        this._isMounted = true;
-
-        this.updateRenderer();
     }
 
     getSnapshotBeforeUpdate(prevProps: Props, prevState: State) {
@@ -142,17 +133,6 @@ class EditorPage extends React.Component<Props, State> {
     }
 
     componentDidUpdate(previousProps: Props, prevState: State, snapshot: any) {
-        // NOTE: It is required to delay the preview update until after the
-        // current frame, to allow for ItemEditor to render its widgets.
-        // This then enables to serialize the widgets properties correctly,
-        // in order to send data to the preview iframe (PreviewWithIframe).
-        // Otherwise, widgets will render in an "empty" state in the preview.
-        // TODO(jeff, CP-3128): Use Wonder Blocks Timing API
-        // eslint-disable-next-line no-restricted-syntax
-        setTimeout(() => {
-            this.updateRenderer();
-        });
-
         // Use serialized snapshot from before unmount
         if (snapshot) {
             this.setState({json: snapshot});
@@ -166,10 +146,6 @@ class EditorPage extends React.Component<Props, State> {
         ) {
             this.syncJsonStateFromProps();
         }
-    }
-
-    componentWillUnmount() {
-        this._isMounted = false;
     }
 
     /**
@@ -202,41 +178,6 @@ class EditorPage extends React.Component<Props, State> {
             },
         );
     };
-
-    updateRenderer() {
-        // Some widgets (namely the image widget) like to call onChange before
-        // anything has actually been mounted, which causes problems here. We
-        // just ensure don't update until we've mounted
-        const hasEditor = !this.props.developerMode || !this.props.jsonMode;
-        if (!this._isMounted || !hasEditor) {
-            return;
-        }
-
-        const touch =
-            this.props.previewDevice === "phone" ||
-            this.props.previewDevice === "tablet";
-        const deviceBasedApiOptions: APIOptionsWithDefaults = {
-            ...this.getApiOptions(),
-            customKeypad: touch,
-            isMobile: touch,
-        };
-
-        this.itemEditor.current?.triggerPreviewUpdate({
-            type: "question",
-            data: _({
-                item: this.serialize(),
-                apiOptions: deviceBasedApiOptions,
-                initialHintsVisible: 0,
-                device: this.props.previewDevice,
-                linterContext: {
-                    contentType: "exercise",
-                    highlightLint: this.state.highlightLint,
-                },
-                reviewMode: true,
-                legacyPerseusLint: this.itemEditor.current?.getSaveWarnings(),
-            }).extend(_(this.props).pick("problemNum")),
-        });
-    }
 
     getApiOptions(): APIOptionsWithDefaults {
         return {
@@ -376,6 +317,8 @@ class EditorPage extends React.Component<Props, State> {
                             previewURL={this.props.previewURL}
                             issues={this.props.issues}
                             additionalTemplates={this.props.additionalTemplates}
+                            highlightLint={this.state.highlightLint}
+                            problemNum={this.props.problemNum}
                         />
                     )}
 

--- a/packages/perseus-editor/src/hint-editor.tsx
+++ b/packages/perseus-editor/src/hint-editor.tsx
@@ -4,14 +4,14 @@
  * Collection of classes for rendering the hint editor area,
  * hint editor boxes, and hint previews
  */
-import {components, iconTrash} from "@khanacademy/perseus";
+import {ApiOptions, components, iconTrash} from "@khanacademy/perseus";
 import * as React from "react";
 import invariant from "tiny-invariant";
 import _ from "underscore";
 
 import DeviceFramer from "./components/device-framer";
 import Editor from "./editor";
-import IframeContentRenderer from "./iframe-content-renderer";
+import PreviewWithIframe from "./preview-with-iframe";
 import {
     iconCircleArrowDown,
     iconCircleArrowUp,
@@ -203,7 +203,7 @@ class CombinedHintEditor extends React.Component<CombinedHintEditorProps> {
     };
 
     editor = React.createRef<HintEditor>();
-    frame = React.createRef<IframeContentRenderer>();
+    frame = React.createRef<React.ElementRef<typeof PreviewWithIframe>>();
 
     componentDidMount() {
         this.updatePreview();
@@ -219,10 +219,11 @@ class CombinedHintEditor extends React.Component<CombinedHintEditorProps> {
             data: {
                 hint: this.props.hint,
                 pos: this.props.pos,
-                apiOptions: this.props.apiOptions,
+                apiOptions: this.props.apiOptions || ApiOptions.defaults,
                 linterContext: {
                     contentType: "hint",
-                    highlightLint: this.props.highlightLint,
+                    highlightLint: this.props.highlightLint || false,
+                    stack: [],
                 },
             },
         });
@@ -277,10 +278,9 @@ class CombinedHintEditor extends React.Component<CombinedHintEditorProps> {
                         deviceType={this.props.deviceType}
                         nochrome={true}
                     >
-                        <IframeContentRenderer
+                        <PreviewWithIframe
                             ref={this.frame}
-                            datasetKey="mobile"
-                            datasetValue={isMobile}
+                            isMobile={isMobile}
                             seamless={true}
                             url={this.props.previewURL}
                         />

--- a/packages/perseus-editor/src/hint-editor.tsx
+++ b/packages/perseus-editor/src/hint-editor.tsx
@@ -182,7 +182,7 @@ type CombinedHintEditorProps = {
     apiOptions?: APIOptions;
     deviceType: DeviceType;
     imageUploader?: ImageUploader;
-    highlightLint?: boolean;
+    highlightLint: boolean;
     isLast: boolean;
     isFirst: boolean;
     hint: Hint;
@@ -198,36 +198,7 @@ type CombinedHintEditorProps = {
 
 /* A single hint-row containing a hint editor and preview */
 class CombinedHintEditor extends React.Component<CombinedHintEditorProps> {
-    static defaultProps = {
-        highlightLint: false,
-    };
-
     editor = React.createRef<HintEditor>();
-    frame = React.createRef<React.ElementRef<typeof PreviewWithIframe>>();
-
-    componentDidMount() {
-        this.updatePreview();
-    }
-
-    componentDidUpdate() {
-        this.updatePreview();
-    }
-
-    updatePreview = () => {
-        this.frame.current?.sendNewData({
-            type: "hint",
-            data: {
-                hint: this.props.hint,
-                pos: this.props.pos,
-                apiOptions: this.props.apiOptions || ApiOptions.defaults,
-                linterContext: {
-                    contentType: "hint",
-                    highlightLint: this.props.highlightLint || false,
-                    stack: [],
-                },
-            },
-        });
-    };
 
     getSaveWarnings = () => {
         return this.editor.current?.getSaveWarnings();
@@ -279,10 +250,23 @@ class CombinedHintEditor extends React.Component<CombinedHintEditorProps> {
                         nochrome={true}
                     >
                         <PreviewWithIframe
-                            ref={this.frame}
                             isMobile={isMobile}
                             seamless={true}
                             url={this.props.previewURL}
+                            content={{
+                                type: "hint",
+                                data: {
+                                    hint: this.props.hint,
+                                    pos: this.props.pos,
+                                    apiOptions:
+                                        this.props.apiOptions ||
+                                        ApiOptions.defaults,
+                                    linterContext: {
+                                        contentType: "hint",
+                                        highlightLint: this.props.highlightLint,
+                                    },
+                                },
+                            }}
                         />
                     </DeviceFramer>
                 </div>
@@ -295,7 +279,7 @@ type CombinedHintsEditorProps = {
     apiOptions?: APIOptions;
     deviceType: DeviceType;
     imageUploader?: ImageUploader;
-    highlightLint?: boolean;
+    highlightLint: boolean;
     hints: Hint[];
     // URL of the route to show on initial load of the preview frames.
     previewURL: string;
@@ -317,13 +301,11 @@ class CombinedHintsEditor extends React.Component<CombinedHintsEditorProps> {
     static HintEditor: typeof HintEditor = HintEditor;
 
     static defaultProps: {
-        highlightLint: boolean;
         hints: ReadonlyArray<any>;
         onChange: () => void;
     } = {
-        onChange: () => {},
         hints: [],
-        highlightLint: false,
+        onChange: () => {},
     };
 
     handleHintChange(i: number, newProps: CombinedHintsEditorProps): void {
@@ -386,7 +368,7 @@ class CombinedHintsEditor extends React.Component<CombinedHintsEditorProps> {
         const editingDisabled = this.props.apiOptions?.editingDisabled ?? false;
         const hintElems = _.map(
             hints,
-            function (hint, i) {
+            (hint, i) => {
                 return (
                     <fieldset disabled={editingDisabled} key={"hintEditor" + i}>
                         <CombinedHintEditor
@@ -396,26 +378,18 @@ class CombinedHintsEditor extends React.Component<CombinedHintsEditorProps> {
                             itemId={itemId}
                             hint={hint}
                             pos={i}
-                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                             imageUploader={this.props.imageUploader}
                             // eslint-disable-next-line react/jsx-no-bind
                             // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                             onChange={this.handleHintChange.bind(this, i)}
                             // eslint-disable-next-line react/jsx-no-bind
-                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                             onRemove={this.handleHintRemove.bind(this, i)}
                             // eslint-disable-next-line react/jsx-no-bind
-                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                             onMove={this.handleHintMove.bind(this, i)}
-                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                             deviceType={this.props.deviceType}
-                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                             apiOptions={this.props.apiOptions}
-                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                             highlightLint={this.props.highlightLint}
-                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                             previewURL={this.props.previewURL}
-                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                             widgetIsOpen={this.props.widgetIsOpen}
                         />
                     </fieldset>

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -7,14 +7,15 @@ import _ from "underscore";
 import DeviceFramer from "./components/device-framer";
 import IssuesPanel from "./components/issues-panel";
 import Editor from "./editor";
-import IframeContentRenderer from "./iframe-content-renderer";
 import ItemExtrasEditor from "./item-extras-editor";
 import {WARNINGS} from "./messages";
+import PreviewWithIframe from "./preview-with-iframe";
 import {runAxeCoreOnUpdate} from "./util/a11y-checker";
 import {ItemEditorContext} from "./util/item-editor-context";
 import {detectTexErrors} from "./util/tex-error-detector";
 
 import type {Issue} from "./components/issues-panel";
+import type {PreviewContent} from "./preview/message-types";
 import type {
     APIOptions,
     ImageUploader,
@@ -28,6 +29,8 @@ import type {
     PerseusRenderer,
     PerseusItem,
 } from "@khanacademy/perseus-core";
+
+type QuestionPreviewData = Extract<PreviewContent, {type: "question"}>;
 
 type Props = {
     /** Additional templates that the host application would like to display
@@ -72,7 +75,7 @@ class ItemEditor extends React.Component<Props, State> {
     static prevWidgets: PerseusWidgetsMap | undefined;
     a11yCheckerTimeoutId: any;
 
-    frame = React.createRef<IframeContentRenderer>();
+    frame = React.createRef<React.ElementRef<typeof PreviewWithIframe>>();
     questionEditor = React.createRef<Editor>();
     itemExtrasEditor = React.createRef<ItemExtrasEditor>();
 
@@ -151,9 +154,9 @@ class ItemEditor extends React.Component<Props, State> {
         this.props.onChange(_(props).extend(newProps));
     };
 
-    triggerPreviewUpdate: (newData?: any) => void = (newData: any) => {
+    triggerPreviewUpdate(newData: QuestionPreviewData) {
         this.frame.current?.sendNewData(newData);
-    };
+    }
 
     // eslint-disable-next-line import/no-deprecated
     handleEditorChange: ChangeHandler = (newProps) => {
@@ -249,11 +252,10 @@ class ItemEditor extends React.Component<Props, State> {
                                     deviceType={this.props.deviceType}
                                     nochrome={true}
                                 >
-                                    <IframeContentRenderer
+                                    <PreviewWithIframe
                                         ref={this.frame}
                                         key={this.props.deviceType}
-                                        datasetKey="mobile"
-                                        datasetValue={isMobile}
+                                        isMobile={isMobile}
                                         seamless={true}
                                         url={this.props.previewURL}
                                     />

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -51,13 +51,17 @@ type Props = {
      */
     itemId?: string;
     issues?: Issue[];
+    /** Whether to highlight lint warnings in the preview. */
+    highlightLint: boolean;
+    /** The problem number, used for deterministic random seeding in the
+     * preview. */
+    problemNum?: number;
 };
 
 type State = {
     issues: Issue[];
     axeCoreIssues: Issue[];
     showAxeCoreIssues: boolean;
-    previewContent?: QuestionPreviewData;
 };
 
 // NOTE: ItemEditor does not actually produce an entire PerseusItem. Hints are
@@ -79,7 +83,7 @@ class ItemEditor extends React.Component<Props, State> {
     questionEditor = React.createRef<Editor>();
     itemExtrasEditor = React.createRef<ItemExtrasEditor>();
 
-    state = {
+    state: State = {
         issues: [],
         axeCoreIssues: [],
         showAxeCoreIssues: false,
@@ -154,10 +158,6 @@ class ItemEditor extends React.Component<Props, State> {
         this.props.onChange(_(props).extend(newProps));
     };
 
-    triggerPreviewUpdate(newData: QuestionPreviewData) {
-        this.setState({previewContent: newData});
-    }
-
     // eslint-disable-next-line import/no-deprecated
     handleEditorChange: ChangeHandler = (newProps) => {
         const question = _.extend({}, this.props.question, newProps);
@@ -191,13 +191,14 @@ class ItemEditor extends React.Component<Props, State> {
         };
     }
 
+    // Builds the preview content from props.
     _derivePreviewContent(): QuestionPreviewData | null {
-        if (!this.questionEditor.current || !this.itemExtrasEditor.current) {
+        const question = this.props.question;
+        const answerArea = this.props.answerArea ?? undefined;
+
+        if (!question) {
             return null;
         }
-
-        const question = this.questionEditor.current.serialize();
-        const answerArea = this.itemExtrasEditor.current.serialize();
 
         return {
             type: "question",
@@ -218,10 +219,11 @@ class ItemEditor extends React.Component<Props, State> {
                 device: this.props.deviceType,
                 linterContext: {
                     contentType: "exercise",
-                    highlightLint: false,
+                    highlightLint: this.props.highlightLint,
                 },
                 reviewMode: true,
                 legacyPerseusLint: this.getSaveWarnings(),
+                problemNum: this.props.problemNum,
             },
         };
     }

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -1,4 +1,4 @@
-import {PerseusMarkdown} from "@khanacademy/perseus";
+import {PerseusMarkdown, ApiOptions} from "@khanacademy/perseus";
 import * as PerseusLinter from "@khanacademy/perseus-linter";
 import * as React from "react";
 import invariant from "tiny-invariant";
@@ -38,7 +38,7 @@ type Props = {
      */
     additionalTemplates?: Record<string, string>;
     apiOptions?: APIOptions;
-    deviceType?: DeviceType;
+    deviceType: DeviceType;
     widgetIsOpen?: boolean;
     imageUploader?: ImageUploader;
     question?: PerseusRenderer;
@@ -57,6 +57,7 @@ type State = {
     issues: Issue[];
     axeCoreIssues: Issue[];
     showAxeCoreIssues: boolean;
+    previewContent?: QuestionPreviewData;
 };
 
 // NOTE: ItemEditor does not actually produce an entire PerseusItem. Hints are
@@ -75,7 +76,6 @@ class ItemEditor extends React.Component<Props, State> {
     static prevWidgets: PerseusWidgetsMap | undefined;
     a11yCheckerTimeoutId: any;
 
-    frame = React.createRef<React.ElementRef<typeof PreviewWithIframe>>();
     questionEditor = React.createRef<Editor>();
     itemExtrasEditor = React.createRef<ItemExtrasEditor>();
 
@@ -155,7 +155,7 @@ class ItemEditor extends React.Component<Props, State> {
     };
 
     triggerPreviewUpdate(newData: QuestionPreviewData) {
-        this.frame.current?.sendNewData(newData);
+        this.setState({previewContent: newData});
     }
 
     // eslint-disable-next-line import/no-deprecated
@@ -188,6 +188,41 @@ class ItemEditor extends React.Component<Props, State> {
         return {
             question: this.questionEditor.current.serialize(),
             answerArea: this.itemExtrasEditor.current.serialize(),
+        };
+    }
+
+    _derivePreviewContent(): QuestionPreviewData | null {
+        if (!this.questionEditor.current || !this.itemExtrasEditor.current) {
+            return null;
+        }
+
+        const question = this.questionEditor.current.serialize();
+        const answerArea = this.itemExtrasEditor.current.serialize();
+
+        return {
+            type: "question",
+            data: {
+                item: {
+                    question,
+                    hints: [],
+                    answerArea,
+                },
+                apiOptions: {
+                    ...ApiOptions.defaults,
+                    ...this.props.apiOptions,
+                    customKeypad:
+                        this.props.deviceType === "phone" ||
+                        this.props.deviceType === "tablet",
+                },
+                initialHintsVisible: 0,
+                device: this.props.deviceType,
+                linterContext: {
+                    contentType: "exercise",
+                    highlightLint: false,
+                },
+                reviewMode: true,
+                legacyPerseusLint: this.getSaveWarnings(),
+            },
         };
     }
 
@@ -253,11 +288,11 @@ class ItemEditor extends React.Component<Props, State> {
                                     nochrome={true}
                                 >
                                     <PreviewWithIframe
-                                        ref={this.frame}
                                         key={this.props.deviceType}
                                         isMobile={isMobile}
                                         seamless={true}
                                         url={this.props.previewURL}
+                                        content={this._derivePreviewContent()}
                                     />
                                 </DeviceFramer>
                             </div>

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -34,6 +34,20 @@ function buildArticleContent(): PreviewContent {
 describe("PreviewWithIframe", () => {
     beforeEach(() => {
         mockHeight = null;
+        mockSendData.mockClear();
+    });
+
+    it("does not call sendData when content is null", () => {
+        render(
+            <PreviewWithIframe
+                url="/preview"
+                isMobile={false}
+                seamless={false}
+                content={null}
+            />,
+        );
+
+        expect(mockSendData).not.toHaveBeenCalled();
     });
 
     it("renders an iframe with the given URL", () => {

--- a/packages/perseus-editor/src/preview-with-iframe.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.tsx
@@ -20,9 +20,10 @@ type Props = {
     seamless: boolean;
 
     /**
-     * The content to render in the preview area.
+     * The content to render in the preview area. `null` means no data has
+     * been provided yet and the iframe should render an empty placeholder.
      */
-    content: PreviewContent;
+    content: PreviewContent | null;
 };
 
 /**
@@ -52,7 +53,9 @@ function PreviewWithIframe(props: Props) {
     // IframeContentRenderer. If performance becomes an issue, we can look at
     // using React.memo() on this component or some other performance fix.
     React.useEffect(() => {
-        sendData(props.content);
+        if (props.content != null) {
+            sendData(props.content);
+        }
     }, [sendData, props.content]);
 
     // Update container height based on iframe content height if we're in

--- a/packages/perseus-editor/src/testing/preview/exercise-preview-page.tsx
+++ b/packages/perseus-editor/src/testing/preview/exercise-preview-page.tsx
@@ -1,115 +1,66 @@
-/* eslint-disable import/no-relative-packages, import/order */
 import {View} from "@khanacademy/wonder-blocks-core";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
-import {PreviewRenderer} from "./preview-renderer";
+import {usePreviewPresenter} from "../../preview/use-preview-presenter";
 
-import type {PreviewContent} from "../../preview/message-types";
+import {PreviewRenderer} from "./preview-renderer";
 
 /**
  * The exercise preview page. This page is loaded inside an iframe and should
  * only be used to support editor previews in Storybook!
  */
 const ExercisePreviewPage = () => {
-    const [previewData, setPreviewData] = React.useState<PreviewContent | null>(
-        null,
-    );
-    const [iframeId, setIframeId] = React.useState<string | null>(null);
+    const {data, reportHeight} = usePreviewPresenter();
     const containerRef = React.useRef<HTMLDivElement>(null);
+    const lastHeightRef = React.useRef<number | null>(null);
 
-    // Read iframe configuration from dataset attributes
+    // Handle body overflow for article-all type (allows scrolling)
     React.useEffect(() => {
-        // eslint-disable-next-line no-restricted-syntax
-        const iframe = window.frameElement as HTMLIFrameElement | null;
-        if (iframe?.dataset.id) {
-            setIframeId(iframe.dataset.id);
+        if (data?.type === "article-all") {
+            document.body.style.overflow = "scroll";
+        } else {
+            document.body.style.overflow = "hidden";
         }
-    }, []);
-
-    // Listen for data from parent
-    React.useEffect(() => {
-        const handleMessage = (event: MessageEvent) => {
-            // For now, we receive the iframe ID and look up data in parent's iframeDataStore
-            if (
-                typeof event.data === "string" ||
-                typeof event.data === "number"
-            ) {
-                const id = String(event.data);
-                // Access parent's iframeDataStore
-                try {
-                    // @ts-expect-error - accessing parent window's custom property
-                    const data = window.parent.iframeDataStore?.[id];
-                    if (data) {
-                        setPreviewData(data);
-                    }
-                } catch (e) {
-                    // Cross-origin access might fail in some cases
-                    // Silently ignore - this is expected in cross-origin scenarios
-                    // eslint-disable-next-line no-console
-                    console.error("Error accessing iframeDataStore", e);
-                }
-            }
-        };
-
-        window.addEventListener("message", handleMessage);
-
-        // Request initial data
-        if (iframeId) {
-            window.parent.postMessage(iframeId, "*");
-        }
-
-        return () => {
-            window.removeEventListener("message", handleMessage);
-        };
-    }, [iframeId]);
+    }, [data?.type]);
 
     // Send height updates to parent
     React.useEffect(() => {
-        if (!iframeId || !containerRef.current) {
+        if (!containerRef.current) {
             return;
         }
 
         const sendHeightUpdate = () => {
             const height = containerRef.current?.scrollHeight;
-            if (height) {
+            if (height && height !== lastHeightRef.current) {
+                lastHeightRef.current = height;
+
                 // NOTE(Jeremy) I'm not sure where this comes from but it's how
                 // production does it.
                 const bottomMargin = 30;
 
-                window.parent.postMessage(
-                    {
-                        id: iframeId,
-                        height: height + bottomMargin,
-                    },
-                    "*",
-                );
+                reportHeight(height + bottomMargin);
             }
         };
 
         // Send initial height
         sendHeightUpdate();
 
-        // Poll for height changes (to capture animations, etc.)
-        const interval = setInterval(sendHeightUpdate, 500);
-
         // Also send on resize
         let resizeObserver: ResizeObserver | undefined;
         const container = containerRef.current;
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        if (container) {
+        if (container != null) {
             resizeObserver = new ResizeObserver(sendHeightUpdate);
             resizeObserver.observe(container);
         }
 
         return () => {
-            clearInterval(interval);
             resizeObserver?.disconnect();
         };
-    }, [iframeId, previewData]);
+    }, [data, reportHeight]);
 
-    if (!previewData) {
+    if (!data) {
         return (
             <View style={styles.loading}>
                 <div>Loading preview...</div>
@@ -119,7 +70,7 @@ const ExercisePreviewPage = () => {
 
     return (
         <div ref={containerRef}>
-            <PreviewRenderer data={previewData} />
+            <PreviewRenderer data={data} />
         </div>
     );
 };

--- a/packages/perseus-editor/src/testing/preview/exercise-preview-page.tsx
+++ b/packages/perseus-editor/src/testing/preview/exercise-preview-page.tsx
@@ -9,10 +9,8 @@ import {PreviewRenderer} from "./preview-renderer";
 import type {PreviewContent} from "../../preview/message-types";
 
 /**
- * Loads the exercise preview frame
- *
- * This is loaded inside the iframe, where it sets up the ExercisePreviewFrame
- * component that handles all communication between the iframe and its parent.
+ * The exercise preview page. This page is loaded inside an iframe and should
+ * only be used to support editor previews in Storybook!
  */
 const ExercisePreviewPage = () => {
     const [previewData, setPreviewData] = React.useState<PreviewContent | null>(


### PR DESCRIPTION
## Summary:

*This PR is part of a series building a typed, hook-based preview system for the Perseus editor. The new system replaces the untyped `window.iframeDataStore` + raw `postMessage(string)` communication with structured, validated message passing via `usePreviewController` and `usePreviewPresenter` hooks. The new system is being built alongside the old one — no existing behavior changes until the final PR in the series flips the switch.*

Previous PRs in this series:
- #3464
- #3467
- #3474
- #3492
- #3495
- #3499
- #3578 

---

This is the Preview NG changeover PR! After this lands, Perseus will be exclusively using the new Preview communication system (no more legacy `iframeDataStore` + string-postMessage preview protocol). This means that all Storybook preview code now uses the new `usePreviewPresenter` hook, and all four editors (`EditorPage`, `ArticleEditor`, `HintEditor`, `ItemEditor`) switch from `IframeContentRenderer` to `PreviewWithIframe` (introduced in #3578).

The legacy `IframeContentRenderer` remains because some client's still use it directly. When this change is released, I will switch clients over as part of the Perseus release. The legacy component will be deleted in a later cleanup pass once that's done.


https://github.com/user-attachments/assets/a801bb4a-2cbd-4154-940f-09a2bd4037c5


NOTE: the issue of the keypad being clipped by the preview iframe is a longstanding issue and is unrelated to the changes in this PR. 


Issue: LEMS-3741

## Test plan:

- [x] `pnpm tsc` clean
- [x] `pnpm lint` clean for touched files
- [x] `pnpm test`
- [ ] Reviewer: open Storybook, navigate to the editor stories, and confirm each editor's preview renders content (question, hint, article single section, article-all). The behaviour should be identical to `main`.
