### PR TITLE
[Interactive Graph] Wire pointLabels through curve graphs (quadratic, sinusoid, tangent, exponential, logarithm) for custom points label

### DIFF
--- a/.changeset/ninety-ads-raise.md
+++ b/.changeset/ninety-ads-raise.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": minor
+---
+
+[Interactive Graph] Wire pointLabels through curve graphs (quadratic, sinusoid, tangent, exponential, logarithm) for custom points label

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/asymptote-input.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/asymptote-input.tsx
@@ -36,7 +36,7 @@ const AsymptoteInput = (props: AsymptoteInputProps) => {
     }
 
     return (
-        <BodyText weight="bold" tag="label" className={styles.row}>
+        <BodyText weight="bold" tag="label" className={styles.tileRow}>
             {`Asymptote ${axis} =`}
             <View className={styles["text-field-wrapper"]}>
                 <ScrolllessNumberTextField

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-exponential.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-exponential.tsx
@@ -1,11 +1,7 @@
-import {View} from "@khanacademy/wonder-blocks-core";
-import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import * as React from "react";
 
-import CoordinatePairInput from "../../../components/coordinate-pair-input";
-
 import AsymptoteInput from "./asymptote-input";
-import styles from "./start-coords-shared.module.css";
+import CoordInput from "./coord-input";
 
 import type {Coord} from "@khanacademy/perseus";
 
@@ -14,41 +10,44 @@ type ExponentialStartCoords = {
     asymptote: number;
 };
 
-type Props = {
+interface StartCoordsExponentialProps {
     startCoords: ExponentialStartCoords;
     onChange: (startCoords: ExponentialStartCoords) => void;
-};
+    pointLabels: ReadonlyArray<string>;
+    onChangePointLabels: (pointLabels: ReadonlyArray<string>) => void;
+}
 
-const StartCoordsExponential = (props: Props) => {
-    const {startCoords, onChange} = props;
+const StartCoordsExponential = (props: StartCoordsExponentialProps) => {
+    const {startCoords, onChange, pointLabels, onChangePointLabels} = props;
     const {coords, asymptote} = startCoords;
+    const updatePointLabel = (index: number, newLabel: string) => {
+        const next: [string, string] = [
+            index === 0 ? newLabel : pointLabels[0] ?? "",
+            index === 1 ? newLabel : pointLabels[1] ?? "",
+        ];
+        onChangePointLabels(next);
+    };
 
     return (
-        <View className={styles.tile}>
-            {/* Point 1 */}
-            <View className={styles.row}>
-                <BodyText weight="bold">Point 1:</BodyText>
-                <CoordinatePairInput
-                    coord={coords[0]}
-                    labels={["x", "y"]}
-                    onChange={(value) =>
-                        onChange({coords: [value, coords[1]], asymptote})
-                    }
-                />
-            </View>
-
-            {/* Point 2 */}
-            <View className={styles.row}>
-                <BodyText weight="bold">Point 2:</BodyText>
-                <CoordinatePairInput
-                    coord={coords[1]}
-                    labels={["x", "y"]}
-                    onChange={(value) =>
-                        onChange({coords: [coords[0], value], asymptote})
-                    }
-                />
-            </View>
-
+        <>
+            <CoordInput
+                label="Point 1"
+                coord={coords[0]}
+                onChange={(value) =>
+                    onChange({coords: [value, coords[1]], asymptote})
+                }
+                pointLabel={pointLabels[0]}
+                onPointLabelChange={(newLabel) => updatePointLabel(0, newLabel)}
+            />
+            <CoordInput
+                label="Point 2"
+                coord={coords[1]}
+                onChange={(value) =>
+                    onChange({coords: [coords[0], value], asymptote})
+                }
+                pointLabel={pointLabels[1]}
+                onPointLabelChange={(newLabel) => updatePointLabel(1, newLabel)}
+            />
             <AsymptoteInput
                 axis="y"
                 value={asymptote}
@@ -58,7 +57,7 @@ const StartCoordsExponential = (props: Props) => {
                     onChange({coords: [coords[0], coords[1]], asymptote: newY})
                 }
             />
-        </View>
+        </>
     );
 };
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-logarithm.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-logarithm.tsx
@@ -2,9 +2,8 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {BodyMonospace, BodyText} from "@khanacademy/wonder-blocks-typography";
 import * as React from "react";
 
-import CoordinatePairInput from "../../../components/coordinate-pair-input";
-
 import AsymptoteInput from "./asymptote-input";
+import CoordInput from "./coord-input";
 import styles from "./start-coords-shared.module.css";
 import {getLogarithmEquation} from "./util";
 
@@ -15,14 +14,23 @@ type LogarithmStartCoords = {
     asymptote: number;
 };
 
-type Props = {
+interface StartCoordsLogarithmProps {
     startCoords: LogarithmStartCoords;
     onChange: (startCoords: LogarithmStartCoords) => void;
-};
+    pointLabels: ReadonlyArray<string>;
+    onChangePointLabels: (pointLabels: ReadonlyArray<string>) => void;
+}
 
-const StartCoordsLogarithm = (props: Props) => {
-    const {startCoords, onChange} = props;
+const StartCoordsLogarithm = (props: StartCoordsLogarithmProps) => {
+    const {startCoords, onChange, pointLabels, onChangePointLabels} = props;
     const {coords, asymptote} = startCoords;
+    const updatePointLabel = (index: number, newLabel: string) => {
+        const next: [string, string] = [
+            index === 0 ? newLabel : pointLabels[0] ?? "",
+            index === 1 ? newLabel : pointLabels[1] ?? "",
+        ];
+        onChangePointLabels(next);
+    };
 
     return (
         <>
@@ -35,44 +43,36 @@ const StartCoordsLogarithm = (props: Props) => {
             </View>
 
             {/* Points UI */}
-            <View className={styles.tile}>
-                {/* Point 1 */}
-                <View className={styles.row}>
-                    <BodyText weight="bold">Point 1:</BodyText>
-                    <CoordinatePairInput
-                        coord={coords[0]}
-                        labels={["x", "y"]}
-                        onChange={(value) =>
-                            onChange({coords: [value, coords[1]], asymptote})
-                        }
-                    />
-                </View>
-
-                {/* Point 2 */}
-                <View className={styles.row}>
-                    <BodyText weight="bold">Point 2:</BodyText>
-                    <CoordinatePairInput
-                        coord={coords[1]}
-                        labels={["x", "y"]}
-                        onChange={(value) =>
-                            onChange({coords: [coords[0], value], asymptote})
-                        }
-                    />
-                </View>
-
-                <AsymptoteInput
-                    axis="x"
-                    value={asymptote}
-                    onChange={(newX) =>
-                        // Rebuild coords so startCoords gets a new reference;
-                        // StatefulMafsGraph only reinitializes on identity change.
-                        onChange({
-                            coords: [coords[0], coords[1]],
-                            asymptote: newX,
-                        })
-                    }
-                />
-            </View>
+            <CoordInput
+                label="Point 1"
+                coord={coords[0]}
+                onChange={(value) =>
+                    onChange({coords: [value, coords[1]], asymptote})
+                }
+                pointLabel={pointLabels[0]}
+                onPointLabelChange={(newLabel) => updatePointLabel(0, newLabel)}
+            />
+            <CoordInput
+                label="Point 2"
+                coord={coords[1]}
+                onChange={(value) =>
+                    onChange({coords: [coords[0], value], asymptote})
+                }
+                pointLabel={pointLabels[1]}
+                onPointLabelChange={(newLabel) => updatePointLabel(1, newLabel)}
+            />
+            <AsymptoteInput
+                axis="x"
+                value={asymptote}
+                onChange={(newX) =>
+                    // Rebuild coords so startCoords gets a new reference;
+                    // StatefulMafsGraph only reinitializes on identity change.
+                    onChange({
+                        coords: [coords[0], coords[1]],
+                        asymptote: newX,
+                    })
+                }
+            />
         </>
     );
 };

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-quadratic.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-quadratic.tsx
@@ -9,13 +9,23 @@ import {getQuadraticEquation} from "./util";
 
 import type {Coord} from "@khanacademy/perseus";
 
-type Props = {
+interface StartCoordsQuadraticProps {
     startCoords: [Coord, Coord, Coord];
     onChange: (startCoords: [Coord, Coord, Coord]) => void;
-};
+    pointLabels: ReadonlyArray<string>;
+    onChangePointLabels: (pointLabels: ReadonlyArray<string>) => void;
+}
 
-const StartCoordsQuadratic = (props: Props) => {
-    const {startCoords, onChange} = props;
+const StartCoordsQuadratic = (props: StartCoordsQuadraticProps) => {
+    const {startCoords, onChange, pointLabels, onChangePointLabels} = props;
+    const updatePointLabel = (index: number, newLabel: string) => {
+        const next: [string, string, string] = [
+            index === 0 ? newLabel : pointLabels[0] ?? "",
+            index === 1 ? newLabel : pointLabels[1] ?? "",
+            index === 2 ? newLabel : pointLabels[2] ?? "",
+        ];
+        onChangePointLabels(next);
+    };
 
     return (
         <>
@@ -34,6 +44,8 @@ const StartCoordsQuadratic = (props: Props) => {
                 onChange={(value) =>
                     onChange([value, startCoords[1], startCoords[2]])
                 }
+                pointLabel={pointLabels[0]}
+                onPointLabelChange={(newLabel) => updatePointLabel(0, newLabel)}
             />
             <CoordInput
                 label="Point 2"
@@ -41,6 +53,8 @@ const StartCoordsQuadratic = (props: Props) => {
                 onChange={(value) =>
                     onChange([startCoords[0], value, startCoords[2]])
                 }
+                pointLabel={pointLabels[1]}
+                onPointLabelChange={(newLabel) => updatePointLabel(1, newLabel)}
             />
             <CoordInput
                 label="Point 3"
@@ -48,6 +62,8 @@ const StartCoordsQuadratic = (props: Props) => {
                 onChange={(value) =>
                     onChange([startCoords[0], startCoords[1], value])
                 }
+                pointLabel={pointLabels[2]}
+                onPointLabelChange={(newLabel) => updatePointLabel(2, newLabel)}
             />
         </>
     );

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.test.tsx
@@ -711,6 +711,51 @@ describe("StartCoordSettings", () => {
                 expect(onChangeMock).toHaveBeenLastCalledWith(expectedCoords);
             },
         );
+
+        it("renders point name fields when onChangePointLabels is provided", () => {
+            // Arrange, Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="sinusoid"
+                    onChange={() => {}}
+                    onChangePointLabels={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(
+                screen.getByRole("textbox", {name: "Point 1 name"}),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole("textbox", {name: "Point 2 name"}),
+            ).toBeInTheDocument();
+        });
+
+        it("calls onChangePointLabels with the schema's 2-tuple shape when a name is typed", async () => {
+            // Arrange
+            const onChangePointLabelsMock = jest.fn();
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="sinusoid"
+                    onChange={() => {}}
+                    onChangePointLabels={onChangePointLabelsMock}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            const nameInput = screen.getByRole("textbox", {
+                name: "Point 1 name",
+            });
+            await userEvent.type(nameInput, "T");
+
+            // Assert — the empty slot must be preserved so the schema
+            // shape stays a 2-tuple even when only one point is named.
+            expect(onChangePointLabelsMock).toHaveBeenLastCalledWith(["T", ""]);
+        });
     });
 
     describe("quadratic graph", () => {
@@ -779,6 +824,247 @@ describe("StartCoordSettings", () => {
                 expect(onChangeMock).toHaveBeenLastCalledWith(expectedCoords);
             },
         );
+
+        it("renders point name fields for all three points when onChangePointLabels is provided", () => {
+            // Arrange, Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="quadratic"
+                    onChange={() => {}}
+                    onChangePointLabels={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(
+                screen.getByRole("textbox", {name: "Point 1 name"}),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole("textbox", {name: "Point 2 name"}),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole("textbox", {name: "Point 3 name"}),
+            ).toBeInTheDocument();
+        });
+
+        it("calls onChangePointLabels with the schema's 3-tuple shape when a name is typed", async () => {
+            // Arrange
+            const onChangePointLabelsMock = jest.fn();
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="quadratic"
+                    onChange={() => {}}
+                    onChangePointLabels={onChangePointLabelsMock}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            const nameInput = screen.getByRole("textbox", {
+                name: "Point 2 name",
+            });
+            await userEvent.type(nameInput, "T");
+
+            // Assert — the empty slots must be preserved so the schema
+            // shape stays a 3-tuple even when only one point is named.
+            expect(onChangePointLabelsMock).toHaveBeenLastCalledWith([
+                "",
+                "T",
+                "",
+            ]);
+        });
+    });
+
+    describe("tangent graph", () => {
+        it("shows the start coordinates UI", () => {
+            // Arrange, Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="tangent"
+                    onChange={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(screen.getByText("Start coordinates")).toBeInTheDocument();
+            expect(screen.getByText("Point 1:")).toBeInTheDocument();
+            expect(screen.getByText("Point 2:")).toBeInTheDocument();
+        });
+
+        it("renders point name fields when onChangePointLabels is provided", () => {
+            // Arrange, Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="tangent"
+                    onChange={() => {}}
+                    onChangePointLabels={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(
+                screen.getByRole("textbox", {name: "Point 1 name"}),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole("textbox", {name: "Point 2 name"}),
+            ).toBeInTheDocument();
+        });
+
+        it("calls onChangePointLabels with the schema's 2-tuple shape when a name is typed", async () => {
+            // Arrange
+            const onChangePointLabelsMock = jest.fn();
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="tangent"
+                    onChange={() => {}}
+                    onChangePointLabels={onChangePointLabelsMock}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            const nameInput = screen.getByRole("textbox", {
+                name: "Point 1 name",
+            });
+            await userEvent.type(nameInput, "T");
+
+            // Assert
+            expect(onChangePointLabelsMock).toHaveBeenLastCalledWith(["T", ""]);
+        });
+    });
+
+    describe("exponential graph", () => {
+        it("shows the start coordinates UI", () => {
+            // Arrange, Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="exponential"
+                    onChange={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(screen.getByText("Start coordinates")).toBeInTheDocument();
+            expect(screen.getByText("Point 1:")).toBeInTheDocument();
+            expect(screen.getByText("Point 2:")).toBeInTheDocument();
+        });
+
+        it("renders point name fields when onChangePointLabels is provided", () => {
+            // Arrange, Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="exponential"
+                    onChange={() => {}}
+                    onChangePointLabels={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(
+                screen.getByRole("textbox", {name: "Point 1 name"}),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole("textbox", {name: "Point 2 name"}),
+            ).toBeInTheDocument();
+        });
+
+        it("calls onChangePointLabels with the schema array shape when a name is typed", async () => {
+            // Arrange
+            const onChangePointLabelsMock = jest.fn();
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="exponential"
+                    onChange={() => {}}
+                    onChangePointLabels={onChangePointLabelsMock}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            const nameInput = screen.getByRole("textbox", {
+                name: "Point 2 name",
+            });
+            await userEvent.type(nameInput, "T");
+
+            // Assert
+            expect(onChangePointLabelsMock).toHaveBeenLastCalledWith(["", "T"]);
+        });
+    });
+
+    describe("logarithm graph", () => {
+        it("shows the start coordinates UI", () => {
+            // Arrange, Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="logarithm"
+                    onChange={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(screen.getByText("Start coordinates")).toBeInTheDocument();
+            expect(screen.getByText("Point 1:")).toBeInTheDocument();
+            expect(screen.getByText("Point 2:")).toBeInTheDocument();
+        });
+
+        it("renders point name fields when onChangePointLabels is provided", () => {
+            // Arrange, Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="logarithm"
+                    onChange={() => {}}
+                    onChangePointLabels={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(
+                screen.getByRole("textbox", {name: "Point 1 name"}),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole("textbox", {name: "Point 2 name"}),
+            ).toBeInTheDocument();
+        });
+
+        it("calls onChangePointLabels with the schema array shape when a name is typed", async () => {
+            // Arrange
+            const onChangePointLabelsMock = jest.fn();
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="logarithm"
+                    onChange={() => {}}
+                    onChangePointLabels={onChangePointLabelsMock}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            const nameInput = screen.getByRole("textbox", {
+                name: "Point 1 name",
+            });
+            await userEvent.type(nameInput, "T");
+
+            // Assert
+            expect(onChangePointLabelsMock).toHaveBeenLastCalledWith(["T", ""]);
+        });
     });
 
     describe("absolute-value graph", () => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
@@ -15,8 +15,6 @@ import {
 } from "@khanacademy/perseus";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import arrowCounterClockwise from "@phosphor-icons/core/bold/arrow-counter-clockwise-bold.svg";
 import * as React from "react";
 
@@ -31,6 +29,7 @@ import StartCoordsLogarithm from "./start-coords-logarithm";
 import StartCoordsMultiline from "./start-coords-multiline";
 import StartCoordsPoint from "./start-coords-point";
 import StartCoordsQuadratic from "./start-coords-quadratic";
+import styles from "./start-coords-shared.module.css";
 import StartCoordsSinusoid from "./start-coords-sinusoid";
 import StartCoordsTangent from "./start-coords-tangent";
 import StartCoordsVector from "./start-coords-vector";
@@ -122,6 +121,8 @@ const StartCoordsSettingsInner = (props: Props) => {
                 <StartCoordsSinusoid
                     startCoords={sinusoidCoords}
                     onChange={onChange}
+                    pointLabels={props.pointLabels ?? []}
+                    onChangePointLabels={onChangePointLabels}
                 />
             );
         case "exponential": {
@@ -140,6 +141,8 @@ const StartCoordsSettingsInner = (props: Props) => {
                 <StartCoordsExponential
                     startCoords={currentStartCoords}
                     onChange={onChange}
+                    pointLabels={props.pointLabels ?? []}
+                    onChangePointLabels={onChangePointLabels}
                 />
             );
         }
@@ -156,6 +159,8 @@ const StartCoordsSettingsInner = (props: Props) => {
                 <StartCoordsLogarithm
                     startCoords={currentLogarithmCoords}
                     onChange={onChange}
+                    pointLabels={props.pointLabels ?? []}
+                    onChangePointLabels={onChangePointLabels}
                 />
             );
         }
@@ -174,6 +179,8 @@ const StartCoordsSettingsInner = (props: Props) => {
                 <StartCoordsTangent
                     startCoords={tangentCoords}
                     onChange={onChange}
+                    pointLabels={props.pointLabels ?? []}
+                    onChangePointLabels={onChangePointLabels}
                 />
             );
         case "quadratic":
@@ -182,6 +189,8 @@ const StartCoordsSettingsInner = (props: Props) => {
                 <StartCoordsQuadratic
                     startCoords={quadraticCoords}
                     onChange={onChange}
+                    pointLabels={props.pointLabels ?? []}
+                    onChangePointLabels={onChangePointLabels}
                 />
             );
         // Graphs with startCoords of type ReadonlyArray<Coord>
@@ -234,19 +243,24 @@ const StartCoordsSettings = (props: Props) => {
                     <StartCoordsSettingsInner {...props} />
 
                     {/* Button to reset to default */}
-                    <Strut size={spacing.small_12} />
-                    <Button
-                        startIcon={arrowCounterClockwise}
-                        kind="tertiary"
-                        size="small"
-                        onClick={() => {
-                            onChange(
-                                getDefaultGraphStartCoords(props, range, step),
-                            );
-                        }}
-                    >
-                        Use default start coordinates
-                    </Button>
+                    <View className={styles.resetButton}>
+                        <Button
+                            startIcon={arrowCounterClockwise}
+                            kind="tertiary"
+                            size="small"
+                            onClick={() => {
+                                onChange(
+                                    getDefaultGraphStartCoords(
+                                        props,
+                                        range,
+                                        step,
+                                    ),
+                                );
+                            }}
+                        >
+                            Use default start coordinates
+                        </Button>
+                    </View>
                 </>
             )}
         </View>

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-shared.module.css
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-shared.module.css
@@ -68,3 +68,7 @@
     padding-right: var(--wb-sizing-size_080) !important;
     font-size: var(--wb-font-size-xSmall) !important;
 }
+
+.reset-button {
+    margin-top: var(--wb-sizing-size_120) !important;
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-sinusoid.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-sinusoid.tsx
@@ -11,13 +11,22 @@ import type {Coord} from "@khanacademy/perseus";
 
 type SinusoidCoords = [Coord, Coord];
 
-type Props = {
+interface StartCoordsSinusoidProps {
     startCoords: SinusoidCoords;
     onChange: (startCoords: SinusoidCoords) => void;
-};
+    pointLabels: ReadonlyArray<string>;
+    onChangePointLabels: (pointLabels: ReadonlyArray<string>) => void;
+}
 
-const StartCoordsSinusoid = (props: Props) => {
-    const {startCoords, onChange} = props;
+const StartCoordsSinusoid = (props: StartCoordsSinusoidProps) => {
+    const {startCoords, onChange, pointLabels, onChangePointLabels} = props;
+    const updatePointLabel = (index: number, newLabel: string) => {
+        const next: [string, string] = [
+            index === 0 ? newLabel : pointLabels[0] ?? "",
+            index === 1 ? newLabel : pointLabels[1] ?? "",
+        ];
+        onChangePointLabels(next);
+    };
 
     return (
         <>
@@ -34,11 +43,15 @@ const StartCoordsSinusoid = (props: Props) => {
                 label="Point 1"
                 coord={startCoords[0]}
                 onChange={(value) => onChange([value, startCoords[1]])}
+                pointLabel={pointLabels[0]}
+                onPointLabelChange={(newLabel) => updatePointLabel(0, newLabel)}
             />
             <CoordInput
                 label="Point 2"
                 coord={startCoords[1]}
                 onChange={(value) => onChange([startCoords[0], value])}
+                pointLabel={pointLabels[1]}
+                onPointLabelChange={(newLabel) => updatePointLabel(1, newLabel)}
             />
         </>
     );

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-tangent.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-tangent.tsx
@@ -10,13 +10,22 @@ import type {Coord} from "@khanacademy/perseus";
 
 type TangentCoords = [Coord, Coord];
 
-type Props = {
+interface StartCoordsTangentProps {
     startCoords: TangentCoords;
     onChange: (startCoords: TangentCoords) => void;
-};
+    pointLabels: ReadonlyArray<string>;
+    onChangePointLabels: (pointLabels: ReadonlyArray<string>) => void;
+}
 
-const StartCoordsTangent = (props: Props) => {
-    const {startCoords, onChange} = props;
+const StartCoordsTangent = (props: StartCoordsTangentProps) => {
+    const {startCoords, onChange, pointLabels, onChangePointLabels} = props;
+    const updatePointLabel = (index: number, newLabel: string) => {
+        const next: [string, string] = [
+            index === 0 ? newLabel : pointLabels[0] ?? "",
+            index === 1 ? newLabel : pointLabels[1] ?? "",
+        ];
+        onChangePointLabels(next);
+    };
 
     return (
         <>
@@ -33,11 +42,15 @@ const StartCoordsTangent = (props: Props) => {
                 label="Point 1"
                 coord={startCoords[0]}
                 onChange={(value) => onChange([value, startCoords[1]])}
+                pointLabel={pointLabels[0]}
+                onPointLabelChange={(newLabel) => updatePointLabel(0, newLabel)}
             />
             <CoordInput
                 label="Point 2"
                 coord={startCoords[1]}
                 onChange={(value) => onChange([startCoords[0], value])}
+                pointLabel={pointLabels[1]}
+                onPointLabelChange={(newLabel) => updatePointLabel(1, newLabel)}
             />
         </>
     );

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
@@ -25,9 +25,14 @@ import {
     segmentWithAllLockedRayVariations,
     absoluteValueQuestion,
     exponentialQuestion,
+    exponentialWithCustomLabelsQuestion,
     logarithmQuestion,
+    logarithmWithCustomLabelsQuestion,
+    quadraticWithCustomLabelsQuestion,
     sinusoidQuestion,
+    sinusoidWithCustomLabelsQuestion,
     tangentQuestion,
+    tangentWithCustomLabelsQuestion,
     vectorQuestion,
     segmentWithLockedEllipses,
     segmentWithLockedVectors,
@@ -226,9 +231,37 @@ export const Exponential: Story = {
     },
 };
 
+/**
+ * An exponential graph whose two curve points are named "A" and "B" via
+ * `pointLabels`, so JAWS announces "Point A / B at …" instead of the
+ * default "Point 1 / 2 at …". The asymptote handle's announcement is
+ * unaffected — `pointLabels` only covers the curve's control points.
+ */
+export const ExponentialWithCustomLabels: Story = {
+    args: {
+        item: generateTestPerseusItem({
+            question: exponentialWithCustomLabelsQuestion,
+        }),
+    },
+};
+
 export const Sinusoid: Story = {
     args: {
         item: generateTestPerseusItem({question: sinusoidQuestion}),
+    },
+};
+
+/**
+ * A sinusoid whose midline intersection and extremum are named "A" and "B"
+ * via `pointLabels`. Overrides the default "Midline intersection at …" /
+ * "Maximum point at …" semantic labels so the SR announcement matches the
+ * prompt's naming convention.
+ */
+export const SinusoidWithCustomLabels: Story = {
+    args: {
+        item: generateTestPerseusItem({
+            question: sinusoidWithCustomLabelsQuestion,
+        }),
     },
 };
 
@@ -238,9 +271,49 @@ export const Logarithm: Story = {
     },
 };
 
+/**
+ * A logarithm whose two curve points are named "A" and "B" via
+ * `pointLabels`, so JAWS announces "Point A / B at …" instead of the
+ * default "Point 1 / 2 at …". The vertical asymptote handle's
+ * announcement is unaffected.
+ */
+export const LogarithmWithCustomLabels: Story = {
+    args: {
+        item: generateTestPerseusItem({
+            question: logarithmWithCustomLabelsQuestion,
+        }),
+    },
+};
+
 export const Tangent: Story = {
     args: {
         item: generateTestPerseusItem({question: tangentQuestion}),
+    },
+};
+
+/**
+ * A tangent whose inflection point and control point are named "A" and "B"
+ * via `pointLabels`. Overrides the default "Inflection point" / "Control
+ * point" semantic labels.
+ */
+export const TangentWithCustomLabels: Story = {
+    args: {
+        item: generateTestPerseusItem({
+            question: tangentWithCustomLabelsQuestion,
+        }),
+    },
+};
+
+/**
+ * A quadratic whose three control points are named "A", "B", "C" via
+ * `pointLabels`. Overrides the default "Point N on parabola …" labels so
+ * the SR announcement matches the prompt's naming convention.
+ */
+export const QuadraticWithCustomLabels: Story = {
+    args: {
+        item: generateTestPerseusItem({
+            question: quadraticWithCustomLabelsQuestion,
+        }),
     },
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/exponential.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/exponential.test.tsx
@@ -219,6 +219,93 @@ describe("Exponential graph screen reader", () => {
     });
 });
 
+// TODO(LEMS-3995, post-PR-7): route the curve SR-tree summaries through buildPointAriaLabel once new locale string keys land.
+describe("Exponential graph pointLabels", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("uses custom pointLabels in each point's accessible name", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseExponentialState, pointLabels: ["A", "B"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point A at 0 comma 3."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at 1 comma 6."}),
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to the default label for indices without a custom label", () => {
+        // Arrange, Act — only the first point is named
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseExponentialState, pointLabels: ["A"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point A at 0 comma 3."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point 2 at 1 comma 6."}),
+        ).toBeInTheDocument();
+    });
+
+    // The editor encodes "only the second point named" as `["", "B"]`.
+    // An empty string at any index must fall back to the default label.
+    it("falls back to the default label for explicit empty-string entries", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseExponentialState, pointLabels: ["", "B"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point 1 at 0 comma 3."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at 1 comma 6."}),
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to the default label for truthy non-string entries (defensive against malformed hand-authored JSON bypassing the parser)", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseExponentialState,
+                    // eslint-disable-next-line no-restricted-syntax -- cast simulates malformed JSON the parser would reject
+                    pointLabels: [42, "B"] as unknown as string[],
+                }}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point 1 at 0 comma 3."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at 1 comma 6."}),
+        ).toBeInTheDocument();
+    });
+});
+
 describe("getExponentialKeyboardConstraint", () => {
     const coords: [vec.Vector2, vec.Vector2] = [
         [0, 3],

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/exponential.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/exponential.tsx
@@ -11,6 +11,7 @@ import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 import {boundToEdgeAndSnapToGrid} from "../utils";
 
+import {usePointAriaLabel} from "./components/build-point-aria-label";
 import {ClipToGraphBounds} from "./components/clip-to-graph-bounds";
 import {MovableAsymptote} from "./components/movable-asymptote";
 import {MovablePoint} from "./components/movable-point";
@@ -55,7 +56,8 @@ function ExponentialGraph(props: ExponentialGraphProps) {
     const id = React.useId();
     const descriptionId = id + "-description";
 
-    const {coords, asymptote, snapStep} = graphState;
+    const {coords, pointLabels, asymptote, snapStep} = graphState;
+    const buildLabel = usePointAriaLabel(pointLabels);
 
     // When the asymptote sits between the two points there is no valid
     // exponential that fits — coeffs will be undefined, and we skip
@@ -135,7 +137,8 @@ function ExponentialGraph(props: ExponentialGraphProps) {
             {coords.map((coord, i) => (
                 <MovablePoint
                     ariaLabel={
-                        i === 0 ? srExponentialPoint1 : srExponentialPoint2
+                        buildLabel(i, coord) ??
+                        (i === 0 ? srExponentialPoint1 : srExponentialPoint2)
                     }
                     key={"point-" + i}
                     point={coord}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/logarithm.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/logarithm.test.tsx
@@ -215,6 +215,93 @@ describe("Logarithm graph screen reader", () => {
     });
 });
 
+// TODO(LEMS-3995, post-PR-7): route the curve SR-tree summaries through buildPointAriaLabel once new locale string keys land.
+describe("Logarithm graph pointLabels", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("uses custom pointLabels in each point's accessible name", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseLogarithmState, pointLabels: ["A", "B"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point A at -4 comma -3."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at -5 comma -7."}),
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to the default label for indices without a custom label", () => {
+        // Arrange, Act — only the first point is named
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseLogarithmState, pointLabels: ["A"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point A at -4 comma -3."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point 2 at -5 comma -7."}),
+        ).toBeInTheDocument();
+    });
+
+    // The editor encodes "only the second point named" as `["", "B"]`.
+    // An empty string at any index must fall back to the default label.
+    it("falls back to the default label for explicit empty-string entries", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseLogarithmState, pointLabels: ["", "B"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point 1 at -4 comma -3."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at -5 comma -7."}),
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to the default label for truthy non-string entries (defensive against malformed hand-authored JSON bypassing the parser)", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseLogarithmState,
+                    // eslint-disable-next-line no-restricted-syntax -- cast simulates malformed JSON the parser would reject
+                    pointLabels: [42, "B"] as unknown as string[],
+                }}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point 1 at -4 comma -3."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at -5 comma -7."}),
+        ).toBeInTheDocument();
+    });
+});
+
 describe("getLogarithmKeyboardConstraint", () => {
     const coords: [vec.Vector2, vec.Vector2] = [
         [-4, -3],

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/logarithm.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/logarithm.tsx
@@ -11,6 +11,7 @@ import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 import {boundToEdgeAndSnapToGrid} from "../utils";
 
+import {usePointAriaLabel} from "./components/build-point-aria-label";
 import {ClipToGraphBounds} from "./components/clip-to-graph-bounds";
 import {MovableAsymptote} from "./components/movable-asymptote";
 import {MovablePoint} from "./components/movable-point";
@@ -55,7 +56,8 @@ function LogarithmGraph(props: LogarithmGraphProps) {
     const id = React.useId();
     const descriptionId = id + "-description";
 
-    const {coords, asymptote, snapStep} = graphState;
+    const {coords, pointLabels, asymptote, snapStep} = graphState;
+    const buildLabel = usePointAriaLabel(pointLabels);
 
     // When the asymptote sits between the two points there is no valid
     // logarithm that fits — coeffs will be undefined, and we skip
@@ -125,7 +127,10 @@ function LogarithmGraph(props: LogarithmGraphProps) {
             </MovableAsymptote>
             {coords.map((coord, i) => (
                 <MovablePoint
-                    ariaLabel={i === 0 ? srLogarithmPoint1 : srLogarithmPoint2}
+                    ariaLabel={
+                        buildLabel(i, coord) ??
+                        (i === 0 ? srLogarithmPoint1 : srLogarithmPoint2)
+                    }
                     key={"point-" + i}
                     point={coord}
                     sequenceNumber={i + 1}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.test.tsx
@@ -256,6 +256,88 @@ describe("Quadratic graph screen reader", () => {
     });
 });
 
+// TODO(LEMS-3995, post-PR-7): route the curve SR-tree summaries through buildPointAriaLabel once new locale string keys land.
+describe("Quadratic graph pointLabels", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("uses custom pointLabels in each point's accessible name", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseQuadraticState, pointLabels: ["A", "B", "C"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point A at -5 comma 5."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at 0 comma -5."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point C at 5 comma 5."}),
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to the default label for indices without a custom label", () => {
+        // Arrange, Act — only the middle point is named
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseQuadraticState, pointLabels: ["", "B", ""]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {
+                name: "Point 1 on parabola in quadrant 2 at -5 comma 5. Vertex is on the Y-axis.",
+            }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at 0 comma -5."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {
+                name: "Point 3 on parabola in quadrant 1 at 5 comma 5. Vertex is on the Y-axis.",
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to the default label for truthy non-string entries (defensive against malformed hand-authored JSON bypassing the parser)", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseQuadraticState,
+                    // eslint-disable-next-line no-restricted-syntax -- cast simulates malformed JSON the parser would reject
+                    pointLabels: [42, "B", "C"] as unknown as string[],
+                }}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {
+                name: "Point 1 on parabola in quadrant 2 at -5 comma 5. Vertex is on the Y-axis.",
+            }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at 0 comma -5."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point C at 5 comma 5."}),
+        ).toBeInTheDocument();
+    });
+});
+
 describe("describedQuadraticGraph interactive elements", () => {
     test("describes interactive elements on a default quadratic graph", () => {
         // Arrange

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/quadratic.tsx
@@ -5,6 +5,7 @@ import {usePerseusI18n} from "../../../components/i18n-context";
 import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 
+import {usePointAriaLabel} from "./components/build-point-aria-label";
 import {ClipToGraphBounds} from "./components/clip-to-graph-bounds";
 import {MovablePoint} from "./components/movable-point";
 import SRDescInSVG from "./components/sr-description-within-svg";
@@ -44,10 +45,11 @@ type QuadraticGraphProps = MafsGraphProps<QuadraticGraphState>;
 function QuadraticGraph(props: QuadraticGraphProps) {
     const {dispatch, graphState} = props;
 
-    const {coords, snapStep} = graphState;
+    const {coords, pointLabels, snapStep} = graphState;
     const {interactiveColor} = useGraphConfig();
 
     const {strings, locale} = usePerseusI18n();
+    const buildLabel = usePointAriaLabel(pointLabels);
     const id = React.useId();
     const quadraticDirectionId = id + "-direction";
     const quadraticVertexId = id + "-vertex";
@@ -110,7 +112,10 @@ function QuadraticGraph(props: QuadraticGraphProps) {
                 return (
                     <MovablePoint
                         key={"point-" + i}
-                        ariaLabel={`${srQuadraticPoint}${srVertex}`}
+                        ariaLabel={
+                            buildLabel(i, coord) ??
+                            `${srQuadraticPoint}${srVertex}`
+                        }
                         point={coord}
                         sequenceNumber={i + 1}
                         constrain={getQuadraticKeyboardConstraint(

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.test.tsx
@@ -189,6 +189,97 @@ describe("Sinusoid graph screen reader", () => {
     });
 });
 
+// TODO(LEMS-3995, post-PR-7): route the curve SR-tree summaries through buildPointAriaLabel once new locale string keys land.
+describe("Sinusoid graph pointLabels", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("uses custom pointLabels in each point's accessible name", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseSinusoidState, pointLabels: ["A", "B"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point A at 0 comma 0."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at 2 comma 2."}),
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to the default semantic label for indices without a custom label", () => {
+        // Arrange, Act — only the root point is named
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseSinusoidState, pointLabels: ["A"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point A at 0 comma 0."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Maximum point at 2 comma 2."}),
+        ).toBeInTheDocument();
+    });
+
+    // The editor encodes "only the second point named" as `["", "B"]`.
+    // An empty string at any index must fall back to the semantic default.
+    it("falls back to the default semantic label for explicit empty-string entries", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseSinusoidState, pointLabels: ["", "B"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {
+                name: "Midline intersection at 0 comma 0.",
+            }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at 2 comma 2."}),
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to the default semantic label for truthy non-string entries (defensive against malformed hand-authored JSON bypassing the parser)", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseSinusoidState,
+                    // eslint-disable-next-line no-restricted-syntax -- cast simulates malformed JSON the parser would reject
+                    pointLabels: [42, "B"] as unknown as string[],
+                }}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {
+                name: "Midline intersection at 0 comma 0.",
+            }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at 2 comma 2."}),
+        ).toBeInTheDocument();
+    });
+});
+
 describe("SinusoidGraph", () => {
     it("should accurately calculate the sine coefficients", () => {
         const coords: SinusoidGraphState["coords"] = [

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/sinusoid.tsx
@@ -9,6 +9,7 @@ import {X, Y} from "../math/coordinates";
 import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 
+import {usePointAriaLabel} from "./components/build-point-aria-label";
 import {ClipToGraphBounds} from "./components/clip-to-graph-bounds";
 import {MovablePoint} from "./components/movable-point";
 import SRDescInSVG from "./components/sr-description-within-svg";
@@ -46,7 +47,8 @@ function SinusoidGraph(props: SinusoidGraphProps) {
     // Destructure the coordinates from the graph state
     // Note: The order of the coordinates is important:
     // The coords[0] is the root and the coords[1] is the first peak
-    const {coords, snapStep} = graphState;
+    const {coords, pointLabels, snapStep} = graphState;
+    const buildLabel = usePointAriaLabel(pointLabels);
 
     // The coefficients are used to calculate the sinusoid equation, plot the graph, and to indicate
     // to content creators the currently selected "correct answer" in the Content Editor.
@@ -94,7 +96,8 @@ function SinusoidGraph(props: SinusoidGraphProps) {
             {coords.map((coord, i) => (
                 <MovablePoint
                     ariaLabel={
-                        i === 0 ? srSinusoidRootPoint : srSinusoidPeakPoint
+                        buildLabel(i, coord) ??
+                        (i === 0 ? srSinusoidRootPoint : srSinusoidPeakPoint)
                     }
                     key={"point-" + i}
                     point={coord}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/tangent.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/tangent.test.tsx
@@ -80,6 +80,97 @@ describe("Tangent graph screen reader", () => {
     });
 });
 
+// TODO(LEMS-3995, post-PR-7): route the curve SR-tree summaries through buildPointAriaLabel once new locale string keys land.
+describe("Tangent graph pointLabels", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("uses custom pointLabels in each point's accessible name", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseTangentState, pointLabels: ["A", "B"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point A at 0 comma 0."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at 2 comma 2."}),
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to the default semantic label for indices without a custom label", () => {
+        // Arrange, Act — only the first point is named
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseTangentState, pointLabels: ["A"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point A at 0 comma 0."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Control point at 2 comma 2."}),
+        ).toBeInTheDocument();
+    });
+
+    // The editor encodes "only the second point named" as `["", "B"]`.
+    // An empty string at any index must fall back to the semantic default.
+    it("falls back to the default semantic label for explicit empty-string entries", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseTangentState, pointLabels: ["", "B"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {
+                name: "Inflection point at 0 comma 0.",
+            }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at 2 comma 2."}),
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to the default semantic label for truthy non-string entries (defensive against malformed hand-authored JSON bypassing the parser)", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseTangentState,
+                    // eslint-disable-next-line no-restricted-syntax -- cast simulates malformed JSON the parser would reject
+                    pointLabels: [42, "B"] as unknown as string[],
+                }}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {
+                name: "Inflection point at 0 comma 0.",
+            }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at 2 comma 2."}),
+        ).toBeInTheDocument();
+    });
+});
+
 describe("TangentGraph", () => {
     it("should accurately calculate the tangent coefficients", () => {
         const coords: TangentGraphState["coords"] = [

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/tangent.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/tangent.tsx
@@ -9,6 +9,7 @@ import {X, Y} from "../math/coordinates";
 import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 
+import {usePointAriaLabel} from "./components/build-point-aria-label";
 import {ClipToGraphBounds} from "./components/clip-to-graph-bounds";
 import {MovablePoint} from "./components/movable-point";
 import SRDescInSVG from "./components/sr-description-within-svg";
@@ -46,7 +47,8 @@ function TangentGraph(props: TangentGraphProps) {
     // Destructure the coordinates from the graph state
     // coords[0] is the inflection point (where tan crosses the midline)
     // coords[1] is a quarter-period away (where amplitude is reached)
-    const {coords, snapStep} = graphState;
+    const {coords, pointLabels, snapStep} = graphState;
+    const buildLabel = usePointAriaLabel(pointLabels);
 
     // The coefficients are used to calculate the tangent equation, plot
     // the graph, and to indicate to content creators the currently selected
@@ -103,9 +105,10 @@ function TangentGraph(props: TangentGraphProps) {
             {coords.map((coord, i) => (
                 <MovablePoint
                     ariaLabel={
-                        i === 0
+                        buildLabel(i, coord) ??
+                        (i === 0
                             ? srTangentInflectionPoint
-                            : srTangentSecondPoint
+                            : srTangentSecondPoint)
                     }
                     key={"point-" + i}
                     point={coord}

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -1454,3 +1454,125 @@ export const polygonWithCustomLabelsQuestion: PerseusRenderer =
             pointLabels: ["A", "B", "C"],
         }),
     });
+
+// Quadratic graph with each control point named via `pointLabels` so JAWS
+// announces "Point A/B/C at …" instead of the per-point "Point N on
+// parabola …" default.
+export const quadraticWithCustomLabelsQuestion: PerseusRenderer =
+    generateInteractiveGraphQuestion({
+        content:
+            "**Drag the three control points $A$, $B$, and $C$ so the parabola opens upward with its vertex at $B$.**\n\n[[☃ interactive-graph 1]]",
+        markings: "graph",
+        gridStep: [1, 1],
+        snapStep: [1, 1],
+        step: [1, 1],
+        range: [
+            [-10, 10],
+            [-10, 10],
+        ],
+        correct: generateIGQuadraticGraph({
+            coords: [
+                [-5, 5],
+                [0, -5],
+                [5, 5],
+            ],
+            pointLabels: ["A", "B", "C"],
+        }),
+    });
+
+// Sinusoid graph with the midline intersection named $A$ and the extremum
+// named $B$ via `pointLabels`. The default "Midline intersection" /
+// "Maximum point" semantic labels are overridden.
+export const sinusoidWithCustomLabelsQuestion: PerseusRenderer =
+    generateInteractiveGraphQuestion({
+        content:
+            "**Drag point $A$ to the midline intersection and point $B$ to the first maximum.**\n\n[[☃ interactive-graph 1]]",
+        markings: "graph",
+        gridStep: [1, 1],
+        snapStep: [1, 1],
+        step: [1, 1],
+        range: [
+            [-10, 10],
+            [-10, 10],
+        ],
+        correct: generateIGSinusoidGraph({
+            coords: [
+                [0, 0],
+                [2, 2],
+            ],
+            pointLabels: ["A", "B"],
+        }),
+    });
+
+// Tangent graph with the inflection point named $A$ and the control point
+// named $B$ via `pointLabels`. Overrides the default "Inflection point" /
+// "Control point" semantic labels.
+export const tangentWithCustomLabelsQuestion: PerseusRenderer =
+    generateInteractiveGraphQuestion({
+        content:
+            "**Drag point $A$ to the inflection point and point $B$ a quarter-period to the right.**\n\n[[☃ interactive-graph 1]]",
+        markings: "graph",
+        gridStep: [1, 1],
+        snapStep: [1, 1],
+        step: [1, 1],
+        range: [
+            [-10, 10],
+            [-10, 10],
+        ],
+        correct: generateIGTangentGraph({
+            coords: [
+                [0, 0],
+                [2, 2],
+            ],
+            pointLabels: ["A", "B"],
+        }),
+    });
+
+// Exponential graph with both curve points named via `pointLabels`. The
+// asymptote handle's announcement is unaffected (custom labels only cover
+// the curve points).
+export const exponentialWithCustomLabelsQuestion: PerseusRenderer =
+    generateInteractiveGraphQuestion({
+        content:
+            "**Drag points $A$ and $B$ so the curve passes through both labeled points above the horizontal asymptote.**\n\n[[☃ interactive-graph 1]]",
+        markings: "graph",
+        gridStep: [1, 1],
+        snapStep: [1, 1],
+        step: [1, 1],
+        range: [
+            [-10, 10],
+            [-10, 10],
+        ],
+        correct: generateIGExponentialGraph({
+            coords: [
+                [0, 3],
+                [1, 6],
+            ],
+            asymptote: 1,
+            pointLabels: ["A", "B"],
+        }),
+    });
+
+// Logarithm graph with both curve points named via `pointLabels`. The
+// vertical asymptote handle's announcement is unaffected.
+export const logarithmWithCustomLabelsQuestion: PerseusRenderer =
+    generateInteractiveGraphQuestion({
+        content:
+            "**Drag points $A$ and $B$ so the curve passes through both labeled points to the right of the vertical asymptote.**\n\n[[☃ interactive-graph 1]]",
+        markings: "graph",
+        gridStep: [1, 1],
+        snapStep: [1, 1],
+        step: [1, 1],
+        range: [
+            [-10, 10],
+            [-10, 10],
+        ],
+        correct: generateIGLogarithmGraph({
+            coords: [
+                [-4, -3],
+                [-5, -7],
+            ],
+            asymptote: -6,
+            pointLabels: ["A", "B"],
+        }),
+    });


### PR DESCRIPTION
## Summary:
- Wires `pointLabels` through the five curve interactive graphs — `quadratic`, `sinusoid`, `tangent`, `exponential`, and `logarithm` — end-to-end on the render side and unlocks the editor label fields for all five types.
- Each interactive curve point now announces its author-supplied label (e.g. *"Point A at 0 comma 0"*). When no custom label is set the existing per-type defaults are preserved unchanged:
  - **quadratic** falls back to its compound *"Point N on parabola …"* + vertex suffix.
  - **sinusoid** falls back to *"Midline intersection at …"* / *"Maximum point at …"* / *"Minimum point at …"* / *"Line through point at …"* (depending on extremum position).
  - **tangent** falls back to *"Inflection point at …"* / *"Control point at …"*.
  - **exponential** and **logarithm** fall back to *"Point 1 at …"* / *"Point 2 at …"* (the generic per-index defaults their `MovablePoint`s already produced).
- Schema shapes are inherited from PR 1: `quadratic` is `[string, string, string]` (3-tuple); `sinusoid`, `tangent`, `exponential`, and `logarithm` are `string[]` (variable, but in practice always length 2). `reshape-point-labels.ts` already covers all five types — `quadratic` via `toTrio`, the other four via `toArray` — so no foundation-file changes are needed in PR 6.

Co-Authored by Claude Code (Opus)
Issue: LEMS-3995

## Test plan:
- [ ] Reviewer manual: open the `QuadraticWithCustomLabels` / `SinusoidWithCustomLabels` / `TangentWithCustomLabels` / `ExponentialWithCustomLabels` / `LogarithmWithCustomLabels` stories. Enable the Storybook a11y addon (or VoiceOver / JAWS) and confirm each interactive point announces *"Point A / B / C at …"* matching its prompt. Confirm the existing base curve stories still announce the per-type defaults.
- [ ] Reviewer manual: open the `InteractiveGraphQuadratic` / `InteractiveGraphSinusoid` / `InteractiveGraphTangent` / `InteractiveGraphExponential` / `InteractiveGraphLogarithm` editor stories, expand "Start coordinates", and confirm each tile renders as three stacked rows — `Point N:` heading on top, `x [_]  y [_]` coord pair in the middle, and `Label [_]` field at the bottom. Type a letter into one of the label fields and confirm the rendered graph's point `aria-label` *and* the **Screen reader tree** panel update on the same render.

## PR Series
- **PR 1** — [Schema — no behavior. Only data-shape stop.](https://github.com/Khan/perseus/pull/3605)
- **PR 2** — [Foundation + Point graph](https://github.com/Khan/perseus/pull/3643)
- **PR 3** — [Polygon (shares start-coords-point.tsx); widen the gate to type === "point" || type === "polygon"](https://github.com/Khan/perseus/pull/3643)
- **PR 4** — [Lines: linear, ray](https://github.com/Khan/perseus/pull/3672)
- **PR 5** — [Multi-line: linear-system, segment](https://github.com/Khan/perseus/pull/3673)
- **follow-up PR** — [Refactor linear, point, polygon, and ray graphs to use usePointAriaLabel instead of buildPointAriaLabel](https://github.com/Khan/perseus/pull/3694)
- 👉🏼 **PR 6** — [Curves: quadratic, sinusoid, tangent, exponential, logarithm](https://github.com/Khan/perseus/pull/3696)
- **PR 7** — [Special shapes: angle, circle, absolute-value](https://github.com/Khan/perseus/pull/3697)