### PR TITLE
Update `convertInputNumberOptionsToNumericInput` to account for the `inexact` widget option

### DIFF
--- a/.changeset/many-hairs-lay.md
+++ b/.changeset/many-hairs-lay.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus-score": patch
+---
+
+Update input-number to numeric-input conversion logic to acccount for `inexact`. When `inexact` is false or undefined, we now set `maxError` to 0.

--- a/packages/perseus-core/src/widgets/input-number/to-numeric-input.test.ts
+++ b/packages/perseus-core/src/widgets/input-number/to-numeric-input.test.ts
@@ -60,7 +60,7 @@ describe("convertInputNumberOptionsToNumericInput", () => {
         const result = convertInputNumberOptionsToNumericInput(options);
 
         expect(result.answers[0].maxError).toBe(0);
-    })
+    });
 
     it("sets maxError to 0 when inexact is undefined", () => {
         const options: PerseusInputNumberWidgetOptions = {
@@ -72,7 +72,7 @@ describe("convertInputNumberOptionsToNumericInput", () => {
         const result = convertInputNumberOptionsToNumericInput(options);
 
         expect(result.answers[0].maxError).toBe(0);
-    })
+    });
 
     it(`converts the "number" answer type to [integer, decimal, proper, improper, mixed]`, () => {
         const options: PerseusInputNumberWidgetOptions = {

--- a/packages/perseus-core/src/widgets/input-number/to-numeric-input.test.ts
+++ b/packages/perseus-core/src/widgets/input-number/to-numeric-input.test.ts
@@ -14,6 +14,7 @@ describe("convertInputNumberOptionsToNumericInput", () => {
     it("converts maxError to a number when present", () => {
         const options: PerseusInputNumberWidgetOptions = {
             ...baseOptions,
+            inexact: true,
             maxError: "0.042",
         };
 
@@ -27,6 +28,7 @@ describe("convertInputNumberOptionsToNumericInput", () => {
         const options: PerseusInputNumberWidgetOptions = {
             ...baseOptions,
             maxError: "42e-3",
+            inexact: true,
         };
 
         const result = convertInputNumberOptionsToNumericInput(options);
@@ -39,6 +41,7 @@ describe("convertInputNumberOptionsToNumericInput", () => {
         const options: PerseusInputNumberWidgetOptions = {
             ...baseOptions,
             maxError: undefined,
+            inexact: true,
         };
 
         const result = convertInputNumberOptionsToNumericInput(options);
@@ -46,6 +49,30 @@ describe("convertInputNumberOptionsToNumericInput", () => {
         expect(result.answers).toHaveLength(1);
         expect(result.answers[0].maxError).toBe(undefined);
     });
+
+    it("sets maxError to 0 when inexact is false", () => {
+        const options: PerseusInputNumberWidgetOptions = {
+            ...baseOptions,
+            maxError: 0.99,
+            inexact: false,
+        };
+
+        const result = convertInputNumberOptionsToNumericInput(options);
+
+        expect(result.answers[0].maxError).toBe(0);
+    })
+
+    it("sets maxError to 0 when inexact is undefined", () => {
+        const options: PerseusInputNumberWidgetOptions = {
+            ...baseOptions,
+            maxError: 0.99,
+            inexact: undefined,
+        };
+
+        const result = convertInputNumberOptionsToNumericInput(options);
+
+        expect(result.answers[0].maxError).toBe(0);
+    })
 
     it(`converts the "number" answer type to [integer, decimal, proper, improper, mixed]`, () => {
         const options: PerseusInputNumberWidgetOptions = {

--- a/packages/perseus-core/src/widgets/input-number/to-numeric-input.ts
+++ b/packages/perseus-core/src/widgets/input-number/to-numeric-input.ts
@@ -48,7 +48,9 @@ export function convertInputNumberOptionsToNumericInput(
     };
 }
 
-function getMaxError(inputNumberOptions: PerseusInputNumberWidgetOptions): number | undefined {
+function getMaxError(
+    inputNumberOptions: PerseusInputNumberWidgetOptions,
+): number | undefined {
     if (!inputNumberOptions.inexact) {
         return 0;
     }

--- a/packages/perseus-core/src/widgets/input-number/to-numeric-input.ts
+++ b/packages/perseus-core/src/widgets/input-number/to-numeric-input.ts
@@ -25,11 +25,6 @@ const mathFormatsForAnswerType: Record<
 export function convertInputNumberOptionsToNumericInput(
     inputNumberOptions: PerseusInputNumberWidgetOptions,
 ): PerseusNumericInputWidgetOptions {
-    const maxError =
-        inputNumberOptions.maxError != null
-            ? Number(inputNumberOptions.maxError)
-            : inputNumberOptions.maxError;
-
     const answerForms: MathFormat[] = inputNumberOptions.answerType
         ? mathFormatsForAnswerType[inputNumberOptions.answerType]
         : ["integer", "proper", "improper", "mixed", "decimal"];
@@ -45,10 +40,22 @@ export function convertInputNumberOptionsToNumericInput(
                 value: Number(inputNumberOptions.value),
                 simplify: inputNumberOptions.simplify,
                 message: "",
-                maxError,
+                maxError: getMaxError(inputNumberOptions),
                 strict: true,
                 answerForms,
             },
         ],
     };
+}
+
+function getMaxError(inputNumberOptions: PerseusInputNumberWidgetOptions): number | undefined {
+    if (!inputNumberOptions.inexact) {
+        return 0;
+    }
+
+    if (inputNumberOptions.maxError == null) {
+        return undefined;
+    }
+
+    return Number(inputNumberOptions.maxError);
 }

--- a/packages/perseus-score/src/input-number-to-numeric-input-regression.test.ts
+++ b/packages/perseus-score/src/input-number-to-numeric-input-regression.test.ts
@@ -18,6 +18,7 @@ interface TestCase {
 // - Search for "side-by-side" in the Perseus service
 // - select "Copy > Copy as JSON"
 // - `pbpaste | jq '.jsonPayload.metadata | {userInput: .inputNumberUserInputs, widgets: .inputNumberWidgets}'`
+// TODO(LEMS-4085): Delete this test file.
 const cases: TestCase[] = [
     {
         title: "when inexact = false",

--- a/packages/perseus-score/src/input-number-to-numeric-input-regression.test.ts
+++ b/packages/perseus-score/src/input-number-to-numeric-input-regression.test.ts
@@ -1,3 +1,5 @@
+import {describe, expect, test} from "@jest/globals";
+
 import type {PerseusWidgetsMap, UserInputMap} from "@khanacademy/perseus-core";
 
 import {
@@ -18,7 +20,7 @@ interface TestCase {
 // - `pbpaste | jq '.jsonPayload.metadata | {userInput: .inputNumberUserInputs, widgets: .inputNumberWidgets}'`
 const cases: TestCase[] = [
     {
-        title: "when inexact: false",
+        title: "when inexact = false",
         userInput: {
             "input-number 1": {
                 currentValue: "6.336",
@@ -68,10 +70,40 @@ const cases: TestCase[] = [
             },
         },
     },
+    {
+        title: "when inexact = false and the correct answer has more than 9 decimal places",
+        userInput: {
+            "input-number 1": {
+                currentValue: "1.123456789",
+            },
+        },
+        widgets: {
+            "input-number 1": {
+                type: "input-number",
+                version: {
+                    major: 0,
+                    minor: 0,
+                },
+                static: false,
+                alignment: "default",
+                options: {
+                    rightAlign: false,
+                    maxError: 0.1,
+                    size: "normal",
+                    inexact: false,
+                    simplify: "required",
+                    // rounds to 1.123456789
+                    value: 1.1234567885,
+                    answerType: "number",
+                },
+                graded: true,
+            },
+        },
+    },
 ];
 
 describe("scoring with input-number converted to numeric-input", () => {
-    it.each(cases)("$title", ({widgets, userInput}) => {
+    test.each(cases)("$title", ({widgets, userInput}) => {
         const content = Object.keys(widgets)
             .map((id) => `[[\u2603 ${id}]]`)
             .join("");

--- a/packages/perseus-score/src/input-number-to-numeric-input-regression.test.ts
+++ b/packages/perseus-score/src/input-number-to-numeric-input-regression.test.ts
@@ -1,0 +1,87 @@
+import type {PerseusWidgetsMap, UserInputMap} from "@khanacademy/perseus-core";
+
+import {
+    scorePerseusItem,
+    scorePerseusItemWithInputNumberAsNumericInput,
+} from "./index";
+
+interface TestCase {
+    title: string;
+    userInput: UserInputMap;
+    widgets: PerseusWidgetsMap;
+}
+
+const cases: TestCase[] = [
+    {
+        title: "???",
+        userInput: {
+            "input-number 1": {
+                currentValue: "6.336",
+            },
+            "input-number 2": {
+                currentValue: "6.308",
+            },
+        },
+        widgets: {
+            "input-number 1": {
+                options: {
+                    value: 6.338,
+                    answerType: "number",
+                    rightAlign: false,
+                    maxError: 0.1,
+                    size: "normal",
+                    simplify: "required",
+                    inexact: false,
+                },
+                graded: true,
+                static: false,
+                version: {
+                    minor: 0,
+                    major: 0,
+                },
+                type: "input-number",
+                alignment: "default",
+            },
+            "input-number 2": {
+                type: "input-number",
+                version: {
+                    major: 0,
+                    minor: 0,
+                },
+                static: false,
+                alignment: "default",
+                options: {
+                    rightAlign: false,
+                    maxError: 0.1,
+                    size: "normal",
+                    inexact: false,
+                    simplify: "required",
+                    value: 6.34,
+                    answerType: "number",
+                },
+                graded: true,
+            },
+        },
+    },
+];
+
+describe("scoring with input-number converted to numeric-input", () => {
+    it.each(cases)("$title", ({widgets, userInput}) => {
+        const content = Object.keys(widgets)
+            .map((id) => `[[\u2603 ${id}]]`)
+            .join("");
+
+        const scoringArgs: Parameters<typeof scorePerseusItem> = [
+            {content, widgets, images: {}},
+            userInput,
+            "en",
+        ];
+
+        const officialScore = scorePerseusItem(...scoringArgs);
+        const inniScore = scorePerseusItemWithInputNumberAsNumericInput(
+            ...scoringArgs,
+        );
+
+        expect(inniScore).toEqual(officialScore);
+    });
+});

--- a/packages/perseus-score/src/input-number-to-numeric-input-regression.test.ts
+++ b/packages/perseus-score/src/input-number-to-numeric-input-regression.test.ts
@@ -18,7 +18,7 @@ interface TestCase {
 // - `pbpaste | jq '.jsonPayload.metadata | {userInput: .inputNumberUserInputs, widgets: .inputNumberWidgets}'`
 const cases: TestCase[] = [
     {
-        title: "???",
+        title: "when inexact: false",
         userInput: {
             "input-number 1": {
                 currentValue: "6.336",

--- a/packages/perseus-score/src/input-number-to-numeric-input-regression.test.ts
+++ b/packages/perseus-score/src/input-number-to-numeric-input-regression.test.ts
@@ -11,6 +11,11 @@ interface TestCase {
     widgets: PerseusWidgetsMap;
 }
 
+// NOTE: To add a test case to this list:
+// - Go to https://console.cloud.google.com/logs
+// - Search for "side-by-side" in the Perseus service
+// - select "Copy > Copy as JSON"
+// - `pbpaste | jq '.jsonPayload.metadata | {userInput: .inputNumberUserInputs, widgets: .inputNumberWidgets}'`
 const cases: TestCase[] = [
     {
         title: "???",


### PR DESCRIPTION
## Summary:
This PR fixes scoring mismatches found in side-by-side testing.  When `inexact`
is undefined or false for an input-number widget, the scoring logic changes in
two ways:

- we force `maxError` to 0.
- decimal answers are rounded to 9 decimal places.

We can invoke the same logic for a numeric-input widget by setting maxError to
zero.

This PR also adds data-driven regression tests that do essentially what the
side-by-side testing in production does. The plan is: any new side-by-side
errors we see get copied to this test suite. The test should fail initially.
When the test passes, it means the side-by-side error is fixed.

Issue: LEMS-4110

## Test plan:

Deploy to the perseus service. Side-by-side testing errors should decrease by
at least 90%.