### PR TITLE
Minor update to ensure the bg locale always uses CDOT for the multiplication symbol

### DIFF
--- a/.changeset/fast-glasses-buy.md
+++ b/.changeset/fast-glasses-buy.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Minor update to ensure the bg locale always uses CDOT for the multiplication symbol

--- a/packages/math-input/src/utils.ts
+++ b/packages/math-input/src/utils.ts
@@ -1,5 +1,6 @@
 const CDOT_ONLY = [
     "az",
+    "bg",
     "cs",
     "da",
     "de",


### PR DESCRIPTION
## Summary:
[bg-noise] Update our i18n math notation support

Issue: LEMS-4156

## Test plan:
- tests pass 