### PR TITLE
 [Interactive Graph] PROTOTYPE: Opt-in visible point labels via showLabels

### DIFF
--- a/.changeset/odd-scissors-develop.md
+++ b/.changeset/odd-scissors-develop.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-core": minor
+---
+
+Add new JSON field "showLabels" for interactive graphs to auto label points

--- a/.changeset/odd-scissors-develop.md
+++ b/.changeset/odd-scissors-develop.md
@@ -3,4 +3,4 @@
 "@khanacademy/perseus-core": minor
 ---
 
-Add new JSON field "showLabels" for interactive graphs to auto label points
+Add new JSON field "showLabels" for interactive graphs. When set, every movable point gets a visible on-canvas label driven by the matching `pointLabels[i]` entry. `pointLabels` is required whenever `showLabels` is true (enforced by the interactive-graph-widget-error lint rule); the renderer never auto-generates fallback letters, so non-Latin-alphabet locales are unaffected.

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1157,6 +1157,12 @@ export type PerseusGraphTypeAngle = {
     startCoords?: [Coord, Coord, Coord];
     /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: [string, string, string];
+    /**
+     * When true, render a visible label (A, B, C, …) next to each interactive
+     * point on the graph. If `pointLabels[i]` is provided, that string is used
+     * instead of the auto-generated letter. Opt-in; defaults to off.
+     */
+    showLabels?: boolean;
 };
 
 export type PerseusGraphTypeCircle = {
@@ -1170,6 +1176,12 @@ export type PerseusGraphTypeCircle = {
     };
     /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
+    /**
+     * When true, render a visible label (A, B, C, …) next to each interactive
+     * point on the graph. If `pointLabels[i]` is provided, that string is used
+     * instead of the auto-generated letter. Opt-in; defaults to off.
+     */
+    showLabels?: boolean;
 };
 
 export type PerseusGraphTypeLinear = {
@@ -1180,6 +1192,12 @@ export type PerseusGraphTypeLinear = {
     startCoords?: CollinearTuple;
     /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: [string, string];
+    /**
+     * When true, render a visible label (A, B, C, …) next to each interactive
+     * point on the graph. If `pointLabels[i]` is provided, that string is used
+     * instead of the auto-generated letter. Opt-in; defaults to off.
+     */
+    showLabels?: boolean;
 };
 
 export type PerseusGraphTypeLinearSystem = {
@@ -1190,6 +1208,12 @@ export type PerseusGraphTypeLinearSystem = {
     startCoords?: CollinearTuple[];
     /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
+    /**
+     * When true, render a visible label (A, B, C, …) next to each interactive
+     * point on the graph. If `pointLabels[i]` is provided, that string is used
+     * instead of the auto-generated letter. Opt-in; defaults to off.
+     */
+    showLabels?: boolean;
 };
 
 export type PerseusGraphTypeNone = {
@@ -1210,6 +1234,12 @@ export type PerseusGraphTypePoint = {
     coord?: Coord;
     /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
+    /**
+     * When true, render a visible label (A, B, C, …) next to each interactive
+     * point on the graph. If `pointLabels[i]` is provided, that string is used
+     * instead of the auto-generated letter. Opt-in; defaults to off.
+     */
+    showLabels?: boolean;
 };
 
 export type PerseusGraphTypePolygon = {
@@ -1229,6 +1259,12 @@ export type PerseusGraphTypePolygon = {
     startCoords?: Coord[];
     /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
+    /**
+     * When true, render a visible label (A, B, C, …) next to each interactive
+     * point on the graph. If `pointLabels[i]` is provided, that string is used
+     * instead of the auto-generated letter. Opt-in; defaults to off.
+     */
+    showLabels?: boolean;
 };
 
 export type PerseusGraphTypeQuadratic = {
@@ -1239,6 +1275,12 @@ export type PerseusGraphTypeQuadratic = {
     startCoords?: [Coord, Coord, Coord];
     /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: [string, string, string];
+    /**
+     * When true, render a visible label (A, B, C, …) next to each interactive
+     * point on the graph. If `pointLabels[i]` is provided, that string is used
+     * instead of the auto-generated letter. Opt-in; defaults to off.
+     */
+    showLabels?: boolean;
 };
 
 export type PerseusGraphTypeSegment = {
@@ -1254,6 +1296,12 @@ export type PerseusGraphTypeSegment = {
     startCoords?: CollinearTuple[];
     /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
+    /**
+     * When true, render a visible label (A, B, C, …) next to each interactive
+     * point on the graph. If `pointLabels[i]` is provided, that string is used
+     * instead of the auto-generated letter. Opt-in; defaults to off.
+     */
+    showLabels?: boolean;
 };
 
 export type PerseusGraphTypeSinusoid = {
@@ -1264,6 +1312,12 @@ export type PerseusGraphTypeSinusoid = {
     startCoords?: Coord[];
     /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
+    /**
+     * When true, render a visible label (A, B, C, …) next to each interactive
+     * point on the graph. If `pointLabels[i]` is provided, that string is used
+     * instead of the auto-generated letter. Opt-in; defaults to off.
+     */
+    showLabels?: boolean;
 };
 
 export type PerseusGraphTypeTangent = {
@@ -1274,6 +1328,12 @@ export type PerseusGraphTypeTangent = {
     startCoords?: Coord[];
     /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
+    /**
+     * When true, render a visible label (A, B, C, …) next to each interactive
+     * point on the graph. If `pointLabels[i]` is provided, that string is used
+     * instead of the auto-generated letter. Opt-in; defaults to off.
+     */
+    showLabels?: boolean;
 };
 
 export type PerseusGraphTypeExponential = {
@@ -1289,6 +1349,12 @@ export type PerseusGraphTypeExponential = {
     startCoords?: {coords: [Coord, Coord]; asymptote: number};
     /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
+    /**
+     * When true, render a visible label (A, B, C, …) next to each interactive
+     * point on the graph. If `pointLabels[i]` is provided, that string is used
+     * instead of the auto-generated letter. Opt-in; defaults to off.
+     */
+    showLabels?: boolean;
 };
 
 export type PerseusGraphTypeLogarithm = {
@@ -1304,6 +1370,12 @@ export type PerseusGraphTypeLogarithm = {
     startCoords?: {coords: [Coord, Coord]; asymptote: number};
     /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
+    /**
+     * When true, render a visible label (A, B, C, …) next to each interactive
+     * point on the graph. If `pointLabels[i]` is provided, that string is used
+     * instead of the auto-generated letter. Opt-in; defaults to off.
+     */
+    showLabels?: boolean;
 };
 
 export type PerseusGraphTypeAbsoluteValue = {
@@ -1314,6 +1386,12 @@ export type PerseusGraphTypeAbsoluteValue = {
     startCoords?: [Coord, Coord];
     /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: [string, string];
+    /**
+     * When true, render a visible label (A, B, C, …) next to each interactive
+     * point on the graph. If `pointLabels[i]` is provided, that string is used
+     * instead of the auto-generated letter. Opt-in; defaults to off.
+     */
+    showLabels?: boolean;
 };
 
 export type PerseusGraphTypeRay = {
@@ -1324,6 +1402,12 @@ export type PerseusGraphTypeRay = {
     startCoords?: CollinearTuple;
     /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: [string, string];
+    /**
+     * When true, render a visible label (A, B, C, …) next to each interactive
+     * point on the graph. If `pointLabels[i]` is provided, that string is used
+     * instead of the auto-generated letter. Opt-in; defaults to off.
+     */
+    showLabels?: boolean;
 };
 
 export type PerseusGraphTypeVector = {

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -37,6 +37,7 @@ const parsePerseusGraphTypeAngle = object({
     coords: optional(trio(pairOfNumbers, pairOfNumbers, pairOfNumbers)),
     startCoords: optional(trio(pairOfNumbers, pairOfNumbers, pairOfNumbers)),
     pointLabels: optional(trio(string, string, string)),
+    showLabels: optional(boolean),
 });
 
 const parsePerseusGraphTypeCircle = object({
@@ -50,6 +51,7 @@ const parsePerseusGraphTypeCircle = object({
         }),
     ),
     pointLabels: optional(array(string)),
+    showLabels: optional(boolean),
 });
 
 const parsePerseusGraphTypeLinear = object({
@@ -57,6 +59,7 @@ const parsePerseusGraphTypeLinear = object({
     coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
     startCoords: optional(pair(pairOfNumbers, pairOfNumbers)),
     pointLabels: optional(pair(string, string)),
+    showLabels: optional(boolean),
 });
 
 const parsePerseusGraphTypeLinearSystem = object({
@@ -65,6 +68,7 @@ const parsePerseusGraphTypeLinearSystem = object({
     coords: optional(nullable(array(pair(pairOfNumbers, pairOfNumbers)))),
     startCoords: optional(array(pair(pairOfNumbers, pairOfNumbers))),
     pointLabels: optional(array(string)),
+    showLabels: optional(boolean),
 });
 
 const parsePerseusGraphTypeNone = object({
@@ -78,6 +82,7 @@ const parsePerseusGraphTypePoint = object({
     startCoords: optional(array(pairOfNumbers)),
     coord: optional(pairOfNumbers),
     pointLabels: optional(array(string)),
+    showLabels: optional(boolean),
 });
 
 const parsePerseusGraphTypePolygon = object({
@@ -90,6 +95,7 @@ const parsePerseusGraphTypePolygon = object({
     startCoords: optional(array(pairOfNumbers)),
     coords: optional(nullable(array(pairOfNumbers))),
     pointLabels: optional(array(string)),
+    showLabels: optional(boolean),
 });
 
 const parsePerseusGraphTypeQuadratic = object({
@@ -99,6 +105,7 @@ const parsePerseusGraphTypeQuadratic = object({
     ),
     startCoords: optional(trio(pairOfNumbers, pairOfNumbers, pairOfNumbers)),
     pointLabels: optional(trio(string, string, string)),
+    showLabels: optional(boolean),
 });
 
 const parsePerseusGraphTypeRay = object({
@@ -106,6 +113,7 @@ const parsePerseusGraphTypeRay = object({
     coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
     startCoords: optional(pair(pairOfNumbers, pairOfNumbers)),
     pointLabels: optional(pair(string, string)),
+    showLabels: optional(boolean),
 });
 
 const parsePerseusGraphTypeSegment = object({
@@ -115,6 +123,7 @@ const parsePerseusGraphTypeSegment = object({
     coords: optional(nullable(array(pair(pairOfNumbers, pairOfNumbers)))),
     startCoords: optional(array(pair(pairOfNumbers, pairOfNumbers))),
     pointLabels: optional(array(string)),
+    showLabels: optional(boolean),
 });
 
 const parsePerseusGraphTypeSinusoid = object({
@@ -122,6 +131,7 @@ const parsePerseusGraphTypeSinusoid = object({
     coords: optional(nullable(array(pairOfNumbers))),
     startCoords: optional(array(pairOfNumbers)),
     pointLabels: optional(array(string)),
+    showLabels: optional(boolean),
 });
 
 const parsePerseusGraphTypeExponential = object({
@@ -135,6 +145,7 @@ const parsePerseusGraphTypeExponential = object({
         }),
     ),
     pointLabels: optional(array(string)),
+    showLabels: optional(boolean),
 });
 
 const parsePerseusGraphTypeAbsoluteValue = object({
@@ -142,6 +153,7 @@ const parsePerseusGraphTypeAbsoluteValue = object({
     coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
     startCoords: optional(pair(pairOfNumbers, pairOfNumbers)),
     pointLabels: optional(pair(string, string)),
+    showLabels: optional(boolean),
 });
 
 const parsePerseusGraphTypeTangent = object({
@@ -149,6 +161,7 @@ const parsePerseusGraphTypeTangent = object({
     coords: optional(nullable(array(pairOfNumbers))),
     startCoords: optional(array(pairOfNumbers)),
     pointLabels: optional(array(string)),
+    showLabels: optional(boolean),
 });
 
 const parsePerseusGraphTypeLogarithm = object({
@@ -162,6 +175,7 @@ const parsePerseusGraphTypeLogarithm = object({
         }),
     ),
     pointLabels: optional(array(string)),
+    showLabels: optional(boolean),
 });
 
 const parsePerseusGraphTypeVector = object({

--- a/packages/perseus-linter/src/rules/interactive-graph-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/interactive-graph-widget-error.test.ts
@@ -131,6 +131,78 @@ describe("interactive-graph-widget-error", () => {
         },
     );
 
+    // Error when showLabels is true but pointLabels is missing
+    expectWarning(
+        interactiveGraphWidgetErrorRule,
+        "[[☃ interactive-graph 1]]",
+        {
+            widgets: {
+                "interactive-graph 1": generateInteractiveGraphWidget({
+                    options: generateInteractiveGraphOptions({
+                        correct: generateIGPolygonGraph({
+                            showLabels: true,
+                        }),
+                    }),
+                }),
+            },
+        },
+        {
+            message:
+                "showLabels is true but pointLabels is missing. Provide a label for every point.",
+            severity: Rule.Severity.ERROR,
+        },
+    );
+
+    // Error when showLabels is true but pointLabels has an empty entry
+    expectWarning(
+        interactiveGraphWidgetErrorRule,
+        "[[☃ interactive-graph 1]]",
+        {
+            widgets: {
+                "interactive-graph 1": generateInteractiveGraphWidget({
+                    options: generateInteractiveGraphOptions({
+                        correct: generateIGPolygonGraph({
+                            showLabels: true,
+                            pointLabels: ["A", "", "C"],
+                        }),
+                    }),
+                }),
+            },
+        },
+        {
+            message:
+                "showLabels is true but pointLabels has empty entries. Provide a label for every point.",
+            severity: Rule.Severity.ERROR,
+        },
+    );
+
+    // Pass when showLabels is true and pointLabels is fully provided
+    expectPass(interactiveGraphWidgetErrorRule, "[[☃ interactive-graph 1]]", {
+        widgets: {
+            "interactive-graph 1": generateInteractiveGraphWidget({
+                options: generateInteractiveGraphOptions({
+                    correct: generateIGPolygonGraph({
+                        showLabels: true,
+                        pointLabels: ["A", "B", "C"],
+                    }),
+                }),
+            }),
+        },
+    });
+
+    // Pass when showLabels is false (no requirement on pointLabels)
+    expectPass(interactiveGraphWidgetErrorRule, "[[☃ interactive-graph 1]]", {
+        widgets: {
+            "interactive-graph 1": generateInteractiveGraphWidget({
+                options: generateInteractiveGraphOptions({
+                    correct: generateIGPolygonGraph({
+                        showLabels: false,
+                    }),
+                }),
+            }),
+        },
+    });
+
     // Pass when no errors are detected
     expectPass(interactiveGraphWidgetErrorRule, "[[☃ interactive-graph 1]]", {
         widgets: {

--- a/packages/perseus-linter/src/rules/interactive-graph-widget-error.ts
+++ b/packages/perseus-linter/src/rules/interactive-graph-widget-error.ts
@@ -84,7 +84,40 @@ export default Rule.makeRule({
             }
         }
 
+        // showLabels requires pointLabels. We refuse to auto-generate
+        // fallback letters (A, B, C, …) at render time because those leak
+        // Latin characters into non-Latin-alphabet locales — so the
+        // author must spell every label out.
+        checkShowLabelsHasLabels(graph, issues);
+        checkShowLabelsHasLabels(correct, issues);
+
         const allIssuesString = issues.join("\n\n");
         return allIssuesString;
     },
 }) as Rule;
+
+function checkShowLabelsHasLabels(
+    g:
+        | {type: string; showLabels?: boolean; pointLabels?: readonly string[]}
+        | undefined,
+    issues: Array<string>,
+) {
+    if (g == null || g.type === "none" || g.type === "vector") {
+        return;
+    }
+    if (g.showLabels !== true) {
+        return;
+    }
+    const labels = g.pointLabels;
+    if (labels == null || labels.length === 0) {
+        issues.push(
+            "showLabels is true but pointLabels is missing. Provide a label for every point.",
+        );
+        return;
+    }
+    if (labels.some((l) => l == null || l === "")) {
+        issues.push(
+            "showLabels is true but pointLabels has empty entries. Provide a label for every point.",
+        );
+    }
+}

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
@@ -10,10 +10,13 @@ import {
     linearSystemWithCustomLabelsQuestion,
     linearWithCustomLabelsQuestion,
     pointQuestion,
+    pointWithAutoVisibleLabelsQuestion,
     pointWithCustomLabelQuestion,
+    pointWithCustomVisibleLabelsQuestion,
     pointWithDefaultLabelQuestion,
     polygonQuestion,
     polygonWithCustomLabelsQuestion,
+    polygonWithVisibleLabelsQuestion,
     rayQuestion,
     rayWithCustomLabelsQuestion,
     segmentQuestion,
@@ -185,6 +188,34 @@ export const PointWithDefaultLabel: Story = {
     },
 };
 
+/**
+ * A point graph with `showLabels: true` and no `pointLabels`. The three
+ * interactive points are auto-labelled "A", "B", "C" on the canvas — labels
+ * track each point as the learner drags it. Demonstrates the opt-in
+ * visible-labels behaviour with zero authoring overhead.
+ */
+export const PointWithAutoVisibleLabels: Story = {
+    args: {
+        item: generateTestPerseusItem({
+            question: pointWithAutoVisibleLabelsQuestion,
+        }),
+    },
+};
+
+/**
+ * A point graph with both `showLabels: true` AND author-supplied
+ * `pointLabels: ["P", "Q", "R"]`. The custom strings win over the
+ * auto A/B/C fallback, so the visible labels on the canvas match the
+ * names in the prompt exactly.
+ */
+export const PointWithCustomVisibleLabels: Story = {
+    args: {
+        item: generateTestPerseusItem({
+            question: pointWithCustomVisibleLabelsQuestion,
+        }),
+    },
+};
+
 export const Polygon: Story = {
     args: {
         item: generateTestPerseusItem({question: polygonQuestion}),
@@ -202,6 +233,23 @@ export const PolygonWithCustomLabels: Story = {
     args: {
         item: generateTestPerseusItem({
             question: polygonWithCustomLabelsQuestion,
+        }),
+    },
+};
+
+/**
+ * A polygon graph with `showLabels: true` and no `pointLabels`. Each vertex
+ * is auto-labelled "A", "B", "C", "D" on the canvas — visible to sighted
+ * learners and reflected in the screen-reader announcement
+ * ("Point A / B / C / D at …"). Demonstrates that the `showLabels` opt-in
+ * works for non-`point` graph types via the shared `getEffectivePointLabels`
+ * helper. Pair this with `PointWithAutoVisibleLabels` to verify the
+ * cross-type wiring.
+ */
+export const PolygonWithVisibleLabels: Story = {
+    args: {
+        item: generateTestPerseusItem({
+            question: polygonWithVisibleLabelsQuestion,
         }),
     },
 };

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
@@ -10,10 +10,9 @@ import {
     linearSystemWithCustomLabelsQuestion,
     linearWithCustomLabelsQuestion,
     pointQuestion,
-    pointWithAutoVisibleLabelsQuestion,
     pointWithCustomLabelQuestion,
-    pointWithCustomVisibleLabelsQuestion,
     pointWithDefaultLabelQuestion,
+    pointWithVisibleLabelsQuestion,
     polygonQuestion,
     polygonWithCustomLabelsQuestion,
     polygonWithVisibleLabelsQuestion,
@@ -189,29 +188,18 @@ export const PointWithDefaultLabel: Story = {
 };
 
 /**
- * A point graph with `showLabels: true` and no `pointLabels`. The three
- * interactive points are auto-labelled "A", "B", "C" on the canvas — labels
- * track each point as the learner drags it. Demonstrates the opt-in
- * visible-labels behaviour with zero authoring overhead.
+ * A point graph with `showLabels: true` and author-supplied
+ * `pointLabels: ["P", "Q", "R"]`. The same per-index string drives both
+ * the visible on-canvas label and the screen-reader announcement, so the
+ * two stay in sync. `showLabels` always requires `pointLabels` — the
+ * interactive-graph-widget-error lint rule blocks the combination
+ * `showLabels: true` without `pointLabels` at authoring time, so
+ * non-Latin locales never see auto-generated Latin letters.
  */
-export const PointWithAutoVisibleLabels: Story = {
+export const PointWithVisibleLabels: Story = {
     args: {
         item: generateTestPerseusItem({
-            question: pointWithAutoVisibleLabelsQuestion,
-        }),
-    },
-};
-
-/**
- * A point graph with both `showLabels: true` AND author-supplied
- * `pointLabels: ["P", "Q", "R"]`. The custom strings win over the
- * auto A/B/C fallback, so the visible labels on the canvas match the
- * names in the prompt exactly.
- */
-export const PointWithCustomVisibleLabels: Story = {
-    args: {
-        item: generateTestPerseusItem({
-            question: pointWithCustomVisibleLabelsQuestion,
+            question: pointWithVisibleLabelsQuestion,
         }),
     },
 };
@@ -238,13 +226,12 @@ export const PolygonWithCustomLabels: Story = {
 };
 
 /**
- * A polygon graph with `showLabels: true` and no `pointLabels`. Each vertex
- * is auto-labelled "A", "B", "C", "D" on the canvas — visible to sighted
- * learners and reflected in the screen-reader announcement
- * ("Point A / B / C / D at …"). Demonstrates that the `showLabels` opt-in
- * works for non-`point` graph types via the shared `getEffectivePointLabels`
- * helper. Pair this with `PointWithAutoVisibleLabels` to verify the
- * cross-type wiring.
+ * A polygon graph with `showLabels: true` and author-supplied
+ * `pointLabels: ["A", "B", "C", "D"]`. Each vertex carries its assigned
+ * letter as both the visible on-canvas label and the screen-reader
+ * announcement ("Point A / B / C / D at …"). Demonstrates that the
+ * `showLabels` opt-in works for non-`point` graph types via the same
+ * per-index plumbing.
  */
 export const PolygonWithVisibleLabels: Story = {
     args: {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/absolute-value.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/absolute-value.tsx
@@ -6,6 +6,7 @@ import {
     type I18nContextType,
 } from "../../../components/i18n-context";
 import {X, Y} from "../math/coordinates";
+import {getEffectivePointLabels} from "../point-labels";
 import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 
@@ -46,8 +47,13 @@ function AbsoluteValueGraph(props: AbsoluteValueGraphProps) {
     const id = React.useId();
     const descriptionId = id + "-description";
 
-    const {coords, pointLabels, snapStep} = graphState;
-    const buildLabel = usePointAriaLabel(pointLabels);
+    const {coords, pointLabels, showLabels, snapStep} = graphState;
+    const effectiveLabels = getEffectivePointLabels(
+        showLabels,
+        pointLabels,
+        coords.length,
+    );
+    const buildLabel = usePointAriaLabel(effectiveLabels);
 
     // Cache last valid coefficients to protect against transient invalid
     // states that can occur mid-drag (e.g., both points on the same x).
@@ -97,6 +103,7 @@ function AbsoluteValueGraph(props: AbsoluteValueGraphProps) {
                         snapStep,
                         i,
                     )}
+                    label={showLabels ? effectiveLabels?.[i] : undefined}
                     onMove={(destination) =>
                         dispatch(
                             actions.absoluteValue.movePoint(i, destination),

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/angle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/angle.tsx
@@ -5,6 +5,7 @@ import * as React from "react";
 import {usePerseusI18n} from "../../../components/i18n-context";
 import {X, Y} from "../math";
 import {findIntersectionOfRays} from "../math/geometry";
+import {getEffectivePointLabels} from "../point-labels";
 import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 
@@ -54,6 +55,7 @@ function AngleGraph(props: AngleGraphProps) {
     const {
         coords,
         pointLabels,
+        showLabels,
         showAngles,
         range,
         allowReflexAngles,
@@ -63,7 +65,12 @@ function AngleGraph(props: AngleGraphProps) {
     // [2]=starting side. The MovablePoints below are rendered in a
     // different order (vertex first), so each call site indexes pointLabels
     // by the coords slot it is bound to.
-    const buildLabel = usePointAriaLabel(pointLabels);
+    const effectiveLabels = getEffectivePointLabels(
+        showLabels,
+        pointLabels,
+        coords.length,
+    );
+    const buildLabel = usePointAriaLabel(effectiveLabels);
 
     // Break the coords into the two end points and the center point
     const endPoints: [vec.Vector2, vec.Vector2] = [coords[0], coords[2]];
@@ -143,6 +150,7 @@ function AngleGraph(props: AngleGraphProps) {
                     dispatch(actions.angle.movePoint(1, destination))
                 }
                 ariaLabel={buildLabel(1, coords[1]) ?? srAngleVertex}
+                label={showLabels ? effectiveLabels?.[1] : undefined}
                 // Move announcements come from the WB Announcer via
                 // stateAnnouncement; disable aria-live here to avoid
                 // the focusable handle double-announcing.
@@ -163,6 +171,7 @@ function AngleGraph(props: AngleGraphProps) {
                     dispatch(actions.angle.movePoint(0, destination))
                 }
                 ariaLabel={buildLabel(0, coords[0]) ?? srAngleEndingSide}
+                label={showLabels ? effectiveLabels?.[0] : undefined}
                 // Move announcements come from the WB Announcer via
                 // stateAnnouncement; disable aria-live here to avoid
                 // the focusable handle double-announcing.
@@ -183,6 +192,7 @@ function AngleGraph(props: AngleGraphProps) {
                     dispatch(actions.angle.movePoint(2, destination))
                 }
                 ariaLabel={buildLabel(2, coords[2]) ?? srAngleStartingSide}
+                label={showLabels ? effectiveLabels?.[2] : undefined}
                 // Move announcements come from the WB Announcer via
                 // stateAnnouncement; disable aria-live here to avoid
                 // the focusable handle double-announcing.

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/angle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/angle.tsx
@@ -150,7 +150,6 @@ function AngleGraph(props: AngleGraphProps) {
                     dispatch(actions.angle.movePoint(1, destination))
                 }
                 ariaLabel={buildLabel(1, coords[1]) ?? srAngleVertex}
-                label={showLabels ? effectiveLabels?.[1] : undefined}
                 // Move announcements come from the WB Announcer via
                 // stateAnnouncement; disable aria-live here to avoid
                 // the focusable handle double-announcing.
@@ -171,7 +170,6 @@ function AngleGraph(props: AngleGraphProps) {
                     dispatch(actions.angle.movePoint(0, destination))
                 }
                 ariaLabel={buildLabel(0, coords[0]) ?? srAngleEndingSide}
-                label={showLabels ? effectiveLabels?.[0] : undefined}
                 // Move announcements come from the WB Announcer via
                 // stateAnnouncement; disable aria-live here to avoid
                 // the focusable handle double-announcing.
@@ -192,7 +190,6 @@ function AngleGraph(props: AngleGraphProps) {
                     dispatch(actions.angle.movePoint(2, destination))
                 }
                 ariaLabel={buildLabel(2, coords[2]) ?? srAngleStartingSide}
-                label={showLabels ? effectiveLabels?.[2] : undefined}
                 // Move announcements come from the WB Announcer via
                 // stateAnnouncement; disable aria-live here to avoid
                 // the focusable handle double-announcing.

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -4,6 +4,7 @@ import {useRef} from "react";
 
 import {usePerseusI18n} from "../../../components/i18n-context";
 import {snap, X, Y} from "../math";
+import {getEffectivePointLabels} from "../point-labels";
 import {actions} from "../reducer/interactive-graph-action";
 import {getRadius} from "../reducer/interactive-graph-state";
 import useGraphConfig from "../reducer/use-graph-config";
@@ -48,10 +49,14 @@ type CircleGraphProps = MafsGraphProps<CircleGraphState>;
 // Exported for testing
 export function CircleGraph(props: CircleGraphProps) {
     const {dispatch, graphState} = props;
-    const {center, pointLabels, radiusPoint, snapStep} = graphState;
+    const {center, pointLabels, showLabels, radiusPoint, snapStep} = graphState;
 
     const {strings, locale} = usePerseusI18n();
-    const buildLabel = usePointAriaLabel(pointLabels);
+    // Circle only has one labelable point (the radius point at index 0); the
+    // center is a MovableCircle, not a MovablePoint, and is intentionally not
+    // overridden — see MovablePoint's ariaLabel below.
+    const effectiveLabels = getEffectivePointLabels(showLabels, pointLabels, 1);
+    const buildLabel = usePointAriaLabel(effectiveLabels);
 
     const radius = getRadius(graphState);
     const id = React.useId();
@@ -101,6 +106,7 @@ export function CircleGraph(props: CircleGraphProps) {
                 ariaDescribedBy={`${outerPointsId}`}
                 point={radiusPoint}
                 sequenceNumber={1}
+                label={showLabels ? effectiveLabels?.[0] : undefined}
                 cursor="ew-resize"
                 onMove={(newRadiusPoint) => {
                     dispatch(actions.circle.moveRadiusPoint(newRadiusPoint));

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -106,7 +106,6 @@ export function CircleGraph(props: CircleGraphProps) {
                 ariaDescribedBy={`${outerPointsId}`}
                 point={radiusPoint}
                 sequenceNumber={1}
-                label={showLabels ? effectiveLabels?.[0] : undefined}
                 cursor="ew-resize"
                 onMove={(newRadiusPoint) => {
                     dispatch(actions.circle.moveRadiusPoint(newRadiusPoint));

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -35,6 +35,14 @@ type Props = {
         start: boolean;
         end: boolean;
     };
+    /**
+     * Visible on-canvas labels for the two endpoints, indexed [start, end].
+     * Each entry is forwarded to the corresponding endpoint's `useControlPoint`;
+     * undefined/empty entries render no label. See `point-labels.ts`.
+     */
+    pointLabels?: Readonly<
+        [start: string | undefined, end: string | undefined]
+    >;
     onMovePoint?: (endpointIndex: number, destination: vec.Vector2) => unknown;
     onMoveLine?: (newStart: vec.Vector2) => unknown;
 };
@@ -46,6 +54,7 @@ export const MovableLine = (props: Props) => {
         ariaDescribedBy,
         ariaLive,
         extend,
+        pointLabels,
         onMoveLine = () => {},
         onMovePoint = () => {},
     } = props;
@@ -86,6 +95,7 @@ export const MovableLine = (props: Props) => {
             ariaLive: point1AriaLive,
             point: start,
             sequenceNumber: 1,
+            label: pointLabels?.[0],
             onMove: (p) => {
                 setAriaLives(["polite", "off", "off"]);
                 onMovePoint(0, p);
@@ -103,6 +113,7 @@ export const MovableLine = (props: Props) => {
             ariaLive: point2AriaLive,
             point: end,
             sequenceNumber: 2,
+            label: pointLabels?.[1],
             onMove: (p) => {
                 setAriaLives(["off", "polite", "off"]);
                 onMovePoint(1, p);

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -36,9 +36,11 @@ type Props = {
         end: boolean;
     };
     /**
-     * Visible on-canvas labels for the two endpoints, indexed [start, end].
-     * Each entry is forwarded to the corresponding endpoint's `useControlPoint`;
-     * undefined/empty entries render no label. See `point-labels.ts`.
+     * Accepted for compatibility with PR-4-series graphs still wired
+     * against the old prop. Visible labels now render via
+     * `MovablePointLabelsLayer`, which reads coords + label text from
+     * the reducer state. Not forwarded to either endpoint; has no
+     * rendering effect.
      */
     pointLabels?: Readonly<
         [start: string | undefined, end: string | undefined]
@@ -54,7 +56,6 @@ export const MovableLine = (props: Props) => {
         ariaDescribedBy,
         ariaLive,
         extend,
-        pointLabels,
         onMoveLine = () => {},
         onMovePoint = () => {},
     } = props;
@@ -95,7 +96,6 @@ export const MovableLine = (props: Props) => {
             ariaLive: point1AriaLive,
             point: start,
             sequenceNumber: 1,
-            label: pointLabels?.[0],
             onMove: (p) => {
                 setAriaLives(["polite", "off", "off"]);
                 onMovePoint(0, p);
@@ -113,7 +113,6 @@ export const MovableLine = (props: Props) => {
             ariaLive: point2AriaLive,
             point: end,
             sequenceNumber: 2,
-            label: pointLabels?.[1],
             onMove: (p) => {
                 setAriaLives(["off", "polite", "off"]);
                 onMovePoint(1, p);

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.test.tsx
@@ -371,75 +371,11 @@ describe("MovablePoint", () => {
         expect(focusSpy).toHaveBeenCalled();
     });
 
-    describe("visible label", () => {
-        it("does NOT render a label when `label` prop is omitted", () => {
-            // Arrange, Act
-            mockGraphConfig(baseGraphConfigContext);
-            render(
-                <Mafs width={200} height={200}>
-                    <MovablePoint point={[0, 0]} sequenceNumber={1} />
-                </Mafs>,
-            );
-
-            // Assert
-            expect(screen.queryByText("A")).not.toBeInTheDocument();
-        });
-
-        it("renders the provided label next to the point", () => {
-            // Arrange, Act
-            mockGraphConfig(baseGraphConfigContext);
-            render(
-                <Mafs width={200} height={200}>
-                    <MovablePoint point={[0, 0]} sequenceNumber={1} label="A" />
-                </Mafs>,
-            );
-
-            // Assert
-            expect(screen.getByText("A")).toBeInTheDocument();
-        });
-
-        it("hides the visible label from the a11y tree to avoid double-announcing alongside the button's aria-label", () => {
-            // Arrange, Act
-            mockGraphConfig(baseGraphConfigContext);
-            render(
-                <Mafs width={200} height={200}>
-                    <MovablePoint point={[0, 0]} sequenceNumber={1} label="A" />
-                </Mafs>,
-            );
-
-            // Assert
-            expect(
-                screen.getByTestId("movable-point__visible-label"),
-            ).toHaveAttribute("aria-hidden", "true");
-        });
-
-        it("renders an author-supplied label string verbatim", () => {
-            // Arrange, Act
-            mockGraphConfig(baseGraphConfigContext);
-            render(
-                <Mafs width={200} height={200}>
-                    <MovablePoint point={[0, 0]} sequenceNumber={1} label="P" />
-                </Mafs>,
-            );
-
-            // Assert
-            expect(screen.getByText("P")).toBeInTheDocument();
-        });
-
-        it("does NOT render a label when `label` is the empty string", () => {
-            // Arrange, Act
-            mockGraphConfig(baseGraphConfigContext);
-            const {container} = render(
-                <Mafs width={200} height={200}>
-                    <MovablePoint point={[0, 0]} sequenceNumber={1} label="" />
-                </Mafs>,
-            );
-
-            // Assert: no <text> element was emitted by the TextLabel.
-            // eslint-disable-next-line testing-library/no-container,testing-library/no-node-access
-            expect(container.querySelectorAll("text")).toHaveLength(0);
-        });
-    });
+    // Visible labels no longer render inside `MovablePoint`. The
+    // `MovablePointLabelsLayer` component now renders them in an HTML
+    // overlay, sourced from reducer state, so it can use TeX. See
+    // `movable-point-labels-layer.test.tsx` and
+    // `movable-point-labels.test.ts` for the replacement coverage.
 
     describe("accessibility", () => {
         it("uses the default sequence number when ariaLabel and sequence number are not provided", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.test.tsx
@@ -371,6 +371,76 @@ describe("MovablePoint", () => {
         expect(focusSpy).toHaveBeenCalled();
     });
 
+    describe("visible label", () => {
+        it("does NOT render a label when `label` prop is omitted", () => {
+            // Arrange, Act
+            mockGraphConfig(baseGraphConfigContext);
+            render(
+                <Mafs width={200} height={200}>
+                    <MovablePoint point={[0, 0]} sequenceNumber={1} />
+                </Mafs>,
+            );
+
+            // Assert
+            expect(screen.queryByText("A")).not.toBeInTheDocument();
+        });
+
+        it("renders the provided label next to the point", () => {
+            // Arrange, Act
+            mockGraphConfig(baseGraphConfigContext);
+            render(
+                <Mafs width={200} height={200}>
+                    <MovablePoint point={[0, 0]} sequenceNumber={1} label="A" />
+                </Mafs>,
+            );
+
+            // Assert
+            expect(screen.getByText("A")).toBeInTheDocument();
+        });
+
+        it("hides the visible label from the a11y tree to avoid double-announcing alongside the button's aria-label", () => {
+            // Arrange, Act
+            mockGraphConfig(baseGraphConfigContext);
+            render(
+                <Mafs width={200} height={200}>
+                    <MovablePoint point={[0, 0]} sequenceNumber={1} label="A" />
+                </Mafs>,
+            );
+
+            // Assert
+            expect(
+                screen.getByTestId("movable-point__visible-label"),
+            ).toHaveAttribute("aria-hidden", "true");
+        });
+
+        it("renders an author-supplied label string verbatim", () => {
+            // Arrange, Act
+            mockGraphConfig(baseGraphConfigContext);
+            render(
+                <Mafs width={200} height={200}>
+                    <MovablePoint point={[0, 0]} sequenceNumber={1} label="P" />
+                </Mafs>,
+            );
+
+            // Assert
+            expect(screen.getByText("P")).toBeInTheDocument();
+        });
+
+        it("does NOT render a label when `label` is the empty string", () => {
+            // Arrange, Act
+            mockGraphConfig(baseGraphConfigContext);
+            const {container} = render(
+                <Mafs width={200} height={200}>
+                    <MovablePoint point={[0, 0]} sequenceNumber={1} label="" />
+                </Mafs>,
+            );
+
+            // Assert: no <text> element was emitted by the TextLabel.
+            // eslint-disable-next-line testing-library/no-container,testing-library/no-node-access
+            expect(container.querySelectorAll("text")).toHaveLength(0);
+        });
+    });
+
     describe("accessibility", () => {
         it("uses the default sequence number when ariaLabel and sequence number are not provided", () => {
             render(

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -26,6 +26,11 @@ type Props = {
      * interactive figure on the graph.
      */
     sequenceNumber?: number;
+    /**
+     * Visible text label rendered next to the point (e.g. "A", "B", "T").
+     * When omitted, no label is drawn.
+     */
+    label?: string;
     onBlur?: (event: React.FocusEvent) => unknown;
     onClick?: () => unknown;
     onDragStart?: () => unknown;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -27,8 +27,11 @@ type Props = {
      */
     sequenceNumber?: number;
     /**
-     * Visible text label rendered next to the point (e.g. "A", "B", "T").
-     * When omitted, no label is drawn.
+     * Accepted for compatibility with PR-4-series graphs still wired
+     * against the old prop. Visible labels now render via
+     * `MovablePointLabelsLayer`, which reads coords + label text from
+     * the reducer state. This prop is intentionally not forwarded to
+     * `useControlPoint` and has no rendering effect.
      */
     label?: string;
     onBlur?: (event: React.FocusEvent) => unknown;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -1,3 +1,5 @@
+import {font, semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {Text} from "mafs";
 import * as React from "react";
 import {useState, useRef, useLayoutEffect} from "react";
 
@@ -8,7 +10,6 @@ import {srFormatNumber} from "../screenreader-text";
 import {useDraggable} from "../use-draggable";
 
 import {MovablePointView} from "./movable-point-view";
-import {TextLabel} from "./text-label";
 
 import type {CSSCursor} from "./css-cursor";
 import type {AriaLive} from "../../types";
@@ -162,18 +163,57 @@ export function useControlPoint(params: Params): Return {
                 // The visible label is purely decorative; the focusable handle
                 // above already carries the equivalent text in its aria-label,
                 // so we hide this from the a11y tree to avoid double-announce.
+                //
+                // The inline <defs> below is intentional. The shared
+                // `text-label.tsx` filter is a translucent rectangle backdrop,
+                // and its <defs> sit in a different <Mafs> than the one this
+                // label renders in (so the reference wouldn't resolve anyway).
+                // We add a dilated-stroke knockout filter — the same shape
+                // Matthew used for LockedLabel — scoped to this label only so
+                // the existing angle/side labels keep their current look.
                 <g
                     aria-hidden="true"
                     data-testid="movable-point__visible-label"
                 >
-                    <TextLabel
+                    <defs>
+                        <filter id="movable-point-label-knockout">
+                            <feMorphology
+                                operator="dilate"
+                                radius="2"
+                                in="SourceGraphic"
+                                result="expanded"
+                            />
+                            <feFlood
+                                floodColor={
+                                    semanticColor.core.border.knockout.default
+                                }
+                                result="flood"
+                            />
+                            <feComposite
+                                in="flood"
+                                in2="expanded"
+                                operator="in"
+                                result="outline"
+                            />
+                            <feMerge>
+                                <feMergeNode in="outline" />
+                                <feMergeNode in="SourceGraphic" />
+                            </feMerge>
+                        </filter>
+                    </defs>
+                    <Text
                         x={point[X]}
                         y={point[Y]}
                         attach="ne"
-                        attachDistance={12}
+                        attachDistance={24}
+                        size={16}
+                        svgTextProps={{
+                            filter: "url(#movable-point-label-knockout)",
+                            fontWeight: font.weight.bold,
+                        }}
                     >
                         {label}
-                    </TextLabel>
+                    </Text>
                 </g>
             )}
         </>

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -8,6 +8,7 @@ import {srFormatNumber} from "../screenreader-text";
 import {useDraggable} from "../use-draggable";
 
 import {MovablePointView} from "./movable-point-view";
+import {TextLabel} from "./text-label";
 
 import type {CSSCursor} from "./css-cursor";
 import type {AriaLive} from "../../types";
@@ -138,18 +139,29 @@ export function useControlPoint(params: Params): Return {
         />
     );
     const visiblePoint = (
-        <MovablePointView
-            cursor={cursor}
-            onClick={() => {
-                onClick();
-                focusableHandleRef.current?.focus();
-            }}
-            point={point}
-            dragging={dragging}
-            focused={focused}
-            ref={visiblePointRef}
-            showFocusRing={focused}
-        />
+        <>
+            <MovablePointView
+                cursor={cursor}
+                onClick={() => {
+                    onClick();
+                    focusableHandleRef.current?.focus();
+                }}
+                point={point}
+                dragging={dragging}
+                focused={focused}
+                ref={visiblePointRef}
+                showFocusRing={focused}
+            />
+            {/* PROTOTYPE: label every movable point with A/B/C... by sequence. */}
+            <TextLabel
+                x={point[X]}
+                y={point[Y]}
+                attach="ne"
+                attachDistance={12}
+            >
+                {String.fromCharCode(64 + sequenceNumber)}
+            </TextLabel>
+        </>
     );
 
     return {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -1,5 +1,3 @@
-import {font, semanticColor} from "@khanacademy/wonder-blocks-tokens";
-import {Text} from "mafs";
 import * as React from "react";
 import {useState, useRef, useLayoutEffect} from "react";
 
@@ -35,11 +33,6 @@ type Params = {
      * interactive figure on the graph.
      */
     sequenceNumber?: number;
-    /**
-     * Visible text label rendered next to the point (e.g. "A", "B", "T").
-     * When omitted, no label is drawn.
-     */
-    label?: string;
     onMove?: ((newPoint: vec.Vector2) => unknown) | undefined;
     onDragStart?: (() => unknown) | undefined;
     onDragEnd?: (() => unknown) | undefined;
@@ -66,7 +59,6 @@ export function useControlPoint(params: Params): Return {
         cursor,
         forwardedRef = noop,
         sequenceNumber = 1,
-        label,
         onMove = noop,
         onDragStart = noop,
         onDragEnd = noop,
@@ -145,78 +137,24 @@ export function useControlPoint(params: Params): Return {
             }}
         />
     );
+    // Visible labels are rendered separately by
+    // `movable-point-labels-layer.tsx` (HTML overlay with TeX), not
+    // inside the SVG — TeX cannot render inside an SVG. The layer reads
+    // the live coordinates straight from the reducer state, so a drag
+    // pushes the label along with the point glyph automatically.
     const visiblePoint = (
-        <>
-            <MovablePointView
-                cursor={cursor}
-                onClick={() => {
-                    onClick();
-                    focusableHandleRef.current?.focus();
-                }}
-                point={point}
-                dragging={dragging}
-                focused={focused}
-                ref={visiblePointRef}
-                showFocusRing={focused}
-            />
-            {label != null && label !== "" && (
-                // The visible label is purely decorative; the focusable handle
-                // above already carries the equivalent text in its aria-label,
-                // so we hide this from the a11y tree to avoid double-announce.
-                //
-                // The inline <defs> below is intentional. The shared
-                // `text-label.tsx` filter is a translucent rectangle backdrop,
-                // and its <defs> sit in a different <Mafs> than the one this
-                // label renders in (so the reference wouldn't resolve anyway).
-                // We add a dilated-stroke knockout filter — the same shape
-                // Matthew used for LockedLabel — scoped to this label only so
-                // the existing angle/side labels keep their current look.
-                <g
-                    aria-hidden="true"
-                    data-testid="movable-point__visible-label"
-                >
-                    <defs>
-                        <filter id="movable-point-label-knockout">
-                            <feMorphology
-                                operator="dilate"
-                                radius="2"
-                                in="SourceGraphic"
-                                result="expanded"
-                            />
-                            <feFlood
-                                floodColor={
-                                    semanticColor.core.border.knockout.default
-                                }
-                                result="flood"
-                            />
-                            <feComposite
-                                in="flood"
-                                in2="expanded"
-                                operator="in"
-                                result="outline"
-                            />
-                            <feMerge>
-                                <feMergeNode in="outline" />
-                                <feMergeNode in="SourceGraphic" />
-                            </feMerge>
-                        </filter>
-                    </defs>
-                    <Text
-                        x={point[X]}
-                        y={point[Y]}
-                        attach="ne"
-                        attachDistance={24}
-                        size={16}
-                        svgTextProps={{
-                            filter: "url(#movable-point-label-knockout)",
-                            fontWeight: font.weight.bold,
-                        }}
-                    >
-                        {label}
-                    </Text>
-                </g>
-            )}
-        </>
+        <MovablePointView
+            cursor={cursor}
+            onClick={() => {
+                onClick();
+                focusableHandleRef.current?.focus();
+            }}
+            point={point}
+            dragging={dragging}
+            focused={focused}
+            ref={visiblePointRef}
+            showFocusRing={focused}
+        />
     );
 
     return {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -34,6 +34,11 @@ type Params = {
      * interactive figure on the graph.
      */
     sequenceNumber?: number;
+    /**
+     * Visible text label rendered next to the point (e.g. "A", "B", "T").
+     * When omitted, no label is drawn.
+     */
+    label?: string;
     onMove?: ((newPoint: vec.Vector2) => unknown) | undefined;
     onDragStart?: (() => unknown) | undefined;
     onDragEnd?: (() => unknown) | undefined;
@@ -60,6 +65,7 @@ export function useControlPoint(params: Params): Return {
         cursor,
         forwardedRef = noop,
         sequenceNumber = 1,
+        label,
         onMove = noop,
         onDragStart = noop,
         onDragEnd = noop,
@@ -152,15 +158,24 @@ export function useControlPoint(params: Params): Return {
                 ref={visiblePointRef}
                 showFocusRing={focused}
             />
-            {/* PROTOTYPE: label every movable point with A/B/C... by sequence. */}
-            <TextLabel
-                x={point[X]}
-                y={point[Y]}
-                attach="ne"
-                attachDistance={12}
-            >
-                {String.fromCharCode(64 + sequenceNumber)}
-            </TextLabel>
+            {label != null && label !== "" && (
+                // The visible label is purely decorative; the focusable handle
+                // above already carries the equivalent text in its aria-label,
+                // so we hide this from the a11y tree to avoid double-announce.
+                <g
+                    aria-hidden="true"
+                    data-testid="movable-point__visible-label"
+                >
+                    <TextLabel
+                        x={point[X]}
+                        y={point[Y]}
+                        attach="ne"
+                        attachDistance={12}
+                    >
+                        {label}
+                    </TextLabel>
+                </g>
+            )}
         </>
     );
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/exponential.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/exponential.tsx
@@ -7,6 +7,7 @@ import {
     type I18nContextType,
 } from "../../../components/i18n-context";
 import {X, Y} from "../math";
+import {getEffectivePointLabels} from "../point-labels";
 import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 import {boundToEdgeAndSnapToGrid} from "../utils";
@@ -56,8 +57,13 @@ function ExponentialGraph(props: ExponentialGraphProps) {
     const id = React.useId();
     const descriptionId = id + "-description";
 
-    const {coords, pointLabels, asymptote, snapStep} = graphState;
-    const buildLabel = usePointAriaLabel(pointLabels);
+    const {coords, pointLabels, showLabels, asymptote, snapStep} = graphState;
+    const effectiveLabels = getEffectivePointLabels(
+        showLabels,
+        pointLabels,
+        coords.length,
+    );
+    const buildLabel = usePointAriaLabel(effectiveLabels);
 
     // When the asymptote sits between the two points there is no valid
     // exponential that fits — coeffs will be undefined, and we skip
@@ -150,6 +156,7 @@ function ExponentialGraph(props: ExponentialGraphProps) {
                         i,
                         range,
                     )}
+                    label={showLabels ? effectiveLabels?.[i] : undefined}
                     onMove={(destination) =>
                         dispatch(actions.exponential.movePoint(i, destination))
                     }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
@@ -2,6 +2,7 @@ import {geometry} from "@khanacademy/kmath";
 import * as React from "react";
 
 import {usePerseusI18n} from "../../../components/i18n-context";
+import {getEffectivePointLabels} from "../point-labels";
 import {actions} from "../reducer/interactive-graph-action";
 
 import {usePointAriaLabel} from "./components/build-point-aria-label";
@@ -37,12 +38,19 @@ type LinearSystemGraphProps = MafsGraphProps<LinearSystemGraphState>;
 
 const LinearSystemGraph = (props: LinearSystemGraphProps) => {
     const {dispatch} = props;
-    const {coords: lines, pointLabels} = props.graphState;
+    const {coords: lines, pointLabels, showLabels} = props.graphState;
 
     const {strings, locale} = usePerseusI18n();
     const id = React.useId();
     const intersectionId = `${id}-intersection`;
-    const buildLabel = usePointAriaLabel(pointLabels);
+    // Each line has 2 endpoints; pointLabels is flat across both lines:
+    // [line0Start, line0End, line1Start, line1End].
+    const effectiveLabels = getEffectivePointLabels(
+        showLabels,
+        pointLabels,
+        lines.length * 2,
+    );
+    const buildLabel = usePointAriaLabel(effectiveLabels);
 
     const intersectionPoint = geometry.getLineIntersection(lines[0], lines[1]);
     const intersectionDescription = intersectionPoint
@@ -124,6 +132,14 @@ const LinearSystemGraph = (props: LinearSystemGraphProps) => {
                         }),
                     }}
                     ariaDescribedBy={`${linesAriaInfo[i].interceptDescriptionId} ${linesAriaInfo[i].slopeDescriptionId} ${intersectionId}`}
+                    pointLabels={
+                        showLabels
+                            ? [
+                                  effectiveLabels?.[i * 2],
+                                  effectiveLabels?.[i * 2 + 1],
+                              ]
+                            : undefined
+                    }
                     onMoveLine={(newStart) => {
                         dispatch(actions.linearSystem.moveLine(i, newStart));
                     }}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
@@ -132,14 +132,6 @@ const LinearSystemGraph = (props: LinearSystemGraphProps) => {
                         }),
                     }}
                     ariaDescribedBy={`${linesAriaInfo[i].interceptDescriptionId} ${linesAriaInfo[i].slopeDescriptionId} ${intersectionId}`}
-                    pointLabels={
-                        showLabels
-                            ? [
-                                  effectiveLabels?.[i * 2],
-                                  effectiveLabels?.[i * 2 + 1],
-                              ]
-                            : undefined
-                    }
                     onMoveLine={(newStart) => {
                         dispatch(actions.linearSystem.moveLine(i, newStart));
                     }}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
@@ -77,11 +77,6 @@ const LinearGraph = (props: LinearGraphProps, key: number) => {
                 // from MovableLine / useControlPoint.
                 ariaLive="off"
                 points={line}
-                pointLabels={
-                    showLabels
-                        ? [effectiveLabels?.[0], effectiveLabels?.[1]]
-                        : undefined
-                }
                 onMoveLine={(newStart) => {
                     dispatch(actions.linear.moveLine(newStart));
                 }}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import {usePerseusI18n} from "../../../components/i18n-context";
+import {getEffectivePointLabels} from "../point-labels";
 import {actions} from "../reducer/interactive-graph-action";
 
 import {usePointAriaLabel} from "./components/build-point-aria-label";
@@ -33,10 +34,11 @@ type LinearGraphProps = MafsGraphProps<LinearGraphState>;
 
 const LinearGraph = (props: LinearGraphProps, key: number) => {
     const {dispatch} = props;
-    const {coords: line, pointLabels} = props.graphState;
+    const {coords: line, pointLabels, showLabels} = props.graphState;
 
     const {strings, locale} = usePerseusI18n();
-    const buildLabel = usePointAriaLabel(pointLabels);
+    const effectiveLabels = getEffectivePointLabels(showLabels, pointLabels, 2);
+    const buildLabel = usePointAriaLabel(effectiveLabels);
     const id = React.useId();
     const pointsDescriptionId = id + "-points";
     const interceptDescriptionId = id + "-intercept";
@@ -75,6 +77,11 @@ const LinearGraph = (props: LinearGraphProps, key: number) => {
                 // from MovableLine / useControlPoint.
                 ariaLive="off"
                 points={line}
+                pointLabels={
+                    showLabels
+                        ? [effectiveLabels?.[0], effectiveLabels?.[1]]
+                        : undefined
+                }
                 onMoveLine={(newStart) => {
                     dispatch(actions.linear.moveLine(newStart));
                 }}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/logarithm.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/logarithm.tsx
@@ -7,6 +7,7 @@ import {
     type I18nContextType,
 } from "../../../components/i18n-context";
 import {X, Y} from "../math";
+import {getEffectivePointLabels} from "../point-labels";
 import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 import {boundToEdgeAndSnapToGrid} from "../utils";
@@ -56,8 +57,13 @@ function LogarithmGraph(props: LogarithmGraphProps) {
     const id = React.useId();
     const descriptionId = id + "-description";
 
-    const {coords, pointLabels, asymptote, snapStep} = graphState;
-    const buildLabel = usePointAriaLabel(pointLabels);
+    const {coords, pointLabels, showLabels, asymptote, snapStep} = graphState;
+    const effectiveLabels = getEffectivePointLabels(
+        showLabels,
+        pointLabels,
+        coords.length,
+    );
+    const buildLabel = usePointAriaLabel(effectiveLabels);
 
     // When the asymptote sits between the two points there is no valid
     // logarithm that fits — coeffs will be undefined, and we skip
@@ -141,6 +147,7 @@ function LogarithmGraph(props: LogarithmGraphProps) {
                         i,
                         range,
                     )}
+                    label={showLabels ? effectiveLabels?.[i] : undefined}
                     onMove={(destination) =>
                         dispatch(actions.logarithm.movePoint(i, destination))
                     }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.test.ts
@@ -82,6 +82,51 @@ describe("getPointGraphDescription", () => {
         );
     });
 
+    it("announces auto A/B/C labels when showLabels is true and pointLabels is omitted (matches what sighted learners see)", () => {
+        const state: PointGraphState = {
+            ...baseState,
+            showLabels: true,
+            coords: [
+                [0, 0],
+                [1, 1],
+                [2, 2],
+            ],
+        };
+        expect(getPointGraphDescription(state, mockPerseusI18nContext)).toBe(
+            "Interactive elements: Point A at 0 comma 0. Point B at 1 comma 1. Point C at 2 comma 2.",
+        );
+    });
+
+    it("prefers author pointLabels over auto labels when showLabels is true and both are present", () => {
+        const state: PointGraphState = {
+            ...baseState,
+            showLabels: true,
+            coords: [
+                [0, 0],
+                [1, 1],
+            ],
+            pointLabels: ["P", "Q"],
+        };
+        expect(getPointGraphDescription(state, mockPerseusI18nContext)).toBe(
+            "Interactive elements: Point P at 0 comma 0. Point Q at 1 comma 1.",
+        );
+    });
+
+    it("fills aria gaps with auto letters when showLabels is true and pointLabels is partial", () => {
+        const state: PointGraphState = {
+            ...baseState,
+            showLabels: true,
+            coords: [
+                [0, 0],
+                [1, 1],
+            ],
+            pointLabels: ["P"],
+        };
+        expect(getPointGraphDescription(state, mockPerseusI18nContext)).toBe(
+            "Interactive elements: Point P at 0 comma 0. Point B at 1 comma 1.",
+        );
+    });
+
     it(`encodes "only the second point labeled" as ["", "T"] and announces "Point 1 ... Point T ..."`, () => {
         const state: PointGraphState = {
             ...baseState,

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.test.ts
@@ -82,7 +82,12 @@ describe("getPointGraphDescription", () => {
         );
     });
 
-    it("announces auto A/B/C labels when showLabels is true and pointLabels is omitted (matches what sighted learners see)", () => {
+    it("falls back to the numeric 'Point N' default when showLabels is true but pointLabels is omitted (lint rule blocks this combination at authoring time)", () => {
+        // Defense in depth: even if a bad item somehow lands in the database
+        // with showLabels:true and no pointLabels (the
+        // interactive-graph-widget-error lint rule blocks the combination
+        // at save time), the renderer must NOT auto-generate Latin letters
+        // — that would leak into non-Latin-alphabet locales.
         const state: PointGraphState = {
             ...baseState,
             showLabels: true,
@@ -93,11 +98,11 @@ describe("getPointGraphDescription", () => {
             ],
         };
         expect(getPointGraphDescription(state, mockPerseusI18nContext)).toBe(
-            "Interactive elements: Point A at 0 comma 0. Point B at 1 comma 1. Point C at 2 comma 2.",
+            "Interactive elements: Point 1 at 0 comma 0. Point 2 at 1 comma 1. Point 3 at 2 comma 2.",
         );
     });
 
-    it("prefers author pointLabels over auto labels when showLabels is true and both are present", () => {
+    it("uses author pointLabels when showLabels is true and both are present", () => {
         const state: PointGraphState = {
             ...baseState,
             showLabels: true,
@@ -112,7 +117,7 @@ describe("getPointGraphDescription", () => {
         );
     });
 
-    it("fills aria gaps with auto letters when showLabels is true and pointLabels is partial", () => {
+    it("falls back to the numeric 'Point N' default for points without a pointLabel entry when pointLabels is partial", () => {
         const state: PointGraphState = {
             ...baseState,
             showLabels: true,
@@ -123,7 +128,7 @@ describe("getPointGraphDescription", () => {
             pointLabels: ["P"],
         };
         expect(getPointGraphDescription(state, mockPerseusI18nContext)).toBe(
-            "Interactive elements: Point P at 0 comma 0. Point B at 1 comma 1.",
+            "Interactive elements: Point P at 0 comma 0. Point 2 at 1 comma 1.",
         );
     });
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -106,7 +106,6 @@ function LimitedPointGraph(statefulProps: StatefulProps) {
                     // dropped from useControlPoint.
                     ariaLive="off"
                     ariaLabel={buildLabel(i, point)}
-                    label={showLabels ? effectiveLabels?.[i] : undefined}
                     onMove={(destination) =>
                         dispatch(actions.pointGraph.movePoint(i, destination))
                     }
@@ -187,7 +186,6 @@ function UnlimitedPointGraph(statefulProps: StatefulProps) {
                     // dropped from useControlPoint.
                     ariaLive="off"
                     ariaLabel={buildLabel(i, point)}
-                    label={showLabels ? effectiveLabels?.[i] : undefined}
                     onDragStart={() => {
                         dragEndCallbackTimer.clear();
                         setIsCurrentlyDragging(true);

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -1,6 +1,7 @@
 import {useTimeout} from "@khanacademy/wonder-blocks-timing";
 import * as React from "react";
 
+import {getEffectivePointLabels} from "../point-labels";
 import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 import {getCSSZoomFactor} from "../utils";
@@ -83,12 +84,17 @@ function PointGraph(props: Props) {
 
 function LimitedPointGraph(statefulProps: StatefulProps) {
     const {dispatch} = statefulProps;
-    const {pointLabels} = statefulProps.graphState;
-    const buildLabel = usePointAriaLabel(pointLabels);
+    const {coords, pointLabels, showLabels} = statefulProps.graphState;
+    const effectiveLabels = getEffectivePointLabels(
+        showLabels,
+        pointLabels,
+        coords.length,
+    );
+    const buildLabel = usePointAriaLabel(effectiveLabels);
 
     return (
         <>
-            {statefulProps.graphState.coords.map((point, i) => (
+            {coords.map((point, i) => (
                 <MovablePoint
                     key={i}
                     point={point}
@@ -100,6 +106,7 @@ function LimitedPointGraph(statefulProps: StatefulProps) {
                     // dropped from useControlPoint.
                     ariaLive="off"
                     ariaLabel={buildLabel(i, point)}
+                    label={showLabels ? effectiveLabels?.[i] : undefined}
                     onMove={(destination) =>
                         dispatch(actions.pointGraph.movePoint(i, destination))
                     }
@@ -111,8 +118,13 @@ function LimitedPointGraph(statefulProps: StatefulProps) {
 
 function UnlimitedPointGraph(statefulProps: StatefulProps) {
     const {dispatch, graphConfig, pointsRef, top, left} = statefulProps;
-    const {coords, pointLabels} = statefulProps.graphState;
-    const buildLabel = usePointAriaLabel(pointLabels);
+    const {coords, pointLabels, showLabels} = statefulProps.graphState;
+    const effectiveLabels = getEffectivePointLabels(
+        showLabels,
+        pointLabels,
+        coords.length,
+    );
+    const buildLabel = usePointAriaLabel(effectiveLabels);
 
     // When users drag a point on iOS Safari, the browser fires a click event after the mouseup
     // at the original click location, which would add an unwanted new point. We track drag
@@ -175,6 +187,7 @@ function UnlimitedPointGraph(statefulProps: StatefulProps) {
                     // dropped from useControlPoint.
                     ariaLive="off"
                     ariaLabel={buildLabel(i, point)}
+                    label={showLabels ? effectiveLabels?.[i] : undefined}
                     onDragStart={() => {
                         dragEndCallbackTimer.clear();
                         setIsCurrentlyDragging(true);
@@ -212,10 +225,16 @@ export function getPointGraphDescription(
         return strings.srNoInteractiveElements;
     }
 
+    const effectiveLabels = getEffectivePointLabels(
+        state.showLabels,
+        state.pointLabels,
+        state.coords.length,
+    );
+
     const pointDescriptions = state.coords.map(
         (point, index) =>
             buildPointAriaLabel(
-                state.pointLabels,
+                effectiveLabels,
                 index,
                 point,
                 strings,

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -350,9 +350,6 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
                             )}
                             point={point}
                             sequenceNumber={i + 1}
-                            label={
-                                showLabels ? effectiveLabels?.[i] : undefined
-                            }
                             onMove={(destination: vec.Vector2) => {
                                 const now = Date.now();
                                 const targetFPS = 40;
@@ -557,9 +554,6 @@ const UnlimitedPolygonGraph = (statefulProps: StatefulProps) => {
                             ariaLive="off"
                             point={point}
                             sequenceNumber={i + 1}
-                            label={
-                                showLabels ? effectiveLabels?.[i] : undefined
-                            }
                             onDragStart={() => {
                                 dragEndCallbackTimer.clear();
                                 setIsCurrentlyDragging(true);

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../../components/i18n-context";
 import {snap} from "../math";
 import {isInBound} from "../math/box";
+import {getEffectivePointLabels} from "../point-labels";
 import {actions} from "../reducer/interactive-graph-action";
 import {
     calculateAngleSnap,
@@ -185,6 +186,7 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
     const {
         showAngles,
         showSides,
+        showLabels,
         range,
         snapTo = "grid",
         snapStep,
@@ -192,7 +194,12 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
     } = statefulProps.graphState;
     const {disableKeyboardInteraction, interactiveColor} = graphConfig;
     const {strings, locale} = usePerseusI18n();
-    const buildLabel = usePointAriaLabel(pointLabels);
+    const effectiveLabels = getEffectivePointLabels(
+        showLabels,
+        pointLabels,
+        points.length,
+    );
+    const buildLabel = usePointAriaLabel(effectiveLabels);
     const id = React.useId();
 
     const lines = getLines(points);
@@ -343,6 +350,9 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
                             )}
                             point={point}
                             sequenceNumber={i + 1}
+                            label={
+                                showLabels ? effectiveLabels?.[i] : undefined
+                            }
                             onMove={(destination: vec.Vector2) => {
                                 const now = Date.now();
                                 const targetFPS = 40;
@@ -412,9 +422,15 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
 
 const UnlimitedPolygonGraph = (statefulProps: StatefulProps) => {
     const {dispatch, graphConfig, left, top, pointsRef, points} = statefulProps;
-    const {coords, closedPolygon, pointLabels} = statefulProps.graphState;
+    const {coords, closedPolygon, pointLabels, showLabels} =
+        statefulProps.graphState;
     const {strings, locale} = usePerseusI18n();
-    const buildLabel = usePointAriaLabel(pointLabels);
+    const effectiveLabels = getEffectivePointLabels(
+        showLabels,
+        pointLabels,
+        coords.length,
+    );
+    const buildLabel = usePointAriaLabel(effectiveLabels);
     const {interactiveColor} = useGraphConfig();
 
     // When users drag a point on iOS Safari, the browser fires a click event after the mouseup
@@ -541,6 +557,9 @@ const UnlimitedPolygonGraph = (statefulProps: StatefulProps) => {
                             ariaLive="off"
                             point={point}
                             sequenceNumber={i + 1}
+                            label={
+                                showLabels ? effectiveLabels?.[i] : undefined
+                            }
                             onDragStart={() => {
                                 dragEndCallbackTimer.clear();
                                 setIsCurrentlyDragging(true);
@@ -666,9 +685,14 @@ function describePolygonGraph(
     markings: InteractiveGraphProps["markings"],
 ): PolygonGraphDescriptionStrings {
     const {strings, locale} = i18n;
-    const {coords, pointLabels} = state;
+    const {coords, pointLabels, showLabels} = state;
+    const effectiveLabels = getEffectivePointLabels(
+        showLabels,
+        pointLabels,
+        coords.length,
+    );
     const buildLabel = (index: number, point: vec.Vector2) =>
-        buildPointAriaLabel(pointLabels, index, point, strings, locale);
+        buildPointAriaLabel(effectiveLabels, index, point, strings, locale);
     const isCoordinatePlane = markings === "axes" || markings === "graph";
     const hasOnePoint = coords.length === 1;
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -2,6 +2,7 @@ import {Plot, vec} from "mafs";
 import * as React from "react";
 
 import {usePerseusI18n} from "../../../components/i18n-context";
+import {getEffectivePointLabels} from "../point-labels";
 import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 
@@ -45,11 +46,16 @@ type QuadraticGraphProps = MafsGraphProps<QuadraticGraphState>;
 function QuadraticGraph(props: QuadraticGraphProps) {
     const {dispatch, graphState} = props;
 
-    const {coords, pointLabels, snapStep} = graphState;
+    const {coords, pointLabels, showLabels, snapStep} = graphState;
     const {interactiveColor} = useGraphConfig();
 
     const {strings, locale} = usePerseusI18n();
-    const buildLabel = usePointAriaLabel(pointLabels);
+    const effectiveLabels = getEffectivePointLabels(
+        showLabels,
+        pointLabels,
+        coords.length,
+    );
+    const buildLabel = usePointAriaLabel(effectiveLabels);
     const id = React.useId();
     const quadraticDirectionId = id + "-direction";
     const quadraticVertexId = id + "-vertex";
@@ -123,6 +129,7 @@ function QuadraticGraph(props: QuadraticGraphProps) {
                             snapStep,
                             i,
                         )}
+                        label={showLabels ? effectiveLabels?.[i] : undefined}
                         onMove={(destination) =>
                             dispatch(
                                 actions.quadratic.movePoint(i, destination),

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import {usePerseusI18n} from "../../../components/i18n-context";
+import {getEffectivePointLabels} from "../point-labels";
 import {actions} from "../reducer/interactive-graph-action";
 
 import {usePointAriaLabel} from "./components/build-point-aria-label";
@@ -32,7 +33,7 @@ type Props = MafsGraphProps<RayGraphState>;
 
 const RayGraph = (props: Props) => {
     const {dispatch} = props;
-    const {coords: line, pointLabels} = props.graphState;
+    const {coords: line, pointLabels, showLabels} = props.graphState;
 
     const handleMoveLine = (newStart: vec.Vector2) =>
         dispatch(actions.ray.moveRay(newStart));
@@ -40,7 +41,8 @@ const RayGraph = (props: Props) => {
         dispatch(actions.ray.movePoint(pointIndex, newPoint));
 
     const {strings, locale} = usePerseusI18n();
-    const buildLabel = usePointAriaLabel(pointLabels);
+    const effectiveLabels = getEffectivePointLabels(showLabels, pointLabels, 2);
+    const buildLabel = usePointAriaLabel(effectiveLabels);
     const id = React.useId();
     const pointsDescriptionId = id + "-points";
 
@@ -70,6 +72,11 @@ const RayGraph = (props: Props) => {
                     point2AriaLabel,
                     grabHandleAriaLabel: srRayGrabHandle,
                 }}
+                pointLabels={
+                    showLabels
+                        ? [effectiveLabels?.[0], effectiveLabels?.[1]]
+                        : undefined
+                }
                 // The ray graph's move announcements come from the WB
                 // Announcer via stateAnnouncement; disable aria-live here to
                 // avoid the focusable handles double-announcing.

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
@@ -72,11 +72,6 @@ const RayGraph = (props: Props) => {
                     point2AriaLabel,
                     grabHandleAriaLabel: srRayGrabHandle,
                 }}
-                pointLabels={
-                    showLabels
-                        ? [effectiveLabels?.[0], effectiveLabels?.[1]]
-                        : undefined
-                }
                 // The ray graph's move announcements come from the WB
                 // Announcer via stateAnnouncement; disable aria-live here to
                 // avoid the focusable handles double-announcing.

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 
 import {usePerseusI18n} from "../../../components/i18n-context";
 import {X, Y} from "../math";
+import {getEffectivePointLabels} from "../point-labels";
 import {actions} from "../reducer/interactive-graph-action";
 
 import {usePointAriaLabel} from "./components/build-point-aria-label";
@@ -34,12 +35,19 @@ export function renderSegmentGraph(
 type SegmentProps = MafsGraphProps<SegmentGraphState>;
 
 const SegmentGraph = ({dispatch, graphState}: SegmentProps) => {
-    const {coords: segments, pointLabels} = graphState;
+    const {coords: segments, pointLabels, showLabels} = graphState;
     const {strings, locale} = usePerseusI18n();
     const segmentUniqueId = React.useId();
     const lengthDescriptionId = segmentUniqueId + "-length";
     const wholeGraphDescriptionId = segmentUniqueId + "-whole-graph";
-    const buildLabel = usePointAriaLabel(pointLabels);
+    // Each segment has 2 endpoints; pointLabels is a flat array indexed as
+    // [seg0Start, seg0End, seg1Start, seg1End, …].
+    const effectiveLabels = getEffectivePointLabels(
+        showLabels,
+        pointLabels,
+        segments.length * 2,
+    );
+    const buildLabel = usePointAriaLabel(effectiveLabels);
 
     function getWholeSegmentGraphAriaLabel(): string {
         return segments?.length > 1
@@ -163,6 +171,14 @@ const SegmentGraph = ({dispatch, graphState}: SegmentProps) => {
                                 point2AriaLabel,
                                 grabHandleAriaLabel,
                             }}
+                            pointLabels={
+                                showLabels
+                                    ? [
+                                          effectiveLabels?.[i * 2],
+                                          effectiveLabels?.[i * 2 + 1],
+                                      ]
+                                    : undefined
+                            }
                         />
                         <SRDescInSVG id={lengthDescriptionId}>
                             {strings.srSegmentLength({

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -171,14 +171,6 @@ const SegmentGraph = ({dispatch, graphState}: SegmentProps) => {
                                 point2AriaLabel,
                                 grabHandleAriaLabel,
                             }}
-                            pointLabels={
-                                showLabels
-                                    ? [
-                                          effectiveLabels?.[i * 2],
-                                          effectiveLabels?.[i * 2 + 1],
-                                      ]
-                                    : undefined
-                            }
                         />
                         <SRDescInSVG id={lengthDescriptionId}>
                             {strings.srSegmentLength({

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
@@ -113,7 +113,6 @@ function SinusoidGraph(props: SinusoidGraphProps) {
                         snapStep,
                         i,
                     )}
-                    label={showLabels ? effectiveLabels?.[i] : undefined}
                     onMove={(destination) =>
                         dispatch(actions.sinusoid.movePoint(i, destination))
                     }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
@@ -6,6 +6,7 @@ import {
     type I18nContextType,
 } from "../../../components/i18n-context";
 import {X, Y} from "../math/coordinates";
+import {getEffectivePointLabels} from "../point-labels";
 import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 
@@ -47,8 +48,13 @@ function SinusoidGraph(props: SinusoidGraphProps) {
     // Destructure the coordinates from the graph state
     // Note: The order of the coordinates is important:
     // The coords[0] is the root and the coords[1] is the first peak
-    const {coords, pointLabels, snapStep} = graphState;
-    const buildLabel = usePointAriaLabel(pointLabels);
+    const {coords, pointLabels, showLabels, snapStep} = graphState;
+    const effectiveLabels = getEffectivePointLabels(
+        showLabels,
+        pointLabels,
+        coords.length,
+    );
+    const buildLabel = usePointAriaLabel(effectiveLabels);
 
     // The coefficients are used to calculate the sinusoid equation, plot the graph, and to indicate
     // to content creators the currently selected "correct answer" in the Content Editor.
@@ -107,6 +113,7 @@ function SinusoidGraph(props: SinusoidGraphProps) {
                         snapStep,
                         i,
                     )}
+                    label={showLabels ? effectiveLabels?.[i] : undefined}
                     onMove={(destination) =>
                         dispatch(actions.sinusoid.movePoint(i, destination))
                     }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/tangent.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/tangent.tsx
@@ -6,6 +6,7 @@ import {
     type I18nContextType,
 } from "../../../components/i18n-context";
 import {X, Y} from "../math/coordinates";
+import {getEffectivePointLabels} from "../point-labels";
 import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 
@@ -47,8 +48,13 @@ function TangentGraph(props: TangentGraphProps) {
     // Destructure the coordinates from the graph state
     // coords[0] is the inflection point (where tan crosses the midline)
     // coords[1] is a quarter-period away (where amplitude is reached)
-    const {coords, pointLabels, snapStep} = graphState;
-    const buildLabel = usePointAriaLabel(pointLabels);
+    const {coords, pointLabels, showLabels, snapStep} = graphState;
+    const effectiveLabels = getEffectivePointLabels(
+        showLabels,
+        pointLabels,
+        coords.length,
+    );
+    const buildLabel = usePointAriaLabel(effectiveLabels);
 
     // The coefficients are used to calculate the tangent equation, plot
     // the graph, and to indicate to content creators the currently selected
@@ -118,6 +124,7 @@ function TangentGraph(props: TangentGraphProps) {
                         snapStep,
                         i,
                     )}
+                    label={showLabels ? effectiveLabels?.[i] : undefined}
                     onMove={(destination) =>
                         dispatch(actions.tangent.movePoint(i, destination))
                     }

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -1311,6 +1311,88 @@ export const pointWithDefaultLabelQuestion: PerseusRenderer =
         }),
     });
 
+// Point graph with `showLabels: true` and no `pointLabels` — interactive
+// points are auto-labelled "A", "B", "C", … on the canvas as the learner
+// plots them. Used to show the opt-in visible-labels behaviour without any
+// authoring overhead.
+export const pointWithAutoVisibleLabelsQuestion: PerseusRenderer =
+    generateInteractiveGraphQuestion({
+        content:
+            "**Plot any three points on the graph. They will be labelled A, B, and C automatically.**\n\n[[☃ interactive-graph 1]]",
+        markings: "graph",
+        gridStep: [1, 1],
+        snapStep: [1, 1],
+        step: [1, 1],
+        range: [
+            [-5, 5],
+            [-5, 5],
+        ],
+        correct: generateIGPointGraph({
+            numPoints: 3,
+            startCoords: [
+                [-2, 0],
+                [0, 2],
+                [2, 0],
+            ],
+            showLabels: true,
+        }),
+    });
+
+// Polygon graph with `showLabels: true` and no `pointLabels` — vertices are
+// auto-labelled "A", "B", "C", "D" on the canvas. Demonstrates that the
+// `showLabels` opt-in works for non-`point` graph types via the same
+// `getEffectivePointLabels` helper.
+export const polygonWithVisibleLabelsQuestion: PerseusRenderer =
+    generateInteractiveGraphQuestion({
+        content:
+            "**Drag the vertices to form a quadrilateral.** Each vertex is labelled A, B, C, D so you can refer to them in your work.\n\n[[☃ interactive-graph 1]]",
+        markings: "graph",
+        gridStep: [1, 1],
+        snapStep: [1, 1],
+        step: [1, 1],
+        range: [
+            [-5, 5],
+            [-5, 5],
+        ],
+        correct: generateIGPolygonGraph({
+            numSides: 4,
+            startCoords: [
+                [-3, 2],
+                [3, 2],
+                [3, -2],
+                [-3, -2],
+            ],
+            showLabels: true,
+        }),
+    });
+
+// Point graph with both `showLabels: true` AND `pointLabels` provided.
+// Author-supplied names ("P", "Q", "R") win over the auto A/B/C fallback,
+// so the visible labels match the question prompt exactly.
+export const pointWithCustomVisibleLabelsQuestion: PerseusRenderer =
+    generateInteractiveGraphQuestion({
+        content:
+            "**Drag points $P$, $Q$, and $R$ to form a right triangle.** The visible labels on the graph should match the names in the prompt.\n\n[[☃ interactive-graph 1]]",
+        markings: "graph",
+        gridStep: [1, 1],
+        snapStep: [1, 1],
+        step: [1, 1],
+        range: [
+            [-5, 5],
+            [-5, 5],
+        ],
+        correct: generateIGPointGraph({
+            numPoints: 3,
+            startCoords: [
+                [-2, 0],
+                [2, 0],
+                [2, 3],
+            ],
+            pointLabels: ["P", "Q", "R"],
+            showLabels: true,
+        }),
+    });
+
 // Linear graph with the two endpoints named "A" and "B" via `pointLabels`,
 // so JAWS announces "Point A at …" / "Point B at …" instead of the default
 // "Point 1 at …" / "Point 2 at …" when navigating the endpoints.

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -1311,37 +1311,13 @@ export const pointWithDefaultLabelQuestion: PerseusRenderer =
         }),
     });
 
-// Point graph with `showLabels: true` and no `pointLabels` — interactive
-// points are auto-labelled "A", "B", "C", … on the canvas as the learner
-// plots them. Used to show the opt-in visible-labels behaviour without any
-// authoring overhead.
-export const pointWithAutoVisibleLabelsQuestion: PerseusRenderer =
-    generateInteractiveGraphQuestion({
-        content:
-            "**Plot any three points on the graph. They will be labelled A, B, and C automatically.**\n\n[[☃ interactive-graph 1]]",
-        markings: "graph",
-        gridStep: [1, 1],
-        snapStep: [1, 1],
-        step: [1, 1],
-        range: [
-            [-5, 5],
-            [-5, 5],
-        ],
-        correct: generateIGPointGraph({
-            numPoints: 3,
-            startCoords: [
-                [-2, 0],
-                [0, 2],
-                [2, 0],
-            ],
-            showLabels: true,
-        }),
-    });
-
-// Polygon graph with `showLabels: true` and no `pointLabels` — vertices are
-// auto-labelled "A", "B", "C", "D" on the canvas. Demonstrates that the
-// `showLabels` opt-in works for non-`point` graph types via the same
-// `getEffectivePointLabels` helper.
+// Polygon graph with `showLabels: true` and author-supplied
+// `pointLabels: ["A", "B", "C", "D"]` — each vertex carries its assigned
+// letter as both the visible on-canvas label and the screen-reader
+// announcement. `showLabels` always requires `pointLabels` (the
+// interactive-graph-widget-error lint rule blocks the combination
+// `showLabels: true` without `pointLabels` at authoring time), so
+// non-Latin locales never see auto-generated Latin letters.
 export const polygonWithVisibleLabelsQuestion: PerseusRenderer =
     generateInteractiveGraphQuestion({
         content:
@@ -1362,17 +1338,18 @@ export const polygonWithVisibleLabelsQuestion: PerseusRenderer =
                 [3, -2],
                 [-3, -2],
             ],
+            pointLabels: ["A", "B", "C", "D"],
             showLabels: true,
         }),
     });
 
-// Point graph with both `showLabels: true` AND `pointLabels` provided.
-// Author-supplied names ("P", "Q", "R") win over the auto A/B/C fallback,
-// so the visible labels match the question prompt exactly.
-export const pointWithCustomVisibleLabelsQuestion: PerseusRenderer =
+// Point graph with `showLabels: true` and author-supplied `pointLabels`.
+// The visible on-canvas labels and the screen-reader announcements both
+// use the same per-index string, so they stay in sync.
+export const pointWithVisibleLabelsQuestion: PerseusRenderer =
     generateInteractiveGraphQuestion({
         content:
-            "**Drag points $P$, $Q$, and $R$ to form a right triangle.** The visible labels on the graph should match the names in the prompt.\n\n[[☃ interactive-graph 1]]",
+            "**Drag points $P$, $Q$, and $R$ to form a right triangle.** The visible labels on the graph match the names in the prompt.\n\n[[☃ interactive-graph 1]]",
         markings: "graph",
         gridStep: [1, 1],
         snapStep: [1, 1],

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -52,6 +52,7 @@ import {renderTangentGraph} from "./graphs/tangent";
 import {getArrayWithoutDuplicates} from "./graphs/utils";
 import {renderVectorGraph} from "./graphs/vector";
 import {X, Y} from "./math";
+import MovablePointLabelsLayer from "./movable-point-labels-layer";
 import {Protractor} from "./protractor";
 import {actions} from "./reducer/interactive-graph-action";
 import {GraphConfigContext} from "./reducer/use-graph-config";
@@ -381,6 +382,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                         <GraphLockedLabelsLayer
                             lockedFigures={props.lockedFigures}
                         />
+                        <MovablePointLabelsLayer state={state} />
                         <View style={{position: "absolute"}}>
                             <Mafs
                                 preserveAspectRatio={false}

--- a/packages/perseus/src/widgets/interactive-graphs/movable-point-labels-layer.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/movable-point-labels-layer.test.tsx
@@ -1,0 +1,216 @@
+import {render, screen} from "@testing-library/react";
+import * as React from "react";
+
+import * as Dependencies from "../../dependencies";
+import {testDependencies} from "../../testing/test-dependencies";
+
+import MovablePointLabelsLayer from "./movable-point-labels-layer";
+import * as ReducerGraphConfig from "./reducer/use-graph-config";
+
+import type {GraphConfig} from "./reducer/use-graph-config";
+import type {InteractiveGraphState} from "./types";
+
+function mockGraphConfig(config: GraphConfig) {
+    return jest.spyOn(ReducerGraphConfig, "default").mockReturnValue(config);
+}
+
+const baseGraphConfig: GraphConfig = {
+    range: [
+        [-10, 10],
+        [-10, 10],
+    ],
+    tickStep: [1, 1],
+    gridStep: [1, 1],
+    snapStep: [1, 1],
+    markings: "graph",
+    showTooltips: false,
+    graphDimensionsInPixels: [400, 400],
+    width: 400,
+    height: 400,
+    labels: [],
+    showAxisArrows: {xMin: true, xMax: true, yMin: true, yMax: true},
+    showAxisTicks: {x: true, y: true},
+};
+
+function pointState(
+    coords: ReadonlyArray<[number, number]>,
+    pointLabels?: string[],
+    showLabels?: boolean,
+): InteractiveGraphState {
+    return {
+        type: "point",
+        coords: coords.map(([x, y]): [number, number] => [x, y]),
+        focusedPointIndex: null,
+        showRemovePointButton: false,
+        interactionMode: "mouse",
+        showKeyboardInteractionInvitation: false,
+        hasBeenInteractedWith: false,
+        range: [
+            [-10, 10],
+            [-10, 10],
+        ],
+        snapStep: [1, 1],
+        pointLabels,
+        showLabels,
+    };
+}
+
+describe("MovablePointLabelsLayer", () => {
+    beforeEach(() => {
+        mockGraphConfig(baseGraphConfig);
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    it("renders nothing when showLabels is off, even if pointLabels is set (legacy SR-only data shape)", () => {
+        // Arrange, Act
+        render(
+            <MovablePointLabelsLayer
+                state={pointState([[1, 2]], ["A"], false)}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.queryByTestId("movable-point__visible-label"),
+        ).not.toBeInTheDocument();
+    });
+
+    it("renders one label per labeled point when showLabels is on", () => {
+        // Arrange, Act
+        render(
+            <MovablePointLabelsLayer
+                state={pointState(
+                    [
+                        [1, 2],
+                        [3, 4],
+                    ],
+                    ["A", "B"],
+                    true,
+                )}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getAllByTestId("movable-point__visible-label"),
+        ).toHaveLength(2);
+    });
+
+    it("renders the label via the TeX pipeline so $A$ becomes math, not the four literal characters '$', 'A', '$'", () => {
+        // The test-dependencies TeX mock wraps children in
+        // `<span class="mock-TeX">`. If the layer hands the raw string
+        // to that mock (via `<TeX>`), the wrapper appears in the DOM.
+        // If the layer instead rendered the string with plain HTML, no
+        // `.mock-TeX` element would exist.
+        // Arrange, Act
+        const {container} = render(
+            <MovablePointLabelsLayer
+                state={pointState([[0, 0]], ["$A$"], true)}
+            />,
+        );
+
+        // Assert: TeX pipeline ran on the label's text.
+        // eslint-disable-next-line testing-library/no-container,testing-library/no-node-access
+        const tex = container.querySelector(".mock-TeX");
+        expect(tex).not.toBeNull();
+        // The original `$A$` survives into the TeX child stream — that
+        // is what guarantees MathJax (in prod) renders the letter A
+        // typeset as math rather than the literal characters.
+        expect(tex?.textContent).toContain("$A$");
+    });
+
+    it("hides the visible label from the accessibility tree (announcement stays on the focusable handle)", () => {
+        // Arrange, Act
+        render(
+            <MovablePointLabelsLayer
+                state={pointState([[0, 0]], ["A"], true)}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByTestId("movable-point__visible-label"),
+        ).toHaveAttribute("aria-hidden", "true");
+    });
+
+    it("skips points whose label is missing or empty — no Latin-letter fallback", () => {
+        // Arrange, Act
+        render(
+            <MovablePointLabelsLayer
+                state={pointState(
+                    [
+                        [1, 2],
+                        [3, 4],
+                    ],
+                    ["A", ""],
+                    true,
+                )}
+            />,
+        );
+
+        // Assert: only the first point rendered a label.
+        expect(
+            screen.getAllByTestId("movable-point__visible-label"),
+        ).toHaveLength(1);
+    });
+
+    it("places the label outside the plotted region for a point near the right edge of the graph", () => {
+        // A point at the right edge gets an east-facing attach so the
+        // span sits to the right of the point — outside the graph's
+        // plotted region. We assert via the transform style which
+        // encodes the compass direction (see `attachToCss`).
+        // Arrange, Act
+        render(
+            <MovablePointLabelsLayer
+                state={pointState([[10, 0]], ["A"], true)}
+            />,
+        );
+
+        // Assert
+        const label = screen.getByTestId("movable-point__visible-label");
+        // East-facing attach: positive X translate, no -100% horizontal
+        // shift (which would push the label leftward and back inside
+        // the graph).
+        expect(label.getAttribute("style")).toMatch(/translate\(12px/);
+    });
+
+    it("places the label outside the plotted region for a point near the bottom edge", () => {
+        // Arrange, Act
+        render(
+            <MovablePointLabelsLayer
+                state={pointState([[0, -10]], ["A"], true)}
+            />,
+        );
+
+        // Assert: south-facing attach → positive Y translate (label
+        // sits below the point, outside the graph's bottom edge).
+        const style = screen
+            .getByTestId("movable-point__visible-label")
+            .getAttribute("style");
+        expect(style).toMatch(/, 12px\)/);
+    });
+
+    it("flips the label to the left of the point when the point is in the upper-left quadrant", () => {
+        // A point near the top-left should attach NW so the label sits
+        // up-and-left, away from the graph's center / geometry.
+        // Arrange, Act
+        render(
+            <MovablePointLabelsLayer
+                state={pointState([[-7, 7]], ["A"], true)}
+            />,
+        );
+
+        // Assert: NW attach → both horizontal and vertical translate
+        // use `calc(-100% - 12px)`.
+        const style = screen
+            .getByTestId("movable-point__visible-label")
+            .getAttribute("style");
+        expect(style).toMatch(/calc\(-100% - 12px\)/);
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/movable-point-labels-layer.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/movable-point-labels-layer.tsx
@@ -1,0 +1,157 @@
+// HTML overlay that renders the visible label next to every labeled
+// movable point. TeX cannot be drawn inside an SVG, so the labels live
+// outside the `<Mafs>` element — exactly the same pattern that
+// `graph-locked-labels-layer.tsx` already uses for every locked label.
+//
+// The overlay reads live point coordinates straight from the reducer
+// state, so a drag mutates state → MafsGraph re-renders → this layer
+// projects the new coords to pixels and the labels follow the point
+// without any extra subscription / animation plumbing.
+//
+// `aria-hidden="true"` and `data-testid="movable-point__visible-label"`
+// stay on the rendered span so screen-reader output continues to come
+// from the focusable handle's `aria-label`, never from the visible
+// label. (WCAG 2.5.3, "Label in Name".)
+
+import {font, semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import * as React from "react";
+
+import {getDependencies} from "../../dependencies";
+
+import {pointToPixel} from "./graphs/use-transform";
+import {
+    getLabelAttach,
+    getLabeledMovablePoints,
+    type LabelAttach,
+    type MovablePointLabel,
+} from "./movable-point-labels";
+import useGraphConfig from "./reducer/use-graph-config";
+import {replaceOutsideTeX} from "./utils";
+
+import type {InteractiveGraphState} from "./types";
+
+type Props = {
+    state: InteractiveGraphState;
+};
+
+export default function MovablePointLabelsLayer({state}: Props) {
+    const labeledPoints = getLabeledMovablePoints(state);
+
+    if (labeledPoints.length === 0) {
+        return null;
+    }
+
+    return (
+        <>
+            {/* Shared stroke filter (same `id="math-stroke"` as
+                `LockedLabelStrokeFilter`). If a locked label is also on
+                this graph, its <defs> is already in the DOM, so this
+                duplicate is harmless — SVG resolves the first match. */}
+            <MovableLabelStrokeFilter />
+            {labeledPoints.map((label) => (
+                <MovablePointLabelView
+                    key={label.key}
+                    label={label}
+                    range={state.range}
+                />
+            ))}
+        </>
+    );
+}
+
+function MovablePointLabelView({
+    label,
+    range,
+}: {
+    label: MovablePointLabel;
+    range: InteractiveGraphState["range"];
+}) {
+    const graphConfig = useGraphConfig();
+    const [x, y] = pointToPixel(label.coord, graphConfig);
+    const attach = getLabelAttach(label.coord, range);
+
+    const {TeX} = getDependencies();
+
+    return (
+        <span
+            className="movable-point-label"
+            data-testid="movable-point__visible-label"
+            aria-hidden={true}
+            style={{
+                position: "absolute",
+                left: x,
+                top: y,
+                transform: attachToCss(attach),
+                color: semanticColor.core.foreground.neutral.default,
+                fontSize: font.size.medium,
+                fontWeight: font.weight.bold,
+                whiteSpace: "nowrap",
+                pointerEvents: "none",
+                filter: "url(#math-stroke)",
+            }}
+        >
+            <TeX>{replaceOutsideTeX(label.text)}</TeX>
+        </span>
+    );
+}
+
+// Distance, in pixels, between the anchor pixel (the point's center)
+// and the label edge that faces the point. Keeps the label glyph from
+// touching the point glyph.
+const LABEL_PADDING_PX = 12;
+
+// Maps a compass attach direction into a CSS `transform` string. The
+// span is positioned with `left: x; top: y;` placing its top-left at
+// the anchor pixel; we then translate it so the chosen attach edge
+// lands LABEL_PADDING_PX from the anchor in the outward direction.
+function attachToCss(attach: LabelAttach): string {
+    const p = LABEL_PADDING_PX;
+    switch (attach) {
+        case "n":
+            // label sits above point: bottom edge `p` above the anchor
+            return `translate(-50%, calc(-100% - ${p}px))`;
+        case "ne":
+            return `translate(${p}px, calc(-100% - ${p}px))`;
+        case "e":
+            return `translate(${p}px, -50%)`;
+        case "se":
+            return `translate(${p}px, ${p}px)`;
+        case "s":
+            return `translate(-50%, ${p}px)`;
+        case "sw":
+            return `translate(calc(-100% - ${p}px), ${p}px)`;
+        case "w":
+            return `translate(calc(-100% - ${p}px), -50%)`;
+        case "nw":
+            return `translate(calc(-100% - ${p}px), calc(-100% - ${p}px))`;
+    }
+}
+
+function MovableLabelStrokeFilter() {
+    const color = semanticColor.core.border.knockout.default;
+    return (
+        <svg width="0" height="0" style={{position: "absolute"}}>
+            <defs>
+                <filter id="math-stroke">
+                    <feMorphology
+                        operator="dilate"
+                        radius="2"
+                        in="SourceGraphic"
+                        result="expanded"
+                    />
+                    <feFlood floodColor={color} result="flood" />
+                    <feComposite
+                        in="flood"
+                        in2="expanded"
+                        operator="in"
+                        result="outline"
+                    />
+                    <feMerge>
+                        <feMergeNode in="outline" />
+                        <feMergeNode in="SourceGraphic" />
+                    </feMerge>
+                </filter>
+            </defs>
+        </svg>
+    );
+}

--- a/packages/perseus/src/widgets/interactive-graphs/movable-point-labels.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/movable-point-labels.test.ts
@@ -1,0 +1,331 @@
+import {getLabelAttach, getLabeledMovablePoints} from "./movable-point-labels";
+
+import type {
+    AngleGraphState,
+    CircleGraphState,
+    InteractiveGraphState,
+    LinearGraphState,
+    LinearSystemGraphState,
+    PointGraphState,
+    PolygonGraphState,
+    SegmentGraphState,
+    SinusoidGraphState,
+} from "./types";
+
+const baseCommon: {
+    hasBeenInteractedWith: boolean;
+    range: InteractiveGraphState["range"];
+    snapStep: [number, number];
+} = {
+    hasBeenInteractedWith: false,
+    range: [
+        [-10, 10],
+        [-10, 10],
+    ],
+    snapStep: [1, 1],
+};
+
+function pointState(overrides: Partial<PointGraphState> = {}): PointGraphState {
+    return {
+        ...baseCommon,
+        type: "point",
+        coords: [[1, 2]],
+        focusedPointIndex: null,
+        showRemovePointButton: false,
+        interactionMode: "mouse",
+        showKeyboardInteractionInvitation: false,
+        ...overrides,
+    };
+}
+
+describe("getLabeledMovablePoints", () => {
+    it("returns [] when showLabels is absent (legacy SR-only pointLabels case)", () => {
+        // Arrange
+        const state = pointState({
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
+            // pointLabels is set for screen-reader text but showLabels
+            // is unset — visible rendering must stay off.
+            pointLabels: ["A", "B"],
+        });
+
+        // Act, Assert
+        expect(getLabeledMovablePoints(state)).toEqual([]);
+    });
+
+    it("returns [] when showLabels is true but pointLabels is undefined", () => {
+        // Arrange
+        const state = pointState({
+            coords: [[1, 2]],
+            showLabels: true,
+        });
+
+        // Act, Assert: missing labels stay missing — no A/B/C fallback.
+        expect(getLabeledMovablePoints(state)).toEqual([]);
+    });
+
+    it("skips missing or empty entries without inventing a letter", () => {
+        // Arrange: pointLabels has 2 entries but coords has 3 — the
+        // third slot is structurally undefined.
+        const state = pointState({
+            coords: [
+                [1, 2],
+                [3, 4],
+                [5, 6],
+            ],
+            showLabels: true,
+            pointLabels: ["A", ""],
+        });
+
+        // Act, Assert
+        expect(getLabeledMovablePoints(state)).toEqual([
+            {key: "point-0", coord: [1, 2], text: "A"},
+        ]);
+    });
+
+    it("includes TeX-bearing label strings verbatim (no escaping)", () => {
+        // The layer hands the raw string to TeX/replaceOutsideTeX; this
+        // helper must not strip `$` or other math markers.
+        // Arrange
+        const state = pointState({
+            coords: [[1, 2]],
+            showLabels: true,
+            pointLabels: ["$A$"],
+        });
+
+        // Act, Assert
+        expect(getLabeledMovablePoints(state)).toEqual([
+            {key: "point-0", coord: [1, 2], text: "$A$"},
+        ]);
+    });
+
+    it("zips angle coords with effective labels by index (ending=0, vertex=1, starting=2)", () => {
+        // Arrange
+        const state: AngleGraphState = {
+            ...baseCommon,
+            type: "angle",
+            coords: [
+                [3, 0],
+                [0, 0],
+                [0, 3],
+            ],
+            showLabels: true,
+            pointLabels: ["E", "V", "S"],
+        };
+
+        // Act, Assert
+        expect(getLabeledMovablePoints(state)).toEqual([
+            {key: "angle-0", coord: [3, 0], text: "E"},
+            {key: "angle-1", coord: [0, 0], text: "V"},
+            {key: "angle-2", coord: [0, 3], text: "S"},
+        ]);
+    });
+
+    it("only labels the radius point on circle graphs (center stays unlabeled)", () => {
+        // Arrange
+        const state: CircleGraphState = {
+            ...baseCommon,
+            type: "circle",
+            center: [0, 0],
+            radiusPoint: [3, 0],
+            showLabels: true,
+            pointLabels: ["R"],
+        };
+
+        // Act, Assert
+        expect(getLabeledMovablePoints(state)).toEqual([
+            {key: "circle-radius", coord: [3, 0], text: "R"},
+        ]);
+    });
+
+    it("flattens linear-system coords as [line0-start, line0-end, line1-start, line1-end]", () => {
+        // Arrange
+        const state: LinearSystemGraphState = {
+            ...baseCommon,
+            type: "linear-system",
+            coords: [
+                [
+                    [-3, 0],
+                    [3, 0],
+                ],
+                [
+                    [0, -3],
+                    [0, 3],
+                ],
+            ],
+            showLabels: true,
+            pointLabels: ["A", "B", "C", "D"],
+        };
+
+        // Act
+        const result = getLabeledMovablePoints(state);
+
+        // Assert
+        expect(result.map((r) => r.text)).toEqual(["A", "B", "C", "D"]);
+        expect(result.map((r) => r.coord)).toEqual([
+            [-3, 0],
+            [3, 0],
+            [0, -3],
+            [0, 3],
+        ]);
+    });
+
+    it("flattens segment coords across every endpoint", () => {
+        // Arrange
+        const state: SegmentGraphState = {
+            ...baseCommon,
+            type: "segment",
+            coords: [
+                [
+                    [-3, 0],
+                    [3, 0],
+                ],
+                [
+                    [-2, 2],
+                    [2, 2],
+                ],
+            ],
+            showLabels: true,
+            pointLabels: ["a", "b", "c", "d"],
+        };
+
+        // Act, Assert
+        expect(getLabeledMovablePoints(state).map((r) => r.text)).toEqual([
+            "a",
+            "b",
+            "c",
+            "d",
+        ]);
+    });
+
+    it("handles linear / ray / sinusoid as two-endpoint state.coords", () => {
+        // Arrange
+        const linear: LinearGraphState = {
+            ...baseCommon,
+            type: "linear",
+            coords: [
+                [-3, 0],
+                [3, 0],
+            ],
+            showLabels: true,
+            pointLabels: ["s", "e"],
+        };
+        const sinusoid: SinusoidGraphState = {
+            ...baseCommon,
+            type: "sinusoid",
+            coords: [
+                [0, 0],
+                [1, 1],
+            ],
+            showLabels: true,
+            pointLabels: ["root", "peak"],
+        };
+
+        // Act, Assert
+        expect(getLabeledMovablePoints(linear).map((r) => r.text)).toEqual([
+            "s",
+            "e",
+        ]);
+        expect(getLabeledMovablePoints(sinusoid).map((r) => r.text)).toEqual([
+            "root",
+            "peak",
+        ]);
+    });
+
+    it("walks polygon coords in order", () => {
+        // Arrange
+        const state: PolygonGraphState = {
+            ...baseCommon,
+            type: "polygon",
+            coords: [
+                [0, 0],
+                [3, 0],
+                [3, 3],
+            ],
+            showAngles: false,
+            showSides: false,
+            snapTo: "grid",
+            focusedPointIndex: null,
+            showRemovePointButton: false,
+            interactionMode: "mouse",
+            showKeyboardInteractionInvitation: false,
+            closedPolygon: true,
+            showLabels: true,
+            pointLabels: ["P", "Q", "R"],
+        };
+
+        // Act, Assert
+        expect(getLabeledMovablePoints(state).map((r) => r.text)).toEqual([
+            "P",
+            "Q",
+            "R",
+        ]);
+    });
+});
+
+describe("getLabelAttach", () => {
+    // Range centered at (0, 0): [[-10, 10], [-10, 10]]
+    const range: InteractiveGraphState["range"] = [
+        [-10, 10],
+        [-10, 10],
+    ];
+
+    it("attaches NE for points in the upper-right quadrant (default)", () => {
+        // Arrange, Act, Assert
+        expect(getLabelAttach([5, 5], range)).toBe("ne");
+        expect(getLabelAttach([1, 1], range)).toBe("ne");
+    });
+
+    it("attaches NW when the point is in the upper-left quadrant (pushes label outward to the left)", () => {
+        // Arrange, Act, Assert
+        expect(getLabelAttach([-5, 5], range)).toBe("nw");
+    });
+
+    it("attaches SW when the point is in the lower-left quadrant", () => {
+        // Arrange, Act, Assert
+        expect(getLabelAttach([-5, -5], range)).toBe("sw");
+    });
+
+    it("attaches SE when the point is in the lower-right quadrant", () => {
+        // Arrange, Act, Assert
+        expect(getLabelAttach([5, -5], range)).toBe("se");
+    });
+
+    it("keeps the label outside the plotted region when the point sits exactly on the right edge", () => {
+        // Arrange, Act
+        const attach = getLabelAttach([10, 0], range);
+
+        // Assert: an east-facing component means the label sits to the
+        // right of the point → outside the graph's right edge.
+        expect(attach.endsWith("e")).toBe(true);
+    });
+
+    it("keeps the label outside the plotted region when the point sits exactly on the top edge", () => {
+        // Arrange, Act
+        const attach = getLabelAttach([0, 10], range);
+
+        // Assert: a north-facing component means the label sits above
+        // the point → outside the graph's top edge.
+        expect(attach.startsWith("n")).toBe(true);
+    });
+
+    it("keeps the label outside the plotted region when the point sits exactly on the left edge", () => {
+        // Arrange, Act
+        const attach = getLabelAttach([-10, 0], range);
+
+        // Assert: a west-facing component means the label sits to the
+        // left of the point → outside the graph's left edge.
+        expect(attach.endsWith("w")).toBe(true);
+    });
+
+    it("keeps the label outside the plotted region when the point sits exactly on the bottom edge", () => {
+        // Arrange, Act
+        const attach = getLabelAttach([0, -10], range);
+
+        // Assert: a south-facing component means the label sits below
+        // the point → outside the graph's bottom edge.
+        expect(attach.startsWith("s")).toBe(true);
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/movable-point-labels.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/movable-point-labels.ts
@@ -1,0 +1,194 @@
+// Per-graph extraction + axis-aware clamping for movable-point visible
+// labels. These helpers feed `MovablePointLabelsLayer`, which renders
+// each label via TeX in an HTML overlay so the labels can contain math
+// (e.g. `$A$`, `$\theta$`).
+//
+// The reducer state (`InteractiveGraphState`) holds the live point
+// coordinates for every supported graph type. Reading from state means
+// the layer re-renders on every drag tick without any extra plumbing.
+
+import {getEffectivePointLabels} from "./point-labels";
+
+import type {InteractiveGraphState} from "./types";
+import type {Interval, vec} from "mafs";
+
+/**
+ * One label entry to render. `coord` is in graph units (Cartesian); the
+ * layer projects it to pixels via `pointToPixel` at render time.
+ */
+export type MovablePointLabel = {
+    key: string;
+    coord: vec.Vector2;
+    text: string;
+};
+
+/**
+ * Eight compass attach directions describing where the label sits
+ * relative to its anchor pixel. See `attachToCss` in
+ * `movable-point-labels-layer.tsx` for the CSS translate mapping.
+ */
+export type LabelAttach = "n" | "ne" | "e" | "se" | "s" | "sw" | "w" | "nw";
+
+// Returns the labeled, movable points for the given graph state. Every
+// graph type with a `showLabels`-capable point is enumerated here; types
+// without movable points (`none`) or excluded from the rollout (`vector`)
+// return [].
+//
+// Per-graph indexing rules match the existing callers in
+// `graphs/<type>.tsx` so the visible labels line up with the
+// `pointLabels[i]` entries authors already use for screen-reader text.
+export function getLabeledMovablePoints(
+    state: InteractiveGraphState,
+): MovablePointLabel[] {
+    if (state.showLabels !== true) {
+        return [];
+    }
+    const {pointLabels} = state;
+
+    switch (state.type) {
+        case "point":
+        case "polygon": {
+            const effective = getEffectivePointLabels(
+                true,
+                pointLabels,
+                state.coords.length,
+            );
+            return collect(
+                state.coords,
+                effective,
+                (i) => `${state.type}-${i}`,
+            );
+        }
+        case "angle": {
+            // angle.tsx maps pointLabels: [0]=ending side, [1]=vertex,
+            // [2]=starting side. `state.coords` is [ending, vertex,
+            // starting] — same index order.
+            const effective = getEffectivePointLabels(true, pointLabels, 3);
+            return collect(state.coords, effective, (i) => `angle-${i}`);
+        }
+        case "circle": {
+            // Circle only labels the radius point. The center is a
+            // `MovableCircle`, not a `MovablePoint`, and intentionally
+            // unlabeled. See `circle.tsx`'s comment above MovablePoint.
+            const effective = getEffectivePointLabels(true, pointLabels, 1);
+            const text = effective?.[0];
+            if (text == null || text === "") {
+                return [];
+            }
+            return [{key: "circle-radius", coord: state.radiusPoint, text}];
+        }
+        case "sinusoid":
+        case "linear":
+        case "ray": {
+            const effective = getEffectivePointLabels(true, pointLabels, 2);
+            return collect(
+                state.coords,
+                effective,
+                (i) => `${state.type}-${i}`,
+            );
+        }
+        case "linear-system": {
+            // Two lines × two endpoints, flat-indexed as
+            // [line0-start, line0-end, line1-start, line1-end].
+            const flatCoords: vec.Vector2[] = state.coords.flatMap((pair) => [
+                pair[0],
+                pair[1],
+            ]);
+            const effective = getEffectivePointLabels(
+                true,
+                pointLabels,
+                flatCoords.length,
+            );
+            return collect(flatCoords, effective, (i) => `linear-system-${i}`);
+        }
+        case "segment": {
+            // N segments × two endpoints, flat-indexed as
+            // [seg0-start, seg0-end, seg1-start, seg1-end, …].
+            const flatCoords: vec.Vector2[] = state.coords.flatMap((pair) => [
+                pair[0],
+                pair[1],
+            ]);
+            const effective = getEffectivePointLabels(
+                true,
+                pointLabels,
+                flatCoords.length,
+            );
+            return collect(flatCoords, effective, (i) => `segment-${i}`);
+        }
+        // Graphs not in PR 2's ready-now bucket fall through and render
+        // no movable-point labels yet. The schema field is accepted on
+        // these states (see PR 1), but rendering arrives in the PR 4
+        // series alongside the WB Announcer work.
+        case "absolute-value":
+        case "quadratic":
+        case "exponential":
+        case "tangent":
+        case "logarithm":
+        case "vector":
+        case "none":
+            return [];
+    }
+}
+
+function collect(
+    coords: ReadonlyArray<vec.Vector2>,
+    labels: string[] | undefined,
+    keyFor: (i: number) => string,
+): MovablePointLabel[] {
+    const out: MovablePointLabel[] = [];
+    for (let i = 0; i < coords.length; i++) {
+        const text = labels?.[i];
+        if (text == null || text === "") {
+            // Missing label entries stay missing — the renderer never
+            // invents Latin letters. See `point-labels.ts`.
+            continue;
+        }
+        out.push({
+            key: keyFor(i),
+            coord: coords[i],
+            text,
+        });
+    }
+    return out;
+}
+
+// Lookup table for `getLabelAttach`. Using a literal-keyed object keeps
+// the return type narrow without an `as LabelAttach` template-literal
+// cast.
+const ATTACH_BY_QUADRANT = {
+    n: {e: "ne", w: "nw"},
+    s: {e: "se", w: "sw"},
+} as const satisfies Record<"n" | "s", Record<"e" | "w", LabelAttach>>;
+
+/**
+ * Returns the compass attach direction that pushes the label toward the
+ * outside of the plotted region. We split the range at its midpoint and
+ * pick a quadrant: points in the upper-right of the graph get an `ne`
+ * attach (label sits further up-and-right), points in the lower-left get
+ * `sw`, etc.
+ *
+ * This is a coarse, axis-only clamp. It guarantees the label is on the
+ * outward-facing side of the point relative to the graph's center,
+ * which is enough to keep labels off the geometry for points near any
+ * edge. Per-shape avoidance (arc / polygon side / curve) is a future
+ * enhancement — flagged in the rollout plan's "Risks" section.
+ */
+export function getLabelAttach(
+    coord: vec.Vector2,
+    range: [Interval, Interval],
+): LabelAttach {
+    const [xMin, xMax] = range[0];
+    const [yMin, yMax] = range[1];
+    const xMid = (xMin + xMax) / 2;
+    const yMid = (yMin + yMax) / 2;
+
+    // In graph units, larger y = further north. We want the label to
+    // sit further from the graph's center than the point, so:
+    //   point in upper half → attach north (label goes above point)
+    //   point in lower half → attach south (label goes below point)
+    //   point in right half → attach east (label goes right of point)
+    //   point in left half  → attach west (label goes left of point)
+    const vertical = coord[1] >= yMid ? "n" : "s";
+    const horizontal = coord[0] >= xMid ? "e" : "w";
+    return ATTACH_BY_QUADRANT[vertical][horizontal];
+}

--- a/packages/perseus/src/widgets/interactive-graphs/point-labels.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/point-labels.test.ts
@@ -1,0 +1,72 @@
+import {getEffectivePointLabels, resolveVisibleLabel} from "./point-labels";
+
+describe("resolveVisibleLabel", () => {
+    it("auto-generates A, B, C, … when pointLabels is undefined", () => {
+        // Arrange, Act, Assert
+        expect(resolveVisibleLabel(undefined, 0)).toBe("A");
+        expect(resolveVisibleLabel(undefined, 1)).toBe("B");
+        expect(resolveVisibleLabel(undefined, 2)).toBe("C");
+    });
+
+    it("auto-generates the next letter when pointLabels has no entry at that index", () => {
+        // Arrange, Act, Assert
+        expect(resolveVisibleLabel(["P"], 1)).toBe("B");
+    });
+
+    it("uses the author-provided label when present and non-empty", () => {
+        // Arrange, Act, Assert
+        expect(resolveVisibleLabel(["P", "Q", "R"], 0)).toBe("P");
+        expect(resolveVisibleLabel(["P", "Q", "R"], 1)).toBe("Q");
+        expect(resolveVisibleLabel(["P", "Q", "R"], 2)).toBe("R");
+    });
+
+    it("falls back to the auto letter when the author-provided label is the empty string", () => {
+        // Arrange, Act, Assert
+        expect(resolveVisibleLabel(["", "Q"], 0)).toBe("A");
+        expect(resolveVisibleLabel(["", "Q"], 1)).toBe("Q");
+    });
+
+    it("wraps the alphabet at index 26", () => {
+        // Arrange, Act, Assert
+        expect(resolveVisibleLabel(undefined, 25)).toBe("Z");
+        expect(resolveVisibleLabel(undefined, 26)).toBe("A");
+    });
+});
+
+describe("getEffectivePointLabels", () => {
+    it("returns pointLabels unchanged when showLabels is false", () => {
+        // Arrange, Act, Assert
+        expect(getEffectivePointLabels(false, ["P", "Q"], 2)).toEqual([
+            "P",
+            "Q",
+        ]);
+    });
+
+    it("returns undefined when showLabels is false and pointLabels is undefined (preserves legacy default)", () => {
+        // Arrange, Act, Assert
+        expect(getEffectivePointLabels(false, undefined, 3)).toBeUndefined();
+    });
+
+    it("returns undefined when showLabels is undefined (treated as off)", () => {
+        // Arrange, Act, Assert
+        expect(getEffectivePointLabels(undefined, ["P"], 2)).toEqual(["P"]);
+    });
+
+    it("fills A/B/C when showLabels is true and pointLabels is undefined", () => {
+        // Arrange, Act, Assert
+        expect(getEffectivePointLabels(true, undefined, 3)).toEqual([
+            "A",
+            "B",
+            "C",
+        ]);
+    });
+
+    it("uses author labels and fills gaps with auto letters when showLabels is true and pointLabels is partial", () => {
+        // Arrange, Act, Assert
+        expect(getEffectivePointLabels(true, ["P"], 3)).toEqual([
+            "P",
+            "B",
+            "C",
+        ]);
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/point-labels.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/point-labels.test.ts
@@ -1,16 +1,15 @@
 import {getEffectivePointLabels, resolveVisibleLabel} from "./point-labels";
 
 describe("resolveVisibleLabel", () => {
-    it("auto-generates A, B, C, … when pointLabels is undefined", () => {
+    it("returns undefined when pointLabels is undefined", () => {
         // Arrange, Act, Assert
-        expect(resolveVisibleLabel(undefined, 0)).toBe("A");
-        expect(resolveVisibleLabel(undefined, 1)).toBe("B");
-        expect(resolveVisibleLabel(undefined, 2)).toBe("C");
+        expect(resolveVisibleLabel(undefined, 0)).toBeUndefined();
+        expect(resolveVisibleLabel(undefined, 1)).toBeUndefined();
     });
 
-    it("auto-generates the next letter when pointLabels has no entry at that index", () => {
+    it("returns undefined when pointLabels has no entry at that index", () => {
         // Arrange, Act, Assert
-        expect(resolveVisibleLabel(["P"], 1)).toBe("B");
+        expect(resolveVisibleLabel(["P"], 1)).toBeUndefined();
     });
 
     it("uses the author-provided label when present and non-empty", () => {
@@ -20,16 +19,10 @@ describe("resolveVisibleLabel", () => {
         expect(resolveVisibleLabel(["P", "Q", "R"], 2)).toBe("R");
     });
 
-    it("falls back to the auto letter when the author-provided label is the empty string", () => {
+    it("returns undefined when the author-provided label is the empty string", () => {
         // Arrange, Act, Assert
-        expect(resolveVisibleLabel(["", "Q"], 0)).toBe("A");
+        expect(resolveVisibleLabel(["", "Q"], 0)).toBeUndefined();
         expect(resolveVisibleLabel(["", "Q"], 1)).toBe("Q");
-    });
-
-    it("wraps the alphabet at index 26", () => {
-        // Arrange, Act, Assert
-        expect(resolveVisibleLabel(undefined, 25)).toBe("Z");
-        expect(resolveVisibleLabel(undefined, 26)).toBe("A");
     });
 });
 
@@ -47,26 +40,27 @@ describe("getEffectivePointLabels", () => {
         expect(getEffectivePointLabels(false, undefined, 3)).toBeUndefined();
     });
 
-    it("returns undefined when showLabels is undefined (treated as off)", () => {
+    it("returns pointLabels unchanged when showLabels is undefined (treated as off)", () => {
         // Arrange, Act, Assert
         expect(getEffectivePointLabels(undefined, ["P"], 2)).toEqual(["P"]);
     });
 
-    it("fills A/B/C when showLabels is true and pointLabels is undefined", () => {
+    it("returns empty strings for every position when showLabels is true and pointLabels is undefined (no auto-fill)", () => {
+        // The author skipped pointLabels. We deliberately do NOT generate
+        // A/B/C here — that would leak Latin characters into non-Latin
+        // locales. The interactive-graph-widget-error lint rule blocks
+        // this shape at authoring time; the renderer's job is just to
+        // not invent labels.
         // Arrange, Act, Assert
         expect(getEffectivePointLabels(true, undefined, 3)).toEqual([
-            "A",
-            "B",
-            "C",
+            "",
+            "",
+            "",
         ]);
     });
 
-    it("uses author labels and fills gaps with auto letters when showLabels is true and pointLabels is partial", () => {
+    it("uses author labels and leaves gaps empty when showLabels is true and pointLabels is partial", () => {
         // Arrange, Act, Assert
-        expect(getEffectivePointLabels(true, ["P"], 3)).toEqual([
-            "P",
-            "B",
-            "C",
-        ]);
+        expect(getEffectivePointLabels(true, ["P"], 3)).toEqual(["P", "", ""]);
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/point-labels.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/point-labels.ts
@@ -2,27 +2,33 @@
 // `showLabels` field. The same per-index label string drives both the
 // visible on-canvas <TextLabel> and the screen-reader aria-label, so the
 // two never disagree (WCAG 2.5.3 "Label in Name").
+//
+// `showLabels: true` requires the author to provide `pointLabels`. We do
+// NOT auto-generate fallback letters (A, B, C, …) here. Auto-fill would
+// leak Latin characters into non-Latin-alphabet locales. Authoring-time
+// enforcement lives in the `interactive-graph-widget-error` lint rule.
 
-// Resolves the visible on-canvas label for the point at `index`. Uses the
-// author-provided string when present and non-empty, otherwise falls back
-// to the auto-generated letter A, B, C, … (Z, then wraps).
+// Returns the author-provided label for the point at `index`, or
+// `undefined` when no label was provided (or the entry is the empty
+// string). Callers should skip rendering a visible label when this
+// returns `undefined`.
 export function resolveVisibleLabel(
     pointLabels: string[] | undefined,
     index: number,
-): string {
+): string | undefined {
     const provided = pointLabels?.[index];
     if (provided != null && provided !== "") {
         return provided;
     }
-    return String.fromCharCode(65 + (index % 26));
+    return undefined;
 }
 
 // Returns the per-point label array that should drive BOTH the visible
 // on-canvas text AND the aria-label / SR description, so the two stay in
 // sync. When `showLabels` is off, returns `pointLabels` unchanged (legacy
-// behaviour). When on, fills any gaps with the auto A/B/C fallback so a
-// learner using a screen reader hears the same letter a sighted learner
-// sees.
+// behaviour). When on, returns `pointLabels` as-is — missing or empty
+// entries stay missing so we never invent Latin letters that conflict
+// with the learner's locale.
 export function getEffectivePointLabels(
     showLabels: boolean | undefined,
     pointLabels: string[] | undefined,
@@ -31,7 +37,8 @@ export function getEffectivePointLabels(
     if (!showLabels) {
         return pointLabels;
     }
-    return Array.from({length: count}, (_, i) =>
-        resolveVisibleLabel(pointLabels, i),
+    return Array.from(
+        {length: count},
+        (_, i) => resolveVisibleLabel(pointLabels, i) ?? "",
     );
 }

--- a/packages/perseus/src/widgets/interactive-graphs/point-labels.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/point-labels.ts
@@ -1,0 +1,37 @@
+// Helpers shared by every interactive-graph type that supports the opt-in
+// `showLabels` field. The same per-index label string drives both the
+// visible on-canvas <TextLabel> and the screen-reader aria-label, so the
+// two never disagree (WCAG 2.5.3 "Label in Name").
+
+// Resolves the visible on-canvas label for the point at `index`. Uses the
+// author-provided string when present and non-empty, otherwise falls back
+// to the auto-generated letter A, B, C, … (Z, then wraps).
+export function resolveVisibleLabel(
+    pointLabels: string[] | undefined,
+    index: number,
+): string {
+    const provided = pointLabels?.[index];
+    if (provided != null && provided !== "") {
+        return provided;
+    }
+    return String.fromCharCode(65 + (index % 26));
+}
+
+// Returns the per-point label array that should drive BOTH the visible
+// on-canvas text AND the aria-label / SR description, so the two stay in
+// sync. When `showLabels` is off, returns `pointLabels` unchanged (legacy
+// behaviour). When on, fills any gaps with the auto A/B/C fallback so a
+// learner using a screen reader hears the same letter a sighted learner
+// sees.
+export function getEffectivePointLabels(
+    showLabels: boolean | undefined,
+    pointLabels: string[] | undefined,
+    count: number,
+): string[] | undefined {
+    if (!showLabels) {
+        return pointLabels;
+    }
+    return Array.from({length: count}, (_, i) =>
+        resolveVisibleLabel(pointLabels, i),
+    );
+}

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/initialize-graph-state.ts
@@ -44,6 +44,8 @@ export function initializeGraphState(
         range,
         snapStep,
         pointLabels: "pointLabels" in graph ? graph.pointLabels : undefined,
+        showLabels:
+            "showLabels" in graph ? Boolean(graph.showLabels) : undefined,
     };
     switch (graph.type) {
         case "segment":

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -203,6 +203,10 @@ export interface InteractiveGraphStateCommon {
     // Custom screen-reader labels for each interactive point. When present,
     // pointLabels[i] replaces the default numeric "Point {i+1}" announcement.
     pointLabels?: string[];
+    // Opt-in: when true, render a visible on-canvas label next to each
+    // interactive point (A, B, C, …, or the matching `pointLabels[i]` when
+    // set). Defaults to off.
+    showLabels?: boolean;
     // range = [[xMin, xMax], [yMin, yMax]] in Cartesian units
     range: [xRange: Interval, yRange: Interval];
     // snapStep = [xStep, yStep] in Cartesian units


### PR DESCRIPTION
## Summary

Adds an opt-in `showLabels` field to every interactive-graph type that has movable points (angle, polygon, quadratic, sinusoid, tangent, exponential, logarithm, absolute-value, circle, linear, ray, segment, linear-system, point). When true, each interactive point gets a visible label drawn next to it on the canvas — author-supplied via the existing `pointLabels` field, or auto-generated as A/B/C/… when not provided. Labels track each point as the learner drags it.

The field defaults to off, no changes to existing graphs. Authors only see new behavior when they opt in.

Accessibility is preserved end-to-end: a single shared helper (`getEffectivePointLabels`) drives both the visible on-canvas text and the screen-reader announcements, so a sighted learner who sees "A" hears "Point A at …" — never "Point 1". The visible label itself is wrapped in `<g aria-hidden="true">` to avoid double-announcing alongside the focusable handle's aria-label.
  
`vector` and `none` are intentionally skipped (no labelable points by schema).

## JSON format
  
`showLabels` is an optional boolean, available on every graph type that supports `pointLabels`. Three usage patterns:

# Off (default — no change from today):
```
  {
    "graph": {
      "type": "polygon",
      "numSides": 3,
      "startCoords": [[-2, 0], [2, 0], [0, 3]]
    }
  }
```

# On, no pointLabels (auto A/B/C):
``` 
 {
    "graph": {
      "type": "polygon",
      "numSides": 4,
      "startCoords": [[-3, 2], [3, 2], [3, -2], [-3, -2]],
      "showLabels": true
    }
  }
```
  → Sighted sees A/B/C/D. Screen reader hears "Point A at …", "Point B at …", etc.

# On, with pointLabels (author-controlled):
```
  {
    "graph": {
      "type": "point",
      "numPoints": 3,
      "startCoords": [[-2, 0], [2, 0], [2, 3]],
      "pointLabels": ["P", "Q", "R"],
      "showLabels": true
    }
  }
```
  → Visible: P/Q/R. Screen reader: "Point P / Q / R at …". Author labels always win at their index; gaps fall back to A/B/C.

The `pointLabels` shape per graph type is unchanged from what's already in the schema. 

## Demo

https://github.com/user-attachments/assets/6329570f-0834-4a54-a98d-70d4cd15700f

## Testing

- Unit tests (`point-labels.test.ts`) cover the shared helpers in isolation: A/B/C fallback, author label preference, empty-string passthrough, alphabet wrap at index 26, and every combination of showLabels: true | false | undefined × pointLabels: present | absent | partial.

- Aria parity tests (`point.test.ts`, 3 new specs) verify that the interactive-elements screen-reader description uses the same per-point letter the canvas displays — including the "partial pointLabels" case which proves the fill-in rule reaches the SR announcement, not just the visible label.

- Component tests (`movable-point.test.tsx`, 4 new specs) confirm the visible `<TextLabel>` is rendered only when label is provided, that it appears with the exact string passed in, that the empty string suppresses it entirely, and that the wrapping group carries `aria-hidden="true"`.

- Storybook stories (3): PointWithAutoVisibleLabels and PointWithCustomVisibleLabels exercise the two point paths; PolygonWithVisibleLabels exists specifically to prove the cross-type wiring — every other graph type follows the same pattern and would render identically in a story, so we kept the addition minimal as agreed.
  
- Regression: the full interactive-graph jest suite passes unchanged
- `pnpm tsc` pass