### PR TITLE
Disallow decimal input when input-number answer has > 10 decimal places

### DIFF
--- a/.changeset/twelve-mayflies-watch.md
+++ b/.changeset/twelve-mayflies-watch.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus-score": patch
+---
+
+When scoring input-number widgets using the numeric-input logic, we now disallow decimal and integer input under the following conditions: `answerType` is `number` or not set, `inexact` is not `true`, and the correct answer `value` has more than 10 decimal places. This ensures that learners are not approximating a rational answer with a decimal. It preserves the existing scoring behavior of input-number.

--- a/packages/perseus-core/src/widgets/input-number/to-numeric-input.test.ts
+++ b/packages/perseus-core/src/widgets/input-number/to-numeric-input.test.ts
@@ -208,4 +208,42 @@ describe("convertInputNumberOptionsToNumericInput", () => {
             "mixed",
         ]);
     });
+
+    it("does not exclude `decimal` and `integer` from `answerForms` when the answer has 10 decimal places", () => {
+        const options: PerseusInputNumberWidgetOptions = {
+            ...baseOptions,
+            answerType: undefined,
+            inexact: undefined,
+            value: "0.1231231234",
+        };
+
+        const result = convertInputNumberOptionsToNumericInput(options);
+        expect(result.answers).toHaveLength(1);
+        expect(result.answers[0].answerForms).toEqual([
+            "integer",
+            "decimal",
+            "proper",
+            "improper",
+            "mixed",
+        ]);
+    });
+
+    it("does not exclude `decimal` and `integer` from `answerForms` when the answer has fewer than 10 decimal places", () => {
+        const options: PerseusInputNumberWidgetOptions = {
+            ...baseOptions,
+            answerType: undefined,
+            inexact: undefined,
+            value: "0.3",
+        };
+
+        const result = convertInputNumberOptionsToNumericInput(options);
+        expect(result.answers).toHaveLength(1);
+        expect(result.answers[0].answerForms).toEqual([
+            "integer",
+            "decimal",
+            "proper",
+            "improper",
+            "mixed",
+        ]);
+    });
 });

--- a/packages/perseus-core/src/widgets/input-number/to-numeric-input.test.ts
+++ b/packages/perseus-core/src/widgets/input-number/to-numeric-input.test.ts
@@ -120,10 +120,10 @@ describe("convertInputNumberOptionsToNumericInput", () => {
         expect(result.answers).toHaveLength(1);
         expect(result.answers[0].answerForms).toEqual([
             "integer",
+            "decimal",
             "proper",
             "improper",
             "mixed",
-            "decimal",
         ]);
     });
 
@@ -137,5 +137,75 @@ describe("convertInputNumberOptionsToNumericInput", () => {
 
         expect(result.answers).toHaveLength(1);
         expect(result.answers[0].value).toEqual(1.5);
+    });
+
+    it("excludes `decimal` and `integer` from `answerForms` when answerType is number, inexact is false, and `value` has more than 10 decimal places", () => {
+        const options: PerseusInputNumberWidgetOptions = {
+            ...baseOptions,
+            answerType: "number",
+            inexact: false,
+            value: "1.12345678901",
+        };
+
+        const result = convertInputNumberOptionsToNumericInput(options);
+        expect(result.answers).toHaveLength(1);
+        expect(result.answers[0].answerForms).toEqual([
+            "proper",
+            "improper",
+            "mixed",
+        ]);
+    });
+
+    it("excludes `decimal` and `integer` from `answerForms` when answerType is undefined, inexact is false, and `value` has more than 10 decimal places", () => {
+        const options: PerseusInputNumberWidgetOptions = {
+            ...baseOptions,
+            answerType: undefined,
+            inexact: false,
+            value: "1.12345678901",
+        };
+
+        const result = convertInputNumberOptionsToNumericInput(options);
+        expect(result.answers).toHaveLength(1);
+        expect(result.answers[0].answerForms).toEqual([
+            "proper",
+            "improper",
+            "mixed",
+        ]);
+    });
+
+    it("excludes `decimal` and `integer` from `answerForms` when inexact is undefined and `value` has more than 10 decimal places", () => {
+        const options: PerseusInputNumberWidgetOptions = {
+            ...baseOptions,
+            answerType: undefined,
+            inexact: undefined,
+            value: "1.12345678901",
+        };
+
+        const result = convertInputNumberOptionsToNumericInput(options);
+        expect(result.answers).toHaveLength(1);
+        expect(result.answers[0].answerForms).toEqual([
+            "proper",
+            "improper",
+            "mixed",
+        ]);
+    });
+
+    it("does not exclude `decimal` and `integer` from `answerForms` when inexact is true", () => {
+        const options: PerseusInputNumberWidgetOptions = {
+            ...baseOptions,
+            answerType: undefined,
+            inexact: true,
+            value: "1.12345678901",
+        };
+
+        const result = convertInputNumberOptionsToNumericInput(options);
+        expect(result.answers).toHaveLength(1);
+        expect(result.answers[0].answerForms).toEqual([
+            "integer",
+            "decimal",
+            "proper",
+            "improper",
+            "mixed",
+        ]);
     });
 });

--- a/packages/perseus-core/src/widgets/input-number/to-numeric-input.ts
+++ b/packages/perseus-core/src/widgets/input-number/to-numeric-input.ts
@@ -5,30 +5,9 @@ import type {
     PerseusNumericInputWidgetOptions,
 } from "../../data-schema";
 
-// NOTE: the information in mathFormatsForAnswerType is duplicated in
-// score-input-number.ts. I think this is okay because inputNumber is
-// deprecated and the scoring logic will be removed as part of this project.
-const mathFormatsForAnswerType: Record<
-    PerseusInputNumberAnswerType,
-    MathFormat[]
-> = {
-    number: ["integer", "decimal", "proper", "improper", "mixed"],
-    decimal: ["decimal"],
-    integer: ["integer"],
-    rational: ["integer", "proper", "improper", "mixed"],
-    improper: ["integer", "proper", "improper"],
-    mixed: ["integer", "proper", "mixed"],
-    percent: ["integer", "decimal", "proper", "improper", "mixed", "percent"],
-    pi: ["pi"],
-};
-
 export function convertInputNumberOptionsToNumericInput(
     inputNumberOptions: PerseusInputNumberWidgetOptions,
 ): PerseusNumericInputWidgetOptions {
-    const answerForms: MathFormat[] = inputNumberOptions.answerType
-        ? mathFormatsForAnswerType[inputNumberOptions.answerType]
-        : ["integer", "proper", "improper", "mixed", "decimal"];
-
     return {
         coefficient: false,
         rightAlign: inputNumberOptions.rightAlign,
@@ -41,7 +20,7 @@ export function convertInputNumberOptionsToNumericInput(
                 message: "",
                 maxError: getMaxError(inputNumberOptions),
                 strict: true,
-                answerForms,
+                answerForms: getAnswerForms(inputNumberOptions),
             },
         ],
     };
@@ -59,4 +38,44 @@ function getMaxError(
     }
 
     return Number(inputNumberOptions.maxError);
+}
+
+// NOTE: the information in mathFormatsForAnswerType is duplicated in
+// score-input-number.ts. I think this is okay because inputNumber is
+// deprecated and the scoring logic will be removed as part of this project.
+const mathFormatsForAnswerType: Record<
+    PerseusInputNumberAnswerType,
+    MathFormat[]
+> = {
+    number: ["integer", "decimal", "proper", "improper", "mixed"],
+    decimal: ["decimal"],
+    integer: ["integer"],
+    rational: ["integer", "proper", "improper", "mixed"],
+    improper: ["integer", "proper", "improper"],
+    mixed: ["integer", "proper", "mixed"],
+    percent: ["integer", "decimal", "proper", "improper", "mixed", "percent"],
+    pi: ["pi"],
+};
+
+function getAnswerForms(
+    options: PerseusInputNumberWidgetOptions,
+): MathFormat[] {
+    const value = Number(options.value);
+    const {inexact} = options;
+    const precision = 1e10;
+    const rounded = Math.round(value * precision) / precision;
+
+    const answerType = options.answerType ?? "number";
+    if (answerType === "number" && !inexact && !equalFloats(rounded, value)) {
+        // Disallow decimal answers when the correct answer has more than 10
+        // decimal places. This is for compatibility with legacy input-number
+        // behavior.
+        return ["proper", "improper", "mixed"];
+    }
+
+    return mathFormatsForAnswerType[answerType];
+}
+
+function equalFloats(a: number, b: number): boolean {
+    return Math.abs(a - b) < Math.pow(2, -42);
 }

--- a/packages/perseus-score/src/input-number-to-numeric-input-regression.test.ts
+++ b/packages/perseus-score/src/input-number-to-numeric-input-regression.test.ts
@@ -101,6 +101,73 @@ const cases: TestCase[] = [
             },
         },
     },
+    {
+        title: "when the user inputs long decimals",
+        userInput: {
+            "input-number 1": {
+                currentValue: "0.7692307692307693",
+            },
+            "input-number 2": {
+                currentValue: "0.3076923076923077",
+            },
+            "input-number 3": {
+                currentValue: "0.2692307692307692",
+            },
+            "input-number 4": {
+                currentValue: "0.8076923076923077",
+            },
+        },
+        widgets: {
+            "input-number 1": {
+                options: {
+                    maxError: 0.031,
+                    simplify: "optional",
+                    answerType: "number",
+                    inexact: false,
+                    size: "normal",
+                    value: 0.7692307692307693,
+                },
+                graded: true,
+                type: "input-number",
+            },
+            "input-number 2": {
+                graded: true,
+                options: {
+                    value: 0.3076923076923077,
+                    simplify: "optional",
+                    maxError: 0.0077,
+                    answerType: "number",
+                    size: "normal",
+                    inexact: false,
+                },
+                type: "input-number",
+            },
+            "input-number 3": {
+                type: "input-number",
+                graded: true,
+                options: {
+                    value: 0.2692307692307692,
+                    inexact: false,
+                    size: "normal",
+                    maxError: 0.031,
+                    simplify: "optional",
+                    answerType: "number",
+                },
+            },
+            "input-number 4": {
+                type: "input-number",
+                options: {
+                    inexact: false,
+                    size: "normal",
+                    maxError: 0.0077,
+                    simplify: "optional",
+                    answerType: "number",
+                    value: 0.8076923076923077,
+                },
+                graded: true,
+            },
+        },
+    },
 ];
 
 describe("scoring with input-number converted to numeric-input", () => {

--- a/packages/perseus-score/src/input-number-to-numeric-input-regression.test.ts
+++ b/packages/perseus-score/src/input-number-to-numeric-input-regression.test.ts
@@ -102,19 +102,10 @@ const cases: TestCase[] = [
         },
     },
     {
-        title: "when the user inputs long decimals",
+        title: "when the user inputs a long decimal",
         userInput: {
             "input-number 1": {
-                currentValue: "0.7692307692307693",
-            },
-            "input-number 2": {
-                currentValue: "0.3076923076923077",
-            },
-            "input-number 3": {
-                currentValue: "0.2692307692307692",
-            },
-            "input-number 4": {
-                currentValue: "0.8076923076923077",
+                currentValue: "0.7692307692307",
             },
         },
         widgets: {
@@ -129,42 +120,6 @@ const cases: TestCase[] = [
                 },
                 graded: true,
                 type: "input-number",
-            },
-            "input-number 2": {
-                graded: true,
-                options: {
-                    value: 0.3076923076923077,
-                    simplify: "optional",
-                    maxError: 0.0077,
-                    answerType: "number",
-                    size: "normal",
-                    inexact: false,
-                },
-                type: "input-number",
-            },
-            "input-number 3": {
-                type: "input-number",
-                graded: true,
-                options: {
-                    value: 0.2692307692307692,
-                    inexact: false,
-                    size: "normal",
-                    maxError: 0.031,
-                    simplify: "optional",
-                    answerType: "number",
-                },
-            },
-            "input-number 4": {
-                type: "input-number",
-                options: {
-                    inexact: false,
-                    size: "normal",
-                    maxError: 0.0077,
-                    simplify: "optional",
-                    answerType: "number",
-                    value: 0.8076923076923077,
-                },
-                graded: true,
             },
         },
     },


### PR DESCRIPTION
## Summary:
When scoring input-number widgets using the numeric-input logic, we now
disallow decimal and integer input under the following conditions: `answerType`
is `number` or not set, `inexact` is not `true`, and the correct answer `value`
has more than 10 decimal places. This ensures that learners are not
approximating a rational answer with a decimal. It preserves the existing
scoring behavior of input-number.

This fixes a side-by-side test mismatch. I added a regression test to reproduce
the mismatch observed in production.

See this doc for more info: https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4767219957/Side-by-side+test+failure+analysis+2026-05-18

Issue: LEMS-4110

## Test plan:

Deploy and watch the perseus service logs. Side-by-side errors should decrease.