### PR TITLE
Add function to convert input number options to numeric input options

### DIFF
--- a/.changeset/hip-schools-cough.md
+++ b/.changeset/hip-schools-cough.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": minor
+---
+
+Export a `convertInputNumberOptionsToNumericInput` function to convert the options for an InputNumber widget to the options for a NumericInput widget.

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -2167,17 +2167,19 @@ export type PerseusVideoWidgetOptions = {
     static?: boolean;
 };
 
+export type PerseusInputNumberAnswerType =
+    | "number"
+    | "decimal"
+    | "integer"
+    | "rational"
+    | "improper"
+    | "mixed"
+    | "percent"
+    | "pi";
+
 /** Options for the input-number widget (deprecated; prefer numeric-input). */
 export type PerseusInputNumberWidgetOptions = {
-    answerType?:
-        | "number"
-        | "decimal"
-        | "integer"
-        | "rational"
-        | "improper"
-        | "mixed"
-        | "percent"
-        | "pi";
+    answerType?: PerseusInputNumberAnswerType;
     inexact?: boolean;
     maxError?: number | string;
     rightAlign?: boolean;

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -207,6 +207,9 @@ export {default as videoLogic} from "./widgets/video";
 export type {VideoDefaultWidgetOptions} from "./widgets/video";
 
 /** @hidden */
+export {convertInputNumberOptionsToNumericInput} from "./widgets/input-number/to-numeric-input";
+
+/** @hidden */
 export {
     applyDefaultsToWidgets,
     applyDefaultsToWidget,

--- a/packages/perseus-core/src/widgets/input-number/to-numeric-input.test.ts
+++ b/packages/perseus-core/src/widgets/input-number/to-numeric-input.test.ts
@@ -1,0 +1,114 @@
+import {describe, it, expect} from "@jest/globals";
+
+import {convertInputNumberOptionsToNumericInput} from "./to-numeric-input";
+
+import type {PerseusInputNumberWidgetOptions} from "../../data-schema";
+
+const baseOptions: PerseusInputNumberWidgetOptions = {
+    simplify: "required",
+    size: "normal",
+    value: "0",
+};
+
+describe("convertInputNumberOptionsToNumericInput", () => {
+    it("converts maxError to a number when present", () => {
+        const options: PerseusInputNumberWidgetOptions = {
+            ...baseOptions,
+            maxError: "0.042",
+        };
+
+        const result = convertInputNumberOptionsToNumericInput(options);
+
+        expect(result.answers).toHaveLength(1);
+        expect(result.answers[0].maxError).toBe(0.042);
+    });
+
+    it("converts maxError values in exponent notation", () => {
+        const options: PerseusInputNumberWidgetOptions = {
+            ...baseOptions,
+            maxError: "42e-3",
+        };
+
+        const result = convertInputNumberOptionsToNumericInput(options);
+
+        expect(result.answers).toHaveLength(1);
+        expect(result.answers[0].maxError).toBe(0.042);
+    });
+
+    it("leaves maxError undefined when undefined", () => {
+        const options: PerseusInputNumberWidgetOptions = {
+            ...baseOptions,
+            maxError: undefined,
+        };
+
+        const result = convertInputNumberOptionsToNumericInput(options);
+
+        expect(result.answers).toHaveLength(1);
+        expect(result.answers[0].maxError).toBe(undefined);
+    });
+
+    it(`converts the "number" answer type to [integer, decimal, proper, improper, mixed]`, () => {
+        const options: PerseusInputNumberWidgetOptions = {
+            ...baseOptions,
+            answerType: "number",
+        };
+
+        const result = convertInputNumberOptionsToNumericInput(options);
+
+        expect(result.answers).toHaveLength(1);
+        expect(result.answers[0].answerForms).toEqual([
+            "integer",
+            "decimal",
+            "proper",
+            "improper",
+            "mixed",
+        ]);
+    });
+
+    it(`converts the "rational" answer type to [integer, proper, improper, mixed]`, () => {
+        const options: PerseusInputNumberWidgetOptions = {
+            ...baseOptions,
+            answerType: "rational",
+        };
+
+        const result = convertInputNumberOptionsToNumericInput(options);
+
+        expect(result.answers).toHaveLength(1);
+        expect(result.answers[0].answerForms).toEqual([
+            "integer",
+            "proper",
+            "improper",
+            "mixed",
+        ]);
+    });
+
+    it("defaults answerForms to [integer, proper, improper, mixed, decimal]", () => {
+        const options: PerseusInputNumberWidgetOptions = {
+            ...baseOptions,
+            answerType: undefined,
+        };
+
+        const result = convertInputNumberOptionsToNumericInput(options);
+
+        expect(result.answers).toHaveLength(1);
+        expect(result.answers[0].answerForms).toEqual([
+            "integer",
+            "proper",
+            "improper",
+            "mixed",
+            "decimal",
+        ]);
+    });
+
+    it("converts the `value` to a number", () => {
+        const options: PerseusInputNumberWidgetOptions = {
+            ...baseOptions,
+            value: "1.5",
+        };
+
+        const result = convertInputNumberOptionsToNumericInput(options);
+
+        expect(result.answers).toHaveLength(1);
+        expect(result.answers[0].value).toEqual(1.5);
+    });
+});

--- a/packages/perseus-core/src/widgets/input-number/to-numeric-input.ts
+++ b/packages/perseus-core/src/widgets/input-number/to-numeric-input.ts
@@ -1,0 +1,54 @@
+import type {
+    MathFormat,
+    PerseusInputNumberAnswerType,
+    PerseusInputNumberWidgetOptions,
+    PerseusNumericInputWidgetOptions,
+} from "../../data-schema";
+
+// NOTE: the information in mathFormatsForAnswerType is duplicated in
+// score-input-number.ts. I think this is okay because inputNumber is
+// deprecated and the scoring logic will be removed as part of this project.
+export const mathFormatsForAnswerType: Record<
+    PerseusInputNumberAnswerType,
+    MathFormat[]
+> = {
+    number: ["integer", "decimal", "proper", "improper", "mixed"],
+    decimal: ["decimal"],
+    integer: ["integer"],
+    rational: ["integer", "proper", "improper", "mixed"],
+    improper: ["integer", "proper", "improper"],
+    mixed: ["integer", "proper", "mixed"],
+    percent: ["integer", "decimal", "proper", "improper", "mixed", "percent"],
+    pi: ["pi"],
+};
+
+export function convertInputNumberOptionsToNumericInput(
+    inputNumberOptions: PerseusInputNumberWidgetOptions,
+): PerseusNumericInputWidgetOptions {
+    const maxError =
+        inputNumberOptions.maxError != null
+            ? Number(inputNumberOptions.maxError)
+            : inputNumberOptions.maxError;
+
+    const answerForms: MathFormat[] = inputNumberOptions.answerType
+        ? mathFormatsForAnswerType[inputNumberOptions.answerType]
+        : ["integer", "proper", "improper", "mixed", "decimal"];
+
+    return {
+        coefficient: false,
+        rightAlign: inputNumberOptions.rightAlign,
+        size: inputNumberOptions.size,
+        static: false,
+        answers: [
+            {
+                status: "correct",
+                value: Number(inputNumberOptions.value),
+                simplify: inputNumberOptions.simplify,
+                message: "",
+                maxError,
+                strict: true,
+                answerForms,
+            },
+        ],
+    };
+}

--- a/packages/perseus-core/src/widgets/input-number/to-numeric-input.ts
+++ b/packages/perseus-core/src/widgets/input-number/to-numeric-input.ts
@@ -8,7 +8,7 @@ import type {
 // NOTE: the information in mathFormatsForAnswerType is duplicated in
 // score-input-number.ts. I think this is okay because inputNumber is
 // deprecated and the scoring logic will be removed as part of this project.
-export const mathFormatsForAnswerType: Record<
+const mathFormatsForAnswerType: Record<
     PerseusInputNumberAnswerType,
     MathFormat[]
 > = {


### PR DESCRIPTION
## Summary:
The plan is to use this to convert input number widgets to numeric inputs at
runtime, for both display and scoring.

Based on [this code analysis](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/edit-v2/4746543421).

Issue: LEMS-4082

## Test plan:

CI checks should pass.