### PR TITLE
[Image] Adding new legacy gif url linter warning for our perseus editor.

### DIFF
--- a/.changeset/wicked-parrots-camp.md
+++ b/.changeset/wicked-parrots-camp.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-linter": patch
+---
+
+Adding a new linter warning for legacy gif urls

--- a/packages/perseus-linter/src/rules/all-rules.ts
+++ b/packages/perseus-linter/src/rules/all-rules.ts
@@ -18,6 +18,7 @@ import ImageWidgetEmptySize from "./image-widget-empty-size";
 import InaccessibleWidget from "./inaccessible-widget";
 import InteractiveGraphWidgetError from "./interactive-graph-widget-error";
 import LabelImageWidgetError from "./label-image-widget-error";
+import LegacyGifUrl from "./legacy-gif-url";
 import LinkClickHere from "./link-click-here";
 import LongParagraph from "./long-paragraph";
 import MatcherWidgetError from "./matcher-widget-error";
@@ -75,6 +76,7 @@ export default [
     ImageSpacesAroundUrls,
     ImageWidgetAltText,
     ImageWidgetEmptySize,
+    LegacyGifUrl,
     InaccessibleWidget,
     RadioWidgetError,
     ExpressionWidgetError,

--- a/packages/perseus-linter/src/rules/legacy-gif-url.test.ts
+++ b/packages/perseus-linter/src/rules/legacy-gif-url.test.ts
@@ -1,0 +1,66 @@
+import {expectWarning, expectPass} from "../__tests__/test-utils";
+
+import legacyGifUrlRule from "./legacy-gif-url";
+
+describe("legacy-gif-url", () => {
+    // Warn for a legacy S3 gif URL
+    expectWarning(legacyGifUrlRule, "[[☃ image 1]]", {
+        widgets: {
+            "image 1": {
+                options: {
+                    backgroundImage: {
+                        url: "https://ka-perseus-images.s3.amazonaws.com/abc123.gif",
+                    },
+                },
+            },
+        },
+    });
+
+    // Warn regardless of the gif extension's casing
+    expectWarning(legacyGifUrlRule, "[[☃ image 1]]", {
+        widgets: {
+            "image 1": {
+                options: {
+                    backgroundImage: {
+                        url: "https://ka-perseus-images.s3.amazonaws.com/abc123.GIF",
+                    },
+                },
+            },
+        },
+    });
+
+    // Pass for a legacy S3 image that isn't a gif
+    expectPass(legacyGifUrlRule, "[[☃ image 1]]", {
+        widgets: {
+            "image 1": {
+                options: {
+                    backgroundImage: {
+                        url: "https://ka-perseus-images.s3.amazonaws.com/abc123.png",
+                    },
+                },
+            },
+        },
+    });
+
+    // Pass for a gif hosted on the CDN
+    expectPass(legacyGifUrlRule, "[[☃ image 1]]", {
+        widgets: {
+            "image 1": {
+                options: {
+                    backgroundImage: {
+                        url: "https://cdn.kastatic.org/ka-perseus-images/abc123.gif",
+                    },
+                },
+            },
+        },
+    });
+
+    // Pass for an image widget with no background image URL
+    expectPass(legacyGifUrlRule, "[[☃ image 1]]", {
+        widgets: {
+            "image 1": {
+                options: {},
+            },
+        },
+    });
+});

--- a/packages/perseus-linter/src/rules/legacy-gif-url.ts
+++ b/packages/perseus-linter/src/rules/legacy-gif-url.ts
@@ -1,0 +1,45 @@
+import Rule from "../rule";
+
+import {getHostname} from "./lint-utils";
+
+const LEGACY_HOSTNAME = "ka-perseus-images.s3.amazonaws.com";
+
+export default Rule.makeRule({
+    name: "legacy-gif-url",
+    severity: Rule.Severity.GUIDELINE,
+    selector: "widget",
+    lint: function (state, content, nodes, match, context) {
+        // This rule only looks at image widgets.
+        if (state.currentNode().widgetType !== "image") {
+            return;
+        }
+
+        const nodeId = state.currentNode().id;
+        if (!nodeId) {
+            return;
+        }
+
+        // If it can't find a definition for the widget it does nothing.
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        const widget = context && context.widgets && context.widgets[nodeId];
+        if (!widget) {
+            return;
+        }
+
+        const url = widget.options?.backgroundImage?.url;
+        if (!url) {
+            return;
+        }
+
+        // Legacy gifs hosted on the old S3 bucket don't render in the editor
+        // iframe, so we encourage content creators to use the CDN URL instead.
+        if (
+            getHostname(url) === LEGACY_HOSTNAME &&
+            url.toLowerCase().endsWith(".gif")
+        ) {
+            return `Legacy gif URL:
+gifs hosted at ${LEGACY_HOSTNAME} won't appear in the editor preview.
+Use a https://cdn.kastatic.org/ka-perseus-images/ URL instead.`;
+        }
+    },
+});

--- a/packages/perseus-linter/src/rules/legacy-gif-url.ts
+++ b/packages/perseus-linter/src/rules/legacy-gif-url.ts
@@ -32,14 +32,17 @@ export default Rule.makeRule({
         }
 
         // Legacy gifs hosted on the old S3 bucket don't render in the editor
-        // iframe, so we encourage content creators to use the CDN URL instead.
+        // iframe, so we encourage content creators to use the CDN URL instead
+        // or confirm that the image displays correctly in the published content.
         if (
             getHostname(url) === LEGACY_HOSTNAME &&
             url.toLowerCase().endsWith(".gif")
         ) {
             return `Legacy gif URL:
-gifs hosted at ${LEGACY_HOSTNAME} won't appear in the editor preview.
-Use a https://cdn.kastatic.org/ka-perseus-images/ URL instead.`;
+gifs hosted at ${LEGACY_HOSTNAME} might not appear in the editor preview,
+but can still be viewed in the published content. Please use a
+cdn.kastatic.org/ka-perseus-images/ URL instead or confirm the
+image displays correctly in the published content.`;
         }
     },
 });


### PR DESCRIPTION
## Summary:
Adds a new `legacy-gif-url` linter rule (GUIDELINE severity) for the Perseus content editor. It flags image widgets whose background image is a `.gif` hosted on the legacy S3 bucket (`ka-perseus-images.s3.amazonaws.com`). These legacy gifs don't render in the editor preview iframe, so the warning nudges content creators to switch to a `cdn.kastatic.org/ka-perseus-images/` URL or to confirm the image displays correctly in published content.

<img width="410" height="752" alt="image" src="https://github.com/user-attachments/assets/e97c6253-ad6f-4d21-a453-d5dddc26fdd5" />

Issue: LEMS-4210

## Test plan:
- `pnpm --filter perseus-linter test legacy-gif-url`
- In the Storybook Editor Page Demo (`/?path=/story/editors-editorpage--demo`), add an Image widget with a background image URL `https://ka-perseus-images.s3.amazonaws.com/df62bbaa0f37073268930ee33995941152ea2545.gif` and confirm the warning appears.
- Verify no warning shows for a non-gif legacy URL `https://cdn.kastatic.org/ka-perseus-images/df62bbaa0f37073268930ee33995941152ea2545.gif`, or a non-image widget.
