### PR TITLE
Remove noisy error log about unbinding event handlers.

### DIFF
--- a/.changeset/nervous-turkeys-punch.md
+++ b/.changeset/nervous-turkeys-punch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: remove noisy error log about unbinding event handlers.

--- a/packages/perseus/src/widgets/orderer/orderer.tsx
+++ b/packages/perseus/src/widgets/orderer/orderer.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
 /* eslint-disable @typescript-eslint/no-invalid-this, react/no-unsafe */
-import {Errors} from "@khanacademy/perseus-core";
 import {linterContextDefault} from "@khanacademy/perseus-linter";
 import $ from "jquery";
 import * as React from "react";
@@ -9,7 +8,6 @@ import _ from "underscore";
 
 import {PerseusI18nContext} from "../../components/i18n-context";
 import {withDependencies} from "../../components/with-dependencies";
-import {Log} from "../../logging/log";
 import Renderer from "../../renderer";
 import Util from "../../util";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/orderer/orderer-ai-utils";
@@ -185,14 +183,7 @@ class Card extends React.Component<CardProps, CardState> {
     }
 
     componentWillUnmount() {
-        // Event handlers should be unbound before component unmounting, but
-        // just in case...
         if (this.mouseMoveUpBound) {
-            Log.error(
-                "Removing an element with bound event handlers.",
-                Errors.Internal,
-            );
-
             this.unbindMouseMoveUp();
             Util.resetTouchHandlers();
         }


### PR DESCRIPTION
## Summary:
I noticed this in an email from Sentry this morning. It's not a real error.
The mousemove and mouseup event handlers are bound at the document level when
dragging starts on an orderer widget and removed on mouseup. That means that if
a user moves their cursor outside the browser window and then releases the
mouse button, the event handlers will not be removed, causing the "error"
message to be logged when the user navigates to another page. 

We already handle this case by removing event listeners on unmount to prevent
memory leaks. Therefore, there's no reason to log.

Issue: none

## Test plan:

Deploy to frontend. Sentry logs with the message `KAInternalError: Removing an
element with bound event handlers.` should diminish.