### PR TITLE
GAAD: Two small fixes to get rid of jsx-a11y exceptions

### DIFF
--- a/.changeset/lucky-masks-refuse.md
+++ b/.changeset/lucky-masks-refuse.md
@@ -1,5 +1,7 @@
 ---
 "@khanacademy/perseus-editor": patch
+"@khanacademy/perseus": patch
 ---
 
-Use button, not clickable div, in CollapsedRow
+- Use button, not clickable div, in CollapsedRow.
+- Remove redundent "role" field on MockWidget.

--- a/.changeset/lucky-masks-refuse.md
+++ b/.changeset/lucky-masks-refuse.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Use button, not clickable div, in CollapsedRow

--- a/packages/perseus-editor/src/diffs/__tests__/__snapshots__/answer-area-diff.test.tsx.snap
+++ b/packages/perseus-editor/src/diffs/__tests__/__snapshots__/answer-area-diff.test.tsx.snap
@@ -161,9 +161,18 @@ exports[`AnswerAreaDiff renders an answer area in the diff view 1`] = `
           <div
             style="padding-left: 0px;"
           >
-            <span>
-               [ show unmodified ] 
-            </span>
+            <button
+              aria-disabled="false"
+              class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+              data-kind="secondary"
+              type="button"
+            >
+              <span
+                class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+              >
+                show unmodified
+              </span>
+            </button>
           </div>
         </div>
         <div
@@ -172,9 +181,18 @@ exports[`AnswerAreaDiff renders an answer area in the diff view 1`] = `
           <div
             style="padding-left: 0px;"
           >
-            <span>
-               [ show unmodified ] 
-            </span>
+            <button
+              aria-disabled="false"
+              class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+              data-kind="secondary"
+              type="button"
+            >
+              <span
+                class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+              >
+                show unmodified
+              </span>
+            </button>
           </div>
         </div>
       </div>

--- a/packages/perseus-editor/src/diffs/__tests__/__snapshots__/article-diff.test.tsx.snap
+++ b/packages/perseus-editor/src/diffs/__tests__/__snapshots__/article-diff.test.tsx.snap
@@ -202,9 +202,18 @@ exports[`ArticleDiff renders an article in the diff view 1`] = `
                     <div
                       style="padding-left: 60px;"
                     >
-                      <span>
-                         [ show unmodified ] 
-                      </span>
+                      <button
+                        aria-disabled="false"
+                        class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+                        data-kind="secondary"
+                        type="button"
+                      >
+                        <span
+                          class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+                        >
+                          show unmodified
+                        </span>
+                      </button>
                     </div>
                   </div>
                   <div
@@ -213,9 +222,18 @@ exports[`ArticleDiff renders an article in the diff view 1`] = `
                     <div
                       style="padding-left: 60px;"
                     >
-                      <span>
-                         [ show unmodified ] 
-                      </span>
+                      <button
+                        aria-disabled="false"
+                        class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+                        data-kind="secondary"
+                        type="button"
+                      >
+                        <span
+                          class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+                        >
+                          show unmodified
+                        </span>
+                      </button>
                     </div>
                   </div>
                 </div>
@@ -230,9 +248,18 @@ exports[`ArticleDiff renders an article in the diff view 1`] = `
                 <div
                   style="padding-left: 20px;"
                 >
-                  <span>
-                     [ show unmodified ] 
-                  </span>
+                  <button
+                    aria-disabled="false"
+                    class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+                    data-kind="secondary"
+                    type="button"
+                  >
+                    <span
+                      class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+                    >
+                      show unmodified
+                    </span>
+                  </button>
                 </div>
               </div>
               <div
@@ -241,9 +268,18 @@ exports[`ArticleDiff renders an article in the diff view 1`] = `
                 <div
                   style="padding-left: 20px;"
                 >
-                  <span>
-                     [ show unmodified ] 
-                  </span>
+                  <button
+                    aria-disabled="false"
+                    class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+                    data-kind="secondary"
+                    type="button"
+                  >
+                    <span
+                      class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+                    >
+                      show unmodified
+                    </span>
+                  </button>
                 </div>
               </div>
             </div>
@@ -485,9 +521,18 @@ exports[`ArticleDiff renders an article in the diff view 1`] = `
                     <div
                       style="padding-left: 60px;"
                     >
-                      <span>
-                         [ show unmodified ] 
-                      </span>
+                      <button
+                        aria-disabled="false"
+                        class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+                        data-kind="secondary"
+                        type="button"
+                      >
+                        <span
+                          class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+                        >
+                          show unmodified
+                        </span>
+                      </button>
                     </div>
                   </div>
                   <div
@@ -496,9 +541,18 @@ exports[`ArticleDiff renders an article in the diff view 1`] = `
                     <div
                       style="padding-left: 60px;"
                     >
-                      <span>
-                         [ show unmodified ] 
-                      </span>
+                      <button
+                        aria-disabled="false"
+                        class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+                        data-kind="secondary"
+                        type="button"
+                      >
+                        <span
+                          class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+                        >
+                          show unmodified
+                        </span>
+                      </button>
                     </div>
                   </div>
                 </div>
@@ -513,9 +567,18 @@ exports[`ArticleDiff renders an article in the diff view 1`] = `
                 <div
                   style="padding-left: 20px;"
                 >
-                  <span>
-                     [ show unmodified ] 
-                  </span>
+                  <button
+                    aria-disabled="false"
+                    class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+                    data-kind="secondary"
+                    type="button"
+                  >
+                    <span
+                      class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+                    >
+                      show unmodified
+                    </span>
+                  </button>
                 </div>
               </div>
               <div
@@ -524,9 +587,18 @@ exports[`ArticleDiff renders an article in the diff view 1`] = `
                 <div
                   style="padding-left: 20px;"
                 >
-                  <span>
-                     [ show unmodified ] 
-                  </span>
+                  <button
+                    aria-disabled="false"
+                    class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+                    data-kind="secondary"
+                    type="button"
+                  >
+                    <span
+                      class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+                    >
+                      show unmodified
+                    </span>
+                  </button>
                 </div>
               </div>
             </div>
@@ -768,9 +840,18 @@ exports[`ArticleDiff renders an article in the diff view 1`] = `
                     <div
                       style="padding-left: 60px;"
                     >
-                      <span>
-                         [ show unmodified ] 
-                      </span>
+                      <button
+                        aria-disabled="false"
+                        class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+                        data-kind="secondary"
+                        type="button"
+                      >
+                        <span
+                          class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+                        >
+                          show unmodified
+                        </span>
+                      </button>
                     </div>
                   </div>
                   <div
@@ -779,9 +860,18 @@ exports[`ArticleDiff renders an article in the diff view 1`] = `
                     <div
                       style="padding-left: 60px;"
                     >
-                      <span>
-                         [ show unmodified ] 
-                      </span>
+                      <button
+                        aria-disabled="false"
+                        class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+                        data-kind="secondary"
+                        type="button"
+                      >
+                        <span
+                          class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+                        >
+                          show unmodified
+                        </span>
+                      </button>
                     </div>
                   </div>
                 </div>
@@ -796,9 +886,18 @@ exports[`ArticleDiff renders an article in the diff view 1`] = `
                 <div
                   style="padding-left: 20px;"
                 >
-                  <span>
-                     [ show unmodified ] 
-                  </span>
+                  <button
+                    aria-disabled="false"
+                    class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+                    data-kind="secondary"
+                    type="button"
+                  >
+                    <span
+                      class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+                    >
+                      show unmodified
+                    </span>
+                  </button>
                 </div>
               </div>
               <div
@@ -807,9 +906,18 @@ exports[`ArticleDiff renders an article in the diff view 1`] = `
                 <div
                   style="padding-left: 20px;"
                 >
-                  <span>
-                     [ show unmodified ] 
-                  </span>
+                  <button
+                    aria-disabled="false"
+                    class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+                    data-kind="secondary"
+                    type="button"
+                  >
+                    <span
+                      class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+                    >
+                      show unmodified
+                    </span>
+                  </button>
                 </div>
               </div>
             </div>

--- a/packages/perseus-editor/src/diffs/__tests__/__snapshots__/item-diff.test.tsx.snap
+++ b/packages/perseus-editor/src/diffs/__tests__/__snapshots__/item-diff.test.tsx.snap
@@ -151,9 +151,18 @@ exports[`ItemDiff renders a diff view 1`] = `
             <div
               style="padding-left: 0px;"
             >
-              <span>
-                 [ show unmodified ] 
-              </span>
+              <button
+                aria-disabled="false"
+                class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+                data-kind="secondary"
+                type="button"
+              >
+                <span
+                  class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+                >
+                  show unmodified
+                </span>
+              </button>
             </div>
           </div>
           <div
@@ -162,9 +171,18 @@ exports[`ItemDiff renders a diff view 1`] = `
             <div
               style="padding-left: 0px;"
             >
-              <span>
-                 [ show unmodified ] 
-              </span>
+              <button
+                aria-disabled="false"
+                class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+                data-kind="secondary"
+                type="button"
+              >
+                <span
+                  class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+                >
+                  show unmodified
+                </span>
+              </button>
             </div>
           </div>
         </div>

--- a/packages/perseus-editor/src/diffs/__tests__/__snapshots__/widget-diff.test.tsx.snap
+++ b/packages/perseus-editor/src/diffs/__tests__/__snapshots__/widget-diff.test.tsx.snap
@@ -112,9 +112,18 @@ exports[`WidgetDiff renders a widget in the diff view 1`] = `
                 <div
                   style="padding-left: 60px;"
                 >
-                  <span>
-                     [ show unmodified ] 
-                  </span>
+                  <button
+                    aria-disabled="false"
+                    class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+                    data-kind="secondary"
+                    type="button"
+                  >
+                    <span
+                      class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+                    >
+                      show unmodified
+                    </span>
+                  </button>
                 </div>
               </div>
               <div
@@ -123,9 +132,18 @@ exports[`WidgetDiff renders a widget in the diff view 1`] = `
                 <div
                   style="padding-left: 60px;"
                 >
-                  <span>
-                     [ show unmodified ] 
-                  </span>
+                  <button
+                    aria-disabled="false"
+                    class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+                    data-kind="secondary"
+                    type="button"
+                  >
+                    <span
+                      class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+                    >
+                      show unmodified
+                    </span>
+                  </button>
                 </div>
               </div>
             </div>
@@ -273,9 +291,18 @@ exports[`WidgetDiff renders a widget in the diff view 1`] = `
           <div
             style="padding-left: 0px;"
           >
-            <span>
-               [ show unmodified ] 
-            </span>
+            <button
+              aria-disabled="false"
+              class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+              data-kind="secondary"
+              type="button"
+            >
+              <span
+                class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+              >
+                show unmodified
+              </span>
+            </button>
           </div>
         </div>
         <div
@@ -284,9 +311,18 @@ exports[`WidgetDiff renders a widget in the diff view 1`] = `
           <div
             style="padding-left: 0px;"
           >
-            <span>
-               [ show unmodified ] 
-            </span>
+            <button
+              aria-disabled="false"
+              class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+              data-kind="secondary"
+              type="button"
+            >
+              <span
+                class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
+              >
+                show unmodified
+              </span>
+            </button>
           </div>
         </div>
       </div>

--- a/packages/perseus-editor/src/diffs/shared/diff-entry.tsx
+++ b/packages/perseus-editor/src/diffs/shared/diff-entry.tsx
@@ -1,3 +1,4 @@
+import Button from "@khanacademy/wonder-blocks-button";
 import classNames from "classnames";
 import * as React from "react";
 import _ from "underscore";
@@ -67,8 +68,7 @@ class CollapsedRow extends React.Component<CollapsedRowProps> {
     render(): React.ReactNode {
         const self = this;
         return (
-            // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events -- TODO(LEMS-2871): Address a11y error
-            <div onClick={self.props.onClick} style={{clear: "both"}}>
+            <div style={{clear: "both"}}>
                 {_.map([BEFORE, AFTER], function (side) {
                     return (
                         <div
@@ -82,7 +82,14 @@ class CollapsedRow extends React.Component<CollapsedRowProps> {
                                     ),
                                 }}
                             >
-                                <span> [ show unmodified ] </span>
+                                <Button
+                                    size="small"
+                                    kind="secondary"
+                                    actionType="neutral"
+                                    onClick={self.props.onClick}
+                                >
+                                    show unmodified
+                                </Button>
                             </div>
                         </div>
                     );

--- a/packages/perseus-editor/src/diffs/shared/diff-entry.tsx
+++ b/packages/perseus-editor/src/diffs/shared/diff-entry.tsx
@@ -1,4 +1,5 @@
 import Button from "@khanacademy/wonder-blocks-button";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import classNames from "classnames";
 import * as React from "react";
 import _ from "underscore";
@@ -77,6 +78,8 @@ class CollapsedRow extends React.Component<CollapsedRowProps> {
                         >
                             <div
                                 style={{
+                                    paddingTop: sizing.size_040,
+                                    paddingBottom: sizing.size_040,
                                     paddingLeft: indentationFromDepth(
                                         self.props.depth,
                                     ),

--- a/packages/perseus/src/__tests__/__snapshots__/server-item-renderer.test.tsx.snap
+++ b/packages/perseus/src/__tests__/__snapshots__/server-item-renderer.test.tsx.snap
@@ -48,7 +48,6 @@ exports[`server item renderer should snapshot: initial render 1`] = `
                   aria-required="false"
                   class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_8fhii8"
                   id="mock-widget 1"
-                  role="textbox"
                   type="text"
                   value=""
                 />

--- a/packages/perseus/src/widgets/mock-widgets/mock-widget.tsx
+++ b/packages/perseus/src/widgets/mock-widgets/mock-widget.tsx
@@ -87,14 +87,12 @@ class MockWidgetComponent extends React.Component<Props> implements Widget {
     render(): React.ReactNode {
         return (
             <View style={styles.widgetContainer}>
-                {/* eslint-disable-next-line jsx-a11y/no-redundant-roles -- TODO(LEMS-2871): Address a11y error */}
                 <TextField
                     ref={(ref) => (this.inputRef = ref)}
                     aria-label="Mock Widget"
                     value={this.props.userInput.currentValue}
                     onChange={this.handleChange}
                     id={this.props.widgetId}
-                    role="textbox"
                     onFocus={this.focusInputPath}
                     onBlur={this.blurInputPath}
                 />


### PR DESCRIPTION
## Summary:

Two small changes that I (accidentally) bundled together to remove jsx-a11y exceptions:

1. `diff-entry.tsx`: replace a clickable `div` with a real button in Diff
2. `mock-widget.tsx`: remove redundant `role` on MockWidget

Everything else is just snapshot updates.