### PR TITLE
[Preview NG] Replace deprecated ChangeHandler with typed onChange signatures

### DIFF
--- a/.changeset/clever-doves-fly.md
+++ b/.changeset/clever-doves-fly.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus-editor": major
 ---
 
-Replace deprecated `Changeable.ChangeableProps` / `ChangeHandler` with concrete typed `onChange` signatures on `Editor` and `ArticleEditor`. The deprecated change handler carried unused `callback` and `silent` parameters that no caller actually passed through; the new signatures are `onChange: (changes: Partial<PerseusRenderer>) => void` for `Editor` and `onChange: (changes: {json: PerseusArticle}) => void` for `ArticleEditor`.
+Replace deprecated `Changeable.ChangeableProps` / `ChangeHandler` with concrete typed `onChange` signatures on `Editor` and `ArticleEditor`. 

--- a/.changeset/clever-doves-fly.md
+++ b/.changeset/clever-doves-fly.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": major
+---
+
+Replace deprecated `Changeable.ChangeableProps` / `ChangeHandler` with concrete typed `onChange` signatures on `Editor` and `ArticleEditor`. The deprecated change handler carried unused `callback` and `silent` parameters that no caller actually passed through; the new signatures are `onChange: (changes: Partial<PerseusRenderer>) => void` for `Editor` and `onChange: (changes: {json: PerseusArticle}) => void` for `ArticleEditor`.

--- a/packages/perseus-editor/src/__tests__/editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/editor.test.tsx
@@ -138,21 +138,17 @@ describe("Editor", () => {
         await userEvent.tab(); // blurring the input triggers onChange to be called
 
         // Assert
-        expect(changeFn).toHaveBeenCalledWith(
-            {
-                widgets: {
-                    "image 1": expect.objectContaining({
-                        type: "image",
-                        graded: true,
-                        options: expect.objectContaining({
-                            caption: "kittens",
-                        }),
+        expect(changeFn).toHaveBeenCalledWith({
+            widgets: {
+                "image 1": expect.objectContaining({
+                    type: "image",
+                    graded: true,
+                    options: expect.objectContaining({
+                        caption: "kittens",
                     }),
-                },
+                }),
             },
-            undefined,
-            undefined,
-        );
+        });
     });
 
     it("should not log a warning given a widget with an undefined key", () => {

--- a/packages/perseus-editor/src/article-editor.tsx
+++ b/packages/perseus-editor/src/article-editor.tsx
@@ -454,7 +454,7 @@ export default class ArticleEditor extends React.Component<Props, State> {
     /**
      * Returns the current version of the edited {@link PerseusArticle}.
      *
-     * @deprecated Use the {@link Props.onChange} prop instead.
+     * @deprecated Use the `onChange` prop instead.
      */
     serialize(): PerseusArticle {
         if (this.props.mode === "edit") {

--- a/packages/perseus-editor/src/article-editor.tsx
+++ b/packages/perseus-editor/src/article-editor.tsx
@@ -35,19 +35,12 @@ import {detectTexErrors} from "./util/tex-error-detector";
 import type {Issue} from "./components/issues-panel";
 import type {
     APIOptions,
-    Changeable,
     ImageUploader,
     PerseusDependenciesV2,
 } from "@khanacademy/perseus";
-import type {PerseusArticle} from "@khanacademy/perseus-core";
+import type {PerseusArticle, PerseusRenderer} from "@khanacademy/perseus-core";
 
 const {HUD} = components;
-
-type RendererProps = {
-    content?: string;
-    widgets?: any;
-    images?: any;
-};
 
 type DefaultProps = {
     json: PerseusArticle;
@@ -65,7 +58,8 @@ type Props = DefaultProps & {
     previewURL: string;
     /** @deprecated `issues` has no effect. */
     issues?: Issue[];
-} & Changeable.ChangeableProps;
+    onChange: (changes: {json: PerseusArticle}) => void;
+};
 
 type State = {
     highlightLint: boolean;
@@ -108,7 +102,7 @@ export default class ArticleEditor extends React.Component<Props, State> {
      */
     _updateIssues() {
         // Get sections array
-        const sections: ReadonlyArray<RendererProps> =
+        const sections: PerseusArticle =
             this.props.json instanceof Array
                 ? this.props.json
                 : [this.props.json];
@@ -172,7 +166,7 @@ export default class ArticleEditor extends React.Component<Props, State> {
         }
     }
 
-    _apiOptionsForSection(section: RendererProps, sectionIndex: number): any {
+    _apiOptionsForSection(section: PerseusRenderer, sectionIndex: number): any {
         // eslint-disable-next-line react/no-string-refs
         const editor = this.refs[`editor${sectionIndex}`];
         return {
@@ -196,7 +190,7 @@ export default class ArticleEditor extends React.Component<Props, State> {
         };
     }
 
-    _sections(): ReadonlyArray<RendererProps> {
+    _sections(): ReadonlyArray<PerseusRenderer> {
         const json = this.props.json;
         return json instanceof Array ? json : [json];
     }
@@ -391,10 +385,10 @@ export default class ArticleEditor extends React.Component<Props, State> {
         this.props.onChange({json: newJson});
     };
 
-    _handleEditorChange: (i: number, newProps: RendererProps) => void = (
-        i,
-        newProps,
-    ) => {
+    _handleEditorChange: (
+        i: number,
+        newProps: Partial<PerseusRenderer>,
+    ) => void = (i, newProps) => {
         const sections = [...this._sections()];
         sections[i] = {...sections[i], ...newProps};
         this.props.onChange({json: sections});
@@ -485,7 +479,7 @@ export default class ArticleEditor extends React.Component<Props, State> {
      *
      * This function can currently only be called in edit mode.
      */
-    getSaveWarnings(): ReadonlyArray<RendererProps> {
+    getSaveWarnings(): ReadonlyArray<PerseusRenderer> {
         if (this.props.mode !== "edit") {
             throw new PerseusError(
                 "Can only get save warnings in edit mode.",

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -26,15 +26,11 @@ import {
     setPerseusClipboardData,
 } from "./util/clipboard";
 
+import type {APIOptions, ImageUploader} from "@khanacademy/perseus";
 import type {
-    APIOptions,
-    ChangeHandler,
-    ImageUploader,
-} from "@khanacademy/perseus";
-import type {
+    PerseusRenderer,
     PerseusWidget,
     PerseusWidgetsMap,
-    PerseusRenderer,
 } from "@khanacademy/perseus-core";
 
 // like [[snowman numeric-input 1]]
@@ -133,8 +129,7 @@ type Props = Readonly<{
     warnNoWidgets: boolean;
     widgetIsOpen?: boolean;
     imageUploader?: ImageUploader;
-    // eslint-disable-next-line import/no-deprecated
-    onChange: ChangeHandler;
+    onChange: (changes: Partial<PerseusRenderer>) => void;
 }>;
 
 type DefaultProps = {
@@ -301,17 +296,10 @@ class Editor extends React.Component<Props, State> {
     _handleWidgetEditorChange: (
         id: string,
         newWidgetInfo: PerseusWidget,
-        cb?: () => unknown,
-        silent?: boolean,
-    ) => void = (
-        id: string,
-        newWidgetInfo: PerseusWidget,
-        cb?: () => unknown,
-        silent?: boolean,
-    ) => {
+    ) => void = (id: string, newWidgetInfo: PerseusWidget) => {
         const widgets = Object.assign({}, this.props.widgets);
         widgets[id] = Object.assign({}, widgets[id], newWidgetInfo);
-        this.props.onChange({widgets}, cb, silent);
+        this.props.onChange({widgets});
     };
 
     _handleWidgetEditorRemove: (id: string) => void = (id: string) => {
@@ -357,14 +345,9 @@ class Editor extends React.Component<Props, State> {
                     width: width,
                     height: height,
                 };
-                props.onChange(
-                    {
-                        images: _.clone(images),
-                    },
-                    // @ts-expect-error - TS2345 - Argument of type 'null' is not assignable to parameter of type '(() => unknown) | undefined'.
-                    null, // callback
-                    true, // silent
-                );
+                props.onChange({
+                    images: _.clone(images),
+                });
             });
         });
     };
@@ -789,7 +772,7 @@ class Editor extends React.Component<Props, State> {
 
         // See componentDidUpdate() for how this flag is used
         this.lastUserValue = this.props.content;
-        this.props.onChange({content: newContent}, this.focusAndMoveToEnd);
+        this.props.onChange({content: newContent});
     };
 
     getSaveWarnings: () => any = () => {


### PR DESCRIPTION
## Summary:

*This PR is part of a series building a typed, hook-based preview system for the Perseus editor. The new system replaces the untyped `window.iframeDataStore` + raw `postMessage(string)` communication with structured, validated message passing via `usePreviewController` and `usePreviewPresenter` hooks. The new system is being built alongside the old one — no existing behavior changes until the final PR in the series flips the switch.*

Previous PRs in this series:
- #3464
- #3467
- #3474
- #3492
- #3495
- #3499
- #3578
- #3581 

--- 

`Editor` and `ArticleEditor` were using `ChangeHandler` (and `Changeable.ChangeableProps`), a deprecated signature whose `callback` and `silent` parameters were dead code throughout the codebase. This replaces both with concrete typed signatures so they are accurate and don't include data that the editor doesn't actually dispatch. 

**Note**: This change ripples in a few places worth flagging in review. Inside `ArticleEditor`, removing `Changeable.ChangeableProps` lets us drop the local `RendererProps` shim type that existed only to widen the parameter; the affected helpers (`_updateIssues`, `_sections`, `_handleEditorChange`, `_apiOptionsForSection`, `getSaveWarnings`) now use `PerseusRenderer` / `PerseusArticle` directly. In `editor.tsx`, two `props.onChange` call sites previously used the trailing `callback` parameter to position the cursor after a synchronous text replacement; that side-effect is dropped here because no caller actually wired it through, and the cursor positioning code wasn't reachable in practice.

Issue: LEMS-3741

## Test plan:

- [x] `pnpm tsc`
- [x] `pnpm test`
- [x] `pnpm lint`
