### PR TITLE
[ColorSync][Interactive Graph] Support exising orange locked figures after color migration

### DIFF
--- a/.changeset/angry-news-sort.md
+++ b/.changeset/angry-news-sort.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus-editor": patch
+---
+
+[ColorSync][interactive graph] Support exising orange locked figures after color migration

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -990,6 +990,8 @@ export const lockedFigureColorNames = [
     "purple",
     "pink",
     "red",
+    // deprecated
+    "orange",
 ] as const;
 
 export type LockedFigureColor = (typeof lockedFigureColorNames)[number];
@@ -1002,6 +1004,9 @@ export const lockedFigureColors: Record<LockedFigureColor, string> = {
     pink: "var(--wb-semanticColor-learning-math-foreground-pink)",
     purple: "var(--wb-semanticColor-learning-math-foreground-purple)",
     red: "var(--wb-semanticColor-learning-math-foreground-red)",
+    // Deprecated: "orange" is the old name for the current "gold" color.
+    // We still have to support this in existing content.
+    orange: "var(--wb-semanticColor-learning-math-foreground-gold)",
 } as const;
 
 export type StrokeWeight = "thin" | "medium" | "thick";

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.test.ts
@@ -311,4 +311,115 @@ describe("parseInteractiveGraphWidget", () => {
             }),
         );
     });
+
+    it("accepts the deprecated 'orange' color on locked figures so existing content keeps rendering", () => {
+        const result = parse(
+            {
+                type: "interactive-graph",
+                options: {
+                    step: [1, 1],
+                    markings: "grid",
+                    showProtractor: false,
+                    range: [
+                        [-10, 10],
+                        [-10, 10],
+                    ],
+                    showAxisArrows: {
+                        xMin: true,
+                        xMax: true,
+                        yMin: true,
+                        yMax: true,
+                    },
+                    showAxisTicks: {x: true, y: true},
+                    correct: {
+                        type: "linear",
+                    },
+                    lockedFigures: [
+                        {
+                            type: "point",
+                            coord: [0, 0],
+                            color: "orange",
+                            filled: true,
+                        },
+                    ],
+                },
+            },
+            parseInteractiveGraphWidget,
+        );
+
+        expect(result).toEqual(
+            success({
+                type: "interactive-graph",
+                options: {
+                    step: [1, 1],
+                    markings: "grid",
+                    showProtractor: false,
+                    range: [
+                        [-10, 10],
+                        [-10, 10],
+                    ],
+                    showAxisArrows: {
+                        xMin: true,
+                        xMax: true,
+                        yMin: true,
+                        yMax: true,
+                    },
+                    showAxisTicks: {x: true, y: true},
+                    correct: {
+                        type: "linear",
+                    },
+                    graph: {
+                        type: "linear",
+                    },
+                    lockedFigures: [
+                        {
+                            type: "point",
+                            coord: [0, 0],
+                            color: "orange",
+                            filled: true,
+                            labels: [],
+                        },
+                    ],
+                },
+            }),
+        );
+    });
+
+    it("rejects unrecognized color names on locked figures", () => {
+        const result = parse(
+            {
+                type: "interactive-graph",
+                options: {
+                    step: [1, 1],
+                    markings: "grid",
+                    showProtractor: false,
+                    range: [
+                        [-10, 10],
+                        [-10, 10],
+                    ],
+                    showAxisArrows: {
+                        xMin: true,
+                        xMax: true,
+                        yMin: true,
+                        yMax: true,
+                    },
+                    showAxisTicks: {x: true, y: true},
+                    correct: {
+                        type: "linear",
+                    },
+                    lockedFigures: [
+                        {
+                            type: "point",
+                            coord: [0, 0],
+                            color: "chartreuse",
+                            filled: true,
+                        },
+                    ],
+                },
+            },
+            parseInteractiveGraphWidget,
+        );
+
+        expect(result).toEqual(anyFailure);
+    });
 });

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/color-select.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/color-select.tsx
@@ -1,4 +1,4 @@
-import {lockedFigureColors} from "@khanacademy/perseus-core";
+import {lockedFigureColorNames} from "@khanacademy/perseus-core";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
@@ -12,8 +12,10 @@ import ColorSwatch from "./color-swatch";
 import type {LockedFigureColor} from "@khanacademy/perseus-core";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-// eslint-disable-next-line no-restricted-syntax
-const possibleColors = Object.keys(lockedFigureColors) as LockedFigureColor[];
+// Get all the possible colors to put in the dropdown,
+// except for the deprecated "orange" color.
+const possibleColors: Exclude<LockedFigureColor, "orange">[] =
+    lockedFigureColorNames.filter((color) => color !== "orange");
 
 type Props = {
     selectedValue: LockedFigureColor;
@@ -30,7 +32,9 @@ const ColorSelect = (props: Props) => {
                 color
                 <Strut size={spacing.xxSmall_6} />
                 <SingleSelect
-                    selectedValue={selectedValue}
+                    selectedValue={
+                        selectedValue === "orange" ? "gold" : selectedValue
+                    }
                     // TODO(LEMS-2656): remove TS suppression
                     // eslint-disable-next-line no-restricted-syntax
                     onChange={onChange as any}


### PR DESCRIPTION
## Summary:
The new math learning tokens use `gold` instead of `orange`. I updated our locked figures colors as such,
but that means existing content with `orange` locked figures started erroring out.

We need to support `orange` for existing content, at least until some sort of backfill can happen.

Issue: none

## Test plan:
Storybook
- `/?path=/story/editors-editorpage--demo`
- Create a new interactive graph
- Add a locked point
- Use the JSON editor to change the locked point color to orange
- Go back to the editor view
- Confirm the selected value is "gold" and the locked figure is still colored appropriately

| setting | graph | json|
| --- | --- | --- |
 | <img width="363" height="551" alt="image" src="https://github.com/user-attachments/assets/8f1b3d03-a2c3-4f23-bf0a-b52efcd2c9de" /> | <img width="451" height="463" alt="image" src="https://github.com/user-attachments/assets/2f477949-a71b-4371-bc3b-d8377d708a50" /> | <img width="405" height="283" alt="image" src="https://github.com/user-attachments/assets/08d08b55-b64c-4e7c-bccc-550fad16aa8f" /> |
