### PR TITLE
[Explanation] Add more visual regression tests

### DIFF
--- a/.changeset/calm-rice-poke.md
+++ b/.changeset/calm-rice-poke.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Explanation] Add more visual regression tests

--- a/.changeset/calm-rice-poke.md
+++ b/.changeset/calm-rice-poke.md
@@ -1,5 +1,6 @@
 ---
 "@khanacademy/perseus": patch
+"@khanacademy/perseus-core": patch
 ---
 
 [Explanation] Add more visual regression tests

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -65,6 +65,7 @@ configureSort({
         },
         editors: null,
         widgets: {
+            "nested widgets": null,
             "**": {
                 docs: null,
                 accessibility: null,

--- a/packages/perseus-core/src/utils/generators/explanation-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/explanation-widget-generator.ts
@@ -22,6 +22,9 @@ export function generateExplanationWidget(
         // Explanations are not graded
         graded: false,
         version: {major: 0, minor: 0},
+        // NOTE: The explanation widget doesn't consume this directly,
+        // instead, Perseus renders an overlay <div /> over top of the
+        // widget that intercepts interactions to it.
         static: false,
         alignment: "default",
         options: generateExplanationOptions(),

--- a/packages/perseus-core/src/utils/generators/explanation-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/explanation-widget-generator.ts
@@ -22,9 +22,6 @@ export function generateExplanationWidget(
         // Explanations are not graded
         graded: false,
         version: {major: 0, minor: 0},
-        // NOTE: The explanation widget doesn't consume this directly,
-        // instead, Perseus renders an overlay <div /> over top of the
-        // widget that intercepts interactions to it.
         static: false,
         alignment: "default",
         options: generateExplanationOptions(),

--- a/packages/perseus/src/__docs__/hints-renderer-decorator.tsx
+++ b/packages/perseus/src/__docs__/hints-renderer-decorator.tsx
@@ -1,0 +1,8 @@
+import * as React from "react";
+
+// Wraps hints in a `bibliotron-exercise` container to reflect hint styling in prod.
+export const bibliotronExerciseDecorator = (Story) => (
+    <div className="bibliotron-exercise">
+        <Story />
+    </div>
+);

--- a/packages/perseus/src/__docs__/hints-renderer-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/__docs__/hints-renderer-initial-state-regression.stories.tsx
@@ -17,32 +17,42 @@ import {
 import {View} from "@khanacademy/wonder-blocks-core";
 import React from "react";
 
+import {themeModes} from "../../../../.storybook/modes";
 import HintsRenderer from "../hints-renderer";
 import {ApiOptions} from "../perseus-api";
 import {storybookDependenciesV2} from "../testing/test-dependencies";
+import {ipsumExample} from "../widgets/explanation/explanation.testdata";
 import {earthMoonImage} from "../widgets/image/utils";
+
+import {bibliotronExerciseDecorator} from "./hints-renderer-decorator";
 
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 const defaultApiOptions = ApiOptions.defaults;
 
 const meta: Meta<typeof HintsRenderer> = {
-    title: "Renderers/Hints Renderer",
+    title: "Renderers/Hints Renderer/Visual Regression Tests/Initial State",
     component: HintsRenderer,
+    tags: ["!autodocs", "!manifest"],
     decorators: [
         (Story) => {
             return (
-                <View style={{left: 80}}>
+                <View style={{paddingLeft: 80}}>
                     <Story />
                 </View>
             );
         },
     ],
-    argTypes: {
-        hintsVisible: {
-            control: {min: 0},
-            defaultValue: 3,
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    "Regression tests for the Hints renderer that do NOT " +
+                    "need any interactions to test, which will be used with " +
+                    "Chromatic.",
+            },
         },
+        chromatic: {disableSnapshot: false, modes: themeModes},
     },
 };
 
@@ -51,6 +61,7 @@ export default meta;
 type Story = StoryObj<typeof HintsRenderer>;
 
 export const Interactive: Story = {
+    decorators: [bibliotronExerciseDecorator],
     args: {
         dependencies: storybookDependenciesV2,
         hints: [
@@ -77,6 +88,7 @@ export const Interactive: Story = {
 };
 
 export const WithAllInteractiveGraphs: Story = {
+    decorators: [bibliotronExerciseDecorator],
     args: {
         apiOptions: defaultApiOptions,
         dependencies: storybookDependenciesV2,
@@ -148,15 +160,7 @@ export const WithAllInteractiveGraphs: Story = {
 export const ImageWidgetInHint: Story = {
     // Need to wrap this in a container with the `bibliotron-exercise` class
     // to show what this would really look like with hint styling in prod.
-    decorators: [
-        (Story) => {
-            return (
-                <div className="bibliotron-exercise">
-                    <Story />
-                </div>
-            );
-        },
-    ],
+    decorators: [bibliotronExerciseDecorator],
     args: {
         dependencies: storybookDependenciesV2,
         hints: [
@@ -176,5 +180,13 @@ export const ImageWidgetInHint: Story = {
                 }),
             },
         ],
+    },
+};
+
+export const ExplanationWidgetInHint: Story = {
+    decorators: [bibliotronExerciseDecorator],
+    args: {
+        dependencies: storybookDependenciesV2,
+        hints: [{...ipsumExample, replace: false}],
     },
 };

--- a/packages/perseus/src/__docs__/hints-renderer-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/__docs__/hints-renderer-initial-state-regression.stories.tsx
@@ -158,8 +158,6 @@ export const WithAllInteractiveGraphs: Story = {
 };
 
 export const ImageWidgetInHint: Story = {
-    // Need to wrap this in a container with the `bibliotron-exercise` class
-    // to show what this would really look like with hint styling in prod.
     decorators: [bibliotronExerciseDecorator],
     args: {
         dependencies: storybookDependenciesV2,

--- a/packages/perseus/src/__docs__/hints-renderer-interactions-regression.stories.tsx
+++ b/packages/perseus/src/__docs__/hints-renderer-interactions-regression.stories.tsx
@@ -48,7 +48,7 @@ export const ExplanationWidgetInHint: Story = {
     },
     play: async ({canvas, userEvent}) => {
         const buttonText =
-            ipsumExample.widgets["explanation 1"]?.options.showPrompt;
+            ipsumExample.widgets["explanation 1"].options.showPrompt;
         const explanationTrigger = canvas.getByRole("button", {
             name: buttonText,
         });

--- a/packages/perseus/src/__docs__/hints-renderer-interactions-regression.stories.tsx
+++ b/packages/perseus/src/__docs__/hints-renderer-interactions-regression.stories.tsx
@@ -1,0 +1,58 @@
+import {View} from "@khanacademy/wonder-blocks-core";
+import React from "react";
+
+import {themeModes} from "../../../../.storybook/modes";
+import HintsRenderer from "../hints-renderer";
+import {storybookDependenciesV2} from "../testing/test-dependencies";
+import {ipsumExample} from "../widgets/explanation/explanation.testdata";
+
+import {bibliotronExerciseDecorator} from "./hints-renderer-decorator";
+
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+const meta: Meta<typeof HintsRenderer> = {
+    title: "Renderers/Hints Renderer/Visual Regression Tests/Interactions",
+    component: HintsRenderer,
+    tags: ["!autodocs", "!manifest"],
+    decorators: [
+        (Story) => {
+            return (
+                <View style={{paddingLeft: 80}}>
+                    <Story />
+                </View>
+            );
+        },
+    ],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    "Regression tests for the Hints renderer that DO need " +
+                    "some sort of interaction to test, which will be used with " +
+                    "Chromatic. Stories are displayed on their own page.",
+            },
+        },
+        chromatic: {disableSnapshot: false, modes: themeModes},
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof HintsRenderer>;
+
+const ipsumExplanationOptions =
+    ipsumExample.widgets["explanation 1"]?.options;
+
+export const ExplanationWidgetInHint: Story = {
+    decorators: [bibliotronExerciseDecorator],
+    args: {
+        dependencies: storybookDependenciesV2,
+        hints: [{...ipsumExample, replace: false}],
+    },
+    play: async ({canvas, userEvent}) => {
+        const explanationTrigger = canvas.getByRole("button", {
+            name: ipsumExplanationOptions.showPrompt,
+        });
+        await userEvent.click(explanationTrigger);
+    },
+};

--- a/packages/perseus/src/__docs__/hints-renderer-interactions-regression.stories.tsx
+++ b/packages/perseus/src/__docs__/hints-renderer-interactions-regression.stories.tsx
@@ -29,7 +29,7 @@ const meta: Meta<typeof HintsRenderer> = {
                 component:
                     "Regression tests for the Hints renderer that DO need " +
                     "some sort of interaction to test, which will be used with " +
-                    "Chromatic. Stories are displayed on their own page.",
+                    "Chromatic.",
             },
         },
         chromatic: {disableSnapshot: false, modes: themeModes},
@@ -40,9 +40,6 @@ export default meta;
 
 type Story = StoryObj<typeof HintsRenderer>;
 
-const ipsumExplanationOptions =
-    ipsumExample.widgets["explanation 1"]?.options;
-
 export const ExplanationWidgetInHint: Story = {
     decorators: [bibliotronExerciseDecorator],
     args: {
@@ -50,8 +47,10 @@ export const ExplanationWidgetInHint: Story = {
         hints: [{...ipsumExample, replace: false}],
     },
     play: async ({canvas, userEvent}) => {
+        const buttonText =
+            ipsumExample.widgets["explanation 1"]?.options.showPrompt;
         const explanationTrigger = canvas.getByRole("button", {
-            name: ipsumExplanationOptions.showPrompt,
+            name: buttonText,
         });
         await userEvent.click(explanationTrigger);
     },

--- a/packages/perseus/src/__docs__/hints-renderer.stories.tsx
+++ b/packages/perseus/src/__docs__/hints-renderer.stories.tsx
@@ -1,0 +1,66 @@
+import {
+    generateTestPerseusRenderer,
+    generateImageWidget,
+    generateImageOptions,
+} from "@khanacademy/perseus-core";
+import {View} from "@khanacademy/wonder-blocks-core";
+import React from "react";
+
+import {themeModes} from "../../../../.storybook/modes";
+import HintsRenderer from "../hints-renderer";
+import {storybookDependenciesV2} from "../testing/test-dependencies";
+import {earthMoonImage} from "../widgets/image/utils";
+
+import {bibliotronExerciseDecorator} from "./hints-renderer-decorator";
+
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+const meta: Meta<typeof HintsRenderer> = {
+    title: "Renderers/Hints Renderer",
+    component: HintsRenderer,
+    decorators: [
+        (Story) => {
+            return (
+                <View style={{paddingLeft: 80}}>
+                    <Story />
+                </View>
+            );
+        },
+    ],
+    parameters: {
+        docs: {
+            description: {
+                component: "Examples of Hint renderer.",
+            },
+        },
+        chromatic: {disableSnapshot: false, modes: themeModes},
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof HintsRenderer>;
+
+export const ImageWidgetInHint: Story = {
+    decorators: [bibliotronExerciseDecorator],
+    args: {
+        dependencies: storybookDependenciesV2,
+        hints: [
+            {
+                ...generateTestPerseusRenderer({
+                    content: "[[☃ image 1]]",
+                    widgets: {
+                        "image 1": generateImageWidget({
+                            options: generateImageOptions({
+                                backgroundImage: earthMoonImage,
+                                alt: "Earth and Moon",
+                                title: "Earth and Moon",
+                                caption: "Earth and Moon",
+                            }),
+                        }),
+                    },
+                }),
+            },
+        ],
+    },
+};

--- a/packages/perseus/src/widgets/__docs__/nested-widgets-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/__docs__/nested-widgets-initial-state-regression.stories.tsx
@@ -1,0 +1,38 @@
+import {themeModes} from "../../../../../.storybook/modes";
+import {gradedGroupWithRadioAndExplanation} from "./nested-widgets.testdata";
+import {articleRendererDecorator} from "./nested-widgets-renderer-decorator";
+
+import type {GradedGroupWidget, PerseusExplanationWidgetOptions} from "@khanacademy/perseus-core";
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+type NestedWidgetStoryArgs =
+    | PerseusExplanationWidgetOptions
+    | GradedGroupWidget["options"];
+
+const meta: Meta<NestedWidgetStoryArgs> = {
+    title: "Widgets/Nested Widgets/Visual Regression Tests/Initial State",
+    tags: ["!autodocs", "!manifest"],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    "Regression tests for widgets nested inside other widgets that do NOT " +
+                    "need any interactions to test, which will be used with " +
+                    "Chromatic. Stories are all displayed on one page.",
+            },
+        },
+        chromatic: {disableSnapshot: false, modes: themeModes},
+        controls: {disable: true},
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const GradedGroupWithRadioAndExplanation: Story = {
+    decorators: [articleRendererDecorator],
+    parameters: {
+        question: gradedGroupWithRadioAndExplanation,
+    },
+};

--- a/packages/perseus/src/widgets/__docs__/nested-widgets-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/__docs__/nested-widgets-initial-state-regression.stories.tsx
@@ -1,15 +1,12 @@
 import {themeModes} from "../../../../../.storybook/modes";
-import {gradedGroupWithRadioAndExplanation} from "./nested-widgets.testdata";
-import {articleRendererDecorator} from "./nested-widgets-renderer-decorator";
 
-import type {GradedGroupWidget, PerseusExplanationWidgetOptions} from "@khanacademy/perseus-core";
+import {articleRendererDecorator} from "./nested-widgets-renderer-decorator";
+import {gradedGroupWithRadioAndExplanation} from "./nested-widgets.testdata";
+
+import type {GradedGroupWidget} from "@khanacademy/perseus-core";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
-type NestedWidgetStoryArgs =
-    | PerseusExplanationWidgetOptions
-    | GradedGroupWidget["options"];
-
-const meta: Meta<NestedWidgetStoryArgs> = {
+const meta: Meta = {
     title: "Widgets/Nested Widgets/Visual Regression Tests/Initial State",
     tags: ["!autodocs", "!manifest"],
     parameters: {
@@ -28,9 +25,9 @@ const meta: Meta<NestedWidgetStoryArgs> = {
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type GradedGroupStory = StoryObj<GradedGroupWidget["options"]>;
 
-export const GradedGroupWithRadioAndExplanation: Story = {
+export const GradedGroupWithRadioAndExplanation: GradedGroupStory = {
     decorators: [articleRendererDecorator],
     parameters: {
         question: gradedGroupWithRadioAndExplanation,

--- a/packages/perseus/src/widgets/__docs__/nested-widgets-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/__docs__/nested-widgets-interactions-regression.stories.tsx
@@ -47,7 +47,7 @@ export const GradedGroupExplanationClicked: GradedGroupStory = {
     },
 };
 
-const videoExample = videoInContent.widgets["explanation 1"]?.options;
+const videoExample = videoInContent.widgets["explanation 1"].options;
 
 export const VideoInContent: ExplanationStory = {
     decorators: [explanationRendererDecorator],
@@ -68,7 +68,7 @@ export const VideoInContent: ExplanationStory = {
     },
 };
 
-const imageExample = imageInContent.widgets["explanation 1"]?.options;
+const imageExample = imageInContent.widgets["explanation 1"].options;
 
 export const ImageInContent: ExplanationStory = {
     decorators: [explanationRendererDecorator],

--- a/packages/perseus/src/widgets/__docs__/nested-widgets-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/__docs__/nested-widgets-interactions-regression.stories.tsx
@@ -1,0 +1,46 @@
+import {themeModes} from "../../../../../.storybook/modes";
+import {imageInContent} from "../explanation/explanation.testdata";
+
+import {explanationRendererDecorator} from "../explanation/__docs__/explanation-renderer-decorator";
+
+import type {PerseusExplanationWidgetOptions} from "@khanacademy/perseus-core";
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+const meta: Meta<PerseusExplanationWidgetOptions> = {
+    title: "Widgets/Nested Widgets/Visual Regression Tests/Interactions",
+    tags: ["!autodocs", "!manifest"],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    "Regression tests for widgets nested inside other widgets that DO need some sort of interaction to test, which will be used with Chromatic. Stories are displayed on their own page.",
+            },
+        },
+        chromatic: {disableSnapshot: false, modes: themeModes},
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const imageExample = imageInContent.widgets["explanation 1"]?.options;
+
+export const ImageInContent: Story = {
+    decorators: [explanationRendererDecorator],
+    args: {
+        hidePrompt: imageExample.hidePrompt,
+        explanation: imageExample.explanation,
+        showPrompt: imageExample.showPrompt,
+    },
+    parameters: {
+        content: imageInContent.content,
+        widgets: imageExample.widgets,
+    },
+    play: async ({canvas, userEvent}) => {
+        const explanationTrigger = canvas.getByRole("button", {
+            name: imageExample.showPrompt,
+        });
+        await userEvent.click(explanationTrigger);
+    },
+};

--- a/packages/perseus/src/widgets/__docs__/nested-widgets-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/__docs__/nested-widgets-interactions-regression.stories.tsx
@@ -1,12 +1,20 @@
 import {themeModes} from "../../../../../.storybook/modes";
-import {imageInContent} from "../explanation/explanation.testdata";
-
 import {explanationRendererDecorator} from "../explanation/__docs__/explanation-renderer-decorator";
 
-import type {PerseusExplanationWidgetOptions} from "@khanacademy/perseus-core";
+import {articleRendererDecorator} from "./nested-widgets-renderer-decorator";
+import {
+    gradedGroupWithRadioAndExplanation,
+    imageInContent,
+    videoInContent,
+} from "./nested-widgets.testdata";
+
+import type {
+    GradedGroupWidget,
+    PerseusExplanationWidgetOptions,
+} from "@khanacademy/perseus-core";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
-const meta: Meta<PerseusExplanationWidgetOptions> = {
+const meta: Meta = {
     title: "Widgets/Nested Widgets/Visual Regression Tests/Interactions",
     tags: ["!autodocs", "!manifest"],
     parameters: {
@@ -17,16 +25,52 @@ const meta: Meta<PerseusExplanationWidgetOptions> = {
             },
         },
         chromatic: {disableSnapshot: false, modes: themeModes},
+        controls: {disable: true},
     },
 };
 
 export default meta;
 
-type Story = StoryObj<typeof meta>;
+type GradedGroupStory = StoryObj<GradedGroupWidget["options"]>;
+type ExplanationStory = StoryObj<PerseusExplanationWidgetOptions>;
+
+export const GradedGroupExplanationClicked: GradedGroupStory = {
+    decorators: [articleRendererDecorator],
+    parameters: {
+        question: gradedGroupWithRadioAndExplanation,
+    },
+    play: async ({canvas, userEvent}) => {
+        const explanationTrigger = canvas.getByRole("button", {
+            name: "Show explanation",
+        });
+        await userEvent.click(explanationTrigger);
+    },
+};
+
+const videoExample = videoInContent.widgets["explanation 1"]?.options;
+
+export const VideoInContent: ExplanationStory = {
+    decorators: [explanationRendererDecorator],
+    args: {
+        hidePrompt: videoExample.hidePrompt,
+        explanation: videoExample.explanation,
+        showPrompt: videoExample.showPrompt,
+    },
+    parameters: {
+        content: videoInContent.content,
+        widgets: videoExample.widgets,
+    },
+    play: async ({canvas, userEvent}) => {
+        const explanationTrigger = canvas.getByRole("button", {
+            name: videoExample.showPrompt,
+        });
+        await userEvent.click(explanationTrigger);
+    },
+};
 
 const imageExample = imageInContent.widgets["explanation 1"]?.options;
 
-export const ImageInContent: Story = {
+export const ImageInContent: ExplanationStory = {
     decorators: [explanationRendererDecorator],
     args: {
         hidePrompt: imageExample.hidePrompt,

--- a/packages/perseus/src/widgets/__docs__/nested-widgets-renderer-decorator.tsx
+++ b/packages/perseus/src/widgets/__docs__/nested-widgets-renderer-decorator.tsx
@@ -1,0 +1,13 @@
+import * as React from "react";
+
+import ArticleRenderer from "../../article-renderer";
+import {storybookDependenciesV2} from "../../testing/test-dependencies";
+
+export const articleRendererDecorator = (_, {parameters}) => {
+    return (
+        <ArticleRenderer
+            json={parameters.question}
+            dependencies={storybookDependenciesV2}
+        />
+    );
+};

--- a/packages/perseus/src/widgets/__docs__/nested-widgets-renderer-decorator.tsx
+++ b/packages/perseus/src/widgets/__docs__/nested-widgets-renderer-decorator.tsx
@@ -3,10 +3,16 @@ import * as React from "react";
 import ArticleRenderer from "../../article-renderer";
 import {storybookDependenciesV2} from "../../testing/test-dependencies";
 
-export const articleRendererDecorator = (_, {parameters}) => {
+import type {PerseusArticle} from "@khanacademy/perseus-core";
+import type {Decorator} from "@storybook/react-vite";
+
+export const articleRendererDecorator: Decorator = (
+    _,
+    {parameters}: {parameters: {question?: PerseusArticle}},
+) => {
     return (
         <ArticleRenderer
-            json={parameters.question}
+            json={parameters.question!}
             dependencies={storybookDependenciesV2}
         />
     );

--- a/packages/perseus/src/widgets/__docs__/nested-widgets.testdata.ts
+++ b/packages/perseus/src/widgets/__docs__/nested-widgets.testdata.ts
@@ -1,0 +1,33 @@
+import {
+    generateExplanationOptions,
+    generateExplanationWidget,
+    generateImageOptions,
+    generateImageWidget,
+    generateTestPerseusRenderer,
+    type PerseusRenderer,
+} from "@khanacademy/perseus-core";
+
+export const imageInContent: PerseusRenderer = generateTestPerseusRenderer({
+    content: `It appears that cats and tribbles share the same "cuteness" gene as tribbles."
+                \n\n[[☃ explanation 1]]`,
+    widgets: {
+        "explanation 1": generateExplanationWidget({
+            options: generateExplanationOptions({
+                hidePrompt: "Hide this cuteness",
+                explanation: `Fur, purring, and lovability are all connected to their DNA.\n\n[[☃ image 1]]`,
+                showPrompt: "Show a cute cat",
+                widgets: {
+                    "image 1": generateImageWidget({
+                        options: generateImageOptions({
+                            backgroundImage: {
+                                url: "https://cdn.kastatic.org/ka-content-images/cabd2dd6c1be5651e5d25ba2cecc4c28e664eca6.gif",
+                            },
+                            caption: "Cat emulating a tribble",
+                            alt: "Cat sleeping on a couch",
+                        }),
+                    }),
+                },
+            }),
+        }),
+    },
+});

--- a/packages/perseus/src/widgets/__docs__/nested-widgets.testdata.ts
+++ b/packages/perseus/src/widgets/__docs__/nested-widgets.testdata.ts
@@ -48,7 +48,7 @@ export const gradedGroupWithRadioAndExplanation: PerseusRenderer =
                                 showPrompt: "Show explanation",
                                 hidePrompt: "Hide explanation",
                                 explanation:
-                                    "Picard commanded the USS Stargazer (NCC-2893) before taking command of the USS Enterprise (NCC-1701-D).",
+                                    "Captain Picard commanded the USS Stargazer (NCC-2893) before taking command of the USS Enterprise (NCC-1701-D).",
                             }),
                         }),
                     },

--- a/packages/perseus/src/widgets/__docs__/nested-widgets.testdata.ts
+++ b/packages/perseus/src/widgets/__docs__/nested-widgets.testdata.ts
@@ -1,11 +1,84 @@
 import {
     generateExplanationOptions,
     generateExplanationWidget,
+    generateGradedGroupOptions,
+    generateGradedGroupWidget,
     generateImageOptions,
     generateImageWidget,
+    generateRadioChoice,
+    generateRadioWidget,
     generateTestPerseusRenderer,
+    generateVideoWidget,
     type PerseusRenderer,
 } from "@khanacademy/perseus-core";
+
+export const gradedGroupWithRadioAndExplanation: PerseusRenderer =
+    generateTestPerseusRenderer({
+        content: "[[☃ graded-group 1]]",
+        widgets: {
+            "graded-group 1": generateGradedGroupWidget({
+                options: generateGradedGroupOptions({
+                    title: "Jean-Luc Picard's first command",
+                    content:
+                        "What ship was Jean-Luc Picard's first command?\n\n[[☃ radio 1]]\n\n[[☃ explanation 1]]",
+                    widgets: {
+                        "radio 1": generateRadioWidget({
+                            options: {
+                                choices: [
+                                    generateRadioChoice(
+                                        "USS Voyager (NCC-74656)",
+                                    ),
+                                    generateRadioChoice(
+                                        "USS Enterprise (NCC-1701-D)",
+                                    ),
+                                    generateRadioChoice(
+                                        "USS Enterprise (NX-01)",
+                                    ),
+                                    generateRadioChoice(
+                                        "USS Stargazer (NCC-2893)",
+                                        {
+                                            correct: true,
+                                        },
+                                    ),
+                                ],
+                            },
+                        }),
+                        "explanation 1": generateExplanationWidget({
+                            options: generateExplanationOptions({
+                                showPrompt: "Show explanation",
+                                hidePrompt: "Hide explanation",
+                                explanation:
+                                    "Picard commanded the USS Stargazer (NCC-2893) before taking command of the USS Enterprise (NCC-1701-D).",
+                            }),
+                        }),
+                    },
+                }),
+            }),
+        },
+    });
+
+export const videoInContent: PerseusRenderer = generateTestPerseusRenderer({
+    content: `Warp energy efficiency has improved significantly!
+                A simple remodulization of the warp field was all that was needed.
+                \n\n[[☃ explanation 1]]`,
+    widgets: {
+        "explanation 1": generateExplanationWidget({
+            options: generateExplanationOptions({
+                hidePrompt: "Close tutorial",
+                explanation: `Excerpt from Starfleet Academy Warp Fields 101 course:\n\n[[☃ video 1]]`,
+                showPrompt: "Show Warp Field tutorial",
+                widgets: {
+                    "video 1": generateVideoWidget({
+                        options: {
+                            location:
+                                "https://youtube.com/embed/7mH6Mal6Oh8?rel=0&controls=0",
+                        },
+                    }),
+                },
+            }),
+        }),
+    },
+});
 
 export const imageInContent: PerseusRenderer = generateTestPerseusRenderer({
     content: `It appears that cats and tribbles share the same "cuteness" gene as tribbles."

--- a/packages/perseus/src/widgets/__docs__/nested-widgets.testdata.ts
+++ b/packages/perseus/src/widgets/__docs__/nested-widgets.testdata.ts
@@ -81,7 +81,7 @@ export const videoInContent: PerseusRenderer = generateTestPerseusRenderer({
 });
 
 export const imageInContent: PerseusRenderer = generateTestPerseusRenderer({
-    content: `It appears that cats and tribbles share the same "cuteness" gene as tribbles."
+    content: `It appears that cats and tribbles share the same "cuteness" gene."
                 \n\n[[☃ explanation 1]]`,
     widgets: {
         "explanation 1": generateExplanationWidget({

--- a/packages/perseus/src/widgets/explanation/__docs__/explanation-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/explanation/__docs__/explanation-initial-state-regression.stories.tsx
@@ -1,19 +1,18 @@
-import {generateTestPerseusItem} from "@khanacademy/perseus-core";
-
 import {themeModes} from "../../../../../../.storybook/modes";
-import {ServerItemRendererWithDebugUI} from "../../../testing/server-item-renderer-with-debug-ui";
 import {question1, wideButton} from "../explanation.testdata";
 
+import {explanationRendererDecorator} from "./explanation-renderer-decorator";
+
+import type {PerseusExplanationWidgetOptions} from "@khanacademy/perseus-core";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 /**
  * This is a visual regression story for the Explanation widget.
  */
 
-const meta: Meta = {
+const meta: Meta<PerseusExplanationWidgetOptions> = {
     title: "Widgets/Explanation/Visual Regression Tests/Initial State",
-    component: ServerItemRendererWithDebugUI,
-    tags: ["!dev", "!manifest"],
+    tags: ["!autodocs", "!manifest"],
     parameters: {
         docs: {
             description: {
@@ -28,16 +27,32 @@ const meta: Meta = {
 };
 export default meta;
 
-type Story = StoryObj<typeof ServerItemRendererWithDebugUI>;
+type Story = StoryObj<typeof meta>;
 
-export const Question1: Story = {
+const simpleExample = question1.widgets["explanation 1"]?.options;
+
+export const SimpleExample: Story = {
+    decorators: [explanationRendererDecorator],
     args: {
-        item: generateTestPerseusItem({question: question1}),
+        hidePrompt: simpleExample.hidePrompt,
+        explanation: simpleExample.explanation,
+        showPrompt: simpleExample.showPrompt,
+    },
+    parameters: {
+        content: question1.content,
     },
 };
 
+const wideExample = wideButton.widgets["explanation 1"]?.options;
+
 export const WideButton: Story = {
+    decorators: [explanationRendererDecorator],
     args: {
-        item: generateTestPerseusItem({question: wideButton}),
+        hidePrompt: wideExample.hidePrompt,
+        explanation: wideExample.explanation,
+        showPrompt: wideExample.showPrompt,
+    },
+    parameters: {
+        content: wideButton.content,
     },
 };

--- a/packages/perseus/src/widgets/explanation/__docs__/explanation-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/explanation/__docs__/explanation-interactions-regression.stories.tsx
@@ -1,14 +1,18 @@
-import {generateTestPerseusItem} from "@khanacademy/perseus-core";
-
 import {themeModes} from "../../../../../../.storybook/modes";
-import {ServerItemRendererWithDebugUI} from "../../../testing/server-item-renderer-with-debug-ui";
-import {question1} from "../explanation.testdata";
+import {
+    question1,
+    imageInContent,
+    tableInContent,
+    videoInContent,
+} from "../explanation.testdata";
 
-import type {Meta} from "@storybook/react-vite";
+import {explanationRendererDecorator} from "./explanation-renderer-decorator";
 
-const meta: Meta = {
+import type {PerseusExplanationWidgetOptions} from "@khanacademy/perseus-core";
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+const meta: Meta<PerseusExplanationWidgetOptions> = {
     title: "Widgets/Explanation/Visual Regression Tests/Interactions",
-    component: ServerItemRendererWithDebugUI,
     tags: ["!autodocs", "!manifest"],
     parameters: {
         docs: {
@@ -23,15 +27,86 @@ const meta: Meta = {
 
 export default meta;
 
-export const ClickedState = {
+type Story = StoryObj<typeof meta>;
+
+const clickedExample = question1.widgets["explanation 1"]?.options;
+
+export const ClickedState: Story = {
+    decorators: [explanationRendererDecorator],
     args: {
-        item: generateTestPerseusItem({
-            question: question1,
-        }),
+        hidePrompt: clickedExample.hidePrompt,
+        explanation: clickedExample.explanation,
+        showPrompt: clickedExample.showPrompt,
+    },
+    parameters: {
+        content: question1.content,
     },
     play: async ({canvas, userEvent}) => {
         const explanationTrigger = canvas.getByRole("button", {
-            name: "Explanation",
+            name: clickedExample.showPrompt,
+        });
+        await userEvent.click(explanationTrigger);
+    },
+};
+
+const imageExample = imageInContent.widgets["explanation 1"]?.options;
+
+export const ImageInContent: Story = {
+    decorators: [explanationRendererDecorator],
+    args: {
+        hidePrompt: imageExample.hidePrompt,
+        explanation: imageExample.explanation,
+        showPrompt: imageExample.showPrompt,
+    },
+    parameters: {
+        content: imageInContent.content,
+        widgets: imageExample.widgets,
+    },
+    play: async ({canvas, userEvent}) => {
+        const explanationTrigger = canvas.getByRole("button", {
+            name: imageExample.showPrompt,
+        });
+        await userEvent.click(explanationTrigger);
+    },
+};
+
+const tableExample = tableInContent.widgets["explanation 1"]?.options;
+
+export const TableInContent: Story = {
+    decorators: [explanationRendererDecorator],
+    args: {
+        hidePrompt: tableExample.hidePrompt,
+        explanation: tableExample.explanation,
+        showPrompt: tableExample.showPrompt,
+    },
+    parameters: {
+        content: tableInContent.content,
+        widgets: tableExample.widgets,
+    },
+    play: async ({canvas, userEvent}) => {
+        const explanationTrigger = canvas.getByRole("button", {
+            name: tableExample.showPrompt,
+        });
+        await userEvent.click(explanationTrigger);
+    },
+};
+
+const videoExample = videoInContent.widgets["explanation 1"]?.options;
+
+export const VideoInContent: Story = {
+    decorators: [explanationRendererDecorator],
+    args: {
+        hidePrompt: videoExample.hidePrompt,
+        explanation: videoExample.explanation,
+        showPrompt: videoExample.showPrompt,
+    },
+    parameters: {
+        content: videoInContent.content,
+        widgets: videoExample.widgets,
+    },
+    play: async ({canvas, userEvent}) => {
+        const explanationTrigger = canvas.getByRole("button", {
+            name: videoExample.showPrompt,
         });
         await userEvent.click(explanationTrigger);
     },

--- a/packages/perseus/src/widgets/explanation/__docs__/explanation-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/explanation/__docs__/explanation-interactions-regression.stories.tsx
@@ -1,10 +1,5 @@
 import {themeModes} from "../../../../../../.storybook/modes";
-import {
-    question1,
-    imageInContent,
-    tableInContent,
-    videoInContent,
-} from "../explanation.testdata";
+import {question1, tableInContent} from "../explanation.testdata";
 
 import {explanationRendererDecorator} from "./explanation-renderer-decorator";
 
@@ -49,27 +44,6 @@ export const ClickedState: Story = {
     },
 };
 
-const imageExample = imageInContent.widgets["explanation 1"]?.options;
-
-export const ImageInContent: Story = {
-    decorators: [explanationRendererDecorator],
-    args: {
-        hidePrompt: imageExample.hidePrompt,
-        explanation: imageExample.explanation,
-        showPrompt: imageExample.showPrompt,
-    },
-    parameters: {
-        content: imageInContent.content,
-        widgets: imageExample.widgets,
-    },
-    play: async ({canvas, userEvent}) => {
-        const explanationTrigger = canvas.getByRole("button", {
-            name: imageExample.showPrompt,
-        });
-        await userEvent.click(explanationTrigger);
-    },
-};
-
 const tableExample = tableInContent.widgets["explanation 1"]?.options;
 
 export const TableInContent: Story = {
@@ -86,27 +60,6 @@ export const TableInContent: Story = {
     play: async ({canvas, userEvent}) => {
         const explanationTrigger = canvas.getByRole("button", {
             name: tableExample.showPrompt,
-        });
-        await userEvent.click(explanationTrigger);
-    },
-};
-
-const videoExample = videoInContent.widgets["explanation 1"]?.options;
-
-export const VideoInContent: Story = {
-    decorators: [explanationRendererDecorator],
-    args: {
-        hidePrompt: videoExample.hidePrompt,
-        explanation: videoExample.explanation,
-        showPrompt: videoExample.showPrompt,
-    },
-    parameters: {
-        content: videoInContent.content,
-        widgets: videoExample.widgets,
-    },
-    play: async ({canvas, userEvent}) => {
-        const explanationTrigger = canvas.getByRole("button", {
-            name: videoExample.showPrompt,
         });
         await userEvent.click(explanationTrigger);
     },

--- a/packages/perseus/src/widgets/explanation/__docs__/explanation-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/explanation/__docs__/explanation-interactions-regression.stories.tsx
@@ -24,7 +24,7 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-const clickedExample = question1.widgets["explanation 1"]?.options;
+const clickedExample = question1.widgets["explanation 1"].options;
 
 export const ClickedState: Story = {
     decorators: [explanationRendererDecorator],
@@ -44,7 +44,7 @@ export const ClickedState: Story = {
     },
 };
 
-const tableExample = tableInContent.widgets["explanation 1"]?.options;
+const tableExample = tableInContent.widgets["explanation 1"].options;
 
 export const TableInContent: Story = {
     decorators: [explanationRendererDecorator],

--- a/packages/perseus/src/widgets/explanation/__docs__/explanation-renderer-decorator.tsx
+++ b/packages/perseus/src/widgets/explanation/__docs__/explanation-renderer-decorator.tsx
@@ -1,0 +1,31 @@
+import {
+    generateExplanationOptions,
+    generateExplanationWidget,
+    generateTestPerseusRenderer,
+} from "@khanacademy/perseus-core";
+import * as React from "react";
+
+import QuestionRendererForStories from "../../__testutils__/question-renderer-for-stories";
+
+export const explanationRendererDecorator = (_, {args, parameters}) => {
+    return (
+        <QuestionRendererForStories
+            question={generateTestPerseusRenderer({
+                content:
+                    parameters?.content ??
+                    "Here's the explanation\n[[☃ explanation 1]]\nDid you get that?",
+                widgets: {
+                    "explanation 1": generateExplanationWidget({
+                        options: generateExplanationOptions({
+                            ...args,
+                            ...(parameters?.widgets
+                                ? {widgets: parameters.widgets}
+                                : {}),
+                        }),
+                    }),
+                },
+            })}
+            apiOptions={parameters?.apiOptions}
+        />
+    );
+};

--- a/packages/perseus/src/widgets/explanation/__docs__/explanation-renderer-decorator.tsx
+++ b/packages/perseus/src/widgets/explanation/__docs__/explanation-renderer-decorator.tsx
@@ -7,7 +7,27 @@ import * as React from "react";
 
 import QuestionRendererForStories from "../../__testutils__/question-renderer-for-stories";
 
-export const explanationRendererDecorator = (_, {args, parameters}) => {
+import type {APIOptions} from "../../../types";
+import type {
+    ExplanationDefaultWidgetOptions,
+    PerseusWidgetsMap,
+} from "@khanacademy/perseus-core";
+import type {Decorator} from "@storybook/react-vite";
+
+export const explanationRendererDecorator: Decorator = (
+    _,
+    {
+        args,
+        parameters,
+    }: {
+        args: Partial<ExplanationDefaultWidgetOptions>;
+        parameters?: {
+            apiOptions?: APIOptions;
+            content?: string;
+            widgets?: PerseusWidgetsMap;
+        };
+    },
+) => {
     return (
         <QuestionRendererForStories
             question={generateTestPerseusRenderer({

--- a/packages/perseus/src/widgets/explanation/explanation.testdata.ts
+++ b/packages/perseus/src/widgets/explanation/explanation.testdata.ts
@@ -1,6 +1,8 @@
 import {
     generateExplanationOptions,
     generateExplanationWidget,
+    generateImageOptions,
+    generateImageWidget,
     generateTestPerseusRenderer,
     type PerseusRenderer,
 } from "@khanacademy/perseus-core";
@@ -94,6 +96,89 @@ export const wideButton: PerseusRenderer = generateTestPerseusRenderer({
                 `,
                 showPrompt:
                     "These appear to be some kind of power-wave-guide conduits which allow them to work collectively as they perform ship functions.",
+            }),
+        }),
+    },
+});
+
+export const imageInContent: PerseusRenderer = generateTestPerseusRenderer({
+    content: `It appears that cats and tribbles share the same "cuteness" gene as tribbles."
+                \n\n[[\u2603 explanation 1]]`,
+    widgets: {
+        "explanation 1": generateExplanationWidget({
+            options: generateExplanationOptions({
+                hidePrompt: "Hide this cuteness",
+                explanation: `Fur, purring, and lovability are all connected to their DNA.\n\n[[\u2603 image 1]]`,
+                showPrompt: "Show a cute cat",
+                widgets: {
+                    "image 1": generateImageWidget({
+                        options: generateImageOptions({
+                            backgroundImage: {
+                                url: "https://cdn.kastatic.org/ka-content-images/cabd2dd6c1be5651e5d25ba2cecc4c28e664eca6.gif",
+                            },
+                            caption: "Cat emulating a tribble",
+                            alt: "Cat sleeping on a couch",
+                        }),
+                    }),
+                },
+            }),
+        }),
+    },
+});
+
+export const tableInContent: PerseusRenderer = generateTestPerseusRenderer({
+    content: `An evaluation of the classes of Federation ships involved in the tachyon blockade during the Klingon Civil
+                War reveals wide range of starship types capable of engaging in complex tactical efforts.
+                \n\n[[\u2603 explanation 1]]`,
+    widgets: {
+        "explanation 1": generateExplanationWidget({
+            options: generateExplanationOptions({
+                hidePrompt: "Hide starship table",
+                showPrompt: "Starship class breakdown",
+                explanation: `Starship name | Vessel class |
+- | -
+USS Ahwahnee | Cheyenne
+USS Ajax | Apollo
+USS Aries | Renaissance
+USS Charleston | Excelsior
+USS Enterprise-D | Galaxy
+USS Excalibur | Ambassador
+USS Goddard | Korolev
+USS Hathaway | Constellation
+USS Hood | Excelsior
+USS Merrimack | Nebula
+USS Sutherland | Nebula
+USS Thomas Paine | New Orleans
+USS Tian An Men | Miranda
+USS Trieste | Merced`,
+            }),
+        }),
+    },
+});
+
+export const videoInContent: PerseusRenderer = generateTestPerseusRenderer({
+    content: `Warp energy efficiency has improved significantly!
+                A simple remodulization of the warp field was all that was needed.
+                \n\n[[\u2603 explanation 1]]`,
+    widgets: {
+        "explanation 1": generateExplanationWidget({
+            options: generateExplanationOptions({
+                hidePrompt: "Close tutorial",
+                explanation: `Excerpt from Starfleet Academy Warp Fields 101 course:\n\n[[\u2603 video 1]]`,
+                showPrompt: "Show Warp Field tutorial",
+                widgets: {
+                    "video 1": {
+                        type: "video",
+                        static: false,
+                        graded: false,
+                        alignment: "block",
+                        options: {
+                            location:
+                                "https://youtube.com/embed/7mH6Mal6Oh8?rel=0&controls=0",
+                            static: false,
+                        },
+                    },
+                },
             }),
         }),
     },

--- a/packages/perseus/src/widgets/explanation/explanation.testdata.ts
+++ b/packages/perseus/src/widgets/explanation/explanation.testdata.ts
@@ -1,8 +1,6 @@
 import {
     generateExplanationOptions,
     generateExplanationWidget,
-    generateImageOptions,
-    generateImageWidget,
     generateTestPerseusRenderer,
     type PerseusRenderer,
 } from "@khanacademy/perseus-core";
@@ -101,31 +99,6 @@ export const wideButton: PerseusRenderer = generateTestPerseusRenderer({
     },
 });
 
-export const imageInContent: PerseusRenderer = generateTestPerseusRenderer({
-    content: `It appears that cats and tribbles share the same "cuteness" gene as tribbles."
-                \n\n[[\u2603 explanation 1]]`,
-    widgets: {
-        "explanation 1": generateExplanationWidget({
-            options: generateExplanationOptions({
-                hidePrompt: "Hide this cuteness",
-                explanation: `Fur, purring, and lovability are all connected to their DNA.\n\n[[\u2603 image 1]]`,
-                showPrompt: "Show a cute cat",
-                widgets: {
-                    "image 1": generateImageWidget({
-                        options: generateImageOptions({
-                            backgroundImage: {
-                                url: "https://cdn.kastatic.org/ka-content-images/cabd2dd6c1be5651e5d25ba2cecc4c28e664eca6.gif",
-                            },
-                            caption: "Cat emulating a tribble",
-                            alt: "Cat sleeping on a couch",
-                        }),
-                    }),
-                },
-            }),
-        }),
-    },
-});
-
 export const tableInContent: PerseusRenderer = generateTestPerseusRenderer({
     content: `An evaluation of the classes of Federation ships involved in the tachyon blockade during the Klingon Civil
                 War reveals wide range of starship types capable of engaging in complex tactical efforts.
@@ -151,34 +124,6 @@ USS Sutherland | Nebula
 USS Thomas Paine | New Orleans
 USS Tian An Men | Miranda
 USS Trieste | Merced`,
-            }),
-        }),
-    },
-});
-
-export const videoInContent: PerseusRenderer = generateTestPerseusRenderer({
-    content: `Warp energy efficiency has improved significantly!
-                A simple remodulization of the warp field was all that was needed.
-                \n\n[[\u2603 explanation 1]]`,
-    widgets: {
-        "explanation 1": generateExplanationWidget({
-            options: generateExplanationOptions({
-                hidePrompt: "Close tutorial",
-                explanation: `Excerpt from Starfleet Academy Warp Fields 101 course:\n\n[[\u2603 video 1]]`,
-                showPrompt: "Show Warp Field tutorial",
-                widgets: {
-                    "video 1": {
-                        type: "video",
-                        static: false,
-                        graded: false,
-                        alignment: "block",
-                        options: {
-                            location:
-                                "https://youtube.com/embed/7mH6Mal6Oh8?rel=0&controls=0",
-                            static: false,
-                        },
-                    },
-                },
             }),
         }),
     },


### PR DESCRIPTION
## Summary:
This PR expands the visual regression test coverage for the Explanation widget,
adding stories that cover embedded video, images, and data tables in explanation
content. It also adds interaction regression stories for hints renderer behavior,
and moves nested widget tests into a dedicated "Nested Widgets" folder to
centralize tests for widgets that contain other widgets.

Issue: LEMS-4130

## Test plan:
1. Open Storybook and navigate to the Explanation widget stories.
   - Verify the new initial-state regression stories render correctly: content
     with images, embedded video, and tables should display without visual
     artifacts.
2. Navigate to the new Nested Widgets folder and verify nested widget stories
   render correctly for both initial state and interactions.
3. Navigate to the Hints Renderer stories and verify the new interactions
   regression story works as expected.