### PR TITLE
Resolve jittering in polygon graph

### DIFF
--- a/.changeset/polygon-mobile-drag-jump.md
+++ b/.changeset/polygon-mobile-drag-jump.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix jumping/drift when dragging an Interactive Graph polygon on mobile. The polygon now dispatches the anchor's absolute target position rather than a delta computed against potentially-stale render state (mirrors the MovableLine fix in #3493).

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -109,9 +109,8 @@ const PolygonGraph = (props: Props) => {
     const {dragging} = useDraggable({
         gestureTarget: polygonRef,
         point: dragReferencePoint,
-        onMove: (newPoint) => {
-            const delta = vec.sub(newPoint, dragReferencePoint);
-            dispatch(actions.polygon.moveAll(delta));
+        onMove: (newStart) => {
+            dispatch(actions.polygon.moveAll(newStart));
         },
         constrainKeyboardMovement: constrain,
     });

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-action.ts
@@ -235,12 +235,12 @@ function openPolygon(): OpenPolygon {
 export const MOVE_ALL = "move-all";
 export interface MoveAll {
     type: typeof MOVE_ALL;
-    delta: vec.Vector2;
+    newStart: vec.Vector2;
 }
-function moveAll(delta: vec.Vector2): MoveAll {
+function moveAll(newStart: vec.Vector2): MoveAll {
     return {
         type: MOVE_ALL,
-        delta,
+        newStart,
     };
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -418,28 +418,21 @@ function doMoveAll(
     action: MoveAll,
 ): InteractiveGraphState {
     const {snapStep, range} = state;
+    const {newStart} = action;
     switch (state.type) {
         case "polygon": {
-            let newCoords: vec.Vector2[];
-            if (state.snapTo === "sides" || state.snapTo === "angles") {
-                const change = getChange(state.coords, action.delta, {
-                    snapStep: [0, 0],
-                    range,
-                });
-
-                newCoords = state.coords.map((point: vec.Vector2) =>
-                    vec.add(point, change),
-                );
-            } else {
-                const change = getChange(state.coords, action.delta, {
-                    snapStep,
-                    range,
-                });
-
-                newCoords = state.coords.map((point: vec.Vector2) =>
-                    snap(snapStep, vec.add(point, change)),
-                );
-            }
+            const useGridSnap =
+                state.snapTo !== "sides" && state.snapTo !== "angles";
+            const desiredDelta = vec.sub(newStart, state.coords[0]);
+            const change = getChange(state.coords, desiredDelta, {
+                snapStep: useGridSnap ? snapStep : [0, 0],
+                range,
+            });
+            const newCoords = state.coords.map((point: vec.Vector2) =>
+                useGridSnap
+                    ? snap(snapStep, vec.add(point, change))
+                    : vec.add(point, change),
+            );
             return {
                 ...state,
                 hasBeenInteractedWith: true,
@@ -447,7 +440,6 @@ function doMoveAll(
             };
         }
         default:
-            // MoveAll is not supported for other state types; just ignore it.
             return state;
     }
 }


### PR DESCRIPTION
## Summary:
This PR resolves a _jitter bug_ in our Polygon graphs on mobile. :) The delta-based movement we were using results in an element jumping around sporadically during drag. 

The solution was to follow [the same fix that I applied for movable line earlier on](https://github.com/Khan/perseus/pull/3493).

Issue: LEMS-2820

## Video of fix:
https://github.com/user-attachments/assets/b97fbc1e-a1a5-4ce6-9417-a9438d5a2699

## Test plan:
- tests pass 
- manual testing in app 