### PR TITLE
Deny `graded` in denylist

### DIFF
--- a/.changeset/wise-elephants-watch.md
+++ b/.changeset/wise-elephants-watch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Deny graded in denylist

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -481,7 +481,6 @@ describe("server item renderer", () => {
                         alignment: "default",
                         currentValue: "-42",
                         static: false,
-                        graded: true,
                         value: "3",
                     },
                 },

--- a/packages/perseus/src/mixins/widget-prop-denylist.ts
+++ b/packages/perseus/src/mixins/widget-prop-denylist.ts
@@ -42,6 +42,7 @@ const denylist = [
     "showSolutions",
     "reviewMode",
     "widgetIndex",
+    "graded",
 ];
 
 export function excludeDenylistKeys(obj: Record<any, any>) {

--- a/packages/perseus/src/widgets/categorizer/serialize-categorizer.test.ts
+++ b/packages/perseus/src/widgets/categorizer/serialize-categorizer.test.ts
@@ -91,7 +91,6 @@ describe("Categorizer serialization", () => {
                 "categorizer 1": {
                     alignment: "default",
                     static: false,
-                    graded: true,
                     categories: ["one", "two", "three"],
                     items: ["uno", "dos", "tres"],
                     randomizeItems: true,

--- a/packages/perseus/src/widgets/cs-program/serialize-cs-program.test.ts
+++ b/packages/perseus/src/widgets/cs-program/serialize-cs-program.test.ts
@@ -80,7 +80,6 @@ describe("CSProgram serialization", () => {
                     settings: [],
                     height: 410,
                     static: false,
-                    graded: true,
                     programID: "6293105639817216",
                     programType: null,
                     showButtons: false,

--- a/packages/perseus/src/widgets/dropdown/serialize-dropdown.test.ts
+++ b/packages/perseus/src/widgets/dropdown/serialize-dropdown.test.ts
@@ -93,7 +93,6 @@ describe("Dropdown serialization", () => {
                 "dropdown 1": {
                     alignment: "default",
                     static: false,
-                    graded: true,
                     choices: ["Correct", "Incorrect"],
                     dependencies: testDependenciesV2,
                     placeholder: "Choose",

--- a/packages/perseus/src/widgets/expression/serialize-expression.test.ts
+++ b/packages/perseus/src/widgets/expression/serialize-expression.test.ts
@@ -98,7 +98,6 @@ describe("Expression serialization", () => {
                 "expression 1": {
                     alignment: "default",
                     static: false,
-                    graded: true,
                     keypadConfiguration: {
                         keypadType: "EXPRESSION",
                         times: false,

--- a/packages/perseus/src/widgets/grapher/serialize-grapher.test.ts
+++ b/packages/perseus/src/widgets/grapher/serialize-grapher.test.ts
@@ -100,7 +100,6 @@ describe("Grapher serialization", () => {
                 "grapher 1": {
                     alignment: "default",
                     static: false,
-                    graded: true,
                     availableTypes: ["linear"],
                     dependencies: testDependenciesV2,
                     graph: {

--- a/packages/perseus/src/widgets/group/group.test.tsx
+++ b/packages/perseus/src/widgets/group/group.test.tsx
@@ -168,7 +168,6 @@ describe("group widget", () => {
             "group 1": {
                 "radio 1": {
                     alignment: "default",
-                    graded: true,
                     choiceStates: [
                         expectedChoiceState,
                         expectedChoiceState,
@@ -241,7 +240,6 @@ describe("group widget", () => {
                     rightAlign: false,
                     size: "normal",
                     static: false,
-                    graded: true,
                 },
                 "numeric-input 2": {
                     alignment: "default",
@@ -252,7 +250,6 @@ describe("group widget", () => {
                     rightAlign: false,
                     size: "normal",
                     static: false,
-                    graded: true,
                 },
             },
         });

--- a/packages/perseus/src/widgets/iframe/serialize-iframe.test.ts
+++ b/packages/perseus/src/widgets/iframe/serialize-iframe.test.ts
@@ -85,7 +85,6 @@ describe("IFrame serialization", () => {
                     allowFullScreen: true,
                     allowTopNavigation: false,
                     static: false,
-                    graded: true,
                 },
             },
             hints: [],

--- a/packages/perseus/src/widgets/interactive-graphs/serialize-interactive-graph.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/serialize-interactive-graph.test.ts
@@ -117,7 +117,6 @@ describe("InteractiveGraph serialization", () => {
                 "interactive-graph 1": {
                     alignment: "default",
                     static: false,
-                    graded: true,
                     labels: ["$x$", "$y$"],
                     labelLocation: "onAxis",
                     range: [

--- a/packages/perseus/src/widgets/label-image/__tests__/serialize-label-image.test.ts
+++ b/packages/perseus/src/widgets/label-image/__tests__/serialize-label-image.test.ts
@@ -124,7 +124,6 @@ describe("LabelImage serialization", () => {
                 "label-image 1": {
                     alignment: "default",
                     static: false,
-                    graded: true,
                     choices: ["One", "Two", "Three"],
                     imageAlt: "Alt text",
                     imageUrl:

--- a/packages/perseus/src/widgets/matrix/serialize-matrix.test.ts
+++ b/packages/perseus/src/widgets/matrix/serialize-matrix.test.ts
@@ -94,7 +94,6 @@ describe("Matrix serialization", () => {
                 "matrix 1": {
                     alignment: "default",
                     static: false,
-                    graded: true,
                     matrixBoardSize: [2, 2],
                     prefix: "",
                     suffix: "",

--- a/packages/perseus/src/widgets/numeric-input/serialize-numeric-input.test.ts
+++ b/packages/perseus/src/widgets/numeric-input/serialize-numeric-input.test.ts
@@ -95,7 +95,6 @@ describe("NumericInput serialization", () => {
                 "numeric-input 1": {
                     alignment: "default",
                     static: false,
-                    graded: true,
                     answerForms: [],
                     coefficient: false,
                     labelText: "",

--- a/packages/perseus/src/widgets/orderer/serialize-orderer.test.ts
+++ b/packages/perseus/src/widgets/orderer/serialize-orderer.test.ts
@@ -93,7 +93,6 @@ describe("Orderer serialization", () => {
                 "orderer 1": {
                     alignment: "default",
                     static: false,
-                    graded: true,
                     // ???
                     otherOptions: [],
                     // The correct order

--- a/packages/perseus/src/widgets/plotter/serialize-plotter.test.ts
+++ b/packages/perseus/src/widgets/plotter/serialize-plotter.test.ts
@@ -95,7 +95,6 @@ describe("Plotter serialization", () => {
                 "plotter 1": {
                     alignment: "default",
                     static: false,
-                    graded: true,
                     scaleY: 1,
                     maxY: 2,
                     snapsPerLine: 1,

--- a/packages/perseus/src/widgets/radio/serialize-radio.test.ts
+++ b/packages/perseus/src/widgets/radio/serialize-radio.test.ts
@@ -15,7 +15,6 @@ import type {UserEvent} from "@testing-library/user-event";
 
 const expectedSerializedRadio = {
     alignment: "default",
-    graded: true,
     numCorrect: 1,
     hasNoneOfTheAbove: false,
     choices: [

--- a/packages/perseus/src/widgets/sorter/serialize-sorter.test.ts
+++ b/packages/perseus/src/widgets/sorter/serialize-sorter.test.ts
@@ -91,7 +91,6 @@ describe("Sorter serialization", () => {
                 "sorter 1": {
                     alignment: "default",
                     static: false,
-                    graded: true,
                     correct: ["First", "Second", "Third"],
                     options: ["First", "Second", "Third"],
                     changed: true,

--- a/packages/perseus/src/widgets/table/serialize-table.test.ts
+++ b/packages/perseus/src/widgets/table/serialize-table.test.ts
@@ -101,7 +101,6 @@ describe("Table serialization", () => {
                 "table 1": {
                     alignment: "default",
                     static: false,
-                    graded: true,
                     headers: ["Column 1", "Column 2"],
                     rows: 2,
                     columns: 2,


### PR DESCRIPTION
## Summary:

`graded` was getting erroneously added to widget options which was breaking publish for certain widgets because the backend doesn't allow unknown fields.

This adds `graded` to the deny list, so that shouldn't happen anymore. It breaks my "interactive but not scored" feature, but that's behind a feature flag so I think that's okay.

See: https://khanacademy.slack.com/archives/C01AZ9H8TTQ/p1778089642003609