### PR TITLE
fix(LEMS-4079): add condition to only trigger answerable callback if there is userinput

### DIFF
--- a/.changeset/real-donuts-return.md
+++ b/.changeset/real-donuts-return.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+sets condition to check for user input before setting answerable

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -305,7 +305,9 @@ class Renderer
             );
         }
 
-        this.props.apiOptions?.answerableCallback?.(this._isAnswerable());
+        if (this.props.userInput) {
+            this.props.apiOptions?.answerableCallback?.(this._isAnswerable());
+        }
     }
 
     UNSAFE_componentWillReceiveProps(nextProps: Props) {


### PR DESCRIPTION
## Summary:
There is a second renderer nested in the popover that opens for the definition widget. This second renderer is setting an unanswerable state for the exercise when opened because definition isn't an answerable widget. 

This change adds a condition to check whether there is user input before firing the answerable callback. 

Issue: LEMS-4079

## Test plan:
ZND:
https://prod-znd-260507-10947-accbae9.khanacademy.org
1. Navigate to exercise with definition widget ([example](https://prod-znd-260507-10947-accbae9.khanacademy.org/ela/9th-grade-reading-vocabulary-indiana/x068d7167a2598a90:bridging-the-gap-9-indiana/x068d7167a2598a90:determining-central-ideas-9-indiana/e/central-ideas-9-indiana))
2. Answer question 
3. Click definition widget 

### Expected behavior 
`Check` button is not disabled at any point when opening the definition popover 

Behavior has been validated by SarahP (see [thread](https://khanacademy.slack.com/archives/C09V0V3PHN0/p1778536867802909?thread_ts=1778257476.527869&cid=C09V0V3PHN0))

### Screen recording
https://github.com/user-attachments/assets/718d4096-3d4c-4099-8011-d6fab9da1b86
