### PR TITLE
[Interactive Graph] Fix screen reader text for point graph to include the pointLabel, custom point label

### DIFF
--- a/.changeset/rotten-tools-hang.md
+++ b/.changeset/rotten-tools-hang.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix screen reader text for point graph to include the pointLabel, custom point label

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -138,7 +138,7 @@ export type PerseusStrings = {
         x,
         y,
     }: {
-        // TODO(LEMS-3995) rename to pointLabel an request for new translation
+        // TODO(LEMS-4206) rename to pointLabel an request for new translation
         num: number | string;
         x: string;
         y: string;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/build-point-aria-label.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/build-point-aria-label.test.ts
@@ -1,8 +1,40 @@
 import {mockPerseusI18nContext} from "../../../../components/i18n-context";
 
-import {buildPointAriaLabel} from "./build-point-aria-label";
+import {buildPointAriaLabel, resolvePointLabel} from "./build-point-aria-label";
 
 const {strings, locale} = mockPerseusI18nContext;
+
+describe("resolvePointLabel", () => {
+    it("returns the 1-indexed default when pointLabels is undefined", () => {
+        expect(resolvePointLabel(undefined, 0)).toBe(1);
+        expect(resolvePointLabel(undefined, 2)).toBe(3);
+    });
+
+    it("returns the 1-indexed default when there is no label at the index", () => {
+        expect(resolvePointLabel(["T"], 1)).toBe(2);
+    });
+
+    it("returns the 1-indexed default when the label at the index is an empty string", () => {
+        expect(resolvePointLabel(["", "B"], 0)).toBe(1);
+    });
+
+    it("returns the custom label when set", () => {
+        expect(resolvePointLabel(["T"], 0)).toBe("T");
+        expect(resolvePointLabel(["A", "B"], 1)).toBe("B");
+    });
+
+    it("returns the 1-indexed default for non-string entries (defensive against malformed JSON)", () => {
+        // eslint-disable-next-line no-restricted-syntax -- cast simulates malformed JSON the parser would reject
+        const labels = [
+            null,
+            undefined,
+            42,
+        ] as unknown as ReadonlyArray<string>;
+        expect(resolvePointLabel(labels, 0)).toBe(1);
+        expect(resolvePointLabel(labels, 1)).toBe(2);
+        expect(resolvePointLabel(labels, 2)).toBe(3);
+    });
+});
 
 describe("buildPointAriaLabel", () => {
     it("returns undefined when pointLabels is undefined", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/build-point-aria-label.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/build-point-aria-label.ts
@@ -3,15 +3,8 @@ import {srFormatNumber} from "../screenreader-text";
 import type {PerseusStrings} from "../../../../strings";
 import type {vec} from "mafs";
 
-/**
- * Returns the screen-reader label for an interactive point at `index`.
- * Returns the custom label from `pointLabels` if present and well-formed;
- * otherwise the 1-indexed sequence number (used as the numeric default).
- *
- * Shared by `buildPointAriaLabel` (focusable-handle aria-label path) and
- * the reducer (live announcement payload) so both surfaces apply the same
- * rule for "what counts as a usable label".
- */
+// Returns the custom label from `pointLabels`, or the 1-indexed sequence
+// number if no custom label is set.
 export function resolvePointLabel(
     pointLabels: ReadonlyArray<string> | undefined,
     index: number,
@@ -19,6 +12,8 @@ export function resolvePointLabel(
     const customLabel = pointLabels?.[index];
     // Fall back to the numeric default if a non-string slips past the parser.
     if (typeof customLabel !== "string" || !customLabel) {
+        // Convert from a 0-indexed array position to the 1-indexed sequence
+        // number screen readers announce (index 0 → "Point 1", etc.).
         return index + 1;
     }
     return customLabel;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/build-point-aria-label.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/build-point-aria-label.ts
@@ -4,6 +4,27 @@ import type {PerseusStrings} from "../../../../strings";
 import type {vec} from "mafs";
 
 /**
+ * Returns the screen-reader label for an interactive point at `index`.
+ * Returns the custom label from `pointLabels` if present and well-formed;
+ * otherwise the 1-indexed sequence number (used as the numeric default).
+ *
+ * Shared by `buildPointAriaLabel` (focusable-handle aria-label path) and
+ * the reducer (live announcement payload) so both surfaces apply the same
+ * rule for "what counts as a usable label".
+ */
+export function resolvePointLabel(
+    pointLabels: ReadonlyArray<string> | undefined,
+    index: number,
+): string | number {
+    const customLabel = pointLabels?.[index];
+    // Fall back to the numeric default if a non-string slips past the parser.
+    if (typeof customLabel !== "string" || !customLabel) {
+        return index + 1;
+    }
+    return customLabel;
+}
+
+/**
  * Returns a screen-reader aria-label for an interactive point using a
  * custom label (e.g. "T"). Returns `undefined` when no custom label
  * is set so callers can fall back to the default label (e.g. "Point 1",
@@ -16,13 +37,14 @@ export function buildPointAriaLabel(
     strings: PerseusStrings,
     locale: string,
 ): string | undefined {
-    const customLabel = pointLabels?.[index];
-    // Fall back to the numeric default if a non-string slips past the parser.
-    if (typeof customLabel !== "string" || !customLabel) {
+    const label = resolvePointLabel(pointLabels, index);
+    // When the resolved label is the numeric default, return undefined so
+    // `useControlPoint` keeps its existing fallback behavior.
+    if (typeof label === "number") {
         return undefined;
     }
     return strings.srPointAtCoordinates({
-        num: customLabel,
+        num: label,
         x: srFormatNumber(point[0], locale),
         y: srFormatNumber(point[1], locale),
     });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.test.ts
@@ -9,14 +9,24 @@ import {
 } from "./screenreader-text";
 
 describe("getAnnouncementText", () => {
-    it("returns the correct string for a move-point announcement", () => {
+    it("returns the correct string for a move-point announcement with a numeric default label", () => {
         const result = getAnnouncementText(
-            {type: "move-point", pointIndex: 0, x: 3, y: 5},
+            {type: "move-point", pointLabel: "1", x: 3, y: 5},
             mockStrings,
             "en",
         );
 
         expect(result).toBe("Point 1 at 3 comma 5.");
+    });
+
+    it("returns the correct string for a move-point announcement with a custom pointLabel", () => {
+        const result = getAnnouncementText(
+            {type: "move-point", pointLabel: "T", x: 3, y: 5},
+            mockStrings,
+            "en",
+        );
+
+        expect(result).toBe("Point T at 3 comma 5.");
     });
 
     it("returns the correct string for a move-radius-point announcement when point is to the right", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.ts
@@ -11,7 +11,7 @@ export function getAnnouncementText(
     switch (state.type) {
         case "move-point":
             return strings.srPointAtCoordinates({
-                num: state.pointIndex + 1,
+                num: state.pointLabel, // TODO(LEMS-4206): fix num -> pointLabel
                 x: srFormatNumber(state.x, locale),
                 y: srFormatNumber(state.y, locale),
             });

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -776,7 +776,53 @@ describe("movePoint on a point graph", () => {
 
         expect(updated.stateAnnouncement).toEqual({
             type: "move-point",
-            pointIndex: 0,
+            pointLabel: "1",
+            x: 3,
+            y: 4,
+        });
+    });
+
+    it("uses the custom pointLabel in the move-point announcement", () => {
+        const state: InteractiveGraphState = {
+            ...basePointGraphState,
+            coords: [[0, 0]],
+            pointLabels: ["T"],
+        };
+
+        const updated = interactiveGraphReducer(
+            state,
+            actions.pointGraph.movePoint(0, [3, 4]),
+        );
+
+        expect(updated.stateAnnouncement).toEqual({
+            type: "move-point",
+            pointLabel: "T",
+            x: 3,
+            y: 4,
+        });
+    });
+
+    it("falls back to the numeric default when the pointLabel slot is empty", () => {
+        // The editor encodes "only the second point labeled" as ["", "B"];
+        // the reducer must keep the unlabeled slot on its numeric default
+        // (stringified to match the announcement payload contract).
+        const state: InteractiveGraphState = {
+            ...basePointGraphState,
+            coords: [
+                [0, 0],
+                [1, 1],
+            ],
+            pointLabels: ["", "B"],
+        };
+
+        const updated = interactiveGraphReducer(
+            state,
+            actions.pointGraph.movePoint(0, [3, 4]),
+        );
+
+        expect(updated.stateAnnouncement).toEqual({
+            type: "move-point",
+            pointLabel: "1",
             x: 3,
             y: 4,
         });

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -10,6 +10,7 @@ import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 import {vec} from "mafs";
 import _ from "underscore";
 
+import {resolvePointLabel} from "../graphs/components/build-point-aria-label";
 import {
     getArrayWithoutDuplicates,
     getAsymptoteHandleCoord,
@@ -540,7 +541,9 @@ function doMovePoint(
                 }),
                 stateAnnouncement: {
                     type: "move-point",
-                    pointIndex: action.index,
+                    pointLabel: String(
+                        resolvePointLabel(state.pointLabels, action.index),
+                    ),
                     x: newCoord[X],
                     y: newCoord[Y],
                 },

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.test.tsx
@@ -151,7 +151,7 @@ describe("StatefulMafsGraph", () => {
                           ...baseState,
                           stateAnnouncement: {
                               type: "move-point" as const,
-                              pointIndex: 0,
+                              pointLabel: "1",
                               x: 3,
                               y: 5,
                           },

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -50,7 +50,7 @@ export type UnlimitedGraphState = PointGraphState | PolygonGraphState;
 
 type MovePointAnnouncement = {
     type: "move-point";
-    pointIndex: number;
+    pointLabel: string;
     x: number;
     y: number;
 };


### PR DESCRIPTION
## Summary:
Fix screen reader text for point graph to include the pointLabel, custom point label

There was a conflicting work between the custom point label and the using the WB announcer tasks.
This PR will make sure that the custom point label is included in the new logic for WB Annoucer.

Related PRs:
1. https://github.com/Khan/perseus/pull/3619
2. https://github.com/Khan/perseus/pull/3674
3. https://github.com/Khan/perseus/pull/3643

This will also serve as the new pattern moving forward for the related work in implementing the feature for the rest of the graph types.


Issue: LEMS-3943

## Test plan: