### PR TITLE
[Image][GIF] Fixing overflow issue.

### DIFF
--- a/.changeset/real-rings-behave.md
+++ b/.changeset/real-rings-behave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fixing horizontal overflow issues in GIF images.

--- a/packages/perseus/src/components/gif-image.tsx
+++ b/packages/perseus/src/components/gif-image.tsx
@@ -298,6 +298,8 @@ const GifImage = (props: Props) => {
     // aspect-ratio derives it so the canvas scales proportionally.
     const displayHeight = !width && height ? height * scale : undefined;
 
+    const aspectRatio = width && height ? `${width} / ${height}` : undefined;
+
     return (
         <>
             {/* Two canvases are needed because there is no canvas API
@@ -319,8 +321,7 @@ const GifImage = (props: Props) => {
                 style={{
                     width: width ? width * scale : undefined,
                     maxWidth: "100%",
-                    aspectRatio:
-                        width && height ? `${width} / ${height}` : undefined,
+                    aspectRatio: aspectRatio,
                     height: displayHeight,
                 }}
             />

--- a/packages/perseus/src/components/gif-image.tsx
+++ b/packages/perseus/src/components/gif-image.tsx
@@ -294,6 +294,10 @@ const GifImage = (props: Props) => {
         [drawFrame],
     );
 
+    // Only set an explicit height when width is absent; otherwise
+    // aspect-ratio derives it so the canvas scales proportionally.
+    const displayHeight = !width && height ? height * scale : undefined;
+
     return (
         <>
             {/* Two canvases are needed because there is no canvas API
@@ -314,7 +318,10 @@ const GifImage = (props: Props) => {
                 data-testid="gif-canvas"
                 style={{
                     width: width ? width * scale : undefined,
-                    height: height ? height * scale : undefined,
+                    maxWidth: "100%",
+                    aspectRatio:
+                        width && height ? `${width} / ${height}` : undefined,
+                    height: displayHeight,
                 }}
             />
             {/* Base canvas: a hidden canvas that acts as a bridge

--- a/packages/perseus/src/widgets/image/__docs__/image-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/image/__docs__/image-initial-state-regression.stories.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 
 import {themeModes} from "../../../../../../.storybook/modes";
+import {ApiOptions} from "../../../perseus-api";
+import {getFeatureFlags} from "../../../testing/feature-flags-util";
 import {getWidget} from "../../../widgets";
 import {imageRendererDecorator} from "../../__testutils__/image-renderer-decorator";
 import {
@@ -16,6 +18,7 @@ import {
 import {
     earthMoonImage,
     frescoImage,
+    gifImageAlt,
     portraitImage,
     portraitImageCaption,
     portraitImageLongDescription,
@@ -321,5 +324,25 @@ export const ImageWithoutWidthOrHeightLarge: Story = {
     args: {
         backgroundImage: {url: frescoImage.url},
         alt: "Fresco painting",
+    },
+};
+
+export const TallGifImage: Story = {
+    decorators: [imageRendererDecorator],
+    parameters: {
+        apiOptions: {
+            ...ApiOptions.defaults,
+            flags: getFeatureFlags({
+                "image-widget-upgrade-gif-controls": true,
+            }),
+        },
+    },
+    args: {
+        backgroundImage: {
+            url: "https://cdn.kastatic.org/ka-content-images/1e6f6fd4de01058c3d548b7a942bd9e76d565fa3.gif",
+        },
+        alt: gifImageAlt,
+        caption: gifImageAlt,
+        longDescription: gifImageAlt,
     },
 };


### PR DESCRIPTION
## Summary:
Fixing overflow issue with GIF images, the root cause being a result of the canvas styles not configured to properly respond to the parent FixedToResponsive component.

Before:
<img width="433" height="484" alt="image" src="https://github.com/user-attachments/assets/c9c9deb5-8d76-480e-b421-2453f1b0d038" />

After:
<img width="908" height="1014" alt="image" src="https://github.com/user-attachments/assets/22824a6e-6807-42c5-9699-b038ca448be7" />


Issue: LEMS-4075

## Test plan:
Run `pnpm test`

Repo: /?path=/story/widgets-image-widget-demo--gif-image