### PR TITLE
Add workaround for `graded` during serialization

### DIFF
--- a/.changeset/warm-stingrays-smoke.md
+++ b/.changeset/warm-stingrays-smoke.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": patch
+---
+
+Deprecate excludeDenylistKeys and add workaround for `graded`

--- a/packages/perseus-editor/src/components/__tests__/widget-editor.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/widget-editor.test.tsx
@@ -6,8 +6,10 @@ import * as React from "react";
 
 import {testDependencies} from "../../testing/test-dependencies";
 import {registerAllWidgetsAndEditorsForTesting} from "../../util/register-all-widgets-and-editors-for-testing";
-import WidgetEditor from "../widget-editor";
+import WidgetEditor, {_upgradeWidgetInfo} from "../widget-editor";
 
+import type {WidgetEditorProps} from "../widget-editor";
+import type {PerseusDefinitionWidgetOptions} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
 
 describe("WidgetEditor", () => {
@@ -200,6 +202,67 @@ describe("WidgetEditor", () => {
                 name: "Alignment",
             });
             expect(dropdown).toHaveAttribute("aria-disabled", "true");
+        });
+    });
+
+    describe("_upgradeWidgetInfo", () => {
+        it("runs data through the denylist", () => {
+            const options: PerseusDefinitionWidgetOptions = {
+                togglePrompt: "Neat prompt",
+                definition: "Cool definition",
+                static: false,
+            };
+
+            const props: WidgetEditorProps = {
+                id: "definition 1",
+                onChange: () => {},
+                onRemove: () => {},
+                apiOptions: {},
+                type: "definition",
+                options,
+            };
+
+            // problemNum is in the denylist,
+            // so we want to make sure it's removed
+            const dirtyProps = {...props, problemNum: 42};
+
+            const output = _upgradeWidgetInfo(dirtyProps);
+
+            // make sure we filter as expected
+            // eslint-disable-next-line no-restricted-syntax
+            expect((output as any).onChange).toBeUndefined();
+            // eslint-disable-next-line no-restricted-syntax
+            expect((output as any).onRemove).toBeUndefined();
+            // eslint-disable-next-line no-restricted-syntax
+            expect((output as any).apiOptions).toBeUndefined();
+            // eslint-disable-next-line no-restricted-syntax
+            expect((output as any).problemNum).toBeUndefined();
+
+            // make sure we're not filtering too much
+            expect(output.type).toBe("definition");
+            expect(output.options).toEqual(options);
+        });
+
+        it("passes graded through", () => {
+            const options: PerseusDefinitionWidgetOptions = {
+                togglePrompt: "Neat prompt",
+                definition: "Cool definition",
+                static: false,
+            };
+
+            const props: WidgetEditorProps = {
+                id: "definition 1",
+                onChange: () => {},
+                onRemove: () => {},
+                apiOptions: {},
+                type: "definition",
+                options,
+                graded: true,
+            };
+
+            const output = _upgradeWidgetInfo(props);
+
+            expect(output.graded).toBe(true);
         });
     });
 });

--- a/packages/perseus-editor/src/components/widget-editor.tsx
+++ b/packages/perseus-editor/src/components/widget-editor.tsx
@@ -16,7 +16,8 @@ import type Editor from "../editor";
 import type {APIOptions} from "@khanacademy/perseus";
 import type {Alignment, PerseusWidget} from "@khanacademy/perseus-core";
 
-type WidgetEditorProps = {
+// exported for tests
+export type WidgetEditorProps = {
     // Unserialized props
     id: string;
     onChange: (
@@ -34,7 +35,8 @@ type WidgetEditorState = {
     widgetInfo: PerseusWidget;
 };
 
-const _upgradeWidgetInfo = (props: WidgetEditorProps): PerseusWidget => {
+// exported for tests
+export const _upgradeWidgetInfo = (props: WidgetEditorProps): PerseusWidget => {
     // We can't call serialize here because this.refs.widget
     // doesn't exist before this component is mounted.
     const filteredProps = excludeDenylistKeys(props);

--- a/packages/perseus-editor/src/components/widget-editor.tsx
+++ b/packages/perseus-editor/src/components/widget-editor.tsx
@@ -38,6 +38,15 @@ const _upgradeWidgetInfo = (props: WidgetEditorProps): PerseusWidget => {
     // We can't call serialize here because this.refs.widget
     // doesn't exist before this component is mounted.
     const filteredProps = excludeDenylistKeys(props);
+
+    // This is circumventing an issue with excludeDenylistKeys;
+    // it removes `graded` from WidgetOptions.options (good)
+    // but it's also recursive so it removes `graded`
+    // from the higher-up WidgetOptions (bad)
+    // See: LEMS-4108 and https://khanacademy.slack.com/archives/C01AZ9H8TTQ/p1778089642003609
+    // eslint-disable-next-line no-restricted-syntax
+    (filteredProps as any).graded = props.graded;
+
     // eslint-disable-next-line no-restricted-syntax
     return applyDefaultsToWidget(filteredProps as PerseusWidget);
 };

--- a/packages/perseus/src/mixins/widget-prop-denylist.ts
+++ b/packages/perseus/src/mixins/widget-prop-denylist.ts
@@ -10,8 +10,8 @@
  * This blocks things that we know don't need to be serialized.
  */
 /**
- * @deprecated and likely a very broken API
- * [LEMS-3185] do not trust serializedState
+ * @deprecated do not use the denylist
+ * See LEMS-4108 for more details
  */
 const denylist = [
     // standard props "added" by react
@@ -45,6 +45,10 @@ const denylist = [
     "graded",
 ];
 
+/**
+ * @deprecated do not use the denylist
+ * See LEMS-4108 for more details
+ */
 export function excludeDenylistKeys(obj: Record<any, any>) {
     if (obj == null) {
         return obj;


### PR DESCRIPTION
## Summary:

The problem: in #3466 we added a switch for `graded`. Everything was just dandy except that we broke publishes. That's because we started passing `graded` down to widgets (which we needed so IG could change its behavior based on the `graded` flag) but then every widgets started getting `graded`. Because of the janky way we serialize, that started adding `graded` in the WidgetOptions of some widgets ([ticket](https://khanacademy.atlassian.net/browse/LEMS-4105) and [Slack convo](https://khanacademy.slack.com/archives/C01AZ9H8TTQ/p1778089642003609)). Rather than discard unneeded fields, the publish pipeline just explodes when it sees a field it doesn't expect (which is totally cool and awesome) and it wasn't expecting `graded`.

The best solution is to make data serialization opt-in vs opt-out (see [LEMS-4108](https://khanacademy.atlassian.net/browse/LEMS-4108)). However that's probably a medium risk change and we have a playtest today, so this change just skips around the denylist for `graded`.

**Why this should be more safe than the last PR:** in #3466 there were some red flags...namely that I had to add `graded` to a bunch of tests. That was reverted as part of the bugfix (#3589) and the fact that I didn't need to add those changes back in this PR to pass checks indicated that this doesn't have the same problem as the last attempt.

[LEMS-4108]: https://khanacademy.atlassian.net/browse/LEMS-4108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ