### PR TITLE
[Radio] Address a bug in Safari that causes the fade zone to partially overlay choice content

### DIFF
--- a/.changeset/hot-peas-prove.md
+++ b/.changeset/hot-peas-prove.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Radio] Address a bug in Safari that causes the fade zone to partially overlay choice content

--- a/packages/perseus/src/widgets/radio/choice-indicator.module.css
+++ b/packages/perseus/src/widgets/radio/choice-indicator.module.css
@@ -43,8 +43,8 @@
 .base:hover,
 .base:focus,
 :has(> .base):hover .base:not(:where(.is-correct, .is-wrong)) {
-    outline-offset: var(--wb-sizing-size_020);
-    outline-width: var(--wb-sizing-size_020);
+    outline-offset: var(--wb-border-width-medium);
+    outline-width: var(--wb-border-width-medium);
 }
 
 /* button is checked */

--- a/packages/perseus/src/widgets/radio/radio-component.module.css
+++ b/packages/perseus/src/widgets/radio/radio-component.module.css
@@ -54,6 +54,13 @@
    This is why --perseus-multiple-choice-content-margin is used on the left side,
         but the right side uses --perseus-multiple-choice-spacing.
    Also, in order to account for text direction, the direction is flipped when in RTL mode.
+   NOTE: The variable --mobile-font-scale is set by Frontend in
+        libs/mobile-app-integration/src/font-scale.tsxlibs/mobile-app-integration/src/font-scale.tsx.
+        It is used here to account for a bug in Safari that incorrectly calculates the width of elements
+            that have zoom applied to them.
+        This variable only exists when the page is displayed within the mobile app, and font sizing is active.
+        Since the fade zone depends upon the width of its container, we need to account for the zoom factor
+            in order to correct the Safari bug.
 */
 .choice-list:before {
     background: linear-gradient(

--- a/packages/perseus/src/widgets/radio/radio-component.module.css
+++ b/packages/perseus/src/widgets/radio/radio-component.module.css
@@ -60,17 +60,35 @@
         /* 90deg or 270deg */ var(--perseus-multiple-choice-fade-direction),
         var(--perseus-multiple-choice-fade-color)
             calc(
-                var(--perseus-multiple-choice-content-margin) +
-                    (var(--perseus-multiple-choice-spacing) / 2)
+                var(--mobile-font-scale, 1) *
+                    (
+                        var(--perseus-multiple-choice-content-margin) +
+                            (var(--perseus-multiple-choice-spacing) / 2)
+                    )
             ),
         transparent
             calc(
-                var(--perseus-multiple-choice-content-margin) +
-                    var(--perseus-multiple-choice-spacing)
+                var(--mobile-font-scale, 1) *
+                    (
+                        var(--perseus-multiple-choice-content-margin) +
+                            var(--perseus-multiple-choice-spacing)
+                    )
             )
-            calc(100% - (var(--perseus-multiple-choice-spacing) * 1.5)),
+            calc(
+                100% -
+                    (
+                        var(--mobile-font-scale, 1) *
+                            var(--perseus-multiple-choice-spacing) * 1.5
+                    )
+            ),
         var(--perseus-multiple-choice-fade-color)
-            calc(100% - var(--perseus-multiple-choice-spacing))
+            calc(
+                100% -
+                    (
+                        var(--mobile-font-scale, 1) *
+                            var(--perseus-multiple-choice-spacing)
+                    )
+            )
     );
     content: "";
     display: block;


### PR DESCRIPTION
## Summary:
There is a bug in Safari that causes it to miscalculate/misreport the width of an element when it (or an ancestor) has `zoom` applied to it. This caused display issues with the Radio widget involving the horizontal scroll fade area (the fade would partially overlap the content). This PR includes the scale value being applied with the `zoom` property, as set in Frontend (PR is forthcoming).

**NOTE:** This PR relies upon a change in Frontend to work ([PR #11403](https://github.com/Khan/frontend/pull/11403)). This change in Perseus has a fallback for when the CSS variable is not in place (it's only there when in mobile on iOS), so there is no failure in normal web pages.

Issue: LEMS-4147

## Test plan (local dev only):
1. Open any radio widget exercise in Test Everything
   - PROD - [Radio, definition, explanation exercise](https://www.khanacademy.org/internal-courses/test-everything/test-everything-2-without-mastery/te-radio/e/relative-minima-and-maxima-recreation-for-testing-?embedded=1&fontScale=0.8)
   - ZND - [Radio, definition, explanation exercise](https://prod-znd-260520-11403-b7b7b39.khanacademy.org/internal-courses/test-everything/test-everything-2-without-mastery/te-radio/e/relative-minima-and-maxima-recreation-for-testing-?embedded=1&fontScale=0.8)
1. Append to the URL of the page the following (if one of the links above was not used) to simulate being in the web app with zoom being applied:
   - `?embedded=1&fontScale=0.8`
1. Note that the fade area is no longer overlapping the content

## Affected UI:
### Before
<img width="507" height="404" alt="Screenshot 2026-05-20 at 12 50 16 PM" src="https://github.com/user-attachments/assets/a6e00ef7-b4be-485a-b344-55ea040c295e" />

### After
<img width="492" height="397" alt="Screenshot 2026-05-20 at 12 50 26 PM" src="https://github.com/user-attachments/assets/cc1c2bee-9956-479f-899d-1b3f66d1c526" />
