### PR TITLE
docs(changeset): Resolve several Safari-based issues for the Interactive Graph's Circle graph

### DIFF
--- a/.changeset/wild-buckets-stare.md
+++ b/.changeset/wild-buckets-stare.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Resolve several Safari-based issues for the Interactive Graph's Circle graph

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.test.tsx
@@ -76,9 +76,12 @@ describe("Circle graph", () => {
     test("Shows hairlines when dragging and 'markings' are NOT set to 'none'", () => {
         // Arrange
         useGraphConfigMock.mockReturnValue(baseGraphConfigContext);
-        // Only mock once so it applies just to the circle and not
-        // to the radius point's MovablePoint.
-        useDraggableMock.mockReturnValueOnce({dragging: true});
+        // MovableCircle uses two `useDraggable` calls (keyboard + mouse) —
+        // mock both so they apply to the circle but not the radius point's
+        // MovablePoint that follows.
+        useDraggableMock
+            .mockReturnValueOnce({dragging: true})
+            .mockReturnValueOnce({dragging: true});
         const {container} = render(
             <Mafs width={200} height={200}>
                 <CircleGraph graphState={baseCircleState} dispatch={() => {}} />
@@ -195,13 +198,13 @@ describe("Circle graph screen reader", () => {
         );
     });
 
-    test("should have aria label for circle graph", () => {
+    test("should have aria label for circle graph", async () => {
         // Arrange
         render(<MafsGraph {...baseMafsGraphProps} state={baseCircleState} />);
 
         // Act
-        // eslint-disable-next-line testing-library/no-node-access
-        const circleGraph = document.querySelector(".movable-circle");
+        const buttons = await screen.findAllByRole("button");
+        const circleGraph = buttons[0];
         const radiusPoint = screen.getByTestId(
             "movable-point__focusable-handle",
         );

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.test.tsx
@@ -203,8 +203,9 @@ describe("Circle graph screen reader", () => {
         render(<MafsGraph {...baseMafsGraphProps} state={baseCircleState} />);
 
         // Act
-        const buttons = await screen.findAllByRole("button");
-        const circleGraph = buttons[0];
+        const circleGraph = await screen.findByRole("button", {
+            name: "Circle. The center point is at 0 comma 0.",
+        });
         const radiusPoint = screen.getByTestId(
             "movable-point__focusable-handle",
         );

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.test.tsx
@@ -128,7 +128,9 @@ describe("Circle graph", () => {
         );
 
         // Act
-        const circleGraph = screen.getAllByRole("button")[0];
+        const circleGraph = await screen.findByRole("button", {
+            name: "Circle. The center point is at 0 comma 0.",
+        });
         await userEvent.click(circleGraph);
 
         // Act
@@ -251,8 +253,9 @@ describe("Circle graph screen reader", () => {
                 }}
             />,
         );
-        const buttons = await screen.findAllByRole("button");
-        const circleGraph = buttons[0];
+        const circleGraph = await screen.findByRole("button", {
+            name: "Circle. The center point is at 2 comma 3.",
+        });
         const radiusPoint = screen.getByTestId(
             "movable-point__focusable-handle",
         );
@@ -335,8 +338,9 @@ describe("Circle graph screen reader", () => {
     test("set aria-live to off on the radius point when the circle is interacted with", async () => {
         // Arrange
         render(<MafsGraph {...baseMafsGraphProps} state={baseCircleState} />);
-        const buttons = await screen.findAllByRole("button");
-        const circleGraph = buttons[0];
+        const circleGraph = await screen.findByRole("button", {
+            name: "Circle. The center point is at 0 comma 0.",
+        });
         const radiusPoint = screen.getByTestId(
             "movable-point__focusable-handle",
         );

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -129,50 +129,80 @@ function MovableCircle(props: {
         useGraphConfig();
     const [focused, setFocused] = React.useState(false);
 
-    const draggableRef = useRef<SVGGElement>(null);
+    // Focus and gesture targets are kept on separate `<g>`s: in Safari,
+    // a focusable SVG group that's also the pointer-capture target leaks
+    // host-page text selection during mouse drag past the graph boundary.
+    const focusableHandleRef = useRef<SVGGElement>(null);
+    const visibleGroupRef = useRef<SVGGElement>(null);
 
-    const {dragging} = useDraggable({
-        gestureTarget: draggableRef,
+    // Keyboard support (on focusableHandleRef)
+    useDraggable({
+        gestureTarget: focusableHandleRef,
         point: center,
         onMove,
         constrainKeyboardMovement: (p) => snap(snapStep, p),
     });
 
+    // Mouse/Touch support (on the visibleGroupRef)
+    const {dragging} = useDraggable({
+        gestureTarget: visibleGroupRef,
+        point: center,
+        onMove,
+        constrainKeyboardMovement: (p) => snap(snapStep, p),
+    });
+
+    React.useLayoutEffect(() => {
+        if (dragging && !focused) {
+            focusableHandleRef.current?.focus();
+        }
+    }, [dragging, focused]);
+
     const [centerPx] = useTransformVectorsToPixels(center);
     const [radiiPx] = useTransformDimensionsToPixels([radius, radius]);
 
     return (
-        <g
-            aria-label={ariaLabel}
-            aria-describedby={ariaDescribedBy}
-            aria-live="polite"
-            aria-disabled={disableKeyboardInteraction}
-            ref={draggableRef}
-            role="button"
-            tabIndex={disableKeyboardInteraction ? -1 : 0}
-            className={`movable-circle ${dragging ? "movable-circle--dragging" : ""}`}
-            onFocus={() => setFocused(true)}
-            onBlur={() => setFocused(false)}
-        >
-            <ellipse
-                className="focus-ring"
-                cx={centerPx[X]}
-                cy={centerPx[Y]}
-                rx={radiiPx[X] + 3}
-                ry={radiiPx[Y] + 3}
+        <>
+            <g
+                ref={focusableHandleRef}
+                className="movable-circle-focusable-handle"
+                tabIndex={disableKeyboardInteraction ? -1 : 0}
+                role="button"
+                aria-label={ariaLabel}
+                aria-describedby={ariaDescribedBy}
+                aria-live="polite"
+                aria-disabled={disableKeyboardInteraction}
+                onFocus={() => setFocused(true)}
+                onBlur={() => setFocused(false)}
             />
-            <ellipse
-                id={id}
-                className="circle"
-                cx={centerPx[X]}
-                cy={centerPx[Y]}
-                rx={radiiPx[X]}
-                ry={radiiPx[Y]}
-                stroke={interactiveColor}
-                data-testid="movable-circle__circle"
-            />
-            <DragHandle center={center} dragging={dragging} focused={focused} />
-        </g>
+            <g
+                aria-hidden={true}
+                ref={visibleGroupRef}
+                className={`movable-circle ${dragging ? "movable-circle--dragging" : ""}`}
+            >
+                <ellipse
+                    className="focus-ring"
+                    cx={centerPx[X]}
+                    cy={centerPx[Y]}
+                    rx={radiiPx[X] + 3}
+                    ry={radiiPx[Y] + 3}
+                />
+                <ellipse
+                    id={id}
+                    className="circle"
+                    cx={centerPx[X]}
+                    cy={centerPx[Y]}
+                    rx={radiiPx[X]}
+                    ry={radiiPx[Y]}
+                    stroke={interactiveColor}
+                    data-testid="movable-circle__circle"
+                />
+                <DragHandle
+                    center={center}
+                    dragging={dragging}
+                    focused={focused}
+                />
+            </g>
+        </>
     );
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -129,9 +129,10 @@ function MovableCircle(props: {
         useGraphConfig();
     const [focused, setFocused] = React.useState(false);
 
-    // Focus and gesture targets are kept on separate `<g>`s: in Safari,
-    // a focusable SVG group that's also the pointer-capture target leaks
-    // host-page text selection during mouse drag past the graph boundary.
+    // Keeping focus and gesture targets on separate `<g>`s works around a
+    // Safari-specific bug where dragging this group can result in the
+    // selection of page content once the cursor crosses the graph's edge.
+    // Splitting them resolves it and better mirrors `useControlPoint`.
     const focusableHandleRef = useRef<SVGGElement>(null);
     const visibleGroupRef = useRef<SVGGElement>(null);
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -211,12 +211,15 @@
     fill: transparent;
 }
 
-.MafsView .movable-circle:focus {
-    outline: none;
+.MafsView
+    .movable-circle-focusable-handle:focus-visible
+    + .movable-circle
+    .focus-ring {
+    visibility: visible;
 }
 
-.MafsView .movable-circle:focus-visible .focus-ring {
-    visibility: visible;
+.MafsView .movable-circle-focusable-handle:focus-visible {
+    outline: none;
 }
 
 .MafsView .movable-circle .movable-circle-handle {


### PR DESCRIPTION
## Summary:
While testing another ticket, our wonderful QA tester discovered two pre-existing issues on our Circle Graph. This PR aims to resolve both: 

- In Safari, dragging a circle and moving your mouse past the graph's boundary started selecting page text. This is not reproducible on any other graph type.
- In Safari, moving the circle and then shift-tabbing backwards would get you stuck in a “focus trap”. This is not reproducible on any other graph type.

While reviewing useControlPoint, I noticed it uses a different structure than `MovableCircle`: two separate `<g>` elements (one focusable with a11y support, one containing the visual elements that's the gesture/pointer-capture target). Mirroring that structure in `MovableCircle` resolves both bugs.

Issue: LEMS-4118

## Test plan:
- tests pass 