### PR TITLE
[Interactive Graph] Wire pointLabels through linear-system and segment graphs for custom points label

### DIFF
--- a/.changeset/spotty-taxis-lay.md
+++ b/.changeset/spotty-taxis-lay.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-core": minor
+"@khanacademy/perseus-editor": minor
+---
+
+[Interactive Graph] Wire pointLabels through linear-system and segment graphs for custom points label

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-multiline.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-multiline.tsx
@@ -1,12 +1,9 @@
-import {View} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
-import CoordinatePairInput from "../../../components/coordinate-pair-input";
 import PerseusEditorAccordion from "../../../components/perseus-editor-accordion";
+
+import CoordInput from "./coord-input";
 
 import type {CollinearTuple} from "@khanacademy/perseus-core";
 
@@ -14,12 +11,22 @@ type Props = {
     type: "linear-system" | "segment";
     startCoords: CollinearTuple[];
     onChange: (startCoords: CollinearTuple[]) => void;
+    pointLabels?: ReadonlyArray<string>;
+    onChangePointLabels?: (pointLabels: ReadonlyArray<string>) => void;
 };
 
 const StartCoordsMultiline = (props: Props) => {
-    const {startCoords, type, onChange} = props;
+    const {startCoords, type, onChange, pointLabels, onChangePointLabels} =
+        props;
 
     const graphName = type === "segment" ? "Segment" : "Line";
+    const updatePointLabel = (flatIndex: number, newLabel: string) => {
+        const totalPoints = startCoords.length * 2;
+        const next = Array.from({length: totalPoints}, (_, i) =>
+            i === flatIndex ? newLabel : pointLabels?.[i] ?? "",
+        );
+        onChangePointLabels?.(next);
+    };
 
     return (
         <>
@@ -35,48 +42,39 @@ const StartCoordsMultiline = (props: Props) => {
                     }
                     expanded={true}
                 >
-                    <View style={styles.nestedTile}>
-                        <BodyText size="medium" weight="bold" tag="span">
-                            Point 1:
-                        </BodyText>
-                        <Strut size={spacing.small_12} />
-                        <CoordinatePairInput
-                            coord={coordPair[0]}
-                            labels={["x", "y"]}
-                            onChange={(value) => {
-                                const newCoords = [...startCoords];
-                                newCoords[i] = [value, coordPair[1]];
-                                onChange(newCoords);
-                            }}
-                        />
-                    </View>
-                    <View style={styles.nestedTile}>
-                        <BodyText size="medium" weight="bold" tag="span">
-                            Point 2:
-                        </BodyText>
-                        <Strut size={spacing.small_12} />
-                        <CoordinatePairInput
-                            coord={coordPair[1]}
-                            labels={["x", "y"]}
-                            onChange={(value) => {
-                                const newCoords = [...startCoords];
-                                newCoords[i] = [coordPair[0], value];
-                                onChange(newCoords);
-                            }}
-                        />
-                    </View>
+                    <CoordInput
+                        label="Point 1"
+                        coord={coordPair[0]}
+                        onChange={(value) => {
+                            const newCoords = [...startCoords];
+                            newCoords[i] = [value, coordPair[1]];
+                            onChange(newCoords);
+                        }}
+                        pointLabel={pointLabels?.[i * 2]}
+                        onPointLabelChange={
+                            onChangePointLabels &&
+                            ((newLabel) => updatePointLabel(i * 2, newLabel))
+                        }
+                    />
+                    <CoordInput
+                        label="Point 2"
+                        coord={coordPair[1]}
+                        onChange={(value) => {
+                            const newCoords = [...startCoords];
+                            newCoords[i] = [coordPair[0], value];
+                            onChange(newCoords);
+                        }}
+                        pointLabel={pointLabels?.[i * 2 + 1]}
+                        onPointLabelChange={
+                            onChangePointLabels &&
+                            ((newLabel) =>
+                                updatePointLabel(i * 2 + 1, newLabel))
+                        }
+                    />
                 </PerseusEditorAccordion>
             ))}
         </>
     );
 };
-
-const styles = StyleSheet.create({
-    nestedTile: {
-        paddingBottom: spacing.small_12,
-        flexDirection: "row",
-        alignItems: "center",
-    },
-});
 
 export default StartCoordsMultiline;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-multiline.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-multiline.tsx
@@ -7,15 +7,15 @@ import CoordInput from "./coord-input";
 
 import type {CollinearTuple} from "@khanacademy/perseus-core";
 
-type Props = {
+interface StartCoordsMultilineProps {
     type: "linear-system" | "segment";
     startCoords: CollinearTuple[];
     onChange: (startCoords: CollinearTuple[]) => void;
-    pointLabels?: ReadonlyArray<string>;
-    onChangePointLabels?: (pointLabels: ReadonlyArray<string>) => void;
-};
+    pointLabels: ReadonlyArray<string>;
+    onChangePointLabels: (pointLabels: ReadonlyArray<string>) => void;
+}
 
-const StartCoordsMultiline = (props: Props) => {
+const StartCoordsMultiline = (props: StartCoordsMultilineProps) => {
     const {startCoords, type, onChange, pointLabels, onChangePointLabels} =
         props;
 
@@ -23,9 +23,9 @@ const StartCoordsMultiline = (props: Props) => {
     const updatePointLabel = (flatIndex: number, newLabel: string) => {
         const totalPoints = startCoords.length * 2;
         const next = Array.from({length: totalPoints}, (_, i) =>
-            i === flatIndex ? newLabel : pointLabels?.[i] ?? "",
+            i === flatIndex ? newLabel : pointLabels[i] ?? "",
         );
-        onChangePointLabels?.(next);
+        onChangePointLabels(next);
     };
 
     return (
@@ -50,10 +50,9 @@ const StartCoordsMultiline = (props: Props) => {
                             newCoords[i] = [value, coordPair[1]];
                             onChange(newCoords);
                         }}
-                        pointLabel={pointLabels?.[i * 2]}
-                        onPointLabelChange={
-                            onChangePointLabels &&
-                            ((newLabel) => updatePointLabel(i * 2, newLabel))
+                        pointLabel={pointLabels[i * 2]}
+                        onPointLabelChange={(newLabel) =>
+                            updatePointLabel(i * 2, newLabel)
                         }
                     />
                     <CoordInput
@@ -64,11 +63,9 @@ const StartCoordsMultiline = (props: Props) => {
                             newCoords[i] = [coordPair[0], value];
                             onChange(newCoords);
                         }}
-                        pointLabel={pointLabels?.[i * 2 + 1]}
-                        onPointLabelChange={
-                            onChangePointLabels &&
-                            ((newLabel) =>
-                                updatePointLabel(i * 2 + 1, newLabel))
+                        pointLabel={pointLabels[i * 2 + 1]}
+                        onPointLabelChange={(newLabel) =>
+                            updatePointLabel(i * 2 + 1, newLabel)
                         }
                     />
                 </PerseusEditorAccordion>

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.test.tsx
@@ -1,6 +1,6 @@
 import {Dependencies} from "@khanacademy/perseus";
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
-import {render, screen} from "@testing-library/react";
+import {render, screen, within} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
@@ -347,24 +347,6 @@ describe("StartCoordSettings", () => {
             ).toHaveLength(2);
         });
 
-        it("does NOT render point name fields when onChangePointLabels is omitted", () => {
-            // Arrange, Act
-            render(
-                <StartCoordsSettings
-                    {...defaultProps}
-                    type="segment"
-                    numSegments={2}
-                    onChange={() => {}}
-                />,
-                {wrapper: RenderStateRoot},
-            );
-
-            // Assert
-            expect(
-                screen.queryByRole("textbox", {name: "Point 1 name"}),
-            ).not.toBeInTheDocument();
-        });
-
         it("calls onChangePointLabels with the flat per-segment array shape when a name is typed", async () => {
             // Arrange
             const onChangePointLabelsMock = jest.fn();
@@ -379,13 +361,19 @@ describe("StartCoordSettings", () => {
                 {wrapper: RenderStateRoot},
             );
 
-            // Act
-            const seg2Point1NameInput = screen.getAllByRole("textbox", {
-                name: "Point 1 name",
-            })[1];
+            // Act — scope the query to segment 2's accordion region so the
+            // "Point 1 name" textbox we pick is unambiguously its first
+            // endpoint. PerseusEditorAccordion renders each section as a
+            // `role="region"` labelled by the header text, so the region's
+            // accessible name is exactly the "Segment 2" header.
+            const seg2Region = screen.getByRole("region", {name: "Segment 2"});
+            const seg2Point1NameInput = within(seg2Region).getByRole(
+                "textbox",
+                {name: "Point 1 name"},
+            );
             await userEvent.type(seg2Point1NameInput, "T");
 
-            // Assert
+            // Assert — flat array shape is [seg1.p1, seg1.p2, seg2.p1, seg2.p2].
             expect(onChangePointLabelsMock).toHaveBeenLastCalledWith([
                 "",
                 "",
@@ -491,23 +479,6 @@ describe("StartCoordSettings", () => {
             ).toHaveLength(2);
         });
 
-        it("does NOT render point name fields when onChangePointLabels is omitted", () => {
-            // Arrange, Act
-            render(
-                <StartCoordsSettings
-                    {...defaultProps}
-                    type="linear-system"
-                    onChange={() => {}}
-                />,
-                {wrapper: RenderStateRoot},
-            );
-
-            // Assert
-            expect(
-                screen.queryByRole("textbox", {name: "Point 1 name"}),
-            ).not.toBeInTheDocument();
-        });
-
         it("calls onChangePointLabels with the flat per-line array shape when a name is typed", async () => {
             // Arrange
             const onChangePointLabelsMock = jest.fn();
@@ -521,13 +492,19 @@ describe("StartCoordSettings", () => {
                 {wrapper: RenderStateRoot},
             );
 
-            // Act
-            const line1Point1NameInput = screen.getAllByRole("textbox", {
-                name: "Point 1 name",
-            })[0];
+            // Act — scope the query to line 1's accordion region so the
+            // "Point 1 name" textbox we pick is unambiguously its first
+            // endpoint. PerseusEditorAccordion renders each section as a
+            // `role="region"` labelled by the header text, so the region's
+            // accessible name is exactly the "Line 1" header.
+            const line1Region = screen.getByRole("region", {name: "Line 1"});
+            const line1Point1NameInput = within(line1Region).getByRole(
+                "textbox",
+                {name: "Point 1 name"},
+            );
             await userEvent.type(line1Point1NameInput, "T");
 
-            // Assert
+            // Assert — flat array shape is [line1.p1, line1.p2, line2.p1, line2.p2].
             expect(onChangePointLabelsMock).toHaveBeenLastCalledWith([
                 "T",
                 "",

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.test.tsx
@@ -324,6 +324,75 @@ describe("StartCoordSettings", () => {
                 expect(onChangeMock).toHaveBeenLastCalledWith(expectedCoords);
             },
         );
+
+        it("renders point name fields when onChangePointLabels is provided", () => {
+            // Arrange, Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="segment"
+                    numSegments={2}
+                    onChange={() => {}}
+                    onChangePointLabels={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert — two segments × two endpoints = four name fields
+            expect(
+                screen.getAllByRole("textbox", {name: "Point 1 name"}),
+            ).toHaveLength(2);
+            expect(
+                screen.getAllByRole("textbox", {name: "Point 2 name"}),
+            ).toHaveLength(2);
+        });
+
+        it("does NOT render point name fields when onChangePointLabels is omitted", () => {
+            // Arrange, Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="segment"
+                    numSegments={2}
+                    onChange={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(
+                screen.queryByRole("textbox", {name: "Point 1 name"}),
+            ).not.toBeInTheDocument();
+        });
+
+        it("calls onChangePointLabels with the flat per-segment array shape when a name is typed", async () => {
+            // Arrange
+            const onChangePointLabelsMock = jest.fn();
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="segment"
+                    numSegments={2}
+                    onChange={() => {}}
+                    onChangePointLabels={onChangePointLabelsMock}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            const seg2Point1NameInput = screen.getAllByRole("textbox", {
+                name: "Point 1 name",
+            })[1];
+            await userEvent.type(seg2Point1NameInput, "T");
+
+            // Assert
+            expect(onChangePointLabelsMock).toHaveBeenLastCalledWith([
+                "",
+                "",
+                "T",
+                "",
+            ]);
+        });
     });
 
     // startCoords with type CollinearTuple[]
@@ -400,6 +469,72 @@ describe("StartCoordSettings", () => {
                 expect(onChangeMock).toHaveBeenLastCalledWith(expectedCoords);
             },
         );
+
+        it("renders point name fields when onChangePointLabels is provided", () => {
+            // Arrange, Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="linear-system"
+                    onChange={() => {}}
+                    onChangePointLabels={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert — two lines × two endpoints = four name fields
+            expect(
+                screen.getAllByRole("textbox", {name: "Point 1 name"}),
+            ).toHaveLength(2);
+            expect(
+                screen.getAllByRole("textbox", {name: "Point 2 name"}),
+            ).toHaveLength(2);
+        });
+
+        it("does NOT render point name fields when onChangePointLabels is omitted", () => {
+            // Arrange, Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="linear-system"
+                    onChange={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(
+                screen.queryByRole("textbox", {name: "Point 1 name"}),
+            ).not.toBeInTheDocument();
+        });
+
+        it("calls onChangePointLabels with the flat per-line array shape when a name is typed", async () => {
+            // Arrange
+            const onChangePointLabelsMock = jest.fn();
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="linear-system"
+                    onChange={() => {}}
+                    onChangePointLabels={onChangePointLabelsMock}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            const line1Point1NameInput = screen.getAllByRole("textbox", {
+                name: "Point 1 name",
+            })[0];
+            await userEvent.type(line1Point1NameInput, "T");
+
+            // Assert
+            expect(onChangePointLabelsMock).toHaveBeenLastCalledWith([
+                "T",
+                "",
+                "",
+                "",
+            ]);
+        });
     });
 
     describe("circle graph", () => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
@@ -101,7 +101,7 @@ const StartCoordsSettingsInner = (props: Props) => {
                     type={type}
                     startCoords={multiLineCoords}
                     onChange={onChange}
-                    pointLabels={props.pointLabels}
+                    pointLabels={props.pointLabels ?? []}
                     onChangePointLabels={onChangePointLabels}
                 />
             );

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
@@ -101,6 +101,8 @@ const StartCoordsSettingsInner = (props: Props) => {
                     type={type}
                     startCoords={multiLineCoords}
                     onChange={onChange}
+                    pointLabels={props.pointLabels}
+                    onChangePointLabels={onChangePointLabels}
                 />
             );
         case "circle":

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
@@ -7,6 +7,7 @@ import {
     circleQuestion,
     linearQuestion,
     linearSystemQuestion,
+    linearSystemWithCustomLabelsQuestion,
     linearWithCustomLabelsQuestion,
     pointQuestion,
     pointWithCustomLabelQuestion,
@@ -16,6 +17,7 @@ import {
     rayQuestion,
     rayWithCustomLabelsQuestion,
     segmentQuestion,
+    segmentWithCustomLabelsQuestion,
     segmentWithLockedPointsQuestion,
     segmentWithLockedLineQuestion,
     segmentWithAllLockedLineSegmentVariations,
@@ -95,6 +97,19 @@ export const LinearWithCustomLabels: Story = {
 export const LinearSystem: Story = {
     args: {
         item: generateTestPerseusItem({question: linearSystemQuestion}),
+    },
+};
+
+/**
+ * A linear system whose four interactive endpoints are named "A", "B", "C",
+ * "D" via `pointLabels` (flat across both lines), so JAWS announces "Point
+ * A / B / C / D at …" instead of the default "Point N on line N at …".
+ */
+export const LinearSystemWithCustomLabels: Story = {
+    args: {
+        item: generateTestPerseusItem({
+            question: linearSystemWithCustomLabelsQuestion,
+        }),
     },
 };
 
@@ -188,6 +203,20 @@ export const Vector: Story = {
 export const Segment: Story = {
     args: {
         item: generateTestPerseusItem({question: segmentQuestion}),
+    },
+};
+
+/**
+ * A segment graph with two segments whose endpoints are named "A", "B",
+ * "C", "D" via `pointLabels` (flat across all segments), so JAWS announces
+ * "Point A / B / C / D at …" instead of the per-segment "Endpoint N on
+ * segment N at …" defaults.
+ */
+export const SegmentWithCustomLabels: Story = {
+    args: {
+        item: generateTestPerseusItem({
+            question: segmentWithCustomLabelsQuestion,
+        }),
     },
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/build-point-aria-label.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/build-point-aria-label.ts
@@ -1,3 +1,4 @@
+import {usePerseusI18n} from "../../../../components/i18n-context";
 import {srFormatNumber} from "../screenreader-text";
 
 import type {PerseusStrings} from "../../../../strings";
@@ -24,6 +25,10 @@ export function resolvePointLabel(
  * custom label (e.g. "T"). Returns `undefined` when no custom label
  * is set so callers can fall back to the default label (e.g. "Point 1",
  * "Point 2", ...) built by `useControlPoint`.
+ *
+ * TODO(LEMS-3995): Prefer the `usePointAriaLabel` hook below in new code.
+ * Existing callers in `polygon.tsx`, `point.tsx`, `ray.tsx`, and `linear.tsx`
+ * should migrate to the hook in a follow-up PR.
  */
 export function buildPointAriaLabel(
     pointLabels: ReadonlyArray<string> | undefined,
@@ -43,4 +48,17 @@ export function buildPointAriaLabel(
         x: srFormatNumber(point[0], locale),
         y: srFormatNumber(point[1], locale),
     });
+}
+
+/**
+ * Hook that returns a point aria-label builder bound to the current locale
+ * and the given `pointLabels`. Returns `undefined` for points without a
+ * custom label so callers can fall back to default labels.
+ */
+export function usePointAriaLabel(
+    pointLabels: ReadonlyArray<string> | undefined,
+) {
+    const {strings, locale} = usePerseusI18n();
+    return (index: number, point: vec.Vector2) =>
+        buildPointAriaLabel(pointLabels, index, point, strings, locale);
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.test.tsx
@@ -300,6 +300,146 @@ describe("Linear System graph screen reader", () => {
     });
 });
 
+describe("Linear System graph pointLabels", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("uses custom pointLabels for each endpoint across both lines", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseLinearSystemState,
+                    pointLabels: ["A", "B", "C", "D"],
+                }}
+            />,
+        );
+        const interactiveElements = screen.getAllByRole("button");
+        const line1Point1 = interactiveElements[0];
+        const line1Point2 = interactiveElements[2];
+        const line2Point1 = interactiveElements[3];
+        const line2Point2 = interactiveElements[5];
+
+        // Assert
+        expect(line1Point1).toHaveAttribute(
+            "aria-label",
+            "Point A at -5 comma 5.",
+        );
+        expect(line1Point2).toHaveAttribute(
+            "aria-label",
+            "Point B at 5 comma 5.",
+        );
+        expect(line2Point1).toHaveAttribute(
+            "aria-label",
+            "Point C at -5 comma -5.",
+        );
+        expect(line2Point2).toHaveAttribute(
+            "aria-label",
+            "Point D at 5 comma -5.",
+        );
+    });
+
+    it("falls back to the per-line default for indices without a custom label", () => {
+        // Arrange, Act — only the first two endpoints (line 1) named
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseLinearSystemState,
+                    pointLabels: ["A", "B"],
+                }}
+            />,
+        );
+        const interactiveElements = screen.getAllByRole("button");
+        const line1Point1 = interactiveElements[0];
+        const line2Point1 = interactiveElements[3];
+        const line2Point2 = interactiveElements[5];
+
+        // Assert
+        expect(line1Point1).toHaveAttribute(
+            "aria-label",
+            "Point A at -5 comma 5.",
+        );
+        expect(line2Point1).toHaveAttribute(
+            "aria-label",
+            "Point 1 on line 2 at -5 comma -5.",
+        );
+        expect(line2Point2).toHaveAttribute(
+            "aria-label",
+            "Point 2 on line 2 at 5 comma -5.",
+        );
+    });
+
+    // The editor encodes "only the line-2 endpoints named" as
+    // ["", "", "C", "D"]. Empty strings must fall back to the per-line default.
+    it("falls back to the per-line default for explicit empty-string entries", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseLinearSystemState,
+                    pointLabels: ["", "", "C", "D"],
+                }}
+            />,
+        );
+        const interactiveElements = screen.getAllByRole("button");
+        const line1Point1 = interactiveElements[0];
+        const line1Point2 = interactiveElements[2];
+        const line2Point1 = interactiveElements[3];
+        const line2Point2 = interactiveElements[5];
+
+        // Assert
+        expect(line1Point1).toHaveAttribute(
+            "aria-label",
+            "Point 1 on line 1 at -5 comma 5.",
+        );
+        expect(line1Point2).toHaveAttribute(
+            "aria-label",
+            "Point 2 on line 1 at 5 comma 5.",
+        );
+        expect(line2Point1).toHaveAttribute(
+            "aria-label",
+            "Point C at -5 comma -5.",
+        );
+        expect(line2Point2).toHaveAttribute(
+            "aria-label",
+            "Point D at 5 comma -5.",
+        );
+    });
+
+    it("falls back to the per-line default for truthy non-string entries", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseLinearSystemState,
+                    // eslint-disable-next-line no-restricted-syntax -- cast simulates malformed JSON the parser would reject
+                    pointLabels: [42, "B", "C", "D"] as unknown as string[],
+                }}
+            />,
+        );
+        const interactiveElements = screen.getAllByRole("button");
+        const line1Point1 = interactiveElements[0];
+        const line1Point2 = interactiveElements[2];
+
+        // Assert
+        expect(line1Point1).toHaveAttribute(
+            "aria-label",
+            "Point 1 on line 1 at -5 comma 5.",
+        );
+        expect(line1Point2).toHaveAttribute(
+            "aria-label",
+            "Point B at 5 comma 5.",
+        );
+    });
+});
+
 describe("getLinearSystemGraphDescription", () => {
     test("describes a default linear system graph", () => {
         // Arrange

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.test.tsx
@@ -318,29 +318,24 @@ describe("Linear System graph pointLabels", () => {
                 }}
             />,
         );
-        const interactiveElements = screen.getAllByRole("button");
-        const line1Point1 = interactiveElements[0];
-        const line1Point2 = interactiveElements[2];
-        const line2Point1 = interactiveElements[3];
-        const line2Point2 = interactiveElements[5];
+        const line1Point1 = screen.getByRole("button", {
+            name: "Point A at -5 comma 5.",
+        });
+        const line1Point2 = screen.getByRole("button", {
+            name: "Point B at 5 comma 5.",
+        });
+        const line2Point1 = screen.getByRole("button", {
+            name: "Point C at -5 comma -5.",
+        });
+        const line2Point2 = screen.getByRole("button", {
+            name: "Point D at 5 comma -5.",
+        });
 
-        // Assert
-        expect(line1Point1).toHaveAttribute(
-            "aria-label",
-            "Point A at -5 comma 5.",
-        );
-        expect(line1Point2).toHaveAttribute(
-            "aria-label",
-            "Point B at 5 comma 5.",
-        );
-        expect(line2Point1).toHaveAttribute(
-            "aria-label",
-            "Point C at -5 comma -5.",
-        );
-        expect(line2Point2).toHaveAttribute(
-            "aria-label",
-            "Point D at 5 comma -5.",
-        );
+        // Assert — each interactive endpoint gets its custom label
+        expect(line1Point1).toBeInTheDocument();
+        expect(line1Point2).toBeInTheDocument();
+        expect(line2Point1).toBeInTheDocument();
+        expect(line2Point2).toBeInTheDocument();
     });
 
     it("falls back to the per-line default for indices without a custom label", () => {
@@ -354,24 +349,21 @@ describe("Linear System graph pointLabels", () => {
                 }}
             />,
         );
-        const interactiveElements = screen.getAllByRole("button");
-        const line1Point1 = interactiveElements[0];
-        const line2Point1 = interactiveElements[3];
-        const line2Point2 = interactiveElements[5];
+        const line1Point1 = screen.getByRole("button", {
+            name: "Point A at -5 comma 5.",
+        });
+        const line2Point1 = screen.getByRole("button", {
+            name: "Point 1 on line 2 at -5 comma -5.",
+        });
+        const line2Point2 = screen.getByRole("button", {
+            name: "Point 2 on line 2 at 5 comma -5.",
+        });
 
-        // Assert
-        expect(line1Point1).toHaveAttribute(
-            "aria-label",
-            "Point A at -5 comma 5.",
-        );
-        expect(line2Point1).toHaveAttribute(
-            "aria-label",
-            "Point 1 on line 2 at -5 comma -5.",
-        );
-        expect(line2Point2).toHaveAttribute(
-            "aria-label",
-            "Point 2 on line 2 at 5 comma -5.",
-        );
+        // Assert — line 1's endpoint uses the custom label;
+        // line 2 falls back to the per-line default.
+        expect(line1Point1).toBeInTheDocument();
+        expect(line2Point1).toBeInTheDocument();
+        expect(line2Point2).toBeInTheDocument();
     });
 
     // The editor encodes "only the line-2 endpoints named" as
@@ -387,29 +379,24 @@ describe("Linear System graph pointLabels", () => {
                 }}
             />,
         );
-        const interactiveElements = screen.getAllByRole("button");
-        const line1Point1 = interactiveElements[0];
-        const line1Point2 = interactiveElements[2];
-        const line2Point1 = interactiveElements[3];
-        const line2Point2 = interactiveElements[5];
+        const line1Point1 = screen.getByRole("button", {
+            name: "Point 1 on line 1 at -5 comma 5.",
+        });
+        const line1Point2 = screen.getByRole("button", {
+            name: "Point 2 on line 1 at 5 comma 5.",
+        });
+        const line2Point1 = screen.getByRole("button", {
+            name: "Point C at -5 comma -5.",
+        });
+        const line2Point2 = screen.getByRole("button", {
+            name: "Point D at 5 comma -5.",
+        });
 
         // Assert
-        expect(line1Point1).toHaveAttribute(
-            "aria-label",
-            "Point 1 on line 1 at -5 comma 5.",
-        );
-        expect(line1Point2).toHaveAttribute(
-            "aria-label",
-            "Point 2 on line 1 at 5 comma 5.",
-        );
-        expect(line2Point1).toHaveAttribute(
-            "aria-label",
-            "Point C at -5 comma -5.",
-        );
-        expect(line2Point2).toHaveAttribute(
-            "aria-label",
-            "Point D at 5 comma -5.",
-        );
+        expect(line1Point1).toBeInTheDocument();
+        expect(line1Point2).toBeInTheDocument();
+        expect(line2Point1).toBeInTheDocument();
+        expect(line2Point2).toBeInTheDocument();
     });
 
     it("falls back to the per-line default for truthy non-string entries", () => {
@@ -424,19 +411,17 @@ describe("Linear System graph pointLabels", () => {
                 }}
             />,
         );
-        const interactiveElements = screen.getAllByRole("button");
-        const line1Point1 = interactiveElements[0];
-        const line1Point2 = interactiveElements[2];
+        const line1Point1 = screen.getByRole("button", {
+            name: "Point 1 on line 1 at -5 comma 5.",
+        });
+        const line1Point2 = screen.getByRole("button", {
+            name: "Point B at 5 comma 5.",
+        });
 
-        // Assert
-        expect(line1Point1).toHaveAttribute(
-            "aria-label",
-            "Point 1 on line 1 at -5 comma 5.",
-        );
-        expect(line1Point2).toHaveAttribute(
-            "aria-label",
-            "Point B at 5 comma 5.",
-        );
+        // Assert — index 0 is a non-string and falls back to the per-line
+        // default; index 1 is a usable string and overrides.
+        expect(line1Point1).toBeInTheDocument();
+        expect(line1Point2).toBeInTheDocument();
     });
 });
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import {usePerseusI18n} from "../../../components/i18n-context";
 import {actions} from "../reducer/interactive-graph-action";
 
+import {buildPointAriaLabel} from "./components/build-point-aria-label";
 import {MovableLine} from "./components/movable-line";
 import SRDescInSVG from "./components/sr-description-within-svg";
 import {srFormatNumber} from "./screenreader-text";
@@ -36,11 +37,13 @@ type LinearSystemGraphProps = MafsGraphProps<LinearSystemGraphState>;
 
 const LinearSystemGraph = (props: LinearSystemGraphProps) => {
     const {dispatch} = props;
-    const {coords: lines} = props.graphState;
+    const {coords: lines, pointLabels} = props.graphState;
 
     const {strings, locale} = usePerseusI18n();
     const id = React.useId();
     const intersectionId = `${id}-intersection`;
+    const buildLabel = (index: number, point: vec.Vector2) =>
+        buildPointAriaLabel(pointLabels, index, point, strings, locale);
 
     const intersectionPoint = geometry.getLineIntersection(lines[0], lines[1]);
     const intersectionDescription = intersectionPoint
@@ -91,18 +94,22 @@ const LinearSystemGraph = (props: LinearSystemGraphProps) => {
                     key={i}
                     points={line}
                     ariaLabels={{
-                        point1AriaLabel: strings.srLinearSystemPoint({
-                            lineNumber: i + 1,
-                            pointSequence: 1,
-                            x: srFormatNumber(line[0][0], locale),
-                            y: srFormatNumber(line[0][1], locale),
-                        }),
-                        point2AriaLabel: strings.srLinearSystemPoint({
-                            lineNumber: i + 1,
-                            pointSequence: 2,
-                            x: srFormatNumber(line[1][0], locale),
-                            y: srFormatNumber(line[1][1], locale),
-                        }),
+                        point1AriaLabel:
+                            buildLabel(i * 2, line[0]) ??
+                            strings.srLinearSystemPoint({
+                                lineNumber: i + 1,
+                                pointSequence: 1,
+                                x: srFormatNumber(line[0][0], locale),
+                                y: srFormatNumber(line[0][1], locale),
+                            }),
+                        point2AriaLabel:
+                            buildLabel(i * 2 + 1, line[1]) ??
+                            strings.srLinearSystemPoint({
+                                lineNumber: i + 1,
+                                pointSequence: 2,
+                                x: srFormatNumber(line[1][0], locale),
+                                y: srFormatNumber(line[1][1], locale),
+                            }),
                         grabHandleAriaLabel: strings.srLinearSystemGrabHandle({
                             lineNumber: i + 1,
                             point1X: srFormatNumber(line[0][0], locale),

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import {usePerseusI18n} from "../../../components/i18n-context";
 import {actions} from "../reducer/interactive-graph-action";
 
-import {buildPointAriaLabel} from "./components/build-point-aria-label";
+import {usePointAriaLabel} from "./components/build-point-aria-label";
 import {MovableLine} from "./components/movable-line";
 import SRDescInSVG from "./components/sr-description-within-svg";
 import {srFormatNumber} from "./screenreader-text";
@@ -42,8 +42,7 @@ const LinearSystemGraph = (props: LinearSystemGraphProps) => {
     const {strings, locale} = usePerseusI18n();
     const id = React.useId();
     const intersectionId = `${id}-intersection`;
-    const buildLabel = (index: number, point: vec.Vector2) =>
-        buildPointAriaLabel(pointLabels, index, point, strings, locale);
+    const buildLabel = usePointAriaLabel(pointLabels);
 
     const intersectionPoint = geometry.getLineIntersection(lines[0], lines[1]);
     const intersectionDescription = intersectionPoint

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.test.tsx
@@ -355,12 +355,16 @@ describe("Segment graph pointLabels", () => {
                 }}
             />,
         );
-        const interactiveElements = screen.getAllByRole("button");
-        const [point1, , point2] = interactiveElements;
+        const point1 = screen.getByRole("button", {
+            name: "Point A at -5 comma 5.",
+        });
+        const point2 = screen.getByRole("button", {
+            name: "Point B at 5 comma 5.",
+        });
 
         // Assert
-        expect(point1).toHaveAttribute("aria-label", "Point A at -5 comma 5.");
-        expect(point2).toHaveAttribute("aria-label", "Point B at 5 comma 5.");
+        expect(point1).toBeInTheDocument();
+        expect(point2).toBeInTheDocument();
     });
 
     it("uses custom pointLabels on a multi-segment graph", () => {
@@ -374,29 +378,24 @@ describe("Segment graph pointLabels", () => {
                 }}
             />,
         );
-        const interactiveElements = screen.getAllByRole("button");
-        const seg1Point1 = interactiveElements[0];
-        const seg1Point2 = interactiveElements[2];
-        const seg2Point1 = interactiveElements[3];
-        const seg2Point2 = interactiveElements[5];
+        const seg1Point1 = screen.getByRole("button", {
+            name: "Point A at -5 comma 5.",
+        });
+        const seg1Point2 = screen.getByRole("button", {
+            name: "Point B at 5 comma 5.",
+        });
+        const seg2Point1 = screen.getByRole("button", {
+            name: "Point C at -5 comma -5.",
+        });
+        const seg2Point2 = screen.getByRole("button", {
+            name: "Point D at 5 comma -5.",
+        });
 
-        // Assert
-        expect(seg1Point1).toHaveAttribute(
-            "aria-label",
-            "Point A at -5 comma 5.",
-        );
-        expect(seg1Point2).toHaveAttribute(
-            "aria-label",
-            "Point B at 5 comma 5.",
-        );
-        expect(seg2Point1).toHaveAttribute(
-            "aria-label",
-            "Point C at -5 comma -5.",
-        );
-        expect(seg2Point2).toHaveAttribute(
-            "aria-label",
-            "Point D at 5 comma -5.",
-        );
+        // Assert — each interactive endpoint gets its custom label
+        expect(seg1Point1).toBeInTheDocument();
+        expect(seg1Point2).toBeInTheDocument();
+        expect(seg2Point1).toBeInTheDocument();
+        expect(seg2Point2).toBeInTheDocument();
     });
 
     it("falls back to the per-segment default for indices without a custom label", () => {
@@ -410,24 +409,21 @@ describe("Segment graph pointLabels", () => {
                 }}
             />,
         );
-        const interactiveElements = screen.getAllByRole("button");
-        const seg1Point1 = interactiveElements[0];
-        const seg2Point1 = interactiveElements[3];
-        const seg2Point2 = interactiveElements[5];
+        const seg1Point1 = screen.getByRole("button", {
+            name: "Point A at -5 comma 5.",
+        });
+        const seg2Point1 = screen.getByRole("button", {
+            name: "Endpoint 1 on segment 2 at -5 comma -5.",
+        });
+        const seg2Point2 = screen.getByRole("button", {
+            name: "Endpoint 2 on segment 2 at 5 comma -5.",
+        });
 
-        // Assert
-        expect(seg1Point1).toHaveAttribute(
-            "aria-label",
-            "Point A at -5 comma 5.",
-        );
-        expect(seg2Point1).toHaveAttribute(
-            "aria-label",
-            "Endpoint 1 on segment 2 at -5 comma -5.",
-        );
-        expect(seg2Point2).toHaveAttribute(
-            "aria-label",
-            "Endpoint 2 on segment 2 at 5 comma -5.",
-        );
+        // Assert — segment 1 uses the custom label; segment 2 falls back
+        // to the per-segment default.
+        expect(seg1Point1).toBeInTheDocument();
+        expect(seg2Point1).toBeInTheDocument();
+        expect(seg2Point2).toBeInTheDocument();
     });
 
     it("falls back to the per-segment default for explicit empty-string entries", () => {
@@ -441,29 +437,24 @@ describe("Segment graph pointLabels", () => {
                 }}
             />,
         );
-        const interactiveElements = screen.getAllByRole("button");
-        const seg1Point1 = interactiveElements[0];
-        const seg1Point2 = interactiveElements[2];
-        const seg2Point1 = interactiveElements[3];
-        const seg2Point2 = interactiveElements[5];
+        const seg1Point1 = screen.getByRole("button", {
+            name: "Endpoint 1 on segment 1 at -5 comma 5.",
+        });
+        const seg1Point2 = screen.getByRole("button", {
+            name: "Endpoint 2 on segment 1 at 5 comma 5.",
+        });
+        const seg2Point1 = screen.getByRole("button", {
+            name: "Point C at -5 comma -5.",
+        });
+        const seg2Point2 = screen.getByRole("button", {
+            name: "Point D at 5 comma -5.",
+        });
 
         // Assert
-        expect(seg1Point1).toHaveAttribute(
-            "aria-label",
-            "Endpoint 1 on segment 1 at -5 comma 5.",
-        );
-        expect(seg1Point2).toHaveAttribute(
-            "aria-label",
-            "Endpoint 2 on segment 1 at 5 comma 5.",
-        );
-        expect(seg2Point1).toHaveAttribute(
-            "aria-label",
-            "Point C at -5 comma -5.",
-        );
-        expect(seg2Point2).toHaveAttribute(
-            "aria-label",
-            "Point D at 5 comma -5.",
-        );
+        expect(seg1Point1).toBeInTheDocument();
+        expect(seg1Point2).toBeInTheDocument();
+        expect(seg2Point1).toBeInTheDocument();
+        expect(seg2Point2).toBeInTheDocument();
     });
 
     it("falls back to the per-segment default for truthy non-string entries", () => {
@@ -478,15 +469,17 @@ describe("Segment graph pointLabels", () => {
                 }}
             />,
         );
-        const interactiveElements = screen.getAllByRole("button");
-        const [point1, , point2] = interactiveElements;
+        const point1 = screen.getByRole("button", {
+            name: "Endpoint 1 at -5 comma 5.",
+        });
+        const point2 = screen.getByRole("button", {
+            name: "Point B at 5 comma 5.",
+        });
 
-        // Assert
-        expect(point1).toHaveAttribute(
-            "aria-label",
-            "Endpoint 1 at -5 comma 5.",
-        );
-        expect(point2).toHaveAttribute("aria-label", "Point B at 5 comma 5.");
+        // Assert — index 0 is a non-string and falls back to the default;
+        // index 1 is a usable string and overrides.
+        expect(point1).toBeInTheDocument();
+        expect(point2).toBeInTheDocument();
     });
 });
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.test.tsx
@@ -337,6 +337,159 @@ describe("Segment graph screen reader", () => {
     );
 });
 
+describe("Segment graph pointLabels", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("uses custom pointLabels on a single-segment graph", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseSingleSegmentState,
+                    pointLabels: ["A", "B"],
+                }}
+            />,
+        );
+        const interactiveElements = screen.getAllByRole("button");
+        const [point1, , point2] = interactiveElements;
+
+        // Assert
+        expect(point1).toHaveAttribute("aria-label", "Point A at -5 comma 5.");
+        expect(point2).toHaveAttribute("aria-label", "Point B at 5 comma 5.");
+    });
+
+    it("uses custom pointLabels on a multi-segment graph", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseMultipleSegmentState,
+                    pointLabels: ["A", "B", "C", "D"],
+                }}
+            />,
+        );
+        const interactiveElements = screen.getAllByRole("button");
+        const seg1Point1 = interactiveElements[0];
+        const seg1Point2 = interactiveElements[2];
+        const seg2Point1 = interactiveElements[3];
+        const seg2Point2 = interactiveElements[5];
+
+        // Assert
+        expect(seg1Point1).toHaveAttribute(
+            "aria-label",
+            "Point A at -5 comma 5.",
+        );
+        expect(seg1Point2).toHaveAttribute(
+            "aria-label",
+            "Point B at 5 comma 5.",
+        );
+        expect(seg2Point1).toHaveAttribute(
+            "aria-label",
+            "Point C at -5 comma -5.",
+        );
+        expect(seg2Point2).toHaveAttribute(
+            "aria-label",
+            "Point D at 5 comma -5.",
+        );
+    });
+
+    it("falls back to the per-segment default for indices without a custom label", () => {
+        // Arrange, Act — only the first segment's endpoints are named
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseMultipleSegmentState,
+                    pointLabels: ["A", "B"],
+                }}
+            />,
+        );
+        const interactiveElements = screen.getAllByRole("button");
+        const seg1Point1 = interactiveElements[0];
+        const seg2Point1 = interactiveElements[3];
+        const seg2Point2 = interactiveElements[5];
+
+        // Assert
+        expect(seg1Point1).toHaveAttribute(
+            "aria-label",
+            "Point A at -5 comma 5.",
+        );
+        expect(seg2Point1).toHaveAttribute(
+            "aria-label",
+            "Endpoint 1 on segment 2 at -5 comma -5.",
+        );
+        expect(seg2Point2).toHaveAttribute(
+            "aria-label",
+            "Endpoint 2 on segment 2 at 5 comma -5.",
+        );
+    });
+
+    it("falls back to the per-segment default for explicit empty-string entries", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseMultipleSegmentState,
+                    pointLabels: ["", "", "C", "D"],
+                }}
+            />,
+        );
+        const interactiveElements = screen.getAllByRole("button");
+        const seg1Point1 = interactiveElements[0];
+        const seg1Point2 = interactiveElements[2];
+        const seg2Point1 = interactiveElements[3];
+        const seg2Point2 = interactiveElements[5];
+
+        // Assert
+        expect(seg1Point1).toHaveAttribute(
+            "aria-label",
+            "Endpoint 1 on segment 1 at -5 comma 5.",
+        );
+        expect(seg1Point2).toHaveAttribute(
+            "aria-label",
+            "Endpoint 2 on segment 1 at 5 comma 5.",
+        );
+        expect(seg2Point1).toHaveAttribute(
+            "aria-label",
+            "Point C at -5 comma -5.",
+        );
+        expect(seg2Point2).toHaveAttribute(
+            "aria-label",
+            "Point D at 5 comma -5.",
+        );
+    });
+
+    it("falls back to the per-segment default for truthy non-string entries", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseSingleSegmentState,
+                    // eslint-disable-next-line no-restricted-syntax -- cast simulates malformed JSON the parser would reject
+                    pointLabels: [42, "B"] as unknown as string[],
+                }}
+            />,
+        );
+        const interactiveElements = screen.getAllByRole("button");
+        const [point1, , point2] = interactiveElements;
+
+        // Assert
+        expect(point1).toHaveAttribute(
+            "aria-label",
+            "Endpoint 1 at -5 comma 5.",
+        );
+        expect(point2).toHaveAttribute("aria-label", "Point B at 5 comma 5.");
+    });
+});
+
 describe("getSegmentGraphDescription", () => {
     test("describes a single segment", () => {
         // Arrange

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -5,7 +5,7 @@ import {usePerseusI18n} from "../../../components/i18n-context";
 import {X, Y} from "../math";
 import {actions} from "../reducer/interactive-graph-action";
 
-import {buildPointAriaLabel} from "./components/build-point-aria-label";
+import {usePointAriaLabel} from "./components/build-point-aria-label";
 import {MovableLine} from "./components/movable-line";
 import SRDescInSVG from "./components/sr-description-within-svg";
 import {srFormatNumber} from "./screenreader-text";
@@ -39,8 +39,7 @@ const SegmentGraph = ({dispatch, graphState}: SegmentProps) => {
     const segmentUniqueId = React.useId();
     const lengthDescriptionId = segmentUniqueId + "-length";
     const wholeGraphDescriptionId = segmentUniqueId + "-whole-graph";
-    const buildLabel = (index: number, point: vec.Vector2) =>
-        buildPointAriaLabel(pointLabels, index, point, strings, locale);
+    const buildLabel = usePointAriaLabel(pointLabels);
 
     function getWholeSegmentGraphAriaLabel(): string {
         return segments?.length > 1
@@ -107,71 +106,69 @@ const SegmentGraph = ({dispatch, graphState}: SegmentProps) => {
             aria-label={wholeSegmentGraphAriaLabel}
             aria-describedby={`${wholeGraphDescriptionId} ${segments.length === 1 && lengthDescriptionId}`}
         >
-            {segments?.map((segment, i) => (
-                <g
-                    aria-label={
-                        segments.length === 1
-                            ? undefined
-                            : getIndividualSegmentAriaLabel(segment, i)
-                    }
-                    aria-describedby={
-                        segments.length === 1 ? undefined : lengthDescriptionId
-                    }
-                    key={`${segmentUniqueId}-${i}`}
-                >
-                    <MovableLine
-                        key={i}
-                        points={segment}
-                        onMoveLine={(newStart) => {
-                            dispatch(actions.segment.moveLine(i, newStart));
-                        }}
-                        onMovePoint={(
-                            endpointIndex: number,
-                            destination: vec.Vector2,
-                        ) => {
-                            dispatch(
-                                actions.segment.movePointInFigure(
-                                    i,
-                                    endpointIndex,
-                                    destination,
+            {segments?.map((segment, i) => {
+                const point1AriaLabel =
+                    buildLabel(i * 2, segment[0]) ??
+                    formatSegment(1, segment[0][X], segment[0][Y], i + 1);
+                const point2AriaLabel =
+                    buildLabel(i * 2 + 1, segment[1]) ??
+                    formatSegment(2, segment[1][X], segment[1][Y], i + 1);
+                const grabHandleAriaLabel = strings.srSegmentGrabHandle({
+                    point1X: srFormatNumber(segment[0][X], locale),
+                    point1Y: srFormatNumber(segment[0][Y], locale),
+                    point2X: srFormatNumber(segment[1][X], locale),
+                    point2Y: srFormatNumber(segment[1][Y], locale),
+                });
+
+                return (
+                    <g
+                        aria-label={
+                            segments.length === 1
+                                ? undefined
+                                : getIndividualSegmentAriaLabel(segment, i)
+                        }
+                        aria-describedby={
+                            segments.length === 1
+                                ? undefined
+                                : lengthDescriptionId
+                        }
+                        key={`${segmentUniqueId}-${i}`}
+                    >
+                        <MovableLine
+                            key={i}
+                            points={segment}
+                            onMoveLine={(newStart) => {
+                                dispatch(actions.segment.moveLine(i, newStart));
+                            }}
+                            onMovePoint={(
+                                endpointIndex: number,
+                                destination: vec.Vector2,
+                            ) => {
+                                dispatch(
+                                    actions.segment.movePointInFigure(
+                                        i,
+                                        endpointIndex,
+                                        destination,
+                                    ),
+                                );
+                            }}
+                            ariaLabels={{
+                                point1AriaLabel,
+                                point2AriaLabel,
+                                grabHandleAriaLabel,
+                            }}
+                        />
+                        <SRDescInSVG id={lengthDescriptionId}>
+                            {strings.srSegmentLength({
+                                length: srFormatNumber(
+                                    getLengthOfSegment(segment),
+                                    locale,
                                 ),
-                            );
-                        }}
-                        ariaLabels={{
-                            point1AriaLabel:
-                                buildLabel(i * 2, segment[0]) ??
-                                formatSegment(
-                                    1,
-                                    segment[0][X],
-                                    segment[0][Y],
-                                    i + 1,
-                                ),
-                            point2AriaLabel:
-                                buildLabel(i * 2 + 1, segment[1]) ??
-                                formatSegment(
-                                    2,
-                                    segment[1][X],
-                                    segment[1][Y],
-                                    i + 1,
-                                ),
-                            grabHandleAriaLabel: strings.srSegmentGrabHandle({
-                                point1X: srFormatNumber(segment[0][X], locale),
-                                point1Y: srFormatNumber(segment[0][Y], locale),
-                                point2X: srFormatNumber(segment[1][X], locale),
-                                point2Y: srFormatNumber(segment[1][Y], locale),
-                            }),
-                        }}
-                    />
-                    <SRDescInSVG id={lengthDescriptionId}>
-                        {strings.srSegmentLength({
-                            length: srFormatNumber(
-                                getLengthOfSegment(segment),
-                                locale,
-                            ),
-                        })}
-                    </SRDescInSVG>
-                </g>
-            ))}
+                            })}
+                        </SRDescInSVG>
+                    </g>
+                );
+            })}
             <SRDescInSVG id={wholeGraphDescriptionId}>
                 {getWholeSegmentGraphAriaDescription()}
             </SRDescInSVG>

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/segment.tsx
@@ -5,6 +5,7 @@ import {usePerseusI18n} from "../../../components/i18n-context";
 import {X, Y} from "../math";
 import {actions} from "../reducer/interactive-graph-action";
 
+import {buildPointAriaLabel} from "./components/build-point-aria-label";
 import {MovableLine} from "./components/movable-line";
 import SRDescInSVG from "./components/sr-description-within-svg";
 import {srFormatNumber} from "./screenreader-text";
@@ -33,11 +34,13 @@ export function renderSegmentGraph(
 type SegmentProps = MafsGraphProps<SegmentGraphState>;
 
 const SegmentGraph = ({dispatch, graphState}: SegmentProps) => {
-    const {coords: segments} = graphState;
+    const {coords: segments, pointLabels} = graphState;
     const {strings, locale} = usePerseusI18n();
     const segmentUniqueId = React.useId();
     const lengthDescriptionId = segmentUniqueId + "-length";
     const wholeGraphDescriptionId = segmentUniqueId + "-whole-graph";
+    const buildLabel = (index: number, point: vec.Vector2) =>
+        buildPointAriaLabel(pointLabels, index, point, strings, locale);
 
     function getWholeSegmentGraphAriaLabel(): string {
         return segments?.length > 1
@@ -135,18 +138,22 @@ const SegmentGraph = ({dispatch, graphState}: SegmentProps) => {
                             );
                         }}
                         ariaLabels={{
-                            point1AriaLabel: formatSegment(
-                                1,
-                                segment[0][X],
-                                segment[0][Y],
-                                i + 1,
-                            ),
-                            point2AriaLabel: formatSegment(
-                                2,
-                                segment[1][X],
-                                segment[1][Y],
-                                i + 1,
-                            ),
+                            point1AriaLabel:
+                                buildLabel(i * 2, segment[0]) ??
+                                formatSegment(
+                                    1,
+                                    segment[0][X],
+                                    segment[0][Y],
+                                    i + 1,
+                                ),
+                            point2AriaLabel:
+                                buildLabel(i * 2 + 1, segment[1]) ??
+                                formatSegment(
+                                    2,
+                                    segment[1][X],
+                                    segment[1][Y],
+                                    i + 1,
+                                ),
                             grabHandleAriaLabel: strings.srSegmentGrabHandle({
                                 point1X: srFormatNumber(segment[0][X], locale),
                                 point1Y: srFormatNumber(segment[0][Y], locale),

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -1347,14 +1347,7 @@ export const rayWithCustomLabelsQuestion: PerseusRenderer =
     generateInteractiveGraphQuestion({
         content:
             "**Drag the ray so its endpoint is at point $A$ and it passes through point $B$.**\n\n[[☃ interactive-graph 1]]",
-        markings: "graph",
-        gridStep: [1, 1],
         snapStep: [1, 1],
-        step: [1, 1],
-        range: [
-            [-10, 10],
-            [-10, 10],
-        ],
         correct: generateIGRayGraph({
             startCoords: [
                 [-5, 5],
@@ -1375,14 +1368,7 @@ export const linearSystemWithCustomLabelsQuestion: PerseusRenderer =
     generateInteractiveGraphQuestion({
         content:
             "**Drag the endpoints so line 1 passes through $A$ and $B$, and line 2 passes through $C$ and $D$.**\n\n[[☃ interactive-graph 1]]",
-        markings: "graph",
-        gridStep: [1, 1],
         snapStep: [1, 1],
-        step: [1, 1],
-        range: [
-            [-10, 10],
-            [-10, 10],
-        ],
         correct: generateIGLinearSystemGraph({
             startCoords: [
                 [
@@ -1415,14 +1401,7 @@ export const segmentWithCustomLabelsQuestion: PerseusRenderer =
     generateInteractiveGraphQuestion({
         content:
             "**Drag the endpoints so segment 1 connects $A$ to $B$ and segment 2 connects $C$ to $D$.**\n\n[[☃ interactive-graph 1]]",
-        markings: "graph",
-        gridStep: [1, 1],
         snapStep: [1, 1],
-        step: [1, 1],
-        range: [
-            [-10, 10],
-            [-10, 10],
-        ],
         correct: generateIGSegmentGraph({
             numSegments: 2,
             startCoords: [

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -1368,6 +1368,87 @@ export const rayWithCustomLabelsQuestion: PerseusRenderer =
         }),
     });
 
+// Linear-system graph with each endpoint named via `pointLabels` (flat
+// across both lines: [line1.p1, line1.p2, line2.p1, line2.p2]) so JAWS
+// announces "Point A/B/C/D at …" instead of "Point N on line N at …".
+export const linearSystemWithCustomLabelsQuestion: PerseusRenderer =
+    generateInteractiveGraphQuestion({
+        content:
+            "**Drag the endpoints so line 1 passes through $A$ and $B$, and line 2 passes through $C$ and $D$.**\n\n[[☃ interactive-graph 1]]",
+        markings: "graph",
+        gridStep: [1, 1],
+        snapStep: [1, 1],
+        step: [1, 1],
+        range: [
+            [-10, 10],
+            [-10, 10],
+        ],
+        correct: generateIGLinearSystemGraph({
+            startCoords: [
+                [
+                    [-5, 5],
+                    [5, 5],
+                ],
+                [
+                    [-5, -5],
+                    [5, -5],
+                ],
+            ],
+            coords: [
+                [
+                    [-5, 5],
+                    [5, 5],
+                ],
+                [
+                    [-5, -5],
+                    [5, -5],
+                ],
+            ],
+            pointLabels: ["A", "B", "C", "D"],
+        }),
+    });
+
+// Segment graph with each endpoint named via `pointLabels` (flat across all
+// segments: [seg1.p1, seg1.p2, seg2.p1, seg2.p2]) so JAWS announces
+// "Point A/B/C/D at …" instead of the per-segment defaults.
+export const segmentWithCustomLabelsQuestion: PerseusRenderer =
+    generateInteractiveGraphQuestion({
+        content:
+            "**Drag the endpoints so segment 1 connects $A$ to $B$ and segment 2 connects $C$ to $D$.**\n\n[[☃ interactive-graph 1]]",
+        markings: "graph",
+        gridStep: [1, 1],
+        snapStep: [1, 1],
+        step: [1, 1],
+        range: [
+            [-10, 10],
+            [-10, 10],
+        ],
+        correct: generateIGSegmentGraph({
+            numSegments: 2,
+            startCoords: [
+                [
+                    [-5, 5],
+                    [5, 5],
+                ],
+                [
+                    [-5, -5],
+                    [5, -5],
+                ],
+            ],
+            coords: [
+                [
+                    [-5, 5],
+                    [5, 5],
+                ],
+                [
+                    [-5, -5],
+                    [5, -5],
+                ],
+            ],
+            pointLabels: ["A", "B", "C", "D"],
+        }),
+    });
+
 export const polygonWithCustomLabelsQuestion: PerseusRenderer =
     generateInteractiveGraphQuestion({
         content:


### PR DESCRIPTION
## Summary:
- Wires `pointLabels` through the two multi-line interactive graphs — `linear-system` and `segment` — end-to-end on the render side and unlocks the editor label fields for both types.
- Each interactive endpoint now announces its author-supplied label (e.g. *"Point A at -5 comma 5"*). When no custom label is set the existing per-type defaults are preserved unchanged:
  - **linear-system** falls back to *"Point N on line M at …"* (the `srLinearSystemPoint` template).
  - **segment** falls back to *"Endpoint N at …"* / *"Endpoint N on segment M at …"* (the `srSingleSegmentGraphEndpointAriaLabel` / `srMultipleSegmentGraphEndpointAriaLabel` templates, depending on segment count).
- `pointLabels` for both types is a single **flat array** across all lines/segments (`string[]` schema): `[line0.p1, line0.p2, line1.p1, line1.p2, …]`. Renderer maps `(lineIndex i, endpointIndex j) → flat index i * 2 + j`. The editor's `updatePointLabel(flatIndex, newLabel)` helper rebuilds the full `startCoords.length * 2`-length array on every keystroke so the unedited slots stay as their existing value (or `""`).

Co-Authored by Claude Code (Opus)
Issue: LEMS-3995

## Risk

Low. No foundation changes. The new code paths are:
- Two render files (linear-system, segment) each gaining a per-component `buildLabel` closure and a `?? defaultLabel` chain on each `MovableLine.ariaLabels` slot.
- `start-coords-multiline.tsx` refactored to consume `CoordInput` (the shared two-row tile component) with `pointLabels` / `onChangePointLabels` plumbed through, plus a local `updatePointLabel` helper that pads the flat array.
- One gate widening per case branch in `start-coords-settings.tsx` (linear-system and segment, mirroring how PR 2/3/4 widened the `point` / `polygon` / `linear` / `ray` cases).

Reviewer focus:
- The flat-array indexing `i * 2 + j` is consistent across the renderer (`linear-system.tsx`, `segment.tsx`) and the editor (`start-coords-multiline.tsx`'s `updatePointLabel`). The render-side test cases assert both endpoints of both lines/segments to lock the indexing in.
- The fallback chain `buildLabel(...) ?? formatSegment(...)` correctly preserves segment's single-vs-multi default phrasing (`Endpoint N at …` vs `Endpoint N on segment M at …`) — locked in by separate tests for single-segment and multi-segment states.
- The `start-coords-multiline.tsx` refactor drops `Strut` / `spacing` / Aphrodite — these were the only remaining users of those imports in this file, so the removal is clean.

## Test plan:

- [x] `pnpm tsc` — passes
- [x] `pnpm lint <changed files>` — passes
- [x] `pnpm prettier --check <changed files>` — passes
- [x] `pnpm jest packages/perseus/src/widgets/interactive-graphs/graphs/linear-system.test.tsx packages/perseus/src/widgets/interactive-graphs/graphs/segment.test.tsx packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.test.tsx` — 173 pass, 0 fail
- [ ] Reviewer manual: open the `LinearSystemWithCustomLabels` / `SegmentWithCustomLabels` stories. Enable the Storybook a11y addon (or VoiceOver / JAWS) and confirm each interactive endpoint announces *"Point A / B / C / D at …"* matching its prompt. Confirm the existing `LinearSystem` / `Segment` stories still announce the legacy per-line / per-segment defaults.
- [ ] Reviewer manual: open the `InteractiveGraphLinearSystem` / `InteractiveGraphSegment` editor stories, expand "Start coordinates", and confirm each line/segment accordion now shows the shared `CoordInput` stacked tile (`Point N:` heading on top, `x [_]  y [_]` coord row, `Label [_]` field below) instead of the previous bespoke single-row `Point 1:  x [_]  y [_]` layout. Type a letter into one of the label fields and confirm the rendered graph's endpoint `aria-label` *and* the **Screen reader tree** panel update on the same render.

## PR Series and Follow-ups (PRs 6–7)

Independent and parallelizable. None of them touch the foundation files. Each wires its graph type's render side and adds the per-type `start-coords-<type>.tsx` plumbing using the same flat `CoordInput` `pointLabel` / `onPointLabelChange` props PR 2 take-2 introduced.

- **PR 1** — [Schema — no behavior. Only data-shape stop.](https://github.com/Khan/perseus/pull/3605)
- **PR 2** — [Foundation + Point graph](https://github.com/Khan/perseus/pull/3643)
- **PR 3** — [Polygon (shares start-coords-point.tsx); widen the gate to type === "point" || type === "polygon"](https://github.com/Khan/perseus/pull/3643)
- **PR 4** — [Lines: linear, ray](https://github.com/Khan/perseus/pull/3672)
- 👉🏼 **PR 5** — [Multi-line: linear-system, segment](https://github.com/Khan/perseus/pull/3673)
- **follow-up PR** — [Refactor linear, point, polygon, and ray graphs to use usePointAriaLabel instead of buildPointAriaLabel](https://github.com/Khan/perseus/pull/3694)
- **PR 6** — [Curves: quadratic, sinusoid, tangent, exponential, logarithm](https://github.com/Khan/perseus/pull/3696)
- **PR 7** — [Special shapes: angle, circle, absolute-value](https://github.com/Khan/perseus/pull/3697)