### PR TITLE
GAAD: Remove a11y lint warning in perseus-api.tsx

### DIFF
--- a/.changeset/gorgeous-pianos-divide.md
+++ b/.changeset/gorgeous-pianos-divide.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Remove a11y lint warning in perseus-api.tsx

--- a/packages/perseus/src/perseus-api.tsx
+++ b/packages/perseus/src/perseus-api.tsx
@@ -130,8 +130,8 @@ export const ApiOptions = {
             Link: (
                 props: any,
             ): React.ReactElement<React.ComponentProps<"a">> => {
-                // eslint-disable-next-line jsx-a11y/anchor-has-content -- TODO(LEMS-2871): Address a11y error
-                return <a {...props} />;
+                const {children, ...rest} = props;
+                return <a {...rest}>{children}</a>;
             },
         },
         setDrawingAreaAvailable: function () {},


### PR DESCRIPTION
## Summary:

There was a warning that `<a>` elements needed content. I believe it's valid to do `<a children={children} />` which is essentially what `<a {...props} />` was doing, but the linter didn't think so. I think my change is a good alternative.