### PR TITLE
[Preview NG] Rename preview data field names and unify article-all apiOptions

### DIFF
--- a/.changeset/grumpy-chairs-promise.md
+++ b/.changeset/grumpy-chairs-promise.md
@@ -1,5 +1,5 @@
 ---
-"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus-editor": major
 ---
 
-Clarify field names in preview messages related to articles (no longer `json`, now `article` or `section` as needed)
+Rework the preview message data shapes exposed via `usePreviewController` / `usePreviewPresenter`: rename `ArticlePreviewData.json` to `article` (now a single section `PerseusRenderer`), drop `QuestionPreviewData.initialHintsVisible`, replace the `article-all` payload with `ArticleAllPreviewData` (a single shared `apiOptions` across all sections), rename the presenter content field from `data` to `content`, and type preview `apiOptions` as the new `SerializableApiOptions` (the `postMessage`-safe subset of `APIOptions`).

--- a/.changeset/grumpy-chairs-promise.md
+++ b/.changeset/grumpy-chairs-promise.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus-editor": major
 ---
 
-Rework the preview message data shapes exposed via `usePreviewController` / `usePreviewPresenter`: rename `ArticlePreviewData.json` to `article` (now a single section `PerseusRenderer`), drop `QuestionPreviewData.initialHintsVisible`, replace the `article-all` payload with `ArticleAllPreviewData` (a single shared `apiOptions` across all sections), rename the presenter content field from `data` to `content`, and type preview `apiOptions` as the new `SerializableApiOptions` (the `postMessage`-safe subset of `APIOptions`).
+Rework the preview message data shapes exposed by `usePreviewController`/`usePreviewPresenter` with clearer field names and a serializable `apiOptions` type.

--- a/.changeset/grumpy-chairs-promise.md
+++ b/.changeset/grumpy-chairs-promise.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Clarify field names in preview messages related to articles (no longer `json`, now `article` or `section` as needed)

--- a/packages/perseus-editor/src/article-editor.tsx
+++ b/packages/perseus-editor/src/article-editor.tsx
@@ -282,7 +282,7 @@ export default class ArticleEditor extends React.Component<Props, State> {
                                             seamless={true}
                                             url={this.props.previewURL}
                                             content={{
-                                                type: "article" as const,
+                                                type: "article-section" as const,
                                                 data: this._previewDataForSection(
                                                     section,
                                                     i,

--- a/packages/perseus-editor/src/article-editor.tsx
+++ b/packages/perseus-editor/src/article-editor.tsx
@@ -138,12 +138,11 @@ export default class ArticleEditor extends React.Component<Props, State> {
         const editor = this.refs[`editor${sectionIndex}`];
 
         return {
+            article: section,
             apiOptions: this._apiOptionsForPreview(),
-            json: section,
             linterContext: {
                 contentType: "article",
                 highlightLint: this.state.highlightLint,
-                stack: [],
             },
             // @ts-expect-error - TS2339 - Property 'getSaveWarnings' does not exist on type 'ReactInstance'.
             legacyPerseusLint: editor?.getSaveWarnings() ?? [],
@@ -353,9 +352,10 @@ export default class ArticleEditor extends React.Component<Props, State> {
                         url={this.props.previewURL}
                         content={{
                             type: "article-all" as const,
-                            data: this._sections().map((section, idx) =>
-                                this._previewDataForSection(section, idx),
-                            ),
+                            data: {
+                                article: this._sections(),
+                                apiOptions: this._apiOptionsForPreview(),
+                            },
                         }}
                     />
                 </DeviceFramer>

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -215,7 +215,6 @@ class ItemEditor extends React.Component<Props, State> {
                         this.props.deviceType === "phone" ||
                         this.props.deviceType === "tablet",
                 },
-                initialHintsVisible: 0,
                 device: this.props.deviceType,
                 linterContext: {
                     contentType: "exercise",

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -194,7 +194,6 @@ class ItemEditor extends React.Component<Props, State> {
     // Builds the preview content from props.
     _derivePreviewContent(): QuestionPreviewData | null {
         const question = this.props.question;
-        const answerArea = this.props.answerArea ?? undefined;
 
         if (!question) {
             return null;
@@ -203,11 +202,7 @@ class ItemEditor extends React.Component<Props, State> {
         return {
             type: "question",
             data: {
-                item: {
-                    question,
-                    hints: [],
-                    answerArea,
-                },
+                question,
                 apiOptions: {
                     ...ApiOptions.defaults,
                     ...this.props.apiOptions,
@@ -215,7 +210,6 @@ class ItemEditor extends React.Component<Props, State> {
                         this.props.deviceType === "phone" ||
                         this.props.deviceType === "tablet",
                 },
-                device: this.props.deviceType,
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: this.props.highlightLint,

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -103,12 +103,8 @@ describe("PreviewWithIframe", () => {
         const data: PreviewContent = {
             type: "question",
             data: {
-                item: {
-                    question: {content: "Q", widgets: {}, images: {}},
-                    hints: [],
-                },
+                question: {content: "Q", widgets: {}, images: {}},
                 apiOptions: {},
-                device: "desktop",
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
@@ -132,12 +128,8 @@ describe("PreviewWithIframe", () => {
         const content: Extract<PreviewContent, {type: "question"}> = {
             type: "question",
             data: {
-                item: {
-                    question: {content: "Q", widgets: {}, images: {}},
-                    hints: [],
-                },
+                question: {content: "Q", widgets: {}, images: {}},
                 apiOptions: {},
-                device: "desktop",
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
@@ -155,7 +147,7 @@ describe("PreviewWithIframe", () => {
         );
 
         const modifiedContent = clone(content);
-        modifiedContent.data.item.question.content = "Abc";
+        modifiedContent.data.question.content = "Abc";
 
         // Act
         rerender(

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -19,7 +19,7 @@ jest.mock("./preview/use-preview-controller", () => ({
 
 function buildArticleContent(): PreviewContent {
     return {
-        type: "article",
+        type: "article-section",
         data: {
             apiOptions: ApiOptions.defaults,
             article: {content: "Hello", widgets: {}, images: {}},

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -22,7 +22,7 @@ function buildArticleContent(): PreviewContent {
         type: "article",
         data: {
             apiOptions: ApiOptions.defaults,
-            json: {content: "Hello", widgets: {}, images: {}},
+            article: {content: "Hello", widgets: {}, images: {}},
             linterContext: {
                 contentType: "article",
                 highlightLint: false,
@@ -109,7 +109,6 @@ describe("PreviewWithIframe", () => {
                 },
                 apiOptions: {},
                 device: "desktop",
-                initialHintsVisible: 0,
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
@@ -130,7 +129,7 @@ describe("PreviewWithIframe", () => {
     });
 
     it("sends content using usePreviewController's sendData", () => {
-        const content: PreviewContent = {
+        const content: Extract<PreviewContent, {type: "question"}> = {
             type: "question",
             data: {
                 item: {
@@ -139,7 +138,6 @@ describe("PreviewWithIframe", () => {
                 },
                 apiOptions: {},
                 device: "desktop",
-                initialHintsVisible: 0,
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,

--- a/packages/perseus-editor/src/preview/message-types.ts
+++ b/packages/perseus-editor/src/preview/message-types.ts
@@ -6,8 +6,8 @@
 import type {APIOptions, DeviceType} from "@khanacademy/perseus";
 import type {
     Hint,
-    PerseusArticle,
     PerseusItem,
+    PerseusRenderer,
 } from "@khanacademy/perseus-core";
 
 /**
@@ -39,7 +39,6 @@ interface PreviewMessageBase {
 export type QuestionPreviewData = {
     item: PerseusItem;
     apiOptions: APIOptions;
-    initialHintsVisible: number;
     device: DeviceType;
     linterContext: PreviewLinterContext;
     reviewMode?: boolean;
@@ -58,13 +57,21 @@ export type HintPreviewData = {
 };
 
 /**
- * Data for article section preview
+ * Data for a single article section preview (used in edit mode for one section)
  */
 export type ArticlePreviewData = {
+    article: PerseusRenderer;
     apiOptions: APIOptions;
-    json: PerseusArticle;
     linterContext: PreviewLinterContext;
     legacyPerseusLint?: ReadonlyArray<string>;
+};
+
+/**
+ * Data for article-all preview (used in preview mode to render all sections at once)
+ */
+export type ArticleAllPreviewData = {
+    article: ReadonlyArray<PerseusRenderer>;
+    apiOptions: APIOptions;
 };
 
 /**
@@ -74,7 +81,7 @@ export type PreviewContent =
     | {type: "question"; data: QuestionPreviewData}
     | {type: "hint"; data: HintPreviewData}
     | {type: "article"; data: ArticlePreviewData}
-    | {type: "article-all"; data: ArticlePreviewData[]};
+    | {type: "article-all"; data: ArticleAllPreviewData};
 
 // ---- Parent → Iframe messages ----
 

--- a/packages/perseus-editor/src/preview/message-types.ts
+++ b/packages/perseus-editor/src/preview/message-types.ts
@@ -3,7 +3,8 @@
  * the preview iframe.
  */
 
-import type {APIOptions, DeviceType} from "@khanacademy/perseus";
+import type {SerializableApiOptions} from "./sanitize-api-options";
+import type {DeviceType} from "@khanacademy/perseus";
 import type {
     Hint,
     PerseusItem,
@@ -38,7 +39,7 @@ interface PreviewMessageBase {
  */
 export type QuestionPreviewData = {
     item: PerseusItem;
-    apiOptions: APIOptions;
+    apiOptions: SerializableApiOptions;
     device: DeviceType;
     linterContext: PreviewLinterContext;
     reviewMode?: boolean;
@@ -52,7 +53,7 @@ export type QuestionPreviewData = {
 export type HintPreviewData = {
     hint: Hint;
     pos: number;
-    apiOptions: APIOptions;
+    apiOptions: SerializableApiOptions;
     linterContext: PreviewLinterContext;
 };
 
@@ -61,7 +62,7 @@ export type HintPreviewData = {
  */
 export type ArticlePreviewData = {
     article: PerseusRenderer;
-    apiOptions: APIOptions;
+    apiOptions: SerializableApiOptions;
     linterContext: PreviewLinterContext;
     legacyPerseusLint?: ReadonlyArray<string>;
 };
@@ -71,7 +72,7 @@ export type ArticlePreviewData = {
  */
 export type ArticleAllPreviewData = {
     article: ReadonlyArray<PerseusRenderer>;
-    apiOptions: APIOptions;
+    apiOptions: SerializableApiOptions;
 };
 
 /**

--- a/packages/perseus-editor/src/preview/message-types.ts
+++ b/packages/perseus-editor/src/preview/message-types.ts
@@ -4,12 +4,7 @@
  */
 
 import type {SerializableApiOptions} from "./sanitize-api-options";
-import type {DeviceType} from "@khanacademy/perseus";
-import type {
-    Hint,
-    PerseusItem,
-    PerseusRenderer,
-} from "@khanacademy/perseus-core";
+import type {Hint, PerseusRenderer} from "@khanacademy/perseus-core";
 
 /**
  * The subset of `LinterContextProps` that's meaningful to send across the
@@ -35,12 +30,16 @@ interface PreviewMessageBase {
 }
 
 /**
- * Data for question preview (full item with question, answer area, and hints)
+ * Data for the read-only question preview shown while editing an exercise.
+ *
+ * This carries just the question's `PerseusRenderer` — the content under edit —
+ * rather than a full `PerseusItem`. The answer widgets live inside the question
+ * renderer itself; the legacy answer-area tools and hints are previewed
+ * elsewhere.
  */
 export type QuestionPreviewData = {
-    item: PerseusItem;
+    question: PerseusRenderer;
     apiOptions: SerializableApiOptions;
-    device: DeviceType;
     linterContext: PreviewLinterContext;
     reviewMode?: boolean;
     legacyPerseusLint?: ReadonlyArray<string>;

--- a/packages/perseus-editor/src/preview/message-types.ts
+++ b/packages/perseus-editor/src/preview/message-types.ts
@@ -59,7 +59,7 @@ export type HintPreviewData = {
 /**
  * Data for a single article section preview (used in edit mode for one section)
  */
-export type ArticlePreviewData = {
+export type ArticleSectionPreviewData = {
     article: PerseusRenderer;
     apiOptions: SerializableApiOptions;
     linterContext: PreviewLinterContext;
@@ -80,7 +80,7 @@ export type ArticleAllPreviewData = {
 export type PreviewContent =
     | {type: "question"; data: QuestionPreviewData}
     | {type: "hint"; data: HintPreviewData}
-    | {type: "article"; data: ArticlePreviewData}
+    | {type: "article-section"; data: ArticleSectionPreviewData}
     | {type: "article-all"; data: ArticleAllPreviewData};
 
 // ---- Parent → Iframe messages ----

--- a/packages/perseus-editor/src/preview/message-validators.test.ts
+++ b/packages/perseus-editor/src/preview/message-validators.test.ts
@@ -104,7 +104,6 @@ describe("message-validators", () => {
                     data: {
                         item: {question: {content: "test"}},
                         apiOptions: {},
-                        initialHintsVisible: 0,
                         device: {type: "phone" as const},
                         linterContext: {contentType: "exercise" as const},
                     },

--- a/packages/perseus-editor/src/preview/message-validators.test.ts
+++ b/packages/perseus-editor/src/preview/message-validators.test.ts
@@ -102,9 +102,8 @@ describe("message-validators", () => {
                 content: {
                     type: "question" as const,
                     data: {
-                        item: {question: {content: "test"}},
+                        question: {content: "test"},
                         apiOptions: {},
-                        device: {type: "phone" as const},
                         linterContext: {contentType: "exercise" as const},
                     },
                 },

--- a/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
+++ b/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
@@ -1,4 +1,3 @@
-import {getDefaultAnswerArea} from "@khanacademy/perseus-core";
 import invariant from "tiny-invariant";
 
 import {sanitizePreviewData} from "./preview-data-sanitizer";
@@ -32,17 +31,12 @@ describe("sanitizePreviewData", () => {
     describe("question preview data", () => {
         it("sanitizes apiOptions in question data", () => {
             const questionData: QuestionPreviewData = {
-                item: {
-                    question: {
-                        content: "What is 2+2?",
-                        widgets: {},
-                        images: {},
-                    },
-                    answerArea: getDefaultAnswerArea(),
-                    hints: [],
+                question: {
+                    content: "What is 2+2?",
+                    widgets: {},
+                    images: {},
                 },
                 apiOptions: createMockApiOptions(),
-                device: "phone",
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
@@ -70,19 +64,14 @@ describe("sanitizePreviewData", () => {
             expect("trackInteraction" in result.data.apiOptions).toBe(false);
 
             // Other properties should remain unchanged
-            expect(result.data.item).toBe(questionData.item);
+            expect(result.data.question).toBe(questionData.question);
         });
 
         it("handles question data with null apiOptions", () => {
             const questionData: QuestionPreviewData = {
-                item: {
-                    question: {content: "Test", widgets: {}, images: {}},
-                    answerArea: getDefaultAnswerArea(),
-                    hints: [],
-                },
+                question: {content: "Test", widgets: {}, images: {}},
                 // eslint-disable-next-line no-restricted-syntax
                 apiOptions: null as any,
-                device: "phone",
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
@@ -104,13 +93,8 @@ describe("sanitizePreviewData", () => {
         it("does not mutate original question data", () => {
             const apiOptions = createMockApiOptions();
             const questionData: QuestionPreviewData = {
-                item: {
-                    question: {content: "Test", widgets: {}, images: {}},
-                    answerArea: getDefaultAnswerArea(),
-                    hints: [],
-                },
+                question: {content: "Test", widgets: {}, images: {}},
                 apiOptions,
-                device: "phone",
                 linterContext: {
                     contentType: "exercise",
                     highlightLint: false,
@@ -330,17 +314,12 @@ describe("sanitizePreviewData", () => {
                         previewContent = {
                             type: "question",
                             data: {
-                                item: {
-                                    question: {
-                                        content: "Q",
-                                        widgets: {},
-                                        images: {},
-                                    },
-                                    answerArea: getDefaultAnswerArea(),
-                                    hints: [],
+                                question: {
+                                    content: "Q",
+                                    widgets: {},
+                                    images: {},
                                 },
                                 apiOptions: {},
-                                device: "phone",
                                 linterContext: {
                                     contentType: "exercise",
                                     highlightLint: false,

--- a/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
+++ b/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
@@ -4,7 +4,7 @@ import {sanitizePreviewData} from "./preview-data-sanitizer";
 
 import type {
     ArticleAllPreviewData,
-    ArticlePreviewData,
+    ArticleSectionPreviewData,
     HintPreviewData,
     PreviewContent,
     QuestionPreviewData,
@@ -175,7 +175,7 @@ describe("sanitizePreviewData", () => {
 
     describe("article preview data", () => {
         it("sanitizes apiOptions in article data", () => {
-            const articleData: ArticlePreviewData = {
+            const articleData: ArticleSectionPreviewData = {
                 article: {content: "# Article Title", widgets: {}, images: {}},
                 apiOptions: createMockApiOptions(),
                 linterContext: {
@@ -185,13 +185,13 @@ describe("sanitizePreviewData", () => {
             };
 
             const previewContent: PreviewContent = {
-                type: "article",
+                type: "article-section",
                 data: articleData,
             };
 
             const result = sanitizePreviewData(previewContent);
 
-            invariant(result.type === "article");
+            invariant(result.type === "article-section");
             // Serializable options should remain
             expect(result.data.apiOptions.customKeypad).toBe(true);
 
@@ -203,7 +203,7 @@ describe("sanitizePreviewData", () => {
         });
 
         it("handles article data with null apiOptions", () => {
-            const articleData: ArticlePreviewData = {
+            const articleData: ArticleSectionPreviewData = {
                 article: {content: "Content", widgets: {}, images: {}},
                 // eslint-disable-next-line no-restricted-syntax
                 apiOptions: null as any,
@@ -214,7 +214,7 @@ describe("sanitizePreviewData", () => {
             };
 
             const previewContent: PreviewContent = {
-                type: "article",
+                type: "article-section",
                 data: articleData,
             };
 
@@ -302,7 +302,7 @@ describe("sanitizePreviewData", () => {
             const types: PreviewContent["type"][] = [
                 "question",
                 "hint",
-                "article",
+                "article-section",
                 "article-all",
             ];
 
@@ -341,9 +341,9 @@ describe("sanitizePreviewData", () => {
                             },
                         };
                         break;
-                    case "article":
+                    case "article-section":
                         previewContent = {
-                            type: "article",
+                            type: "article-section",
                             data: {
                                 article: {
                                     content: "A",

--- a/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
+++ b/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
@@ -63,11 +63,11 @@ describe("sanitizePreviewData", () => {
             expect(result.data.apiOptions.customKeypad).toBe(true);
 
             // Non-serializable functions should be removed
-            expect(result.data.apiOptions.onFocusChange).toBeUndefined();
-            expect(result.data.apiOptions.answerableCallback).toBeUndefined();
-            expect(result.data.apiOptions.getAnotherHint).toBeUndefined();
-            expect(result.data.apiOptions.interactionCallback).toBeUndefined();
-            expect(result.data.apiOptions.trackInteraction).toBeUndefined();
+            expect("onFocusChange" in result.data.apiOptions).toBe(false);
+            expect("answerableCallback" in result.data.apiOptions).toBe(false);
+            expect("getAnotherHint" in result.data.apiOptions).toBe(false);
+            expect("interactionCallback" in result.data.apiOptions).toBe(false);
+            expect("trackInteraction" in result.data.apiOptions).toBe(false);
 
             // Other properties should remain unchanged
             expect(result.data.item).toBe(questionData.item);
@@ -158,8 +158,8 @@ describe("sanitizePreviewData", () => {
             expect(result.data.apiOptions.readOnly).toBe(true);
 
             // Non-serializable functions should be removed
-            expect(result.data.apiOptions.onFocusChange).toBeUndefined();
-            expect(result.data.apiOptions.trackInteraction).toBeUndefined();
+            expect("onFocusChange" in result.data.apiOptions).toBe(false);
+            expect("trackInteraction" in result.data.apiOptions).toBe(false);
 
             // Other properties should remain unchanged
             expect(result.data.hint).toBe(hintData.hint);
@@ -212,7 +212,7 @@ describe("sanitizePreviewData", () => {
             expect(result.data.apiOptions.customKeypad).toBe(true);
 
             // Non-serializable functions should be removed
-            expect(result.data.apiOptions.interactionCallback).toBeUndefined();
+            expect("interactionCallback" in result.data.apiOptions).toBe(false);
 
             // Other properties should remain unchanged
             expect(result.data.article).toBe(articleData.article);
@@ -260,8 +260,8 @@ describe("sanitizePreviewData", () => {
             invariant(result.type === "article-all");
             expect(result.data.article).toHaveLength(2);
             expect(result.data.apiOptions.readOnly).toBe(true);
-            expect(result.data.apiOptions.onFocusChange).toBeUndefined();
-            expect(result.data.apiOptions.trackInteraction).toBeUndefined();
+            expect("onFocusChange" in result.data.apiOptions).toBe(false);
+            expect("trackInteraction" in result.data.apiOptions).toBe(false);
         });
 
         it("handles empty article-all sections array", () => {

--- a/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
+++ b/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
@@ -4,6 +4,7 @@ import invariant from "tiny-invariant";
 import {sanitizePreviewData} from "./preview-data-sanitizer";
 
 import type {
+    ArticleAllPreviewData,
     ArticlePreviewData,
     HintPreviewData,
     PreviewContent,
@@ -41,7 +42,6 @@ describe("sanitizePreviewData", () => {
                     hints: [],
                 },
                 apiOptions: createMockApiOptions(),
-                initialHintsVisible: 0,
                 device: "phone",
                 linterContext: {
                     contentType: "exercise",
@@ -71,7 +71,6 @@ describe("sanitizePreviewData", () => {
 
             // Other properties should remain unchanged
             expect(result.data.item).toBe(questionData.item);
-            expect(result.data.initialHintsVisible).toBe(0);
         });
 
         it("handles question data with null apiOptions", () => {
@@ -83,7 +82,6 @@ describe("sanitizePreviewData", () => {
                 },
                 // eslint-disable-next-line no-restricted-syntax
                 apiOptions: null as any,
-                initialHintsVisible: 0,
                 device: "phone",
                 linterContext: {
                     contentType: "exercise",
@@ -112,7 +110,6 @@ describe("sanitizePreviewData", () => {
                     hints: [],
                 },
                 apiOptions,
-                initialHintsVisible: 0,
                 device: "phone",
                 linterContext: {
                     contentType: "exercise",
@@ -195,7 +192,7 @@ describe("sanitizePreviewData", () => {
     describe("article preview data", () => {
         it("sanitizes apiOptions in article data", () => {
             const articleData: ArticlePreviewData = {
-                json: [{content: "# Article Title", widgets: {}, images: {}}],
+                article: {content: "# Article Title", widgets: {}, images: {}},
                 apiOptions: createMockApiOptions(),
                 linterContext: {
                     contentType: "article",
@@ -218,12 +215,12 @@ describe("sanitizePreviewData", () => {
             expect(result.data.apiOptions.interactionCallback).toBeUndefined();
 
             // Other properties should remain unchanged
-            expect(result.data.json).toBe(articleData.json);
+            expect(result.data.article).toBe(articleData.article);
         });
 
         it("handles article data with null apiOptions", () => {
             const articleData: ArticlePreviewData = {
-                json: [{content: "Content", widgets: {}, images: {}}],
+                article: {content: "Content", widgets: {}, images: {}},
                 // eslint-disable-next-line no-restricted-syntax
                 apiOptions: null as any,
                 linterContext: {
@@ -243,72 +240,55 @@ describe("sanitizePreviewData", () => {
         });
     });
 
-    // NOTE: The article-all type currently uses ArticlePreviewData[] where
-    // each section carries its own apiOptions. This will be simplified to a
-    // single apiOptions when we restructure the preview data types.
     describe("article-all preview data", () => {
-        it("sanitizes apiOptions in all article sections", () => {
-            const section1: ArticlePreviewData = {
-                json: [{content: "Section 1", widgets: {}, images: {}}],
+        it("sanitizes the shared apiOptions across all sections", () => {
+            const articleAllData: ArticleAllPreviewData = {
+                article: [
+                    {content: "Section 1", widgets: {}, images: {}},
+                    {content: "Section 2", widgets: {}, images: {}},
+                ],
                 apiOptions: createMockApiOptions(),
-                linterContext: {
-                    contentType: "article",
-                    highlightLint: false,
-                },
-            };
-            const section2: ArticlePreviewData = {
-                json: [{content: "Section 2", widgets: {}, images: {}}],
-                apiOptions: {
-                    ...createMockApiOptions(),
-                    readOnly: false,
-                },
-                linterContext: {
-                    contentType: "article",
-                    highlightLint: false,
-                },
             };
 
             const previewContent: PreviewContent = {
                 type: "article-all",
-                data: [section1, section2],
+                data: articleAllData,
             };
 
             const result = sanitizePreviewData(previewContent);
 
             invariant(result.type === "article-all");
-            expect(result.data).toHaveLength(2);
-            expect(result.data[0].apiOptions.readOnly).toBe(true);
-            expect(result.data[0].apiOptions.onFocusChange).toBeUndefined();
-            expect(result.data[1].apiOptions.readOnly).toBe(false);
-            expect(result.data[1].apiOptions.onFocusChange).toBeUndefined();
+            expect(result.data.article).toHaveLength(2);
+            expect(result.data.apiOptions.readOnly).toBe(true);
+            expect(result.data.apiOptions.onFocusChange).toBeUndefined();
+            expect(result.data.apiOptions.trackInteraction).toBeUndefined();
         });
 
-        it("handles empty article-all array", () => {
+        it("handles empty article-all sections array", () => {
             const previewContent: PreviewContent = {
                 type: "article-all",
-                data: [],
+                data: {
+                    article: [],
+                    apiOptions: createMockApiOptions(),
+                },
             };
 
             const result = sanitizePreviewData(previewContent);
 
             invariant(result.type === "article-all");
-            expect(result.data).toHaveLength(0);
+            expect(result.data.article).toHaveLength(0);
         });
 
         it("does not mutate original article-all data", () => {
             const apiOptions = createMockApiOptions();
-            const section: ArticlePreviewData = {
-                json: [{content: "Section 1", widgets: {}, images: {}}],
+            const articleAllData: ArticleAllPreviewData = {
+                article: [{content: "Section 1", widgets: {}, images: {}}],
                 apiOptions,
-                linterContext: {
-                    contentType: "article",
-                    highlightLint: false,
-                },
             };
 
             const previewContent: PreviewContent = {
                 type: "article-all",
-                data: [section],
+                data: articleAllData,
             };
 
             sanitizePreviewData(previewContent);
@@ -317,37 +297,19 @@ describe("sanitizePreviewData", () => {
             expect(apiOptions.onFocusChange).toBeDefined();
         });
 
-        it("handles sections with null apiOptions", () => {
-            const section1: ArticlePreviewData = {
-                json: [{content: "Section 1", widgets: {}, images: {}}],
-                apiOptions: createMockApiOptions(),
-                linterContext: {
-                    contentType: "article",
-                    highlightLint: false,
-                },
-            };
-            const section2: ArticlePreviewData = {
-                json: [{content: "Section 2", widgets: {}, images: {}}],
-                // eslint-disable-next-line no-restricted-syntax
-                apiOptions: null as any,
-                linterContext: {
-                    contentType: "article",
-                    highlightLint: false,
-                },
-            };
-
+        it("handles article-all with null apiOptions", () => {
             const previewContent: PreviewContent = {
                 type: "article-all",
-                data: [section1, section2],
+                data: {
+                    article: [{content: "Section 1", widgets: {}, images: {}}],
+                    // eslint-disable-next-line no-restricted-syntax
+                    apiOptions: null as any,
+                },
             };
 
             const result = sanitizePreviewData(previewContent);
 
-            invariant(result.type === "article-all");
-            expect(result.data).toHaveLength(2);
-            expect(result.data[0].apiOptions.onFocusChange).toBeUndefined();
-            // Section with null apiOptions should be unchanged
-            expect(result.data[1].apiOptions).toBeNull();
+            expect(result).toEqual(previewContent);
         });
     });
 
@@ -378,7 +340,6 @@ describe("sanitizePreviewData", () => {
                                     hints: [],
                                 },
                                 apiOptions: {},
-                                initialHintsVisible: 0,
                                 device: "phone",
                                 linterContext: {
                                     contentType: "exercise",
@@ -405,13 +366,11 @@ describe("sanitizePreviewData", () => {
                         previewContent = {
                             type: "article",
                             data: {
-                                json: [
-                                    {
-                                        content: "A",
-                                        widgets: {},
-                                        images: {},
-                                    },
-                                ],
+                                article: {
+                                    content: "A",
+                                    widgets: {},
+                                    images: {},
+                                },
                                 apiOptions: {},
                                 linterContext: {
                                     contentType: "article",
@@ -423,22 +382,16 @@ describe("sanitizePreviewData", () => {
                     case "article-all":
                         previewContent = {
                             type: "article-all",
-                            data: [
-                                {
-                                    json: [
-                                        {
-                                            content: "Paragraph A",
-                                            widgets: {},
-                                            images: {},
-                                        },
-                                    ],
-                                    apiOptions: {},
-                                    linterContext: {
-                                        contentType: "article",
-                                        highlightLint: false,
+                            data: {
+                                article: [
+                                    {
+                                        content: "Paragraph A",
+                                        widgets: {},
+                                        images: {},
                                     },
-                                },
-                            ],
+                                ],
+                                apiOptions: {},
+                            },
                         };
                         break;
                 }

--- a/packages/perseus-editor/src/preview/preview-data-sanitizer.ts
+++ b/packages/perseus-editor/src/preview/preview-data-sanitizer.ts
@@ -39,7 +39,7 @@ export function sanitizePreviewData(
                     apiOptions: sanitizedApiOptions,
                 },
             };
-        case "article":
+        case "article-section":
             return {
                 type: content.type,
                 data: {

--- a/packages/perseus-editor/src/preview/preview-data-sanitizer.ts
+++ b/packages/perseus-editor/src/preview/preview-data-sanitizer.ts
@@ -1,3 +1,5 @@
+import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
+
 import {sanitizeApiOptions} from "./sanitize-api-options";
 
 import type {PreviewContent} from "./message-types";
@@ -14,12 +16,46 @@ export function sanitizePreviewData(
         return content;
     }
 
-    // eslint-disable-next-line no-restricted-syntax
-    return {
-        ...content,
-        data: {
-            ...content.data,
-            apiOptions: sanitizeApiOptions(content.data.apiOptions),
-        },
-    } as PreviewContent;
+    const sanitizedApiOptions = sanitizeApiOptions(content.data.apiOptions);
+
+    // We switch on `content.type` and rebuild each variant explicitly so the
+    // result stays a properly-correlated member of the `PreviewContent`
+    // discriminated union — a single `{...content, data: {...}}` spread would
+    // widen `type` and `data` independently and no longer be assignable.
+    switch (content.type) {
+        case "question":
+            return {
+                type: content.type,
+                data: {
+                    ...content.data,
+                    apiOptions: sanitizedApiOptions,
+                },
+            };
+        case "hint":
+            return {
+                type: content.type,
+                data: {
+                    ...content.data,
+                    apiOptions: sanitizedApiOptions,
+                },
+            };
+        case "article":
+            return {
+                type: content.type,
+                data: {
+                    ...content.data,
+                    apiOptions: sanitizedApiOptions,
+                },
+            };
+        case "article-all":
+            return {
+                type: content.type,
+                data: {
+                    ...content.data,
+                    apiOptions: sanitizedApiOptions,
+                },
+            };
+        default:
+            throw new UnreachableCaseError(content);
+    }
 }

--- a/packages/perseus-editor/src/preview/preview-data-sanitizer.ts
+++ b/packages/perseus-editor/src/preview/preview-data-sanitizer.ts
@@ -5,46 +5,21 @@ import type {PreviewContent} from "./message-types";
 /**
  * Sanitizes preview content by removing non-serializable functions and React
  * components from apiOptions before sending via postMessage.
- *
- * NOTE: The article-all case currently sanitizes apiOptions on each section
- * individually because the current type is ArticlePreviewData[] (each section
- * carries its own apiOptions). This will be simplified to a single apiOptions
- * when we restructure the preview data types.
  */
 export function sanitizePreviewData(
     /** Preview content to sanitize */
     content: PreviewContent,
 ): PreviewContent {
-    if (
-        (content.type === "question" ||
-            content.type === "hint" ||
-            content.type === "article") &&
-        content.data.apiOptions != null
-    ) {
-        // eslint-disable-next-line no-restricted-syntax
-        return {
-            ...content,
-            data: {
-                ...content.data,
-                apiOptions: sanitizeApiOptions(content.data.apiOptions),
-            },
-        } as PreviewContent;
+    if (content.data.apiOptions == null) {
+        return content;
     }
 
-    if (content.type === "article-all") {
-        // eslint-disable-next-line no-restricted-syntax
-        return {
-            ...content,
-            data: content.data.map((section) =>
-                section.apiOptions != null
-                    ? {
-                          ...section,
-                          apiOptions: sanitizeApiOptions(section.apiOptions),
-                      }
-                    : section,
-            ),
-        } as PreviewContent;
-    }
-
-    return content;
+    // eslint-disable-next-line no-restricted-syntax
+    return {
+        ...content,
+        data: {
+            ...content.data,
+            apiOptions: sanitizeApiOptions(content.data.apiOptions),
+        },
+    } as PreviewContent;
 }

--- a/packages/perseus-editor/src/preview/sanitize-api-options.ts
+++ b/packages/perseus-editor/src/preview/sanitize-api-options.ts
@@ -1,7 +1,29 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import React from "react";
-
 import type {APIOptions} from "@khanacademy/perseus";
+
+/**
+ * The `APIOptions` fields that can't survive `postMessage`'s structured-clone
+ * algorithm — function callbacks and React nodes. `sanitizeApiOptions` strips
+ * exactly these, so keep this list and the destructuring below in sync.
+ */
+type NonSerializableApiOptionKey =
+    | "onFocusChange"
+    | "answerableCallback"
+    | "getAnotherHint"
+    | "interactionCallback"
+    | "trackInteraction"
+    | "baseElements"
+    | "imagePlaceholder"
+    | "widgetPlaceholder";
+
+/**
+ * `APIOptions` with the non-serializable fields removed. This is the shape that
+ * actually crosses the preview postMessage bridge, so the preview message types
+ * describe their `apiOptions` with this rather than the full `APIOptions`.
+ */
+export type SerializableApiOptions = Omit<
+    APIOptions,
+    NonSerializableApiOptionKey
+>;
 
 /**
  * Removes non-serializable functions and React components from APIOptions
@@ -14,11 +36,8 @@ import type {APIOptions} from "@khanacademy/perseus";
  */
 export function sanitizeApiOptions(
     apiOptions: APIOptions,
-): Partial<APIOptions> | null {
-    if (apiOptions == null) {
-        return null;
-    }
-
+): SerializableApiOptions {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const {
         onFocusChange: _,
         answerableCallback: __,

--- a/packages/perseus-editor/src/preview/use-preview-controller.test.ts
+++ b/packages/perseus-editor/src/preview/use-preview-controller.test.ts
@@ -141,10 +141,8 @@ describe("usePreviewController", () => {
                 expect.objectContaining({
                     content: expect.objectContaining({
                         data: expect.objectContaining({
-                            item: expect.objectContaining({
-                                question: expect.objectContaining({
-                                    content: "Question 2",
-                                }),
+                            question: expect.objectContaining({
+                                content: "Question 2",
                             }),
                         }),
                     }),
@@ -629,22 +627,15 @@ function createQuestionPreview(overrides?: {
     return {
         type: "question",
         data: {
-            item: {
-                question: {
-                    content: overrides?.content ?? "What is 2+2?",
-                    widgets: {},
-                    images: {},
-                },
-                // eslint-disable-next-line no-restricted-syntax
-                answerArea: {calculator: false} as any,
-                hints: [],
+            question: {
+                content: overrides?.content ?? "What is 2+2?",
+                widgets: {},
+                images: {},
             },
             apiOptions: {
                 readOnly: true,
                 ...overrides?.apiOptions,
             },
-            // eslint-disable-next-line no-restricted-syntax
-            device: {type: "phone"} as any,
             linterContext: {
                 contentType: "exercise",
                 highlightLint: false,

--- a/packages/perseus-editor/src/preview/use-preview-controller.test.ts
+++ b/packages/perseus-editor/src/preview/use-preview-controller.test.ts
@@ -587,32 +587,18 @@ describe("usePreviewController", () => {
 
             const articleData: PreviewContent = {
                 type: "article-all",
-                data: [
-                    {
-                        json: [{content: "Section 1", widgets: {}, images: {}}],
-                        // eslint-disable-next-line no-restricted-syntax
-                        apiOptions: {
-                            readOnly: true,
-                            onFocusChange: jest.fn(),
-                        } as any,
-                        linterContext: {
-                            contentType: "article",
-                            highlightLint: false,
-                        },
-                    },
-                    {
-                        json: [{content: "Section 2", widgets: {}, images: {}}],
-                        // eslint-disable-next-line no-restricted-syntax
-                        apiOptions: {
-                            isMobile: true,
-                            trackInteraction: jest.fn(),
-                        } as any,
-                        linterContext: {
-                            contentType: "article",
-                            highlightLint: false,
-                        },
-                    },
-                ],
+                data: {
+                    article: [
+                        {content: "Section 1", widgets: {}, images: {}},
+                        {content: "Section 2", widgets: {}, images: {}},
+                    ],
+                    // eslint-disable-next-line no-restricted-syntax
+                    apiOptions: {
+                        readOnly: true,
+                        onFocusChange: jest.fn(),
+                        trackInteraction: jest.fn(),
+                    } as any,
+                },
             };
 
             act(() => {
@@ -623,16 +609,15 @@ describe("usePreviewController", () => {
             const sentMessage = (mockContentWindow.postMessage as jest.Mock)
                 .mock.calls[0][0];
 
-            // Both sections should have apiOptions sanitized
-            expect(sentMessage.content.data).toHaveLength(2);
+            // The shared apiOptions should be sanitized
+            expect(sentMessage.content.data.article).toHaveLength(2);
             expect(
-                sentMessage.content.data[0].apiOptions.onFocusChange,
+                sentMessage.content.data.apiOptions.onFocusChange,
             ).toBeUndefined();
-            expect(sentMessage.content.data[0].apiOptions.readOnly).toBe(true);
             expect(
-                sentMessage.content.data[1].apiOptions.trackInteraction,
+                sentMessage.content.data.apiOptions.trackInteraction,
             ).toBeUndefined();
-            expect(sentMessage.content.data[1].apiOptions.isMobile).toBe(true);
+            expect(sentMessage.content.data.apiOptions.readOnly).toBe(true);
         });
     });
 });
@@ -658,7 +643,6 @@ function createQuestionPreview(overrides?: {
                 readOnly: true,
                 ...overrides?.apiOptions,
             },
-            initialHintsVisible: 0,
             // eslint-disable-next-line no-restricted-syntax
             device: {type: "phone"} as any,
             linterContext: {

--- a/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
+++ b/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
@@ -56,10 +56,10 @@ describe("usePreviewPresenter", () => {
     });
 
     describe("initialization", () => {
-        it("initializes with null data", () => {
+        it("initializes with null content", () => {
             const {result} = renderHook(() => usePreviewPresenter());
 
-            expect(result.current.data).toBeNull();
+            expect(result.current.content).toBeNull();
             expect(result.current.isMobile).toBe(false);
             expect(result.current.hasLintGutter).toBe(false);
         });
@@ -175,7 +175,7 @@ describe("usePreviewPresenter", () => {
                 );
             });
 
-            expect(result.current.data).toEqual(questionContent);
+            expect(result.current.content).toEqual(questionContent);
         });
 
         it("updates data for hint content", () => {
@@ -209,7 +209,7 @@ describe("usePreviewPresenter", () => {
                 );
             });
 
-            expect(result.current.data).toEqual(hintContent);
+            expect(result.current.content).toEqual(hintContent);
         });
 
         it("updates data for article content", () => {
@@ -242,7 +242,7 @@ describe("usePreviewPresenter", () => {
                 );
             });
 
-            expect(result.current.data).toEqual(articleContent);
+            expect(result.current.content).toEqual(articleContent);
         });
 
         it("updates data for article-all content", () => {
@@ -270,7 +270,7 @@ describe("usePreviewPresenter", () => {
                 );
             });
 
-            expect(result.current.data).toEqual(articleAllContent);
+            expect(result.current.content).toEqual(articleAllContent);
         });
 
         it("ignores content-data from non-parent source", () => {
@@ -301,7 +301,7 @@ describe("usePreviewPresenter", () => {
             });
 
             // Data should remain null
-            expect(result.current.data).toBeNull();
+            expect(result.current.content).toBeNull();
         });
 
         it("updates data multiple times", () => {
@@ -339,7 +339,7 @@ describe("usePreviewPresenter", () => {
                 );
             });
 
-            expect(result.current.data).toEqual(content1);
+            expect(result.current.content).toEqual(content1);
 
             const content2: PreviewContent = {
                 type: "hint",
@@ -363,7 +363,7 @@ describe("usePreviewPresenter", () => {
                 );
             });
 
-            expect(result.current.data).toEqual(content2);
+            expect(result.current.content).toEqual(content2);
         });
     });
 
@@ -457,7 +457,7 @@ describe("usePreviewPresenter", () => {
             });
 
             // Data should remain null
-            expect(result.current.data).toBeNull();
+            expect(result.current.content).toBeNull();
         });
 
         it("ignores messages without correct source identifier", () => {
@@ -478,7 +478,7 @@ describe("usePreviewPresenter", () => {
             });
 
             // Data should remain null
-            expect(result.current.data).toBeNull();
+            expect(result.current.content).toBeNull();
         });
 
         it("ignores non-Perseus messages", () => {
@@ -497,7 +497,7 @@ describe("usePreviewPresenter", () => {
             });
 
             // Should not crash or change state
-            expect(result.current.data).toBeNull();
+            expect(result.current.content).toBeNull();
         });
 
         it("ignores malformed messages", () => {
@@ -512,7 +512,7 @@ describe("usePreviewPresenter", () => {
                 );
             });
 
-            expect(result.current.data).toBeNull();
+            expect(result.current.content).toBeNull();
 
             act(() => {
                 window.dispatchEvent(
@@ -523,7 +523,7 @@ describe("usePreviewPresenter", () => {
                 );
             });
 
-            expect(result.current.data).toBeNull();
+            expect(result.current.content).toBeNull();
         });
     });
 
@@ -629,7 +629,7 @@ describe("usePreviewPresenter", () => {
                 );
             });
 
-            expect(result.current.data).toEqual(content);
+            expect(result.current.content).toEqual(content);
 
             // 3. Report height
             act(() => {
@@ -710,7 +710,7 @@ describe("usePreviewPresenter", () => {
             });
 
             // Should have the last content
-            expect(result.current.data).toEqual(contents[2]);
+            expect(result.current.content).toEqual(contents[2]);
         });
     });
 });

--- a/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
+++ b/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
@@ -155,7 +155,6 @@ describe("usePreviewPresenter", () => {
                         hints: [],
                     },
                     apiOptions: {readOnly: true},
-                    initialHintsVisible: 0,
                     // eslint-disable-next-line no-restricted-syntax
                     device: {type: "phone"} as any,
                     linterContext: {
@@ -219,13 +218,11 @@ describe("usePreviewPresenter", () => {
             const articleContent: PreviewContent = {
                 type: "article",
                 data: {
-                    json: [
-                        {
-                            content: "# Article Title\n\nArticle content",
-                            widgets: {},
-                            images: {},
-                        },
-                    ],
+                    article: {
+                        content: "# Article Title\n\nArticle content",
+                        widgets: {},
+                        images: {},
+                    },
                     apiOptions: {},
                     linterContext: {
                         contentType: "article",
@@ -253,24 +250,13 @@ describe("usePreviewPresenter", () => {
 
             const articleAllContent: PreviewContent = {
                 type: "article-all",
-                data: [
-                    {
-                        json: [{content: "Section 1", widgets: {}, images: {}}],
-                        apiOptions: {},
-                        linterContext: {
-                            contentType: "article",
-                            highlightLint: false,
-                        },
-                    },
-                    {
-                        json: [{content: "Section 2", widgets: {}, images: {}}],
-                        apiOptions: {},
-                        linterContext: {
-                            contentType: "article",
-                            highlightLint: false,
-                        },
-                    },
-                ],
+                data: {
+                    article: [
+                        {content: "Section 1", widgets: {}, images: {}},
+                        {content: "Section 2", widgets: {}, images: {}},
+                    ],
+                    apiOptions: {},
+                },
             };
 
             const message = createContentDataMessage(articleAllContent);
@@ -335,7 +321,6 @@ describe("usePreviewPresenter", () => {
                         hints: [],
                     },
                     apiOptions: {},
-                    initialHintsVisible: 0,
                     // eslint-disable-next-line no-restricted-syntax
                     device: {type: "phone"} as any,
                     linterContext: {
@@ -621,7 +606,6 @@ describe("usePreviewPresenter", () => {
                         hints: [],
                     },
                     apiOptions: {},
-                    initialHintsVisible: 0,
                     // eslint-disable-next-line no-restricted-syntax
                     device: {type: "phone"} as any,
                     linterContext: {
@@ -675,7 +659,6 @@ describe("usePreviewPresenter", () => {
                             hints: [],
                         },
                         apiOptions: {},
-                        initialHintsVisible: 0,
                         // eslint-disable-next-line no-restricted-syntax
                         device: {type: "phone"} as any,
                         linterContext: {
@@ -699,7 +682,7 @@ describe("usePreviewPresenter", () => {
                 {
                     type: "article",
                     data: {
-                        json: [{content: "A1", widgets: {}, images: {}}],
+                        article: {content: "A1", widgets: {}, images: {}},
                         apiOptions: {},
                         linterContext: {
                             contentType: "article",

--- a/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
+++ b/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
@@ -144,19 +144,12 @@ describe("usePreviewPresenter", () => {
             const questionContent: PreviewContent = {
                 type: "question",
                 data: {
-                    item: {
-                        question: {
-                            content: "What is 2+2?",
-                            widgets: {},
-                            images: {},
-                        },
-                        // eslint-disable-next-line no-restricted-syntax
-                        answerArea: {calculator: false} as any,
-                        hints: [],
+                    question: {
+                        content: "What is 2+2?",
+                        widgets: {},
+                        images: {},
                     },
                     apiOptions: {readOnly: true},
-                    // eslint-disable-next-line no-restricted-syntax
-                    device: {type: "phone"} as any,
                     linterContext: {
                         contentType: "exercise",
                         highlightLint: false,
@@ -310,19 +303,12 @@ describe("usePreviewPresenter", () => {
             const content1: PreviewContent = {
                 type: "question",
                 data: {
-                    item: {
-                        question: {
-                            content: "Question 1",
-                            widgets: {},
-                            images: {},
-                        },
-                        // eslint-disable-next-line no-restricted-syntax
-                        answerArea: {calculator: false} as any,
-                        hints: [],
+                    question: {
+                        content: "Question 1",
+                        widgets: {},
+                        images: {},
                     },
                     apiOptions: {},
-                    // eslint-disable-next-line no-restricted-syntax
-                    device: {type: "phone"} as any,
                     linterContext: {
                         contentType: "exercise",
                         highlightLint: false,
@@ -599,15 +585,8 @@ describe("usePreviewPresenter", () => {
             const content: PreviewContent = {
                 type: "question",
                 data: {
-                    item: {
-                        question: {content: "Test", widgets: {}, images: {}},
-                        // eslint-disable-next-line no-restricted-syntax
-                        answerArea: {calculator: false} as any,
-                        hints: [],
-                    },
+                    question: {content: "Test", widgets: {}, images: {}},
                     apiOptions: {},
-                    // eslint-disable-next-line no-restricted-syntax
-                    device: {type: "phone"} as any,
                     linterContext: {
                         contentType: "exercise",
                         highlightLint: false,
@@ -652,15 +631,8 @@ describe("usePreviewPresenter", () => {
                 {
                     type: "question",
                     data: {
-                        item: {
-                            question: {content: "Q1", widgets: {}, images: {}},
-                            // eslint-disable-next-line no-restricted-syntax
-                            answerArea: {calculator: false} as any,
-                            hints: [],
-                        },
+                        question: {content: "Q1", widgets: {}, images: {}},
                         apiOptions: {},
-                        // eslint-disable-next-line no-restricted-syntax
-                        device: {type: "phone"} as any,
                         linterContext: {
                             contentType: "exercise",
                             highlightLint: false,

--- a/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
+++ b/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
@@ -209,7 +209,7 @@ describe("usePreviewPresenter", () => {
             const {result} = renderHook(() => usePreviewPresenter());
 
             const articleContent: PreviewContent = {
-                type: "article",
+                type: "article-section",
                 data: {
                     article: {
                         content: "# Article Title\n\nArticle content",
@@ -652,7 +652,7 @@ describe("usePreviewPresenter", () => {
                     },
                 },
                 {
-                    type: "article",
+                    type: "article-section",
                     data: {
                         article: {content: "A1", widgets: {}, images: {}},
                         apiOptions: {},

--- a/packages/perseus-editor/src/preview/use-preview-presenter.ts
+++ b/packages/perseus-editor/src/preview/use-preview-presenter.ts
@@ -15,9 +15,9 @@ import type {
 
 type UsePreviewPresenterResult = {
     /**
-     * The preview content data received from the parent, or null if not yet loaded
+     * The preview content received from the parent, or null if not yet loaded
      */
-    data: PreviewContent | null;
+    content: PreviewContent | null;
     /**
      * Whether the preview should render in mobile mode (from data-mobile attribute)
      */
@@ -44,25 +44,25 @@ type UsePreviewPresenterResult = {
  * @example
  * ```tsx
  * function PreviewPage() {
- *   const { data, isMobile, reportHeight } = usePreviewPresenter();
+ *   const { content, isMobile, reportHeight } = usePreviewPresenter();
  *
  *   React.useEffect(() => {
  *     if (containerRef.current) {
  *       reportHeight(containerRef.current.scrollHeight);
  *     }
- *   }, [data, reportHeight]);
+ *   }, [content, reportHeight]);
  *
- *   if (!data) return <div>Loading...</div>;
+ *   if (!content) return <div>Loading...</div>;
  *   return <PreviewRenderer
  *       ref={containerRef}
- *       data={data}
+ *       content={content}
  *       isMobile={isMobile}
  *   />;
  * }
  * ```
  */
 export function usePreviewPresenter(): UsePreviewPresenterResult {
-    const [data, setData] = React.useState<PreviewContent | null>(null);
+    const [content, setContent] = React.useState<PreviewContent | null>(null);
 
     // eslint-disable-next-line no-restricted-syntax
     const iframe = window.frameElement as HTMLIFrameElement | null;
@@ -87,7 +87,7 @@ export function usePreviewPresenter(): UsePreviewPresenterResult {
 
             switch (message.type) {
                 case "content-data":
-                    setData(message.content);
+                    setContent(message.content);
                     break;
 
                 default:
@@ -120,7 +120,7 @@ export function usePreviewPresenter(): UsePreviewPresenterResult {
     }, []);
 
     return {
-        data,
+        content,
         isMobile: iframe.dataset.mobile === "true",
         hasLintGutter: iframe.dataset.lintGutter === "true",
         reportHeight,

--- a/packages/perseus-editor/src/testing/preview/exercise-preview-page.tsx
+++ b/packages/perseus-editor/src/testing/preview/exercise-preview-page.tsx
@@ -12,18 +12,18 @@ import {PreviewRenderer} from "./preview-renderer";
  * only be used to support editor previews in Storybook!
  */
 const ExercisePreviewPage = () => {
-    const {data, reportHeight} = usePreviewPresenter();
+    const {content, reportHeight} = usePreviewPresenter();
     const containerRef = React.useRef<HTMLDivElement>(null);
     const lastHeightRef = React.useRef<number | null>(null);
 
     // Handle body overflow for article-all type (allows scrolling)
     React.useEffect(() => {
-        if (data?.type === "article-all") {
+        if (content?.type === "article-all") {
             document.body.style.overflow = "scroll";
         } else {
             document.body.style.overflow = "hidden";
         }
-    }, [data?.type]);
+    }, [content?.type]);
 
     // Send height updates to parent
     React.useEffect(() => {
@@ -58,9 +58,9 @@ const ExercisePreviewPage = () => {
         return () => {
             resizeObserver?.disconnect();
         };
-    }, [data, reportHeight]);
+    }, [content, reportHeight]);
 
-    if (!data) {
+    if (!content) {
         return (
             <View style={styles.loading}>
                 <div>Loading preview...</div>
@@ -70,7 +70,7 @@ const ExercisePreviewPage = () => {
 
     return (
         <div ref={containerRef}>
-            <PreviewRenderer data={data} />
+            <PreviewRenderer content={content} />
         </div>
     );
 };

--- a/packages/perseus-editor/src/testing/preview/preview-renderer.tsx
+++ b/packages/perseus-editor/src/testing/preview/preview-renderer.tsx
@@ -8,7 +8,6 @@ import {
     ArticleRenderer,
     Dependencies,
     Renderer,
-    ServerItemRenderer,
     usePerseusI18n,
 } from "@khanacademy/perseus";
 import {pushContextStack} from "@khanacademy/perseus-linter";
@@ -78,24 +77,25 @@ export function PreviewRenderer({content}: Props) {
     const i18n = usePerseusI18n();
 
     if (content.type === "question") {
-        const {item, apiOptions, linterContext, reviewMode, problemNum} =
+        const {question, apiOptions, linterContext, reviewMode, problemNum} =
             content.data;
 
         return (
             <PreviewWithKeypad>
                 {({keypadElement, isMobile}) => (
-                    <ServerItemRenderer
-                        item={item}
+                    <Renderer
+                        strings={i18n.strings}
+                        content={question.content}
+                        widgets={question.widgets}
+                        images={question.images}
                         apiOptions={{...apiOptions, isMobile}}
                         keypadElement={keypadElement}
+                        reviewMode={reviewMode}
+                        problemNum={problemNum}
                         linterContext={pushContextStack(
                             linterContext,
                             "question",
                         )}
-                        hintsVisible={0}
-                        reviewMode={reviewMode}
-                        problemNum={problemNum}
-                        dependencies={storybookDependenciesV2}
                     />
                 )}
             </PreviewWithKeypad>

--- a/packages/perseus-editor/src/testing/preview/preview-renderer.tsx
+++ b/packages/perseus-editor/src/testing/preview/preview-renderer.tsx
@@ -23,7 +23,7 @@ import {storybookDependenciesV2} from "../test-dependencies";
 import type {PreviewContent} from "../../preview/message-types";
 
 type Props = {
-    data: PreviewContent;
+    content: PreviewContent;
 };
 
 function PreviewWithKeypad({
@@ -74,12 +74,12 @@ function PreviewWithKeypad({
 /**
  * Renders the appropriate content based on preview data type
  */
-export function PreviewRenderer({data}: Props) {
+export function PreviewRenderer({content}: Props) {
     const i18n = usePerseusI18n();
 
-    if (data.type === "question") {
+    if (content.type === "question") {
         const {item, apiOptions, linterContext, reviewMode, problemNum} =
-            data.data;
+            content.data;
 
         return (
             <PreviewWithKeypad>
@@ -102,8 +102,8 @@ export function PreviewRenderer({data}: Props) {
         );
     }
 
-    if (data.type === "hint") {
-        const {hint, apiOptions, linterContext} = data.data;
+    if (content.type === "hint") {
+        const {hint, apiOptions, linterContext} = content.data;
 
         return (
             <PreviewWithKeypad>
@@ -122,9 +122,9 @@ export function PreviewRenderer({data}: Props) {
         );
     }
 
-    if (data.type === "article") {
+    if (content.type === "article") {
         const {article, apiOptions, legacyPerseusLint, linterContext} =
-            data.data;
+            content.data;
 
         return (
             <PreviewWithKeypad>
@@ -145,8 +145,8 @@ export function PreviewRenderer({data}: Props) {
         );
     }
 
-    if (data.type === "article-all") {
-        const {article, apiOptions} = data.data;
+    if (content.type === "article-all") {
+        const {article, apiOptions} = content.data;
 
         return (
             <PreviewWithKeypad>

--- a/packages/perseus-editor/src/testing/preview/preview-renderer.tsx
+++ b/packages/perseus-editor/src/testing/preview/preview-renderer.tsx
@@ -78,14 +78,8 @@ export function PreviewRenderer({data}: Props) {
     const i18n = usePerseusI18n();
 
     if (data.type === "question") {
-        const {
-            item,
-            apiOptions,
-            initialHintsVisible,
-            linterContext,
-            reviewMode,
-            problemNum,
-        } = data.data;
+        const {item, apiOptions, linterContext, reviewMode, problemNum} =
+            data.data;
 
         return (
             <PreviewWithKeypad>
@@ -98,7 +92,7 @@ export function PreviewRenderer({data}: Props) {
                             linterContext,
                             "question",
                         )}
-                        hintsVisible={initialHintsVisible}
+                        hintsVisible={0}
                         reviewMode={reviewMode}
                         problemNum={problemNum}
                         dependencies={storybookDependenciesV2}
@@ -129,13 +123,14 @@ export function PreviewRenderer({data}: Props) {
     }
 
     if (data.type === "article") {
-        const {json, apiOptions, legacyPerseusLint, linterContext} = data.data;
+        const {article, apiOptions, legacyPerseusLint, linterContext} =
+            data.data;
 
         return (
             <PreviewWithKeypad>
                 {({keypadElement, isMobile}) => (
                     <ArticleRenderer
-                        json={json}
+                        json={article}
                         apiOptions={{...apiOptions, isMobile}}
                         keypadElement={keypadElement}
                         legacyPerseusLint={legacyPerseusLint}
@@ -151,25 +146,17 @@ export function PreviewRenderer({data}: Props) {
     }
 
     if (data.type === "article-all") {
+        const {article, apiOptions} = data.data;
+
         return (
             <PreviewWithKeypad>
                 {({keypadElement, isMobile}) => (
-                    <>
-                        {data.data.map((article, i) => (
-                            <ArticleRenderer
-                                key={i}
-                                json={article.json}
-                                apiOptions={{...article.apiOptions, isMobile}}
-                                keypadElement={keypadElement}
-                                legacyPerseusLint={article.legacyPerseusLint}
-                                linterContext={pushContextStack(
-                                    article.linterContext,
-                                    "article",
-                                )}
-                                dependencies={storybookDependenciesV2}
-                            />
-                        ))}
-                    </>
+                    <ArticleRenderer
+                        json={[...article]}
+                        apiOptions={{...apiOptions, isMobile}}
+                        keypadElement={keypadElement}
+                        dependencies={storybookDependenciesV2}
+                    />
                 )}
             </PreviewWithKeypad>
         );

--- a/packages/perseus-editor/src/testing/preview/preview-renderer.tsx
+++ b/packages/perseus-editor/src/testing/preview/preview-renderer.tsx
@@ -122,7 +122,7 @@ export function PreviewRenderer({content}: Props) {
         );
     }
 
-    if (content.type === "article") {
+    if (content.type === "article-section") {
         const {article, apiOptions, legacyPerseusLint, linterContext} =
             content.data;
 


### PR DESCRIPTION
## Summary:

*This PR is part of a series building a typed, hook-based preview system for the Perseus editor. The new system replaces the untyped `window.iframeDataStore` + raw `postMessage(string)` communication with structured, validated message passing via `usePreviewController` and `usePreviewPresenter` hooks. The new system is being built alongside the old one — no existing behavior changes until the final PR in the series flips the switch.*

Previous PRs in this series:
- #3464
- #3467
- #3474
- #3492
- #3495
- #3499
- #3578
- #3588
- #3581 
- #3590 

-- 

This PR is a message-field cleanup — it restructures the preview data shapes now that the editor migration is in place (#3581).

  * The data-shape changes: `ArticlePreviewData.json` is renamed to `article` (and is now a single `PerseusRenderer` for the one section being edited, not an array)
  * `QuestionPreviewData.initialHintsVisible` is dropped (it was always `0` in practice)
  * `article-all` previews now use a new `ArticleAllPreviewData` (`{article: ReadonlyArray<PerseusRenderer>, apiOptions}`) with a single shared `apiOptions` instead of the previous per-section `ArticlePreviewData[]`
  * The presenter hook's returned `data` is also now named `content`, so consumers read `content` instead of the awkward `message.content.data`.
  * The preview message types now type their `apiOptions` as a new `SerializableApiOptions` defined next to the stripping logic in `sanitize-api-options.ts`) rather than the full `APIOptions`. This makes the types honest about what actually survives the `postMessage` structured-clone boundary.

Issue: LEMS-3741

## Test plan:

- [x] `pnpm tsc`
- [x] `pnpm lint`
- [x] `pnpm test`
- [ ] Reviewer: open Storybook, navigate to the editor previews, and confirm:
  - Question preview still renders (no visible hints; behavior matches main)
  - Article single-section preview renders content
  - Article-all preview renders all sections concatenated with shared apiOptions
  - Hint preview unchanged