### PR TITLE
[Image] Fix flakey graphie snapshot again

### DIFF
--- a/.changeset/four-humans-pull.md
+++ b/.changeset/four-humans-pull.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Image] Make Graphie wait for fonts to load before calculating margins

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1710,9 +1710,7 @@ const setLabelMargins = function (span: HTMLElement, size: Coord): void {
     // Wait for fonts to load before setting label margins,
     // so that the margins are not flakey.
     if (document.fonts?.status === "loading") {
-        setTimeout(() => {
-            setLabelMargins(span, size);
-        }, 5);
+        document.fonts.ready.then(() => setLabelMargins(span, size));
         return;
     }
 

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1709,7 +1709,7 @@ const SVG_SPECIFIC_STYLE_MASK = {
 const setLabelMargins = function (span: HTMLElement, size: Coord): void {
     // Wait for fonts to load before setting label margins,
     // so that the margins are not flakey.
-    if (document.fonts?.status !== "loaded") {
+    if (document.fonts?.status === "loading") {
         setTimeout(() => {
             setLabelMargins(span, size);
         }, 5);

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1707,6 +1707,15 @@ const SVG_SPECIFIC_STYLE_MASK = {
 } as const;
 
 const setLabelMargins = function (span: HTMLElement, size: Coord): void {
+    // Wait for fonts to load before setting label margins,
+    // so that the margins are not flakey.
+    if (document.fonts?.status !== "loaded") {
+        setTimeout(() => {
+            setLabelMargins(span, size);
+        }, 5);
+        return;
+    }
+
     const $span = $(span);
     const direction = $span.data("labelDirection");
     let [width, height] = size;

--- a/packages/perseus/src/widgets/image/__docs__/image-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/image/__docs__/image-initial-state-regression.stories.tsx
@@ -17,6 +17,7 @@ import {
     earthMoonImage,
     frescoImage,
     gifImageAlt,
+    graphieImage,
     portraitImage,
     portraitImageCaption,
     portraitImageLongDescription,
@@ -338,5 +339,14 @@ export const TallGifImage: Story = {
         alt: gifImageAlt,
         caption: gifImageAlt,
         longDescription: gifImageAlt,
+    },
+};
+
+export const GraphieImage: Story = {
+    decorators: [imageRendererDecorator],
+    args: {
+        backgroundImage: graphieImage,
+        alt: "Graphie image",
+        title: "Graphie image",
     },
 };

--- a/packages/perseus/src/widgets/image/__docs__/image-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/image/__docs__/image-interactions-regression.stories.tsx
@@ -135,20 +135,19 @@ export const ZoomClickedState: Story = {
     },
 };
 
-// TODO: Test flaky, commenting until it's fixed
-// export const ZoomClickedWithGraphieImage: Story = {
-//     decorators: [imageRendererDecorator],
-//     args: {
-//         backgroundImage: graphieImage,
-//         alt: "Graphie image",
-//     },
-//     play: async ({canvas, userEvent}) => {
-//         const zoomTrigger = canvas.getByRole("button", {
-//             name: "Make image bigger.",
-//         });
-//         await userEvent.click(zoomTrigger);
-//     },
-// };
+export const ZoomClickedWithGraphieImage: Story = {
+    decorators: [imageRendererDecorator],
+    args: {
+        backgroundImage: graphieImage,
+        alt: "Graphie image",
+    },
+    play: async ({canvas, userEvent}) => {
+        const zoomTrigger = canvas.getByRole("button", {
+            name: "Make image bigger.",
+        });
+        await userEvent.click(zoomTrigger);
+    },
+};
 
 export const ZoomClickedLargeImage: Story = {
     decorators: [imageRendererDecorator],


### PR DESCRIPTION
## Summary:
I did a deep dive with Mark and we figured out that the source of the flakiness
is coming from inconsistent span height, which was coming from fonts not having
been loaded yet.

To fix this, I'm adding a small timeout (5 milliseconds) to let the fonts load
before attempting to calculate the label margins.

Issue: https://khanacademy.atlassian.net/browse/LEMS-4053

## Test plan:
- check below for UI Test updates
- marginTop should be `-15.389285714285714` for all labels