### PR TITLE
[Radio] Remove feature flags

### DIFF
--- a/.changeset/fuzzy-lions-act.md
+++ b/.changeset/fuzzy-lions-act.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus-editor": patch
+---
+
+[Radio] Remove feature flags

--- a/packages/perseus-core/src/feature-flags.test.ts
+++ b/packages/perseus-core/src/feature-flags.test.ts
@@ -2,13 +2,13 @@ import {isFeatureOn} from "./feature-flags";
 
 describe("isFeatureOn", () => {
     it("returns true when the flag is enabled", () => {
-        const props = {apiOptions: {flags: {"new-radio-widget": true}}};
-        expect(isFeatureOn(props, "new-radio-widget")).toBe(true);
+        const props = {apiOptions: {flags: {"widget-feature-flag": true}}};
+        expect(isFeatureOn(props, "widget-feature-flag")).toBe(true);
     });
 
     it("returns false when the flag is disabled", () => {
-        const props = {apiOptions: {flags: {"new-radio-widget": false}}};
-        expect(isFeatureOn(props, "new-radio-widget")).toBe(false);
+        const props = {apiOptions: {flags: {"widget-feature-flag": false}}};
+        expect(isFeatureOn(props, "widget-feature-flag")).toBe(false);
     });
 
     it("returns false when the flag is missing", () => {
@@ -18,11 +18,11 @@ describe("isFeatureOn", () => {
 
     it("returns false when flags is undefined", () => {
         const props = {apiOptions: {}};
-        expect(isFeatureOn(props, "new-radio-widget")).toBe(false);
+        expect(isFeatureOn(props, "widget-feature-flag")).toBe(false);
     });
 
     it("returns false when apiOptions is undefined", () => {
         const props = {};
-        expect(isFeatureOn(props, "new-radio-widget")).toBe(false);
+        expect(isFeatureOn(props, "widget-feature-flag")).toBe(false);
     });
 });

--- a/packages/perseus-core/src/feature-flags.ts
+++ b/packages/perseus-core/src/feature-flags.ts
@@ -10,7 +10,6 @@
  * 4. Also update the testing/feature-flags-util.ts for testing purpose
  */
 const PerseusFeatureFlags = [
-    "new-radio-widget", // TODO(LEMS-2994): clean up feature flag
     "image-widget-upgrade-gif-controls", // TODO(LEMS-3914): clean up feature flag
     "image-widget-upgrade-scale", // TODO(LEMS-3912): clean up feature flag
     "interactive-graph-vector", // TODO(LEMS-3976): clean up feature flag

--- a/packages/perseus-editor/src/testing/feature-flags-util.ts
+++ b/packages/perseus-editor/src/testing/feature-flags-util.ts
@@ -3,7 +3,6 @@ const DEFAULT_FEATURE_FLAGS = {
     "perseus-test-flag-1": false,
     "perseus-test-flag-2": false,
     // Real production flags.
-    "new-radio-widget": false,
     "image-widget-upgrade-gif-controls": false,
     "image-widget-upgrade-scale": false,
     "interactive-graph-vector": false,

--- a/packages/perseus/src/testing/feature-flags-util.ts
+++ b/packages/perseus/src/testing/feature-flags-util.ts
@@ -3,7 +3,6 @@ const DEFAULT_FEATURE_FLAGS = {
     "perseus-test-flag-1": false,
     "perseus-test-flag-2": false,
     // Real production flags.
-    "new-radio-widget": false,
     "image-widget-upgrade-gif-controls": false,
     "image-widget-upgrade-scale": false,
     "interactive-graph-vector": false,

--- a/packages/perseus/src/widgets/radio/__docs__/multiple-choice-demo.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/multiple-choice-demo.stories.tsx
@@ -1,7 +1,6 @@
 import {generateTestPerseusItem} from "@khanacademy/perseus-core";
 import * as React from "react";
 
-import {getFeatureFlags} from "../../../testing/feature-flags-util";
 import {ServerItemRendererWithDebugUI} from "../../../testing/server-item-renderer-with-debug-ui";
 import {narrowViewportDecorator} from "../../__testutils__/story-decorators";
 import {groupedRadioRationaleQuestion} from "../../graded-group/graded-group.testdata";
@@ -18,7 +17,6 @@ import {
     singleSelectWithTallMath,
 } from "../__tests__/radio.testdata";
 
-import type {APIOptions} from "../../../types";
 import type {PerseusItem} from "@khanacademy/perseus-core";
 import type {Meta} from "@storybook/react-vite";
 
@@ -45,7 +43,7 @@ export default {
         docs: {
             description: {
                 component:
-                    "A new version of the radio widget that allows users to select a single option from a list of choices,\
+                    "A widget that allows users to select a single option from a list of choices,\
                     with improved accessibility and interface features.",
             },
         },
@@ -67,27 +65,13 @@ export default {
     },
     render: (args: StoryArgs) => (
         <ServerItemRendererWithDebugUI
-            item={applyStoryArgs(args)}
-            apiOptions={buildApiOptions(args)}
+            item={{...args.item}}
+            apiOptions={}
             reviewMode={args.reviewMode}
             showSolutions={args.showSolutions}
         />
     ),
 } satisfies Meta<StoryArgs>;
-
-const applyStoryArgs = (args: StoryArgs): PerseusItem => {
-    const storyItem = {
-        ...args.item,
-        apiOptions: {
-            flags: getFeatureFlags({"new-radio-widget": true}),
-        },
-    };
-    return storyItem;
-};
-
-const buildApiOptions = (args: StoryArgs): APIOptions => ({
-    flags: getFeatureFlags({"new-radio-widget": true}),
-});
 
 export const SingleSelect = {
     args: {

--- a/packages/perseus/src/widgets/radio/__docs__/multiple-choice-demo.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/multiple-choice-demo.stories.tsx
@@ -28,13 +28,6 @@ type StoryArgs = {
     "reviewMode" | "showSolutions"
 >;
 
-/**
- * This is a story for the new radio widget.
- * It will replace radio.stories.tsx after the feature flag is no longer needed.
- *
- * TODO(LEMS-2994): Clean up this file.
- */
-
 export default {
     title: "Widgets/Radio/Widget Demo",
     component: ServerItemRendererWithDebugUI,
@@ -66,7 +59,6 @@ export default {
     render: (args: StoryArgs) => (
         <ServerItemRendererWithDebugUI
             item={{...args.item}}
-            apiOptions={}
             reviewMode={args.reviewMode}
             showSolutions={args.showSolutions}
         />

--- a/packages/perseus/src/widgets/radio/__docs__/multiple-choice-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/multiple-choice-initial-state-regression.stories.tsx
@@ -10,7 +10,6 @@ import * as React from "react";
 
 import {ApiOptions} from "../../../perseus-api";
 import {ServerItemRenderer} from "../../../server-item-renderer";
-import {getFeatureFlags} from "../../../testing/feature-flags-util";
 import {testDependenciesV2} from "../../../testing/test-dependencies";
 import {narrowViewportDecorator} from "../../__testutils__/story-decorators";
 import {
@@ -380,10 +379,7 @@ function RadioQuestionRenderer(props: {
         <div dir={rtl ? "rtl" : "ltr"}>
             <ServerItemRenderer
                 item={item}
-                apiOptions={{
-                    ...ApiOptions.defaults,
-                    flags: getFeatureFlags({"new-radio-widget": true}),
-                }}
+                apiOptions={{...ApiOptions.defaults}}
                 reviewMode={showSolutions === "all"}
                 showSolutions={showSolutions}
                 dependencies={testDependenciesV2}

--- a/packages/perseus/src/widgets/radio/__docs__/multiple-choice-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/multiple-choice-interactions-regression.stories.tsx
@@ -9,13 +9,11 @@ import {
 import * as React from "react";
 
 import ArticleRenderer from "../../../article-renderer";
-import {getFeatureFlags} from "../../../testing/feature-flags-util";
 import {ServerItemRendererWithDebugUI} from "../../../testing/server-item-renderer-with-debug-ui";
 import {storybookDependenciesV2} from "../../../testing/test-dependencies";
 import {groupedRadioRationaleQuestion} from "../../graded-group/graded-group.testdata";
 import {choicesWithMathFont, question} from "../__tests__/radio.testdata";
 
-import type {APIOptions} from "../../../types";
 import type {PerseusItem} from "@khanacademy/perseus-core";
 import type {Meta} from "@storybook/react-vite";
 
@@ -57,27 +55,12 @@ export default {
     },
     render: (args: StoryArgs) => (
         <ServerItemRendererWithDebugUI
-            item={applyStoryArgs(args)}
-            apiOptions={buildApiOptions(args)}
+            item={{...args.item}}
             reviewMode={args.reviewMode}
             showSolutions={args.showSolutions}
         />
     ),
 } satisfies Meta<StoryArgs>;
-
-const applyStoryArgs = (args: StoryArgs): PerseusItem => {
-    const storyItem = {
-        ...args.item,
-        apiOptions: {
-            flags: getFeatureFlags({"new-radio-widget": true}),
-        },
-    };
-    return storyItem;
-};
-
-const buildApiOptions = (args: StoryArgs): APIOptions => ({
-    flags: getFeatureFlags({"new-radio-widget": true}),
-});
 
 export const GradedGroupWrapper = {
     args: {
@@ -151,10 +134,8 @@ export const ChoiceTextColorInArticle = (): React.ReactNode => {
             }),
         },
     });
-    const apiOptions = {flags: getFeatureFlags({"new-radio-widget": true})};
     return (
         <ArticleRenderer
-            apiOptions={apiOptions}
             json={question}
             dependencies={storybookDependenciesV2}
         />

--- a/packages/perseus/src/widgets/radio/__docs__/multiple-choice.doc.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/multiple-choice.doc.stories.tsx
@@ -7,7 +7,6 @@ import * as React from "react";
 import {ApiOptions} from "../../../perseus-api";
 import Renderer from "../../../renderer";
 import {mockStrings} from "../../../strings";
-import {getFeatureFlags} from "../../../testing/feature-flags-util";
 import UserInputManager from "../../../user-input-manager";
 
 import type {Meta, StoryObj} from "@storybook/react-vite";
@@ -227,10 +226,7 @@ function RadioDemo({
                     content={question.content}
                     widgets={question.widgets}
                     images={question.images}
-                    apiOptions={{
-                        ...ApiOptions.defaults,
-                        flags: getFeatureFlags({"new-radio-widget": true}),
-                    }}
+                    apiOptions={{...ApiOptions.defaults}}
                 />
             )}
         </UserInputManager>

--- a/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
+++ b/packages/perseus/src/widgets/radio/__tests__/radio.test.ts
@@ -8,7 +8,6 @@ import {screen, fireEvent} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 
 import * as Dependencies from "../../../dependencies";
-import {getFeatureFlags} from "../../../testing/feature-flags-util";
 import {clone} from "../../../testing/object-utils";
 import {
     testDependencies,
@@ -360,15 +359,7 @@ describe("Radio Widget", () => {
             };
 
             // Act
-            // Analytics event only exists on the new radio widget.
-            // Please remove once fully released.
-            renderQuestion(
-                question,
-                {flags: getFeatureFlags({"new-radio-widget": true})},
-                undefined,
-                undefined,
-                depsV2,
-            );
+            renderQuestion(question, undefined, undefined, undefined, depsV2);
 
             // Assert
             expect(onAnalyticsEventSpy).toHaveBeenCalledWith({
@@ -646,15 +637,7 @@ describe("Radio Widget", () => {
             };
 
             // Act
-            // Analytics event only exists on the new radio widget.
-            // Please remove once fully released.
-            renderQuestion(
-                question,
-                {flags: getFeatureFlags({"new-radio-widget": true})},
-                undefined,
-                undefined,
-                depsV2,
-            );
+            renderQuestion(question, undefined, undefined, undefined, depsV2);
 
             // Assert
             expect(onAnalyticsEventSpy).toHaveBeenCalledWith({


### PR DESCRIPTION
## Summary:
The radio revitalization project is complete. This PR removes references to the feature flag that was used during development. It is no longer needed - only one version of the widget is now in place.

Issue: LEMS-2994

## Test plan:
1. All unit tests
1. Stories function normally