### PR TITLE
[Interactive Graph] Use WB Announcer in Point Graph.

### DIFF
--- a/.changeset/tidy-doors-allow.md
+++ b/.changeset/tidy-doors-allow.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Interactive Graph] Add WB Announcer to Point graph events.

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -3413,7 +3413,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
                       <g
                         aria-disabled="false"
                         aria-label="Point 1 at 0 comma 0."
-                        aria-live="polite"
+                        aria-live="off"
                         class="movable-point__focusable-handle"
                         data-testid="movable-point__focusable-handle"
                         role="button"
@@ -3457,7 +3457,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
                       <g
                         aria-disabled="false"
                         aria-label="Point 2 at -2.5 comma 0."
-                        aria-live="polite"
+                        aria-live="off"
                         class="movable-point__focusable-handle"
                         data-testid="movable-point__focusable-handle"
                         role="button"
@@ -3501,7 +3501,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
                       <g
                         aria-disabled="false"
                         aria-label="Point 3 at -1 comma 0."
-                        aria-live="polite"
+                        aria-live="off"
                         class="movable-point__focusable-handle"
                         data-testid="movable-point__focusable-handle"
                         role="button"

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -162,7 +162,6 @@ function MovableCircle(props: {
                 role="button"
                 aria-label={ariaLabel}
                 aria-describedby={ariaDescribedBy}
-                aria-live="polite"
                 aria-disabled={disableKeyboardInteraction}
                 onFocus={() => setFocused(true)}
                 onBlur={() => setFocused(false)}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -185,6 +185,8 @@ const Line = (props: LineProps) => {
                 tabIndex={disableKeyboardInteraction ? -1 : 0}
                 aria-label={ariaLabel}
                 aria-describedby={ariaDescribedBy}
+                // TODO(LEMS-4189): Remove aria-live once every interactive
+                // graph type emits its move through the WB Announcer.
                 aria-live={ariaLive}
                 aria-disabled={disableKeyboardInteraction}
                 className="movable-line"

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point.tsx
@@ -11,6 +11,8 @@ type Props = {
     point: vec.Vector2;
     ariaDescribedBy?: string;
     ariaLabel?: string;
+    // TODO(LEMS-4189): Remove ariaLive once every interactive graph type
+    // emits its move through the WB Announcer.
     ariaLive?: AriaLive;
     color?: string;
     constrain?: KeyboardMovementConstraint;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -123,6 +123,8 @@ export function useControlPoint(params: Params): Return {
             role="button"
             aria-describedby={ariaDescribedBy}
             aria-label={pointAriaLabel}
+            // TODO(LEMS-4189): Remove aria-live once every interactive graph
+            // type emits its move through the WB Announcer.
             aria-live={ariaLive}
             aria-disabled={disableKeyboardInteraction}
             onFocus={(event) => {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -87,6 +87,12 @@ function LimitedPointGraph(statefulProps: StatefulProps) {
                     key={i}
                     point={point}
                     sequenceNumber={i + 1}
+                    // The point graph's move announcements come from the WB
+                    // Announcer via stateAnnouncement; disable aria-live here
+                    // to avoid the focusable handle double-announcing.
+                    // TODO(LEMS-4189): Remove ariaLive once aria-live is
+                    // dropped from useControlPoint.
+                    ariaLive="off"
                     onMove={(destination) =>
                         dispatch(actions.pointGraph.movePoint(i, destination))
                     }
@@ -154,6 +160,12 @@ function UnlimitedPointGraph(statefulProps: StatefulProps) {
                     key={i}
                     point={point}
                     sequenceNumber={i + 1}
+                    // The point graph's move announcements come from the WB
+                    // Announcer via stateAnnouncement; disable aria-live here
+                    // to avoid the focusable handle double-announcing.
+                    // TODO(LEMS-4189): Remove ariaLive once aria-live is
+                    // dropped from useControlPoint.
+                    ariaLive="off"
                     onDragStart={() => {
                         dragEndCallbackTimer.clear();
                         setIsCurrentlyDragging(true);

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -762,6 +762,25 @@ describe("movePoint on a point graph", () => {
 
         expect(updated.hasBeenInteractedWith).toBe(true);
     });
+
+    it("sets stateAnnouncement to a move-point with the new position", () => {
+        const state: InteractiveGraphState = {
+            ...basePointGraphState,
+            coords: [[0, 0]],
+        };
+
+        const updated = interactiveGraphReducer(
+            state,
+            actions.pointGraph.movePoint(0, [3, 4]),
+        );
+
+        expect(updated.stateAnnouncement).toEqual({
+            type: "move-point",
+            pointIndex: 0,
+            x: 3,
+            y: 4,
+        });
+    });
 });
 
 describe("movePoint on an angle graph", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -525,6 +525,10 @@ function doMovePoint(
                 coords: newCoords,
             };
         case "point": {
+            const newCoord = boundToEdgeAndSnapToGrid(
+                action.destination,
+                state,
+            );
             return {
                 ...state,
                 hasBeenInteractedWith: true,
@@ -532,11 +536,14 @@ function doMovePoint(
                 coords: setAtIndex({
                     array: state.coords,
                     index: action.index,
-                    newValue: boundToEdgeAndSnapToGrid(
-                        action.destination,
-                        state,
-                    ),
+                    newValue: newCoord,
                 }),
+                stateAnnouncement: {
+                    type: "move-point",
+                    pointIndex: action.index,
+                    x: newCoord[X],
+                    y: newCoord[Y],
+                },
             };
         }
         case "sinusoid": {


### PR DESCRIPTION
## Summary:
Wires the Point graph's `movePoint` action into the existing WB Announcer
pipeline.

What this PR does:
- Reducer: the `case "point"` in `interactive-graph-reducer.ts` now emits
  `stateAnnouncement: {type: "move-point", pointIndex, x, y}` on every
  move. The existing `stateful-mafs-graph.tsx → getAnnouncementText →
  WB Announcer` plumbing then announces it.
- Point graph: both `<MovablePoint>` call sites in `point.tsx`
  (Limited + Unlimited) pass `ariaLive="off"` so the focusable handle's
  legacy `aria-live="polite"` no longer fires alongside the WB Announcer.
  This is the only graph type with the announcer wired up, so other graphs
  (polygon, angle, linear, etc.) are intentionally untouched.
- TODOs reference [LEMS-4189](https://khanacademy.atlassian.net/browse/LEMS-4189),
  which tracks removing `aria-live` from `useControlPoint`, `MovablePoint`,
  and `MovableLine` once every graph's reducer is wired to the announcer.

Issue: LEMS-3943

## Test plan:
### Manual (reviewer)
- [ ] Open the **Interactive Graph → Point** story in Storybook (`pnpm storybook`). Turn on VoiceOver / NVDA (or enable the Storybook a11y addon's live-region inspector).
- [ ] Tab to one of the point handles. Confirm the initial focus announces *"Point N at X comma Y."* (this comes from `aria-label`, unchanged).
- [ ] Press arrow keys to move the point one snap step at a time. Confirm:
  - You hear *"Point N at X comma Y."* after each move (this is the new WB Announcer payload).
  - You do **not** hear the announcement twice. Before this PR, both `aria-live="polite"` on the handle AND the WB Announcer would have fired.
- [ ] Repeat in the **Unlimited Point** story (multi-point graph) — confirm each point announces only its own move.
- [ ] Regression: open the **Polygon**, **Linear**, and **Circle** stories and confirm they still announce moves the same way they did before (their behavior is unchanged in this PR).

[LEMS-4189]: https://khanacademy.atlassian.net/browse/LEMS-4189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ