### PR TITLE
[Interactive Graph] Adding new announcing reducer to link together all the graph events.

### DIFF
--- a/.changeset/orange-shirts-protect.md
+++ b/.changeset/orange-shirts-protect.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Interactive Graph] Adding initial WB Announcer functionality.

--- a/packages/perseus/src/widgets/interactive-graphs/announcer/central-announcer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/announcer/central-announcer.test.ts
@@ -1,11 +1,11 @@
 import {mockStrings} from "../../../strings";
+import {initializeGraphState} from "../reducer/initialize-graph-state";
 import {
     actions,
     changeRange,
     changeSnapStep,
     reinitialize,
 } from "../reducer/interactive-graph-action";
-import {initializeGraphState} from "../reducer/initialize-graph-state";
 
 import {getAnnouncementForAction} from "./central-announcer";
 
@@ -29,16 +29,36 @@ const locale = "en";
 // null — this table locks in the dormant default and forces future
 // contributors to *deliberately* add a case rather than silently inheriting
 // null.
-const actions_table: Array<[string, InteractiveGraphAction]> = [
-    ["reinitialize", reinitialize({graph: {type: "point"}, range: [[-10, 10], [-10, 10]], step: [1, 1], snapStep: [1, 1]})],
-    ["move-point-in-figure", actions.linearSystem.movePointInFigure(0, 0, [1, 1])],
+const actionsTable: Array<[string, InteractiveGraphAction]> = [
+    [
+        "reinitialize",
+        reinitialize({
+            graph: {type: "point"},
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            step: [1, 1],
+            snapStep: [1, 1],
+        }),
+    ],
+    [
+        "move-point-in-figure",
+        actions.linearSystem.movePointInFigure(0, 0, [1, 1]),
+    ],
     ["move-line", actions.linear.moveLine([1, 1])],
     ["move-all", actions.polygon.moveAll([1, 0])],
     ["move-point", actions.angle.movePoint(0, [1, 1])],
     ["move-center", actions.circle.moveCenter([1, 1])],
     ["move-radius-point", actions.circle.moveRadiusPoint([2, 0])],
     ["change-snap-step", changeSnapStep([1, 1])],
-    ["change-range", changeRange([[-10, 10], [-10, 10]])],
+    [
+        "change-range",
+        changeRange([
+            [-10, 10],
+            [-10, 10],
+        ]),
+    ],
     ["add-point", actions.polygon.addPoint([3, 3])],
     ["remove-point", actions.polygon.removePoint(0)],
     ["focus-point", actions.polygon.focusPoint(0)],
@@ -47,22 +67,25 @@ const actions_table: Array<[string, InteractiveGraphAction]> = [
     ["click-point", actions.polygon.clickPoint(0)],
     ["close-polygon", actions.polygon.closePolygon()],
     ["open-polygon", actions.polygon.openPolygon()],
-    ["change-interaction-mode", actions.global.changeInteractionMode("keyboard")],
-    ["change-keyboard-invitation-visibility", actions.global.changeKeyboardInvitationVisibility(true)],
+    [
+        "change-interaction-mode",
+        actions.global.changeInteractionMode("keyboard"),
+    ],
+    [
+        "change-keyboard-invitation-visibility",
+        actions.global.changeKeyboardInvitationVisibility(true),
+    ],
 ];
 
 describe("getAnnouncementForAction (Phase 1 — dormant)", () => {
-    it.each(actions_table)(
-        "returns null for %s",
-        (_label, action) => {
-            const result = getAnnouncementForAction(
-                action,
-                baseState,
-                baseState,
-                mockStrings,
-                locale,
-            );
-            expect(result).toBeNull();
-        },
-    );
+    it.each(actionsTable)("returns null for %s", (_label, action) => {
+        const result = getAnnouncementForAction(
+            action,
+            baseState,
+            baseState,
+            mockStrings,
+            locale,
+        );
+        expect(result).toBeNull();
+    });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/announcer/central-announcer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/announcer/central-announcer.test.ts
@@ -1,0 +1,68 @@
+import {mockStrings} from "../../../strings";
+import {
+    actions,
+    changeRange,
+    changeSnapStep,
+    reinitialize,
+} from "../reducer/interactive-graph-action";
+import {initializeGraphState} from "../reducer/initialize-graph-state";
+
+import {getAnnouncementForAction} from "./central-announcer";
+
+import type {InteractiveGraphAction} from "../reducer/interactive-graph-action";
+import type {InteractiveGraphState} from "../types";
+
+// A minimal valid state used as prevState/nextState across all rows.
+const baseState: InteractiveGraphState = initializeGraphState({
+    graph: {type: "point", numPoints: 2},
+    range: [
+        [-10, 10],
+        [-10, 10],
+    ],
+    step: [1, 1],
+    snapStep: [1, 1],
+});
+
+const locale = "en";
+
+// One row per InteractiveGraphAction type.  In Phase 1 every action returns
+// null — this table locks in the dormant default and forces future
+// contributors to *deliberately* add a case rather than silently inheriting
+// null.
+const actions_table: Array<[string, InteractiveGraphAction]> = [
+    ["reinitialize", reinitialize({graph: {type: "point"}, range: [[-10, 10], [-10, 10]], step: [1, 1], snapStep: [1, 1]})],
+    ["move-point-in-figure", actions.linearSystem.movePointInFigure(0, 0, [1, 1])],
+    ["move-line", actions.linear.moveLine([1, 1])],
+    ["move-all", actions.polygon.moveAll([1, 0])],
+    ["move-point", actions.angle.movePoint(0, [1, 1])],
+    ["move-center", actions.circle.moveCenter([1, 1])],
+    ["move-radius-point", actions.circle.moveRadiusPoint([2, 0])],
+    ["change-snap-step", changeSnapStep([1, 1])],
+    ["change-range", changeRange([[-10, 10], [-10, 10]])],
+    ["add-point", actions.polygon.addPoint([3, 3])],
+    ["remove-point", actions.polygon.removePoint(0)],
+    ["focus-point", actions.polygon.focusPoint(0)],
+    ["blur-point", actions.polygon.blurPoint()],
+    ["delete-intent", actions.global.deleteIntent()],
+    ["click-point", actions.polygon.clickPoint(0)],
+    ["close-polygon", actions.polygon.closePolygon()],
+    ["open-polygon", actions.polygon.openPolygon()],
+    ["change-interaction-mode", actions.global.changeInteractionMode("keyboard")],
+    ["change-keyboard-invitation-visibility", actions.global.changeKeyboardInvitationVisibility(true)],
+];
+
+describe("getAnnouncementForAction (Phase 1 — dormant)", () => {
+    it.each(actions_table)(
+        "returns null for %s",
+        (_label, action) => {
+            const result = getAnnouncementForAction(
+                action,
+                baseState,
+                baseState,
+                mockStrings,
+                locale,
+            );
+            expect(result).toBeNull();
+        },
+    );
+});

--- a/packages/perseus/src/widgets/interactive-graphs/announcer/central-announcer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/announcer/central-announcer.ts
@@ -1,6 +1,6 @@
+import type {PerseusStrings} from "../../../strings";
 import type {InteractiveGraphAction} from "../reducer/interactive-graph-action";
 import type {InteractiveGraphState} from "../types";
-import type {PerseusStrings} from "../../../strings";
 
 /**
  * Pure function mapping a dispatched action to an SR announcement string (or

--- a/packages/perseus/src/widgets/interactive-graphs/announcer/central-announcer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/announcer/central-announcer.ts
@@ -1,0 +1,27 @@
+import type {InteractiveGraphAction} from "../reducer/interactive-graph-action";
+import type {InteractiveGraphState} from "../types";
+import type {PerseusStrings} from "../../../strings";
+
+/**
+ * Pure function mapping a dispatched action to an SR announcement string (or
+ * null when no announcement is needed).  React-free so it is unit-testable
+ * without a DOM.
+ *
+ * Routing rule (OQ3): only universal events (those that don't need per-graph
+ * math context) live here.  Per-graph math-heavy announcements go through
+ * useGraphAnnouncer in each graph's own file.  Do NOT import getRadius,
+ * getSlopeStringForLine, getClockwiseAngle, or similar math utilities into
+ * this file — if a case needs one, the announcement belongs per-graph.
+ */
+export function getAnnouncementForAction(
+    action: InteractiveGraphAction,
+    prevState: InteractiveGraphState,
+    nextState: InteractiveGraphState,
+    strings: PerseusStrings,
+    locale: string,
+): string | null {
+    switch (action.type) {
+        default:
+            return null;
+    }
+}

--- a/packages/perseus/src/widgets/interactive-graphs/announcer/use-announcing-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/announcer/use-announcing-reducer.test.ts
@@ -1,0 +1,129 @@
+import {announceMessage} from "@khanacademy/wonder-blocks-announcer";
+import {renderHook, act} from "@testing-library/react";
+import * as React from "react";
+
+import {initializeGraphState} from "../reducer/initialize-graph-state";
+import {actions} from "../reducer/interactive-graph-action";
+import {interactiveGraphReducer} from "../reducer/interactive-graph-reducer";
+
+import {
+    useAnnouncingReducer,
+    useGraphAnnouncer,
+} from "./use-announcing-reducer";
+
+import type {InitializeGraphStateParams} from "../reducer/initialize-graph-state";
+
+jest.mock("@khanacademy/wonder-blocks-announcer");
+
+const baseParams: InitializeGraphStateParams = {
+    graph: {type: "point", numPoints: 2},
+    range: [
+        [-10, 10],
+        [-10, 10],
+    ],
+    step: [1, 1],
+    snapStep: [1, 1],
+};
+
+describe("useAnnouncingReducer", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("keeps state in lockstep with interactiveGraphReducer after dispatch", () => {
+        const {result} = renderHook(() => {
+            const [state, dispatch] = React.useReducer(
+                interactiveGraphReducer,
+                baseParams,
+                initializeGraphState,
+            );
+            const announcingDispatch = useAnnouncingReducer(state, dispatch);
+            return {state, announcingDispatch};
+        });
+
+        const action = actions.pointGraph.movePoint(0, [3, 4]);
+        act(() => {
+            result.current.announcingDispatch(action);
+        });
+
+        const expected = interactiveGraphReducer(
+            initializeGraphState(baseParams),
+            action,
+        );
+        expect(result.current.state).toEqual(expected);
+    });
+
+    it("does not call announceMessage when the central handler returns null", () => {
+        const {result} = renderHook(() => {
+            const [state, dispatch] = React.useReducer(
+                interactiveGraphReducer,
+                baseParams,
+                initializeGraphState,
+            );
+            return useAnnouncingReducer(state, dispatch);
+        });
+
+        act(() => {
+            result.current(actions.pointGraph.movePoint(0, [1, 1]));
+        });
+
+        expect(announceMessage).not.toHaveBeenCalled();
+    });
+
+    it("returns a stable dispatch reference across re-renders", () => {
+        const {result, rerender} = renderHook(() => {
+            const [state, dispatch] = React.useReducer(
+                interactiveGraphReducer,
+                baseParams,
+                initializeGraphState,
+            );
+            return useAnnouncingReducer(state, dispatch);
+        });
+        const firstDispatch = result.current;
+        rerender();
+        expect(result.current).toBe(firstDispatch);
+    });
+});
+
+describe("useGraphAnnouncer", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("calls announceMessage with the provided message", () => {
+        const {result} = renderHook(() => useGraphAnnouncer());
+        act(() => {
+            result.current.announce("test message");
+        });
+        expect(announceMessage).toHaveBeenCalledWith(
+            expect.objectContaining({message: "test message"}),
+        );
+    });
+
+    it("applies the default 500 ms debounce threshold", () => {
+        const {result} = renderHook(() => useGraphAnnouncer());
+        act(() => {
+            result.current.announce("test message");
+        });
+        expect(announceMessage).toHaveBeenCalledWith(
+            expect.objectContaining({debounceThreshold: 500}),
+        );
+    });
+
+    it("honours a per-call debounceThreshold override", () => {
+        const {result} = renderHook(() => useGraphAnnouncer());
+        act(() => {
+            result.current.announce("test message", {debounceThreshold: 0});
+        });
+        expect(announceMessage).toHaveBeenCalledWith(
+            expect.objectContaining({debounceThreshold: 0}),
+        );
+    });
+
+    it("returns a stable announce reference across re-renders", () => {
+        const {result, rerender} = renderHook(() => useGraphAnnouncer());
+        const firstAnnounce = result.current.announce;
+        rerender();
+        expect(result.current.announce).toBe(firstAnnounce);
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/announcer/use-announcing-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/announcer/use-announcing-reducer.ts
@@ -1,0 +1,87 @@
+import {announceMessage} from "@khanacademy/wonder-blocks-announcer";
+import {useCallback, useRef} from "react";
+
+import {usePerseusI18n} from "../../../components/i18n-context";
+import {interactiveGraphReducer} from "../reducer/interactive-graph-reducer";
+
+import {getAnnouncementForAction} from "./central-announcer";
+
+import type {InteractiveGraphAction} from "../reducer/interactive-graph-action";
+import type {InteractiveGraphState} from "../types";
+import type * as React from "react";
+
+const DEFAULT_DEBOUNCE_THRESHOLD_MS = 500;
+
+/**
+ * Wraps a dispatch function with WB Announcer integration.
+ *
+ * Pass in the state and dispatch from your own React.useReducer call.
+ * Returns a wrapped dispatch that consults the central announcer before
+ * forwarding each action.  In the initial (Phase 1) state the central handler
+ * returns null for every action, so no announcement fires and the returned
+ * dispatch is behaviourally identical to the original.
+ *
+ * Internal useEffect / bookkeeping dispatches (changeSnapStep, changeRange,
+ * reinitialize) can stay on the raw dispatch from useReducer — the central
+ * handler returns null for those anyway.
+ */
+export function useAnnouncingReducer(
+    state: InteractiveGraphState,
+    dispatch: React.Dispatch<InteractiveGraphAction>,
+): React.Dispatch<InteractiveGraphAction> {
+    const {strings, locale} = usePerseusI18n();
+
+    // Mirror the current state into a ref so the wrapped dispatch can read
+    // prevState synchronously at call time without closing over a stale value.
+    const stateRef = useRef<InteractiveGraphState>(state);
+    stateRef.current = state;
+
+    return useCallback(
+        (action: InteractiveGraphAction) => {
+            const prevState = stateRef.current;
+            // Run the reducer to get nextState for the announcer.
+            // The real dispatch below runs the same reducer internally;
+            // the double-compute is acceptable for announcement correctness.
+            const nextState = interactiveGraphReducer(prevState, action);
+            const message = getAnnouncementForAction(
+                action,
+                prevState,
+                nextState,
+                strings,
+                locale,
+            );
+            if (message !== null) {
+                announceMessage({message});
+            }
+            dispatch(action);
+        },
+        [dispatch, strings, locale],
+    );
+}
+
+type AnnounceOptions = {
+    debounceThreshold?: number;
+};
+
+/**
+ * Per-graph escape hatch for math-heavy announcements that belong in the
+ * graph component rather than the central handler (OQ3 routing rule).
+ *
+ * Returns {announce} — call it with a localised string to fire the WB
+ * Announcer.  A 500 ms debounce is applied by default; pass
+ * {debounceThreshold: N} to override per call.
+ */
+export function useGraphAnnouncer() {
+    const announce = useCallback(
+        (message: string, options?: AnnounceOptions) => {
+            announceMessage({
+                message,
+                debounceThreshold:
+                    options?.debounceThreshold ?? DEFAULT_DEBOUNCE_THRESHOLD_MS,
+            });
+        },
+        [],
+    );
+
+    return {announce};
+}

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -2,6 +2,7 @@ import {useLatestRef} from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
 import {useEffect, useImperativeHandle, useRef} from "react";
 
+import {useAnnouncingReducer} from "./announcer/use-announcing-reducer";
 import {MafsGraph} from "./mafs-graph";
 import {mafsStateToInteractiveGraph} from "./mafs-state-to-interactive-graph";
 import {initializeGraphState} from "./reducer/initialize-graph-state";
@@ -64,6 +65,7 @@ export const StatefulMafsGraph = React.forwardRef<
         props,
         initializeGraphState,
     );
+    const announcingDispatch = useAnnouncingReducer(state, dispatch);
 
     useImperativeHandle(ref, () => ({
         getUserInput: () => getGradableGraph(state, graph),
@@ -143,10 +145,10 @@ export const StatefulMafsGraph = React.forwardRef<
             <MafsGraph
                 {...props}
                 state={initializeGraphState({...props, graph: props.correct})}
-                dispatch={dispatch}
+                dispatch={announcingDispatch}
             />
         );
     }
 
-    return <MafsGraph {...props} state={state} dispatch={dispatch} />;
+    return <MafsGraph {...props} state={state} dispatch={announcingDispatch} />;
 });


### PR DESCRIPTION
## Summary:
Part of our work to improve the screen reader experience for interactive graph. This work is the start of implementing WonderBlock's Announcer component to dynamically announce state changes in the graph.

Issue: LEMS-3943

## Test plan:
TBD