### PR TITLE
Deprecate EditorJsonify

### DIFF
--- a/.changeset/ten-rivers-grow.md
+++ b/.changeset/ten-rivers-grow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Deprecate EditorJsonify

--- a/packages/perseus/src/mixins/editor-jsonify.ts
+++ b/packages/perseus/src/mixins/editor-jsonify.ts
@@ -2,6 +2,10 @@ import _ from "underscore";
 
 import {excludeDenylistKeys} from "./widget-prop-denylist";
 
+/**
+ * @deprecated do not use EditorJsonify
+ * See LEMS-4108 for more details
+ */
 const EditorJsonify = {
     serialize: function (): any {
         // Omit props that get passed to all widgets


### PR DESCRIPTION
## Summary:
We should be explicit about what we serialize.

See:
- [Remove EditorJsonify and the denylist from Perseus](https://khanacademy.atlassian.net/browse/LEMS-4108)
- ["EditorJsonify needs to die"](https://khanacademy.atlassian.net/wiki/spaces/ENG/pages/4765221980/graded+breaks+content+pipeline?focusedCommentId=4766990629)