### PR TITLE
You put the Numeric in the Input Number and you drink 'em both together

### DIFF
--- a/.changeset/input-number-to-numeric-input-render.md
+++ b/.changeset/input-number-to-numeric-input-render.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Render input-number widgets using NumericInput when the `input-number-to-numeric-input` flag is on. Add the missing `percent` entry to NumericInput's example strings.

--- a/packages/perseus/src/widgets/input-number/input-number-as-numeric-input.stories.tsx
+++ b/packages/perseus/src/widgets/input-number/input-number-as-numeric-input.stories.tsx
@@ -12,7 +12,7 @@ import * as React from "react";
 
 import {getFeatureFlags} from "../../testing/feature-flags-util";
 import {ServerItemRendererWithDebugUI} from "../../testing/server-item-renderer-with-debug-ui";
-import {getAnswerfulItem} from "../../util/test-utils";
+import {getAnswerfulItem, getAnswerlessItem} from "../../util/test-utils";
 
 import {question1, question2, question3} from "./input-number.testdata";
 
@@ -82,14 +82,11 @@ const meta: Meta = {
 };
 export default meta;
 
-type Question = PerseusRenderer;
-type InputNumberOptions = PerseusInputNumberWidgetOptions;
-
 const updateWidgetOptions = (
-    question: Question,
+    question: PerseusRenderer,
     widgetId: string,
-    options: InputNumberOptions,
-): Question => {
+    options: PerseusInputNumberWidgetOptions,
+): PerseusRenderer => {
     const widget = question.widgets[widgetId];
     return {
         ...question,
@@ -105,7 +102,9 @@ const updateWidgetOptions = (
     };
 };
 
-export const Rational = (args: InputNumberOptions): React.ReactElement => {
+export const Rational = (
+    args: PerseusInputNumberWidgetOptions,
+): React.ReactElement => {
     const question = updateWidgetOptions(question1, "input-number 1", args);
     return (
         <ServerItemRendererWithDebugUI
@@ -116,7 +115,9 @@ export const Rational = (args: InputNumberOptions): React.ReactElement => {
 };
 Rational.args = question1.widgets["input-number 1"].options;
 
-export const PiSimplify = (args: InputNumberOptions): React.ReactElement => {
+export const PiSimplify = (
+    args: PerseusInputNumberWidgetOptions,
+): React.ReactElement => {
     const question = updateWidgetOptions(question2, "input-number 1", args);
     return (
         <ServerItemRendererWithDebugUI
@@ -127,7 +128,9 @@ export const PiSimplify = (args: InputNumberOptions): React.ReactElement => {
 };
 PiSimplify.args = question2.widgets["input-number 1"].options;
 
-export const Percent = (args: InputNumberOptions): React.ReactElement => {
+export const Percent = (
+    args: PerseusInputNumberWidgetOptions,
+): React.ReactElement => {
     const question = updateWidgetOptions(question3, "input-number 1", args);
     return (
         <ServerItemRendererWithDebugUI
@@ -156,7 +159,7 @@ export const Answerful = (): React.ReactElement => {
 };
 
 export const Answerless = (): React.ReactElement => {
-    const item = getAnswerfulItem("input-number", {
+    const item = getAnswerlessItem("input-number", {
         simplify: "optional",
         size: "normal",
         value: 42,

--- a/packages/perseus/src/widgets/input-number/input-number-as-numeric-input.stories.tsx
+++ b/packages/perseus/src/widgets/input-number/input-number-as-numeric-input.stories.tsx
@@ -1,0 +1,173 @@
+// Mirrors `input-number.stories.tsx`, but renders every story with the
+// `input-number-to-numeric-input` feature flag enabled — so we can verify the
+// flag-on rendering side-by-side with the existing stories during the
+// migration. This file should be deleted once the flag is removed and
+// numeric-input is the only rendering path.
+import {
+    type PerseusRenderer,
+    type PerseusInputNumberWidgetOptions,
+    generateTestPerseusItem,
+} from "@khanacademy/perseus-core";
+import * as React from "react";
+
+import {getFeatureFlags} from "../../testing/feature-flags-util";
+import {ServerItemRendererWithDebugUI} from "../../testing/server-item-renderer-with-debug-ui";
+import {getAnswerfulItem} from "../../util/test-utils";
+
+import {question1, question2, question3} from "./input-number.testdata";
+
+import type {Meta} from "@storybook/react-vite";
+
+const apiOptionsWithFlag = {
+    flags: getFeatureFlags({"input-number-to-numeric-input": true}),
+};
+
+const meta: Meta = {
+    title: "Widgets/Input Number (Numeric Input flag)",
+    component: ServerItemRendererWithDebugUI,
+    tags: ["!dev"],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    "Same content as the Input Number stories, but rendered with the \
+                    `input-number-to-numeric-input` feature flag on. Use these to \
+                    visually verify the migration path.",
+            },
+        },
+    },
+    argTypes: {
+        maxError: {
+            control: {
+                type: "range",
+                min: 0,
+                max: 1,
+                step: 0.1,
+            },
+        },
+        inexact: {
+            control: {type: "boolean"},
+        },
+        value: {
+            control: {type: "number"},
+        },
+        simplify: {
+            control: {
+                type: "select",
+                options: ["required", "optional", "enforced"],
+            },
+        },
+        answerType: {
+            control: {
+                type: "select",
+                options: [
+                    "number",
+                    "decimal",
+                    "integer",
+                    "rational",
+                    "improper",
+                    "mixed",
+                    "percent",
+                    "pi",
+                ],
+            },
+        },
+        size: {
+            control: {type: "select", options: ["normal", "small"]},
+        },
+        rightAlign: {
+            control: {type: "boolean"},
+        },
+    },
+};
+export default meta;
+
+type Question = PerseusRenderer;
+type InputNumberOptions = PerseusInputNumberWidgetOptions;
+
+const updateWidgetOptions = (
+    question: Question,
+    widgetId: string,
+    options: InputNumberOptions,
+): Question => {
+    const widget = question.widgets[widgetId];
+    return {
+        ...question,
+        widgets: {
+            [widgetId]: {
+                ...widget,
+                options: {
+                    ...widget.options,
+                    ...options,
+                },
+            },
+        },
+    };
+};
+
+export const Rational = (args: InputNumberOptions): React.ReactElement => {
+    const question = updateWidgetOptions(question1, "input-number 1", args);
+    return (
+        <ServerItemRendererWithDebugUI
+            item={generateTestPerseusItem({question})}
+            apiOptions={apiOptionsWithFlag}
+        />
+    );
+};
+Rational.args = question1.widgets["input-number 1"].options;
+
+export const PiSimplify = (args: InputNumberOptions): React.ReactElement => {
+    const question = updateWidgetOptions(question2, "input-number 1", args);
+    return (
+        <ServerItemRendererWithDebugUI
+            item={generateTestPerseusItem({question})}
+            apiOptions={apiOptionsWithFlag}
+        />
+    );
+};
+PiSimplify.args = question2.widgets["input-number 1"].options;
+
+export const Percent = (args: InputNumberOptions): React.ReactElement => {
+    const question = updateWidgetOptions(question3, "input-number 1", args);
+    return (
+        <ServerItemRendererWithDebugUI
+            item={generateTestPerseusItem({question})}
+            apiOptions={apiOptionsWithFlag}
+        />
+    );
+};
+Percent.args = question3.widgets["input-number 1"].options;
+
+export const Answerful = (): React.ReactElement => {
+    const item = getAnswerfulItem("input-number", {
+        simplify: "optional",
+        size: "normal",
+        value: 42,
+    });
+    // TODO(LEMS-3083): Remove eslint suppression
+    // eslint-disable-next-line
+    item.question.content = `The answer is 42\n${item.question.content}`;
+    return (
+        <ServerItemRendererWithDebugUI
+            item={item}
+            apiOptions={apiOptionsWithFlag}
+        />
+    );
+};
+
+export const Answerless = (): React.ReactElement => {
+    const item = getAnswerfulItem("input-number", {
+        simplify: "optional",
+        size: "normal",
+        value: 42,
+    });
+    // TODO(LEMS-3083): Remove eslint suppression
+    // eslint-disable-next-line
+    item.question.content = `The answer is 42\n${item.question.content}`;
+    return (
+        <ServerItemRendererWithDebugUI
+            item={item}
+            apiOptions={apiOptionsWithFlag}
+        />
+    );
+};

--- a/packages/perseus/src/widgets/input-number/input-number.stories.tsx
+++ b/packages/perseus/src/widgets/input-number/input-number.stories.tsx
@@ -6,7 +6,7 @@ import {
 import * as React from "react";
 
 import {ServerItemRendererWithDebugUI} from "../../testing/server-item-renderer-with-debug-ui";
-import {getAnswerfulItem} from "../../util/test-utils";
+import {getAnswerfulItem, getAnswerlessItem} from "../../util/test-utils";
 
 import {question1, question2, question3} from "./input-number.testdata";
 
@@ -71,14 +71,11 @@ const meta: Meta = {
 };
 export default meta;
 
-type Question = PerseusRenderer;
-type InputNumberOptions = PerseusInputNumberWidgetOptions;
-
 const updateWidgetOptions = (
-    question: Question,
+    question: PerseusRenderer,
     widgetId: string,
-    options: InputNumberOptions,
-): Question => {
+    options: PerseusInputNumberWidgetOptions,
+): PerseusRenderer => {
     const widget = question.widgets[widgetId];
     return {
         ...question,
@@ -94,7 +91,9 @@ const updateWidgetOptions = (
     };
 };
 
-export const Rational = (args: InputNumberOptions): React.ReactElement => {
+export const Rational = (
+    args: PerseusInputNumberWidgetOptions,
+): React.ReactElement => {
     const question = updateWidgetOptions(question1, "input-number 1", args);
     return (
         <ServerItemRendererWithDebugUI
@@ -104,7 +103,9 @@ export const Rational = (args: InputNumberOptions): React.ReactElement => {
 };
 Rational.args = question1.widgets["input-number 1"].options;
 
-export const PiSimplify = (args: InputNumberOptions): React.ReactElement => {
+export const PiSimplify = (
+    args: PerseusInputNumberWidgetOptions,
+): React.ReactElement => {
     const question = updateWidgetOptions(question2, "input-number 1", args);
     return (
         <ServerItemRendererWithDebugUI
@@ -114,7 +115,9 @@ export const PiSimplify = (args: InputNumberOptions): React.ReactElement => {
 };
 PiSimplify.args = question2.widgets["input-number 1"].options;
 
-export const Percent = (args: InputNumberOptions): React.ReactElement => {
+export const Percent = (
+    args: PerseusInputNumberWidgetOptions,
+): React.ReactElement => {
     const question = updateWidgetOptions(question3, "input-number 1", args);
     return (
         <ServerItemRendererWithDebugUI
@@ -137,7 +140,7 @@ export const Answerful = (): React.ReactElement => {
 };
 
 export const Answerless = (): React.ReactElement => {
-    const item = getAnswerfulItem("input-number", {
+    const item = getAnswerlessItem("input-number", {
         simplify: "optional",
         size: "normal",
         value: 42,

--- a/packages/perseus/src/widgets/input-number/input-number.test.ts
+++ b/packages/perseus/src/widgets/input-number/input-number.test.ts
@@ -7,6 +7,7 @@ import {userEvent as userEventLib} from "@testing-library/user-event";
 import _ from "underscore";
 
 import * as Dependencies from "../../dependencies";
+import {getFeatureFlags} from "../../testing/feature-flags-util";
 import {
     testDependencies,
     testDependenciesV2,
@@ -267,6 +268,108 @@ describe("input-number", function () {
             expect(score).toHaveBeenAnsweredIncorrectly();
         });
     });
+});
+
+describe("input-number with input-number-to-numeric-input flag on", () => {
+    let userEvent: UserEvent;
+    const apiOptionsWithFlag = {
+        flags: getFeatureFlags({"input-number-to-numeric-input": true}),
+    };
+
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("renders the NumericInput UI (default aria-label)", () => {
+        // Arrange, Act
+        renderQuestion(question, apiOptionsWithFlag);
+
+        // Assert
+        expect(screen.getByRole("textbox")).toHaveAccessibleName(
+            "Your answer:",
+        );
+    });
+
+    it("scores a correct answer using the input-number scorer", async () => {
+        // Arrange
+        const {renderer} = renderQuestion(question, apiOptionsWithFlag);
+
+        // Act
+        const textbox = await screen.findByRole("textbox");
+        await userEvent.click(textbox);
+        await userEvent.type(textbox, "1/2");
+        const score = scorePerseusItemTesting(
+            question,
+            renderer.getUserInputMap(),
+        );
+
+        // Assert
+        expect(score).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("scores an incorrect answer using the input-number scorer", async () => {
+        // Arrange
+        const {renderer} = renderQuestion(question, apiOptionsWithFlag);
+
+        // Act
+        const textbox = await screen.findByRole("textbox");
+        await userEvent.click(textbox);
+        await userEvent.type(textbox, "0.7");
+        const score = scorePerseusItemTesting(
+            question,
+            renderer.getUserInputMap(),
+        );
+
+        // Assert
+        expect(score).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it.each([
+        ["rational", 0.3333333333333333, "1/3", "normal" as const],
+        ["percent", 0.5, "50%", "small" as const],
+        ["pi", 241.90263432641407, "77 pi", "normal" as const],
+    ] as const)(
+        "accepts a correct answer when answerType is %s",
+        async (answerType, value, correctAnswer, size) => {
+            // Arrange
+            const item: PerseusRenderer = {
+                content: "[[☃ input-number 1]]",
+                images: {},
+                widgets: {
+                    "input-number 1": {
+                        type: "input-number",
+                        graded: true,
+                        options: {
+                            maxError: 0.1,
+                            inexact: false,
+                            value,
+                            simplify: "optional",
+                            answerType,
+                            size,
+                        },
+                    },
+                },
+            };
+            const {renderer} = renderQuestion(item, apiOptionsWithFlag);
+
+            // Act
+            const textbox = await screen.findByRole("textbox");
+            await userEvent.type(textbox, correctAnswer);
+            const score = scorePerseusItemTesting(
+                item,
+                renderer.getUserInputMap(),
+            );
+
+            // Assert
+            expect(score).toHaveBeenAnsweredCorrectly();
+        },
+    );
 });
 
 describe("getOneCorrectAnswerFromRubric", () => {

--- a/packages/perseus/src/widgets/input-number/input-number.test.ts
+++ b/packages/perseus/src/widgets/input-number/input-number.test.ts
@@ -370,6 +370,33 @@ describe("input-number with input-number-to-numeric-input flag on", () => {
             expect(score).toHaveBeenAnsweredCorrectly();
         },
     );
+
+    it("supports focusing", async () => {
+        // Arrange
+        const {renderer} = renderQuestion(question, apiOptionsWithFlag);
+
+        // Act
+        const gotFocus = await act(() => renderer.focus());
+
+        // Assert
+        expect(screen.getByRole("textbox")).toHaveFocus();
+        expect(gotFocus).toBe(true);
+    });
+
+    it("supports blurring", async () => {
+        // Arrange
+        const {renderer} = renderQuestion(question, apiOptionsWithFlag);
+        await act(() => renderer.focus());
+        expect(screen.getByRole("textbox")).toHaveFocus();
+
+        // Act
+        await act(() => renderer.blur());
+
+        // Assert
+        await waitFor(() => {
+            expect(screen.getByRole("textbox")).not.toHaveFocus();
+        });
+    });
 });
 
 describe("getOneCorrectAnswerFromRubric", () => {

--- a/packages/perseus/src/widgets/input-number/input-number.tsx
+++ b/packages/perseus/src/widgets/input-number/input-number.tsx
@@ -202,9 +202,7 @@ class InputNumber extends React.Component<Props> implements Widget {
             return (
                 <NumericInput
                     {...this.props}
-                    answers={numericInputOptions.answers}
-                    coefficient={numericInputOptions.coefficient}
-                    static={this.props.static ?? false}
+                    {...numericInputOptions}
                     labelText=""
                     ref={this.handleInputRef}
                 />

--- a/packages/perseus/src/widgets/input-number/input-number.tsx
+++ b/packages/perseus/src/widgets/input-number/input-number.tsx
@@ -92,7 +92,7 @@ class InputNumber extends React.Component<Props> implements Widget {
     static contextType = PerseusI18nContext;
     declare context: React.ContextType<typeof PerseusI18nContext>;
 
-    // [LEMS-4085] Single ref shared by both the legacy and NumericInput render paths.
+    // TODO(LEMS-4085): Single ref shared by both the legacy and NumericInput render paths.
     // Both targets satisfy `Focusable`, so focus/blur delegation is uniform.
     inputRef: {current: Focusable | null} = {current: null};
 
@@ -191,7 +191,7 @@ class InputNumber extends React.Component<Props> implements Widget {
     }
 
     render(): React.ReactNode {
-        // [LEMS-4085] This logic renders the Numeric Input widget instead of the
+        // TODO(LEMS-4085): This logic renders the Numeric Input widget instead of the
         // Input Number widget when the appropriate flag is on. We will want to
         // remove the flag check when we're ready to fully replace Input Number.
         if (isFeatureOn(this.props, "input-number-to-numeric-input")) {

--- a/packages/perseus/src/widgets/input-number/input-number.tsx
+++ b/packages/perseus/src/widgets/input-number/input-number.tsx
@@ -18,6 +18,7 @@ import {NumericInput} from "../numeric-input/numeric-input.class";
 
 import type {PerseusStrings} from "../../strings";
 import type {
+    Focusable,
     Path,
     PerseusDependenciesV2,
     Widget,
@@ -91,7 +92,9 @@ class InputNumber extends React.Component<Props> implements Widget {
     static contextType = PerseusI18nContext;
     declare context: React.ContextType<typeof PerseusI18nContext>;
 
-    numericInputRef = React.createRef<NumericInput>();
+    // [LEMS-4085] Single ref shared by both the legacy and NumericInput render paths.
+    // Both targets satisfy `Focusable`, so focus/blur delegation is uniform.
+    inputRef: {current: Focusable | null} = {current: null};
 
     static defaultProps: DefaultProps = {
         size: "normal",
@@ -115,6 +118,10 @@ class InputNumber extends React.Component<Props> implements Widget {
         });
     }
 
+    private handleInputRef = (instance: Focusable | null): void => {
+        this.inputRef.current = instance;
+    };
+
     shouldShowExamples: () => boolean = () => {
         return this.props.answerType !== "number";
     };
@@ -132,42 +139,16 @@ class InputNumber extends React.Component<Props> implements Widget {
     };
 
     focus: () => boolean = () => {
-        if (isFeatureOn(this.props, "input-number-to-numeric-input")) {
-            this.numericInputRef.current?.focus();
-            return true;
-        }
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'ReactInstance'.
-        this.refs.input.focus();
+        this.inputRef.current?.focus();
         return true;
     };
 
-    // TODO(LEMS-2656): remove TS suppression
-    // @ts-expect-error: Type 'FocusPath' is not assignable to type 'Path'.
-    focusInputPath: (arg1: Path) => void = (inputPath) => {
-        if (isFeatureOn(this.props, "input-number-to-numeric-input")) {
-            this.numericInputRef.current?.focusInputPath();
-            return;
-        }
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'ReactInstance'.
-        this.refs.input.focus();
+    focusInputPath: () => void = () => {
+        this.inputRef.current?.focus();
     };
 
-    // TODO(LEMS-2656): remove TS suppression
-    // @ts-expect-error: Type 'FocusPath' is not assignable to type 'Path'.
-    blurInputPath: (arg1: Path) => void = (inputPath) => {
-        if (isFeatureOn(this.props, "input-number-to-numeric-input")) {
-            this.numericInputRef.current?.blurInputPath();
-            return;
-        }
-        // eslint-disable-next-line react/no-string-refs
-        // @ts-expect-error - TS2339 - Property 'blur' does not exist on type 'ReactInstance'.
-        if (typeof this.refs.input?.blur === "function") {
-            // eslint-disable-next-line react/no-string-refs
-            // @ts-expect-error - TS2339 - Property 'blur' does not exist on type 'ReactInstance'.
-            this.refs.input?.blur();
-        }
+    blurInputPath: () => void = () => {
+        this.inputRef.current?.blur();
     };
 
     getInputPaths: () => ReadonlyArray<Path> = () => {
@@ -210,17 +191,12 @@ class InputNumber extends React.Component<Props> implements Widget {
     }
 
     render(): React.ReactNode {
+        // [LEMS-4085] This logic renders the Numeric Input widget instead of the
+        // Input Number widget when the appropriate flag is on. We will want to
+        // remove the flag check when we're ready to fully replace Input Number.
         if (isFeatureOn(this.props, "input-number-to-numeric-input")) {
             const numericInputOptions = convertInputNumberOptionsToNumericInput(
-                {
-                    value: this.props.value,
-                    simplify: this.props.simplify,
-                    size: this.props.size,
-                    rightAlign: this.props.rightAlign,
-                    answerType: this.props.answerType,
-                    maxError: this.props.maxError,
-                    inexact: this.props.inexact,
-                },
+                this.props,
             );
 
             return (
@@ -228,11 +204,9 @@ class InputNumber extends React.Component<Props> implements Widget {
                     {...this.props}
                     answers={numericInputOptions.answers}
                     coefficient={numericInputOptions.coefficient}
-                    size={numericInputOptions.size ?? "normal"}
-                    rightAlign={numericInputOptions.rightAlign ?? false}
                     static={this.props.static ?? false}
                     labelText=""
-                    ref={this.numericInputRef}
+                    ref={this.handleInputRef}
                 />
             );
         }
@@ -240,8 +214,7 @@ class InputNumber extends React.Component<Props> implements Widget {
         if (this.props.apiOptions.customKeypad) {
             const input = (
                 <SimpleKeypadInput
-                    // eslint-disable-next-line react/no-string-refs
-                    ref="input"
+                    ref={this.handleInputRef}
                     value={this.props.userInput.currentValue}
                     keypadElement={this.props.keypadElement}
                     onChange={this.handleChange}
@@ -272,8 +245,7 @@ class InputNumber extends React.Component<Props> implements Widget {
 
         return (
             <InputWithExamples
-                // eslint-disable-next-line react/no-string-refs
-                ref="input"
+                ref={this.handleInputRef}
                 value={this.props.userInput.currentValue}
                 onChange={this.handleChange}
                 style={inputStyles}

--- a/packages/perseus/src/widgets/input-number/input-number.tsx
+++ b/packages/perseus/src/widgets/input-number/input-number.tsx
@@ -1,3 +1,7 @@
+import {
+    convertInputNumberOptionsToNumericInput,
+    isFeatureOn,
+} from "@khanacademy/perseus-core";
 import {linterContextDefault} from "@khanacademy/perseus-linter";
 import {inputNumberAnswerTypes} from "@khanacademy/perseus-score";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
@@ -10,6 +14,7 @@ import {withDependencies} from "../../components/with-dependencies";
 import {ApiOptions} from "../../perseus-api";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/input-number/input-number-ai-utils";
 import InputWithExamples from "../numeric-input/input-with-examples";
+import {NumericInput} from "../numeric-input/numeric-input.class";
 
 import type {PerseusStrings} from "../../strings";
 import type {
@@ -86,6 +91,8 @@ class InputNumber extends React.Component<Props> implements Widget {
     static contextType = PerseusI18nContext;
     declare context: React.ContextType<typeof PerseusI18nContext>;
 
+    numericInputRef = React.createRef<NumericInput>();
+
     static defaultProps: DefaultProps = {
         size: "normal",
         answerType: "number",
@@ -125,6 +132,10 @@ class InputNumber extends React.Component<Props> implements Widget {
     };
 
     focus: () => boolean = () => {
+        if (isFeatureOn(this.props, "input-number-to-numeric-input")) {
+            this.numericInputRef.current?.focus();
+            return true;
+        }
         // eslint-disable-next-line react/no-string-refs
         // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'ReactInstance'.
         this.refs.input.focus();
@@ -134,6 +145,10 @@ class InputNumber extends React.Component<Props> implements Widget {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type 'FocusPath' is not assignable to type 'Path'.
     focusInputPath: (arg1: Path) => void = (inputPath) => {
+        if (isFeatureOn(this.props, "input-number-to-numeric-input")) {
+            this.numericInputRef.current?.focusInputPath();
+            return;
+        }
         // eslint-disable-next-line react/no-string-refs
         // @ts-expect-error - TS2339 - Property 'focus' does not exist on type 'ReactInstance'.
         this.refs.input.focus();
@@ -142,6 +157,10 @@ class InputNumber extends React.Component<Props> implements Widget {
     // TODO(LEMS-2656): remove TS suppression
     // @ts-expect-error: Type 'FocusPath' is not assignable to type 'Path'.
     blurInputPath: (arg1: Path) => void = (inputPath) => {
+        if (isFeatureOn(this.props, "input-number-to-numeric-input")) {
+            this.numericInputRef.current?.blurInputPath();
+            return;
+        }
         // eslint-disable-next-line react/no-string-refs
         // @ts-expect-error - TS2339 - Property 'blur' does not exist on type 'ReactInstance'.
         if (typeof this.refs.input?.blur === "function") {
@@ -191,6 +210,33 @@ class InputNumber extends React.Component<Props> implements Widget {
     }
 
     render(): React.ReactNode {
+        if (isFeatureOn(this.props, "input-number-to-numeric-input")) {
+            const numericInputOptions = convertInputNumberOptionsToNumericInput(
+                {
+                    value: this.props.value,
+                    simplify: this.props.simplify,
+                    size: this.props.size,
+                    rightAlign: this.props.rightAlign,
+                    answerType: this.props.answerType,
+                    maxError: this.props.maxError,
+                    inexact: this.props.inexact,
+                },
+            );
+
+            return (
+                <NumericInput
+                    {...this.props}
+                    answers={numericInputOptions.answers}
+                    coefficient={numericInputOptions.coefficient}
+                    size={numericInputOptions.size ?? "normal"}
+                    rightAlign={numericInputOptions.rightAlign ?? false}
+                    static={this.props.static ?? false}
+                    labelText=""
+                    ref={this.numericInputRef}
+                />
+            );
+        }
+
         if (this.props.apiOptions.customKeypad) {
             const input = (
                 <SimpleKeypadInput

--- a/packages/perseus/src/widgets/numeric-input/__docs__/numeric-input.stories.tsx
+++ b/packages/perseus/src/widgets/numeric-input/__docs__/numeric-input.stories.tsx
@@ -13,6 +13,7 @@ import {
     improperProblem,
     integerProblem,
     mixedProblem,
+    percentFormProblem,
     piProblem,
     properProblem,
     withCoefficient,
@@ -341,6 +342,29 @@ PiExample.parameters = {
     docs: {
         description: {
             story: "Numeric Inputs set to strictly pi mode will only accept answers in terms of π. Approximating pi will result in an incorrect answer and a hint.",
+        },
+    },
+};
+
+export const PercentExample = (
+    args: PerseusNumericInputWidgetOptions,
+): React.ReactElement => {
+    const question = updateWidgetOptions(
+        percentFormProblem,
+        "numeric-input 1",
+        args,
+    );
+    return (
+        <ServerItemRendererWithDebugUI
+            item={generateTestPerseusItem({question})}
+        />
+    );
+};
+PercentExample.args = percentFormProblem.widgets["numeric-input 1"].options;
+PercentExample.parameters = {
+    docs: {
+        description: {
+            story: 'Numeric Input with "percent" in `answerForms`. Demonstrates that the renderer currently crashes because `NumericExampleStrings` (in utils.ts) is missing a `percent` entry even though `MathFormat` lists it as valid.',
         },
     },
 };

--- a/packages/perseus/src/widgets/numeric-input/__docs__/numeric-input.stories.tsx
+++ b/packages/perseus/src/widgets/numeric-input/__docs__/numeric-input.stories.tsx
@@ -364,7 +364,7 @@ PercentExample.args = percentFormProblem.widgets["numeric-input 1"].options;
 PercentExample.parameters = {
     docs: {
         description: {
-            story: 'Numeric Input with "percent" in `answerForms`. Demonstrates that the renderer currently crashes because `NumericExampleStrings` (in utils.ts) is missing a `percent` entry even though `MathFormat` lists it as valid.',
+            story: 'Numeric Input with "percent" in `answerForms`.',
         },
     },
 };

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.class.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.class.tsx
@@ -90,6 +90,13 @@ export class NumericInput
         return true;
     };
 
+    // [LEMS-4085] While we cannot find any callers of this method,
+    // adding it is the simplest way to resolve temporary type issues
+    // regarding rendering the Input Number widget as a Numeric Input
+    blur: () => void = () => {
+        this.inputRef.current?.blur();
+    };
+
     focusInputPath: () => void = () => {
         this.inputRef.current?.focus();
     };

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.class.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.class.tsx
@@ -90,7 +90,7 @@ export class NumericInput
         return true;
     };
 
-    // [LEMS-4085] While we cannot find any callers of this method,
+    // TODO(LEMS-4085): While we cannot find any callers of this method,
     // adding it is the simplest way to resolve temporary type issues
     // regarding rendering the Input Number widget as a Numeric Input
     blur: () => void = () => {

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.testdata.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.testdata.ts
@@ -152,6 +152,25 @@ export const properProblem: PerseusRenderer = generateTestPerseusRenderer({
     },
 });
 
+// Demonstrates the renderer crash when "percent" appears in `answerForms`.
+// `NumericExampleStrings` (in utils.ts) is missing a `percent` entry even though
+// `MathFormat` lists it as valid.
+export const percentFormProblem: PerseusRenderer = generateTestPerseusRenderer({
+    content: "$50\\% =$ [[☃ numeric-input 1]] \n\n‎",
+    widgets: {
+        "numeric-input 1": generateNumericInputWidget({
+            options: generateNumericInputOptions({
+                answers: [
+                    generateNumericInputAnswer({
+                        value: 0.5,
+                        answerForms: ["percent"],
+                    }),
+                ],
+            }),
+        }),
+    },
+});
+
 export const percentageProblem: PerseusRenderer = generateTestPerseusRenderer({
     content: "$5008 \\div 4 =$ [[\u2603 numeric-input 1]] ",
     widgets: {

--- a/packages/perseus/src/widgets/numeric-input/utils.test.ts
+++ b/packages/perseus/src/widgets/numeric-input/utils.test.ts
@@ -125,6 +125,10 @@ describe("shouldShowExamples", () => {
                 simplify: "optional",
             },
             {
+                name: "percent",
+                simplify: "optional",
+            },
+            {
                 name: "pi",
                 simplify: "required",
             },

--- a/packages/perseus/src/widgets/numeric-input/utils.ts
+++ b/packages/perseus/src/widgets/numeric-input/utils.ts
@@ -25,6 +25,7 @@ const NumericExampleStrings: {
             : strings.simplifiedImproperExample,
     mixed: (form, strings) => strings.mixedExample,
     decimal: (form, strings) => strings.decimalExample,
+    percent: (form, strings) => strings.percentExample,
     pi: (form, strings) => strings.piExample,
 };
 


### PR DESCRIPTION
## Summary:
This main purpose of this PR is to update Input Number so that it renders as a Numeric Input if the `input-number-to-numeric-input` flag is turned on. 

In order to do this, I needed to make too updates to the Numeric Input Widget:

1. I added a `blur()` method to Numeric input in order to satisfy the `Focusable` type so that we could update the old string ref to a more modern implementation. This seemed like the best approach to keep the logic as clean as possible. This method can be temporary until we remove the old render logic for Input Number, or we can keep it around so that Numeric Input follows the `Focusable` standard. However, it really doesn't seem like `blur() `ever gets called from anywhere. 
2. I had to add support to Numeric Input for rendering questions when the `answerForms` includes `percent`. This is a pre-existing bug with Numeric Input, despite the fact that we have logic to support `percent` during scoring. All that was required was to ensure that we consider `percent` when generating the example text. I've added a new story for Numeric Input for this answer form. 

I've also created a clone of the Input Number Widget story that hard-codes the `input-number-to-numeric-input` flag to `true`, so that we can easily compare with the original stories during the conversion process.

Issue: LEMS-4098

## Test plan:
- Tests Pass 
- Upcoming manual testing with blur / focus to ensure no regressions 