### PR TITLE
Remove deprecated/unused APIOptions and renderer props

### DIFF
--- a/.changeset/violet-coats-fly.md
+++ b/.changeset/violet-coats-fly.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": major
+"@khanacademy/perseus-editor": patch
+---
+
+Unused and deprecated APIOptions and renderer props have been removed. Callers should stop passing these options, as they will have no effect.

--- a/packages/perseus-editor/src/preview/sanitize-api-options.ts
+++ b/packages/perseus-editor/src/preview/sanitize-api-options.ts
@@ -26,7 +26,6 @@ export function sanitizeApiOptions(
         interactionCallback: ____,
         trackInteraction: _____,
         baseElements: _______,
-        nativeKeypadProxy: ________,
         // Remove React nodes (placeholders)
         imagePlaceholder: _________,
         widgetPlaceholder: __________,

--- a/packages/perseus-editor/src/preview/sanitize-api-options.ts
+++ b/packages/perseus-editor/src/preview/sanitize-api-options.ts
@@ -26,12 +26,11 @@ export function sanitizeApiOptions(
         interactionCallback: ____,
         imagePreloader: _____,
         trackInteraction: ______,
-        setDrawingAreaAvailable: ________,
-        baseElements: _________,
-        nativeKeypadProxy: __________,
+        baseElements: _______,
+        nativeKeypadProxy: ________,
         // Remove React nodes (placeholders)
-        imagePlaceholder: ___________,
-        widgetPlaceholder: ____________,
+        imagePlaceholder: _________,
+        widgetPlaceholder: __________,
         ...serializableOptions
     } = apiOptions;
 

--- a/packages/perseus-editor/src/preview/sanitize-api-options.ts
+++ b/packages/perseus-editor/src/preview/sanitize-api-options.ts
@@ -24,8 +24,7 @@ export function sanitizeApiOptions(
         answerableCallback: __,
         getAnotherHint: ___,
         interactionCallback: ____,
-        imagePreloader: _____,
-        trackInteraction: ______,
+        trackInteraction: _____,
         baseElements: _______,
         nativeKeypadProxy: ________,
         // Remove React nodes (placeholders)

--- a/packages/perseus/src/__tests__/__snapshots__/renderer.test.tsx.snap
+++ b/packages/perseus/src/__tests__/__snapshots__/renderer.test.tsx.snap
@@ -343,7 +343,7 @@ exports[`renderer snapshots correct answer: correct answer 1`] = `
       >
         The total number of boxes the forklift can carry is 
         <div
-          class="perseus-widget-container widget-nohighlight widget-inline-block"
+          class="perseus-widget-container widget-inline-block"
         >
           <div
             class="default_xu2jcg"
@@ -428,7 +428,7 @@ exports[`renderer snapshots incorrect answer: incorrect answer 1`] = `
       >
         The total number of boxes the forklift can carry is 
         <div
-          class="perseus-widget-container widget-nohighlight widget-inline-block"
+          class="perseus-widget-container widget-inline-block"
         >
           <div
             class="default_xu2jcg"
@@ -513,7 +513,7 @@ exports[`renderer snapshots initial render: initial render 1`] = `
       >
         The total number of boxes the forklift can carry is 
         <div
-          class="perseus-widget-container widget-nohighlight widget-inline-block"
+          class="perseus-widget-container widget-inline-block"
         >
           <div
             class="default_xu2jcg"
@@ -597,7 +597,7 @@ exports[`renderer snapshots renders a placeholder for a deprecated widget: depre
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             style="padding-top: 8px; padding-bottom: 8px;"

--- a/packages/perseus/src/__tests__/__snapshots__/server-item-renderer.test.tsx.snap
+++ b/packages/perseus/src/__tests__/__snapshots__/server-item-renderer.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`server item renderer should snapshot: initial render 1`] = `
             </span>
              in the box: 
             <div
-              class="perseus-widget-container widget-nohighlight widget-block"
+              class="perseus-widget-container widget-block"
             >
               <div
                 class="default_xu2jcg-o_O-widgetContainer_137u7ef"

--- a/packages/perseus/src/__tests__/widget-container.test.tsx
+++ b/packages/perseus/src/__tests__/widget-container.test.tsx
@@ -42,7 +42,6 @@ describe("widget-container", () => {
             <WidgetContainer
                 type="invalid-widget"
                 id="invalid-widget 1"
-                shouldHighlight={false}
                 widgetProps={{apiOptions: {isMobile: false}}}
             />,
         );
@@ -69,7 +68,6 @@ describe("widget-container", () => {
                 <WidgetContainer
                     type="explanation"
                     id="explanation 1"
-                    shouldHighlight={false}
                     widgetProps={{
                         showPrompt: "Explanation",
                         hidePrompt: "Hide explanation",
@@ -112,7 +110,6 @@ describe("widget-container", () => {
                 <WidgetContainer
                     type="mock-widget"
                     id="mock-widget 1"
-                    shouldHighlight={false}
                     widgetProps={{
                         text: "Hello world!",
                         fail: true,

--- a/packages/perseus/src/components/__docs__/graphie.stories.tsx
+++ b/packages/perseus/src/components/__docs__/graphie.stories.tsx
@@ -31,7 +31,6 @@ export const PieChartGraphieLabels: Story = {
     args: {
         box: [size, size],
         setup: () => {},
-        setDrawingAreaAvailable: () => {},
     },
     render: (args) => <ServerItemRendererWithDebugUI item={itemWithPieChart} />,
 };
@@ -40,6 +39,5 @@ export const SquareBoxSizeAndOtherwiseEmpty: Story = {
     args: {
         box: [size, size],
         setup: () => {},
-        setDrawingAreaAvailable: () => {},
     },
 };

--- a/packages/perseus/src/components/__tests__/__snapshots__/sorter.test.tsx.snap
+++ b/packages/perseus/src/components/__tests__/__snapshots__/sorter.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`sorter widget should snapshot on mobile: first mobile render 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="perseus-widget-sorter perseus-clearfix"
@@ -138,7 +138,7 @@ exports[`sorter widget should snapshot: first render 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="perseus-widget-sorter perseus-clearfix"

--- a/packages/perseus/src/components/graphie.tsx
+++ b/packages/perseus/src/components/graphie.tsx
@@ -37,7 +37,6 @@ type Props = {
 
     options: any;
 
-    setDrawingAreaAvailable?: (boolean) => void;
     setup: (
         graphie: any,
         options: {
@@ -201,7 +200,6 @@ class Graphie extends React.Component<Props> {
                 onClick: this.props.onClick,
                 onMouseDown: this.props.onMouseDown,
                 onMouseMove: this.props.onMouseMove,
-                setDrawingAreaAvailable: this.props.setDrawingAreaAvailable,
             });
         }
 

--- a/packages/perseus/src/components/svg-image.tsx
+++ b/packages/perseus/src/components/svg-image.tsx
@@ -18,14 +18,14 @@ import {ZoomImageButton} from "./zoom-image-button";
 
 import type {ImageProps} from "./image-loader";
 import type {Coord} from "../interactive2/types";
-import type {APIOptions, Dimensions} from "../types";
+import type {APIOptions} from "../types";
 import type {Alignment, Size} from "@khanacademy/perseus-core";
 
 function isImageProbablyPhotograph(imageUrl) {
     return /\.(jpg|jpeg)$/i.test(imageUrl);
 }
 
-function defaultPreloader(dimensions: Dimensions) {
+function spinner() {
     return (
         <span
             style={{
@@ -58,7 +58,7 @@ export type Props = {
     };
     height?: number;
     /**
-     * When the DOM updates to replace the preloader with the image, or
+     * When the DOM updates to replace the spinner with the image, or
      * vice-versa, we trigger this callback.
      */
     onUpdate: () => void;
@@ -67,7 +67,6 @@ export type Props = {
      * is set.
      */
     overrideAriaHidden?: boolean;
-    preloader?: (dimensions: Dimensions) => React.ReactNode;
     /**
      * By default, this component attempts to be responsive whenever
      * possible (specifically, when width and height are passed in).
@@ -454,18 +453,6 @@ class SvgImage extends React.Component<Props, State> {
             );
         }
 
-        // If preloader is undefined, we use the default. If it's
-        // null, there will be no preloader in use.
-        const preloaderBaseFunc =
-            this.props.preloader === undefined
-                ? defaultPreloader
-                : this.props.preloader;
-
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        const preloader = preloaderBaseFunc
-            ? () => preloaderBaseFunc(dimensions)
-            : null;
-
         // *********** Normal/Non-Graphie images ***********
 
         if (!Util.isLabeledSVG(imageSrc)) {
@@ -485,7 +472,7 @@ class SvgImage extends React.Component<Props, State> {
                                 <ImageLoader
                                     src={imageSrc}
                                     imgProps={imageProps}
-                                    preloader={preloader}
+                                    preloader={spinner}
                                     onUpdate={this.handleUpdate}
                                 />
                                 {extraGraphie}
@@ -538,7 +525,7 @@ class SvgImage extends React.Component<Props, State> {
             return (
                 <ImageLoader
                     src={imageSrc}
-                    preloader={preloader}
+                    preloader={spinner}
                     imgProps={imageProps}
                     onUpdate={this.handleUpdate}
                 />
@@ -598,7 +585,7 @@ class SvgImage extends React.Component<Props, State> {
                         src={imageUrl}
                         onLoad={this.onImageLoad}
                         onUpdate={this.handleUpdate}
-                        preloader={preloader}
+                        preloader={spinner}
                         imgProps={imageProps}
                     />
                     {graphie}
@@ -635,7 +622,7 @@ class SvgImage extends React.Component<Props, State> {
                     src={imageUrl}
                     onLoad={this.onImageLoad}
                     onUpdate={this.handleUpdate}
-                    preloader={preloader}
+                    preloader={spinner}
                     imgProps={imageProps}
                 />
                 {graphie}

--- a/packages/perseus/src/perseus-api.tsx
+++ b/packages/perseus/src/perseus-api.tsx
@@ -59,10 +59,6 @@ export const ApiOptions = {
             Link: PropTypes.func,
         }),
 
-        // Function that takes dimensions and returns a React component
-        // to display while an image is loading
-        imagePreloader: PropTypes.func,
-
         // Function that takes an object argument. The object should
         // include type and id, both strings, at least and can optionally
         // include a boolean "correct" value. This is used for keeping

--- a/packages/perseus/src/perseus-api.tsx
+++ b/packages/perseus/src/perseus-api.tsx
@@ -97,24 +97,6 @@ export const ApiOptions = {
 
         // The color used for the hint progress indicator (eg. 1 / 3)
         hintProgressColor: PropTypes.string,
-
-        // Whether this Renderer is allowed to auto-scroll the rest of the
-        // page. For example, if this is enabled, the most recently used
-        // radio widget will attempt to keep the "selected" answer in view
-        // after entering review mode.
-        //
-        // Defaults to `false`.
-        canScrollPage: PropTypes.bool,
-        // The value in milliseconds by which the local state of content
-        // in a editor is delayed before propagated to a prop. For example,
-        // when text is typed in the text area of an Editor component,
-        // there will be a delay equal to the value of `editorChangeDelay`
-        // before the change is propagated. This is added for better
-        // responsiveness of the editor when used in certain contexts such
-        // as StructuredItem exercises where constant re-rendering for each
-        // keystroke caused text typed in the text area to appear in it
-        // only after a good few seconds.
-        editorChangeDelay: PropTypes.number,
     }).isRequired,
 
     // eslint-disable-next-line no-restricted-syntax
@@ -135,8 +117,6 @@ export const ApiOptions = {
             },
         },
         setDrawingAreaAvailable: function () {},
-        canScrollPage: false,
-        editorChangeDelay: 0,
     } as APIOptionsWithDefaults,
 } as const;
 

--- a/packages/perseus/src/perseus-api.tsx
+++ b/packages/perseus/src/perseus-api.tsx
@@ -72,14 +72,6 @@ export const ApiOptions = {
         // input components.
         customKeypad: PropTypes.bool,
 
-        // If this is provided, it is called instead of appending an instance
-        // of `math-input`'s keypad to the body. This is used by the native
-        // apps so they can have the keypad be defined on the native side.
-        // It is called with an function that, when called, blurs the input,
-        // and is expected to return an object of the shape
-        // keypadElementPropType from math-input/src/prop-types.js.
-        nativeKeypadProxy: PropTypes.func,
-
         // Indicates whether or not to use mobile styling.
         isMobile: PropTypes.bool,
 

--- a/packages/perseus/src/perseus-api.tsx
+++ b/packages/perseus/src/perseus-api.tsx
@@ -90,11 +90,6 @@ export const ApiOptions = {
         // Indicates whether or not to use mobile app styling.
         isMobileApp: PropTypes.bool,
 
-        // A function, called with a bool indicating whether use of the
-        // drawing area (scratchpad) should be allowed/disallowed.
-        // Previously handled by `Khan.scratchpad.enable/disable`
-        setDrawingAreaAvailable: PropTypes.func,
-
         // The color used for the hint progress indicator (eg. 1 / 3)
         hintProgressColor: PropTypes.string,
     }).isRequired,
@@ -116,7 +111,6 @@ export const ApiOptions = {
                 return <a {...rest}>{children}</a>;
             },
         },
-        setDrawingAreaAvailable: function () {},
     } as APIOptionsWithDefaults,
 } as const;
 

--- a/packages/perseus/src/renderer.tsx
+++ b/packages/perseus/src/renderer.tsx
@@ -133,7 +133,6 @@ type Props = Partial<React.ContextType<typeof DependenciesContext>> & {
     onRender: (node?: any) => void;
     problemNum?: number;
     reviewMode?: boolean | null | undefined;
-    highlightEmptyWidgets?: boolean;
 
     /**
      * If set to "all", all rationales or solutions will be shown. If set to
@@ -466,11 +465,6 @@ class Renderer
         if (widgetInfo) {
             const type = (widgetInfo && widgetInfo.type) || impliedType;
 
-            let shouldHighlight = false;
-            if (this.props.highlightEmptyWidgets && this.props.userInput) {
-                shouldHighlight = this.emptyWidgets().includes(id);
-            }
-
             // By this point we should have no duplicates, which are
             // filtered out in this.render(), so we shouldn't have to
             // worry about using this widget key and ref:
@@ -488,7 +482,6 @@ class Renderer
                     }}
                     type={type}
                     widgetProps={this.getWidgetProps(id)}
-                    shouldHighlight={shouldHighlight}
                     linterContext={PerseusLinter.pushContextStack(
                         this.props.linterContext,
                         "widget",

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -46,7 +46,6 @@ type OwnProps = {
     item: PerseusItem;
     problemNum?: number;
     reviewMode?: boolean;
-    highlightEmptyWidgets?: boolean;
     keypadElement?: KeypadAPI | null | undefined;
     dependencies: PerseusDependenciesV2;
     showSolutions?: ShowSolutions;

--- a/packages/perseus/src/styles/widget-container.css
+++ b/packages/perseus/src/styles/widget-container.css
@@ -1,13 +1,3 @@
-/* Highlight states for editor/interaction */
-.perseus-widget-container.widget-nohighlight {
-    transition: all 0.15s;
-}
-
-.perseus-widget-container.widget-highlight {
-    box-shadow: 0px 0px 0px var(--wb-sizing-size_020) #ffa500;
-    transition: all 0.15s;
-}
-
 /******************* Start for WidgetContainer's alignment CSS styling *******************/
 /* Base display modes */
 .perseus-widget-container.widget-inline {

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -251,34 +251,11 @@ export type APIOptions = Readonly<{
      * Previously handled by `Khan.scratchpad.enable/disable`
      * @deprecated setDrawingAreaAvailable is not used in frontend code.
      */
+    // FIXME: remove setDrawingAreaAvailable. Remove code branches that handle
+    // non-undefined values of setDrawingAreaAvailable.
     setDrawingAreaAvailable?: (arg1: boolean) => unknown;
     /** The color used for the hint progress indicator (eg. 1 / 3) */
     hintProgressColor?: string;
-    // TODO(benchristel): Remove canScrollPage
-    /**
-     * Whether this Renderer is allowed to auto-scroll the rest of the
-     * page. For example, if this is enabled, the most recently used
-     * radio widget will attempt to keep the "selected" answer in view
-     * after entering review mode.
-     *
-     * Defaults to `false`.
-     * @deprecated canScrollPage has no effect.
-     */
-    canScrollPage?: boolean;
-    // TODO(benchristel): Remove editorChangeDelay
-    /**
-     * The value in milliseconds by which the local state of content
-     * in a editor is delayed before propagated to a prop. For example,
-     * when text is typed in the text area of an Editor component,
-     * there will be a delay equal to the value of `editorChangeDelay`
-     * before the change is propagated. This is added for better
-     * responsiveness of the editor when used in certain contexts such
-     * as StructuredItem exercises where constant re-rendering for each
-     * keystroke caused text typed in the text area to appear in it
-     * only after a good few seconds.
-     * @deprecated editorChangeDelay has no effect.
-     */
-    editorChangeDelay?: number;
     /**
      * Feature flags that can be passed from consuming application.
      * Define the feature flag name in packages/perseus-core/src/feature-flags.ts
@@ -432,8 +409,6 @@ export interface PerseusDependenciesV2 {
 export type APIOptionsWithDefaults = Readonly<
     APIOptions & {
         baseElements: NonNullable<APIOptions["baseElements"]>;
-        canScrollPage: NonNullable<APIOptions["canScrollPage"]>;
-        editorChangeDelay: NonNullable<APIOptions["editorChangeDelay"]>;
         isArticle: NonNullable<APIOptions["isArticle"]>;
         isMobile: NonNullable<APIOptions["isMobile"]>;
         isMobileApp: NonNullable<APIOptions["isMobileApp"]>;

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -1,7 +1,6 @@
 import type {ILogger} from "./logging/log";
 import type {SizeClass} from "./util/sizing-utils";
 import type {WidgetPromptJSON} from "./widget-ai-utils/prompt-types";
-import type {KeypadAPI} from "@khanacademy/math-input";
 // MAGIC: Removal of this comment may cause `tsc --build` to output a syntax
 // error in packages/perseus/dist/server-item-renderer.d.ts and then fail. This
 // appears to be a bug introduced in TS 5.6. If you are curious about this, try

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -226,15 +226,6 @@ export type APIOptions = Readonly<{
      * input components.
      */
     customKeypad?: boolean;
-    /**
-     * If this is provided, it is called instead of appending an instance
-     * of `math-input`'s keypad to the body. This is used by the native
-     * apps so they can have the keypad be defined on the native side.
-     * It is called with an function that, when called, blurs the input,
-     * and is expected to return an object of the shape
-     * keypadElementPropType from math-input/src/prop-types.js.
-     */
-    nativeKeypadProxy?: (blur: () => void) => KeypadAPI;
     /** Indicates whether or not to use mobile styling. */
     isMobile?: boolean;
     /** Indicates whether or not to use mobile app styling. */

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -216,6 +216,8 @@ export type APIOptions = Readonly<{
      * Function that takes dimensions and returns a React component
      * to display while an image is loading.
      */
+    // FIXME: remove imagePreloader and all code that handles non-undefined values of imagePreloader.
+    //  Client code no longer passes it.
     imagePreloader?: (dimensions: Dimensions) => React.ReactNode;
     /**
      * A function that is called when the user has interacted with a widget. It

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -244,16 +244,6 @@ export type APIOptions = Readonly<{
     isMobile?: boolean;
     /** Indicates whether or not to use mobile app styling. */
     isMobileApp?: boolean;
-    // TODO(benchristel): Remove setDrawingAreaAvailable
-    /** A function, called with a bool indicating whether use of the
-     * drawing area (scratchpad) should be allowed/disallowed.
-     *
-     * Previously handled by `Khan.scratchpad.enable/disable`
-     * @deprecated setDrawingAreaAvailable is not used in frontend code.
-     */
-    // FIXME: remove setDrawingAreaAvailable. Remove code branches that handle
-    // non-undefined values of setDrawingAreaAvailable.
-    setDrawingAreaAvailable?: (arg1: boolean) => unknown;
     /** The color used for the hint progress indicator (eg. 1 / 3) */
     hintProgressColor?: string;
     /**
@@ -415,9 +405,6 @@ export type APIOptionsWithDefaults = Readonly<
         editingDisabled: NonNullable<APIOptions["editingDisabled"]>;
         onFocusChange: NonNullable<APIOptions["onFocusChange"]>;
         readOnly: NonNullable<APIOptions["readOnly"]>;
-        setDrawingAreaAvailable: NonNullable<
-            APIOptions["setDrawingAreaAvailable"]
-        >;
         showAlignmentOptions: NonNullable<APIOptions["showAlignmentOptions"]>;
     }
 >;

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -213,13 +213,6 @@ export type APIOptions = Readonly<{
         Link: React.ComponentType<any>;
     };
     /**
-     * Function that takes dimensions and returns a React component
-     * to display while an image is loading.
-     */
-    // FIXME: remove imagePreloader and all code that handles non-undefined values of imagePreloader.
-    //  Client code no longer passes it.
-    imagePreloader?: (dimensions: Dimensions) => React.ReactNode;
-    /**
      * A function that is called when the user has interacted with a widget. It
      * also includes any extra parameters that the originating widget provided.
      * This is used for keeping track of widget interactions.

--- a/packages/perseus/src/util/graphie.test.ts
+++ b/packages/perseus/src/util/graphie.test.ts
@@ -1308,17 +1308,6 @@ describe("Graphie drawing tools", () => {
                 expect(target?.getAttribute("height")).toBe("50");
             },
         );
-
-        it("should disable drawing area if allowScratchpad is false", async () => {
-            const graphie = createAndInitGraphie();
-            const onSetDrawingAreaAvailable = jest.fn();
-            graphie.addMouseLayer({
-                setDrawingAreaAvailable: onSetDrawingAreaAvailable,
-                allowScratchpad: false,
-            });
-
-            expect(onSetDrawingAreaAvailable).toHaveBeenCalledWith(false);
-        });
     });
 
     describe("getMousePx", () => {

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1451,12 +1451,9 @@ export class Graphie {
         onMouseOut?: MouseHandler | null;
         onMouseUp?: MouseHandler | null;
         allowScratchpad?: boolean;
-        setDrawingAreaAvailable?: (available: boolean) => void;
     }): void {
         const localOptions = {
             allowScratchpad: false,
-            setDrawingAreaAvailable: function () {},
-
             ...options,
         };
 
@@ -1520,10 +1517,6 @@ export class Graphie {
                 });
             }
         }
-        if (!localOptions.allowScratchpad) {
-            localOptions.setDrawingAreaAvailable?.(false);
-        }
-
         // Add mouse and visible wrapper layers for DOM-node-wrapped movables
         this._mouselayerWrapper = document.createElement("div");
         $(this._mouselayerWrapper).css({

--- a/packages/perseus/src/widget-container.tsx
+++ b/packages/perseus/src/widget-container.tsx
@@ -18,7 +18,6 @@ import type {WidgetProps} from "./types";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
 type Props = {
-    shouldHighlight: boolean;
     type: string; // widget type/name,
     id: string; // widget id
     widgetProps: WidgetProps<any, PerseusWidgetOptions>;
@@ -80,8 +79,6 @@ class WidgetContainer extends React.Component<Props, State> {
     render(): React.ReactNode {
         let className = classNames({
             "perseus-widget-container": true,
-            "widget-highlight": this.props.shouldHighlight,
-            "widget-nohighlight": !this.props.shouldHighlight,
             // HACK(matthewc): perseus-widget-container is setting a font-size
             // but we want the definition prompt to match the surrounding font
             // I'm sorry, but there's a time crunch

--- a/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
+++ b/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
@@ -49,7 +49,7 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="categorizer-container fullBleedContainer_8ybp6"
@@ -466,7 +466,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="categorizer-container "

--- a/packages/perseus/src/widgets/cs-program/__snapshots__/cs-program.test.ts.snap
+++ b/packages/perseus/src/widgets/cs-program/__snapshots__/cs-program.test.ts.snap
@@ -13,7 +13,7 @@ exports[`cs-program widget should snapshot on mobile: first mobile render 1`] = 
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="container_1v2yujs"
@@ -47,7 +47,7 @@ exports[`cs-program widget should snapshot: first render 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="container_1v2yujs"

--- a/packages/perseus/src/widgets/definition/__snapshots__/definition.test.ts.snap
+++ b/packages/perseus/src/widgets/definition/__snapshots__/definition.test.ts.snap
@@ -24,7 +24,7 @@ exports[`Definition widget should have a default snapshot: first render 1`] = `
       >
         The Governor and Council of the Massachusetts had much conference many days; and at last . . . . concluded a peace and friendship with 
         <div
-          class="perseus-widget-container widget-nohighlight perseus-widget__definition widget-inline"
+          class="perseus-widget-container perseus-widget__definition widget-inline"
         >
           <button
             aria-controls=":r0:"
@@ -71,7 +71,7 @@ exports[`Definition widget should have an open state snapshot: open state 1`] = 
       >
         The Governor and Council of the Massachusetts had much conference many days; and at last . . . . concluded a peace and friendship with 
         <div
-          class="perseus-widget-container widget-nohighlight perseus-widget__definition widget-inline"
+          class="perseus-widget-container perseus-widget__definition widget-inline"
         >
           <button
             aria-controls=":r2:"

--- a/packages/perseus/src/widgets/deprecated-standin/__snapshots__/deprecated-standin.test.ts.snap
+++ b/packages/perseus/src/widgets/deprecated-standin/__snapshots__/deprecated-standin.test.ts.snap
@@ -24,7 +24,7 @@ exports[`Deprecated Standin widget should have a default snapshot: first render 
       >
         The Governor and Council of the Massachusetts had much conference many days; and at last . . . . concluded a peace and friendship with 
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             style="padding-top: 8px; padding-bottom: 8px;"

--- a/packages/perseus/src/widgets/dropdown/__snapshots__/dropdown.test.ts.snap
+++ b/packages/perseus/src/widgets/dropdown/__snapshots__/dropdown.test.ts.snap
@@ -14,7 +14,7 @@ exports[`Dropdown widget should snapshot when opened: dropdown open 1`] = `
       >
         The total number of boxes the forklift can carry is 
         <div
-          class="perseus-widget-container widget-nohighlight widget-inline-block"
+          class="perseus-widget-container widget-inline-block"
         >
           <div
             class="default_xu2jcg"
@@ -93,7 +93,7 @@ exports[`Dropdown widget should snapshot: initial render 1`] = `
       >
         The total number of boxes the forklift can carry is 
         <div
-          class="perseus-widget-container widget-nohighlight widget-inline-block"
+          class="perseus-widget-container widget-inline-block"
         >
           <div
             class="default_xu2jcg"

--- a/packages/perseus/src/widgets/explanation/__snapshots__/explanation.test.ts.snap
+++ b/packages/perseus/src/widgets/explanation/__snapshots__/explanation.test.ts.snap
@@ -15,7 +15,7 @@ exports[`Explanation should snapshot when expanded: expanded 1`] = `
         Here's the explanation
 
         <div
-          class="perseus-widget-container widget-nohighlight widget-inline"
+          class="perseus-widget-container widget-inline"
         >
           <button
             aria-controls=":r1:"
@@ -87,7 +87,7 @@ exports[`Explanation should snapshot: initial render 1`] = `
         Here's the explanation
 
         <div
-          class="perseus-widget-container widget-nohighlight widget-inline"
+          class="perseus-widget-container widget-inline"
         >
           <button
             aria-controls=":r0:"

--- a/packages/perseus/src/widgets/free-response/__snapshots__/free-response.test.tsx.snap
+++ b/packages/perseus/src/widgets/free-response/__snapshots__/free-response.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`free-response widget should snapshot on mobile: first mobile render 1`]
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="default_xu2jcg-o_O-container_lci7r free-response"
@@ -99,7 +99,7 @@ exports[`free-response widget should snapshot: first render 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="default_xu2jcg-o_O-container_lci7r free-response"

--- a/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set-jipt.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set-jipt.test.ts.snap
@@ -21,7 +21,7 @@ exports[`graded-group-set should render all graded groups 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="container_14sgdtb"
@@ -57,7 +57,7 @@ exports[`graded-group-set should render all graded groups 1`] = `
                     </span>
                        
                     <div
-                      class="perseus-widget-container widget-nohighlight widget-inline-block"
+                      class="perseus-widget-container widget-inline-block"
                     >
                       <input
                         aria-disabled="false"
@@ -148,7 +148,7 @@ exports[`graded-group-set should render all graded groups 1`] = `
                     </span>
                        
                     <div
-                      class="perseus-widget-container widget-nohighlight widget-inline-block"
+                      class="perseus-widget-container widget-inline-block"
                     >
                       <input
                         aria-disabled="false"
@@ -239,7 +239,7 @@ exports[`graded-group-set should render all graded groups 1`] = `
                     </span>
                        
                     <div
-                      class="perseus-widget-container widget-nohighlight widget-inline-block"
+                      class="perseus-widget-container widget-inline-block"
                     >
                       <input
                         aria-disabled="false"

--- a/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set.test.ts.snap
@@ -21,7 +21,7 @@ exports[`graded group set widget should snapshot 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="container_14sgdtb"
@@ -117,7 +117,7 @@ exports[`graded group set widget should snapshot 1`] = `
                     </span>
                        
                     <div
-                      class="perseus-widget-container widget-nohighlight widget-inline-block"
+                      class="perseus-widget-container widget-inline-block"
                     >
                       <input
                         aria-disabled="false"

--- a/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
@@ -29,7 +29,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="perseus-graded-group"
@@ -61,7 +61,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                       class="paragraph"
                     >
                       <div
-                        class="perseus-widget-container widget-nohighlight widget-block"
+                        class="perseus-widget-container widget-block"
                       >
                         <div
                           class="categorizer-container "
@@ -473,7 +473,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="gradedGroup_14sgdtb perseus-graded-group"
@@ -505,7 +505,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                       class="paragraph"
                     >
                       <div
-                        class="perseus-widget-container widget-nohighlight widget-block"
+                        class="perseus-widget-container widget-block"
                       >
                         <div
                           class="categorizer-container fullBleedContainer_8ybp6"

--- a/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
+++ b/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
@@ -37,7 +37,7 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div>
             <div
@@ -1356,7 +1356,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div>
             <div

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -73,7 +73,6 @@ type FunctionGrapherProps = {
     hideHairlines: () => void;
     isMobile: boolean;
     model: any;
-    setDrawingAreaAvailable: () => void;
     showHairlines: () => void;
     showTooltips: boolean;
     static: boolean;
@@ -331,12 +330,7 @@ class FunctionGrapher extends React.Component<FunctionGrapherProps> {
                     }}
                 >
                     {image}
-                    <Graphie
-                        {...this.props.graph}
-                        setDrawingAreaAvailable={
-                            this.props.setDrawingAreaAvailable
-                        }
-                    >
+                    <Graphie {...this.props.graph}>
                         {this.props.model && this.renderPlot()}
                         {this.props.model && this.renderAsymptote()}
                         {this.props.model && points}
@@ -598,8 +592,6 @@ class Grapher extends React.Component<Props> implements Widget {
             coords: coords,
             asymptote: asymptote,
             static: this.props.static,
-            setDrawingAreaAvailable:
-                this.props.apiOptions.setDrawingAreaAvailable,
             isMobile: this.props.apiOptions.isMobile,
             showTooltips: this.props.graph.showTooltips,
             showHairlines: this.showHairlines,

--- a/packages/perseus/src/widgets/group/__snapshots__/group.test.tsx.snap
+++ b/packages/perseus/src/widgets/group/__snapshots__/group.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`group widget should snapshot: initial render 1`] = `
               class="paragraph"
             >
               <div
-                class="perseus-widget-container widget-nohighlight widget-block"
+                class="perseus-widget-container widget-block"
               >
                 <div
                   class="perseus-group"
@@ -105,7 +105,7 @@ exports[`group widget should snapshot: initial render 1`] = `
                         class="paragraph"
                       >
                         <div
-                          class="perseus-widget-container widget-nohighlight widget-block"
+                          class="perseus-widget-container widget-block"
                         >
                           <fieldset
                             class="container"
@@ -387,7 +387,7 @@ exports[`group widget should snapshot: initial render 1`] = `
               class="paragraph"
             >
               <div
-                class="perseus-widget-container widget-nohighlight widget-block"
+                class="perseus-widget-container widget-block"
               >
                 <div
                   class="perseus-group"
@@ -428,7 +428,7 @@ exports[`group widget should snapshot: initial render 1`] = `
                         class="paragraph"
                       >
                         <div
-                          class="perseus-widget-container widget-nohighlight widget-inline-block"
+                          class="perseus-widget-container widget-inline-block"
                         >
                           <input
                             aria-disabled="false"
@@ -485,7 +485,7 @@ exports[`group widget should snapshot: initial render 1`] = `
                         class="paragraph"
                       >
                         <div
-                          class="perseus-widget-container widget-nohighlight widget-inline-block"
+                          class="perseus-widget-container widget-inline-block"
                         >
                           <input
                             aria-disabled="false"
@@ -517,7 +517,7 @@ exports[`group widget should snapshot: initial render 1`] = `
                         class="paragraph"
                       >
                         <div
-                          class="perseus-widget-container widget-nohighlight widget-block"
+                          class="perseus-widget-container widget-block"
                         >
                           <figure
                             class="perseus-image-widget"

--- a/packages/perseus/src/widgets/iframe/__snapshots__/iframe.test.ts.snap
+++ b/packages/perseus/src/widgets/iframe/__snapshots__/iframe.test.ts.snap
@@ -15,7 +15,7 @@ exports[`iframe widget should snapshot on mobile: first mobile render 1`] = `
         Try matching the target image
 
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <iframe
             allowfullscreen=""
@@ -46,7 +46,7 @@ exports[`iframe widget should snapshot: first render 1`] = `
         Try matching the target image
 
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <iframe
             allowfullscreen=""

--- a/packages/perseus/src/widgets/image/__snapshots__/image.test.ts.snap
+++ b/packages/perseus/src/widgets/image/__snapshots__/image.test.ts.snap
@@ -13,7 +13,7 @@ exports[`image widget - isMobile(false) custom alignment should render image wit
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-wrap-left"
+          class="perseus-widget-container widget-wrap-left"
         >
           <figure
             class="perseus-image-widget"
@@ -97,7 +97,7 @@ exports[`image widget - isMobile(false) custom alignment should render image wit
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-wrap-right"
+          class="perseus-widget-container widget-wrap-right"
         >
           <figure
             class="perseus-image-widget"
@@ -280,7 +280,7 @@ exports[`image widget - isMobile(false) should snapshot: first render 1`] = `
               class="paragraph"
             >
               <div
-                class="perseus-widget-container widget-nohighlight widget-block"
+                class="perseus-widget-container widget-block"
               >
                 <figure
                   class="perseus-image-widget"
@@ -454,7 +454,7 @@ exports[`image widget - isMobile(true) custom alignment should render image with
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-wrap-left"
+          class="perseus-widget-container widget-wrap-left"
         >
           <figure
             class="perseus-image-widget"
@@ -538,7 +538,7 @@ exports[`image widget - isMobile(true) custom alignment should render image with
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-wrap-right"
+          class="perseus-widget-container widget-wrap-right"
         >
           <figure
             class="perseus-image-widget"
@@ -721,7 +721,7 @@ exports[`image widget - isMobile(true) should snapshot: first render 1`] = `
               class="paragraph"
             >
               <div
-                class="perseus-widget-container widget-nohighlight widget-block"
+                class="perseus-widget-container widget-block"
               >
                 <figure
                   class="perseus-image-widget"

--- a/packages/perseus/src/widgets/image/components/explore-image-modal-content.tsx
+++ b/packages/perseus/src/widgets/image/components/explore-image-modal-content.tsx
@@ -99,7 +99,6 @@ export default function ExploreImageModalContent({
                             width={width}
                             height={height}
                             scale={scale}
-                            preloader={apiOptions.imagePreloader}
                             extraGraphie={{
                                 box: box,
                                 range: range,

--- a/packages/perseus/src/widgets/image/image.tsx
+++ b/packages/perseus/src/widgets/image/image.tsx
@@ -81,7 +81,6 @@ export const ImageComponent = (props: ImageWidgetProps) => {
                     width={backgroundImage.width}
                     height={backgroundImage.height}
                     scale={scale}
-                    preloader={apiOptions.imagePreloader}
                     extraGraphie={{
                         box: box,
                         range: range,

--- a/packages/perseus/src/widgets/input-number/__snapshots__/input-number.test.ts.snap
+++ b/packages/perseus/src/widgets/input-number/__snapshots__/input-number.test.ts.snap
@@ -163,7 +163,7 @@ exports[`rendering supports mobile rendering: mobile render 1`] = `
         </strong>
          If necessary, round your answer to the nearest hundredth. 
         <div
-          class="perseus-widget-container widget-nohighlight widget-inline-block"
+          class="perseus-widget-container widget-inline-block"
         >
           <div
             aria-label="Math input box Tap with one or two fingers to open keyboard"

--- a/packages/perseus/src/widgets/interaction/__snapshots__/interaction.test.ts.snap
+++ b/packages/perseus/src/widgets/interaction/__snapshots__/interaction.test.ts.snap
@@ -13,7 +13,7 @@ exports[`interaction widget renders movable point elements with blank constraint
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="graphie-container"
@@ -835,7 +835,7 @@ exports[`interaction widget should render 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="graphie-container"

--- a/packages/perseus/src/widgets/interaction/interaction.tsx
+++ b/packages/perseus/src/widgets/interaction/interaction.tsx
@@ -270,9 +270,6 @@ class Interaction extends React.Component<Props, State> implements Widget {
                 range={this.props.graph.range}
                 options={this.props.graph}
                 setup={this._setupGraphie}
-                setDrawingAreaAvailable={
-                    this.props.apiOptions.setDrawingAreaAvailable
-                }
             >
                 {this.props.graph.markings === "graph" && (
                     <Label

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Interactive Graph A none-type graph renders predictably: first render 1
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="default_xu2jcg mafs-graph-container"
@@ -1087,7 +1087,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
         . 
 
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="default_xu2jcg mafs-graph-container"
@@ -1523,7 +1523,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="default_xu2jcg mafs-graph-container"
@@ -1965,7 +1965,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="default_xu2jcg mafs-graph-container"
@@ -2215,7 +2215,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="default_xu2jcg mafs-graph-container"
@@ -2443,7 +2443,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
         . 
 
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="default_xu2jcg mafs-graph-container"
@@ -2852,7 +2852,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="default_xu2jcg mafs-graph-container"
@@ -3294,7 +3294,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="default_xu2jcg mafs-graph-container"
@@ -3651,7 +3651,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="default_xu2jcg mafs-graph-container"

--- a/packages/perseus/src/widgets/matcher/__snapshots__/matcher.test.tsx.snap
+++ b/packages/perseus/src/widgets/matcher/__snapshots__/matcher.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`matcher widget can reorder options: moved items 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <table
             class="widget_lf609f perseus-widget-matcher"
@@ -319,7 +319,7 @@ exports[`matcher widget should snapshot on mobile: first mobile render 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <table
             class="widget_lf609f perseus-widget-matcher"
@@ -613,7 +613,7 @@ exports[`matcher widget should snapshot: first render 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <table
             class="widget_lf609f perseus-widget-matcher"

--- a/packages/perseus/src/widgets/matrix/__snapshots__/matrix.test.ts.snap
+++ b/packages/perseus/src/widgets/matrix/__snapshots__/matrix.test.ts.snap
@@ -64,7 +64,7 @@ exports[`matrix widget should snapshot on mobile: first mobile render 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="perseus-matrix"
@@ -364,7 +364,7 @@ exports[`matrix widget should snapshot: first render 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="perseus-matrix"

--- a/packages/perseus/src/widgets/measurer/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.tsx
@@ -107,8 +107,6 @@ class Measurer extends React.Component<Props> implements Widget {
         });
         graphie.addMouseLayer({
             allowScratchpad: true,
-            setDrawingAreaAvailable:
-                this.props.apiOptions.setDrawingAreaAvailable,
         });
 
         if (this.protractor) {

--- a/packages/perseus/src/widgets/number-line/__snapshots__/number-line.test.ts.snap
+++ b/packages/perseus/src/widgets/number-line/__snapshots__/number-line.test.ts.snap
@@ -56,7 +56,7 @@ exports[`number-line widget snapshots all tick labels show when "Style" is "deci
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="perseus-widget perseus-widget-interactive-number-line"
@@ -621,7 +621,7 @@ exports[`number-line widget snapshots can handle fractions: show fractions 1`] =
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="perseus-widget perseus-widget-interactive-number-line"
@@ -978,7 +978,7 @@ exports[`number-line widget snapshots default: first render 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="perseus-widget perseus-widget-interactive-number-line"
@@ -1351,7 +1351,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="perseus-widget perseus-widget-interactive-number-line"
@@ -1916,7 +1916,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="perseus-widget perseus-widget-interactive-number-line"
@@ -2481,7 +2481,7 @@ exports[`number-line widget snapshots labels are highlighted when part of the ti
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="perseus-widget perseus-widget-interactive-number-line"
@@ -2886,7 +2886,7 @@ exports[`number-line widget snapshots labels are inserted when NOT part of the t
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="perseus-widget perseus-widget-interactive-number-line"
@@ -3328,7 +3328,7 @@ exports[`number-line widget snapshots mobile: first mobile render 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="perseus-widget perseus-widget-interactive-number-line"
@@ -3701,7 +3701,7 @@ exports[`number-line widget snapshots only endpoints/labels show when "Show labe
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="perseus-widget perseus-widget-interactive-number-line"
@@ -4095,7 +4095,7 @@ exports[`number-line widget snapshots only endpoints/labels show when "Show labe
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="perseus-widget perseus-widget-interactive-number-line"

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -425,9 +425,6 @@ class NumberLine extends React.Component<Props, State> implements Widget {
                     this.refs.graphie.movables.numberLinePoint.grab(coord);
                 }}
                 setup={this._setupGraphie}
-                setDrawingAreaAvailable={
-                    this.props.apiOptions.setDrawingAreaAvailable
-                }
                 isMobile={this.props.apiOptions.isMobile}
             >
                 <TickMarks

--- a/packages/perseus/src/widgets/numeric-input/__snapshots__/numeric-input.test.ts.snap
+++ b/packages/perseus/src/widgets/numeric-input/__snapshots__/numeric-input.test.ts.snap
@@ -25,7 +25,7 @@ exports[`Numeric input widget styles differently on mobile: mobile render 1`] = 
         </span>
          
         <div
-          class="perseus-widget-container widget-nohighlight widget-inline-block"
+          class="perseus-widget-container widget-inline-block"
         >
           <div>
             <div
@@ -90,7 +90,7 @@ exports[`numeric-input widget Should render predictably: after interaction 1`] =
         </span>
          
         <div
-          class="perseus-widget-container widget-nohighlight widget-inline-block"
+          class="perseus-widget-container widget-inline-block"
         >
           <input
             aria-disabled="false"
@@ -144,7 +144,7 @@ exports[`numeric-input widget Should render predictably: first render 1`] = `
         </span>
          
         <div
-          class="perseus-widget-container widget-nohighlight widget-inline-block"
+          class="perseus-widget-container widget-inline-block"
         >
           <input
             aria-disabled="false"
@@ -198,7 +198,7 @@ exports[`numeric-input widget Should render tooltip as list when multiple format
         </span>
          
         <div
-          class="perseus-widget-container widget-nohighlight widget-inline-block"
+          class="perseus-widget-container widget-inline-block"
         >
           <input
             aria-describedby="aria-for-:ri:"
@@ -258,7 +258,7 @@ exports[`numeric-input widget Should render tooltip using only correct answer fo
         </span>
          
         <div
-          class="perseus-widget-container widget-nohighlight widget-inline-block"
+          class="perseus-widget-container widget-inline-block"
         >
           <input
             aria-describedby="aria-for-:rl:"
@@ -316,7 +316,7 @@ exports[`numeric-input widget Should render tooltip when format option is given:
         </span>
          
         <div
-          class="perseus-widget-container widget-nohighlight widget-inline-block"
+          class="perseus-widget-container widget-inline-block"
         >
           <input
             aria-describedby="aria-for-:rc:"

--- a/packages/perseus/src/widgets/orderer/__snapshots__/orderer.test.ts.snap
+++ b/packages/perseus/src/widgets/orderer/__snapshots__/orderer.test.ts.snap
@@ -26,7 +26,7 @@ exports[`orderer widget should snapshot on mobile: first mobile render 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="draggy-boxy-thing orderer height-normal layout-horizontal blank-background perseus-clearfix "
@@ -147,7 +147,7 @@ exports[`orderer widget should snapshot: first render 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="draggy-boxy-thing orderer height-normal layout-horizontal blank-background perseus-clearfix "

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -286,8 +286,6 @@ class Plotter extends React.Component<Props, State> implements Widget {
         });
         graphie.addMouseLayer({
             allowScratchpad: true,
-            setDrawingAreaAvailable:
-                this.props.apiOptions.setDrawingAreaAvailable,
         });
 
         if (!isTiledPlot) {

--- a/packages/perseus/src/widgets/python-program/__snapshots__/python-program.test.ts.snap
+++ b/packages/perseus/src/widgets/python-program/__snapshots__/python-program.test.ts.snap
@@ -13,7 +13,7 @@ exports[`python-program widget should snapshot on mobile: first mobile render 1`
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="default_xu2jcg-o_O-container_1s1lg5o"
@@ -46,7 +46,7 @@ exports[`python-program widget should snapshot: first render 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="default_xu2jcg-o_O-container_1s1lg5o"

--- a/packages/perseus/src/widgets/radio/__tests__/__snapshots__/radio.test.ts.snap
+++ b/packages/perseus/src/widgets/radio/__tests__/__snapshots__/radio.test.ts.snap
@@ -37,7 +37,7 @@ exports[`Radio Widget multi-choice question should snapshot the same when invali
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <fieldset
             class="container"
@@ -325,7 +325,7 @@ exports[`Radio Widget single-choice question reviewMode: false should snapshot t
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <fieldset
             class="container"
@@ -617,7 +617,7 @@ exports[`Radio Widget single-choice question reviewMode: false should snapshot t
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <fieldset
             class="container"
@@ -909,7 +909,7 @@ exports[`Radio Widget single-choice question reviewMode: false should snapshot t
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <fieldset
             class="container"
@@ -1201,7 +1201,7 @@ exports[`Radio Widget single-choice question reviewMode: true should snapshot th
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <fieldset
             class="container"
@@ -1493,7 +1493,7 @@ exports[`Radio Widget single-choice question reviewMode: true should snapshot th
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <fieldset
             class="container"
@@ -1785,7 +1785,7 @@ exports[`Radio Widget single-choice question reviewMode: true should snapshot th
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <fieldset
             class="container"

--- a/packages/perseus/src/widgets/table/__snapshots__/table.test.tsx.snap
+++ b/packages/perseus/src/widgets/table/__snapshots__/table.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`table answerful vs answerless answerful: snapshots 1`] = `
         The answer is 42
 
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <table
             class="perseus-widget-table-of-values non-markdown"
@@ -109,7 +109,7 @@ exports[`table answerful vs answerless answerless: snapshots 1`] = `
         The answer is 42
 
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <table
             class="perseus-widget-table-of-values non-markdown"

--- a/packages/perseus/src/widgets/video/__snapshots__/video.test.ts.snap
+++ b/packages/perseus/src/widgets/video/__snapshots__/video.test.ts.snap
@@ -23,7 +23,7 @@ exports[`video widget should snapshot on mobile: first mobile render 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="default_xu2jcg"
@@ -93,7 +93,7 @@ exports[`video widget should snapshot: first render 1`] = `
         class="paragraph"
       >
         <div
-          class="perseus-widget-container widget-nohighlight widget-block"
+          class="perseus-widget-container widget-block"
         >
           <div
             class="default_xu2jcg"


### PR DESCRIPTION
## Summary:
All of the removed properties were either not used by Perseus or not used in
any clients.

This PR will be easiest to review one commit at a time.

Issue: none

## Test plan:

CI checks should pass.