### PR TITLE
docs(changeset): Fix blue line on vector when graph becomes interactive after correct answer

### DIFF
--- a/.changeset/eleven-moles-reflect.md
+++ b/.changeset/eleven-moles-reflect.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix blue line on vector when graph becomes interactive after correct answer

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/vector.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/vector.tsx
@@ -190,6 +190,7 @@ const VectorBody = (props: VectorBodyProps) => {
                 start={tailPx}
                 end={lineEndPx}
                 className={`movable-vector-line ${active ? "movable-dragging" : ""}`}
+                style={{stroke: interactiveColor}}
                 testId="movable-vector__line"
             />
             {/* Tail dot — inside the body group so hovering/dragging

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -315,7 +315,6 @@
 
 /* Vector graph line styling */
 .MafsView .movable-vector-line {
-    stroke: var(--mafs-blue);
     stroke-width: var(--movable-line-stroke-weight);
     stroke-linecap: round;
 }


### PR DESCRIPTION
## Summary:
[grey-hair] Fix blue line on vector when graph becomes interactive after correct answer

Issue: LEMS-XXXX

## Test plan: