### PR TITLE
IG: linter rule when missing description and contains locked figures

### DIFF
--- a/.changeset/gold-donuts-share.md
+++ b/.changeset/gold-donuts-share.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-linter": minor
+---
+
+Add lint rule for IG descriptions when using locked figures

--- a/packages/perseus-linter/src/rules/interactive-graph-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/interactive-graph-widget-error.test.ts
@@ -33,6 +33,7 @@ describe("interactive-graph-widget-error", () => {
                                 ],
                             },
                         ],
+                        fullGraphAriaDescription: "test description",
                     },
                 },
             },
@@ -61,6 +62,7 @@ describe("interactive-graph-widget-error", () => {
                                 ],
                             },
                         ],
+                        fullGraphAriaDescription: "test description",
                     },
                 },
             },
@@ -91,6 +93,7 @@ describe("interactive-graph-widget-error", () => {
                                 labels: [],
                             },
                         ],
+                        fullGraphAriaDescription: "test description",
                     },
                 },
             },
@@ -121,6 +124,7 @@ describe("interactive-graph-widget-error", () => {
                                 labels: [],
                             },
                         ],
+                        fullGraphAriaDescription: "test description",
                     },
                 },
             },
@@ -144,6 +148,7 @@ describe("interactive-graph-widget-error", () => {
                             numSides: "unlimited",
                             coords: undefined,
                         },
+                        lockedFigures: [],
                     },
                 },
             },
@@ -207,8 +212,76 @@ describe("interactive-graph-widget-error", () => {
                             labels: [],
                         },
                     ],
+                    fullGraphAriaDescription: "test description",
                 },
             },
         },
     });
+
+    // error when using locked figures but without providing a description
+    expectWarning(
+        interactiveGraphWidgetErrorRule,
+        "[[☃ interactive-graph 1]]",
+        {
+            widgets: {
+                "interactive-graph 1": {
+                    options: {
+                        correct: {
+                            type: "polygon",
+                            numSides: "unlimited",
+                            coords: [
+                                [0, 0],
+                                [2, 0],
+                                [1, 1],
+                            ],
+                        },
+                        lockedFigures: [
+                            {
+                                type: "line",
+                                points: [
+                                    {
+                                        type: "point",
+                                        coord: [0, 0],
+                                        color: "grayH",
+                                        filled: true,
+                                        labels: [],
+                                    },
+                                    {
+                                        type: "point",
+                                        coord: [2, 3],
+                                        color: "grayH",
+                                        filled: true,
+                                        labels: [],
+                                    },
+                                ],
+                            },
+                            {
+                                type: "polygon",
+                                points: [
+                                    [0, 0],
+                                    [0, 2],
+                                    [1, 1],
+                                ],
+                            },
+                            {
+                                type: "ellipse",
+                                center: [0, 0],
+                                radius: [2, 2],
+                                color: "grayH",
+                                fillStyle: "none",
+                                strokeStyle: "solid",
+                                weight: "medium",
+                                labels: [],
+                            },
+                        ],
+                    },
+                },
+            },
+        },
+        {
+            message:
+                "Aria description required when using locked figures. Locked figures aren't automatically described.",
+            severity: Rule.Severity.ERROR,
+        },
+    );
 });

--- a/packages/perseus-linter/src/rules/interactive-graph-widget-error.ts
+++ b/packages/perseus-linter/src/rules/interactive-graph-widget-error.ts
@@ -2,6 +2,8 @@ import {vector as kvector} from "@khanacademy/kmath";
 
 import Rule from "../rule";
 
+import type {PerseusInteractiveGraphWidgetOptions} from "@khanacademy/perseus-core";
+
 // eslint-disable-next-line no-restricted-syntax
 export default Rule.makeRule({
     name: "interactive-graph-widget-error",
@@ -25,7 +27,16 @@ export default Rule.makeRule({
         }
 
         const issues: Array<any | string> = [];
-        const {correct, graph, lockedFigures} = widget.options;
+        const widgetOptons: PerseusInteractiveGraphWidgetOptions =
+            widget.options;
+        const {correct, graph, lockedFigures, fullGraphAriaDescription} =
+            widgetOptons;
+
+        if (lockedFigures.length > 0 && !fullGraphAriaDescription) {
+            issues.push(
+                "Aria description required when using locked figures. Locked figures aren't automatically described.",
+            );
+        }
 
         for (const figure of lockedFigures ?? []) {
             // A locked line on the graph cannot have length 0.


### PR DESCRIPTION
## Summary:

This PR will likely be closed in favor of: https://github.com/Khan/perseus/pull/3640

---

Just a simple rule for checking for a description when there are locked figures.

While doing this work, I ran into some tech debt that I think needs to be addressed. I didn't want to bloat the PR, so I followed established patterns and added new tickets to circle back to:

- [LEMS-4138](https://khanacademy.atlassian.net/browse/LEMS-4138): test should use IG generators
- [LEMS-4139](https://khanacademy.atlassian.net/browse/LEMS-4139): break up the `interactive-graph-widget-error` rule
- [LEMS-4140](https://khanacademy.atlassian.net/browse/LEMS-4140): `expectPass` and `expectWarning` should not contain `it`

Issue: LEMS-4125

[LEMS-4138]: https://khanacademy.atlassian.net/browse/LEMS-4138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LEMS-4139]: https://khanacademy.atlassian.net/browse/LEMS-4139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LEMS-4140]: https://khanacademy.atlassian.net/browse/LEMS-4140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ