### PR TITLE
[Interactive Graph] Add pointLabels props for interactive graph types

### DIFF
--- a/.changeset/friendly-foxes-draw.md
+++ b/.changeset/friendly-foxes-draw.md
@@ -1,5 +1,4 @@
 ---
-"@khanacademy/perseus": minor
 "@khanacademy/perseus-core": minor
 ---
 

--- a/.changeset/friendly-foxes-draw.md
+++ b/.changeset/friendly-foxes-draw.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-core": minor
+---
+
+Add pointLabels props for interactive graph related types this will be used for custom point labels

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1146,6 +1146,17 @@ export type PerseusGraphTypeAngle = {
      * the vertex, while rays BA and BC form the angle.
      */
     startCoords?: [Coord, Coord, Coord];
+    /**
+     * Custom screen-reader labels for each interactive point.
+     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
+     * announcement. Type is string so authors can use letters (e.g., "T") to
+     * match question text, but the editor defaults to the numeric "1", "2", …
+     * — authors override only when they want a letter.
+     *
+     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
+     *          (instead of the default "Point 1 at 0 comma 0")
+     */
+    pointLabels?: string[];
 };
 
 export type PerseusGraphTypeCircle = {
@@ -1157,6 +1168,17 @@ export type PerseusGraphTypeCircle = {
         center: Coord;
         radius: number;
     };
+    /**
+     * Custom screen-reader labels for each interactive point.
+     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
+     * announcement. Type is string so authors can use letters (e.g., "T") to
+     * match question text, but the editor defaults to the numeric "1", "2", …
+     * — authors override only when they want a letter.
+     *
+     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
+     *          (instead of the default "Point 1 at 0 comma 0")
+     */
+    pointLabels?: string[];
 };
 
 export type PerseusGraphTypeLinear = {
@@ -1165,6 +1187,17 @@ export type PerseusGraphTypeLinear = {
     coords?: CollinearTuple | null;
     /** The initial coordinates the graph renders with. */
     startCoords?: CollinearTuple;
+    /**
+     * Custom screen-reader labels for each interactive point.
+     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
+     * announcement. Type is string so authors can use letters (e.g., "T") to
+     * match question text, but the editor defaults to the numeric "1", "2", …
+     * — authors override only when they want a letter.
+     *
+     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
+     *          (instead of the default "Point 1 at 0 comma 0")
+     */
+    pointLabels?: string[];
 };
 
 export type PerseusGraphTypeLinearSystem = {
@@ -1173,6 +1206,17 @@ export type PerseusGraphTypeLinearSystem = {
     coords?: CollinearTuple[] | null;
     /** The initial coordinates the graph renders with. */
     startCoords?: CollinearTuple[];
+    /**
+     * Custom screen-reader labels for each interactive point.
+     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
+     * announcement. Type is string so authors can use letters (e.g., "T") to
+     * match question text, but the editor defaults to the numeric "1", "2", …
+     * — authors override only when they want a letter.
+     *
+     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
+     *          (instead of the default "Point 1 at 0 comma 0")
+     */
+    pointLabels?: string[];
 };
 
 export type PerseusGraphTypeNone = {
@@ -1191,6 +1235,17 @@ export type PerseusGraphTypePoint = {
     startCoords?: Coord[];
     /** Used instead of `coords` in some old graphs that have only one point. */
     coord?: Coord;
+    /**
+     * Custom screen-reader labels for each interactive point.
+     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
+     * announcement. Type is string so authors can use letters (e.g., "T") to
+     * match question text, but the editor defaults to the numeric "1", "2", …
+     * — authors override only when they want a letter.
+     *
+     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
+     *          (instead of the default "Point 1 at 0 comma 0")
+     */
+    pointLabels?: string[];
 };
 
 export type PerseusGraphTypePolygon = {
@@ -1208,6 +1263,17 @@ export type PerseusGraphTypePolygon = {
     coords?: Coord[] | null;
     /** The initial coordinates the graph renders with. */
     startCoords?: Coord[];
+    /**
+     * Custom screen-reader labels for each interactive point.
+     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
+     * announcement. Type is string so authors can use letters (e.g., "T") to
+     * match question text, but the editor defaults to the numeric "1", "2", …
+     * — authors override only when they want a letter.
+     *
+     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
+     *          (instead of the default "Point 1 at 0 comma 0")
+     */
+    pointLabels?: string[];
 };
 
 export type PerseusGraphTypeQuadratic = {
@@ -1216,6 +1282,17 @@ export type PerseusGraphTypeQuadratic = {
     coords?: [Coord, Coord, Coord] | null;
     /** The initial coordinates the graph renders with. */
     startCoords?: [Coord, Coord, Coord];
+    /**
+     * Custom screen-reader labels for each interactive point.
+     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
+     * announcement. Type is string so authors can use letters (e.g., "T") to
+     * match question text, but the editor defaults to the numeric "1", "2", …
+     * — authors override only when they want a letter.
+     *
+     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
+     *          (instead of the default "Point 1 at 0 comma 0")
+     */
+    pointLabels?: string[];
 };
 
 export type PerseusGraphTypeSegment = {
@@ -1229,6 +1306,17 @@ export type PerseusGraphTypeSegment = {
     coords?: CollinearTuple[] | null;
     /** The initial coordinates the graph renders with. */
     startCoords?: CollinearTuple[];
+    /**
+     * Custom screen-reader labels for each interactive point.
+     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
+     * announcement. Type is string so authors can use letters (e.g., "T") to
+     * match question text, but the editor defaults to the numeric "1", "2", …
+     * — authors override only when they want a letter.
+     *
+     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
+     *          (instead of the default "Point 1 at 0 comma 0")
+     */
+    pointLabels?: string[];
 };
 
 export type PerseusGraphTypeSinusoid = {
@@ -1237,6 +1325,17 @@ export type PerseusGraphTypeSinusoid = {
     coords?: Coord[] | null;
     /** The initial coordinates the graph renders with. */
     startCoords?: Coord[];
+    /**
+     * Custom screen-reader labels for each interactive point.
+     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
+     * announcement. Type is string so authors can use letters (e.g., "T") to
+     * match question text, but the editor defaults to the numeric "1", "2", …
+     * — authors override only when they want a letter.
+     *
+     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
+     *          (instead of the default "Point 1 at 0 comma 0")
+     */
+    pointLabels?: string[];
 };
 
 export type PerseusGraphTypeTangent = {
@@ -1245,6 +1344,17 @@ export type PerseusGraphTypeTangent = {
     coords?: Coord[] | null;
     // The initial coordinates the graph renders with.
     startCoords?: Coord[];
+    /**
+     * Custom screen-reader labels for each interactive point.
+     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
+     * announcement. Type is string so authors can use letters (e.g., "T") to
+     * match question text, but the editor defaults to the numeric "1", "2", …
+     * — authors override only when they want a letter.
+     *
+     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
+     *          (instead of the default "Point 1 at 0 comma 0")
+     */
+    pointLabels?: string[];
 };
 
 export type PerseusGraphTypeExponential = {
@@ -1258,6 +1368,17 @@ export type PerseusGraphTypeExponential = {
     asymptote?: number | null;
     /** The initial coordinates the graph renders with. */
     startCoords?: {coords: [Coord, Coord]; asymptote: number};
+    /**
+     * Custom screen-reader labels for each interactive point.
+     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
+     * announcement. Type is string so authors can use letters (e.g., "T") to
+     * match question text, but the editor defaults to the numeric "1", "2", …
+     * — authors override only when they want a letter.
+     *
+     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
+     *          (instead of the default "Point 1 at 0 comma 0")
+     */
+    pointLabels?: string[];
 };
 
 export type PerseusGraphTypeLogarithm = {
@@ -1271,6 +1392,17 @@ export type PerseusGraphTypeLogarithm = {
     asymptote?: number | null;
     /** The initial coordinates the graph renders with. */
     startCoords?: {coords: [Coord, Coord]; asymptote: number};
+    /**
+     * Custom screen-reader labels for each interactive point.
+     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
+     * announcement. Type is string so authors can use letters (e.g., "T") to
+     * match question text, but the editor defaults to the numeric "1", "2", …
+     * — authors override only when they want a letter.
+     *
+     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
+     *          (instead of the default "Point 1 at 0 comma 0")
+     */
+    pointLabels?: string[];
 };
 
 export type PerseusGraphTypeAbsoluteValue = {
@@ -1279,6 +1411,17 @@ export type PerseusGraphTypeAbsoluteValue = {
     coords?: [Coord, Coord] | null;
     // The initial coordinates the graph renders with.
     startCoords?: [Coord, Coord];
+    /**
+     * Custom screen-reader labels for each interactive point.
+     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
+     * announcement. Type is string so authors can use letters (e.g., "T") to
+     * match question text, but the editor defaults to the numeric "1", "2", …
+     * — authors override only when they want a letter.
+     *
+     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
+     *          (instead of the default "Point 1 at 0 comma 0")
+     */
+    pointLabels?: string[];
 };
 
 export type PerseusGraphTypeRay = {
@@ -1287,6 +1430,17 @@ export type PerseusGraphTypeRay = {
     coords?: CollinearTuple | null;
     /** The initial coordinates the graph renders with. */
     startCoords?: CollinearTuple;
+    /**
+     * Custom screen-reader labels for each interactive point.
+     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
+     * announcement. Type is string so authors can use letters (e.g., "T") to
+     * match question text, but the editor defaults to the numeric "1", "2", …
+     * — authors override only when they want a letter.
+     *
+     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
+     *          (instead of the default "Point 1 at 0 comma 0")
+     */
+    pointLabels?: string[];
 };
 
 export type PerseusGraphTypeVector = {
@@ -1299,6 +1453,17 @@ export type PerseusGraphTypeVector = {
      *  "exact" (default) — both tail and tip must match exactly.
      *  "congruent" — same direction and magnitude, any position. */
     match?: "exact" | "congruent";
+    /**
+     * Custom screen-reader labels for each interactive point.
+     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
+     * announcement. Type is string so authors can use letters (e.g., "T") to
+     * match question text, but the editor defaults to the numeric "1", "2", …
+     * — authors override only when they want a letter.
+     *
+     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
+     *          (instead of the default "Point 1 at 0 comma 0")
+     */
+    pointLabels?: string[];
 };
 
 type AbsoluteValueGraphCorrect = {

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1146,17 +1146,8 @@ export type PerseusGraphTypeAngle = {
      * the vertex, while rays BA and BC form the angle.
      */
     startCoords?: [Coord, Coord, Coord];
-    /**
-     * Custom screen-reader labels for each interactive point.
-     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
-     * announcement. Type is string so authors can use letters (e.g., "T") to
-     * match question text, but the editor defaults to the numeric "1", "2", …
-     * — authors override only when they want a letter.
-     *
-     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
-     *          (instead of the default "Point 1 at 0 comma 0")
-     */
-    pointLabels?: string[];
+    /** Custom label for each interactive point that will help with the screen reader. */
+    pointLabels?: [string, string, string];
 };
 
 export type PerseusGraphTypeCircle = {
@@ -1168,16 +1159,7 @@ export type PerseusGraphTypeCircle = {
         center: Coord;
         radius: number;
     };
-    /**
-     * Custom screen-reader labels for each interactive point.
-     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
-     * announcement. Type is string so authors can use letters (e.g., "T") to
-     * match question text, but the editor defaults to the numeric "1", "2", …
-     * — authors override only when they want a letter.
-     *
-     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
-     *          (instead of the default "Point 1 at 0 comma 0")
-     */
+    /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
 };
 
@@ -1187,17 +1169,8 @@ export type PerseusGraphTypeLinear = {
     coords?: CollinearTuple | null;
     /** The initial coordinates the graph renders with. */
     startCoords?: CollinearTuple;
-    /**
-     * Custom screen-reader labels for each interactive point.
-     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
-     * announcement. Type is string so authors can use letters (e.g., "T") to
-     * match question text, but the editor defaults to the numeric "1", "2", …
-     * — authors override only when they want a letter.
-     *
-     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
-     *          (instead of the default "Point 1 at 0 comma 0")
-     */
-    pointLabels?: string[];
+    /** Custom label for each interactive point that will help with the screen reader. */
+    pointLabels?: [string, string];
 };
 
 export type PerseusGraphTypeLinearSystem = {
@@ -1206,16 +1179,7 @@ export type PerseusGraphTypeLinearSystem = {
     coords?: CollinearTuple[] | null;
     /** The initial coordinates the graph renders with. */
     startCoords?: CollinearTuple[];
-    /**
-     * Custom screen-reader labels for each interactive point.
-     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
-     * announcement. Type is string so authors can use letters (e.g., "T") to
-     * match question text, but the editor defaults to the numeric "1", "2", …
-     * — authors override only when they want a letter.
-     *
-     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
-     *          (instead of the default "Point 1 at 0 comma 0")
-     */
+    /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
 };
 
@@ -1235,16 +1199,7 @@ export type PerseusGraphTypePoint = {
     startCoords?: Coord[];
     /** Used instead of `coords` in some old graphs that have only one point. */
     coord?: Coord;
-    /**
-     * Custom screen-reader labels for each interactive point.
-     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
-     * announcement. Type is string so authors can use letters (e.g., "T") to
-     * match question text, but the editor defaults to the numeric "1", "2", …
-     * — authors override only when they want a letter.
-     *
-     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
-     *          (instead of the default "Point 1 at 0 comma 0")
-     */
+    /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
 };
 
@@ -1263,16 +1218,7 @@ export type PerseusGraphTypePolygon = {
     coords?: Coord[] | null;
     /** The initial coordinates the graph renders with. */
     startCoords?: Coord[];
-    /**
-     * Custom screen-reader labels for each interactive point.
-     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
-     * announcement. Type is string so authors can use letters (e.g., "T") to
-     * match question text, but the editor defaults to the numeric "1", "2", …
-     * — authors override only when they want a letter.
-     *
-     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
-     *          (instead of the default "Point 1 at 0 comma 0")
-     */
+    /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
 };
 
@@ -1282,17 +1228,8 @@ export type PerseusGraphTypeQuadratic = {
     coords?: [Coord, Coord, Coord] | null;
     /** The initial coordinates the graph renders with. */
     startCoords?: [Coord, Coord, Coord];
-    /**
-     * Custom screen-reader labels for each interactive point.
-     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
-     * announcement. Type is string so authors can use letters (e.g., "T") to
-     * match question text, but the editor defaults to the numeric "1", "2", …
-     * — authors override only when they want a letter.
-     *
-     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
-     *          (instead of the default "Point 1 at 0 comma 0")
-     */
-    pointLabels?: string[];
+    /** Custom label for each interactive point that will help with the screen reader. */
+    pointLabels?: [string, string, string];
 };
 
 export type PerseusGraphTypeSegment = {
@@ -1306,16 +1243,7 @@ export type PerseusGraphTypeSegment = {
     coords?: CollinearTuple[] | null;
     /** The initial coordinates the graph renders with. */
     startCoords?: CollinearTuple[];
-    /**
-     * Custom screen-reader labels for each interactive point.
-     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
-     * announcement. Type is string so authors can use letters (e.g., "T") to
-     * match question text, but the editor defaults to the numeric "1", "2", …
-     * — authors override only when they want a letter.
-     *
-     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
-     *          (instead of the default "Point 1 at 0 comma 0")
-     */
+    /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
 };
 
@@ -1325,16 +1253,7 @@ export type PerseusGraphTypeSinusoid = {
     coords?: Coord[] | null;
     /** The initial coordinates the graph renders with. */
     startCoords?: Coord[];
-    /**
-     * Custom screen-reader labels for each interactive point.
-     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
-     * announcement. Type is string so authors can use letters (e.g., "T") to
-     * match question text, but the editor defaults to the numeric "1", "2", …
-     * — authors override only when they want a letter.
-     *
-     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
-     *          (instead of the default "Point 1 at 0 comma 0")
-     */
+    /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
 };
 
@@ -1344,16 +1263,7 @@ export type PerseusGraphTypeTangent = {
     coords?: Coord[] | null;
     // The initial coordinates the graph renders with.
     startCoords?: Coord[];
-    /**
-     * Custom screen-reader labels for each interactive point.
-     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
-     * announcement. Type is string so authors can use letters (e.g., "T") to
-     * match question text, but the editor defaults to the numeric "1", "2", …
-     * — authors override only when they want a letter.
-     *
-     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
-     *          (instead of the default "Point 1 at 0 comma 0")
-     */
+    /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
 };
 
@@ -1368,16 +1278,7 @@ export type PerseusGraphTypeExponential = {
     asymptote?: number | null;
     /** The initial coordinates the graph renders with. */
     startCoords?: {coords: [Coord, Coord]; asymptote: number};
-    /**
-     * Custom screen-reader labels for each interactive point.
-     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
-     * announcement. Type is string so authors can use letters (e.g., "T") to
-     * match question text, but the editor defaults to the numeric "1", "2", …
-     * — authors override only when they want a letter.
-     *
-     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
-     *          (instead of the default "Point 1 at 0 comma 0")
-     */
+    /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
 };
 
@@ -1392,16 +1293,7 @@ export type PerseusGraphTypeLogarithm = {
     asymptote?: number | null;
     /** The initial coordinates the graph renders with. */
     startCoords?: {coords: [Coord, Coord]; asymptote: number};
-    /**
-     * Custom screen-reader labels for each interactive point.
-     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
-     * announcement. Type is string so authors can use letters (e.g., "T") to
-     * match question text, but the editor defaults to the numeric "1", "2", …
-     * — authors override only when they want a letter.
-     *
-     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
-     *          (instead of the default "Point 1 at 0 comma 0")
-     */
+    /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
 };
 
@@ -1411,17 +1303,8 @@ export type PerseusGraphTypeAbsoluteValue = {
     coords?: [Coord, Coord] | null;
     // The initial coordinates the graph renders with.
     startCoords?: [Coord, Coord];
-    /**
-     * Custom screen-reader labels for each interactive point.
-     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
-     * announcement. Type is string so authors can use letters (e.g., "T") to
-     * match question text, but the editor defaults to the numeric "1", "2", …
-     * — authors override only when they want a letter.
-     *
-     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
-     *          (instead of the default "Point 1 at 0 comma 0")
-     */
-    pointLabels?: string[];
+    /** Custom label for each interactive point that will help with the screen reader. */
+    pointLabels?: [string, string];
 };
 
 export type PerseusGraphTypeRay = {
@@ -1430,17 +1313,8 @@ export type PerseusGraphTypeRay = {
     coords?: CollinearTuple | null;
     /** The initial coordinates the graph renders with. */
     startCoords?: CollinearTuple;
-    /**
-     * Custom screen-reader labels for each interactive point.
-     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
-     * announcement. Type is string so authors can use letters (e.g., "T") to
-     * match question text, but the editor defaults to the numeric "1", "2", …
-     * — authors override only when they want a letter.
-     *
-     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
-     *          (instead of the default "Point 1 at 0 comma 0")
-     */
-    pointLabels?: string[];
+    /** Custom label for each interactive point that will help with the screen reader. */
+    pointLabels?: [string, string];
 };
 
 export type PerseusGraphTypeVector = {
@@ -1453,17 +1327,8 @@ export type PerseusGraphTypeVector = {
      *  "exact" (default) — both tail and tip must match exactly.
      *  "congruent" — same direction and magnitude, any position. */
     match?: "exact" | "congruent";
-    /**
-     * Custom screen-reader labels for each interactive point.
-     * If provided, pointLabels[i] replaces the default numeric "Point {i+1}"
-     * announcement. Type is string so authors can use letters (e.g., "T") to
-     * match question text, but the editor defaults to the numeric "1", "2", …
-     * — authors override only when they want a letter.
-     *
-     * Example: pointLabels: ["T"] → "Point T at 0 comma 0"
-     *          (instead of the default "Point 1 at 0 comma 0")
-     */
-    pointLabels?: string[];
+    /** Custom label for each interactive point that will help with the screen reader. */
+    pointLabels?: [string, string];
 };
 
 type AbsoluteValueGraphCorrect = {

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -35,7 +35,7 @@ const parsePerseusGraphTypeAngle = object({
     match: optional(constant("congruent")),
     coords: optional(trio(pairOfNumbers, pairOfNumbers, pairOfNumbers)),
     startCoords: optional(trio(pairOfNumbers, pairOfNumbers, pairOfNumbers)),
-    pointLabels: optional(array(string)),
+    pointLabels: optional(trio(string, string, string)),
 });
 
 const parsePerseusGraphTypeCircle = object({
@@ -55,7 +55,7 @@ const parsePerseusGraphTypeLinear = object({
     type: constant("linear"),
     coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
     startCoords: optional(pair(pairOfNumbers, pairOfNumbers)),
-    pointLabels: optional(array(string)),
+    pointLabels: optional(pair(string, string)),
 });
 
 const parsePerseusGraphTypeLinearSystem = object({
@@ -97,14 +97,14 @@ const parsePerseusGraphTypeQuadratic = object({
         nullable(trio(pairOfNumbers, pairOfNumbers, pairOfNumbers)),
     ),
     startCoords: optional(trio(pairOfNumbers, pairOfNumbers, pairOfNumbers)),
-    pointLabels: optional(array(string)),
+    pointLabels: optional(trio(string, string, string)),
 });
 
 const parsePerseusGraphTypeRay = object({
     type: constant("ray"),
     coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
     startCoords: optional(pair(pairOfNumbers, pairOfNumbers)),
-    pointLabels: optional(array(string)),
+    pointLabels: optional(pair(string, string)),
 });
 
 const parsePerseusGraphTypeSegment = object({
@@ -140,7 +140,7 @@ const parsePerseusGraphTypeAbsoluteValue = object({
     type: constant("absolute-value"),
     coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
     startCoords: optional(pair(pairOfNumbers, pairOfNumbers)),
-    pointLabels: optional(array(string)),
+    pointLabels: optional(pair(string, string)),
 });
 
 const parsePerseusGraphTypeTangent = object({
@@ -168,7 +168,7 @@ const parsePerseusGraphTypeVector = object({
     coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
     startCoords: optional(pair(pairOfNumbers, pairOfNumbers)),
     match: optional(enumeration("exact", "congruent")),
-    pointLabels: optional(array(string)),
+    pointLabels: optional(pair(string, string)),
 });
 
 export const parsePerseusGraphType = discriminatedUnionOn("type")

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -35,6 +35,7 @@ const parsePerseusGraphTypeAngle = object({
     match: optional(constant("congruent")),
     coords: optional(trio(pairOfNumbers, pairOfNumbers, pairOfNumbers)),
     startCoords: optional(trio(pairOfNumbers, pairOfNumbers, pairOfNumbers)),
+    pointLabels: optional(array(string)),
 });
 
 const parsePerseusGraphTypeCircle = object({
@@ -47,12 +48,14 @@ const parsePerseusGraphTypeCircle = object({
             radius: number,
         }),
     ),
+    pointLabels: optional(array(string)),
 });
 
 const parsePerseusGraphTypeLinear = object({
     type: constant("linear"),
     coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
     startCoords: optional(pair(pairOfNumbers, pairOfNumbers)),
+    pointLabels: optional(array(string)),
 });
 
 const parsePerseusGraphTypeLinearSystem = object({
@@ -60,6 +63,7 @@ const parsePerseusGraphTypeLinearSystem = object({
     // TODO(benchristel): default coords to empty array?
     coords: optional(nullable(array(pair(pairOfNumbers, pairOfNumbers)))),
     startCoords: optional(array(pair(pairOfNumbers, pairOfNumbers))),
+    pointLabels: optional(array(string)),
 });
 
 const parsePerseusGraphTypeNone = object({
@@ -72,6 +76,7 @@ const parsePerseusGraphTypePoint = object({
     coords: optional(nullable(array(pairOfNumbers))),
     startCoords: optional(array(pairOfNumbers)),
     coord: optional(pairOfNumbers),
+    pointLabels: optional(array(string)),
 });
 
 const parsePerseusGraphTypePolygon = object({
@@ -83,6 +88,7 @@ const parsePerseusGraphTypePolygon = object({
     match: optional(enumeration("similar", "congruent", "approx", "exact")),
     startCoords: optional(array(pairOfNumbers)),
     coords: optional(nullable(array(pairOfNumbers))),
+    pointLabels: optional(array(string)),
 });
 
 const parsePerseusGraphTypeQuadratic = object({
@@ -91,12 +97,14 @@ const parsePerseusGraphTypeQuadratic = object({
         nullable(trio(pairOfNumbers, pairOfNumbers, pairOfNumbers)),
     ),
     startCoords: optional(trio(pairOfNumbers, pairOfNumbers, pairOfNumbers)),
+    pointLabels: optional(array(string)),
 });
 
 const parsePerseusGraphTypeRay = object({
     type: constant("ray"),
     coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
     startCoords: optional(pair(pairOfNumbers, pairOfNumbers)),
+    pointLabels: optional(array(string)),
 });
 
 const parsePerseusGraphTypeSegment = object({
@@ -105,12 +113,14 @@ const parsePerseusGraphTypeSegment = object({
     numSegments: optional(number),
     coords: optional(nullable(array(pair(pairOfNumbers, pairOfNumbers)))),
     startCoords: optional(array(pair(pairOfNumbers, pairOfNumbers))),
+    pointLabels: optional(array(string)),
 });
 
 const parsePerseusGraphTypeSinusoid = object({
     type: constant("sinusoid"),
     coords: optional(nullable(array(pairOfNumbers))),
     startCoords: optional(array(pairOfNumbers)),
+    pointLabels: optional(array(string)),
 });
 
 const parsePerseusGraphTypeExponential = object({
@@ -123,18 +133,21 @@ const parsePerseusGraphTypeExponential = object({
             asymptote: number,
         }),
     ),
+    pointLabels: optional(array(string)),
 });
 
 const parsePerseusGraphTypeAbsoluteValue = object({
     type: constant("absolute-value"),
     coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
     startCoords: optional(pair(pairOfNumbers, pairOfNumbers)),
+    pointLabels: optional(array(string)),
 });
 
 const parsePerseusGraphTypeTangent = object({
     type: constant("tangent"),
     coords: optional(nullable(array(pairOfNumbers))),
     startCoords: optional(array(pairOfNumbers)),
+    pointLabels: optional(array(string)),
 });
 
 const parsePerseusGraphTypeLogarithm = object({
@@ -147,6 +160,7 @@ const parsePerseusGraphTypeLogarithm = object({
             asymptote: number,
         }),
     ),
+    pointLabels: optional(array(string)),
 });
 
 const parsePerseusGraphTypeVector = object({
@@ -154,6 +168,7 @@ const parsePerseusGraphTypeVector = object({
     coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
     startCoords: optional(pair(pairOfNumbers, pairOfNumbers)),
     match: optional(enumeration("exact", "congruent")),
+    pointLabels: optional(array(string)),
 });
 
 export const parsePerseusGraphType = discriminatedUnionOn("type")

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -135,7 +135,7 @@ export type PerseusStrings = {
         x,
         y,
     }: {
-        num: number;
+        num: number | string;
         x: string;
         y: string;
     }) => string;

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -135,7 +135,7 @@ export type PerseusStrings = {
         x,
         y,
     }: {
-        num: number | string;
+        num: number;
         x: string;
         y: string;
     }) => string;


### PR DESCRIPTION
## Summary:
Add pointLabels props for interactive graph related types this will be used for custom point labels.

- Adds optional `pointLabels?: string[]` to all 15 interactive `PerseusGraphType<X>` union members in `packages/perseus-core/src/data-schema.ts`
- Teaches the JSON parser at `packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts` to accept the new field
- **Pure data-shape change. No behavior, no rendering, no editor surface yet — those land in succeeding PRs 2–7.**

> **i18n note:** an earlier draft of this PR widened `srPointAtCoordinates`'s `num` parameter from `number` to `number | string`. Reverted — `num` is reserved file-wide for plural selection (see `strings.ts:8-9`, `:640-641`). PR 2 will introduce a separate string key (e.g., `srPointAtCoordinatesNamed`) for the named-point announcement instead of overloading `num`.

## Background — the bug overview

**Bug:** Interactive coordinate-plane questions ask the learner to plot a specific named point — e.g., *"Plot point T to complete the rectangle"* — but JAWS announces the point as *"Point 1 at zero comma zero"* instead of *"Point T at zero comma zero."* The screen-reader label is hard-coded to a numeric index across every interactive graph type, so it never matches the prompt and confuses screen-reader users.

**Solution:** Add an optional `pointLabels?: string[]` field to each interactive graph type's data schema. Content authors can supply a label per point (e.g., `["T"]`), and the graph uses it to build the screen-reader announcement instead of the default index. Existing content keeps working unchanged — authors opt in only when they want letters that match the prompt. This PR (PR 1 of 7) only adds the data shape; rendering, state, and editor surface land in PRs 2–7.

The full fix ships across **7 sequential PRs**:

- 👉🏼 **PR 1** — [Schema — no behavior. Only data-shape stop.](https://github.com/Khan/perseus/pull/3605)
- **PR 2** — [Foundation + Point graph](https://github.com/Khan/perseus/pull/3643)
- **PR 3** — [Polygon (shares start-coords-point.tsx); widen the gate to type === "point" || type === "polygon"](https://github.com/Khan/perseus/pull/3643)
- **PR 4** — [Lines: linear, ray](https://github.com/Khan/perseus/pull/3672)
- **PR 5** — [Multi-line: linear-system, segment](https://github.com/Khan/perseus/pull/3673)
- **follow-up PR** — [Refactor linear, point, polygon, and ray graphs to use usePointAriaLabel instead of buildPointAriaLabel](https://github.com/Khan/perseus/pull/3694)
- **PR 6** — [Curves: quadratic, sinusoid, tangent, exponential, logarithm](https://github.com/Khan/perseus/pull/3696)
- **PR 7** — [Special shapes: angle, circle, absolute-value](https://github.com/Khan/perseus/pull/3697)

## Schema-first rationale

1. **Decouples reviewer concerns.** This PR is reviewed for "does the type shape make sense across the union?" — no behavior to litigate.
2. **Web-app integration is one-shot.** Schema-only changes are additive type widenings. The web app updates its mirror types once.
3. **Avoids per-PR schema drift.** No window where some graph types have `pointLabels` and others don't.

The "ships dead code" concern is real but small — `pointLabels?: string[]` is observably a no-op until PR 2 reads it. Mitigated by landing PR 2 close behind.

## i18n notes

- This PR makes **no** changes to `strings.ts`. The named-point announcement string will be introduced in PR 2 as a separate key, so existing `srPointAtCoordinates` translations stay valid and the `num`-is-for-plurality convention is preserved.
- `pointLabels` itself is content data, not a translation string. If an English item ships with `pointLabels: ["T"]`, translators need to update both the prompt AND `pointLabels` if their locale uses different letter conventions. Will be called out in the rollout / release notes.

Issue: LEMS-3995
Co-Authored by Claude Code (Opus)

## Test plan

- [x] `pnpm tsc` — passes
- [x] `pnpm lint packages/perseus packages/perseus-core` — passes
- [x] `pnpm --filter perseus-core test` — 1047 tests pass (including `interactive-graph-widget.test.ts` and `parse-perseus-json-regression.test.ts`)
- [x] `pnpm test packages/perseus/src/widgets/interactive-graphs` — 1094 tests pass, 28 pre-existing skips
- [ ] Reviewer sanity-check: schema additions match the documented JSDoc verbatim across all 15 types