### PR TITLE
Use the `numeric-input` scoring code to score `input-number` widgets.

### DIFF
--- a/.changeset/late-rivers-shave.md
+++ b/.changeset/late-rivers-shave.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-core": minor
+"@khanacademy/perseus-score": minor
+---
+
+Use the `numeric-input` scoring code to score `input-number` widgets. This changes behavior in only one case: when the input-number widget's answer is between 0 and 1 and the answerType is `"number"`, user inputs formatted as percentages are accepted as correct. Previously, percentage inputs were never accepted when answerType was `"number"`.

--- a/packages/perseus-core/src/validation.types.ts
+++ b/packages/perseus-core/src/validation.types.ts
@@ -44,7 +44,7 @@ import type {
     PerseusGraphCorrectType,
     MakeWidgetMap,
     PerseusFreeResponseWidgetScoringCriterion,
-    PerseusRenderer,
+    PerseusRenderer, PerseusInputNumberWidgetOptions,
 } from "./data-schema";
 import type {ErrorCode} from "./error-codes";
 import type {Relationship} from "./types";
@@ -256,79 +256,6 @@ export type PerseusIFrameUserInput = {
     status: UserInputStatus;
     /** An optional message from the iframe to display alongside the score. */
     message?: string | null;
-};
-
-/** Scoring rubric for the InputNumber widget. */
-export type PerseusInputNumberRubric = {
-    /**
-     * Constrains which numeric forms are accepted (ie. these don't change the
-     * correct numerical value - they only restrict which input representation
-     * the scorer accepts as valid).
-     *
-     * Defaults to "number" if unset.
-     *
-     *  - "number"   - Any standard numeric form: integer, decimal, proper
-     *                 fraction, improper fraction, or mixed number (note that
-     *                 "percent" and "pi" are _not_ included in this format).
-     *  - "decimal"  - Decimal notation only (e.g. 1.5)
-     *  - "integer"  - Whole numbers only (e.g. 3, -7)
-     *  - "rational" - Integer, proper fraction, improper fraction, or mixed
-     *                 number — but no decimals
-     *  - "improper" - Integer, proper or improper fraction — mixed numbers
-     *                 like 1 3/4 are rejected
-     *  - "mixed"    - Integer, proper fraction, or mixed number — standalone
-     *                 improper fractions are rejected
-     *  - "percent"  - All numeric forms plus percent notation (e.g. 50%); all
-     *                 number forms are accepted, but the % sign is required
-     *                 when entering the value as a percentage (e.g. 50%)
-     *                 rather than as the equivalent decimal (e.g. 0.5).
-     *  - "pi"       - Expressions involving π or τ (e.g. 3 pi, 5/6 pi, 2 \pi);
-     *                 the user must express the answer as a multiple of pi. 0
-     *                 is accepted literally since 0·π = 0. Decimal
-     *                 approximations within 0.01 of a multiple of π or τ are
-     *                 also accepted. Any fraction with 7 as the denominator
-     *                 (ie. `x/7`) is resolved to a numeric value and compared
-     *                 against the answer (approximating pi).
-     */
-    answerType?:
-        | "number"
-        | "decimal"
-        | "integer"
-        | "rational"
-        | "improper"
-        | "mixed"
-        | "percent"
-        | "pi";
-    /**
-     * When true, approximate answers within `maxError` of the correct
-     * value are accepted.
-     */
-    inexact?: boolean;
-    /**
-     * The maximum allowable deviation from the correct value when
-     * `inexact` is true.
-     *
-     * Legacy content encodes this number as a string (eg. "0.5"), encoding the
-     * values as the `number` type is preferred!
-     */
-    maxError?: number | string;
-    /**
-     * Controls how the scorer handles unsimplified fractions (e.g. 2/4
-     * instead of 1/2) when the numerical value is otherwise correct.
-     *
-     *  - "required"  - The unsimplified answer is treated as not yet
-     *                  submitted: the scorer returns an invalid/empty result
-     *                  with a "needs to be simplified" prompt, so the learner
-     *                  must simplify before their attempt is graded.
-     *  - "optional"  - Unsimplified fractions are accepted as fully correct;
-     *                  simplification is not checked.
-     *  - "enforced"  - Unsimplified fractions are scored as wrong (incorrect,
-     *                  not just unsubmitted), with a "needs to be simplified"
-     *                  message shown alongside the incorrect result.
-     */
-    simplify: "required" | "optional" | "enforced";
-    /** The correct answer value. */
-    value: string | number;
 };
 
 /** User input for the InputNumber widget. */
@@ -628,7 +555,8 @@ export interface RubricRegistry {
     "graded-group": PerseusGradedGroupRubric;
     grapher: PerseusGrapherRubric;
     group: PerseusGroupRubric;
-    "input-number": PerseusInputNumberRubric;
+    // TODO(LEMS-4085): change to PerseusNumericInputRubric;
+    "input-number": PerseusInputNumberWidgetOptions;
     "interactive-graph": PerseusInteractiveGraphRubric;
     "label-image": PerseusLabelImageRubric;
     matcher: PerseusMatcherRubric;

--- a/packages/perseus-core/src/validation.types.ts
+++ b/packages/perseus-core/src/validation.types.ts
@@ -44,7 +44,8 @@ import type {
     PerseusGraphCorrectType,
     MakeWidgetMap,
     PerseusFreeResponseWidgetScoringCriterion,
-    PerseusRenderer, PerseusInputNumberWidgetOptions,
+    PerseusRenderer,
+    PerseusInputNumberWidgetOptions,
 } from "./data-schema";
 import type {ErrorCode} from "./error-codes";
 import type {Relationship} from "./types";

--- a/packages/perseus-core/src/widgets/input-number/to-numeric-input.ts
+++ b/packages/perseus-core/src/widgets/input-number/to-numeric-input.ts
@@ -5,6 +5,8 @@ import type {
     PerseusNumericInputWidgetOptions,
 } from "../../data-schema";
 
+// TODO(LEMS-4085): move this function to the input-number widget parser; it
+//  should only be used there by the end of this project.
 export function convertInputNumberOptionsToNumericInput(
     inputNumberOptions: PerseusInputNumberWidgetOptions,
 ): PerseusNumericInputWidgetOptions {

--- a/packages/perseus-score/src/widgets/input-number/score-input-number.test.ts
+++ b/packages/perseus-score/src/widgets/input-number/score-input-number.test.ts
@@ -1,18 +1,20 @@
 import scoreInputNumber from "./score-input-number";
 
 import type {
-    PerseusInputNumberRubric,
+    PerseusInputNumberWidgetOptions,
     PerseusInputNumberUserInput,
 } from "@khanacademy/perseus-core";
 
+// TODO(LEMS-4085): Delete these tests; scoreInputNumber will be replaced by scoreNumericInput.
 describe("scoreInputNumber", () => {
     it("scores undefined user input as invalid", () => {
-        const rubric: PerseusInputNumberRubric = {
+        const rubric: PerseusInputNumberWidgetOptions = {
             maxError: 0.1,
             inexact: false,
             value: 1,
             simplify: "optional",
             answerType: "percent",
+            size: "normal",
         };
 
         const userInput = undefined;
@@ -23,12 +25,13 @@ describe("scoreInputNumber", () => {
     });
 
     it("scores correct answer correctly", () => {
-        const rubric: PerseusInputNumberRubric = {
+        const rubric: PerseusInputNumberWidgetOptions = {
             maxError: 0.1,
             inexact: false,
             value: 1,
             simplify: "optional",
             answerType: "percent",
+            size: "normal",
         };
 
         const useInput: PerseusInputNumberUserInput = {
@@ -41,12 +44,13 @@ describe("scoreInputNumber", () => {
     });
 
     it("scores incorrect answer correctly", () => {
-        const rubric: PerseusInputNumberRubric = {
+        const rubric: PerseusInputNumberWidgetOptions = {
             maxError: 0.1,
             inexact: false,
             value: 1,
             simplify: "optional",
             answerType: "percent",
+            size: "normal",
         };
 
         const useInput: PerseusInputNumberUserInput = {
@@ -59,12 +63,13 @@ describe("scoreInputNumber", () => {
     });
 
     it("shows as invalid with a nonsense answer", () => {
-        const rubric: PerseusInputNumberRubric = {
+        const rubric: PerseusInputNumberWidgetOptions = {
             maxError: 0.1,
             inexact: false,
             value: 1,
             simplify: "optional",
             answerType: "percent",
+            size: "normal",
         };
 
         const useInput: PerseusInputNumberUserInput = {
@@ -83,11 +88,12 @@ describe("scoreInputNumber", () => {
     // important to the test.
     // https://khanacademy.atlassian.net/browse/LC-691
     it("doesn't default to validating pi", () => {
-        const rubric: PerseusInputNumberRubric = {
+        const rubric: PerseusInputNumberWidgetOptions = {
             maxError: 0.1,
             inexact: false,
             value: 241.90263432641407,
             simplify: "required",
+            size: "normal",
         };
 
         const userInput: PerseusInputNumberUserInput = {
@@ -110,12 +116,13 @@ describe("scoreInputNumber", () => {
     });
 
     it("validates against pi if provided in answerType", () => {
-        const rubric: PerseusInputNumberRubric = {
+        const rubric: PerseusInputNumberWidgetOptions = {
             maxError: 0.1,
             inexact: false,
             value: 241.90263432641407,
             simplify: "required",
             answerType: "pi",
+            size: "normal",
         };
 
         const userInput: PerseusInputNumberUserInput = {
@@ -128,9 +135,10 @@ describe("scoreInputNumber", () => {
     });
 
     it("should handle invalid answers with no error callback", function () {
-        const rubric: PerseusInputNumberRubric = {
+        const rubric: PerseusInputNumberWidgetOptions = {
             value: "2^{-2}-3",
             simplify: "optional",
+            size: "normal",
         };
 
         const userInput: PerseusInputNumberUserInput = {currentValue: "x+1"};
@@ -144,12 +152,13 @@ describe("scoreInputNumber", () => {
     });
 
     it("should not consider commas as a decimal separator in the EN locale", () => {
-        const rubric: PerseusInputNumberRubric = {
+        const rubric: PerseusInputNumberWidgetOptions = {
             maxError: 0.1,
             inexact: false,
             value: 16,
             simplify: "optional",
             answerType: "number",
+            size: "normal",
         };
 
         const userInput: PerseusInputNumberUserInput = {
@@ -162,12 +171,13 @@ describe("scoreInputNumber", () => {
     });
 
     it("should reject European decimal format in EN locale", () => {
-        const rubric: PerseusInputNumberRubric = {
+        const rubric: PerseusInputNumberWidgetOptions = {
             maxError: 0.1,
             inexact: false,
             value: 16.5,
             simplify: "optional",
             answerType: "decimal",
+            size: "normal",
         };
 
         const userInput: PerseusInputNumberUserInput = {
@@ -182,12 +192,13 @@ describe("scoreInputNumber", () => {
     });
 
     it("should consider commas as the decimal separator in the FR locale", () => {
-        const rubric: PerseusInputNumberRubric = {
+        const rubric: PerseusInputNumberWidgetOptions = {
             maxError: 0.1,
             inexact: false,
             value: 16.5,
             simplify: "optional",
             answerType: "decimal",
+            size: "normal",
         };
 
         const userInput: PerseusInputNumberUserInput = {
@@ -201,12 +212,13 @@ describe("scoreInputNumber", () => {
     });
 
     it("should consider decimals as the thousands separator in FR locale", () => {
-        const rubric: PerseusInputNumberRubric = {
+        const rubric: PerseusInputNumberWidgetOptions = {
             maxError: 0.1,
             inexact: false,
             value: 16.5,
             simplify: "optional",
             answerType: "decimal",
+            size: "normal",
         };
 
         const userInput: PerseusInputNumberUserInput = {

--- a/packages/perseus-score/src/widgets/input-number/score-input-number.ts
+++ b/packages/perseus-score/src/widgets/input-number/score-input-number.ts
@@ -1,14 +1,8 @@
-import {getDecimalSeparator} from "@khanacademy/perseus-core";
+import type {PerseusInputNumberUserInput, PerseusScore,} from "@khanacademy/perseus-core";
+import {convertInputNumberOptionsToNumericInput, PerseusInputNumberWidgetOptions} from "@khanacademy/perseus-core";
+import {scoreNumericInput} from "@khanacademy/perseus-score";
 
-import KhanAnswerTypes from "../../util/answer-types";
-import {parseTex} from "../../util/tex-wrangler";
-
-import type {
-    PerseusInputNumberRubric,
-    PerseusInputNumberUserInput,
-    PerseusScore,
-} from "@khanacademy/perseus-core";
-
+// TODO(LEMS-4085): Delete inputNumberAnswerTypes.
 export const inputNumberAnswerTypes = {
     number: {
         name: "Numbers",
@@ -44,53 +38,17 @@ export const inputNumberAnswerTypes = {
     },
 } as const;
 
+// TODO(LEMS-4085): Delete; scoreInputNumber will be replaced by
+//  scoreNumericInput in the registry once the parser migrates input-number
+//  widget options to a numeric-input compatible form.
 function scoreInputNumber(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusInputNumberUserInput | undefined,
-    rubric: PerseusInputNumberRubric,
+    rubric: PerseusInputNumberWidgetOptions,
     locale?: string,
 ): PerseusScore {
-    if (userInput == null) {
-        return {type: "invalid", message: null};
-    }
-
-    if (rubric.answerType == null) {
-        rubric.answerType = "number";
-    }
-
-    // note(matthewc): this will get immediately parsed again by
-    // `KhanAnswerTypes.number.convertToPredicate`, but a string is
-    // expected here
-    const stringValue = `${rubric.value}`;
-    const val = KhanAnswerTypes.number.createValidatorFunctional(stringValue, {
-        simplify: rubric.simplify,
-        inexact: rubric.inexact || undefined,
-        maxError: rubric.maxError,
-        forms: inputNumberAnswerTypes[rubric.answerType].forms,
-        // Pass locale-specific decimal separator to ensure that
-        // we're properly parsing numbers according to the locale.
-        ...(locale && {decimal_separator: getDecimalSeparator(locale)}),
-    });
-
-    // We may have received TeX; try to parse it before grading.
-    // If `currentValue` is not TeX, this should be a no-op.
-    const currentValue = parseTex(userInput.currentValue);
-
-    const result = val(currentValue);
-
-    if (result.empty) {
-        return {
-            type: "invalid",
-            message: result.message,
-        };
-    }
-    return {
-        type: "points",
-        earned: result.correct ? 1 : 0,
-        total: 1,
-        message: result.message,
-    };
+    return scoreNumericInput(userInput, convertInputNumberOptionsToNumericInput(rubric), locale);
 }
 
 export default scoreInputNumber;

--- a/packages/perseus-score/src/widgets/input-number/score-input-number.ts
+++ b/packages/perseus-score/src/widgets/input-number/score-input-number.ts
@@ -1,6 +1,12 @@
-import type {PerseusInputNumberUserInput, PerseusScore,} from "@khanacademy/perseus-core";
-import {convertInputNumberOptionsToNumericInput, PerseusInputNumberWidgetOptions} from "@khanacademy/perseus-core";
-import {scoreNumericInput} from "@khanacademy/perseus-score";
+import {convertInputNumberOptionsToNumericInput} from "@khanacademy/perseus-core";
+
+import scoreNumericInput from "../numeric-input/score-numeric-input";
+
+import type {
+    PerseusInputNumberUserInput,
+    PerseusScore,
+    PerseusInputNumberWidgetOptions,
+} from "@khanacademy/perseus-core";
 
 // TODO(LEMS-4085): Delete inputNumberAnswerTypes.
 export const inputNumberAnswerTypes = {
@@ -48,7 +54,11 @@ function scoreInputNumber(
     rubric: PerseusInputNumberWidgetOptions,
     locale?: string,
 ): PerseusScore {
-    return scoreNumericInput(userInput, convertInputNumberOptionsToNumericInput(rubric), locale);
+    return scoreNumericInput(
+        userInput,
+        convertInputNumberOptionsToNumericInput(rubric),
+        locale,
+    );
 }
 
 export default scoreInputNumber;


### PR DESCRIPTION
## Summary:
This changes behavior in only one case: when the input-number widget's answer
is between 0 and 1 and the answerType is `"number"`, user inputs formatted as
percentages are accepted as correct. Previously, percentage inputs were never
accepted when answerType was `"number"`.

More information: https://khanacademy.slack.com/archives/C0B0ZG7T4AF/p1779485472979299

Issue: LEMS-4112

## Test plan:

Deploy to the perseus service. There should be no more side-by-side scoring
mismatches in the logs, since the scoring logic is now identical for
input-number and numeric-input.