### PR TITLE
docs(changeset): Added a label to define with the definition widget button does for screenreaders

### DIFF
--- a/.changeset/seven-experts-move.md
+++ b/.changeset/seven-experts-move.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Added a label to define with the definition widget button does for screenreaders

--- a/packages/perseus/src/widgets/definition/definition.tsx
+++ b/packages/perseus/src/widgets/definition/definition.tsx
@@ -91,6 +91,10 @@ class Definition extends React.Component<DefinitionProps> implements Widget {
                                 this.props.trackInteraction();
                                 setActiveDefinitionId(this.props.widgetId);
                             }}
+                            aria-label={`Click for the definition of: ${this.props.togglePrompt}`}
+                            aria-expanded={
+                                activeDefinitionId === this.props.widgetId
+                            }
                         >
                             {() => (
                                 <span className={styles.definition}>


### PR DESCRIPTION
## Summary:
[LEMS-4104/the-purpose-of-clickable-definition-buttons-in-question-text-is-unclear] Added a label to define what the definition widget button does for screenreaders

Issue: LEMS-4104

## Test plan: