### PR TITLE
[Image] | (UX) | Remove extra space in Hint image widget caption and title

### DIFF
--- a/.changeset/orange-baboons-brake.md
+++ b/.changeset/orange-baboons-brake.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Image] | (UX) | Remove extra space in Hint image widget caption and title

--- a/packages/perseus/src/__docs__/hints-renderer.stories.tsx
+++ b/packages/perseus/src/__docs__/hints-renderer.stories.tsx
@@ -10,6 +10,9 @@ import {
     generateIGRayGraph,
     generateIGSegmentGraph,
     generateIGSinusoidGraph,
+    generateTestPerseusRenderer,
+    generateImageWidget,
+    generateImageOptions,
 } from "@khanacademy/perseus-core";
 import {View} from "@khanacademy/wonder-blocks-core";
 import React from "react";
@@ -17,6 +20,7 @@ import React from "react";
 import HintsRenderer from "../hints-renderer";
 import {ApiOptions} from "../perseus-api";
 import {storybookDependenciesV2} from "../testing/test-dependencies";
+import {earthMoonImage} from "../widgets/image/utils";
 
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
@@ -136,6 +140,40 @@ export const WithAllInteractiveGraphs: Story = {
                     correct: generateIGSinusoidGraph(),
                 }),
                 replace: false,
+            },
+        ],
+    },
+};
+
+export const ImageWidgetInHint: Story = {
+    // Need to wrap this in a container with the `bibliotron-exercise` class
+    // to show what this would really look like with hint styling in prod.
+    decorators: [
+        (Story) => {
+            return (
+                <div className="bibliotron-exercise">
+                    <Story />
+                </div>
+            );
+        },
+    ],
+    args: {
+        dependencies: storybookDependenciesV2,
+        hints: [
+            {
+                ...generateTestPerseusRenderer({
+                    content: "[[☃ image 1]]",
+                    widgets: {
+                        "image 1": generateImageWidget({
+                            options: generateImageOptions({
+                                backgroundImage: earthMoonImage,
+                                alt: "Earth and Moon",
+                                title: "Earth and Moon",
+                                caption: "Earth and Moon",
+                            }),
+                        }),
+                    },
+                }),
             },
         ],
     },

--- a/packages/perseus/src/styles/widgets/image.css
+++ b/packages/perseus/src/styles/widgets/image.css
@@ -11,8 +11,11 @@
 .perseus-image-widget .perseus-image-title {
     text-align: center;
 }
-/* Reset default paragarph margins. */
-.perseus-image-widget .perseus-image-title .paragraph {
+/* Reset default paragraph margins. Use a type selector (div) to raise
+   specificity above the hint-renderer's `.bibliotron-exercise
+   .perseus-hint-renderer div.paragraph` rule, which would otherwise re-apply
+   a 16px margin-block-end inside hints. */
+.perseus-image-widget div.perseus-image-title div.paragraph {
     margin-block: 0;
 }
 .perseus-image-widget .perseus-image-caption {
@@ -20,7 +23,10 @@
     padding-left: 16px;
     position: relative;
 }
-.perseus-image-widget .perseus-image-caption .paragraph {
+/* Use type selectors (figcaption, div) to raise specificity above the
+   hint-renderer's `.bibliotron-exercise .perseus-hint-renderer div.paragraph`
+   rule, which would otherwise re-apply a 16px margin-block-end inside hints. */
+.perseus-image-widget figcaption.perseus-image-caption div.paragraph {
     font-size: var(--wb-font-body-size-small);
     line-height: var(--wb-font-body-lineHeight-small);
     padding-right: 12px;


### PR DESCRIPTION
## Summary:
The `.paragraph` styling in hints was overriding the spacing for Image widget's
title and caption.

Increasing specificity of image styles here to override the hint styling.

Issue: none

## Test plan:
`/?path=/story/renderers-hints-renderer--image-widget-in-hint`

| Before | After |
| --- | --- |
| <img width="551" height="409" alt="Screenshot 2026-05-08 at 2 37 07 PM" src="https://github.com/user-attachments/assets/7bc1a30b-643e-4206-bf2a-0aae71d5ef9e" /> | <img width="542" height="393" alt="Screenshot 2026-05-08 at 2 40 39 PM" src="https://github.com/user-attachments/assets/36f5bc34-e736-4bb0-9b04-ea43018c0d4b" /> |
