### PR TITLE
Make schema/item-splitting check failures self-explanatory

### DIFF
--- a/.github/actions/branch-compare/action.yml
+++ b/.github/actions/branch-compare/action.yml
@@ -170,18 +170,23 @@ runs:
                   } else {
                       const details = (process.env.CHANGE_DETAILS || "").trim();
                       const diff = process.env.DIFF_CONTENT || "";
+                      // Render the ack label as a link to its label page so
+                      // reviewers can see the real label badge (and the PRs
+                      // currently carrying it) with one click.
+                      const labelUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/labels/${encodeURIComponent(ackLabel)}`;
+                      const ackLabelMd = `[\`${ackLabel}\`](${labelUrl})`;
                       const parts = [];
                       if (details) {
                           parts.push(details, "");
                       }
                       if (isAcked) {
                           parts.push(
-                              `> Acknowledged via the **\`${ackLabel}\`** label. Remove the label to require re-acknowledgement.`,
+                              `> Acknowledged via the **${ackLabelMd}** label. Remove the label to require re-acknowledgement.`,
                               "",
                           );
                       } else {
                           parts.push(
-                              `👀 **Review the diff below.** Once you've confirmed the change is intentional and any required follow-ups are in motion, add the \`${ackLabel}\` label to acknowledge. The check will re-run automatically.`,
+                              `👀 **Review the diff below.** Once you've confirmed the change is intentional and any required follow-ups are in motion, add the ${ackLabelMd} label to acknowledge. The check will re-run automatically.`,
                               "",
                           );
                       }

--- a/.github/actions/branch-compare/action.yml
+++ b/.github/actions/branch-compare/action.yml
@@ -122,13 +122,13 @@ runs:
                   gh pr edit "$PR_NUMBER" --add-label "${{ inputs.label-name }}"
               fi
 
-        # Render the result as a job step summary and let the job's natural
-        # success/failure carry the conclusion. The job's auto-check is then
-        # the single source of truth on the PR — no second check row, no
-        # check_suite attribution quirks. Reviewers click the auto-check's
-        # "Details" to land on the workflow run page, where this summary is
-        # rendered.
-        - name: Render summary and set job conclusion
+        # Publish the result as a custom GitHub Check run. The job itself
+        # always succeeds; the custom Check carries the meaningful pass/fail.
+        # That keeps the PR's checks list to a single red row when a change
+        # is detected, and clicking the row lands directly on a page that
+        # renders the title + rich summary (rather than the workflow logs,
+        # where reviewers struggle to find the Summary tab).
+        - name: Publish result as a GitHub Check
           if: always() && github.event.pull_request != null
           uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
           env:
@@ -137,6 +137,7 @@ runs:
               DIFF_CONTENT: ${{ steps.compare-artifacts.outputs.diff-content }}
               CHANGE_DETAILS: ${{ inputs.change-details }}
               ACK_LABEL_NAME: ${{ inputs.ack-label-name }}
+              HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           with:
               github-token: ${{ inputs.github-token }}
               script: |
@@ -148,24 +149,28 @@ runs:
                       .map((l) => l.name);
                   const isAcked = labels.includes(ackLabel);
 
-                  let heading;
-                  let shouldFail = false;
+                  let conclusion;
+                  let title;
                   if (noChanges) {
-                      heading = `${checkName}: No Changes ✅`;
+                      conclusion = "success";
+                      title = `${checkName}: No Changes ✅`;
                   } else if (isAcked) {
-                      heading = `${checkName}: Changes Acknowledged ✅`;
+                      conclusion = "success";
+                      title = `${checkName}: Changes Acknowledged ✅`;
                   } else {
-                      heading = `${checkName}: Changes Detected — Acknowledgement Required ❌`;
-                      shouldFail = true;
+                      conclusion = "failure";
+                      title = `${checkName}: Changes Detected — Acknowledgement Required ❌`;
                   }
 
-                  const parts = [`## ${heading}`, ""];
-
+                  // The Checks UI renders `output.title` as a heading above
+                  // the summary, so the summary should NOT repeat the title.
+                  let summary;
                   if (noChanges) {
-                      parts.push("No differences vs. the base branch.");
+                      summary = "No differences vs. the base branch.";
                   } else {
                       const details = (process.env.CHANGE_DETAILS || "").trim();
                       const diff = process.env.DIFF_CONTENT || "";
+                      const parts = [];
                       if (details) {
                           parts.push(details, "");
                       }
@@ -189,10 +194,15 @@ runs:
                           "",
                           "</details>",
                       );
+                      summary = parts.join("\n");
                   }
 
-                  await core.summary.addRaw(parts.join("\n")).write();
-
-                  if (shouldFail) {
-                      core.setFailed(heading);
-                  }
+                  await github.rest.checks.create({
+                      owner: context.repo.owner,
+                      repo: context.repo.repo,
+                      name: checkName,
+                      head_sha: process.env.HEAD_SHA,
+                      status: "completed",
+                      conclusion,
+                      output: {title, summary},
+                  });

--- a/.github/actions/branch-compare/action.yml
+++ b/.github/actions/branch-compare/action.yml
@@ -186,7 +186,7 @@ runs:
                           );
                       }
                       parts.push(
-                          "<details><summary>View diff</summary>",
+                          "<details open><summary>View diff</summary>",
                           "",
                           "```diff",
                           diff,

--- a/.github/actions/branch-compare/action.yml
+++ b/.github/actions/branch-compare/action.yml
@@ -159,7 +159,7 @@ runs:
                       title = `${checkName}: Changes Acknowledged ✅`;
                   } else {
                       conclusion = "failure";
-                      title = `${checkName}: Changes Detected — Acknowledgement Required ❌`;
+                      title = `${checkName}: Changes Detected — Review Required ❌`;
                   }
 
                   // The Checks UI renders `output.title` as a heading above
@@ -181,7 +181,7 @@ runs:
                           );
                       } else {
                           parts.push(
-                              `> **To acknowledge this change and pass this check, add the \`${ackLabel}\` label to this PR.** The check will re-run automatically.`,
+                              `> **Review the diff below.** Once you've confirmed the change is intentional and any required follow-ups are in motion, add the \`${ackLabel}\` label to acknowledge. The check will re-run automatically.`,
                               "",
                           );
                       }

--- a/.github/actions/branch-compare/action.yml
+++ b/.github/actions/branch-compare/action.yml
@@ -181,7 +181,7 @@ runs:
                           );
                       } else {
                           parts.push(
-                              `> **Review the diff below.** Once you've confirmed the change is intentional and any required follow-ups are in motion, add the \`${ackLabel}\` label to acknowledge. The check will re-run automatically.`,
+                              `👀 **Review the diff below.** Once you've confirmed the change is intentional and any required follow-ups are in motion, add the \`${ackLabel}\` label to acknowledge. The check will re-run automatically.`,
                               "",
                           );
                       }

--- a/.github/workflows/pr-comparison-checks.yml
+++ b/.github/workflows/pr-comparison-checks.yml
@@ -14,6 +14,7 @@ permissions:
     contents: read
     pull-requests: write
     issues: write
+    checks: write
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/pr-comparison-checks.yml
+++ b/.github/workflows/pr-comparison-checks.yml
@@ -74,18 +74,18 @@ jobs:
                   # Markdown links must stay on one line — folding inserts
                   # spaces between content lines, which would break URLs.
                   change-details: >
-                      **Usually this means you need to update the Go parser
-                      that Content Platform maintains!!!** Follow these
+                      **This PR contains critical changes to Perseus that
+                      affect published data.** Please review the changes
+                      and note that you may need to coordinate deployment
+                      of these changes with other teams at Khan Academy,
+                      especially with #cp-eng to publish a content update.
+
+
+                      Usually this means you need to update the Go parser
+                      that Content Platform maintains. Follow these
                       [steps](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4161831001/Releasing+and+deploying+a+data-schema+change+in+Perseus#tl%3Bdr)
                       on how to release.
                       [See this list of post-mortems for more information.](https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/4504322159/Content+Platform+Breaks)
-
-
-                      This PR contains critical changes to Perseus that
-                      affect published data. Please review the changes and
-                      note that you may need to coordinate deployment of
-                      these changes with other teams at Khan Academy,
-                      especially with #cp-eng to publish a content update.
 
     check_item_splitting:
         name: Item splitting

--- a/.github/workflows/pr-comparison-checks.yml
+++ b/.github/workflows/pr-comparison-checks.yml
@@ -124,9 +124,7 @@ jobs:
               uses: ./.github/actions/branch-compare
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
-                  build-command: |
-                      pnpm install && pnpm build
-                      pnpm prettier --write packages/perseus-core/dist/es/index.item-splitting.js
+                  build-command: pnpm install && pnpm build
                   path-to-artifact: packages/perseus-core/dist/es/index.item-splitting.js
                   label-name: item-splitting-change
                   check-name: "PR Comparison: 🛠️ Item Splitting"

--- a/.github/workflows/pr-comparison-checks.yml
+++ b/.github/workflows/pr-comparison-checks.yml
@@ -67,7 +67,7 @@ jobs:
                       pnpm prettier --write ${{ runner.temp }}/schema.d.ts
                   path-to-artifact: ${{ runner.temp }}/schema.d.ts
                   label-name: schema-change
-                  check-name: 🗄️ Schema Change
+                  check-name: "PR Comparison: 🗄️ Schema Change"
                   ack-label-name: schema-change-ack
                   # Folded (`>`) so paragraphs can wrap freely. Two blank
                   # lines are required for a Markdown paragraph break.
@@ -127,5 +127,5 @@ jobs:
                   build-command: pnpm install && pnpm build
                   path-to-artifact: packages/perseus-core/dist/es/index.item-splitting.js
                   label-name: item-splitting-change
-                  check-name: 🛠️ Item Splitting
+                  check-name: "PR Comparison: 🛠️ Item Splitting"
                   ack-label-name: item-splitting-change-ack

--- a/.github/workflows/pr-comparison-checks.yml
+++ b/.github/workflows/pr-comparison-checks.yml
@@ -124,7 +124,9 @@ jobs:
               uses: ./.github/actions/branch-compare
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
-                  build-command: pnpm install && pnpm build
+                  build-command: |
+                      pnpm install && pnpm build
+                      pnpm prettier --write packages/perseus-core/dist/es/index.item-splitting.js
                   path-to-artifact: packages/perseus-core/dist/es/index.item-splitting.js
                   label-name: item-splitting-change
                   check-name: "PR Comparison: 🛠️ Item Splitting"

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -2024,7 +2024,7 @@ export type PerseusInteractionMovablePointElementOptions = {
 
 export type PerseusInteractionParametricElementOptions = {
     /** The function for the X coordinate. e.g. "\\cos(t)" */
-    t: string;
+    x: string;
     /** The function for the Y coordinate. e.g. "\\sin(t)" */
     y: string;
     /** The range of points to start plotting */
@@ -2042,8 +2042,10 @@ export type PerseusInteractionParametricElementOptions = {
 export type PerseusInteractionPointElementOptions = {
     /** The color of the point. e.g. "black" */
     color: string;
-    /** The coordinate of the point */
-    coord: [x: number, y: number];
+    /** The X coordinate of the point */
+    coordX: string;
+    /** The Y coordinate of the point */
+    coordY: string;
 };
 
 export type PerseusInteractionRectangleElementOptions = {

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -2024,7 +2024,7 @@ export type PerseusInteractionMovablePointElementOptions = {
 
 export type PerseusInteractionParametricElementOptions = {
     /** The function for the X coordinate. e.g. "\\cos(t)" */
-    x: string;
+    t: string;
     /** The function for the Y coordinate. e.g. "\\sin(t)" */
     y: string;
     /** The range of points to start plotting */
@@ -2042,10 +2042,8 @@ export type PerseusInteractionParametricElementOptions = {
 export type PerseusInteractionPointElementOptions = {
     /** The color of the point. e.g. "black" */
     color: string;
-    /** The X coordinate of the point */
-    coordX: string;
-    /** The Y coordinate of the point */
-    coordY: string;
+    /** The coordinate of the point */
+    coord: [x: number, y: number];
 };
 
 export type PerseusInteractionRectangleElementOptions = {


### PR DESCRIPTION
Follow-up to #3592. After that landed, folks reported that they couldn't tell what to do when `🗄️ Schema Change` or `🛠️ Item Splitting` failed. The action items, ack instructions, and diff were rendered as a workflow-run **Summary tab** — but clicking the failing check's "Details" lands on the failed step's logs, and the Summary link in the run-page sidebar doesn't read as the place where the actual answer lives.

---

<img width="300" src="https://github.com/user-attachments/assets/f80f5485-0834-4d8b-aa6c-6564d77684ac" />

---

This PR moves to use the custom Checks API. With the custom check, clicking a failing check on the PR lands directly on a dedicated check-run page that renders the rich title and summary inline — no Summary tab to discover.

One small annoyance is that now the check run job always succeeds, but when there is a data-schema or item-splitting change detected we _add_ a new check that's failed. This means a tripped PR shows exactly **one red row** (the custom check), and that single red row is the one with the rich content behind it.

I've also retitled the failing state from "Acknowledgement Required" to "Review Required" and updated the call-to-action message to lead with *"Review the diff below"* before the label step — the previous wording subtly nudged authors toward labelling without actually reviewing.

Now, when the data-schema detection triggers, you see this: 

<img width="500" src="https://github.com/user-attachments/assets/ed7f9346-f10d-4675-ad7f-cb8d52386fed" />

And clicking on the failed check takes you directly to this page: 

<img width="500" src="https://github.com/user-attachments/assets/7fd0ae45-753c-4cb4-8e4e-f62e174ba279" />


Issue: <none>

## Test plan

- On a PR with no relevant diff, both checks render ✅ "No Changes".
- Adding a schema diff produces a red ❌ `🗄️ Schema Change: Changes Detected — Review Required` row; clicking "Details" lands on a page that renders the title + Content Platform action items + "Review the diff below" call-to-action + collapsible diff inline.
-Adding the `schema-change-ack` label re-runs only the schema job and flips the check to ✅ "Changes Acknowledged".
- The `PR Comparison Checks / Schema change` auto-check stays green throughout (job no longer fails on un-acked diffs).
- Reverting the diff restores ✅ "No Changes" and auto-removes the ack label.
- Item-splitting flow behaves identically with `item-splitting-change-ack`.
