### PR TITLE
Outline Locked Labels with SVG filter

### DIFF
--- a/.changeset/silent-lobsters-smoke.md
+++ b/.changeset/silent-lobsters-smoke.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Use an opaque border around locked labels rather than a transparent background

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-label.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-label.tsx
@@ -2,7 +2,7 @@ import {
     lockedFigureColors,
     type LockedLabelType,
 } from "@khanacademy/perseus-core";
-import {font} from "@khanacademy/wonder-blocks-tokens";
+import {font, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import * as React from "react";
 
 import {getDependencies} from "../../../dependencies";
@@ -19,19 +19,75 @@ export default function LockedLabel(props: LockedLabelType) {
 
     // Note: The TeX component cannot be rendered within an SVG
     return (
-        <span
-            className="locked-label"
-            style={{
-                position: "absolute",
-                left: x,
-                top: y,
-                color: lockedFigureColors[color],
-                fontSize: font.size[size],
-                backgroundColor: "rgba(255, 255, 255, 0.8)",
-            }}
-            aria-hidden={true}
-        >
-            <TeX>{replaceOutsideTeX(text)}</TeX>
-        </span>
+        <>
+            <LockedLabelStrokeFilter />
+            <span
+                className="locked-label"
+                style={{
+                    position: "absolute",
+                    left: x,
+                    top: y,
+                    color: lockedFigureColors[color],
+                    fontSize: font.size[size],
+                    filter: "url(#math-stroke)",
+                }}
+                aria-hidden={true}
+            >
+                <TeX>{replaceOutsideTeX(text)}</TeX>
+            </span>
+        </>
+    );
+}
+
+/**
+ * This helps us create a stroke around locked labels
+ * which isn't as obvious as it would seem because Mathjax
+ * renders HTML and uses borders for some lines.
+ *
+ * This creates a composite of the rendered output and
+ * thickens the output.
+ *
+ * See: LEMS-4106 for more information
+ */
+function LockedLabelStrokeFilter() {
+    const color = semanticColor.core.border.knockout.default;
+
+    return (
+        <svg width="0" height="0" style={{position: "absolute"}}>
+            <defs>
+                <filter
+                    id="math-stroke"
+                    x="-5%"
+                    y="-5%"
+                    width="110%"
+                    height="110%"
+                >
+                    {/* expand edges outward */}
+                    <feMorphology
+                        operator="dilate"
+                        radius="2"
+                        in="SourceGraphic"
+                        result="expanded"
+                    />
+
+                    {/* flood with color */}
+                    <feFlood floodColor={color} result={color} />
+
+                    {/* clip the flood to the expanded shape */}
+                    <feComposite
+                        in={color}
+                        in2="expanded"
+                        operator="in"
+                        result="outline"
+                    />
+
+                    {/* draw outline behind original */}
+                    <feMerge>
+                        <feMergeNode in="outline" />
+                        <feMergeNode in="SourceGraphic" />
+                    </feMerge>
+                </filter>
+            </defs>
+        </svg>
     );
 }

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-label.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-label.tsx
@@ -55,13 +55,7 @@ function LockedLabelStrokeFilter() {
     return (
         <svg width="0" height="0" style={{position: "absolute"}}>
             <defs>
-                <filter
-                    id="math-stroke"
-                    x="-5%"
-                    y="-5%"
-                    width="110%"
-                    height="110%"
-                >
+                <filter id="math-stroke">
                     {/* expand edges outward */}
                     <feMorphology
                         operator="dilate"
@@ -71,11 +65,11 @@ function LockedLabelStrokeFilter() {
                     />
 
                     {/* flood with color */}
-                    <feFlood floodColor={color} result={color} />
+                    <feFlood floodColor={color} result="flood" />
 
                     {/* clip the flood to the expanded shape */}
                     <feComposite
-                        in={color}
+                        in="flood"
                         in2="expanded"
                         operator="in"
                         result="outline"


### PR DESCRIPTION
## Summary:
Replaces the transparent white background with an opaque white border for locked labels.

Issue: LEMS-4106

## Test plan:

### Before:

<img width="851" height="854" alt="Screenshot 2026-05-12 at 10 44 27 AM" src="https://github.com/user-attachments/assets/552b156c-bf0d-443b-b1a9-05452f6f3cae" />

### After:

<img width="855" height="853" alt="Screenshot 2026-05-12 at 10 44 51 AM" src="https://github.com/user-attachments/assets/7662a431-2e64-4aa9-b667-d0132a9d0d7a" />
