### PR TITLE
Minor improvements for GAAD

### DIFF
--- a/.changeset/short-grapes-joke.md
+++ b/.changeset/short-grapes-joke.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Minor fixes for A11Y

--- a/packages/perseus/src/components/image-loader.tsx
+++ b/packages/perseus/src/components/image-loader.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
-/* eslint-disable jsx-a11y/alt-text, react/no-unsafe */
-// TODO(scottgrant): Enable the alt-text eslint rule above.
+/* eslint-disable react/no-unsafe */
 
 import * as React from "react";
 
@@ -134,10 +133,14 @@ class ImageLoader extends React.Component<Props, State> {
      */
     renderImg: () => React.ReactElement<React.ComponentProps<"img">> = () => {
         const {src, imgProps} = this.props;
-        // Destructure to exclude props that shouldn't be on the <img> element
+        // Pull `alt` (and `title`) out of the spread so the static
+        // `jsx-a11y/alt-text` rule can see they're set.
+        const {alt, title, ...restImgProps} = imgProps;
 
         return (
             <img
+                alt={alt}
+                title={title}
                 // Class name makes this img findable in Cypress tests.
                 className="image-loader-img"
                 src={this.props.dependencies.generateUrl({
@@ -161,7 +164,7 @@ class ImageLoader extends React.Component<Props, State> {
                         width: "100%",
                     }),
                 }}
-                {...imgProps}
+                {...restImgProps}
             />
         );
     };

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -114,6 +114,9 @@ export type PerseusStrings = {
     videoTranscript: string;
     somethingWrong: string;
     videoWrapper: string;
+    pythonProgram: string;
+    computerScienceProgram: string;
+    embeddedContent: string;
     mathInputTitle: string;
     mathInputDescription: string;
     sin: string;
@@ -787,6 +790,9 @@ export const strings = {
     videoTranscript: "See video transcript",
     somethingWrong: "Something went wrong.",
     videoWrapper: "Khan Academy video wrapper",
+    pythonProgram: "Python program",
+    computerScienceProgram: "Computer science program",
+    embeddedContent: "Embedded content",
     mathInputTitle: "mathematics keyboard",
     mathInputDescription:
         "Use keyboard/mouse to interact with math-based input fields",
@@ -1522,6 +1528,9 @@ export const mockStrings: PerseusStrings = {
     videoTranscript: "See video transcript",
     somethingWrong: "Something went wrong.",
     videoWrapper: "Khan Academy video wrapper",
+    pythonProgram: "Python program",
+    computerScienceProgram: "Computer science program",
+    embeddedContent: "Embedded content",
     mathInputTitle: "mathematics keyboard",
     mathInputDescription:
         "Use keyboard/mouse to interact with math-based input fields",

--- a/packages/perseus/src/widgets/cs-program/__snapshots__/cs-program.test.ts.snap
+++ b/packages/perseus/src/widgets/cs-program/__snapshots__/cs-program.test.ts.snap
@@ -24,6 +24,7 @@ exports[`cs-program widget should snapshot on mobile: first mobile render 1`] = 
               sandbox="allow-popups allow-same-origin allow-scripts allow-top-navigation"
               src="http://localhost/computer-programming/program/6293105639817216/embedded?embed=yes&author=no&editor=no&width=688&buttons=no&settings=%7B%7D&lang=en"
               style="height: 540px; width: 100%;"
+              title="Computer science program"
             />
           </div>
         </div>
@@ -57,6 +58,7 @@ exports[`cs-program widget should snapshot: first render 1`] = `
               sandbox="allow-popups allow-same-origin allow-scripts allow-top-navigation"
               src="http://localhost/computer-programming/program/6293105639817216/embedded?embed=yes&author=no&editor=no&width=688&buttons=no&settings=%7B%7D&lang=en"
               style="height: 540px; width: 100%;"
+              title="Computer science program"
             />
           </div>
         </div>

--- a/packages/perseus/src/widgets/cs-program/cs-program.tsx
+++ b/packages/perseus/src/widgets/cs-program/cs-program.tsx
@@ -176,8 +176,8 @@ class CSProgram extends React.Component<Props> implements Widget {
         // http://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/
         return (
             <div className={css(styleContainer && styles.container)}>
-                {/* eslint-disable-next-line jsx-a11y/iframe-has-title -- TODO(LEMS-2871): Address a11y error */}
                 <iframe
+                    title={this.context.strings.computerScienceProgram}
                     sandbox={sandboxOptions}
                     src={url}
                     style={style}

--- a/packages/perseus/src/widgets/iframe/__snapshots__/iframe.test.ts.snap
+++ b/packages/perseus/src/widgets/iframe/__snapshots__/iframe.test.ts.snap
@@ -22,6 +22,7 @@ exports[`iframe widget should snapshot on mobile: first mobile render 1`] = `
             sandbox="allow-same-origin allow-scripts allow-top-navigation"
             src="https://www.khanacademy.org/computer-programming/program/4960944252/embedded?buttons=no&embed=yes&editor=no&author=no&width=410&height=410&origin=origin-test-interface&lang=en&settings=%7B%22hue%22%3A%22210%22%2C%22subdivisions%22%3A%220%22%2C%22zoom%22%3A%222%22%2C%22seed%22%3A%226%22%7D"
             style="width: 410px; height: 410px;"
+            title="Embedded content"
           />
         </div>
       </div>
@@ -52,6 +53,7 @@ exports[`iframe widget should snapshot: first render 1`] = `
             sandbox="allow-same-origin allow-scripts allow-top-navigation"
             src="https://www.khanacademy.org/computer-programming/program/4960944252/embedded?buttons=no&embed=yes&editor=no&author=no&width=410&height=410&origin=origin-test-interface&lang=en&settings=%7B%22hue%22%3A%22210%22%2C%22subdivisions%22%3A%220%22%2C%22zoom%22%3A%222%22%2C%22seed%22%3A%226%22%7D"
             style="width: 410px; height: 410px;"
+            title="Embedded content"
           />
         </div>
       </div>

--- a/packages/perseus/src/widgets/iframe/iframe.tsx
+++ b/packages/perseus/src/widgets/iframe/iframe.tsx
@@ -146,8 +146,8 @@ class Iframe extends React.Component<Props> implements Widget {
         //  creator "went wild".
         // http://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/
         return (
-            // eslint-disable-next-line jsx-a11y/iframe-has-title -- TODO(LEMS-2871): Address a11y error
             <iframe
+                title={this.context.strings.embeddedContent}
                 sandbox={sandboxProperties}
                 style={style}
                 src={url}

--- a/packages/perseus/src/widgets/python-program/__snapshots__/python-program.test.ts.snap
+++ b/packages/perseus/src/widgets/python-program/__snapshots__/python-program.test.ts.snap
@@ -23,6 +23,7 @@ exports[`python-program widget should snapshot on mobile: first mobile render 1`
               sandbox="allow-popups allow-same-origin allow-scripts allow-top-navigation"
               src="/python-program/5207287069147136/embedded"
               style="height: 400px; width: 100%;"
+              title="Python program"
             />
           </div>
         </div>
@@ -55,6 +56,7 @@ exports[`python-program widget should snapshot: first render 1`] = `
               sandbox="allow-popups allow-same-origin allow-scripts allow-top-navigation"
               src="/python-program/5207287069147136/embedded"
               style="height: 400px; width: 100%;"
+              title="Python program"
             />
           </div>
         </div>

--- a/packages/perseus/src/widgets/python-program/python-program.tsx
+++ b/packages/perseus/src/widgets/python-program/python-program.tsx
@@ -71,8 +71,8 @@ class PythonProgram extends React.Component<Props> implements Widget {
         // http://www.html5rocks.com/en/tutorials/security/sandboxed-iframes/
         return (
             <View style={styles.container}>
-                {/* eslint-disable-next-line jsx-a11y/iframe-has-title -- TODO(LEMS-2871): Address a11y error */}
                 <iframe
+                    title={this.context.strings.pythonProgram}
                     sandbox={sandboxOptions}
                     src={url}
                     style={iframeStyle}

--- a/packages/perseus/src/widgets/video/__snapshots__/video.test.ts.snap
+++ b/packages/perseus/src/widgets/video/__snapshots__/video.test.ts.snap
@@ -32,11 +32,6 @@ exports[`video widget should snapshot on mobile: first mobile render 1`] = `
               class="fixed-to-responsive"
               style="max-width: 1280px; max-height: 720px;"
             >
-              <div
-                class="default_xu2jcg-o_O-srOnly_19bpjuy"
-              >
-                Khan Academy video wrapper
-              </div>
               <iframe
                 allow="autoplay"
                 allowfullscreen=""
@@ -44,6 +39,7 @@ exports[`video widget should snapshot on mobile: first mobile render 1`] = `
                 height="720"
                 sandbox="allow-same-origin allow-scripts"
                 src="https://www.khanacademy.org/embed_video?slug=biogeography-where-life-lives&internal_video_only=1"
+                title="Khan Academy video wrapper"
                 width="1280"
               />
             </div>
@@ -106,11 +102,6 @@ exports[`video widget should snapshot: first render 1`] = `
               class="fixed-to-responsive"
               style="max-width: 1280px; max-height: 720px;"
             >
-              <div
-                class="default_xu2jcg-o_O-srOnly_19bpjuy"
-              >
-                Khan Academy video wrapper
-              </div>
               <iframe
                 allow="autoplay"
                 allowfullscreen=""
@@ -118,6 +109,7 @@ exports[`video widget should snapshot: first render 1`] = `
                 height="720"
                 sandbox="allow-same-origin allow-scripts"
                 src="https://www.khanacademy.org/embed_video?slug=biogeography-where-life-lives&internal_video_only=1"
+                title="Khan Academy video wrapper"
                 width="1280"
               />
             </div>

--- a/packages/perseus/src/widgets/video/video.tsx
+++ b/packages/perseus/src/widgets/video/video.tsx
@@ -16,7 +16,6 @@ import {
     type WidgetExports,
     type WidgetProps,
 } from "../../types";
-import a11y from "../../util/a11y";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/video/video-ai-utils";
 
 import VideoTranscriptLink from "./video-transcript-link";
@@ -109,12 +108,8 @@ class Video extends React.Component<Props> implements Widget {
                     // any changes cause a re-rendering of the frame.
                     key={location + this.props.alignment}
                 >
-                    <View style={a11y.srOnly}>
-                        {this.context.strings.videoWrapper}
-                    </View>
-
-                    {/* eslint-disable-next-line jsx-a11y/iframe-has-title -- TODO(LEMS-2871): Address a11y error */}
                     <iframe
+                        title={this.context.strings.videoWrapper}
                         className="perseus-video-widget"
                         sandbox="allow-same-origin allow-scripts"
                         width={DEFAULT_WIDTH}


### PR DESCRIPTION
## Summary:
Minor a11y improvements as part of GAAD: 

1. Split out `alt` and `title` from `imgProps` for `image-loader.tsx`
2. Created new strings and added titles to `iframe`, `cs-program`, and `python-program` widgets 
3. Add title to `video` widget, and removed confusing old workaround

## Test plan:
- Tests pass 
- Manual testing 