### PR TITLE
[Interactive Graph] Refactor linear, point, polygon, and ray graphs to use usePointAriaLabel instead of buildPointAriaLabel

### DIFF
--- a/.changeset/tall-hotels-crash.md
+++ b/.changeset/tall-hotels-crash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Interactive Graph] Refactor linear, point, polygon, and ray graphs to use usePointAriaLabel instead of buildPointAriaLabel

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/build-point-aria-label.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/build-point-aria-label.ts
@@ -26,9 +26,11 @@ export function resolvePointLabel(
  * is set so callers can fall back to the default label (e.g. "Point 1",
  * "Point 2", ...) built by `useControlPoint`.
  *
- * TODO(LEMS-3995): Prefer the `usePointAriaLabel` hook below in new code.
- * Existing callers in `polygon.tsx`, `point.tsx`, `ray.tsx`, and `linear.tsx`
- * should migrate to the hook in a follow-up PR.
+ * Prefer `usePointAriaLabel` in React components — it binds `strings` and
+ * `locale` from `usePerseusI18n()` so call sites read `buildLabel(i, point)`.
+ * Use `buildPointAriaLabel` directly only from non-React functions (e.g.
+ * graph-description helpers) that already receive `strings` / `locale` as
+ * parameters and therefore can't use a hook.
  */
 export function buildPointAriaLabel(
     pointLabels: ReadonlyArray<string> | undefined,

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/linear.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import {usePerseusI18n} from "../../../components/i18n-context";
 import {actions} from "../reducer/interactive-graph-action";
 
-import {buildPointAriaLabel} from "./components/build-point-aria-label";
+import {usePointAriaLabel} from "./components/build-point-aria-label";
 import {MovableLine} from "./components/movable-line";
 import SRDescInSVG from "./components/sr-description-within-svg";
 import {srFormatNumber} from "./screenreader-text";
@@ -36,6 +36,7 @@ const LinearGraph = (props: LinearGraphProps, key: number) => {
     const {coords: line, pointLabels} = props.graphState;
 
     const {strings, locale} = usePerseusI18n();
+    const buildLabel = usePointAriaLabel(pointLabels);
     const id = React.useId();
     const pointsDescriptionId = id + "-points";
     const interceptDescriptionId = id + "-intercept";
@@ -63,20 +64,8 @@ const LinearGraph = (props: LinearGraphProps, key: number) => {
                 key={0}
                 ariaLabels={{
                     grabHandleAriaLabel: srLinearGrabHandle,
-                    point1AriaLabel: buildPointAriaLabel(
-                        pointLabels,
-                        0,
-                        line[0],
-                        strings,
-                        locale,
-                    ),
-                    point2AriaLabel: buildPointAriaLabel(
-                        pointLabels,
-                        1,
-                        line[1],
-                        strings,
-                        locale,
-                    ),
+                    point1AriaLabel: buildLabel(0, line[0]),
+                    point2AriaLabel: buildLabel(1, line[1]),
                 }}
                 ariaDescribedBy={`${interceptDescriptionId} ${slopeDescriptionId}`}
                 points={line}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/point.tsx
@@ -1,12 +1,14 @@
 import {useTimeout} from "@khanacademy/wonder-blocks-timing";
 import * as React from "react";
 
-import {usePerseusI18n} from "../../../components/i18n-context";
 import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 import {getCSSZoomFactor} from "../utils";
 
-import {buildPointAriaLabel} from "./components/build-point-aria-label";
+import {
+    buildPointAriaLabel,
+    usePointAriaLabel,
+} from "./components/build-point-aria-label";
 import {MovablePoint} from "./components/movable-point";
 import {srFormatNumber} from "./screenreader-text";
 import {useTransformVectorsToPixels, pixelsToVectors} from "./use-transform";
@@ -82,7 +84,7 @@ function PointGraph(props: Props) {
 function LimitedPointGraph(statefulProps: StatefulProps) {
     const {dispatch} = statefulProps;
     const {pointLabels} = statefulProps.graphState;
-    const {strings, locale} = usePerseusI18n();
+    const buildLabel = usePointAriaLabel(pointLabels);
 
     return (
         <>
@@ -97,13 +99,7 @@ function LimitedPointGraph(statefulProps: StatefulProps) {
                     // TODO(LEMS-4189): Remove ariaLive once aria-live is
                     // dropped from useControlPoint.
                     ariaLive="off"
-                    ariaLabel={buildPointAriaLabel(
-                        pointLabels,
-                        i,
-                        point,
-                        strings,
-                        locale,
-                    )}
+                    ariaLabel={buildLabel(i, point)}
                     onMove={(destination) =>
                         dispatch(actions.pointGraph.movePoint(i, destination))
                     }
@@ -116,7 +112,7 @@ function LimitedPointGraph(statefulProps: StatefulProps) {
 function UnlimitedPointGraph(statefulProps: StatefulProps) {
     const {dispatch, graphConfig, pointsRef, top, left} = statefulProps;
     const {coords, pointLabels} = statefulProps.graphState;
-    const {strings, locale} = usePerseusI18n();
+    const buildLabel = usePointAriaLabel(pointLabels);
 
     // When users drag a point on iOS Safari, the browser fires a click event after the mouseup
     // at the original click location, which would add an unwanted new point. We track drag
@@ -178,13 +174,7 @@ function UnlimitedPointGraph(statefulProps: StatefulProps) {
                     // TODO(LEMS-4189): Remove ariaLive once aria-live is
                     // dropped from useControlPoint.
                     ariaLive="off"
-                    ariaLabel={buildPointAriaLabel(
-                        pointLabels,
-                        i,
-                        point,
-                        strings,
-                        locale,
-                    )}
+                    ariaLabel={buildLabel(i, point)}
                     onDragStart={() => {
                         dragEndCallbackTimer.clear();
                         setIsCurrentlyDragging(true);

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -20,7 +20,10 @@ import useGraphConfig from "../reducer/use-graph-config";
 import {bound, getCSSZoomFactor, TARGET_SIZE} from "../utils";
 
 import {PolygonAngle} from "./components/angle-indicators";
-import {buildPointAriaLabel} from "./components/build-point-aria-label";
+import {
+    buildPointAriaLabel,
+    usePointAriaLabel,
+} from "./components/build-point-aria-label";
 import {MovablePoint} from "./components/movable-point";
 import SRDescInSVG from "./components/sr-description-within-svg";
 import {TextLabel} from "./components/text-label";
@@ -190,8 +193,7 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
     } = statefulProps.graphState;
     const {disableKeyboardInteraction, interactiveColor} = graphConfig;
     const {strings, locale} = usePerseusI18n();
-    const buildLabel = (index: number, point: vec.Vector2) =>
-        buildPointAriaLabel(pointLabels, index, point, strings, locale);
+    const buildLabel = usePointAriaLabel(pointLabels);
     const id = React.useId();
     const pointsOffArray = Array(points.length).fill("off");
     // When moving an element, set its aria-live to "polite" and the others
@@ -427,8 +429,7 @@ const UnlimitedPolygonGraph = (statefulProps: StatefulProps) => {
     const {dispatch, graphConfig, left, top, pointsRef, points} = statefulProps;
     const {coords, closedPolygon, pointLabels} = statefulProps.graphState;
     const {strings, locale} = usePerseusI18n();
-    const buildLabel = (index: number, point: vec.Vector2) =>
-        buildPointAriaLabel(pointLabels, index, point, strings, locale);
+    const buildLabel = usePointAriaLabel(pointLabels);
     const {interactiveColor} = useGraphConfig();
 
     // When users drag a point on iOS Safari, the browser fires a click event after the mouseup

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/ray.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import {usePerseusI18n} from "../../../components/i18n-context";
 import {actions} from "../reducer/interactive-graph-action";
 
-import {buildPointAriaLabel} from "./components/build-point-aria-label";
+import {usePointAriaLabel} from "./components/build-point-aria-label";
 import {MovableLine} from "./components/movable-line";
 import SRDescInSVG from "./components/sr-description-within-svg";
 import {srFormatNumber} from "./screenreader-text";
@@ -40,6 +40,7 @@ const RayGraph = (props: Props) => {
         dispatch(actions.ray.movePoint(pointIndex, newPoint));
 
     const {strings, locale} = usePerseusI18n();
+    const buildLabel = usePointAriaLabel(pointLabels);
     const id = React.useId();
     const pointsDescriptionId = id + "-points";
 
@@ -52,12 +53,8 @@ const RayGraph = (props: Props) => {
         srRayGrabHandle,
     } = describeRayGraph(props.graphState, {strings, locale});
 
-    const point1AriaLabel =
-        buildPointAriaLabel(pointLabels, 0, line[0], strings, locale) ??
-        srRayEndpoint;
-    const point2AriaLabel =
-        buildPointAriaLabel(pointLabels, 1, line[1], strings, locale) ??
-        srRayTerminalPoint;
+    const point1AriaLabel = buildLabel(0, line[0]) ?? srRayEndpoint;
+    const point2AriaLabel = buildLabel(1, line[1]) ?? srRayTerminalPoint;
 
     // Ray graphs only have one line
     return (


### PR DESCRIPTION
## Summary:
- Migrates the React-component `buildPointAriaLabel` call sites in `polygon.tsx`, `point.tsx`, `ray.tsx`, and `linear.tsx` to the `usePointAriaLabel` hook that PR 5 introduced.
- Each migrated component drops a 2-line closure (`const buildLabel = (i, pt) => buildPointAriaLabel(pointLabels, i, pt, strings, locale)`) or its inlined 5-arg call for a 1-line `const buildLabel = usePointAriaLabel(pointLabels)`. The hook binds `strings` and `locale` from `usePerseusI18n()` internally, so call sites read `buildLabel(i, point)` instead of repeating the contextual args.
- `point.tsx` also drops its now-unused `usePerseusI18n` import — only its non-React description function (`getPointGraphDescription`) still needs `strings` / `locale`, and that function already receives them as parameters.
- Pure refactor. No behavior change, no schema change, no editor change, no test changes — the same screen-reader announcements ship before and after.
- Updates the JSDoc on `buildPointAriaLabel` from a "TODO: migrate to the hook" note to a usage guideline (`usePointAriaLabel` in React components, `buildPointAriaLabel` directly only from non-React functions that already receive `strings` / `locale` as parameters).

Issue: LEMS-3995

## Test plan:
- [ ] Reviewer manual: open any of the `PointWithCustomLabel`, `PolygonWithCustomLabels`, `RayWithCustomLabels`, or `LineWithCustomLabels` stories (added in PRs 2 / 3 / 4) and confirm the screen-reader announcements are unchanged before and after this PR — e.g. `PointWithCustomLabel` still announces *"Point T at 0 comma 0"*.

## PR Series
- **PR 1** — [Schema — no behavior. Only data-shape stop.](https://github.com/Khan/perseus/pull/3605)
- **PR 2** — [Foundation + Point graph](https://github.com/Khan/perseus/pull/3643)
- **PR 3** — [Polygon (shares start-coords-point.tsx); widen the gate to type === "point" || type === "polygon"](https://github.com/Khan/perseus/pull/3643)
- **PR 4** — [Lines: linear, ray](https://github.com/Khan/perseus/pull/3672)
- **PR 5** — [Multi-line: linear-system, segment](https://github.com/Khan/perseus/pull/3673)
- 👉🏼 **follow-up PR** — [Refactor linear, point, polygon, and ray graphs to use usePointAriaLabel instead of buildPointAriaLabel](https://github.com/Khan/perseus/pull/3694)
- **PR 6** — [Curves: quadratic, sinusoid, tangent, exponential, logarithm](https://github.com/Khan/perseus/pull/3696)
- **PR 7** — [Special shapes: angle, circle, absolute-value](https://github.com/Khan/perseus/pull/3697)