### PR TITLE
[Definitions] Added a label to define with the definition widget button does for screenreaders

### DIFF
--- a/.changeset/nervous-berries-move.md
+++ b/.changeset/nervous-berries-move.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Added a label to define what the definition widget button does for screenreaders

--- a/packages/perseus/src/widgets/definition/__docs__/definition-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/definition/__docs__/definition-interactions-regression.stories.tsx
@@ -31,7 +31,7 @@ export const FocusedState = {
     },
     play: async ({canvas}) => {
         const definitionTrigger = canvas.getByRole("button", {
-            name: "the Pequots",
+            name: "Definition of: the Pequots",
         });
         definitionTrigger.focus();
     },
@@ -45,7 +45,7 @@ export const ClickedState = {
     },
     play: async ({canvas, userEvent}) => {
         const definitionTrigger = canvas.getByRole("button", {
-            name: "the Pequots",
+            name: "Definition of: the Pequots",
         });
         await userEvent.click(definitionTrigger);
     },

--- a/packages/perseus/src/widgets/definition/__snapshots__/definition.test.ts.snap
+++ b/packages/perseus/src/widgets/definition/__snapshots__/definition.test.ts.snap
@@ -29,6 +29,7 @@ exports[`Definition widget should have a default snapshot: first render 1`] = `
           <button
             aria-controls=":r0:"
             aria-expanded="false"
+            aria-label="Definition of: the Pequots"
             class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
             id=":r0:-anchor"
             type="button"
@@ -76,6 +77,7 @@ exports[`Definition widget should have an open state snapshot: open state 1`] = 
           <button
             aria-controls=":r2:"
             aria-expanded="true"
+            aria-label="Definition of: the Pequots"
             class="button_vr44p2-o_O-reset_152ygtm-o_O-link_13xlah4"
             id=":r2:-anchor"
             type="button"

--- a/packages/perseus/src/widgets/definition/definition.tsx
+++ b/packages/perseus/src/widgets/definition/definition.tsx
@@ -91,6 +91,7 @@ class Definition extends React.Component<DefinitionProps> implements Widget {
                                 this.props.trackInteraction();
                                 setActiveDefinitionId(this.props.widgetId);
                             }}
+                            aria-label={`Definition of: ${this.props.togglePrompt}`}
                         >
                             {() => (
                                 <span className={styles.definition}>


### PR DESCRIPTION
## Summary:
[LEMS-4104/the-purpose-of-clickable-definition-buttons-in-question-text-is-unclear] Added a label to define what the definition widget button does for screenreaders

Issue: LEMS-4104

## Test plan:
- Go to definition widget and use the voiceover tool to see if the button is read out as "Definition of: {Word}"