### PR TITLE
[Image] | (CX) | Handle null width/height in image editor

### DIFF
--- a/.changeset/thick-donuts-fly.md
+++ b/.changeset/thick-donuts-fly.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Image] | (CX) | Handle null width/height in image editor

--- a/packages/perseus-editor/src/widgets/__docs__/image-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/__docs__/image-editor.stories.tsx
@@ -129,7 +129,7 @@ export const GraphieImageWithScaleFlag: Story = {
 };
 
 /**
- * This Image widget editor has a zero-sized image.
+ * This Image widget editor has an image with missing size.
  */
 export const ImageWithEmptySize: Story = {
     name: "Image With Empty Size (Within Editor Page)",
@@ -138,6 +138,27 @@ export const ImageWithEmptySize: Story = {
         backgroundImage: {url: earthMoonImage.url},
         caption:
             "The Moon above Earth's horizon, captured by the International Space Station, [NASA](https://images.nasa.gov/details/iss071e515452)",
+    },
+};
+
+/**
+ * This Image widget editor has an image with missing size and the scale flag is enabled.
+ */
+export const ImageWithEmptySizeWithScaleFlag: Story = {
+    name: "Image With Empty Size with Scale Flag (Within Editor Page)",
+    decorators: [withinEditorPageDecorator],
+    args: {
+        backgroundImage: {url: earthMoonImage.url},
+        caption:
+            "The Moon above Earth's horizon, captured by the International Space Station, [NASA](https://images.nasa.gov/details/iss071e515452)",
+    },
+    parameters: {
+        apiOptions: {
+            ...ApiOptions.defaults,
+            flags: getFeatureFlags({
+                "image-widget-upgrade-scale": true,
+            }),
+        },
     },
 };
 

--- a/packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx
@@ -1092,6 +1092,119 @@ describe("image editor", () => {
             // Assert
             expect(onChangeMock).not.toHaveBeenCalled();
         });
+
+        it("should disable the scale inputs when the image size is invalid", () => {
+            // Arrange, Act
+            const onChangeMock = jest.fn();
+            render(
+                <ImageEditorWithDependencies
+                    apiOptions={apiOptionsWithScaleFlag}
+                    backgroundImage={{
+                        // Missing width and height
+                        url: earthMoonImage.url,
+                    }}
+                    onChange={onChangeMock}
+                />,
+            );
+
+            // Assert
+            const scaleField = screen.getByRole("spinbutton", {name: "Scale"});
+            const scaledWidthField = screen.getByRole("spinbutton", {
+                name: "Scaled Width",
+            });
+            const scaledHeightField = screen.getByRole("spinbutton", {
+                name: "Scaled Height",
+            });
+            expect(scaleField).toHaveAttribute("aria-disabled", "true");
+            expect(scaledWidthField).toHaveAttribute("aria-disabled", "true");
+            expect(scaledHeightField).toHaveAttribute("aria-disabled", "true");
+        });
+
+        it("should show the warning when the image size is missing", () => {
+            // Arrange, Act
+            render(
+                <ImageEditorWithDependencies
+                    apiOptions={apiOptionsWithScaleFlag}
+                    backgroundImage={{url: earthMoonImage.url}}
+                    onChange={() => {}}
+                />,
+            );
+
+            // Assert
+            expect(
+                screen.getByText(
+                    'Image size is invalid. Please use the "Recalculate natural size" button to enable scaling.',
+                ),
+            ).toBeInTheDocument();
+        });
+
+        it("should show the warning when the image size is zero", () => {
+            // Arrange, Act
+            render(
+                <ImageEditorWithDependencies
+                    apiOptions={apiOptionsWithScaleFlag}
+                    backgroundImage={{
+                        url: earthMoonImage.url,
+                        width: 0,
+                        height: 0,
+                    }}
+                    onChange={() => {}}
+                />,
+            );
+
+            // Assert
+            expect(
+                screen.getByText(
+                    'Image size is invalid. Please use the "Recalculate natural size" button to enable scaling.',
+                ),
+            ).toBeInTheDocument();
+        });
+
+        it("should enable the scale inputs when the image size is valid", () => {
+            // Arrange, Act
+            const onChangeMock = jest.fn();
+            render(
+                <ImageEditorWithDependencies
+                    apiOptions={apiOptionsWithScaleFlag}
+                    backgroundImage={{
+                        url: earthMoonImage.url,
+                        width: earthMoonImage.width,
+                        height: earthMoonImage.height,
+                    }}
+                    onChange={onChangeMock}
+                />,
+            );
+
+            // Assert
+            const scaleField = screen.getByRole("spinbutton", {name: "Scale"});
+            const scaledWidthField = screen.getByRole("spinbutton", {
+                name: "Scaled Width",
+            });
+            const scaledHeightField = screen.getByRole("spinbutton", {
+                name: "Scaled Height",
+            });
+            expect(scaleField).toHaveAttribute("aria-disabled", "false");
+            expect(scaledWidthField).toHaveAttribute("aria-disabled", "false");
+            expect(scaledHeightField).toHaveAttribute("aria-disabled", "false");
+        });
+
+        it("should hide the warning when the image size is valid", () => {
+            // Arrange, Act
+            render(
+                <ImageEditorWithDependencies
+                    apiOptions={apiOptionsWithScaleFlag}
+                    backgroundImage={earthMoonImage}
+                    onChange={() => {}}
+                />,
+            );
+
+            // Assert
+            expect(
+                screen.queryByText(
+                    'Image size is invalid. Please use the "Recalculate natural size" button to enable scaling.',
+                ),
+            ).not.toBeInTheDocument();
+        });
     });
 
     describe("flags", () => {

--- a/packages/perseus-editor/src/widgets/image-editor/components/image-scale-input.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/components/image-scale-input.tsx
@@ -2,6 +2,7 @@ import {Util} from "@khanacademy/perseus";
 import Banner from "@khanacademy/wonder-blocks-banner";
 import Button from "@khanacademy/wonder-blocks-button";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyMonospace} from "@khanacademy/wonder-blocks-typography";
 import arrowCounterClockwise from "@phosphor-icons/core/bold/arrow-counter-clockwise-bold.svg";
 import * as React from "react";
@@ -29,6 +30,7 @@ export default function ImageScaleInput({
 }: Props) {
     const width = backgroundImage.width ?? 0;
     const height = backgroundImage.height ?? 0;
+    const hasInvalidDimensions = width === 0 || height === 0;
 
     function handleScaleChange(newScale: string) {
         const scaleNum = Number(newScale);
@@ -51,6 +53,11 @@ export default function ImageScaleInput({
             return;
         }
 
+        // Avoid dividing by zero.
+        if (width === 0) {
+            return;
+        }
+
         const newScale = newScaledWidthNum / width;
 
         onChange({
@@ -63,6 +70,11 @@ export default function ImageScaleInput({
 
         // Height needs to be a positive number.
         if (isNaN(newScaledHeightNum) || newScaledHeightNum <= 0) {
+            return;
+        }
+
+        // Avoid dividing by zero.
+        if (height === 0) {
             return;
         }
 
@@ -122,6 +134,16 @@ export default function ImageScaleInput({
 
             <div className={styles.horizontalLine} />
 
+            {hasInvalidDimensions && (
+                <Banner
+                    kind="warning"
+                    text='Image size is invalid. Please use the "Recalculate natural size" button to enable scaling.'
+                    // TODO(LEMS-3686): Use CSS modules after Wonder Blocks
+                    // supports it instead of inline styles.
+                    styles={{root: {marginBottom: sizing.size_080}}}
+                />
+            )}
+
             <LabeledField
                 label="Scale"
                 description="Use 1 to display image at original size."
@@ -130,6 +152,7 @@ export default function ImageScaleInput({
                         value={scale.toString()}
                         min={0}
                         onChange={handleScaleChange}
+                        disabled={hasInvalidDimensions}
                     />
                 }
                 styles={wbFieldStyles}
@@ -142,6 +165,7 @@ export default function ImageScaleInput({
                             value={(width * scale).toString()}
                             min={0}
                             onChange={handleScaledWidthChange}
+                            disabled={hasInvalidDimensions}
                         />
                     }
                     styles={wbFieldStyles}
@@ -154,6 +178,7 @@ export default function ImageScaleInput({
                             value={(height * scale).toString()}
                             min={0}
                             onChange={handleScaledHeightChange}
+                            disabled={hasInvalidDimensions}
                         />
                     }
                     styles={wbFieldStyles}

--- a/packages/perseus-editor/src/widgets/image-editor/components/image-scale-input.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/components/image-scale-input.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 
 import ScrolllessNumberTextField from "../../../components/scrollless-number-text-field";
 import styles from "../image-editor.module.css";
-import {wbFieldStyles} from "../utils";
+import {isInvalidDimension, wbFieldStyles} from "../utils";
 
 import type {Props as ImageEditorProps} from "../image-editor";
 import type {PerseusImageBackground} from "@khanacademy/perseus-core";
@@ -30,7 +30,9 @@ export default function ImageScaleInput({
 }: Props) {
     const width = backgroundImage.width ?? 0;
     const height = backgroundImage.height ?? 0;
-    const hasInvalidDimensions = width === 0 || height === 0;
+    // Dimension needs to be a positive real number.
+    const hasInvalidDimensions =
+        isInvalidDimension(width) || isInvalidDimension(height);
 
     function handleScaleChange(newScale: string) {
         const scaleNum = Number(newScale);

--- a/packages/perseus-editor/src/widgets/image-editor/utils.test.ts
+++ b/packages/perseus-editor/src/widgets/image-editor/utils.test.ts
@@ -1,4 +1,7 @@
-import {getOtherSideLengthWithPreservedAspectRatio} from "./utils";
+import {
+    getOtherSideLengthWithPreservedAspectRatio,
+    isInvalidDimension,
+} from "./utils";
 
 describe("getOtherSideLengthWithPreservedAspectRatio", () => {
     it.each`
@@ -24,6 +27,27 @@ describe("getOtherSideLengthWithPreservedAspectRatio", () => {
                 newSideLength,
             );
             expect(result).toEqual(expectedResult);
+        },
+    );
+});
+
+describe("isInvalidDimension", () => {
+    it.each`
+        dimension    | expectedResult
+        ${NaN}       | ${true}
+        ${0}         | ${true}
+        ${-1}        | ${true}
+        ${Infinity}  | ${true}
+        ${-Infinity} | ${true}
+        ${undefined} | ${true}
+        ${null}      | ${true}
+        ${1}         | ${false}
+        ${100}       | ${false}
+        ${1.5}       | ${false}
+    `(
+        "should return $expectedResult for dimension $dimension",
+        ({dimension, expectedResult}) => {
+            expect(isInvalidDimension(dimension)).toEqual(expectedResult);
         },
     );
 });

--- a/packages/perseus-editor/src/widgets/image-editor/utils.ts
+++ b/packages/perseus-editor/src/widgets/image-editor/utils.ts
@@ -54,3 +54,13 @@ export function getOtherSideLengthWithPreservedAspectRatio(
 
     return (newSideLength * otherSideLength) / sideLength;
 }
+
+/**
+ * Checks if a dimension is invalid. A dimension is valid if it's
+ * a positive, non-infinite number.
+ * @param dimension - The dimension (height or width) to check.
+ * @returns True if the dimension is invalid, false otherwise.
+ */
+export function isInvalidDimension(dimension: number): boolean {
+    return isNaN(dimension) || dimension <= 0 || dimension === Infinity;
+}


### PR DESCRIPTION
## Summary:
There was a crash that happened due to a divide by zero error when the
width or height was zero.

Adding a check for that.

I also disabled the scale fields for images with invalid size, along
with a warning encouraging pressing the recalculate button.

Issue: https://khanacademy.atlassian.net/browse/LEMS-4080

## Test plan:
`pnpm jest packages/perseus-editor/src/widgets/image-editor/components/image-scale-input.tsx`

Storybook
- `/?path=/story/widgets-image-editor-demo--image-with-empty-size-with-scale-flag`

## Screenshots & demo

| Before | After |
| --- | --- |
| <img width="363" height="646" alt="Screenshot 2026-05-05 at 6 37 16 PM" src="https://github.com/user-attachments/assets/d4d1f0f8-d600-4771-940a-3156d38cad77" /> | <img width="355" height="735" alt="Screenshot 2026-05-05 at 6 40 07 PM" src="https://github.com/user-attachments/assets/4ba5333f-6519-4d88-9a0c-d5f9625a5ca9" /> |


https://github.com/user-attachments/assets/21553a20-82cd-4de8-8d36-2fecf9ade3dd


