### PR TITLE
Add `scorePerseusItemWithInputNumberAsNumericInput` for side-by-side testing

### DIFF
--- a/.changeset/green-beans-deliver.md
+++ b/.changeset/green-beans-deliver.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-core": minor
+"@khanacademy/perseus-score": minor
+---
+
+Internal: add a `scorePerseusItemWithInputNumberAsNumericInput` function for side-by-side testing of the input-number to numeric-input migration.

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -368,6 +368,10 @@ export {
     generateImageOptions,
     generateImageWidget,
 } from "./utils/generators/image-widget-generator";
+export {
+    generateInputNumberOptions,
+    generateInputNumberWidget,
+} from "./utils/generators/input-number-widget-generator";
 /** @hidden */
 export {
     generateLabelImageOptions,

--- a/packages/perseus-core/src/utils/generators/input-number-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/input-number-widget-generator.ts
@@ -1,0 +1,29 @@
+import inputNumberWidgetLogic from "../../widgets/input-number";
+
+import type {
+    InputNumberWidget,
+    PerseusInputNumberWidgetOptions,
+} from "../../data-schema";
+
+// TODO(LEMS-4085): Delete this file.
+
+export function generateInputNumberWidget(
+    inputNumberWidgetProperties?: Partial<Omit<InputNumberWidget, "type">>,
+): InputNumberWidget {
+    return {
+        type: "input-number",
+        graded: true,
+        static: false,
+        options: generateInputNumberOptions(),
+        ...inputNumberWidgetProperties,
+    };
+}
+
+export function generateInputNumberOptions(
+    options?: Partial<PerseusInputNumberWidgetOptions>,
+): PerseusInputNumberWidgetOptions {
+    return {
+        ...inputNumberWidgetLogic.defaultWidgetOptions,
+        ...options,
+    };
+}

--- a/packages/perseus-score/src/index.ts
+++ b/packages/perseus-score/src/index.ts
@@ -37,7 +37,11 @@ export {
     inputNumberAnswerTypes,
 } from "./widgets/input-number/score-input-number";
 
-export {scorePerseusItem, scoreWidgetsFunctional} from "./score";
+export {
+    scorePerseusItem,
+    scorePerseusItemWithInputNumberAsNumericInput,
+    scoreWidgetsFunctional,
+} from "./score";
 export {default as flattenScores} from "./util/flatten-scores";
 export {validateUserInput, emptyWidgetsFunctional} from "./validate";
 export {default as hasEmptyDINERWidgets} from "./has-empty-diner-widgets";

--- a/packages/perseus-score/src/score.test.ts
+++ b/packages/perseus-score/src/score.test.ts
@@ -5,9 +5,15 @@ import {
     type DropdownWidget,
     type PerseusWidgetsMap,
     type UserInputMap,
+    generateInputNumberWidget,
+    generateInputNumberOptions,
 } from "@khanacademy/perseus-core";
 
-import {scorePerseusItem, scoreWidgetsFunctional} from "./score";
+import {
+    scorePerseusItem,
+    scorePerseusItemWithInputNumberAsNumericInput,
+    scoreWidgetsFunctional,
+} from "./score";
 import {getExpressionWidget, getTestDropdownWidget} from "./util/test-helpers";
 
 describe("scoreWidgetsFunctional", () => {
@@ -467,5 +473,197 @@ describe("scorePerseusItem", () => {
         expect(score).toHaveBeenAnsweredCorrectly({
             shouldHavePoints: true,
         });
+    });
+});
+
+describe("scorePerseusItemWithInputNumberAsNumericInput", () => {
+    it("scores a correctly-answered input-number widget", () => {
+        const renderer = {
+            content: "[[☃ input-number 1]]",
+            widgets: {
+                "input-number 1": generateInputNumberWidget({
+                    options: generateInputNumberOptions({value: "42"}),
+                }),
+            },
+            images: {},
+        };
+
+        const userInputMap = {
+            "input-number 1": {
+                currentValue: "42",
+            },
+        };
+
+        const score = scorePerseusItemWithInputNumberAsNumericInput(
+            renderer,
+            userInputMap,
+            "en",
+        );
+
+        expect(score).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("scores an incorrectly-answered input-number widget", () => {
+        const renderer = {
+            content: "[[☃ input-number 1]]",
+            widgets: {
+                "input-number 1": generateInputNumberWidget({
+                    options: generateInputNumberOptions({value: "42"}),
+                }),
+            },
+            images: {},
+        };
+
+        const userInputMap = {
+            "input-number 1": {
+                currentValue: "99",
+            },
+        };
+
+        const score = scorePerseusItemWithInputNumberAsNumericInput(
+            renderer,
+            userInputMap,
+            "en",
+        );
+
+        expect(score).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("scores an empty input-number widget", () => {
+        const renderer = {
+            content: "[[☃ input-number 1]]",
+            widgets: {
+                "input-number 1": generateInputNumberWidget({
+                    options: generateInputNumberOptions({value: "42"}),
+                }),
+            },
+            images: {},
+        };
+
+        const userInputMap = {
+            "input-number 1": {
+                currentValue: "",
+            },
+        };
+
+        const score = scorePerseusItemWithInputNumberAsNumericInput(
+            renderer,
+            userInputMap,
+            "en",
+        );
+
+        expect(score).toHaveInvalidInput();
+    });
+
+    it("ignores an input-number widget that does not have a placeholder in the content string", () => {
+        const renderer = {
+            content: "",
+            widgets: {
+                "input-number 1": generateInputNumberWidget({
+                    options: generateInputNumberOptions({value: "42"}),
+                }),
+            },
+            images: {},
+        };
+
+        const userInputMap = {
+            "input-number 1": {
+                currentValue: "",
+            },
+        };
+
+        const score = scorePerseusItemWithInputNumberAsNumericInput(
+            renderer,
+            userInputMap,
+            "en",
+        );
+
+        expect(score).toHaveBeenAnsweredCorrectly({shouldHavePoints: false});
+    });
+
+    it("ignores an input-number widget that is not graded", () => {
+        const renderer = {
+            content: "[[☃ input-number 1]]",
+            widgets: {
+                "input-number 1": generateInputNumberWidget({
+                    graded: false,
+                    options: generateInputNumberOptions({value: "42"}),
+                }),
+            },
+            images: {},
+        };
+
+        const userInputMap = {
+            "input-number 1": {
+                currentValue: "",
+            },
+        };
+
+        const score = scorePerseusItemWithInputNumberAsNumericInput(
+            renderer,
+            userInputMap,
+            "en",
+        );
+
+        expect(score).toHaveBeenAnsweredCorrectly({shouldHavePoints: false});
+    });
+
+    it("scores correctly-answered widgets other than input-number", () => {
+        const renderer = {
+            content: "[[☃ dropdown 1]]",
+            widgets: {
+                "dropdown 1": generateDropdownWidget({
+                    options: generateDropdownOptions({
+                        choices: [{content: "A", correct: true}],
+                    }),
+                }),
+            },
+            images: {},
+        };
+
+        const userInputMap: UserInputMap = {
+            "dropdown 1": {
+                value: 1,
+            },
+        };
+
+        const score = scorePerseusItemWithInputNumberAsNumericInput(
+            renderer,
+            userInputMap,
+            "en",
+        );
+
+        expect(score).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("scores incorrectly-answered widgets other than input-number", () => {
+        const renderer = {
+            content: "[[☃ dropdown 1]]",
+            widgets: {
+                "dropdown 1": generateDropdownWidget({
+                    options: generateDropdownOptions({
+                        choices: [
+                            {content: "A", correct: true},
+                            {content: "B", correct: false},
+                        ],
+                    }),
+                }),
+            },
+            images: {},
+        };
+
+        const userInputMap: UserInputMap = {
+            "dropdown 1": {
+                value: 2,
+            },
+        };
+
+        const score = scorePerseusItemWithInputNumberAsNumericInput(
+            renderer,
+            userInputMap,
+            "en",
+        );
+
+        expect(score).toHaveBeenAnsweredIncorrectly();
     });
 });

--- a/packages/perseus-score/src/score.ts
+++ b/packages/perseus-score/src/score.ts
@@ -1,3 +1,5 @@
+import {convertInputNumberOptionsToNumericInput} from "@khanacademy/perseus-core";
+
 import flattenScores from "./util/flatten-scores";
 import getScoreableWidgets from "./util/get-scoreable-widgets";
 import isWidgetScoreable from "./util/is-widget-scoreable";
@@ -36,6 +38,27 @@ export function scorePerseusItem(
     return flattenScores(scores);
 }
 
+/**
+ * @experimental - this is a temporary function for use by the Input Number to
+ * Numeric Input project. It will be removed in a future minor version.
+ */
+// TODO(LEMS-4085): remove this function once the Input Number to Numeric
+//  Input project is complete.
+export function scorePerseusItemWithInputNumberAsNumericInput(
+    perseusRenderData: PerseusRenderer,
+    userInputMap: UserInputMap,
+    locale: string,
+): PerseusScore {
+    const scoreableWidgetIds = getScoreableWidgets(perseusRenderData);
+    const scores = scoreWidgetsFunctionalWithInputNumberAsNumericInput(
+        perseusRenderData.widgets,
+        scoreableWidgetIds,
+        userInputMap,
+        locale,
+    );
+    return flattenScores(scores);
+}
+
 export function scoreWidgetsFunctional(
     widgets: PerseusWidgetsMap,
     // This is a port of old code, I'm not sure why
@@ -65,6 +88,57 @@ export function scoreWidgetsFunctional(
         const score =
             validator?.(userInput, widget.options, locale) ??
             scorer?.(userInput, widget.options, locale);
+        if (score != null) {
+            widgetScores[id] = score;
+        }
+    });
+
+    return widgetScores;
+}
+
+// TODO(LEMS-4085): remove this function once the Input Number to Numeric
+//  Input project is complete.
+export function scoreWidgetsFunctionalWithInputNumberAsNumericInput(
+    widgets: PerseusWidgetsMap,
+    // This is a port of old code, I'm not sure why
+    // we need widgetIds vs the keys of the widgets object
+    widgetIds: ReadonlyArray<string>,
+    userInputMap: UserInputMap,
+    locale: string,
+): {[widgetId: string]: PerseusScore} {
+    const gradedWidgetIds = widgetIds.filter((id) =>
+        isWidgetScoreable(widgets[id]),
+    );
+
+    const widgetScores: Record<string, PerseusScore> = {};
+    gradedWidgetIds.forEach((id) => {
+        const widget = widgets[id]!;
+
+        // TODO(benchristel): Without the explicit type annotation, the type of
+        // userInput would be inferred as `any`. This is because the keys of
+        // userInputMap are strings with a specific format, but `id` is any old
+        // string. Find a way to make this more typesafe.
+        const userInput: UserInput | undefined = userInputMap[id];
+        let widgetType;
+        let widgetOptions;
+        if (widget.type === "input-number") {
+            widgetType = "numeric-input";
+            widgetOptions = convertInputNumberOptionsToNumericInput(
+                widget.options,
+            );
+        } else {
+            widgetType = widget.type;
+            widgetOptions = widget.options;
+        }
+
+        const validator = getWidgetValidator(widgetType);
+        const scorer = getWidgetScorer(widgetType);
+
+        // We do validation (empty checks) first and then scoring. If
+        // validation fails, it's result is itself a PerseusScore.
+        const score =
+            validator?.(userInput, widgetOptions, locale) ??
+            scorer?.(userInput, widgetOptions, locale);
         if (score != null) {
             widgetScores[id] = score;
         }

--- a/packages/perseus-score/src/score.ts
+++ b/packages/perseus-score/src/score.ts
@@ -98,7 +98,7 @@ export function scoreWidgetsFunctional(
 
 // TODO(LEMS-4085): remove this function once the Input Number to Numeric
 //  Input project is complete.
-export function scoreWidgetsFunctionalWithInputNumberAsNumericInput(
+function scoreWidgetsFunctionalWithInputNumberAsNumericInput(
     widgets: PerseusWidgetsMap,
     // This is a port of old code, I'm not sure why
     // we need widgetIds vs the keys of the widgets object


### PR DESCRIPTION
## Summary:
The plan is to call this function in the Perseus service when scoring,
side-by-side with the current scoring logic, and log any differences. If
converting input-number widgets to numeric-input results in a different score,
it means we messed up the conversion logic somewhere.

Issue: LEMS-4091

## Test plan:

CI checks should pass.