### PR TITLE
[Interactive Graph] Wire pointLabels through line and ray graphs for custom points label

### DIFF
--- a/.changeset/lovely-dodos-sit.md
+++ b/.changeset/lovely-dodos-sit.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-core": minor
+"@khanacademy/perseus-editor": minor
+---
+
+[Interactive Graph] Wire pointLabels through line and ray graphs for custom points label

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1341,8 +1341,6 @@ export type PerseusGraphTypeVector = {
      *  "exact" (default) — both tail and tip must match exactly.
      *  "congruent" — same direction and magnitude, any position. */
     match?: "exact" | "congruent";
-    /** Custom label for each interactive point that will help with the screen reader. */
-    pointLabels?: [string, string];
 };
 
 type AbsoluteValueGraphCorrect = {

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -168,7 +168,6 @@ const parsePerseusGraphTypeVector = object({
     coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
     startCoords: optional(pair(pairOfNumbers, pairOfNumbers)),
     match: optional(enumeration("exact", "congruent")),
-    pointLabels: optional(pair(string, string)),
 });
 
 export const parsePerseusGraphType = discriminatedUnionOn("type")

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-line.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-line.tsx
@@ -4,21 +4,21 @@ import CoordInput from "./coord-input";
 
 import type {CollinearTuple} from "@khanacademy/perseus-core";
 
-type Props = {
+interface StartCoordsLineProps {
     startCoords: CollinearTuple;
     onChange: (startCoords: CollinearTuple) => void;
-    pointLabels?: ReadonlyArray<string>;
-    onChangePointLabels?: (pointLabels: ReadonlyArray<string>) => void;
-};
+    pointLabels: ReadonlyArray<string>;
+    onChangePointLabels: (pointLabels: ReadonlyArray<string>) => void;
+}
 
-const StartCoordsLine = (props: Props) => {
+const StartCoordsLine = (props: StartCoordsLineProps) => {
     const {startCoords, onChange, pointLabels, onChangePointLabels} = props;
     const updatePointLabel = (index: number, newLabel: string) => {
         const next: [string, string] = [
-            index === 0 ? newLabel : pointLabels?.[0] ?? "",
-            index === 1 ? newLabel : pointLabels?.[1] ?? "",
+            index === 0 ? newLabel : pointLabels[0] ?? "",
+            index === 1 ? newLabel : pointLabels[1] ?? "",
         ];
-        onChangePointLabels?.(next);
+        onChangePointLabels(next);
     };
 
     return (
@@ -27,21 +27,15 @@ const StartCoordsLine = (props: Props) => {
                 label="Point 1"
                 coord={startCoords[0]}
                 onChange={(value) => onChange([value, startCoords[1]])}
-                pointLabel={pointLabels?.[0]}
-                onPointLabelChange={
-                    onChangePointLabels &&
-                    ((newLabel) => updatePointLabel(0, newLabel))
-                }
+                pointLabel={pointLabels[0]}
+                onPointLabelChange={(newLabel) => updatePointLabel(0, newLabel)}
             />
             <CoordInput
                 label="Point 2"
                 coord={startCoords[1]}
                 onChange={(value) => onChange([startCoords[0], value])}
-                pointLabel={pointLabels?.[1]}
-                onPointLabelChange={
-                    onChangePointLabels &&
-                    ((newLabel) => updatePointLabel(1, newLabel))
-                }
+                pointLabel={pointLabels[1]}
+                onPointLabelChange={(newLabel) => updatePointLabel(1, newLabel)}
             />
         </>
     );

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-line.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-line.tsx
@@ -7,10 +7,19 @@ import type {CollinearTuple} from "@khanacademy/perseus-core";
 type Props = {
     startCoords: CollinearTuple;
     onChange: (startCoords: CollinearTuple) => void;
+    pointLabels?: ReadonlyArray<string>;
+    onChangePointLabels?: (pointLabels: ReadonlyArray<string>) => void;
 };
 
 const StartCoordsLine = (props: Props) => {
-    const {startCoords, onChange} = props;
+    const {startCoords, onChange, pointLabels, onChangePointLabels} = props;
+    const updatePointLabel = (index: number, newLabel: string) => {
+        const next: [string, string] = [
+            index === 0 ? newLabel : pointLabels?.[0] ?? "",
+            index === 1 ? newLabel : pointLabels?.[1] ?? "",
+        ];
+        onChangePointLabels?.(next);
+    };
 
     return (
         <>
@@ -18,11 +27,21 @@ const StartCoordsLine = (props: Props) => {
                 label="Point 1"
                 coord={startCoords[0]}
                 onChange={(value) => onChange([value, startCoords[1]])}
+                pointLabel={pointLabels?.[0]}
+                onPointLabelChange={
+                    onChangePointLabels &&
+                    ((newLabel) => updatePointLabel(0, newLabel))
+                }
             />
             <CoordInput
                 label="Point 2"
                 coord={startCoords[1]}
                 onChange={(value) => onChange([startCoords[0], value])}
+                pointLabel={pointLabels?.[1]}
+                onPointLabelChange={
+                    onChangePointLabels &&
+                    ((newLabel) => updatePointLabel(1, newLabel))
+                }
             />
         </>
     );

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.test.tsx
@@ -18,6 +18,7 @@ const defaultProps = {
         [-10, 10],
     ] satisfies [Range, Range],
     step: [1, 1] satisfies [number, number],
+    onChangePointLabels: () => {},
 };
 describe("StartCoordSettings", () => {
     let userEvent: UserEvent;
@@ -176,24 +177,7 @@ describe("StartCoordSettings", () => {
             ).toBeInTheDocument();
         });
 
-        it(`does NOT render point name fields when onChangePointLabels is omitted for ${type}`, () => {
-            // Arrange, Act
-            render(
-                <StartCoordsSettings
-                    {...defaultProps}
-                    type={type}
-                    onChange={() => {}}
-                />,
-                {wrapper: RenderStateRoot},
-            );
-
-            // Assert
-            expect(
-                screen.queryByRole("textbox", {name: "Point 1 name"}),
-            ).not.toBeInTheDocument();
-        });
-
-        it(`calls onChangePointLabels with the schema's 2-tuple shape when a name is typed for ${type}`, async () => {
+        it(`${type}: calls onChangePointLabels with the schema's 2-tuple shape when a name is typed`, async () => {
             // Arrange
             const onChangePointLabelsMock = jest.fn();
             render(
@@ -215,6 +199,31 @@ describe("StartCoordSettings", () => {
             // Assert — the empty slot must be preserved so the schema
             // shape stays a 2-tuple even when only one point is named.
             expect(onChangePointLabelsMock).toHaveBeenLastCalledWith(["T", ""]);
+        });
+    });
+
+    describe("vector graph", () => {
+        it("shows the start coordinates UI without point name fields", () => {
+            // Arrange, Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="vector"
+                    onChange={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert — coord inputs render
+            expect(screen.getByText("Point 1:")).toBeInTheDocument();
+            expect(screen.getByText("Point 2:")).toBeInTheDocument();
+            // Assert — vector is intentionally excluded from custom labels
+            expect(
+                screen.queryByRole("textbox", {name: "Point 1 name"}),
+            ).not.toBeInTheDocument();
+            expect(
+                screen.queryByRole("textbox", {name: "Point 2 name"}),
+            ).not.toBeInTheDocument();
         });
     });
 
@@ -828,24 +837,6 @@ describe("StartCoordSettings", () => {
             ).toBeInTheDocument();
         });
 
-        it("does NOT render point name fields when onChangePointLabels is omitted", () => {
-            // Arrange, Act
-            render(
-                <StartCoordsSettings
-                    {...defaultProps}
-                    type="point"
-                    numPoints={2}
-                    onChange={() => {}}
-                />,
-                {wrapper: RenderStateRoot},
-            );
-
-            // Assert
-            expect(
-                screen.queryByRole("textbox", {name: "Point 1 name"}),
-            ).not.toBeInTheDocument();
-        });
-
         it("calls onChangePointLabels when a point name is typed", async () => {
             // Arrange
             const onChangePointLabelsMock = jest.fn();
@@ -945,23 +936,6 @@ describe("StartCoordSettings", () => {
             expect(
                 screen.getByRole("textbox", {name: "Point 3 name"}),
             ).toBeInTheDocument();
-        });
-
-        it("does NOT render point name fields when onChangePointLabels is omitted", () => {
-            // Arrange, Act
-            render(
-                <StartCoordsSettings
-                    {...defaultProps}
-                    type="polygon"
-                    onChange={() => {}}
-                />,
-                {wrapper: RenderStateRoot},
-            );
-
-            // Assert
-            expect(
-                screen.queryByRole("textbox", {name: "Point 1 name"}),
-            ).not.toBeInTheDocument();
         });
 
         it("calls onChangePointLabels when a point name is typed", async () => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.test.tsx
@@ -154,6 +154,68 @@ describe("StartCoordSettings", () => {
                 expect(onChangeMock).toHaveBeenLastCalledWith(expectedCoords);
             },
         );
+
+        it(`renders point name fields when onChangePointLabels is provided for ${type}`, () => {
+            // Arrange, Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type={type}
+                    onChange={() => {}}
+                    onChangePointLabels={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(
+                screen.getByRole("textbox", {name: "Point 1 name"}),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole("textbox", {name: "Point 2 name"}),
+            ).toBeInTheDocument();
+        });
+
+        it(`does NOT render point name fields when onChangePointLabels is omitted for ${type}`, () => {
+            // Arrange, Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type={type}
+                    onChange={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(
+                screen.queryByRole("textbox", {name: "Point 1 name"}),
+            ).not.toBeInTheDocument();
+        });
+
+        it(`calls onChangePointLabels with the schema's 2-tuple shape when a name is typed for ${type}`, async () => {
+            // Arrange
+            const onChangePointLabelsMock = jest.fn();
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type={type}
+                    onChange={() => {}}
+                    onChangePointLabels={onChangePointLabelsMock}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            const nameInput = screen.getByRole("textbox", {
+                name: "Point 1 name",
+            });
+            await userEvent.type(nameInput, "T");
+
+            // Assert — the empty slot must be preserved so the schema
+            // shape stays a 2-tuple even when only one point is named.
+            expect(onChangePointLabelsMock).toHaveBeenLastCalledWith(["T", ""]);
+        });
     });
 
     // startCoords with type CollinearTuple[]

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
@@ -33,19 +33,22 @@ import StartCoordsPoint from "./start-coords-point";
 import StartCoordsQuadratic from "./start-coords-quadratic";
 import StartCoordsSinusoid from "./start-coords-sinusoid";
 import StartCoordsTangent from "./start-coords-tangent";
+import StartCoordsVector from "./start-coords-vector";
 import {getDefaultGraphStartCoords} from "./util";
 
 import type {StartCoords} from "./types";
 import type {Coord} from "@khanacademy/perseus";
 import type {PerseusGraphType, Range} from "@khanacademy/perseus-core";
 
-type Props = PerseusGraphType & {
+interface StartCoordsSettingsProps {
     range: [x: Range, y: Range];
     step: [x: number, y: number];
     allowReflexAngles?: boolean;
     onChange: (startCoords: StartCoords) => void;
-    onChangePointLabels?: (pointLabels: ReadonlyArray<string>) => void;
-};
+    onChangePointLabels: (pointLabels: ReadonlyArray<string>) => void;
+}
+
+type Props = PerseusGraphType & StartCoordsSettingsProps;
 
 const StartCoordsSettingsInner = (props: Props) => {
     const {
@@ -80,7 +83,7 @@ const StartCoordsSettingsInner = (props: Props) => {
                 <StartCoordsLine
                     startCoords={linearCoords}
                     onChange={onChange}
-                    pointLabels={props.pointLabels}
+                    pointLabels={props.pointLabels ?? []}
                     onChangePointLabels={onChangePointLabels}
                 />
             );
@@ -157,7 +160,7 @@ const StartCoordsSettingsInner = (props: Props) => {
         case "vector": {
             const vectorCoords = getVectorCoords(props, range, step);
             return (
-                <StartCoordsLine
+                <StartCoordsVector
                     startCoords={vectorCoords}
                     onChange={onChange}
                 />

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
@@ -80,6 +80,8 @@ const StartCoordsSettingsInner = (props: Props) => {
                 <StartCoordsLine
                     startCoords={linearCoords}
                     onChange={onChange}
+                    pointLabels={props.pointLabels}
+                    onChangePointLabels={onChangePointLabels}
                 />
             );
         // Graphs with startCoords of type CollinearTuple[]

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-vector.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-vector.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+
+import CoordInput from "./coord-input";
+
+import type {CollinearTuple} from "@khanacademy/perseus-core";
+
+interface StartCoordsVectorProps {
+    startCoords: CollinearTuple;
+    onChange: (startCoords: CollinearTuple) => void;
+}
+
+const StartCoordsVector = (props: StartCoordsVectorProps) => {
+    const {startCoords, onChange} = props;
+
+    return (
+        <>
+            <CoordInput
+                label="Point 1"
+                coord={startCoords[0]}
+                onChange={(value) => onChange([value, startCoords[1]])}
+            />
+            <CoordInput
+                label="Point 2"
+                coord={startCoords[1]}
+                onChange={(value) => onChange([startCoords[0], value])}
+            />
+        </>
+    );
+};
+
+export default StartCoordsVector;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/utils/reshape-point-labels.ts
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/utils/reshape-point-labels.ts
@@ -39,8 +39,7 @@ export function reshapePointLabelsForGraphType(
         }
         case "absolute-value":
         case "linear":
-        case "ray":
-        case "vector": {
+        case "ray": {
             const reshaped = toPair(pointLabels);
             nextGraph = {...graph, pointLabels: reshaped};
             if (correct.type === graph.type) {
@@ -64,6 +63,7 @@ export function reshapePointLabelsForGraphType(
             }
             break;
         }
+        case "vector":
         case "none":
             return null;
     }

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
@@ -7,12 +7,14 @@ import {
     circleQuestion,
     linearQuestion,
     linearSystemQuestion,
+    linearWithCustomLabelsQuestion,
     pointQuestion,
     pointWithCustomLabelQuestion,
     pointWithDefaultLabelQuestion,
     polygonQuestion,
     polygonWithCustomLabelsQuestion,
     rayQuestion,
+    rayWithCustomLabelsQuestion,
     segmentQuestion,
     segmentWithLockedPointsQuestion,
     segmentWithLockedLineQuestion,
@@ -74,6 +76,19 @@ export const Circle: Story = {
 export const Linear: Story = {
     args: {
         item: generateTestPerseusItem({question: linearQuestion}),
+    },
+};
+
+/**
+ * A linear graph whose two endpoints are named "A" and "B" via `pointLabels`,
+ * so JAWS announces "Point A at …" / "Point B at …" instead of the default
+ * "Point 1 at …" / "Point 2 at …".
+ */
+export const LinearWithCustomLabels: Story = {
+    args: {
+        item: generateTestPerseusItem({
+            question: linearWithCustomLabelsQuestion,
+        }),
     },
 };
 
@@ -147,6 +162,20 @@ export const UnlimitedPolygon: Story = {
 export const Ray: Story = {
     args: {
         item: generateTestPerseusItem({question: rayQuestion}),
+    },
+};
+
+/**
+ * A ray whose endpoint and through point are named "A" and "B" via
+ * `pointLabels`. The default semantic "Endpoint at …" / "Through point at …"
+ * labels are overridden so the SR announcement matches the prompt's
+ * naming convention.
+ */
+export const RayWithCustomLabels: Story = {
+    args: {
+        item: generateTestPerseusItem({
+            question: rayWithCustomLabelsQuestion,
+        }),
     },
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.test.tsx
@@ -241,6 +241,80 @@ describe("Linear graph screen reader", () => {
     );
 });
 
+describe("Linear graph pointLabels", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("uses custom pointLabels in each endpoint's accessible name", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseLinearState, pointLabels: ["A", "B"]}}
+            />,
+        );
+        const [point1, , point2] = screen.getAllByRole("button");
+
+        // Assert
+        expect(point1).toHaveAttribute("aria-label", "Point A at -5 comma 5.");
+        expect(point2).toHaveAttribute("aria-label", "Point B at 5 comma 5.");
+    });
+
+    it("falls back to numeric default for indices without a custom label", () => {
+        // Arrange, Act — only the first endpoint is named
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseLinearState, pointLabels: ["A"]}}
+            />,
+        );
+        const [point1, , point2] = screen.getAllByRole("button");
+
+        // Assert
+        expect(point1).toHaveAttribute("aria-label", "Point A at -5 comma 5.");
+        expect(point2).toHaveAttribute("aria-label", "Point 2 at 5 comma 5.");
+    });
+
+    // The editor encodes "only the second endpoint named" as `["", "B"]`.
+    // An empty string at any index must fall back to the numeric default.
+    it("falls back to numeric default for explicit empty-string entries", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseLinearState, pointLabels: ["", "B"]}}
+            />,
+        );
+        const [point1, , point2] = screen.getAllByRole("button");
+
+        // Assert
+        expect(point1).toHaveAttribute("aria-label", "Point 1 at -5 comma 5.");
+        expect(point2).toHaveAttribute("aria-label", "Point B at 5 comma 5.");
+    });
+
+    it("falls back to the numeric default for truthy non-string entries (defensive against malformed hand-authored JSON bypassing the parser)", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseLinearState,
+                    // eslint-disable-next-line no-restricted-syntax -- cast simulates malformed JSON the parser would reject
+                    pointLabels: [42, "B"] as unknown as string[],
+                }}
+            />,
+        );
+        const [point1, , point2] = screen.getAllByRole("button");
+
+        // Assert
+        expect(point1).toHaveAttribute("aria-label", "Point 1 at -5 comma 5.");
+        expect(point2).toHaveAttribute("aria-label", "Point B at 5 comma 5.");
+    });
+});
+
 describe("describeLinearGraph", () => {
     test("describes a default linear graph", () => {
         // Arrange

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.test.tsx
@@ -1,3 +1,7 @@
+import {
+    generateIGLinearGraph,
+    generateInteractiveGraphQuestion,
+} from "@khanacademy/perseus-core";
 import {act, render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
@@ -5,6 +9,7 @@ import * as React from "react";
 import {mockPerseusI18nContext} from "../../../components/i18n-context";
 import * as Dependencies from "../../../dependencies";
 import {testDependencies} from "../../../testing/test-dependencies";
+import {renderQuestion} from "../../__testutils__/renderQuestion";
 import {MafsGraph} from "../mafs-graph";
 import {getBaseMafsGraphPropsForTests} from "../utils";
 
@@ -250,11 +255,12 @@ describe("Linear graph pointLabels", () => {
 
     it("uses custom pointLabels in each endpoint's accessible name", () => {
         // Arrange, Act
-        render(
-            <MafsGraph
-                {...baseMafsGraphProps}
-                state={{...baseLinearState, pointLabels: ["A", "B"]}}
-            />,
+        renderQuestion(
+            generateInteractiveGraphQuestion({
+                correct: generateIGLinearGraph({
+                    pointLabels: ["A", "B"],
+                }),
+            }),
         );
         const [point1, , point2] = screen.getAllByRole("button");
 
@@ -265,11 +271,13 @@ describe("Linear graph pointLabels", () => {
 
     it("falls back to numeric default for indices without a custom label", () => {
         // Arrange, Act — only the first endpoint is named
-        render(
-            <MafsGraph
-                {...baseMafsGraphProps}
-                state={{...baseLinearState, pointLabels: ["A"]}}
-            />,
+        renderQuestion(
+            generateInteractiveGraphQuestion({
+                correct: generateIGLinearGraph({
+                    // eslint-disable-next-line no-restricted-syntax -- short array tests the missing-index fallback
+                    pointLabels: ["A"] as unknown as [string, string],
+                }),
+            }),
         );
         const [point1, , point2] = screen.getAllByRole("button");
 
@@ -282,11 +290,12 @@ describe("Linear graph pointLabels", () => {
     // An empty string at any index must fall back to the numeric default.
     it("falls back to numeric default for explicit empty-string entries", () => {
         // Arrange, Act
-        render(
-            <MafsGraph
-                {...baseMafsGraphProps}
-                state={{...baseLinearState, pointLabels: ["", "B"]}}
-            />,
+        renderQuestion(
+            generateInteractiveGraphQuestion({
+                correct: generateIGLinearGraph({
+                    pointLabels: ["", "B"],
+                }),
+            }),
         );
         const [point1, , point2] = screen.getAllByRole("button");
 
@@ -297,15 +306,13 @@ describe("Linear graph pointLabels", () => {
 
     it("falls back to the numeric default for truthy non-string entries (defensive against malformed hand-authored JSON bypassing the parser)", () => {
         // Arrange, Act
-        render(
-            <MafsGraph
-                {...baseMafsGraphProps}
-                state={{
-                    ...baseLinearState,
+        renderQuestion(
+            generateInteractiveGraphQuestion({
+                correct: generateIGLinearGraph({
                     // eslint-disable-next-line no-restricted-syntax -- cast simulates malformed JSON the parser would reject
-                    pointLabels: [42, "B"] as unknown as string[],
-                }}
-            />,
+                    pointLabels: [42, "B"] as unknown as [string, string],
+                }),
+            }),
         );
         const [point1, , point2] = screen.getAllByRole("button");
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import {usePerseusI18n} from "../../../components/i18n-context";
 import {actions} from "../reducer/interactive-graph-action";
 
+import {buildPointAriaLabel} from "./components/build-point-aria-label";
 import {MovableLine} from "./components/movable-line";
 import SRDescInSVG from "./components/sr-description-within-svg";
 import {srFormatNumber} from "./screenreader-text";
@@ -32,7 +33,7 @@ type LinearGraphProps = MafsGraphProps<LinearGraphState>;
 
 const LinearGraph = (props: LinearGraphProps, key: number) => {
     const {dispatch} = props;
-    const {coords: line} = props.graphState;
+    const {coords: line, pointLabels} = props.graphState;
 
     const {strings, locale} = usePerseusI18n();
     const id = React.useId();
@@ -60,7 +61,23 @@ const LinearGraph = (props: LinearGraphProps, key: number) => {
         >
             <MovableLine
                 key={0}
-                ariaLabels={{grabHandleAriaLabel: srLinearGrabHandle}}
+                ariaLabels={{
+                    grabHandleAriaLabel: srLinearGrabHandle,
+                    point1AriaLabel: buildPointAriaLabel(
+                        pointLabels,
+                        0,
+                        line[0],
+                        strings,
+                        locale,
+                    ),
+                    point2AriaLabel: buildPointAriaLabel(
+                        pointLabels,
+                        1,
+                        line[1],
+                        strings,
+                        locale,
+                    ),
+                }}
                 ariaDescribedBy={`${interceptDescriptionId} ${slopeDescriptionId}`}
                 points={line}
                 onMoveLine={(newStart) => {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/ray.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/ray.test.tsx
@@ -30,7 +30,7 @@ const baseRayState: InteractiveGraphState = {
 
 const overallGraphLabel = "A ray on a coordinate plane.";
 
-describe("Linear graph screen reader", () => {
+describe("Ray graph screen reader", () => {
     let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({
@@ -155,6 +155,89 @@ describe("Linear graph screen reader", () => {
             expect(point2).toHaveAttribute("aria-live", expectedAriaLive[2]);
         },
     );
+});
+
+describe("Ray graph pointLabels", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("uses custom pointLabels and overrides the semantic Endpoint / Through point defaults", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseRayState, pointLabels: ["A", "B"]}}
+            />,
+        );
+        const [point1, , point2] = screen.getAllByRole("button");
+
+        // Assert
+        expect(point1).toHaveAttribute("aria-label", "Point A at -5 comma 5.");
+        expect(point2).toHaveAttribute("aria-label", "Point B at 5 comma 5.");
+        expect(
+            screen.queryByLabelText("Endpoint at -5 comma 5."),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByLabelText("Through point at 5 comma 5."),
+        ).not.toBeInTheDocument();
+    });
+
+    it("falls back to the semantic Endpoint / Through point labels for indices without a custom label", () => {
+        // Arrange, Act — only the endpoint is named
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseRayState, pointLabels: ["A"]}}
+            />,
+        );
+        const [point1, , point2] = screen.getAllByRole("button");
+
+        // Assert
+        expect(point1).toHaveAttribute("aria-label", "Point A at -5 comma 5.");
+        expect(point2).toHaveAttribute(
+            "aria-label",
+            "Through point at 5 comma 5.",
+        );
+    });
+
+    // The editor encodes "only the through point named" as `["", "B"]`.
+    // An empty string at any index must fall back to the semantic default.
+    it("falls back to the semantic default for explicit empty-string entries", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseRayState, pointLabels: ["", "B"]}}
+            />,
+        );
+        const [point1, , point2] = screen.getAllByRole("button");
+
+        // Assert
+        expect(point1).toHaveAttribute("aria-label", "Endpoint at -5 comma 5.");
+        expect(point2).toHaveAttribute("aria-label", "Point B at 5 comma 5.");
+    });
+
+    it("falls back to the semantic default for truthy non-string entries (defensive against malformed hand-authored JSON bypassing the parser)", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseRayState,
+                    // eslint-disable-next-line no-restricted-syntax -- cast simulates malformed JSON the parser would reject
+                    pointLabels: [42, "B"] as unknown as string[],
+                }}
+            />,
+        );
+        const [point1, , point2] = screen.getAllByRole("button");
+
+        // Assert
+        expect(point1).toHaveAttribute("aria-label", "Endpoint at -5 comma 5.");
+        expect(point2).toHaveAttribute("aria-label", "Point B at 5 comma 5.");
+    });
 });
 
 describe("describeRayGraph", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import {usePerseusI18n} from "../../../components/i18n-context";
 import {actions} from "../reducer/interactive-graph-action";
 
+import {buildPointAriaLabel} from "./components/build-point-aria-label";
 import {MovableLine} from "./components/movable-line";
 import SRDescInSVG from "./components/sr-description-within-svg";
 import {srFormatNumber} from "./screenreader-text";
@@ -31,7 +32,7 @@ type Props = MafsGraphProps<RayGraphState>;
 
 const RayGraph = (props: Props) => {
     const {dispatch} = props;
-    const {coords: line} = props.graphState;
+    const {coords: line, pointLabels} = props.graphState;
 
     const handleMoveLine = (newStart: vec.Vector2) =>
         dispatch(actions.ray.moveRay(newStart));
@@ -61,8 +62,22 @@ const RayGraph = (props: Props) => {
             <MovableLine
                 points={line}
                 ariaLabels={{
-                    point1AriaLabel: srRayEndpoint,
-                    point2AriaLabel: srRayTerminalPoint,
+                    point1AriaLabel:
+                        buildPointAriaLabel(
+                            pointLabels,
+                            0,
+                            line[0],
+                            strings,
+                            locale,
+                        ) ?? srRayEndpoint,
+                    point2AriaLabel:
+                        buildPointAriaLabel(
+                            pointLabels,
+                            1,
+                            line[1],
+                            strings,
+                            locale,
+                        ) ?? srRayTerminalPoint,
                     grabHandleAriaLabel: srRayGrabHandle,
                 }}
                 onMoveLine={handleMoveLine}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
@@ -52,6 +52,13 @@ const RayGraph = (props: Props) => {
         srRayGrabHandle,
     } = describeRayGraph(props.graphState, {strings, locale});
 
+    const point1AriaLabel =
+        buildPointAriaLabel(pointLabels, 0, line[0], strings, locale) ??
+        srRayEndpoint;
+    const point2AriaLabel =
+        buildPointAriaLabel(pointLabels, 1, line[1], strings, locale) ??
+        srRayTerminalPoint;
+
     // Ray graphs only have one line
     return (
         <g
@@ -62,22 +69,8 @@ const RayGraph = (props: Props) => {
             <MovableLine
                 points={line}
                 ariaLabels={{
-                    point1AriaLabel:
-                        buildPointAriaLabel(
-                            pointLabels,
-                            0,
-                            line[0],
-                            strings,
-                            locale,
-                        ) ?? srRayEndpoint,
-                    point2AriaLabel:
-                        buildPointAriaLabel(
-                            pointLabels,
-                            1,
-                            line[1],
-                            strings,
-                            locale,
-                        ) ?? srRayTerminalPoint,
+                    point1AriaLabel,
+                    point2AriaLabel,
                     grabHandleAriaLabel: srRayGrabHandle,
                 }}
                 onMoveLine={handleMoveLine}

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -1311,6 +1311,63 @@ export const pointWithDefaultLabelQuestion: PerseusRenderer =
         }),
     });
 
+// Linear graph with the two endpoints named "A" and "B" via `pointLabels`,
+// so JAWS announces "Point A at …" / "Point B at …" instead of the default
+// "Point 1 at …" / "Point 2 at …" when navigating the endpoints.
+export const linearWithCustomLabelsQuestion: PerseusRenderer =
+    generateInteractiveGraphQuestion({
+        content:
+            "**Drag points $A$ and $B$ so the line passes through both labeled points.**\n\n[[☃ interactive-graph 1]]",
+        markings: "graph",
+        gridStep: [1, 1],
+        snapStep: [1, 1],
+        step: [1, 1],
+        range: [
+            [-10, 10],
+            [-10, 10],
+        ],
+        correct: generateIGLinearGraph({
+            startCoords: [
+                [-5, 5],
+                [5, 5],
+            ],
+            coords: [
+                [-5, 5],
+                [5, 5],
+            ],
+            pointLabels: ["A", "B"],
+        }),
+    });
+
+// Ray graph with the endpoint named "A" and the through point named "B"
+// via `pointLabels`. The default "Endpoint at …" / "Through point at …"
+// semantic labels are overridden so the SR announcement matches the
+// prompt's naming convention.
+export const rayWithCustomLabelsQuestion: PerseusRenderer =
+    generateInteractiveGraphQuestion({
+        content:
+            "**Drag the ray so its endpoint is at point $A$ and it passes through point $B$.**\n\n[[☃ interactive-graph 1]]",
+        markings: "graph",
+        gridStep: [1, 1],
+        snapStep: [1, 1],
+        step: [1, 1],
+        range: [
+            [-10, 10],
+            [-10, 10],
+        ],
+        correct: generateIGRayGraph({
+            startCoords: [
+                [-5, 5],
+                [5, 5],
+            ],
+            coords: [
+                [-5, 5],
+                [5, 5],
+            ],
+            pointLabels: ["A", "B"],
+        }),
+    });
+
 export const polygonWithCustomLabelsQuestion: PerseusRenderer =
     generateInteractiveGraphQuestion({
         content:


### PR DESCRIPTION
## Summary:
- Wires `pointLabels` through two of the three line-family interactive graphs — `linear` and `ray` — end-to-end on the render side and unlocks the editor label fields for those two types.
- Each interactive endpoint now announces its author-supplied label (e.g. *"Point A at -5 comma 5"*); when no custom label is set the existing default behavior is preserved per graph type:
  - **linear** falls back to the generic *"Point 1 at …"* / *"Point 2 at …"* defaults (same as before).
  - **ray** falls back to the semantic *"Endpoint at …"* / *"Through point at …"* defaults (same as before).
- **Vector is excluded** from this PR and from the LEMS-3995 rollout entirely. The `pointLabels` field on `PerseusGraphTypeVector` (originally shipped by PR 1) is **removed from the schema and parser in this PR** so the type reflects the runtime behaviour. The original plan listed `vector` alongside `linear` and `ray` because all three share the `[string, string]` schema shape and the `start-coords-line.tsx` editor component. The vector has tail and tip which is already mathematically correct for screen readers.

Issue: LEMS-3995
Co-Authored by Claude Code (Opus)

## Risk

Low. The new code paths are:
- Two render files (linear, ray) each gaining a few lines that read `pointLabels` from state and pass the helper output as `ariaLabel`.
- `start-coords-line.tsx` extended with `pointLabels` / `onChangePointLabels` props, the flat `pointLabel` / `onPointLabelChange` forwarded to each `<CoordInput>`, and a small `updatePointLabel` helper that pads the 2-tuple shape. Vector continues to call `<StartCoordsLine>` without those props, so its editor UX is unchanged.
- One gate widening per case branch in `start-coords-settings.tsx` (only linear / ray; vector deliberately not widened).
- The schema cleanup (removing `pointLabels` from `PerseusGraphTypeVector` and the parser) is two line deletions touching `data-schema.ts` and `interactive-graph-widget.ts`. Because the field was only ever optional and was never written to by the editor or read at runtime, no production content can break: any content that *does* carry `pointLabels` on a vector was hand-authored (the editor never produced it) and the field was already a no-op.
- One case relocation in `reshape-point-labels.ts` (`case "vector":` moves from `toPair` to the no-op group) — required for TypeScript to keep type-checking after the schema field disappears.

Reviewer focus:
- For each of linear / ray, (a) the focusable handle uses the custom label when set, (b) the right default is preserved when it's not (generic vs semantic).
- For vector, confirm that nothing changed at runtime: the SR announcements are still `"Tip point at X comma Y"` regardless of any `pointLabels` value (now impossible to set via the schema), and the editor's `<StartCoordsLine>` for vector still renders without the `Label [_]` field.
- **Schema cleanup verification.** Confirm no consumer of `PerseusGraphTypeVector` reads `pointLabels`. The `pnpm tsc` pass is the structural lock — any consumer that *was* reading it would fail compilation now. The full `perseus-core` jest suite is the runtime lock — any parser regression test asserting the field was accepted on vector would fail; none did, which means no such test existed (the field was never authored in fixtures).
- The rationale for excluding vector — see [Vector intentionally skipped](#vector-intentionally-skipped). Anyone uncomfortable with the schema-level removal can be directed at the decision log entry in the plan doc.

## Test plan

- [x] `pnpm tsc` — passes (the schema cleanup is structurally consistent across `data-schema.ts`, `interactive-graph-widget.ts`, and `reshape-point-labels.ts`)
- [x] `pnpm lint <changed files>` — passes
- [x] `pnpm prettier --check <changed files>` — passes
- [x] `pnpm jest packages/perseus-core packages/perseus-editor/src/widgets/interactive-graph-editor/utils/reshape-point-labels.test.ts packages/perseus/src/widgets/interactive-graphs/graphs/{linear,ray,vector}.test.tsx packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.test.tsx` — 1762/1763 pass, 1 pre-existing skip. Includes the full `perseus-core` suite (parser regression tests, generator tests) as a non-regression check for the schema cleanup; includes `reshape-point-labels.test.ts` to confirm the relocated vector case behaves the same as `none`.
- [ ] Reviewer manual: open the `LinearWithCustomLabels` / `RayWithCustomLabels` stories. Enable the Storybook a11y addon (or VoiceOver / JAWS) and confirm each interactive endpoint announces *"Point A at …"* / *"Point B at …"* matching its prompt. Confirm the existing `Linear` / `Ray` stories still announce the legacy defaults.
- [ ] Reviewer manual: open the `InteractiveGraphLinear` / `InteractiveGraphRay` editor stories, expand "Start coordinates", and confirm each row reads as `Point N:`.

## PR Series and Follow-ups (PRs 5–7)

Independent and parallelizable. None of them touch the foundation files. Each wires its graph type's render side and adds the per-type `start-coords-<type>.tsx` plumbing using the same flat `CoordInput` `pointLabel` / `onPointLabelChange` props PR 2 take-2 introduced.

- **PR 1** — [Schema — no behavior. Only data-shape stop.](https://github.com/Khan/perseus/pull/3605)
- **PR 2** — [Foundation + Point graph](https://github.com/Khan/perseus/pull/3643)
- **PR 3** — [Polygon (shares start-coords-point.tsx); widen the gate to type === "point" || type === "polygon"](https://github.com/Khan/perseus/pull/3643)
- 👉🏼 **PR 4** — [Lines: linear, ray](https://github.com/Khan/perseus/pull/3672)
- **PR 5** — [Multi-line: linear-system, segment](https://github.com/Khan/perseus/pull/3673)
- **follow-up PR** — [Refactor linear, point, polygon, and ray graphs to use usePointAriaLabel instead of buildPointAriaLabel](https://github.com/Khan/perseus/pull/3694)
- **PR 6** — [Curves: quadratic, sinusoid, tangent, exponential, logarithm](https://github.com/Khan/perseus/pull/3696)
- **PR 7** — [Special shapes: angle, circle, absolute-value](https://github.com/Khan/perseus/pull/3697)