### PR TITLE
Don't show ungraded text for 'none' graph

### DIFF
--- a/.changeset/quiet-pugs-check.md
+++ b/.changeset/quiet-pugs-check.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Don't show ungraded text for 'none' graph

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -2141,5 +2141,24 @@ describe("Interactive Graph", function () {
                 ),
             ).not.toBeInTheDocument();
         });
+
+        it("does not render a 'not graded' message when graph type is 'none'", () => {
+            // Arrange, Act
+            const question = generateInteractiveGraphQuestion({
+                // normally would show the "not graded" text
+                graded: false,
+                // but shouldn't because of the "none" type
+                correct: generateIGNoneGraph(),
+            });
+
+            renderQuestion(question, blankOptions);
+
+            // Assert
+            expect(
+                screen.queryByText(
+                    "Use this graph to check your thinking, but it does not count as your answer.",
+                ),
+            ).not.toBeInTheDocument();
+        });
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.tsx
@@ -268,9 +268,12 @@ class InteractiveGraph extends React.Component<Props, State> {
                 ),
         };
 
+        const showUngradedText =
+            this.props.graded === false && this.props.graph.type !== "none";
+
         return (
             <>
-                {this.props.graded === false && (
+                {showUngradedText && (
                     <p>{this.context.strings.ungradedInteractiveGraph}</p>
                 )}
                 <StatefulMafsGraph


### PR DESCRIPTION
## Summary:

Small change to hide "ungraded" text when a graph is "none" type (which is already not graded).

See: https://khanacademy.slack.com/archives/C05MUPEJUPP/p1780076351228929