### PR TITLE
[Interactive Graph] Wire pointLabels through special-shape graphs (angle, circle, absolute-value)

### DIFF
--- a/.changeset/weak-singers-train.md
+++ b/.changeset/weak-singers-train.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": minor
+---
+
+[Interactive Graph] Wire pointLabels through special-shape graphs (angle, circle, absolute-value)

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-absolute-value.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-absolute-value.tsx
@@ -6,14 +6,23 @@ import type {Coord} from "@khanacademy/perseus";
 
 type AbsoluteValueCoords = [Coord, Coord];
 
-type Props = {
+interface StartCoordsAbsoluteValueProps {
     startCoords: AbsoluteValueCoords;
     onChange: (startCoords: AbsoluteValueCoords) => void;
-};
+    pointLabels: ReadonlyArray<string>;
+    onChangePointLabels: (pointLabels: ReadonlyArray<string>) => void;
+}
 
-const StartCoordsAbsoluteValue = (props: Props) => {
-    const {startCoords, onChange} = props;
+const StartCoordsAbsoluteValue = (props: StartCoordsAbsoluteValueProps) => {
+    const {startCoords, onChange, pointLabels, onChangePointLabels} = props;
     const [vertex, arm] = startCoords;
+    const updatePointLabel = (index: number, newLabel: string) => {
+        const next: [string, string] = [
+            index === 0 ? newLabel : pointLabels[0] ?? "",
+            index === 1 ? newLabel : pointLabels[1] ?? "",
+        ];
+        onChangePointLabels(next);
+    };
 
     return (
         <>
@@ -21,11 +30,15 @@ const StartCoordsAbsoluteValue = (props: Props) => {
                 label="Vertex"
                 coord={vertex}
                 onChange={(value) => onChange([value, arm])}
+                pointLabel={pointLabels[0]}
+                onPointLabelChange={(newLabel) => updatePointLabel(0, newLabel)}
             />
             <CoordInput
                 label="Arm"
                 coord={arm}
                 onChange={(value) => onChange([vertex, value])}
+                pointLabel={pointLabels[1]}
+                onPointLabelChange={(newLabel) => updatePointLabel(1, newLabel)}
             />
         </>
     );

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-angle.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-angle.tsx
@@ -11,14 +11,31 @@ import type {Coord} from "@khanacademy/perseus";
 
 type AngleCoords = [Coord, Coord, Coord];
 
-type Props = {
+interface StartCoordsAngleProps {
     startCoords: AngleCoords;
     allowReflexAngles?: boolean;
     onChange: (startCoords: AngleCoords) => void;
-};
+    pointLabels: ReadonlyArray<string>;
+    onChangePointLabels: (pointLabels: ReadonlyArray<string>) => void;
+}
 
-const StartCoordsAngle = (props: Props) => {
-    const {startCoords, allowReflexAngles, onChange} = props;
+const StartCoordsAngle = (props: StartCoordsAngleProps) => {
+    const {
+        startCoords,
+        allowReflexAngles,
+        onChange,
+        pointLabels,
+        onChangePointLabels,
+    } = props;
+    const updatePointLabel = (index: number, newLabel: string) => {
+        const next: [string, string, string] = [
+            index === 0 ? newLabel : pointLabels[0] ?? "",
+            index === 1 ? newLabel : pointLabels[1] ?? "",
+            index === 2 ? newLabel : pointLabels[2] ?? "",
+        ];
+        onChangePointLabels(next);
+    };
+
     return (
         <>
             {/* Current equation */}
@@ -29,13 +46,16 @@ const StartCoordsAngle = (props: Props) => {
                 </BodyMonospace>
             </View>
 
-            {/* Points UI */}
+            {/* Points UI — indexed to match `coords`:
+                [0]=ending side, [1]=vertex, [2]=starting side. */}
             <CoordInput
                 label="Point 1"
                 coord={startCoords[0]}
                 onChange={(value) =>
                     onChange([value, startCoords[1], startCoords[2]])
                 }
+                pointLabel={pointLabels[0]}
+                onPointLabelChange={(newLabel) => updatePointLabel(0, newLabel)}
             />
             <CoordInput
                 label="Vertex"
@@ -43,6 +63,8 @@ const StartCoordsAngle = (props: Props) => {
                 onChange={(value) =>
                     onChange([startCoords[0], value, startCoords[2]])
                 }
+                pointLabel={pointLabels[1]}
+                onPointLabelChange={(newLabel) => updatePointLabel(1, newLabel)}
             />
             <CoordInput
                 label="Point 2"
@@ -50,6 +72,8 @@ const StartCoordsAngle = (props: Props) => {
                 onChange={(value) =>
                     onChange([startCoords[0], startCoords[1], value])
                 }
+                pointLabel={pointLabels[2]}
+                onPointLabelChange={(newLabel) => updatePointLabel(2, newLabel)}
             />
         </>
     );

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-circle.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-circle.tsx
@@ -1,4 +1,5 @@
 import {View} from "@khanacademy/wonder-blocks-core";
+import {TextField} from "@khanacademy/wonder-blocks-form";
 import {Strut} from "@khanacademy/wonder-blocks-layout";
 import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
@@ -15,13 +16,15 @@ type CircleCoords = {
     radius: number;
 };
 
-type Props = {
+interface StartCoordsCircleProps {
     startCoords: CircleCoords;
     onChange: (startCoords: CircleCoords) => void;
-};
+    pointLabels: ReadonlyArray<string>;
+    onChangePointLabels: (pointLabels: ReadonlyArray<string>) => void;
+}
 
-const StartCoordsCircle = (props: Props) => {
-    const {startCoords, onChange} = props;
+const StartCoordsCircle = (props: StartCoordsCircleProps) => {
+    const {startCoords, onChange, pointLabels, onChangePointLabels} = props;
 
     const [radiusState, setRadiusState] = React.useState(
         startCoords.radius.toString(),
@@ -82,6 +85,27 @@ const StartCoordsCircle = (props: Props) => {
                     onChange={handleRadiuschange}
                     style={styles.textField}
                 />
+            </BodyText>
+
+            {/* Radius point label.
+                The schema's `pointLabels?: string[]` is interpreted for
+                circle as `[radiusPointLabel]`: only the radius point (a
+                `MovablePoint`) is labelable. The center is a
+                `MovableCircle` whose announcement describes the whole
+                shape ("Circle. The center point is at X comma Y.") and is not
+                overridden. */}
+            <Strut size={spacing.small_12} />
+            <BodyText size="medium" weight="bold" tag="span" style={styles.row}>
+                Radius point label:
+                <Strut size={spacing.small_12} />
+                <View style={styles.textField}>
+                    <TextField
+                        aria-label="Radius point name"
+                        value={pointLabels[0] ?? ""}
+                        placeholder="Radius point"
+                        onChange={(newLabel) => onChangePointLabels([newLabel])}
+                    />
+                </View>
             </BodyText>
         </View>
     );

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.test.tsx
@@ -1129,6 +1129,52 @@ describe("StartCoordSettings", () => {
                 expect(onChangeMock).toHaveBeenLastCalledWith(expectedCoords);
             },
         );
+
+        it("renders point name fields when onChangePointLabels is provided", () => {
+            // Arrange, Act — labels read as `Vertex name` / `Arm name`
+            // because CoordInput derives aria-label from each row's
+            // semantic heading.
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="absolute-value"
+                    onChange={() => {}}
+                    onChangePointLabels={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(
+                screen.getByRole("textbox", {name: "Vertex name"}),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole("textbox", {name: "Arm name"}),
+            ).toBeInTheDocument();
+        });
+
+        it("calls onChangePointLabels with the schema's 2-tuple shape when a name is typed", async () => {
+            // Arrange
+            const onChangePointLabelsMock = jest.fn();
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="absolute-value"
+                    onChange={() => {}}
+                    onChangePointLabels={onChangePointLabelsMock}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            const nameInput = screen.getByRole("textbox", {
+                name: "Vertex name",
+            });
+            await userEvent.type(nameInput, "V");
+
+            // Assert
+            expect(onChangePointLabelsMock).toHaveBeenLastCalledWith(["V", ""]);
+        });
     });
 
     describe("point graph", () => {
@@ -1540,5 +1586,102 @@ describe("StartCoordSettings", () => {
                 expect(onChangeMock).toHaveBeenLastCalledWith(expectedCoords);
             },
         );
+
+        it("renders point name fields for all three points when onChangePointLabels is provided", () => {
+            // Arrange, Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="angle"
+                    onChange={() => {}}
+                    onChangePointLabels={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert — CoordInput's aria-label derives from each row's
+            // heading: "Point 1 name" / "Vertex name" / "Point 2 name".
+            expect(
+                screen.getByRole("textbox", {name: "Point 1 name"}),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole("textbox", {name: "Vertex name"}),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByRole("textbox", {name: "Point 2 name"}),
+            ).toBeInTheDocument();
+        });
+
+        it("calls onChangePointLabels with the schema's 3-tuple shape when the vertex name is typed", async () => {
+            // Arrange
+            const onChangePointLabelsMock = jest.fn();
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="angle"
+                    onChange={() => {}}
+                    onChangePointLabels={onChangePointLabelsMock}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act — the vertex maps to coords index 1.
+            const nameInput = screen.getByRole("textbox", {
+                name: "Vertex name",
+            });
+            await userEvent.type(nameInput, "V");
+
+            // Assert
+            expect(onChangePointLabelsMock).toHaveBeenLastCalledWith([
+                "",
+                "V",
+                "",
+            ]);
+        });
+    });
+
+    describe("circle graph pointLabels", () => {
+        it("renders the radius point label field when onChangePointLabels is provided", () => {
+            // Arrange, Act
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="circle"
+                    onChange={() => {}}
+                    onChangePointLabels={() => {}}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Assert
+            expect(
+                screen.getByRole("textbox", {name: "Radius point name"}),
+            ).toBeInTheDocument();
+        });
+
+        it("calls onChangePointLabels with a 1-element array when the radius point label is typed", async () => {
+            // Arrange — the schema is `string[]` and circle only labels
+            // the radius point (index 0), so a single-element array is
+            // the expected emitted shape.
+            const onChangePointLabelsMock = jest.fn();
+            render(
+                <StartCoordsSettings
+                    {...defaultProps}
+                    type="circle"
+                    onChange={() => {}}
+                    onChangePointLabels={onChangePointLabelsMock}
+                />,
+                {wrapper: RenderStateRoot},
+            );
+
+            // Act
+            const nameInput = screen.getByRole("textbox", {
+                name: "Radius point name",
+            });
+            await userEvent.type(nameInput, "R");
+
+            // Assert
+            expect(onChangePointLabelsMock).toHaveBeenLastCalledWith(["R"]);
+        });
     });
 });

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
@@ -70,6 +70,8 @@ const StartCoordsSettingsInner = (props: Props) => {
                 <StartCoordsAbsoluteValue
                     startCoords={absoluteValueCoords}
                     onChange={onChange}
+                    pointLabels={props.pointLabels ?? []}
+                    onChangePointLabels={onChangePointLabels}
                 />
             );
         // Graphs with startCoords of type CollinearTuple
@@ -113,6 +115,8 @@ const StartCoordsSettingsInner = (props: Props) => {
                 <StartCoordsCircle
                     startCoords={{center: circleCoords.center, radius}}
                     onChange={onChange}
+                    pointLabels={props.pointLabels ?? []}
+                    onChangePointLabels={onChangePointLabels}
                 />
             );
         case "sinusoid":
@@ -215,6 +219,8 @@ const StartCoordsSettingsInner = (props: Props) => {
                     startCoords={angleCoords}
                     allowReflexAngles={allowReflexAngles}
                     onChange={onChange}
+                    pointLabels={props.pointLabels ?? []}
+                    onChangePointLabels={onChangePointLabels}
                 />
             );
         default:

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
@@ -24,6 +24,9 @@ import {
     segmentWithAllLockedLineVariations,
     segmentWithAllLockedRayVariations,
     absoluteValueQuestion,
+    absoluteValueWithCustomLabelsQuestion,
+    angleWithCustomLabelsQuestion,
+    circleWithCustomLabelsQuestion,
     exponentialQuestion,
     exponentialWithCustomLabelsQuestion,
     logarithmQuestion,
@@ -74,9 +77,39 @@ export const Angle: Story = {
     },
 };
 
+/**
+ * An angle whose vertex and two side points are named "B", "A", and "C"
+ * via `pointLabels`. The schema array is indexed by `coords`:
+ * `[endingSide, vertex, startingSide]`. Overrides the default "Point 1,
+ * vertex …" / "Point 2, ending side …" / "Point 3, starting side …"
+ * announcements so JAWS reads the prompt's letter names instead.
+ */
+export const AngleWithCustomLabels: Story = {
+    args: {
+        item: generateTestPerseusItem({
+            question: angleWithCustomLabelsQuestion,
+        }),
+    },
+};
+
 export const Circle: Story = {
     args: {
         item: generateTestPerseusItem({question: circleQuestion}),
+    },
+};
+
+/**
+ * A circle whose radius point is named "R" via `pointLabels`. Schema
+ * `string[]` for circle is interpreted as `[radiusPointLabel]` — only
+ * the radius point (a `MovablePoint`) is labelable. The center is a
+ * `MovableCircle` whose announcement describes the whole shape and is
+ * intentionally not overridden.
+ */
+export const CircleWithCustomLabels: Story = {
+    args: {
+        item: generateTestPerseusItem({
+            question: circleWithCustomLabelsQuestion,
+        }),
     },
 };
 
@@ -320,6 +353,20 @@ export const QuadraticWithCustomLabels: Story = {
 export const AbsoluteValue: Story = {
     args: {
         item: generateTestPerseusItem({question: absoluteValueQuestion}),
+    },
+};
+
+/**
+ * An absolute value graph whose vertex and arm point are named "V" and
+ * "A" via `pointLabels`. Overrides the default "Vertex point at …" /
+ * "Point on arm at …" semantic labels so the SR announcement matches
+ * the prompt's naming convention.
+ */
+export const AbsoluteValueWithCustomLabels: Story = {
+    args: {
+        item: generateTestPerseusItem({
+            question: absoluteValueWithCustomLabelsQuestion,
+        }),
     },
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/absolute-value.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/absolute-value.test.tsx
@@ -218,3 +218,90 @@ describe("Absolute value graph screen reader", () => {
         expect(points[1]).toHaveAccessibleName("Point on arm at 3 comma 5.");
     });
 });
+
+// TODO(LEMS-3995, post-PR-7): route the absolute-value SR-tree summary through buildPointAriaLabel once new locale string keys land.
+describe("Absolute value graph pointLabels", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("uses custom pointLabels in each point's accessible name", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseAbsoluteValueState, pointLabels: ["A", "B"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point A at 0 comma 0."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at 2 comma 2."}),
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to the default semantic label for indices without a custom label", () => {
+        // Arrange, Act — only the vertex is named
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseAbsoluteValueState, pointLabels: ["A"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point A at 0 comma 0."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point on arm at 2 comma 2."}),
+        ).toBeInTheDocument();
+    });
+
+    // The editor encodes "only the arm point named" as `["", "B"]`.
+    // An empty string at any index must fall back to the semantic default.
+    it("falls back to the default semantic label for explicit empty-string entries", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseAbsoluteValueState, pointLabels: ["", "B"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Vertex point at 0 comma 0."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at 2 comma 2."}),
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to the default semantic label for truthy non-string entries (defensive against malformed hand-authored JSON bypassing the parser)", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseAbsoluteValueState,
+                    // eslint-disable-next-line no-restricted-syntax -- cast simulates malformed JSON the parser would reject
+                    pointLabels: [42, "B"] as unknown as string[],
+                }}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Vertex point at 0 comma 0."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point B at 2 comma 2."}),
+        ).toBeInTheDocument();
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/absolute-value.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/absolute-value.tsx
@@ -9,6 +9,7 @@ import {X, Y} from "../math/coordinates";
 import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 
+import {usePointAriaLabel} from "./components/build-point-aria-label";
 import {ClipToGraphBounds} from "./components/clip-to-graph-bounds";
 import {MovablePoint} from "./components/movable-point";
 import SRDescInSVG from "./components/sr-description-within-svg";
@@ -45,7 +46,8 @@ function AbsoluteValueGraph(props: AbsoluteValueGraphProps) {
     const id = React.useId();
     const descriptionId = id + "-description";
 
-    const {coords, snapStep} = graphState;
+    const {coords, pointLabels, snapStep} = graphState;
+    const buildLabel = usePointAriaLabel(pointLabels);
 
     // Cache last valid coefficients to protect against transient invalid
     // states that can occur mid-drag (e.g., both points on the same x).
@@ -83,9 +85,10 @@ function AbsoluteValueGraph(props: AbsoluteValueGraphProps) {
                 <MovablePoint
                     key={"point-" + i}
                     ariaLabel={
-                        i === 0
+                        buildLabel(i, coord) ??
+                        (i === 0
                             ? srAbsoluteValueVertexPoint
-                            : srAbsoluteValueSecondPoint
+                            : srAbsoluteValueSecondPoint)
                     }
                     point={coord}
                     sequenceNumber={i + 1}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/angle.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/angle.test.tsx
@@ -172,6 +172,95 @@ describe("Angle graph screen reader", () => {
     });
 });
 
+// TODO(LEMS-3995, post-PR-7): route the angle SR-tree summary through buildPointAriaLabel once new locale string keys land.
+describe("Angle graph pointLabels", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    // pointLabels is indexed by `coords`: [0]=ending side, [1]=vertex,
+    // [2]=starting side. The MovablePoints are rendered in a different
+    // DOM order (vertex first), but each assertion just queries by
+    // accessible name.
+    it("uses custom pointLabels in each point's accessible name", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsProps}
+                state={{...baseAngleState, pointLabels: ["A", "B", "C"]}}
+                dispatch={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point B at 0 comma 0."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point A at -1 comma 1."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point C at 1 comma 1."}),
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to the default semantic label for indices without a custom label", () => {
+        // Arrange, Act — only the vertex (index 1) is named
+        render(
+            <MafsGraph
+                {...baseMafsProps}
+                state={{...baseAngleState, pointLabels: ["", "B", ""]}}
+                dispatch={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point B at 0 comma 0."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {
+                name: "Point 2, ending side at -1 comma 1.",
+            }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {
+                name: "Point 3, starting side at 1 comma 1.",
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to the default semantic label for truthy non-string entries (defensive against malformed hand-authored JSON bypassing the parser)", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsProps}
+                state={{
+                    ...baseAngleState,
+                    // eslint-disable-next-line no-restricted-syntax -- cast simulates malformed JSON the parser would reject
+                    pointLabels: [42, "B", "C"] as unknown as string[],
+                }}
+                dispatch={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point B at 0 comma 0."}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {
+                name: "Point 2, ending side at -1 comma 1.",
+            }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Point C at 1 comma 1."}),
+        ).toBeInTheDocument();
+    });
+});
+
 describe("getAngleSideConstraint", () => {
     it("prevents vertical movement given a vertical side of an angle", () => {
         const side: vec.Vector2 = [0, 5];

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/angle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/angle.tsx
@@ -9,6 +9,7 @@ import {actions} from "../reducer/interactive-graph-action";
 import useGraphConfig from "../reducer/use-graph-config";
 
 import {Angle} from "./components/angle-indicators";
+import {usePointAriaLabel} from "./components/build-point-aria-label";
 import {trimRange} from "./components/movable-line";
 import {MovablePoint} from "./components/movable-point";
 import SRDescInSVG from "./components/sr-description-within-svg";
@@ -50,8 +51,19 @@ function AngleGraph(props: AngleGraphProps) {
     const id = React.useId();
     const descriptionId = id + "-description";
 
-    const {coords, showAngles, range, allowReflexAngles, snapDegrees} =
-        graphState;
+    const {
+        coords,
+        pointLabels,
+        showAngles,
+        range,
+        allowReflexAngles,
+        snapDegrees,
+    } = graphState;
+    // pointLabels is indexed by `coords`: [0]=ending side, [1]=vertex,
+    // [2]=starting side. The MovablePoints below are rendered in a
+    // different order (vertex first), so each call site indexes pointLabels
+    // by the coords slot it is bound to.
+    const buildLabel = usePointAriaLabel(pointLabels);
 
     // Break the coords into the two end points and the center point
     const endPoints: [vec.Vector2, vec.Vector2] = [coords[0], coords[2]];
@@ -130,7 +142,7 @@ function AngleGraph(props: AngleGraphProps) {
                 onMove={(destination: vec.Vector2) =>
                     dispatch(actions.angle.movePoint(1, destination))
                 }
-                ariaLabel={srAngleVertex}
+                ariaLabel={buildLabel(1, coords[1]) ?? srAngleVertex}
             />
             {/* side 1 */}
             <MovablePoint
@@ -144,7 +156,7 @@ function AngleGraph(props: AngleGraphProps) {
                 onMove={(destination: vec.Vector2) =>
                     dispatch(actions.angle.movePoint(0, destination))
                 }
-                ariaLabel={srAngleEndingSide}
+                ariaLabel={buildLabel(0, coords[0]) ?? srAngleEndingSide}
             />
             {/* side 2 */}
             <MovablePoint
@@ -158,7 +170,7 @@ function AngleGraph(props: AngleGraphProps) {
                 onMove={(destination: vec.Vector2) =>
                     dispatch(actions.angle.movePoint(2, destination))
                 }
-                ariaLabel={srAngleStartingSide}
+                ariaLabel={buildLabel(2, coords[2]) ?? srAngleStartingSide}
             />
             <SRDescInSVG id={descriptionId}>
                 {srAngleGraphAriaDescription}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.test.tsx
@@ -354,6 +354,91 @@ describe("describeCircleGraph", () => {
     });
 });
 
+// pointLabels for circle is interpreted as `[radiusPointLabel]`: only the
+// radius point (a `MovablePoint`) is labelable. The center is a
+// `MovableCircle` whose announcement describes the whole shape and is not
+// overridden. The SR-tree summary is deferred to the post-PR-7 i18n work.
+// TODO(LEMS-3995, post-PR-7): route the circle SR-tree summary through buildPointAriaLabel once new locale string keys land.
+describe("Circle graph pointLabels", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("uses a custom pointLabels[0] for the radius point's accessible name", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseCircleState, pointLabels: ["R"]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Point R at 1 comma 0."}),
+        ).toBeInTheDocument();
+    });
+
+    it("does not override the center's announcement", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseCircleState, pointLabels: ["R"]}}
+            />,
+        );
+
+        // Assert — the center is a MovableCircle and intentionally NOT
+        // labelable; its announcement keeps its shape description even
+        // when `pointLabels` is set.
+        expect(
+            screen.getByRole("button", {
+                name: "Circle. The center point is at 0 comma 0.",
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to the default semantic label for an empty-string entry", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{...baseCircleState, pointLabels: [""]}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {
+                name: "Right radius endpoint at 1 comma 0. Circle radius is 1.",
+            }),
+        ).toBeInTheDocument();
+    });
+
+    it("falls back to the default semantic label for truthy non-string entries (defensive against malformed hand-authored JSON bypassing the parser)", () => {
+        // Arrange, Act
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseCircleState,
+                    // eslint-disable-next-line no-restricted-syntax -- cast simulates malformed JSON the parser would reject
+                    pointLabels: [42] as unknown as string[],
+                }}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {
+                name: "Right radius endpoint at 1 comma 0. Circle radius is 1.",
+            }),
+        ).toBeInTheDocument();
+    });
+});
+
 describe("getCircleKeyboardConstraint", () => {
     it("should snap to the snapStep and avoid putting points on a vertical line", () => {
         const radiusPoint: vec.Vector2 = [0, 0];

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -8,6 +8,7 @@ import {actions} from "../reducer/interactive-graph-action";
 import {getRadius} from "../reducer/interactive-graph-state";
 import useGraphConfig from "../reducer/use-graph-config";
 
+import {usePointAriaLabel} from "./components/build-point-aria-label";
 import {ClipToGraphBounds} from "./components/clip-to-graph-bounds";
 import Hairlines from "./components/hairlines";
 import {MovablePoint} from "./components/movable-point";
@@ -47,9 +48,10 @@ type CircleGraphProps = MafsGraphProps<CircleGraphState>;
 // Exported for testing
 export function CircleGraph(props: CircleGraphProps) {
     const {dispatch, graphState} = props;
-    const {center, radiusPoint, snapStep} = graphState;
+    const {center, pointLabels, radiusPoint, snapStep} = graphState;
 
     const {strings, locale} = usePerseusI18n();
+    const buildLabel = usePointAriaLabel(pointLabels);
 
     const radius = getRadius(graphState);
     const id = React.useId();
@@ -84,8 +86,17 @@ export function CircleGraph(props: CircleGraphProps) {
                 }}
             />
             <MovablePoint
-                // Radius point aria label reads with every update.
-                ariaLabel={`${srCircleRadiusPoint} ${srCircleRadius}`}
+                // Radius point aria label reads with every update. The
+                // schema `pointLabels?: string[]` is interpreted for
+                // circle as `[radiusPointLabel]` — only the radius point
+                // (a `MovablePoint`) is labelable. The center is a
+                // `MovableCircle` whose announcement describes the whole
+                // shape ("Circle. The center point is at X comma Y.") and is not
+                // overridden.
+                ariaLabel={
+                    buildLabel(0, radiusPoint) ??
+                    `${srCircleRadiusPoint} ${srCircleRadius}`
+                }
                 // Aria-describedby describes additional info on focus.
                 ariaDescribedBy={`${outerPointsId}`}
                 point={radiusPoint}

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -1576,3 +1576,58 @@ export const logarithmWithCustomLabelsQuestion: PerseusRenderer =
             pointLabels: ["A", "B"],
         }),
     });
+
+// Angle graph with all three handles named via `pointLabels`. The array
+// is indexed by `coords` order: [0]=ending side, [1]=vertex, [2]=starting
+// side. JAWS will announce "Point A / B / C at …" in coord order while
+// the visual DOM order is vertex first (it stays focusable first).
+export const angleWithCustomLabelsQuestion: PerseusRenderer =
+    generateInteractiveGraphQuestion({
+        content:
+            "**Drag the vertex $B$ and the rays through points $A$ and $C$ so the angle measures 90°.**\n\n[[☃ interactive-graph 1]]",
+        snapStep: [1, 1],
+        correct: generateIGAngleGraph({
+            coords: [
+                [-1, 1],
+                [0, 0],
+                [1, 1],
+            ],
+            showAngles: true,
+            allowReflexAngles: true,
+            pointLabels: ["A", "B", "C"],
+        }),
+    });
+
+// Absolute-value graph with the vertex named "V" and the arm point named
+// "A" via `pointLabels`. Overrides the default "Vertex point at …" /
+// "Point on arm at …" labels.
+export const absoluteValueWithCustomLabelsQuestion: PerseusRenderer =
+    generateInteractiveGraphQuestion({
+        content:
+            "**Drag the vertex $V$ to the origin and the arm point $A$ so the slope is 1.**\n\n[[☃ interactive-graph 1]]",
+        snapStep: [1, 1],
+        correct: generateIGAbsoluteValueGraph({
+            coords: [
+                [0, 0],
+                [2, 2],
+            ],
+            pointLabels: ["V", "A"],
+        }),
+    });
+
+// Circle graph with the radius point named "R" via `pointLabels`. The
+// schema array for circle is interpreted as `[radiusPointLabel]` — only
+// the radius point (a `MovablePoint`) is labelable. The center is a
+// `MovableCircle` whose announcement describes the whole shape and is
+// not overridden.
+export const circleWithCustomLabelsQuestion: PerseusRenderer =
+    generateInteractiveGraphQuestion({
+        content:
+            "**Drag the radius point $R$ so the circle has radius 3.**\n\n[[☃ interactive-graph 1]]",
+        snapStep: [1, 1],
+        correct: generateIGCircleGraph({
+            center: [0, 0],
+            radius: 3,
+            pointLabels: ["R"],
+        }),
+    });


### PR DESCRIPTION
## Summary:
- Wires `pointLabels` through the three special-shape interactive graphs — `angle`, `circle`, and `absolute-value` — closing out the LEMS-3995 rollout (PRs 1–6 already shipped).
- Each interactive `MovablePoint` now announces its author-supplied label when set. Per-type fallbacks when `pointLabels` is unset, empty, or non-string:
  - **angle** falls back to the existing slot-aware semantic defaults: *"Point 1, vertex at …"* / *"Point 2, ending side at …"* / *"Point 3, starting side at …"*.
  - **absolute-value** falls back to *"Vertex point at …"* / *"Point on arm at …"*.
  - **circle** falls back to the compound *"Right/Left radius endpoint at … Circle radius is N."* — see scope note below.

Co-Authored by Claude Code (Opus)
Issue: LEMS-3995

## Test plan:
- [ ] Reviewer manual: open the `AngleWithCustomLabels` / `CircleWithCustomLabels` / `AbsoluteValueWithCustomLabels` stories. Enable the Storybook a11y addon (or VoiceOver / JAWS) and confirm each interactive handle announces *"Point A / B / C / V / R at …"* matching its prompt. Confirm the existing base stories still announce the per-type defaults. For circle, confirm the center's announcement (*"Circle. The center point is at …"*) is NOT overridden even when `pointLabels` is set.
- [ ] Reviewer manual: open the `InteractiveGraphAngle` / `InteractiveGraphCircle` / `InteractiveGraphAbsoluteValue` editor stories, expand "Start coordinates", and confirm each label field is present. For angle/absolute-value, the field sits inside the existing `CoordInput` tile. For circle, the field appears as a separate "Radius point label:" row at the bottom (only visible when `onChangePointLabels` is wired by the surrounding `interactive-graph-editor.tsx`). Type a letter into each field and confirm the rendered graph's point `aria-label` *and* the **Screen reader tree** panel update on the same render.

## PR Series
- **PR 1** — [Schema — no behavior. Only data-shape stop.](https://github.com/Khan/perseus/pull/3605)
- **PR 2** — [Foundation + Point graph](https://github.com/Khan/perseus/pull/3643)
- **PR 3** — [Polygon (shares start-coords-point.tsx); widen the gate to type === "point" || type === "polygon"](https://github.com/Khan/perseus/pull/3643)
- **PR 4** — [Lines: linear, ray](https://github.com/Khan/perseus/pull/3672)
- **PR 5** — [Multi-line: linear-system, segment](https://github.com/Khan/perseus/pull/3673)
- **follow-up PR** — [Refactor linear, point, polygon, and ray graphs to use usePointAriaLabel instead of buildPointAriaLabel](https://github.com/Khan/perseus/pull/3694)
- **PR 6** — [Curves: quadratic, sinusoid, tangent, exponential, logarithm](https://github.com/Khan/perseus/pull/3696)
- 👉🏼 **PR 7** — [Special shapes: angle, circle, absolute-value](https://github.com/Khan/perseus/pull/3697)