### PR TITLE
[Interactive Graph] Wire pointLabels through polygon graphs for custom points label

### DIFF
--- a/.changeset/sharp-seahorses-speak.md
+++ b/.changeset/sharp-seahorses-speak.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": minor
+---
+
+[Interactive Graph] Wire pointLabels through polygon graphs for custom points label

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.test.tsx
@@ -861,13 +861,7 @@ describe("StartCoordSettings", () => {
             expect(screen.getByText("Point 3:")).toBeInTheDocument();
         });
 
-        // Polygon's render side does not consume `pointLabels` until PR 3,
-        // so the editor name fields are intentionally gated off here even
-        // when `onChangePointLabels` is forwarded by the parent editor.
-        // TODO(LEMS-3995, PR 3): flip this assertion to `toBeInTheDocument()`
-        // when the `type === "point"` gate in start-coords-settings.tsx is
-        // widened to include polygon.
-        it("does NOT render point name fields for polygon graphs", () => {
+        it("renders point name fields when onChangePointLabels is provided", () => {
             // Arrange, Act
             render(
                 <StartCoordsSettings
@@ -881,8 +875,58 @@ describe("StartCoordSettings", () => {
 
             // Assert
             expect(
+                screen.getByRole("textbox", {name: "Point 1 name"}),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole("textbox", {name: "Point 2 name"}),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole("textbox", {name: "Point 3 name"}),
+            ).toBeInTheDocument();
+        });
+
+        it("does NOT render point name fields when onChangePointLabels is omitted", () => {
+            // Arrange, Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="polygon"
+                    onChange={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(
                 screen.queryByRole("textbox", {name: "Point 1 name"}),
             ).not.toBeInTheDocument();
+        });
+
+        it("calls onChangePointLabels when a point name is typed", async () => {
+            // Arrange
+            const onChangePointLabelsMock = jest.fn();
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="polygon"
+                    onChange={() => {}}
+                    onChangePointLabels={onChangePointLabelsMock}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            const nameInput = screen.getByRole("textbox", {
+                name: "Point 1 name",
+            });
+            await userEvent.type(nameInput, "A");
+
+            // Assert
+            expect(onChangePointLabelsMock).toHaveBeenLastCalledWith([
+                "A",
+                "",
+                "",
+            ]);
         });
 
         it("shows the start coordinates UI: 6 sides", () => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
@@ -184,20 +184,12 @@ const StartCoordsSettingsInner = (props: Props) => {
                 type === "point"
                     ? getPointCoords(props, range, step)
                     : getPolygonCoords(props, range, step);
-            // Only `point` consumes `pointLabels` at runtime in PR 2 —
-            // polygon's render side wires up in PR 3. Gate the editor
-            // name fields to match so polygon authors don't fill in
-            // values that would silently have no screen-reader effect.
             return (
                 <StartCoordsPoint
                     startCoords={pointCoords}
                     onChange={onChange}
-                    pointLabels={
-                        type === "point" ? props.pointLabels : undefined
-                    }
-                    onChangePointLabels={
-                        type === "point" ? onChangePointLabels : undefined
-                    }
+                    pointLabels={props.pointLabels}
+                    onChangePointLabels={onChangePointLabels}
                 />
             );
         case "angle":

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
@@ -11,6 +11,7 @@ import {
     pointWithCustomLabelQuestion,
     pointWithDefaultLabelQuestion,
     polygonQuestion,
+    polygonWithCustomLabelsQuestion,
     rayQuestion,
     segmentQuestion,
     segmentWithLockedPointsQuestion,
@@ -119,6 +120,21 @@ export const PointWithDefaultLabel: Story = {
 export const Polygon: Story = {
     args: {
         item: generateTestPerseusItem({question: polygonQuestion}),
+    },
+};
+
+/**
+ * A polygon graph whose vertices use custom screen-reader
+ * labels ("A", "B", "C") via `pointLabels`, so the announcements
+ * match the question prompt instead of the generic "Point 1/2/3 …".
+ * Open with the Storybook a11y addon (or VoiceOver / JAWS) to verify
+ * each vertex announces "Point A / B / C at …".
+ */
+export const PolygonWithCustomLabels: Story = {
+    args: {
+        item: generateTestPerseusItem({
+            question: polygonWithCustomLabelsQuestion,
+        }),
     },
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.test.tsx
@@ -564,6 +564,130 @@ describe("Unlimited Polygon (open) screen reader", () => {
     );
 });
 
+describe.each`
+    polygonType             | polygonState
+    ${"Limited"}            | ${baseLimitedPolygonState}
+    ${"Unlimited (closed)"} | ${baseUnlimitedPolygonStateClosed}
+    ${"Unlimited (open)"}   | ${baseUnlimitedPolygonStateOpen}
+`("$polygonType Polygon pointLabels", ({polygonState}) => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("uses custom pointLabels in each point's accessible name", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...polygonState, pointLabels: ["A", "B", "C"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point A at 3 comma -2."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at 0 comma 4."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point C at -3 comma -2."}),
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to numeric default for indices without a custom label", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...polygonState, pointLabels: ["A"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point A at 3 comma -2."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point 2 at 0 comma 4."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point 3 at -3 comma -2."}),
+        ).toBeInTheDocument();
+    });
+
+    // The editor produces a full-length array like ["", "B", ""] when an
+    // author names only one vertex; explicit empty strings must fall back
+    // to the numeric default for that index, same as missing entries.
+    it("treats explicit empty-string entries as numeric defaults", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...polygonState, pointLabels: ["", "B", ""]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point 1 at 3 comma -2."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at 0 comma 4."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point 3 at -3 comma -2."}),
+        ).toBeInTheDocument();
+    });
+
+    it("uses custom pointLabels in the interactive elements description", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...polygonState, pointLabels: ["A", "B", "C"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByText(
+                "Interactive elements: A polygon with 3 points. Point A at 3 comma -2. Point B at 0 comma 4. Point C at -3 comma -2.",
+            ),
+        ).toBeInTheDocument();
+    });
+
+    // Defense-in-depth against malformed hand-authored JSON that bypasses the
+    // parser. Locks in that the focusable handle and the SR-tree summary share
+    // the helper's fallback rule for non-string entries.
+    it("falls back to numeric default for truthy non-string entries on both the handle and the summary", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...polygonState,
+                    // eslint-disable-next-line no-restricted-syntax -- cast simulates malformed JSON the parser would reject
+                    pointLabels: [42, "B", "C"] as unknown as string[],
+                }}
+            />,
+        );
+
+        // Assert — handle path (per-point MovablePoint aria-label)
+        expect(
+            screen.getByRole("button", {name: "Point 1 at 3 comma -2."}),
+        ).toBeInTheDocument();
+        // Assert — summary path (InteractiveGraphSRTree)
+        expect(
+            screen.getByText(
+                "Interactive elements: A polygon with 3 points. Point 1 at 3 comma -2. Point B at 0 comma 4. Point C at -3 comma -2.",
+            ),
+        ).toBeInTheDocument();
+    });
+});
+
 describe("getSideSnapConstraint", () => {
     it("should find the next available coordinate to maintain a whole length sides", () => {
         const range: PolygonGraphState["range"] = [

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -20,6 +20,7 @@ import useGraphConfig from "../reducer/use-graph-config";
 import {bound, getCSSZoomFactor, TARGET_SIZE} from "../utils";
 
 import {PolygonAngle} from "./components/angle-indicators";
+import {buildPointAriaLabel} from "./components/build-point-aria-label";
 import {MovablePoint} from "./components/movable-point";
 import SRDescInSVG from "./components/sr-description-within-svg";
 import {TextLabel} from "./components/text-label";
@@ -185,9 +186,12 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
         range,
         snapTo = "grid",
         snapStep,
+        pointLabels,
     } = statefulProps.graphState;
     const {disableKeyboardInteraction, interactiveColor} = graphConfig;
     const {strings, locale} = usePerseusI18n();
+    const buildLabel = (index: number, point: vec.Vector2) =>
+        buildPointAriaLabel(pointLabels, index, point, strings, locale);
     const id = React.useId();
     const pointsOffArray = Array(points.length).fill("off");
     // When moving an element, set its aria-live to "polite" and the others
@@ -334,6 +338,7 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
                     <g key={"point-" + i}>
                         <MovablePoint
                             ariaDescribedBy={`${angleId} ${side1Id} ${side2Id}`}
+                            ariaLabel={buildLabel(i, point)}
                             ariaLive={ariaLives[i + 1]}
                             constrain={getKeyboardMovementConstraintForPoint(
                                 points,
@@ -420,8 +425,10 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
 
 const UnlimitedPolygonGraph = (statefulProps: StatefulProps) => {
     const {dispatch, graphConfig, left, top, pointsRef, points} = statefulProps;
-    const {coords, closedPolygon} = statefulProps.graphState;
+    const {coords, closedPolygon, pointLabels} = statefulProps.graphState;
     const {strings, locale} = usePerseusI18n();
+    const buildLabel = (index: number, point: vec.Vector2) =>
+        buildPointAriaLabel(pointLabels, index, point, strings, locale);
     const {interactiveColor} = useGraphConfig();
 
     // When users drag a point on iOS Safari, the browser fires a click event after the mouseup
@@ -546,6 +553,7 @@ const UnlimitedPolygonGraph = (statefulProps: StatefulProps) => {
                     <g key={"point-" + i}>
                         <MovablePoint
                             ariaDescribedBy={`${angleId} ${sideIds}`}
+                            ariaLabel={buildLabel(i, point)}
                             ariaLive={ariaLives[i]}
                             point={point}
                             sequenceNumber={i + 1}
@@ -679,7 +687,9 @@ function describePolygonGraph(
     markings: InteractiveGraphProps["markings"],
 ): PolygonGraphDescriptionStrings {
     const {strings, locale} = i18n;
-    const {coords} = state;
+    const {coords, pointLabels} = state;
+    const buildLabel = (index: number, point: vec.Vector2) =>
+        buildPointAriaLabel(pointLabels, index, point, strings, locale);
     const isCoordinatePlane = markings === "axes" || markings === "graph";
     const hasOnePoint = coords.length === 1;
 
@@ -698,13 +708,16 @@ function describePolygonGraph(
     // If the graph is not on a coordinate plane, we should not include
     // the points' coordinates in the description.
     if (isCoordinatePlane) {
-        const pointsString = coords.map((coord, i) => {
-            return strings.srPointAtCoordinates({
-                num: i + 1,
-                x: srFormatNumber(coord[0], locale),
-                y: srFormatNumber(coord[1], locale),
-            });
-        });
+        const pointsString = coords.map(
+            (coord, i) =>
+                // Share the helper's defensive rules with the MovablePoint handle's aria-label.
+                buildLabel(i, coord) ??
+                strings.srPointAtCoordinates({
+                    num: i + 1,
+                    x: srFormatNumber(coord[0], locale),
+                    y: srFormatNumber(coord[1], locale),
+                }),
+        );
         srPolygonGraphPoints = pointsString.join(" ");
     }
 

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -1310,3 +1310,30 @@ export const pointWithDefaultLabelQuestion: PerseusRenderer =
             coords: [[-4, 2]],
         }),
     });
+
+export const polygonWithCustomLabelsQuestion: PerseusRenderer =
+    generateInteractiveGraphQuestion({
+        content:
+            "**Drag the vertices $A$, $B$, and $C$ to form a triangle with a right angle at vertex $B$.**\n\n[[☃ interactive-graph 1]]",
+        markings: "graph",
+        gridStep: [1, 1],
+        snapStep: [1, 1],
+        step: [1, 1],
+        range: [
+            [-6, 6],
+            [-6, 6],
+        ],
+        correct: generateIGPolygonGraph({
+            snapTo: "grid",
+            match: "congruent",
+            numSides: 3,
+            showAngles: true,
+            showSides: true,
+            coords: [
+                [-2, -1],
+                [2, -1],
+                [2, 3],
+            ],
+            pointLabels: ["A", "B", "C"],
+        }),
+    });


### PR DESCRIPTION
## Summary:
- Wires `pointLabels` through polygon graphs (Limited, Unlimited closed, and Unlimited open) end-to-end on the render side and unlocks the editor label fields that were already plumbed in PR 2.
- Each `MovablePoint` on a polygon now announces its author-supplied label (e.g. *"Point A at -2 comma -1"*); the polygon's interactive-elements summary uses the same labels. Indices without a custom label fall back to the existing numeric *"Point N at …"* default per index.

Co-authored by Claude Code (Opus)
Issue: LEMS-3995

## Risk

Low. No foundation changes. The new code paths are:
- Two `MovablePoint` call sites (one per polygon variant) gaining an `ariaLabel` prop that falls back to `undefined` when no custom label is set.
- One per-point string-builder branch in `describePolygonGraph`, now routed through `buildPointAriaLabel` so it shares fallback rules with the focusable handle.
- One gate removal in the editor.

Reviewer focus: confirm the SR-tree summary, the polygon's overall `aria-label`, and each `MovablePoint`'s accessible name all use the same labels when `pointLabels` is set, and all fall back consistently when it isn't (including the truthy-non-string defense-in-depth case the new test locks in).

## Test plan

- [x] `pnpm tsc` — passes
- [x] `pnpm lint packages/perseus packages/perseus-editor` — passes
- [x] `pnpm prettier . --check` — passes
- [x] `pnpm test packages/perseus/src/widgets/interactive-graphs` — 1114 pass, 28 pre-existing skips, 12 snapshots
- [x] `pnpm --filter perseus-editor test` — passes
- [ ] Reviewer manual: open the `PolygonWithCustomLabels` story, enable the Storybook a11y addon (or VoiceOver / JAWS), and confirm each vertex announces *"Point A / B / C at …"* matching the prompt. Confirm the existing `Polygon` story (no `pointLabels`) still announces the legacy *"Point 1 / 2 / 3 at …"* defaults.
- [ ] Reviewer manual: open the `InteractiveGraphPolygon` editor story, expand "Start coordinates", type a letter into one of the polygon vertices' label fields, and confirm the rendered graph's vertex `aria-label` *and* the **Screen reader tree** panel both update on the same render — same dual-write contract PR 2 added for `point`.

## PR Series and Follow-ups (PRs 4–7)

Independent and parallelizable. None of them touch the foundation files (`data-schema.ts`, the parser, `strings.ts`, `InteractiveGraphStateCommon`, `interactive-graph-editor.tsx`'s handler/serialization, or `buildPointAriaLabel` / `CoordInput`). Each one wires its graph type's render side and adds the per-type `start-coords-<type>.tsx` plumbing using the same `CoordInput` `pointLabel` prop bundle PR 2 introduced.

- **PR 1** — [Schema — no behavior. Only data-shape stop.](https://github.com/Khan/perseus/pull/3605)
- **PR 2** — [Foundation + Point graph](https://github.com/Khan/perseus/pull/3643)
- 👉🏼 **PR 3** — [Polygon (shares start-coords-point.tsx); widen the gate to type === "point" || type === "polygon"](https://github.com/Khan/perseus/pull/3669)
- **PR 4** — [Lines: linear, ray](https://github.com/Khan/perseus/pull/3672)
- **PR 5** — [Multi-line: linear-system, segment](https://github.com/Khan/perseus/pull/3673)
- **PR 6** — Curves: quadratic, sinusoid, tangent, exponential, logarithm.
- **PR 7** — Special shapes: angle, circle, absolute-value.