### PR TITLE
Fix flaky TeX Chromatic snapshots for Matcher and Sorter widgets

### DIFF
--- a/.changeset/stale-carrots-tease.md
+++ b/.changeset/stale-carrots-tease.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix flakey TeX Chromatic snapshots for Matcher and Sorter widgets.

--- a/packages/perseus/src/components/__tests__/with-asset-context.test.tsx
+++ b/packages/perseus/src/components/__tests__/with-asset-context.test.tsx
@@ -20,7 +20,6 @@ function MockComponent(props: MockComponentProps): React.ReactElement {
     return (
         <button
             onClick={() => props.setAssetStatus(props.assetKey, true)}
-            data-testid={props.label}
             data-asset-key={props.assetKey}
         >
             {props.label}
@@ -46,7 +45,7 @@ describe("withAssetContext", () => {
                 <Wrapped label="hello" />
             </AssetContext.Provider>,
         );
-        screen.getByTestId("hello").click();
+        screen.getByRole("button", {name: "hello"}).click();
 
         // Assert
         expect(setAssetStatusSpy).toHaveBeenCalled();
@@ -58,9 +57,9 @@ describe("withAssetContext", () => {
         render(<Wrapped label="hello" />);
 
         // Assert
-        expect(screen.getByTestId("hello").dataset.assetKey).toMatch(
-            /^widget-/,
-        );
+        expect(
+            screen.getByRole("button", {name: "hello"}).dataset.assetKey,
+        ).toMatch(/^widget-/);
     });
 
     it("generates a unique assetKey per rendered instance", () => {
@@ -74,8 +73,8 @@ describe("withAssetContext", () => {
         );
 
         // Assert
-        const first = screen.getByTestId("first");
-        const second = screen.getByTestId("second");
+        const first = screen.getByRole("button", {name: "first"});
+        const second = screen.getByRole("button", {name: "second"});
         expect(first.dataset.assetKey).not.toBe(second.dataset.assetKey);
     });
 
@@ -87,7 +86,7 @@ describe("withAssetContext", () => {
         // Assert — the HOC still generates an assetKey (useId works without
         // a Provider) and the default no-op setAssetStatus is callable (so
         // the click handler doesn't crash).
-        const button = screen.getByTestId("hello");
+        const button = screen.getByRole("button", {name: "hello"});
         expect(button.dataset.assetKey).toMatch(/^widget-/);
         expect(() => button.click()).not.toThrow();
     });

--- a/packages/perseus/src/components/__tests__/with-asset-context.test.tsx
+++ b/packages/perseus/src/components/__tests__/with-asset-context.test.tsx
@@ -1,0 +1,94 @@
+import {render, screen} from "@testing-library/react";
+import * as React from "react";
+
+import AssetContext from "../../asset-context";
+import {withAssetContext} from "../with-asset-context";
+
+// Minimal test-only component used to exercise withAssetContext. It accepts
+// the props the HOC injects (`setAssetStatus` and `assetKey`) and surfaces
+// them in two ways the tests can observe: as a `data-asset-key` attribute on
+// the rendered button (for inspecting which key the HOC generated), and via
+// a click handler that calls `setAssetStatus` (so tests can verify the
+// injected function reaches the wrapped component and is callable).
+type MockComponentProps = {
+    label: string;
+    setAssetStatus: (assetKey: string, loaded: boolean) => void;
+    assetKey: string;
+};
+
+function MockComponent(props: MockComponentProps): React.ReactElement {
+    return (
+        <button
+            onClick={() => props.setAssetStatus(props.assetKey, true)}
+            data-testid={props.label}
+            data-asset-key={props.assetKey}
+        >
+            {props.label}
+        </button>
+    );
+}
+
+describe("withAssetContext", () => {
+    it("injects setAssetStatus from AssetContext as a prop", () => {
+        // Arrange
+        const setAssetStatusSpy = jest.fn();
+        const Wrapped = withAssetContext(MockComponent, "widget");
+
+        // Act — clicking calls setAssetStatus via the injected prop, which
+        // proves the function from the Provider reached MockComponent.
+        render(
+            <AssetContext.Provider
+                value={{
+                    assetStatuses: {},
+                    setAssetStatus: setAssetStatusSpy,
+                }}
+            >
+                <Wrapped label="hello" />
+            </AssetContext.Provider>,
+        );
+        screen.getByTestId("hello").click();
+
+        // Assert
+        expect(setAssetStatusSpy).toHaveBeenCalled();
+    });
+
+    it("injects an assetKey with the configured prefix", () => {
+        // Arrange, Act
+        const Wrapped = withAssetContext(MockComponent, "widget");
+        render(<Wrapped label="hello" />);
+
+        // Assert
+        expect(screen.getByTestId("hello").dataset.assetKey).toMatch(
+            /^widget-/,
+        );
+    });
+
+    it("generates a unique assetKey per rendered instance", () => {
+        // Arrange, Act
+        const Wrapped = withAssetContext(MockComponent, "widget");
+        render(
+            <>
+                <Wrapped label="first" />
+                <Wrapped label="second" />
+            </>,
+        );
+
+        // Assert
+        const first = screen.getByTestId("first");
+        const second = screen.getByTestId("second");
+        expect(first.dataset.assetKey).not.toBe(second.dataset.assetKey);
+    });
+
+    it("uses the AssetContext default no-op when no Provider is above", () => {
+        // Arrange, Act — render without an AssetContext.Provider.
+        const Wrapped = withAssetContext(MockComponent, "widget");
+        render(<Wrapped label="hello" />);
+
+        // Assert — the HOC still generates an assetKey (useId works without
+        // a Provider) and the default no-op setAssetStatus is callable (so
+        // the click handler doesn't crash).
+        const button = screen.getByTestId("hello");
+        expect(button.dataset.assetKey).toMatch(/^widget-/);
+        expect(() => button.click()).not.toThrow();
+    });
+});

--- a/packages/perseus/src/components/with-asset-context.tsx
+++ b/packages/perseus/src/components/with-asset-context.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+
+import AssetContext from "../asset-context";
+
+type SetAssetStatus = (assetKey: string, loaded: boolean) => void;
+
+type InjectedProps = {
+    setAssetStatus: SetAssetStatus;
+    assetKey: string;
+};
+
+export function withAssetContext<P extends InjectedProps>(
+    WrappedComponent: React.ComponentType<P>,
+    keyPrefix: string,
+): React.ForwardRefExoticComponent<
+    React.PropsWithoutRef<Omit<P, keyof InjectedProps>> &
+        React.RefAttributes<any>
+> {
+    const WithAssetContextComponent = React.forwardRef<
+        any,
+        Omit<P, keyof InjectedProps>
+    >((props, ref) => {
+        const {setAssetStatus} = React.useContext(AssetContext);
+        const uniqueId = React.useId();
+        const assetKey = `${keyPrefix}-${uniqueId}`;
+
+        return (
+            <WrappedComponent
+                // eslint-disable-next-line no-restricted-syntax -- TypeScript can't verify that spreading `Omit<P, K>` + adding `K`-properties reconstitutes P (the "P could be a different subtype" limitation). The runtime behavior is sound: we provide every field P needs.
+                {...(props as P)}
+                setAssetStatus={setAssetStatus}
+                assetKey={assetKey}
+                ref={ref}
+            />
+        );
+    });
+
+    WithAssetContextComponent.displayName = `withAssetContext(${
+        WrappedComponent.displayName || WrappedComponent.name || "Component"
+    })`;
+
+    return WithAssetContextComponent;
+}

--- a/packages/perseus/src/widgets/matcher/__docs__/matcher-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/matcher/__docs__/matcher-initial-state-regression.stories.tsx
@@ -5,8 +5,8 @@ import {
 } from "@khanacademy/perseus-core";
 import * as React from "react";
 
-import {ServerItemRendererWithDebugUI} from "../../../testing/server-item-renderer-with-debug-ui";
 import {themeModes} from "../../../../../../.storybook/modes";
+import {ServerItemRendererWithDebugUI} from "../../../testing/server-item-renderer-with-debug-ui";
 
 import {matcherRendererDecorator} from "./matcher-renderer-decorator";
 

--- a/packages/perseus/src/widgets/matcher/__docs__/matcher-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/matcher/__docs__/matcher-initial-state-regression.stories.tsx
@@ -1,3 +1,11 @@
+import {
+    generateMatcherWidget,
+    generateTestPerseusItem,
+    generateTestPerseusRenderer,
+} from "@khanacademy/perseus-core";
+import * as React from "react";
+
+import {ServerItemRendererWithDebugUI} from "../../../testing/server-item-renderer-with-debug-ui";
 import {themeModes} from "../../../../../../.storybook/modes";
 
 import {matcherRendererDecorator} from "./matcher-renderer-decorator";
@@ -57,27 +65,38 @@ export const WithoutLabels: Story = {
     },
 };
 
-// Verifies TeX rendering in both column labels and item cards. Matcher
-// coordinates AssetContext, marking itself settled once both columns have
-// measured at heights consistent with the shared constraint — so Chromatic
-// snapshots only fire after the measurement cascade settles, no manual
-// delay required.
+// Verifies TeX rendering in both column labels and item cards. Rendered
+// through ServerItemRenderer so AssetContext.Provider is in the tree and
+// the measurement-cascade settling signal reaches the renderer.
 export const WithTeX: Story = {
-    decorators: [matcherRendererDecorator],
-    args: {
-        ...sharedArgs,
-        labels: ["$f(x)$", "$f'(x)$"],
-        left: [
-            "$f(x) = \\dfrac{1}{x}$",
-            "$f(x) = \\dfrac{1}{x^2}$",
-            "$f(x) = \\dfrac{1}{x^3}$",
-        ],
-        right: [
-            "$f'(x) = -\\dfrac{1}{x^2}$",
-            "$f'(x) = -\\dfrac{2}{x^3}$",
-            "$f'(x) = -\\dfrac{3}{x^4}$",
-        ],
-    },
+    render: () => (
+        <ServerItemRendererWithDebugUI
+            item={generateTestPerseusItem({
+                question: generateTestPerseusRenderer({
+                    content: "[[☃ matcher 1]]",
+                    widgets: {
+                        "matcher 1": generateMatcherWidget({
+                            options: {
+                                labels: ["$f(x)$", "$f'(x)$"],
+                                left: [
+                                    "$f(x) = \\dfrac{1}{x}$",
+                                    "$f(x) = \\dfrac{1}{x^2}$",
+                                    "$f(x) = \\dfrac{1}{x^3}$",
+                                ],
+                                right: [
+                                    "$f'(x) = -\\dfrac{1}{x^2}$",
+                                    "$f'(x) = -\\dfrac{2}{x^3}$",
+                                    "$f'(x) = -\\dfrac{3}{x^4}$",
+                                ],
+                                orderMatters: false,
+                                padding: true,
+                            },
+                        }),
+                    },
+                }),
+            })}
+        />
+    ),
 };
 
 // Verifies the orderMatters state: both columns render as draggable cards

--- a/packages/perseus/src/widgets/matcher/__docs__/matcher-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/matcher/__docs__/matcher-initial-state-regression.stories.tsx
@@ -57,10 +57,11 @@ export const WithoutLabels: Story = {
     },
 };
 
-// Verifies TeX rendering in both column labels and item cards. Sortable
-// participates in AssetContext, so the renderer's onRendered now waits for
-// MathJax typeset and the post-typeset measurement cascade to settle before
-// Chromatic snapshots — no manual delay required.
+// Verifies TeX rendering in both column labels and item cards. Matcher
+// coordinates AssetContext, marking itself settled once both columns have
+// measured at heights consistent with the shared constraint — so Chromatic
+// snapshots only fire after the measurement cascade settles, no manual
+// delay required.
 export const WithTeX: Story = {
     decorators: [matcherRendererDecorator],
     args: {

--- a/packages/perseus/src/widgets/matcher/__docs__/matcher-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/matcher/__docs__/matcher-initial-state-regression.stories.tsx
@@ -57,30 +57,27 @@ export const WithoutLabels: Story = {
     },
 };
 
-// TODO: Test flaky, commenting until it's fixed
-// Verifies TeX rendering in both column labels and item cards. The 500ms delay
-// gives MathJax time to finish rendering and onMeasure to settle before
-// Chromatic takes its snapshot.
-// export const WithTeX: Story = {
-//     decorators: [matcherRendererDecorator],
-//     parameters: {
-//         chromatic: {delay: 1000},
-//     },
-//     args: {
-//         ...sharedArgs,
-//         labels: ["$f(x)$", "$f'(x)$"],
-//         left: [
-//             "$f(x) = \\dfrac{1}{x}$",
-//             "$f(x) = \\dfrac{1}{x^2}$",
-//             "$f(x) = \\dfrac{1}{x^3}$",
-//         ],
-//         right: [
-//             "$f'(x) = -\\dfrac{1}{x^2}$",
-//             "$f'(x) = -\\dfrac{2}{x^3}$",
-//             "$f'(x) = -\\dfrac{3}{x^4}$",
-//         ],
-//     },
-// };
+// Verifies TeX rendering in both column labels and item cards. Sortable
+// participates in AssetContext, so the renderer's onRendered now waits for
+// MathJax typeset and the post-typeset measurement cascade to settle before
+// Chromatic snapshots — no manual delay required.
+export const WithTeX: Story = {
+    decorators: [matcherRendererDecorator],
+    args: {
+        ...sharedArgs,
+        labels: ["$f(x)$", "$f'(x)$"],
+        left: [
+            "$f(x) = \\dfrac{1}{x}$",
+            "$f(x) = \\dfrac{1}{x^2}$",
+            "$f(x) = \\dfrac{1}{x^3}$",
+        ],
+        right: [
+            "$f'(x) = -\\dfrac{1}{x^2}$",
+            "$f'(x) = -\\dfrac{2}{x^3}$",
+            "$f'(x) = -\\dfrac{3}{x^4}$",
+        ],
+    },
+};
 
 // Verifies the orderMatters state: both columns render as draggable cards
 // (white background, visible border) rather than the left column appearing

--- a/packages/perseus/src/widgets/matcher/matcher.test.tsx
+++ b/packages/perseus/src/widgets/matcher/matcher.test.tsx
@@ -1,5 +1,6 @@
 import {
     generateTestPerseusItem,
+    generateTestPerseusRenderer,
     splitPerseusItem,
 } from "@khanacademy/perseus-core";
 import {act} from "@testing-library/react";
@@ -31,6 +32,13 @@ describe("matcher widget", () => {
 
         jest.useRealTimers();
 
+        // Replace the real TeX dependency with a synchronous stub. Real TeX
+        // uses MathJax, which doesn't render reliably in jsdom and would
+        // leave Matcher stuck on its loading spinner (since it waits for
+        // `onRender` to fire before rendering its items). The stub fulfills
+        // the same contract — calling `onRender` once the component mounts —
+        // so the rest of the production code thinks TeX is ready and
+        // proceeds normally.
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
             ...testDependencies,
             TeX: ({
@@ -214,6 +222,148 @@ describe("matcher widget", () => {
 
             // Assert
             expect(score).toHaveBeenAnsweredIncorrectly();
+        });
+    });
+
+    describe("AssetContext tracking", () => {
+        it("marks left column stable on mount when left options are empty", () => {
+            // Arrange
+            const question = generateTestPerseusRenderer({
+                content: "[[☃ matcher 1]]",
+                widgets: {
+                    "matcher 1": {
+                        type: "matcher",
+                        options: {
+                            labels: ["", ""],
+                            padding: true,
+                            orderMatters: false,
+                            left: [],
+                            right: ["a", "b"],
+                        },
+                    },
+                },
+            });
+
+            // Act
+            const {renderer} = renderQuestion(question);
+            const matcher: Matcher = renderer.findWidgets("matcher 1")[0];
+
+            // Assert
+            expect(matcher._leftStable).toBe(true);
+            expect(matcher._rightStable).toBe(false);
+        });
+
+        it("marks both columns stable on mount when both are empty", () => {
+            // Arrange
+            const question = generateTestPerseusRenderer({
+                content: "[[☃ matcher 1]]",
+                widgets: {
+                    "matcher 1": {
+                        type: "matcher",
+                        options: {
+                            labels: ["", ""],
+                            padding: true,
+                            orderMatters: false,
+                            left: [],
+                            right: [],
+                        },
+                    },
+                },
+            });
+
+            // Act
+            const {renderer} = renderQuestion(question);
+            const matcher: Matcher = renderer.findWidgets("matcher 1")[0];
+
+            // Assert
+            expect(matcher._leftStable).toBe(true);
+            expect(matcher._rightStable).toBe(true);
+        });
+
+        it("does not mark sides stable on first onMeasure when heights differ from initial constraint", () => {
+            // Arrange — fresh render; matcher state is leftHeight=0, rightHeight=0
+            // before any measurement. currentConstraint = max(0, 0) = 0.
+            const {renderer} = renderQuestion(question1);
+            const matcher: Matcher = renderer.findWidgets("matcher 1")[0];
+            // Force-reset stability flags (the natural cascade may have already
+            // started by the time we get here).
+            matcher._leftStable = false;
+            matcher._rightStable = false;
+
+            // Act — fire onMeasureLeft with a non-zero height against the zero
+            // initial constraint. height (74) !== currentConstraint (0).
+            act(() => {
+                matcher.onMeasureLeft({heights: [74, 74, 74], widths: []});
+            });
+
+            // Assert — first cycle is not stable; the `currentConstraint > 0`
+            // guard prevents premature settlement.
+            expect(matcher._leftStable).toBe(false);
+        });
+
+        it("receives an asset key prefixed with 'matcher-' from the HOC", () => {
+            // Arrange, Act
+            const {renderer} = renderQuestion(question1);
+            const matcher: Matcher = renderer.findWidgets("matcher 1")[0];
+
+            // Assert
+            expect(matcher.props.assetKey).toMatch(/^matcher-/);
+        });
+
+        it("generates a unique asset key per matcher instance", () => {
+            // Arrange, Act — render the same question twice to compare keys
+            // across separate Matcher instances.
+            const {renderer: firstRenderer} = renderQuestion(question1);
+            const firstMatcher: Matcher =
+                firstRenderer.findWidgets("matcher 1")[0];
+            const {renderer: secondRenderer} = renderQuestion(question1);
+            const secondMatcher: Matcher =
+                secondRenderer.findWidgets("matcher 1")[0];
+
+            // Assert
+            expect(firstMatcher.props.assetKey).not.toBe(
+                secondMatcher.props.assetKey,
+            );
+        });
+
+        it("settles the asset on unmount", () => {
+            // Arrange
+            const {renderer, unmount} = renderQuestion(question1);
+            const matcher: Matcher = renderer.findWidgets("matcher 1")[0];
+            const setAssetStatusSpy = jest.spyOn(matcher, "_setAssetStatus");
+
+            // Act
+            unmount();
+
+            // Assert
+            expect(setAssetStatusSpy).toHaveBeenCalledWith(true);
+        });
+
+        it("marks both sides stable and settles the asset when measurements match the constraint", () => {
+            // Arrange — get the matcher and prep its state to simulate
+            // a converged constraint (post-cycle-1).
+            const {renderer} = renderQuestion(question1);
+            const matcher: Matcher = renderer.findWidgets("matcher 1")[0];
+            const setAssetStatusSpy = jest.spyOn(matcher, "_setAssetStatus");
+            matcher._leftStable = false;
+            matcher._rightStable = false;
+            act(() => {
+                matcher.setState({leftHeight: 74, rightHeight: 74});
+            });
+
+            // Act — fire both onMeasures with heights matching the constraint,
+            // mirroring what cycle 2 of the natural cascade looks like.
+            act(() => {
+                matcher.onMeasureLeft({heights: [74, 74, 74], widths: []});
+            });
+            act(() => {
+                matcher.onMeasureRight({heights: [74, 74, 74], widths: []});
+            });
+
+            // Assert — both sides now stable, settle was triggered.
+            expect(matcher._leftStable).toBe(true);
+            expect(matcher._rightStable).toBe(true);
+            expect(setAssetStatusSpy).toHaveBeenCalledWith(true);
         });
     });
 });

--- a/packages/perseus/src/widgets/matcher/matcher.test.tsx
+++ b/packages/perseus/src/widgets/matcher/matcher.test.tsx
@@ -365,5 +365,34 @@ describe("matcher widget", () => {
             expect(matcher._rightStable).toBe(true);
             expect(setAssetStatusSpy).toHaveBeenCalledWith(true);
         });
+
+        it("marks both sides stable and settles when columns have asymmetric natural heights", () => {
+            // Arrange — simulate post-cycle-1 state where the right column is
+            // taller: constraint = max(74, 80) = 80. The shorter left column's
+            // natural height (74) is less than the constraint (80), so the
+            // current === check incorrectly keeps _leftStable false forever.
+            const {renderer} = renderQuestion(question1);
+            const matcher: Matcher = renderer.findWidgets("matcher 1")[0];
+            const setAssetStatusSpy = jest.spyOn(matcher, "_setAssetStatus");
+            matcher._leftStable = false;
+            matcher._rightStable = false;
+            act(() => {
+                matcher.setState({leftHeight: 74, rightHeight: 80});
+            });
+
+            // Act — fire both onMeasures with their natural heights, mirroring
+            // what cycle 2 looks like: left measures 74, right measures 80.
+            act(() => {
+                matcher.onMeasureLeft({heights: [74, 74, 74], widths: []});
+            });
+            act(() => {
+                matcher.onMeasureRight({heights: [80, 80, 80], widths: []});
+            });
+
+            // Assert — both sides stable and settled despite left < constraint.
+            expect(matcher._leftStable).toBe(true);
+            expect(matcher._rightStable).toBe(true);
+            expect(setAssetStatusSpy).toHaveBeenCalledWith(true);
+        });
     });
 });

--- a/packages/perseus/src/widgets/matcher/matcher.tsx
+++ b/packages/perseus/src/widgets/matcher/matcher.tsx
@@ -118,12 +118,10 @@ export class Matcher extends React.Component<Props, State> implements Widget {
         this.props.trackInteraction();
     };
 
-    // A side is considered "stable" once its measurement matches the shared
-    // constraint — meaning further re-measurement of that side won't push
-    // the constraint to change. Settling requires both sides stable (see
-    // _maybeSettle). The check is intentionally not symmetric with the
-    // *opposite* side's state; it just verifies "this measurement won't
-    // drive future change."
+    // A side is considered "stable" once its natural height is at or below the
+    // shared constraint — meaning it won't push the constraint higher and
+    // trigger another re-measurement cycle. Settling requires both sides
+    // stable (see _maybeSettle).
     onMeasureLeft: (arg1: any) => void = (dimensions) => {
         const height = _.max(dimensions.heights);
         const currentConstraint = _.max([
@@ -131,7 +129,7 @@ export class Matcher extends React.Component<Props, State> implements Widget {
             this.state.rightHeight,
         ]);
         this.setState({leftHeight: height});
-        if (height === currentConstraint && currentConstraint > 0) {
+        if (height <= currentConstraint && currentConstraint > 0) {
             this._leftStable = true;
             this._maybeSettle();
         }
@@ -144,7 +142,7 @@ export class Matcher extends React.Component<Props, State> implements Widget {
             this.state.rightHeight,
         ]);
         this.setState({rightHeight: height});
-        if (height === currentConstraint && currentConstraint > 0) {
+        if (height <= currentConstraint && currentConstraint > 0) {
             this._rightStable = true;
             this._maybeSettle();
         }

--- a/packages/perseus/src/widgets/matcher/matcher.tsx
+++ b/packages/perseus/src/widgets/matcher/matcher.tsx
@@ -7,6 +7,7 @@ import _ from "underscore";
 
 import {PerseusI18nContext} from "../../components/i18n-context";
 import Sortable from "../../components/sortable";
+import {withAssetContext} from "../../components/with-asset-context";
 import {withDependencies} from "../../components/with-dependencies";
 import {getDependencies} from "../../dependencies";
 import Renderer from "../../renderer";
@@ -33,6 +34,8 @@ type Props = WidgetProps<
     PerseusMatcherUserInput
 > & {
     dependencies: PerseusDependenciesV2;
+    setAssetStatus: (assetKey: string, loaded: boolean) => void;
+    assetKey: string;
 };
 
 type DefaultProps = {
@@ -72,6 +75,9 @@ export class Matcher extends React.Component<Props, State> implements Widget {
         texRendererLoaded: false,
     };
 
+    _leftStable: boolean = false;
+    _rightStable: boolean = false;
+
     componentDidMount(): void {
         this.props.dependencies.analytics.onAnalyticsEvent({
             type: "perseus:widget:rendered:ti",
@@ -81,7 +87,30 @@ export class Matcher extends React.Component<Props, State> implements Widget {
                 widgetId: this.props.widgetId,
             },
         });
+        // Register as unsettled; we'll flip to settled once both columns have
+        // measured at heights consistent with the shared constraint.
+        this._setAssetStatus(false);
+        // A column with no options never fires onMeasure — mark it stable up
+        // front so a single-sided matcher (or a fully empty one) can still
+        // settle.
+        if (this.props.userInput.left.length === 0) {
+            this._leftStable = true;
+        }
+        if (this.props.userInput.right.length === 0) {
+            this._rightStable = true;
+        }
+        this._maybeSettle();
     }
+
+    componentWillUnmount(): void {
+        // Settle on unmount so a tear-down mid-cascade doesn't block the
+        // renderer's onRendered indefinitely.
+        this._setAssetStatus(true);
+    }
+
+    _setAssetStatus: (loaded: boolean) => void = (loaded) => {
+        this.props.setAssetStatus(this.props.assetKey, loaded);
+    };
 
     changeAndTrack: () => void = () => {
         const nextUserInput = this._getUserInputFromSortable();
@@ -89,14 +118,42 @@ export class Matcher extends React.Component<Props, State> implements Widget {
         this.props.trackInteraction();
     };
 
+    // A side is considered "stable" once its measurement matches the shared
+    // constraint — meaning further re-measurement of that side won't push
+    // the constraint to change. Settling requires both sides stable (see
+    // _maybeSettle). The check is intentionally not symmetric with the
+    // *opposite* side's state; it just verifies "this measurement won't
+    // drive future change."
     onMeasureLeft: (arg1: any) => void = (dimensions) => {
         const height = _.max(dimensions.heights);
+        const currentConstraint = _.max([
+            this.state.leftHeight,
+            this.state.rightHeight,
+        ]);
         this.setState({leftHeight: height});
+        if (height === currentConstraint && currentConstraint > 0) {
+            this._leftStable = true;
+            this._maybeSettle();
+        }
     };
 
     onMeasureRight: (arg1: any) => void = (dimensions) => {
         const height = _.max(dimensions.heights);
+        const currentConstraint = _.max([
+            this.state.leftHeight,
+            this.state.rightHeight,
+        ]);
         this.setState({rightHeight: height});
+        if (height === currentConstraint && currentConstraint > 0) {
+            this._rightStable = true;
+            this._maybeSettle();
+        }
+    };
+
+    _maybeSettle: () => void = () => {
+        if (this._leftStable && this._rightStable) {
+            this._setAssetStatus(true);
+        }
     };
 
     _getUserInputFromSortable: () => PerseusMatcherUserInput = () => {
@@ -274,7 +331,7 @@ function getUserInputFromSerializedState(
     };
 }
 
-const WrappedMatcher = withDependencies(Matcher);
+const WrappedMatcher = withAssetContext(withDependencies(Matcher), "matcher");
 
 export default {
     name: "matcher",

--- a/packages/perseus/src/widgets/matcher/matcher.tsx
+++ b/packages/perseus/src/widgets/matcher/matcher.tsx
@@ -118,16 +118,19 @@ export class Matcher extends React.Component<Props, State> implements Widget {
         this.props.trackInteraction();
     };
 
+    // The shared height constraint applied to both columns: the taller
+    // column's natural height. Used by both measure handlers and render.
+    _getConstraint: () => number = () => {
+        return Math.max(this.state.leftHeight, this.state.rightHeight);
+    };
+
     // A side is considered "stable" once its natural height is at or below the
     // shared constraint — meaning it won't push the constraint higher and
     // trigger another re-measurement cycle. Settling requires both sides
     // stable (see _maybeSettle).
     onMeasureLeft: (arg1: any) => void = (dimensions) => {
         const height = _.max(dimensions.heights);
-        const currentConstraint = _.max([
-            this.state.leftHeight,
-            this.state.rightHeight,
-        ]);
+        const currentConstraint = this._getConstraint();
         this.setState({leftHeight: height});
         if (height <= currentConstraint && currentConstraint > 0) {
             this._leftStable = true;
@@ -137,10 +140,7 @@ export class Matcher extends React.Component<Props, State> implements Widget {
 
     onMeasureRight: (arg1: any) => void = (dimensions) => {
         const height = _.max(dimensions.heights);
-        const currentConstraint = _.max([
-            this.state.leftHeight,
-            this.state.rightHeight,
-        ]);
+        const currentConstraint = this._getConstraint();
         this.setState({rightHeight: height});
         if (height <= currentConstraint && currentConstraint > 0) {
             this._rightStable = true;
@@ -233,7 +233,7 @@ export class Matcher extends React.Component<Props, State> implements Widget {
 
         const showLabels = _.any(this.props.labels);
         const constraints = {
-            height: _.max([this.state.leftHeight, this.state.rightHeight]),
+            height: this._getConstraint(),
         } as const;
 
         const cellMarginPx = this.props.apiOptions.isMobile ? 8 : 5;

--- a/packages/perseus/src/widgets/sorter/__docs__/sorter-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/sorter/__docs__/sorter-initial-state-regression.stories.tsx
@@ -6,8 +6,8 @@ import {
 } from "@khanacademy/perseus-core";
 import * as React from "react";
 
-import {ServerItemRendererWithDebugUI} from "../../../testing/server-item-renderer-with-debug-ui";
 import {themeModes} from "../../../../../../.storybook/modes";
+import {ServerItemRendererWithDebugUI} from "../../../testing/server-item-renderer-with-debug-ui";
 import {mobileDecorator} from "../../__testutils__/story-decorators";
 
 import {sorterRendererDecorator} from "./sorter-renderer-decorator";

--- a/packages/perseus/src/widgets/sorter/__docs__/sorter-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/sorter/__docs__/sorter-initial-state-regression.stories.tsx
@@ -1,3 +1,12 @@
+import {
+    generateSorterOptions,
+    generateSorterWidget,
+    generateTestPerseusItem,
+    generateTestPerseusRenderer,
+} from "@khanacademy/perseus-core";
+import * as React from "react";
+
+import {ServerItemRendererWithDebugUI} from "../../../testing/server-item-renderer-with-debug-ui";
 import {themeModes} from "../../../../../../.storybook/modes";
 import {mobileDecorator} from "../../__testutils__/story-decorators";
 
@@ -9,7 +18,6 @@ import type {Meta, StoryObj} from "@storybook/react-vite";
 const meta: Meta<PerseusSorterWidgetOptions> = {
     title: "Widgets/Sorter/Visual Regression Tests/Initial State",
     tags: ["!autodocs", "!manifest"],
-    decorators: [sorterRendererDecorator],
     parameters: {
         docs: {
             description: {
@@ -33,11 +41,13 @@ const horizontalItems: Partial<PerseusSorterWidgetOptions> = {
 
 // Verifies the default horizontal layout: cards arranged in a row with padding
 export const DefaultHorizontal: Story = {
+    decorators: [sorterRendererDecorator],
     args: horizontalItems,
 };
 
 // Verifies the vertical layout: cards stacked in a column with padding
 export const DefaultVertical: Story = {
+    decorators: [sorterRendererDecorator],
     args: {
         correct: [
             "Longest option in the list",
@@ -52,7 +62,7 @@ export const DefaultVertical: Story = {
 
 // Verifies the horizontal layout on mobile: narrower margin between cards (8px vs 5px)
 export const MobileHorizontal: Story = {
-    decorators: [mobileDecorator],
+    decorators: [mobileDecorator, sorterRendererDecorator],
     parameters: {
         apiOptions: {isMobile: true},
     },
@@ -61,6 +71,7 @@ export const MobileHorizontal: Story = {
 
 // Verifies horizontal layout with padding disabled: cards rendered without inner spacing
 export const NoPadding: Story = {
+    decorators: [sorterRendererDecorator],
     args: {
         correct: ["Item one", "Item two", "Item three"],
         padding: false,
@@ -68,18 +79,30 @@ export const NoPadding: Story = {
     },
 };
 
-// Verifies TeX rendering in card content. Sorter coordinates AssetContext,
-// marking itself settled once Sortable has produced its first measurement
-// after the post-typeset measurement cascade — so Chromatic snapshots only
-// fire after measurement settles, no manual delay required.
+// Verifies TeX rendering in card content. Rendered through ServerItemRenderer
+// so AssetContext.Provider is in the tree and the measurement-cascade settling
+// signal reaches the renderer.
 export const WithTeX: Story = {
-    args: {
-        correct: [
-            "$f(x) = \\dfrac{1}{x}$",
-            "$f(x) = \\dfrac{1}{x^2}$",
-            "$f(x) = \\dfrac{1}{x^3}$",
-        ],
-        padding: true,
-        layout: "horizontal",
-    },
+    render: () => (
+        <ServerItemRendererWithDebugUI
+            item={generateTestPerseusItem({
+                question: generateTestPerseusRenderer({
+                    content: "Arrange these items in order. [[☃ sorter 1]]",
+                    widgets: {
+                        "sorter 1": generateSorterWidget({
+                            options: generateSorterOptions({
+                                correct: [
+                                    "$f(x) = \\dfrac{1}{x}$",
+                                    "$f(x) = \\dfrac{1}{x^2}$",
+                                    "$f(x) = \\dfrac{1}{x^3}$",
+                                ],
+                                padding: true,
+                                layout: "horizontal",
+                            }),
+                        }),
+                    },
+                }),
+            })}
+        />
+    ),
 };

--- a/packages/perseus/src/widgets/sorter/__docs__/sorter-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/sorter/__docs__/sorter-initial-state-regression.stories.tsx
@@ -67,3 +67,19 @@ export const NoPadding: Story = {
         layout: "horizontal",
     },
 };
+
+// Verifies TeX rendering in card content. Sortable participates in
+// AssetContext, so the renderer's onRendered waits for MathJax typeset and
+// the post-typeset measurement cascade to settle before Chromatic snapshots
+// — no manual delay required.
+export const WithTeX: Story = {
+    args: {
+        correct: [
+            "$f(x) = \\dfrac{1}{x}$",
+            "$f(x) = \\dfrac{1}{x^2}$",
+            "$f(x) = \\dfrac{1}{x^3}$",
+        ],
+        padding: true,
+        layout: "horizontal",
+    },
+};

--- a/packages/perseus/src/widgets/sorter/__docs__/sorter-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/sorter/__docs__/sorter-initial-state-regression.stories.tsx
@@ -68,10 +68,10 @@ export const NoPadding: Story = {
     },
 };
 
-// Verifies TeX rendering in card content. Sortable participates in
-// AssetContext, so the renderer's onRendered waits for MathJax typeset and
-// the post-typeset measurement cascade to settle before Chromatic snapshots
-// — no manual delay required.
+// Verifies TeX rendering in card content. Sorter coordinates AssetContext,
+// marking itself settled once Sortable has produced its first measurement
+// after the post-typeset measurement cascade — so Chromatic snapshots only
+// fire after measurement settles, no manual delay required.
 export const WithTeX: Story = {
     args: {
         correct: [

--- a/packages/perseus/src/widgets/sorter/sorter.test.tsx
+++ b/packages/perseus/src/widgets/sorter/sorter.test.tsx
@@ -1,0 +1,109 @@
+import {generateTestPerseusRenderer} from "@khanacademy/perseus-core";
+import {act} from "@testing-library/react";
+import * as React from "react";
+
+import * as Dependencies from "../../dependencies";
+import {testDependencies} from "../../testing/test-dependencies";
+import {wait} from "../../testing/wait";
+import {renderQuestion} from "../__testutils__/renderQuestion";
+
+import type {Sorter} from "./sorter";
+
+describe("Sorter widget", () => {
+    beforeEach(() => {
+        jest.spyOn(console, "warn").mockImplementation(() => {});
+        jest.spyOn(console, "error").mockImplementation(() => {});
+        jest.useRealTimers();
+
+        // Replace the real TeX dependency with a synchronous stub. Real TeX
+        // uses MathJax, which doesn't render reliably in jsdom and would
+        // leave Sorter stuck on its loading spinner (since it waits for
+        // `onRender` to fire before rendering its items). The stub fulfills
+        // the same contract — calling `onRender` once the component mounts —
+        // so the rest of the production code thinks TeX is ready and
+        // proceeds normally.
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
+            ...testDependencies,
+            TeX: ({
+                children,
+                onRender: onLoad,
+            }: {
+                children: React.ReactNode;
+                onRender?: () => unknown;
+            }) => {
+                React.useLayoutEffect(() => {
+                    onLoad?.();
+                }, [onLoad]);
+                return <span className="tex-mock">{children}</span>;
+            },
+        });
+    });
+
+    describe("AssetContext tracking", () => {
+        const question = generateTestPerseusRenderer({
+            content: "[[☃ sorter 1]]",
+            widgets: {
+                "sorter 1": {
+                    type: "sorter",
+                    options: {
+                        correct: ["a", "b", "c"],
+                        padding: true,
+                        layout: "horizontal",
+                    },
+                },
+            },
+        });
+
+        it("receives an asset key prefixed with 'sorter-' from the HOC", () => {
+            // Arrange, Act
+            const {renderer} = renderQuestion(question);
+            const sorter: Sorter = renderer.findWidgets("sorter 1")[0];
+
+            // Assert
+            expect(sorter.props.assetKey).toMatch(/^sorter-/);
+        });
+
+        it("generates a unique asset key per sorter instance", () => {
+            // Arrange, Act — render the same question twice to compare keys
+            // across separate Sorter instances.
+            const {renderer: firstRenderer} = renderQuestion(question);
+            const firstSorter: Sorter =
+                firstRenderer.findWidgets("sorter 1")[0];
+            const {renderer: secondRenderer} = renderQuestion(question);
+            const secondSorter: Sorter =
+                secondRenderer.findWidgets("sorter 1")[0];
+
+            // Assert
+            expect(firstSorter.props.assetKey).not.toBe(
+                secondSorter.props.assetKey,
+            );
+        });
+
+        it("settles the asset when onMeasure fires", async () => {
+            // Arrange
+            const {renderer} = renderQuestion(question);
+            await wait();
+            const sorter: Sorter = renderer.findWidgets("sorter 1")[0];
+            const setAssetStatusSpy = jest.spyOn(sorter, "_setAssetStatus");
+
+            // Act
+            act(() => sorter.onMeasure());
+
+            // Assert
+            expect(setAssetStatusSpy).toHaveBeenCalledWith(true);
+        });
+
+        it("settles the asset on unmount", () => {
+            // Arrange
+            const {renderer, unmount} = renderQuestion(question);
+            const sorter: Sorter = renderer.findWidgets("sorter 1")[0];
+            const setAssetStatusSpy = jest.spyOn(sorter, "_setAssetStatus");
+
+            // Act
+            unmount();
+
+            // Assert
+            expect(setAssetStatusSpy).toHaveBeenCalledWith(true);
+        });
+    });
+});

--- a/packages/perseus/src/widgets/sorter/sorter.tsx
+++ b/packages/perseus/src/widgets/sorter/sorter.tsx
@@ -3,6 +3,7 @@ import {linterContextDefault} from "@khanacademy/perseus-linter";
 import * as React from "react";
 
 import Sortable from "../../components/sortable";
+import {withAssetContext} from "../../components/with-asset-context";
 import {withDependencies} from "../../components/with-dependencies";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/sorter/sorter-ai-utils";
 
@@ -22,6 +23,8 @@ import type {
 
 type Props = WidgetProps<PerseusSorterWidgetOptions, PerseusSorterUserInput> & {
     dependencies: PerseusDependenciesV2;
+    setAssetStatus: (assetKey: string, loaded: boolean) => void;
+    assetKey: string;
 };
 
 type DefaultProps = {
@@ -32,7 +35,7 @@ type DefaultProps = {
     linterContext: Props["linterContext"];
 };
 
-class Sorter extends React.Component<Props> implements Widget {
+export class Sorter extends React.Component<Props> implements Widget {
     _isMounted: boolean = false;
 
     static defaultProps: DefaultProps = {
@@ -53,11 +56,29 @@ class Sorter extends React.Component<Props> implements Widget {
                 widgetId: this.props.widgetId,
             },
         });
+        // Register as unsettled; we'll flip to settled on first onMeasure.
+        // An empty options list won't fire onMeasure, so settle immediately
+        // in that case to avoid hanging the renderer's onRendered.
+        this._setAssetStatus(this.props.userInput.options.length === 0);
     }
 
     componentWillUnmount() {
         this._isMounted = false;
+        // Settle on unmount so a tear-down mid-cascade doesn't block the
+        // renderer's onRendered indefinitely.
+        this._setAssetStatus(true);
     }
+
+    onMeasure: () => void = () => {
+        // Sorter has no constraint distribution, so Sortable's first
+        // measurement is authoritative. Settle on each call (idempotent);
+        // the renderer's _fullyRendered is a one-way latch.
+        this._setAssetStatus(true);
+    };
+
+    _setAssetStatus: (loaded: boolean) => void = (loaded) => {
+        this.props.setAssetStatus(this.props.assetKey, loaded);
+    };
 
     handleChange: (arg1: React.ChangeEvent<HTMLInputElement>) => void = (e) => {
         if (!this._isMounted) {
@@ -102,7 +123,12 @@ class Sorter extends React.Component<Props> implements Widget {
      * [LEMS-3185] do not trust serializedState
      */
     getSerializedState(): any {
-        const {userInput, ...rest} = this.props;
+        const {
+            userInput,
+            setAssetStatus: _,
+            assetKey: __,
+            ...rest
+        } = this.props;
         return {
             ...rest,
             changed: userInput.changed,
@@ -122,6 +148,7 @@ class Sorter extends React.Component<Props> implements Widget {
                     margin={marginPx}
                     padding={this.props.padding}
                     onChange={this.handleChange}
+                    onMeasure={this.onMeasure}
                     linterContext={this.props.linterContext}
                     // eslint-disable-next-line react/no-string-refs
                     ref="sortable"
@@ -156,7 +183,7 @@ function getUserInputFromSerializedState(
     };
 }
 
-const WrappedSorter = withDependencies(Sorter);
+const WrappedSorter = withAssetContext(withDependencies(Sorter), "sorter");
 
 export default {
     name: "sorter",

--- a/packages/perseus/src/widgets/sorter/sorter.tsx
+++ b/packages/perseus/src/widgets/sorter/sorter.tsx
@@ -23,6 +23,8 @@ import type {
 
 type Props = WidgetProps<PerseusSorterWidgetOptions, PerseusSorterUserInput> & {
     dependencies: PerseusDependenciesV2;
+    // `setAssetStatus` is assumed to be idempotent; Sorter may call it with
+    // the same value on every measurement.
     setAssetStatus: (assetKey: string, loaded: boolean) => void;
     assetKey: string;
 };
@@ -70,9 +72,9 @@ export class Sorter extends React.Component<Props> implements Widget {
     }
 
     onMeasure: () => void = () => {
-        // Sorter has no constraint distribution, so Sortable's first
-        // measurement is authoritative. Settle on each call (idempotent);
-        // the renderer's _fullyRendered is a one-way latch.
+        // Unlike Matcher, Sorter doesn't resize its items to a shared height,
+        // so the first measurement means the cards have finished rendering.
+        // Settle on every measurement (see Props re: idempotency).
         this._setAssetStatus(true);
     };
 


### PR DESCRIPTION
## Summary:
- Fixes flaky Chromatic snapshots for Matcher and Sorter widgets containing TeX content. Previously, `ServerItemRenderer.onRendered` fired as soon as TeX finished typesetting, but before the cross-column measurement cascade settled — so snapshots could capture intermediate layouts.
- Moves readiness coordination from the Sortable component (the approach attempted in #3612) up to the widget level where the cascade structure is actually known. Matcher waits for both columns to measure at heights consistent with the shared constraint; Sorter settles after its first measurement (no constraint distribution loop). The Sortable component itself remains a dumb measurement primitive — it doesn't know how many constraint-propagation rounds its parent needs and shouldn't be making that decision.
- Introduces `withAssetContext`, a small HOC that mirrors `withDependencies` and injects `setAssetStatus` plus a `useId()`-generated `assetKey` as props. This lets class-component widgets consume AssetContext without changing their existing `contextType`.
- Supersedes #3612 — see that PR's discussion thread for the analysis that led to this architectural reframe (and the reasons the Sortable-level timer approach was abandoned).

Issue: LEMS-4117

## Test plan:
- [ ] Manually verify in Storybook that `Widgets/Matcher/Visual Regression Tests/Initial State/With TeX` renders stably with no layout flicker.
- [ ] Manually verify `Widgets/Sorter/Visual Regression Tests/Initial State/With TeX` renders stably.
- [ ] Confirm existing Matcher behavior is unaffected (drag/drop reordering, scoring, focus handling).
- [ ] Confirm existing Sorter behavior is unaffected.
- [ ] Run Chromatic and confirm the new `WithTeX` stories produce stable baselines across multiple runs.
- [ ] Confirm CI passes: `pnpm test`, `pnpm tsc`, `pnpm lint`.