### PR TITLE
[Preview NG] Support dual-protocol editor preview (support legacy mode)

### DIFF
--- a/.changeset/quiet-bridges-stand.md
+++ b/.changeset/quiet-bridges-stand.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+`PreviewWithIframe` now also speaks the legacy `IframeContentRenderer` wire protocol (raw-string handshake + `window.iframeDataStore`) alongside the typed `usePreviewController` protocol, so editor consumers can drive preview frames from older perseus versions without code changes. This is transitional — will be removed once all clients can upgrade to a version of Perseus that supports the modernized preview system (aka `usePreviewPresenter`).

--- a/packages/perseus-editor/src/iframe-content-renderer.tsx
+++ b/packages/perseus-editor/src/iframe-content-renderer.tsx
@@ -17,7 +17,6 @@ import * as React from "react";
 let nextIframeID = 0;
 const requestIframeData: Record<string, any> = {};
 const updateIframeHeight: Record<string, any> = {};
-// @ts-expect-error - TS2339 - Property 'iframeDataStore' does not exist on type 'Window & typeof globalThis'.
 window.iframeDataStore = {};
 
 // This is called once after Perseus is loaded and the iframe
@@ -183,8 +182,7 @@ class IframeContentRenderer extends React.Component<Props> {
 
             // We can't use JSON.stringify/parse for this because the apiOptions
             // includes the function onFocusChange.
-            // @ts-expect-error - TS2339 - Property 'iframeDataStore' does not exist on type 'Window & typeof globalThis'.
-            window.iframeDataStore[this.iframeID] = data;
+            window.iframeDataStore![this.iframeID] = data;
             frame.contentWindow.postMessage(this.iframeID, "*");
         }
     }

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -16,9 +16,22 @@ jest.mock("./preview/use-preview-controller", () => ({
     }),
 }));
 
+const mockSendLegacyData = jest.fn();
+let mockLegacyHeight: number | null = null;
+const mockLegacyIframeId = "legacy-id-7";
+
+jest.mock("./preview/use-legacy-preview-controller", () => ({
+    useLegacyPreviewController: () => ({
+        iframeId: mockLegacyIframeId,
+        sendData: mockSendLegacyData,
+        height: mockLegacyHeight,
+    }),
+}));
+
 describe("PreviewWithIframe", () => {
     beforeEach(() => {
         mockHeight = null;
+        mockLegacyHeight = null;
     });
 
     it("renders an iframe with the given URL", () => {
@@ -67,7 +80,7 @@ describe("PreviewWithIframe", () => {
         },
     );
 
-    it("delegates sendNewData to usePreviewController's sendData via ref", () => {
+    it("delegates sendNewData to both usePreviewController's and useLegacyPreviewController's sendData via ref", () => {
         const ref = React.createRef<PreviewWithIframeRef>();
 
         render(
@@ -101,6 +114,20 @@ describe("PreviewWithIframe", () => {
         ref.current?.sendNewData(data);
 
         expect(mockSendData).toHaveBeenCalledWith(data);
+        expect(mockSendLegacyData).toHaveBeenCalledWith(data);
+    });
+
+    it("sets data-id on the iframe so legacy preview frames can read their assigned id", () => {
+        render(
+            <PreviewWithIframe
+                url="/preview"
+                isMobile={false}
+                seamless={false}
+            />,
+        );
+
+        const iframe = screen.getByTitle(/perseus-preview/);
+        expect(iframe.dataset.id).toBe(mockLegacyIframeId);
     });
 
     it("sets container height to '100%' when seamless is false", () => {
@@ -129,5 +156,21 @@ describe("PreviewWithIframe", () => {
 
         const div = screen.getByTestId("preview-with-iframe-container");
         expect(div.style.height).toBe("500px");
+    });
+
+    it("falls back to the legacy controller's height when the typed protocol hasn't reported one", () => {
+        mockHeight = null;
+        mockLegacyHeight = 320;
+
+        render(
+            <PreviewWithIframe
+                url="/preview"
+                isMobile={false}
+                seamless={true}
+            />,
+        );
+
+        const div = screen.getByTestId("preview-with-iframe-container");
+        expect(div.style.height).toBe("320px");
     });
 });

--- a/packages/perseus-editor/src/preview-with-iframe.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.tsx
@@ -13,9 +13,16 @@
  * once all editors have migrated. It exists alongside the legacy component so
  * that consumers can keep using `IframeContentRenderer` until they are all
  * ported over.
+ *
+ * For backwards compatibility, this component also speaks the legacy
+ * `IframeContentRenderer` wire protocol via `useLegacyPreviewController`,
+ * so it can drive preview frames running an older version of Perseus (one
+ * from before the typed-protocol preview existed). The legacy support is
+ * transitional — see that hook's docs for the deletion trigger.
  */
 import * as React from "react";
 
+import {useLegacyPreviewController} from "./preview/use-legacy-preview-controller";
 import {usePreviewController} from "./preview/use-preview-controller";
 
 import type {PreviewContent} from "./preview/message-types";
@@ -39,7 +46,12 @@ const PreviewWithIframe = React.forwardRef<PreviewWithIframeRef, Props>(
         const containerRef = React.useRef<HTMLDivElement>(null);
         const iframeRef = React.useRef<HTMLIFrameElement>(null);
 
-        const {sendData, height} = usePreviewController(iframeRef);
+        const {sendData, height: typedHeight} = usePreviewController(iframeRef);
+        const {
+            iframeId: legacyIframeId,
+            sendData: sendLegacyData,
+            height: legacyHeight,
+        } = useLegacyPreviewController(iframeRef);
 
         // Expose sendNewData method via ref
         React.useImperativeHandle(
@@ -47,10 +59,15 @@ const PreviewWithIframe = React.forwardRef<PreviewWithIframeRef, Props>(
             () => ({
                 sendNewData: (data: PreviewContent) => {
                     sendData(data);
+                    sendLegacyData(data);
                 },
             }),
-            [sendData],
+            [sendData, sendLegacyData],
         );
+
+        // Either protocol can populate height; only one will in practice for
+        // a given iframe.
+        const height = typedHeight ?? legacyHeight;
 
         // Update container height based on iframe content height
         let containerHeight = "100%";
@@ -75,6 +92,10 @@ const PreviewWithIframe = React.forwardRef<PreviewWithIframeRef, Props>(
                     // to be displaying editor previews and want to leave some room
                     // for lint indicators in the right margin.
                     data-lint-gutter={props.seamless ? "true" : "false"}
+                    // Identifier read by legacy preview frames via
+                    // `window.frameElement.dataset.id`. New typed-protocol
+                    // frames ignore it. See `useLegacyPreviewController`.
+                    data-id={legacyIframeId}
                     style={{width: "100%", height: "100%"}}
                     src={props.url}
                 />

--- a/packages/perseus-editor/src/preview/use-legacy-preview-controller.test.ts
+++ b/packages/perseus-editor/src/preview/use-legacy-preview-controller.test.ts
@@ -1,0 +1,275 @@
+import {renderHook, act} from "@testing-library/react";
+
+import {useLegacyPreviewController} from "./use-legacy-preview-controller";
+
+import type {PreviewContent} from "./message-types";
+import type * as React from "react";
+
+describe("useLegacyPreviewController", () => {
+    let mockIframe: {contentWindow: Window | null; dataset: any};
+    let mockContentWindow: Window;
+    let iframeRef: React.RefObject<HTMLIFrameElement>;
+
+    beforeEach(() => {
+        mockContentWindow = {
+            postMessage: jest.fn(),
+        } as unknown as Window;
+
+        mockIframe = {
+            contentWindow: mockContentWindow,
+            dataset: {},
+        };
+
+        iframeRef = {current: mockIframe as any};
+
+        // Reset the global store between tests so leakage is impossible
+        delete window.iframeDataStore;
+    });
+
+    describe("initialization", () => {
+        it("returns a stable iframeId across renders", () => {
+            const {result, rerender} = renderHook(() =>
+                useLegacyPreviewController(iframeRef),
+            );
+            const initialId = result.current.iframeId;
+
+            rerender();
+
+            expect(result.current.iframeId).toBe(initialId);
+        });
+
+        it("returns null height before any legacy height update", () => {
+            const {result} = renderHook(() =>
+                useLegacyPreviewController(iframeRef),
+            );
+
+            expect(result.current.height).toBeNull();
+        });
+
+        it("creates window.iframeDataStore on first use", () => {
+            renderHook(() => useLegacyPreviewController(iframeRef));
+
+            expect(window.iframeDataStore).toBeDefined();
+        });
+
+        it("removes its entry from window.iframeDataStore on unmount", () => {
+            const {result, unmount} = renderHook(() =>
+                useLegacyPreviewController(iframeRef),
+            );
+            const id = result.current.iframeId;
+
+            act(() => {
+                result.current.sendData(createQuestionPreview());
+            });
+            expect(window.iframeDataStore?.[id]).toBeDefined();
+
+            unmount();
+
+            expect(window.iframeDataStore?.[id]).toBeUndefined();
+        });
+    });
+
+    describe("sendData", () => {
+        it("writes the latest data into window.iframeDataStore", () => {
+            const {result} = renderHook(() =>
+                useLegacyPreviewController(iframeRef),
+            );
+            const data = createQuestionPreview();
+
+            act(() => {
+                result.current.sendData(data);
+            });
+
+            expect(window.iframeDataStore?.[result.current.iframeId]).toBe(
+                data,
+            );
+        });
+
+        it("doesn't post to the iframe before the legacy handshake", () => {
+            const {result} = renderHook(() =>
+                useLegacyPreviewController(iframeRef),
+            );
+
+            act(() => {
+                result.current.sendData(createQuestionPreview());
+            });
+
+            expect(mockContentWindow.postMessage).not.toHaveBeenCalled();
+        });
+
+        it("posts the iframeId to the iframe after the legacy handshake", () => {
+            const {result} = renderHook(() =>
+                useLegacyPreviewController(iframeRef),
+            );
+            const id = result.current.iframeId;
+
+            // Iframe handshakes with no buffered data
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: id,
+                        source: mockContentWindow,
+                    }),
+                );
+            });
+
+            // Now send data — should immediately post id back
+            act(() => {
+                result.current.sendData(createQuestionPreview());
+            });
+
+            expect(mockContentWindow.postMessage).toHaveBeenCalledWith(id, "*");
+        });
+    });
+
+    describe("legacy handshake", () => {
+        it("on receiving the iframeId as a string, writes buffered data and posts the id back", () => {
+            const {result} = renderHook(() =>
+                useLegacyPreviewController(iframeRef),
+            );
+            const id = result.current.iframeId;
+            const data = createQuestionPreview();
+
+            // Buffer data before handshake
+            act(() => {
+                result.current.sendData(data);
+            });
+            expect(mockContentWindow.postMessage).not.toHaveBeenCalled();
+
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: id,
+                        source: mockContentWindow,
+                    }),
+                );
+            });
+
+            expect(window.iframeDataStore?.[id]).toBe(data);
+            expect(mockContentWindow.postMessage).toHaveBeenCalledWith(id, "*");
+        });
+
+        it("ignores string handshakes from other windows", () => {
+            const {result} = renderHook(() =>
+                useLegacyPreviewController(iframeRef),
+            );
+            const id = result.current.iframeId;
+            const otherWindow = {postMessage: jest.fn()} as unknown as Window;
+
+            act(() => {
+                result.current.sendData(createQuestionPreview());
+            });
+
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: id,
+                        source: otherWindow,
+                    }),
+                );
+            });
+
+            expect(mockContentWindow.postMessage).not.toHaveBeenCalled();
+        });
+
+        it("ignores string messages that don't match this iframe's id", () => {
+            const {result} = renderHook(() =>
+                useLegacyPreviewController(iframeRef),
+            );
+
+            act(() => {
+                result.current.sendData(createQuestionPreview());
+            });
+
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: "some-other-id",
+                        source: mockContentWindow,
+                    }),
+                );
+            });
+
+            expect(mockContentWindow.postMessage).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("legacy height updates", () => {
+        it("updates height from {id, height} messages", () => {
+            const {result} = renderHook(() =>
+                useLegacyPreviewController(iframeRef),
+            );
+            const id = result.current.iframeId;
+
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {id, height: 320},
+                        source: mockContentWindow,
+                    }),
+                );
+            });
+
+            expect(result.current.height).toBe(320);
+        });
+
+        it("ignores height messages with a non-matching id", () => {
+            const {result} = renderHook(() =>
+                useLegacyPreviewController(iframeRef),
+            );
+
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {id: "nope", height: 320},
+                        source: mockContentWindow,
+                    }),
+                );
+            });
+
+            expect(result.current.height).toBeNull();
+        });
+
+        it("ignores typed-protocol messages (those have source/type, not id)", () => {
+            const {result} = renderHook(() =>
+                useLegacyPreviewController(iframeRef),
+            );
+
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            source: "perseus-preview",
+                            type: "height-update",
+                            height: 999,
+                        },
+                        source: mockContentWindow,
+                    }),
+                );
+            });
+
+            expect(result.current.height).toBeNull();
+        });
+    });
+});
+
+function createQuestionPreview(): PreviewContent {
+    return {
+        type: "question",
+        data: {
+            item: {
+                question: {content: "Q", widgets: {}, images: {}},
+                answerArea: {calculator: false} as any,
+                hints: [],
+            },
+            apiOptions: {},
+            initialHintsVisible: 0,
+            device: "desktop",
+            linterContext: {
+                contentType: "exercise",
+                highlightLint: false,
+                stack: [],
+            },
+        },
+    };
+}

--- a/packages/perseus-editor/src/preview/use-legacy-preview-controller.ts
+++ b/packages/perseus-editor/src/preview/use-legacy-preview-controller.ts
@@ -1,0 +1,135 @@
+import * as React from "react";
+
+import type {PreviewContent} from "./message-types";
+
+let nextLegacyIframeId = 0;
+
+declare global {
+    interface Window {
+        iframeDataStore?: Record<string, unknown>;
+    }
+}
+
+type Result = {
+    /**
+     * Stable id assigned to the iframe; pass through to the iframe element's
+     * `data-id` attribute so the legacy receiver can read it from
+     * `window.frameElement.dataset.id`.
+     */
+    iframeId: string;
+    /**
+     * Send the latest preview data to the legacy iframe by writing it into
+     * `window.iframeDataStore[iframeId]` and (once the iframe has handshook)
+     * posting `iframeId` back to it. Call this on every content update —
+     * the legacy iframe doesn't kick anything off until it sees the id.
+     */
+    sendData: (data: PreviewContent) => void;
+    /**
+     * Height reported via the legacy `{id, height}` message. `null` until the
+     * iframe sends one (or always `null` if the iframe is on the typed
+     * protocol — in that case the typed `height` from `usePreviewController`
+     * is what's populated).
+     */
+    height: number | null;
+};
+
+/**
+ * Parent-side preview controller for the legacy postMessage protocol.
+ *
+ * **Transitional — delete once all consumers have upgraded to a Perseus
+ * version that uses `usePreviewPresenter` on the iframe side.**
+ *
+ * Teaches `PreviewWithIframe` to also speak the legacy `IframeContentRenderer`
+ * wire protocol, alongside the typed protocol that `usePreviewController`
+ * already implements. The two are mutually exclusive for any given iframe —
+ * a preview frame loaded from a Perseus version that predates
+ * `usePreviewPresenter` only ever sends/receives the legacy shape, and a
+ * frame on the typed protocol never touches `window.iframeDataStore`.
+ *
+ * The legacy protocol:
+ *   1. Parent assigns the iframe an id via `dataset.id` (aka `data-id={x}`).
+ *   2. Iframe sends that id back to parent as a raw string when ready.
+ *   3. Parent writes the latest data into `window.iframeDataStore[id]` and
+ *      posts the id back to the iframe.
+ *   4. Iframe reads `window.parent.iframeDataStore[id]` for its content.
+ *   5. Iframe reports height via postMessage() as `{id, height}` (object, not
+ *      string).
+ *
+ * This controller runs in addition to `usePreviewController`. The typed
+ * listener filters by `source: "perseus-preview"` and ignores raw strings /
+ * `{id, ...}` objects; this listener filters by the iframe's id and ignores
+ * typed messages. Heights from either protocol surface through the typed
+ * controller's `height` (typed) or this hook's `height` (legacy);
+ * `PreviewWithIframe` combines them.
+ */
+export function useLegacyPreviewController(
+    iframeRef: React.RefObject<HTMLIFrameElement>,
+): Result {
+    const [iframeId] = React.useState(() => String(nextLegacyIframeId++));
+    const [height, setHeight] = React.useState<number | null>(null);
+    const [isReady, setIsReady] = React.useState(false);
+    const latestDataRef = React.useRef<PreviewContent | null>(null);
+
+    React.useEffect(() => {
+        if (!window.iframeDataStore) {
+            window.iframeDataStore = {};
+        }
+
+        return () => {
+            if (window.iframeDataStore) {
+                delete window.iframeDataStore[iframeId];
+            }
+        };
+    }, [iframeId]);
+
+    React.useEffect(() => {
+        const handleMessage = (event: MessageEvent) => {
+            const contentWindow = iframeRef.current?.contentWindow;
+            if (contentWindow == null || event.source !== contentWindow) {
+                return;
+            }
+
+            // Legacy ready handshake: the iframe posts its assigned id back
+            // as a raw string.
+            if (typeof event.data === "string" && event.data === iframeId) {
+                if (latestDataRef.current != null && window.iframeDataStore) {
+                    window.iframeDataStore[iframeId] = latestDataRef.current;
+                    contentWindow.postMessage(iframeId, "*");
+                }
+                setIsReady(true);
+                return;
+            }
+
+            // Legacy height update: `{id, height}`.
+            if (
+                event.data != null &&
+                typeof event.data === "object" &&
+                (event.data as {id?: unknown}).id === iframeId &&
+                typeof (event.data as {height?: unknown}).height === "number"
+            ) {
+                setHeight((event.data as {height: number}).height);
+            }
+        };
+
+        window.addEventListener("message", handleMessage);
+        return () => window.removeEventListener("message", handleMessage);
+    }, [iframeRef, iframeId]);
+
+    const sendData = React.useCallback(
+        (data: PreviewContent) => {
+            latestDataRef.current = data;
+
+            if (!window.iframeDataStore) {
+                window.iframeDataStore = {};
+            }
+            window.iframeDataStore[iframeId] = data;
+
+            if (isReady) {
+                iframeRef.current?.contentWindow?.postMessage(iframeId, "*");
+            }
+        },
+        [iframeRef, iframeId, isReady],
+    );
+
+    return {iframeId, sendData, height};
+}


### PR DESCRIPTION
## Summary:

*This PR is part of a series building a typed, hook-based preview system for the Perseus editor. The new system replaces the untyped `window.iframeDataStore` + raw `postMessage(string)` communication with structured, validated message passing via `usePreviewController` and `usePreviewPresenter` hooks. The new system is being built alongside the old one — no existing behavior changes until the final PR in the series flips the switch.*

Previous PRs in this series:
- #3464
- #3467
- #3474
- #3492
- #3495
- #3499
- #3578
- #3588
- #3581 

---

This PR adds a parallel legacy preview controller hook to `PreviewWithIframe` so the component can drive both new typed-protocol preview frames and legacy frames (running an older Perseus that predates `usePreviewPresenter`) without code changes at the call site.

The new `useLegacyPreviewController` mirrors the API shape of `usePreviewController` (`{sendData, height, ...}`) but speaks the legacy wire protocol: parent assigns each iframe an id via `data-id`, the iframe posts that id back as a raw string when ready, parent writes the latest preview content into `window.iframeDataStore[id]` and posts the id back, and the iframe reports height as `{id, height}` postMessages (vs. the typed protocol's `{source: "perseus-preview", type: "height-update", height}`).

`PreviewWithIframe` now invokes both controllers unconditionally and fans `sendNewData` out to both `sendData` calls. The two protocols are mutually exclusive for any given iframe — the typed listener filters by `source: "perseus-preview"` and ignores raw strings / `{id, ...}` objects; the legacy listener filters by the iframe's id and ignores typed messages — so they don't interfere. Heights from either protocol surface as `typedHeight ?? legacyHeight`.

The legacy support is transitional. Once all downstream consumers have upgraded to a Perseus version that uses usePreviewPresenter, both this hook and the legacy `IframeContentRenderer` class component can be deleted. The hook's JSDoc and the component's file header both note the deletion trigger; this is also why the deferred Branch 9 (message-field rework) stays deferred — its renames would break the data shape the legacy receivers consume.

Issue: LEMS-3741

Test plan:

  * `pnpm test`
  * `pnpm tsc`
  * `pnpm lint`