### PR TITLE
refactor: locked polygon points shape

### DIFF
--- a/.changeset/hungry-masks-hang.md
+++ b/.changeset/hungry-masks-hang.md
@@ -1,0 +1,8 @@
+---
+"@khanacademy/perseus-core": major
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-editor": minor
+"@khanacademy/perseus-linter": minor
+---
+
+Change shape of `LockedPolygonType.points` from `[]Coord` to `LockedPolygonPointType`. This is to support adding fields to the Locked Polygon points in the future. Callers should migrate to using the new shape.

--- a/__docs__/sample-data.ts
+++ b/__docs__/sample-data.ts
@@ -83,15 +83,13 @@ export const graphExample: PerseusRenderer = {
                         color: "gold",
                         weight: "thick",
                         fillStyle: "translucent",
-                        points: {
-                            coord: [
-                                [7, -3],
-                                [8, -5],
-                                [4, -7],
-                                [0, -7],
-                                [2, -3],
-                            ],
-                        },
+                        points: [
+                            {coord: [7, -3]},
+                            {coord: [8, -5]},
+                            {coord: [4, -7]},
+                            {coord: [0, -7]},
+                            {coord: [2, -3]},
+                        ],
                         showVertices: false,
                         strokeStyle: "solid",
                     },

--- a/__docs__/sample-data.ts
+++ b/__docs__/sample-data.ts
@@ -83,13 +83,15 @@ export const graphExample: PerseusRenderer = {
                         color: "gold",
                         weight: "thick",
                         fillStyle: "translucent",
-                        points: [
-                            [7, -3],
-                            [8, -5],
-                            [4, -7],
-                            [0, -7],
-                            [2, -3],
-                        ],
+                        points: {
+                            coord: [
+                                [7, -3],
+                                [8, -5],
+                                [4, -7],
+                                [0, -7],
+                                [2, -3],
+                            ],
+                        },
                         showVertices: false,
                         strokeStyle: "solid",
                     },

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1076,12 +1076,12 @@ export type LockedEllipseType = {
 };
 
 export type LockedPolygonPointType = {
-    coord: Coord[];
+    coord: Coord;
 };
 
 export type LockedPolygonType = {
     type: "polygon";
-    points: LockedPolygonPointType;
+    points: LockedPolygonPointType[];
     color: LockedFigureColor;
     showVertices: boolean;
     fillStyle: LockedFigureFillType;

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1075,9 +1075,13 @@ export type LockedEllipseType = {
     ariaLabel?: string;
 };
 
+export type LockedPolygonPointType = {
+    coord: Coord[];
+};
+
 export type LockedPolygonType = {
     type: "polygon";
-    points: Coord[];
+    points: LockedPolygonPointType;
     color: LockedFigureColor;
     showVertices: boolean;
     fillStyle: LockedFigureFillType;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.test.ts
@@ -410,13 +410,11 @@ describe("parseInteractiveGraphWidget", () => {
                     lockedFigures: [
                         {
                             type: "polygon",
-                            points: {
-                                coord: [
-                                    [0, 0],
-                                    [1, 0],
-                                    [1, 1],
-                                ],
-                            },
+                            points: [
+                                {coord: [0, 0]},
+                                {coord: [1, 0]},
+                                {coord: [1, 1]},
+                            ],
                             color: "blue",
                             showVertices: false,
                             fillStyle: "none",
@@ -456,13 +454,11 @@ describe("parseInteractiveGraphWidget", () => {
                     lockedFigures: [
                         {
                             type: "polygon",
-                            points: {
-                                coord: [
-                                    [0, 0],
-                                    [1, 0],
-                                    [1, 1],
-                                ],
-                            },
+                            points: [
+                                {coord: [0, 0]},
+                                {coord: [1, 0]},
+                                {coord: [1, 1]},
+                            ],
                             color: "blue",
                             showVertices: false,
                             fillStyle: "none",
@@ -545,13 +541,11 @@ describe("parseInteractiveGraphWidget", () => {
                     lockedFigures: [
                         {
                             type: "polygon",
-                            points: {
-                                coord: [
-                                    [0, 0],
-                                    [1, 0],
-                                    [1, 1],
-                                ],
-                            },
+                            points: [
+                                {coord: [0, 0]},
+                                {coord: [1, 0]},
+                                {coord: [1, 1]},
+                            ],
                             color: "blue",
                             showVertices: false,
                             fillStyle: "none",

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.test.ts
@@ -385,6 +385,186 @@ describe("parseInteractiveGraphWidget", () => {
         );
     });
 
+    it("parses locked polygon points with coord field", () => {
+        const result = parse(
+            {
+                type: "interactive-graph",
+                options: {
+                    step: [1, 1],
+                    markings: "grid",
+                    showProtractor: false,
+                    range: [
+                        [-10, 10],
+                        [-10, 10],
+                    ],
+                    showAxisArrows: {
+                        xMin: true,
+                        xMax: true,
+                        yMin: true,
+                        yMax: true,
+                    },
+                    showAxisTicks: {x: true, y: true},
+                    correct: {
+                        type: "linear",
+                    },
+                    lockedFigures: [
+                        {
+                            type: "polygon",
+                            points: {
+                                coord: [
+                                    [0, 0],
+                                    [1, 0],
+                                    [1, 1],
+                                ],
+                            },
+                            color: "blue",
+                            showVertices: false,
+                            fillStyle: "none",
+                            strokeStyle: "solid",
+                            weight: "medium",
+                        },
+                    ],
+                },
+            },
+            parseInteractiveGraphWidget,
+        );
+
+        expect(result).toEqual(
+            success({
+                type: "interactive-graph",
+                options: {
+                    step: [1, 1],
+                    markings: "grid",
+                    showProtractor: false,
+                    range: [
+                        [-10, 10],
+                        [-10, 10],
+                    ],
+                    showAxisArrows: {
+                        xMin: true,
+                        xMax: true,
+                        yMin: true,
+                        yMax: true,
+                    },
+                    showAxisTicks: {x: true, y: true},
+                    correct: {
+                        type: "linear",
+                    },
+                    graph: {
+                        type: "linear",
+                    },
+                    lockedFigures: [
+                        {
+                            type: "polygon",
+                            points: {
+                                coord: [
+                                    [0, 0],
+                                    [1, 0],
+                                    [1, 1],
+                                ],
+                            },
+                            color: "blue",
+                            showVertices: false,
+                            fillStyle: "none",
+                            strokeStyle: "solid",
+                            weight: "medium",
+                            labels: [],
+                        },
+                    ],
+                },
+            }),
+        );
+    });
+
+    it("normalizes legacy locked polygon points array to coord field", () => {
+        const result = parse(
+            {
+                type: "interactive-graph",
+                options: {
+                    step: [1, 1],
+                    markings: "grid",
+                    showProtractor: false,
+                    range: [
+                        [-10, 10],
+                        [-10, 10],
+                    ],
+                    showAxisArrows: {
+                        xMin: true,
+                        xMax: true,
+                        yMin: true,
+                        yMax: true,
+                    },
+                    showAxisTicks: {x: true, y: true},
+                    correct: {
+                        type: "linear",
+                    },
+                    lockedFigures: [
+                        {
+                            type: "polygon",
+                            points: [
+                                [0, 0],
+                                [1, 0],
+                                [1, 1],
+                            ],
+                            color: "blue",
+                            showVertices: false,
+                            fillStyle: "none",
+                            strokeStyle: "solid",
+                            weight: "medium",
+                        },
+                    ],
+                },
+            },
+            parseInteractiveGraphWidget,
+        );
+
+        expect(result).toEqual(
+            success({
+                type: "interactive-graph",
+                options: {
+                    step: [1, 1],
+                    markings: "grid",
+                    showProtractor: false,
+                    range: [
+                        [-10, 10],
+                        [-10, 10],
+                    ],
+                    showAxisArrows: {
+                        xMin: true,
+                        xMax: true,
+                        yMin: true,
+                        yMax: true,
+                    },
+                    showAxisTicks: {x: true, y: true},
+                    correct: {
+                        type: "linear",
+                    },
+                    graph: {
+                        type: "linear",
+                    },
+                    lockedFigures: [
+                        {
+                            type: "polygon",
+                            points: {
+                                coord: [
+                                    [0, 0],
+                                    [1, 0],
+                                    [1, 1],
+                                ],
+                            },
+                            color: "blue",
+                            showVertices: false,
+                            fillStyle: "none",
+                            strokeStyle: "solid",
+                            weight: "medium",
+                            labels: [],
+                        },
+                    ],
+                },
+            }),
+        );
+    });
+
     it("rejects unrecognized color names on locked figures", () => {
         const result = parse(
             {

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -256,9 +256,18 @@ const parseLockedEllipseType = object({
     ariaLabel: optional(string),
 });
 
+const parseLockedPolygonPointsType = union(
+    object({
+        coord: array(pairOfNumbers),
+    }),
+).or(
+    pipeParsers(array(pairOfNumbers)).then(convert((coord) => ({coord})))
+        .parser,
+).parser;
+
 const parseLockedPolygonType = object({
     type: constant("polygon"),
-    points: array(pairOfNumbers),
+    points: parseLockedPolygonPointsType,
     color: parseLockedFigureColor,
     showVertices: boolean,
     fillStyle: parseLockedFigureFillType,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -260,20 +260,13 @@ const parseLockedPolygonPointType = object({
     coord: pairOfNumbers,
 });
 
-const parseLockedPolygonPointsType = union(array(parseLockedPolygonPointType))
-    .or(
-        pipeParsers(array(pairOfNumbers)).then(
-            convert((coords) => coords.map((coord) => ({coord}))),
-        ).parser,
-    )
-    .or(
-        pipeParsers(
-            object({
-                coord: array(pairOfNumbers),
-            }),
-        ).then(convert(({coord}) => coord.map((point) => ({coord: point}))))
-            .parser,
-    ).parser;
+const parseLockedPolygonPointsType = union(
+    array(parseLockedPolygonPointType),
+).or(
+    pipeParsers(array(pairOfNumbers)).then(
+        convert((coords) => coords.map((coord) => ({coord}))),
+    ).parser,
+).parser;
 
 const parseLockedPolygonType = object({
     type: constant("polygon"),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -256,14 +256,24 @@ const parseLockedEllipseType = object({
     ariaLabel: optional(string),
 });
 
-const parseLockedPolygonPointsType = union(
-    object({
-        coord: array(pairOfNumbers),
-    }),
-).or(
-    pipeParsers(array(pairOfNumbers)).then(convert((coord) => ({coord})))
-        .parser,
-).parser;
+const parseLockedPolygonPointType = object({
+    coord: pairOfNumbers,
+});
+
+const parseLockedPolygonPointsType = union(array(parseLockedPolygonPointType))
+    .or(
+        pipeParsers(array(pairOfNumbers)).then(
+            convert((coords) => coords.map((coord) => ({coord}))),
+        ).parser,
+    )
+    .or(
+        pipeParsers(
+            object({
+                coord: array(pairOfNumbers),
+            }),
+        ).then(convert(({coord}) => coord.map((point) => ({coord: point}))))
+            .parser,
+    ).parser;
 
 const parseLockedPolygonType = object({
     type: constant("polygon"),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -263,6 +263,8 @@ const parseLockedPolygonPointType = object({
 const parseLockedPolygonPointsType = union(
     array(parseLockedPolygonPointType),
 ).or(
+    // Normalize legacy representation of points as Coord[] to
+    // LockedPolygonPointType[].
     pipeParsers(array(pairOfNumbers)).then(
         convert((coords) => coords.map((coord) => ({coord}))),
     ).parser,

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -6971,22 +6971,26 @@ exports[`parseAndMigratePerseusItem given interactive-graph-locked-figures-missi
               "color": "pink",
               "fillStyle": "none",
               "labels": [],
-              "points": {
-                "coord": [
-                  [
+              "points": [
+                {
+                  "coord": [
                     -8,
                     -7,
                   ],
-                  [
+                },
+                {
+                  "coord": [
                     -8,
                     -3,
                   ],
-                  [
+                },
+                {
+                  "coord": [
                     -4,
                     -3,
                   ],
-                ],
-              },
+                },
+              ],
               "showVertices": false,
               "strokeStyle": "solid",
               "type": "polygon",
@@ -7249,22 +7253,26 @@ exports[`parseAndMigratePerseusItem given interactive-graph-locked-figures-missi
               "color": "pink",
               "fillStyle": "none",
               "labels": [],
-              "points": {
-                "coord": [
-                  [
+              "points": [
+                {
+                  "coord": [
                     -8,
                     -7,
                   ],
-                  [
+                },
+                {
+                  "coord": [
                     -8,
                     -3,
                   ],
-                  [
+                },
+                {
+                  "coord": [
                     -4,
                     -3,
                   ],
-                ],
-              },
+                },
+              ],
               "showVertices": false,
               "strokeStyle": "solid",
               "type": "polygon",

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -6971,20 +6971,22 @@ exports[`parseAndMigratePerseusItem given interactive-graph-locked-figures-missi
               "color": "pink",
               "fillStyle": "none",
               "labels": [],
-              "points": [
-                [
-                  -8,
-                  -7,
+              "points": {
+                "coord": [
+                  [
+                    -8,
+                    -7,
+                  ],
+                  [
+                    -8,
+                    -3,
+                  ],
+                  [
+                    -4,
+                    -3,
+                  ],
                 ],
-                [
-                  -8,
-                  -3,
-                ],
-                [
-                  -4,
-                  -3,
-                ],
-              ],
+              },
               "showVertices": false,
               "strokeStyle": "solid",
               "type": "polygon",
@@ -7247,20 +7249,22 @@ exports[`parseAndMigratePerseusItem given interactive-graph-locked-figures-missi
               "color": "pink",
               "fillStyle": "none",
               "labels": [],
-              "points": [
-                [
-                  -8,
-                  -7,
+              "points": {
+                "coord": [
+                  [
+                    -8,
+                    -7,
+                  ],
+                  [
+                    -8,
+                    -3,
+                  ],
+                  [
+                    -4,
+                    -3,
+                  ],
                 ],
-                [
-                  -8,
-                  -3,
-                ],
-                [
-                  -4,
-                  -3,
-                ],
-              ],
+              },
               "showVertices": false,
               "strokeStyle": "solid",
               "type": "polygon",

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/interactive-graph-locked-figures-missing-weights.ts
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/interactive-graph-locked-figures-missing-weights.ts
@@ -140,9 +140,9 @@ export default {
                         {
                             type: "polygon",
                             points: [
-                                {coord: [-8, -7]},
-                                {coord: [-8, -3]},
-                                {coord: [-4, -3]},
+                                [-8, -7],
+                                [-8, -3],
+                                [-4, -3],
                             ],
                             color: "pink",
                             showVertices: false,

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/interactive-graph-locked-figures-missing-weights.ts
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/interactive-graph-locked-figures-missing-weights.ts
@@ -139,13 +139,11 @@ export default {
                         },
                         {
                             type: "polygon",
-                            points: {
-                                coord: [
-                                    [-8, -7],
-                                    [-8, -3],
-                                    [-4, -3],
-                                ],
-                            },
+                            points: [
+                                {coord: [-8, -7]},
+                                {coord: [-8, -3]},
+                                {coord: [-4, -3]},
+                            ],
                             color: "pink",
                             showVertices: false,
                             fillStyle: "none",

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/interactive-graph-locked-figures-missing-weights.ts
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/interactive-graph-locked-figures-missing-weights.ts
@@ -139,11 +139,13 @@ export default {
                         },
                         {
                             type: "polygon",
-                            points: [
-                                [-8, -7],
-                                [-8, -3],
-                                [-4, -3],
-                            ],
+                            points: {
+                                coord: [
+                                    [-8, -7],
+                                    [-8, -3],
+                                    [-4, -3],
+                                ],
+                            },
                             color: "pink",
                             showVertices: false,
                             fillStyle: "none",

--- a/packages/perseus-core/src/utils/generators/interactive-graph-widget-generator.test.ts
+++ b/packages/perseus-core/src/utils/generators/interactive-graph-widget-generator.test.ts
@@ -1179,7 +1179,17 @@ describe("generateIGLockedPolygon", () => {
         // Assert
         expect(lockedPolygon).toEqual({
             type: "polygon",
-            points: [{coord: [0, 2]}, {coord: [-1, 0]}, {coord: [1, 0]}],
+            points: [
+                {
+                    coord: [0, 2],
+                },
+                {
+                    coord: [-1, 0],
+                },
+                {
+                    coord: [1, 0],
+                },
+            ],
             color: "grayH",
             showVertices: false,
             fillStyle: "none",
@@ -1192,7 +1202,17 @@ describe("generateIGLockedPolygon", () => {
     it("builds a locked polygon with all props", () => {
         // Arrange, Act
         const lockedPolygon = generateIGLockedPolygon({
-            points: [{coord: [1, 1]}, {coord: [2, 2]}, {coord: [3, 3]}],
+            points: [
+                {
+                    coord: [1, 1],
+                },
+                {
+                    coord: [2, 2],
+                },
+                {
+                    coord: [3, 3],
+                },
+            ],
             color: "blue",
             showVertices: true,
             fillStyle: "solid",
@@ -1213,7 +1233,17 @@ describe("generateIGLockedPolygon", () => {
         // Assert
         expect(lockedPolygon).toEqual({
             type: "polygon",
-            points: [{coord: [1, 1]}, {coord: [2, 2]}, {coord: [3, 3]}],
+            points: [
+                {
+                    coord: [1, 1],
+                },
+                {
+                    coord: [2, 2],
+                },
+                {
+                    coord: [3, 3],
+                },
+            ],
             color: "blue",
             showVertices: true,
             fillStyle: "solid",

--- a/packages/perseus-core/src/utils/generators/interactive-graph-widget-generator.test.ts
+++ b/packages/perseus-core/src/utils/generators/interactive-graph-widget-generator.test.ts
@@ -1179,13 +1179,7 @@ describe("generateIGLockedPolygon", () => {
         // Assert
         expect(lockedPolygon).toEqual({
             type: "polygon",
-            points: {
-                coord: [
-                    [0, 2],
-                    [-1, 0],
-                    [1, 0],
-                ],
-            },
+            points: [{coord: [0, 2]}, {coord: [-1, 0]}, {coord: [1, 0]}],
             color: "grayH",
             showVertices: false,
             fillStyle: "none",
@@ -1198,13 +1192,7 @@ describe("generateIGLockedPolygon", () => {
     it("builds a locked polygon with all props", () => {
         // Arrange, Act
         const lockedPolygon = generateIGLockedPolygon({
-            points: {
-                coord: [
-                    [1, 1],
-                    [2, 2],
-                    [3, 3],
-                ],
-            },
+            points: [{coord: [1, 1]}, {coord: [2, 2]}, {coord: [3, 3]}],
             color: "blue",
             showVertices: true,
             fillStyle: "solid",
@@ -1225,13 +1213,7 @@ describe("generateIGLockedPolygon", () => {
         // Assert
         expect(lockedPolygon).toEqual({
             type: "polygon",
-            points: {
-                coord: [
-                    [1, 1],
-                    [2, 2],
-                    [3, 3],
-                ],
-            },
+            points: [{coord: [1, 1]}, {coord: [2, 2]}, {coord: [3, 3]}],
             color: "blue",
             showVertices: true,
             fillStyle: "solid",

--- a/packages/perseus-core/src/utils/generators/interactive-graph-widget-generator.test.ts
+++ b/packages/perseus-core/src/utils/generators/interactive-graph-widget-generator.test.ts
@@ -1179,11 +1179,13 @@ describe("generateIGLockedPolygon", () => {
         // Assert
         expect(lockedPolygon).toEqual({
             type: "polygon",
-            points: [
-                [0, 2],
-                [-1, 0],
-                [1, 0],
-            ],
+            points: {
+                coord: [
+                    [0, 2],
+                    [-1, 0],
+                    [1, 0],
+                ],
+            },
             color: "grayH",
             showVertices: false,
             fillStyle: "none",
@@ -1196,11 +1198,13 @@ describe("generateIGLockedPolygon", () => {
     it("builds a locked polygon with all props", () => {
         // Arrange, Act
         const lockedPolygon = generateIGLockedPolygon({
-            points: [
-                [1, 1],
-                [2, 2],
-                [3, 3],
-            ],
+            points: {
+                coord: [
+                    [1, 1],
+                    [2, 2],
+                    [3, 3],
+                ],
+            },
             color: "blue",
             showVertices: true,
             fillStyle: "solid",
@@ -1221,11 +1225,13 @@ describe("generateIGLockedPolygon", () => {
         // Assert
         expect(lockedPolygon).toEqual({
             type: "polygon",
-            points: [
-                [1, 1],
-                [2, 2],
-                [3, 3],
-            ],
+            points: {
+                coord: [
+                    [1, 1],
+                    [2, 2],
+                    [3, 3],
+                ],
+            },
             color: "blue",
             showVertices: true,
             fillStyle: "solid",

--- a/packages/perseus-core/src/utils/get-default-figure-for-type.test.ts
+++ b/packages/perseus-core/src/utils/get-default-figure-for-type.test.ts
@@ -75,11 +75,13 @@ describe("getDefaultFigureForType", () => {
         const figure = getDefaultFigureForType("polygon");
         expect(figure).toEqual({
             type: "polygon",
-            points: [
-                [0, 2],
-                [-1, 0],
-                [1, 0],
-            ],
+            points: {
+                coord: [
+                    [0, 2],
+                    [-1, 0],
+                    [1, 0],
+                ],
+            },
             color: "grayH",
             showVertices: false,
             fillStyle: "none",

--- a/packages/perseus-core/src/utils/get-default-figure-for-type.test.ts
+++ b/packages/perseus-core/src/utils/get-default-figure-for-type.test.ts
@@ -75,13 +75,7 @@ describe("getDefaultFigureForType", () => {
         const figure = getDefaultFigureForType("polygon");
         expect(figure).toEqual({
             type: "polygon",
-            points: {
-                coord: [
-                    [0, 2],
-                    [-1, 0],
-                    [1, 0],
-                ],
-            },
+            points: [{coord: [0, 2]}, {coord: [-1, 0]}, {coord: [1, 0]}],
             color: "grayH",
             showVertices: false,
             fillStyle: "none",

--- a/packages/perseus-core/src/utils/get-default-figure-for-type.ts
+++ b/packages/perseus-core/src/utils/get-default-figure-for-type.ts
@@ -77,13 +77,7 @@ export function getDefaultFigureForType(type: LockedFigureType): LockedFigure {
         case "polygon":
             return {
                 type: "polygon",
-                points: {
-                    coord: [
-                        [0, 2],
-                        [-1, 0],
-                        [1, 0],
-                    ],
-                },
+                points: [{coord: [0, 2]}, {coord: [-1, 0]}, {coord: [1, 0]}],
                 color: DEFAULT_COLOR,
                 showVertices: false,
                 fillStyle: "none",

--- a/packages/perseus-core/src/utils/get-default-figure-for-type.ts
+++ b/packages/perseus-core/src/utils/get-default-figure-for-type.ts
@@ -77,11 +77,13 @@ export function getDefaultFigureForType(type: LockedFigureType): LockedFigure {
         case "polygon":
             return {
                 type: "polygon",
-                points: [
-                    [0, 2],
-                    [-1, 0],
-                    [1, 0],
-                ],
+                points: {
+                    coord: [
+                        [0, 2],
+                        [-1, 0],
+                        [1, 0],
+                    ],
+                },
                 color: DEFAULT_COLOR,
                 showVertices: false,
                 fillStyle: "none",

--- a/packages/perseus-editor/src/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus-editor/src/__testdata__/interactive-graph.testdata.ts
@@ -264,14 +264,12 @@ export const segmentWithLockedFigures: PerseusRenderer =
                 ariaLabel: "Ellipse D",
             }),
             generateIGLockedPolygon({
-                points: {
-                    coord: [
-                        [-9, 4],
-                        [-6, 4],
-                        [-6, 1],
-                        [-9, 1],
-                    ],
-                },
+                points: [
+                    {coord: [-9, 4]},
+                    {coord: [-6, 4]},
+                    {coord: [-6, 1]},
+                    {coord: [-9, 1]},
+                ],
                 color: "pink",
                 labels: [
                     generateIGLockedLabel({

--- a/packages/perseus-editor/src/__testdata__/interactive-graph.testdata.ts
+++ b/packages/perseus-editor/src/__testdata__/interactive-graph.testdata.ts
@@ -264,12 +264,14 @@ export const segmentWithLockedFigures: PerseusRenderer =
                 ariaLabel: "Ellipse D",
             }),
             generateIGLockedPolygon({
-                points: [
-                    [-9, 4],
-                    [-6, 4],
-                    [-6, 1],
-                    [-9, 1],
-                ],
+                points: {
+                    coord: [
+                        [-9, 4],
+                        [-6, 4],
+                        [-6, 1],
+                        [-9, 1],
+                    ],
+                },
                 color: "pink",
                 labels: [
                     generateIGLockedLabel({

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
@@ -1091,10 +1091,10 @@ describe("InteractiveGraphEditor locked figures", () => {
             const onChangeMock = jest.fn();
 
             const squarePolygonPoints = [
-                [-9, 4],
-                [-6, 4],
-                [-6, 1],
-                [-9, 1],
+                {coord: [-9, 4]},
+                {coord: [-6, 4]},
+                {coord: [-6, 1]},
+                {coord: [-9, 1]},
             ];
 
             renderEditor({
@@ -1102,7 +1102,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 lockedFigures: [
                     {
                         ...defaultPolygon,
-                        points: squarePolygonPoints.map((coord) => ({coord})),
+                        points: squarePolygonPoints,
                     },
                 ],
             });
@@ -1119,9 +1119,11 @@ describe("InteractiveGraphEditor locked figures", () => {
                     lockedFigures: [
                         expect.objectContaining({
                             type: "polygon",
-                            points: squarePolygonPoints
-                                .slice(1)
-                                .map((coord) => ({coord})),
+                            points: [
+                                {coord: [-6, 4]},
+                                {coord: [-6, 1]},
+                                {coord: [-9, 1]},
+                            ],
                         }),
                     ],
                 }),

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
@@ -1079,7 +1079,9 @@ describe("InteractiveGraphEditor locked figures", () => {
                     lockedFigures: [
                         expect.objectContaining({
                             type: "polygon",
-                            points: [...defaultPolygon.points, [0, 0]],
+                            points: {
+                                coord: [...defaultPolygon.points.coord, [0, 0]],
+                            },
                         }),
                     ],
                 }),
@@ -1102,7 +1104,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 lockedFigures: [
                     {
                         ...defaultPolygon,
-                        points: squarePolygonPoints,
+                        points: {coord: squarePolygonPoints},
                     },
                 ],
             });
@@ -1119,7 +1121,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                     lockedFigures: [
                         expect.objectContaining({
                             type: "polygon",
-                            points: squarePolygonPoints.slice(1),
+                            points: {coord: squarePolygonPoints.slice(1)},
                         }),
                     ],
                 }),
@@ -1148,11 +1150,13 @@ describe("InteractiveGraphEditor locked figures", () => {
                     lockedFigures: [
                         expect.objectContaining({
                             type: "polygon",
-                            points: [
-                                [7, 2],
-                                [-1, 0],
-                                [1, 0],
-                            ],
+                            points: {
+                                coord: [
+                                    [7, 2],
+                                    [-1, 0],
+                                    [1, 0],
+                                ],
+                            },
                         }),
                     ],
                 }),
@@ -1181,11 +1185,13 @@ describe("InteractiveGraphEditor locked figures", () => {
                     lockedFigures: [
                         expect.objectContaining({
                             type: "polygon",
-                            points: [
-                                [0, 7],
-                                [-1, 0],
-                                [1, 0],
-                            ],
+                            points: {
+                                coord: [
+                                    [0, 7],
+                                    [-1, 0],
+                                    [1, 0],
+                                ],
+                            },
                         }),
                     ],
                 }),

--- a/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/interactive-graph-editor-locked-figures.test.tsx
@@ -1079,9 +1079,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                     lockedFigures: [
                         expect.objectContaining({
                             type: "polygon",
-                            points: {
-                                coord: [...defaultPolygon.points.coord, [0, 0]],
-                            },
+                            points: [...defaultPolygon.points, {coord: [0, 0]}],
                         }),
                     ],
                 }),
@@ -1104,7 +1102,7 @@ describe("InteractiveGraphEditor locked figures", () => {
                 lockedFigures: [
                     {
                         ...defaultPolygon,
-                        points: {coord: squarePolygonPoints},
+                        points: squarePolygonPoints.map((coord) => ({coord})),
                     },
                 ],
             });
@@ -1121,7 +1119,9 @@ describe("InteractiveGraphEditor locked figures", () => {
                     lockedFigures: [
                         expect.objectContaining({
                             type: "polygon",
-                            points: {coord: squarePolygonPoints.slice(1)},
+                            points: squarePolygonPoints
+                                .slice(1)
+                                .map((coord) => ({coord})),
                         }),
                     ],
                 }),
@@ -1150,13 +1150,11 @@ describe("InteractiveGraphEditor locked figures", () => {
                     lockedFigures: [
                         expect.objectContaining({
                             type: "polygon",
-                            points: {
-                                coord: [
-                                    [7, 2],
-                                    [-1, 0],
-                                    [1, 0],
-                                ],
-                            },
+                            points: [
+                                {coord: [7, 2]},
+                                {coord: [-1, 0]},
+                                {coord: [1, 0]},
+                            ],
                         }),
                     ],
                 }),
@@ -1185,13 +1183,11 @@ describe("InteractiveGraphEditor locked figures", () => {
                     lockedFigures: [
                         expect.objectContaining({
                             type: "polygon",
-                            points: {
-                                coord: [
-                                    [0, 7],
-                                    [-1, 0],
-                                    [1, 0],
-                                ],
-                            },
+                            points: [
+                                {coord: [0, 7]},
+                                {coord: [-1, 0]},
+                                {coord: [1, 0]},
+                            ],
                         }),
                     ],
                 }),

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.test.tsx
@@ -46,12 +46,14 @@ describe("LockedPolygonSettings", () => {
         render(
             <LockedPolygonSettings
                 {...defaultProps}
-                points={[
-                    [0, 0],
-                    [1, 1],
-                    [2, 2],
-                    [1, -1],
-                ]}
+                points={{
+                    coord: [
+                        [0, 0],
+                        [1, 1],
+                        [2, 2],
+                        [1, -1],
+                    ],
+                }}
             />,
             {
                 wrapper: RenderStateRoot,
@@ -118,12 +120,14 @@ describe("LockedPolygonSettings", () => {
         render(
             <LockedPolygonSettings
                 {...defaultProps}
-                points={[
-                    [0, 0],
-                    [1, 1],
-                    [2, 2],
-                    [1, -1],
-                ]}
+                points={{
+                    coord: [
+                        [0, 0],
+                        [1, 1],
+                        [2, 2],
+                        [1, -1],
+                    ],
+                }}
             />,
             {
                 wrapper: RenderStateRoot,
@@ -184,12 +188,14 @@ describe("LockedPolygonSettings", () => {
                 {...defaultProps}
                 labels={[initialLabel]}
                 onChangeProps={onChangeSpy}
-                points={[
-                    [1, 1],
-                    [2, 1],
-                    [2, 2],
-                    [1, 2],
-                ]}
+                points={{
+                    coord: [
+                        [1, 1],
+                        [2, 1],
+                        [2, 2],
+                        [1, 2],
+                    ],
+                }}
             />,
             {
                 wrapper: RenderStateRoot,
@@ -203,12 +209,14 @@ describe("LockedPolygonSettings", () => {
         // Assert
         expect(onChangeSpy).toHaveBeenCalledWith({
             labels: [{...initialLabel, coord: [0, 1]}],
-            points: [
-                [1, 2],
-                [2, 2],
-                [2, 3],
-                [1, 3],
-            ],
+            points: {
+                coord: [
+                    [1, 2],
+                    [2, 2],
+                    [2, 3],
+                    [1, 3],
+                ],
+            },
         });
     });
 
@@ -227,12 +235,14 @@ describe("LockedPolygonSettings", () => {
                 {...defaultProps}
                 labels={[initialLabel]}
                 onChangeProps={onChangeSpy}
-                points={[
-                    [1, 1],
-                    [2, 1],
-                    [2, 2],
-                    [1, 2],
-                ]}
+                points={{
+                    coord: [
+                        [1, 1],
+                        [2, 1],
+                        [2, 2],
+                        [1, 2],
+                    ],
+                }}
             />,
             {
                 wrapper: RenderStateRoot,
@@ -246,12 +256,14 @@ describe("LockedPolygonSettings", () => {
         // Assert
         expect(onChangeSpy).toHaveBeenCalledWith({
             labels: [{...initialLabel, coord: [0, -1]}],
-            points: [
-                [1, 0],
-                [2, 0],
-                [2, 1],
-                [1, 1],
-            ],
+            points: {
+                coord: [
+                    [1, 0],
+                    [2, 0],
+                    [2, 1],
+                    [1, 1],
+                ],
+            },
         });
     });
 
@@ -270,12 +282,14 @@ describe("LockedPolygonSettings", () => {
                 {...defaultProps}
                 onChangeProps={onChangeSpy}
                 labels={[initialLabel]}
-                points={[
-                    [1, 1],
-                    [2, 1],
-                    [2, 2],
-                    [1, 2],
-                ]}
+                points={{
+                    coord: [
+                        [1, 1],
+                        [2, 1],
+                        [2, 2],
+                        [1, 2],
+                    ],
+                }}
             />,
             {
                 wrapper: RenderStateRoot,
@@ -289,12 +303,14 @@ describe("LockedPolygonSettings", () => {
         // Assert
         expect(onChangeSpy).toHaveBeenCalledWith({
             labels: [{...initialLabel, coord: [-1, 0]}],
-            points: [
-                [0, 1],
-                [1, 1],
-                [1, 2],
-                [0, 2],
-            ],
+            points: {
+                coord: [
+                    [0, 1],
+                    [1, 1],
+                    [1, 2],
+                    [0, 2],
+                ],
+            },
         });
     });
 
@@ -313,12 +329,14 @@ describe("LockedPolygonSettings", () => {
                 {...defaultProps}
                 onChangeProps={onChangeSpy}
                 labels={[initialLabel]}
-                points={[
-                    [1, 1],
-                    [2, 1],
-                    [2, 2],
-                    [1, 2],
-                ]}
+                points={{
+                    coord: [
+                        [1, 1],
+                        [2, 1],
+                        [2, 2],
+                        [1, 2],
+                    ],
+                }}
             />,
             {
                 wrapper: RenderStateRoot,
@@ -332,12 +350,14 @@ describe("LockedPolygonSettings", () => {
         // Assert
         expect(onChangeSpy).toHaveBeenCalledWith({
             labels: [{...initialLabel, coord: [1, 0]}],
-            points: [
-                [2, 1],
-                [3, 1],
-                [3, 2],
-                [2, 2],
-            ],
+            points: {
+                coord: [
+                    [2, 1],
+                    [3, 1],
+                    [3, 2],
+                    [2, 2],
+                ],
+            },
         });
     });
 
@@ -407,7 +427,7 @@ describe("LockedPolygonSettings", () => {
                 render(
                     <LockedPolygonSettings
                         {...defaultProps}
-                        points={startingCoords}
+                        points={{coord: startingCoords}}
                         labels={[
                             {
                                 ...defaultLabel,
@@ -433,7 +453,7 @@ describe("LockedPolygonSettings", () => {
 
                 // Assert
                 expect(onChangeProps).toHaveBeenCalledWith({
-                    points: expectedCoords,
+                    points: {coord: expectedCoords},
                     labels: [
                         {
                             ...defaultLabel,
@@ -542,11 +562,13 @@ describe("LockedPolygonSettings", () => {
             render(
                 <LockedPolygonSettings
                     {...defaultProps}
-                    points={[
-                        [0, 0],
-                        [1, 0],
-                        [1, 1],
-                    ]}
+                    points={{
+                        coord: [
+                            [0, 0],
+                            [1, 0],
+                            [1, 1],
+                        ],
+                    }}
                     labels={[
                         {
                             ...defaultLabel,
@@ -630,11 +652,13 @@ describe("LockedPolygonSettings", () => {
             render(
                 <LockedPolygonSettings
                     {...defaultProps}
-                    points={[
-                        [0, 0],
-                        [0, 1],
-                        [1, 1],
-                    ]}
+                    points={{
+                        coord: [
+                            [0, 0],
+                            [0, 1],
+                            [1, 1],
+                        ],
+                    }}
                     ariaLabel={undefined}
                     onChangeProps={onChangeProps}
                 />,
@@ -663,11 +687,13 @@ describe("LockedPolygonSettings", () => {
             render(
                 <LockedPolygonSettings
                     {...defaultProps}
-                    points={[
-                        [0, 0],
-                        [0, 1],
-                        [1, 1],
-                    ]}
+                    points={{
+                        coord: [
+                            [0, 0],
+                            [0, 1],
+                            [1, 1],
+                        ],
+                    }}
                     ariaLabel={undefined}
                     onChangeProps={onChangeProps}
                     labels={[
@@ -703,11 +729,13 @@ describe("LockedPolygonSettings", () => {
             render(
                 <LockedPolygonSettings
                     {...defaultProps}
-                    points={[
-                        [0, 0],
-                        [0, 1],
-                        [1, 1],
-                    ]}
+                    points={{
+                        coord: [
+                            [0, 0],
+                            [0, 1],
+                            [1, 1],
+                        ],
+                    }}
                     ariaLabel={undefined}
                     onChangeProps={onChangeProps}
                     labels={[

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.test.tsx
@@ -46,14 +46,12 @@ describe("LockedPolygonSettings", () => {
         render(
             <LockedPolygonSettings
                 {...defaultProps}
-                points={{
-                    coord: [
-                        [0, 0],
-                        [1, 1],
-                        [2, 2],
-                        [1, -1],
-                    ],
-                }}
+                points={[
+                    {coord: [0, 0]},
+                    {coord: [1, 1]},
+                    {coord: [2, 2]},
+                    {coord: [1, -1]},
+                ]}
             />,
             {
                 wrapper: RenderStateRoot,
@@ -120,14 +118,12 @@ describe("LockedPolygonSettings", () => {
         render(
             <LockedPolygonSettings
                 {...defaultProps}
-                points={{
-                    coord: [
-                        [0, 0],
-                        [1, 1],
-                        [2, 2],
-                        [1, -1],
-                    ],
-                }}
+                points={[
+                    {coord: [0, 0]},
+                    {coord: [1, 1]},
+                    {coord: [2, 2]},
+                    {coord: [1, -1]},
+                ]}
             />,
             {
                 wrapper: RenderStateRoot,
@@ -188,14 +184,12 @@ describe("LockedPolygonSettings", () => {
                 {...defaultProps}
                 labels={[initialLabel]}
                 onChangeProps={onChangeSpy}
-                points={{
-                    coord: [
-                        [1, 1],
-                        [2, 1],
-                        [2, 2],
-                        [1, 2],
-                    ],
-                }}
+                points={[
+                    {coord: [1, 1]},
+                    {coord: [2, 1]},
+                    {coord: [2, 2]},
+                    {coord: [1, 2]},
+                ]}
             />,
             {
                 wrapper: RenderStateRoot,
@@ -209,14 +203,12 @@ describe("LockedPolygonSettings", () => {
         // Assert
         expect(onChangeSpy).toHaveBeenCalledWith({
             labels: [{...initialLabel, coord: [0, 1]}],
-            points: {
-                coord: [
-                    [1, 2],
-                    [2, 2],
-                    [2, 3],
-                    [1, 3],
-                ],
-            },
+            points: [
+                {coord: [1, 2]},
+                {coord: [2, 2]},
+                {coord: [2, 3]},
+                {coord: [1, 3]},
+            ],
         });
     });
 
@@ -235,14 +227,12 @@ describe("LockedPolygonSettings", () => {
                 {...defaultProps}
                 labels={[initialLabel]}
                 onChangeProps={onChangeSpy}
-                points={{
-                    coord: [
-                        [1, 1],
-                        [2, 1],
-                        [2, 2],
-                        [1, 2],
-                    ],
-                }}
+                points={[
+                    {coord: [1, 1]},
+                    {coord: [2, 1]},
+                    {coord: [2, 2]},
+                    {coord: [1, 2]},
+                ]}
             />,
             {
                 wrapper: RenderStateRoot,
@@ -256,14 +246,12 @@ describe("LockedPolygonSettings", () => {
         // Assert
         expect(onChangeSpy).toHaveBeenCalledWith({
             labels: [{...initialLabel, coord: [0, -1]}],
-            points: {
-                coord: [
-                    [1, 0],
-                    [2, 0],
-                    [2, 1],
-                    [1, 1],
-                ],
-            },
+            points: [
+                {coord: [1, 0]},
+                {coord: [2, 0]},
+                {coord: [2, 1]},
+                {coord: [1, 1]},
+            ],
         });
     });
 
@@ -282,14 +270,12 @@ describe("LockedPolygonSettings", () => {
                 {...defaultProps}
                 onChangeProps={onChangeSpy}
                 labels={[initialLabel]}
-                points={{
-                    coord: [
-                        [1, 1],
-                        [2, 1],
-                        [2, 2],
-                        [1, 2],
-                    ],
-                }}
+                points={[
+                    {coord: [1, 1]},
+                    {coord: [2, 1]},
+                    {coord: [2, 2]},
+                    {coord: [1, 2]},
+                ]}
             />,
             {
                 wrapper: RenderStateRoot,
@@ -303,14 +289,12 @@ describe("LockedPolygonSettings", () => {
         // Assert
         expect(onChangeSpy).toHaveBeenCalledWith({
             labels: [{...initialLabel, coord: [-1, 0]}],
-            points: {
-                coord: [
-                    [0, 1],
-                    [1, 1],
-                    [1, 2],
-                    [0, 2],
-                ],
-            },
+            points: [
+                {coord: [0, 1]},
+                {coord: [1, 1]},
+                {coord: [1, 2]},
+                {coord: [0, 2]},
+            ],
         });
     });
 
@@ -329,14 +313,12 @@ describe("LockedPolygonSettings", () => {
                 {...defaultProps}
                 onChangeProps={onChangeSpy}
                 labels={[initialLabel]}
-                points={{
-                    coord: [
-                        [1, 1],
-                        [2, 1],
-                        [2, 2],
-                        [1, 2],
-                    ],
-                }}
+                points={[
+                    {coord: [1, 1]},
+                    {coord: [2, 1]},
+                    {coord: [2, 2]},
+                    {coord: [1, 2]},
+                ]}
             />,
             {
                 wrapper: RenderStateRoot,
@@ -350,14 +332,12 @@ describe("LockedPolygonSettings", () => {
         // Assert
         expect(onChangeSpy).toHaveBeenCalledWith({
             labels: [{...initialLabel, coord: [1, 0]}],
-            points: {
-                coord: [
-                    [2, 1],
-                    [3, 1],
-                    [3, 2],
-                    [2, 2],
-                ],
-            },
+            points: [
+                {coord: [2, 1]},
+                {coord: [3, 1]},
+                {coord: [3, 2]},
+                {coord: [2, 2]},
+            ],
         });
     });
 
@@ -427,7 +407,7 @@ describe("LockedPolygonSettings", () => {
                 render(
                     <LockedPolygonSettings
                         {...defaultProps}
-                        points={{coord: startingCoords}}
+                        points={startingCoords.map((coord) => ({coord}))}
                         labels={[
                             {
                                 ...defaultLabel,
@@ -453,7 +433,7 @@ describe("LockedPolygonSettings", () => {
 
                 // Assert
                 expect(onChangeProps).toHaveBeenCalledWith({
-                    points: {coord: expectedCoords},
+                    points: expectedCoords.map((coord) => ({coord})),
                     labels: [
                         {
                             ...defaultLabel,
@@ -562,13 +542,7 @@ describe("LockedPolygonSettings", () => {
             render(
                 <LockedPolygonSettings
                     {...defaultProps}
-                    points={{
-                        coord: [
-                            [0, 0],
-                            [1, 0],
-                            [1, 1],
-                        ],
-                    }}
+                    points={[{coord: [0, 0]}, {coord: [1, 0]}, {coord: [1, 1]}]}
                     labels={[
                         {
                             ...defaultLabel,
@@ -652,13 +626,7 @@ describe("LockedPolygonSettings", () => {
             render(
                 <LockedPolygonSettings
                     {...defaultProps}
-                    points={{
-                        coord: [
-                            [0, 0],
-                            [0, 1],
-                            [1, 1],
-                        ],
-                    }}
+                    points={[{coord: [0, 0]}, {coord: [0, 1]}, {coord: [1, 1]}]}
                     ariaLabel={undefined}
                     onChangeProps={onChangeProps}
                 />,
@@ -687,13 +655,7 @@ describe("LockedPolygonSettings", () => {
             render(
                 <LockedPolygonSettings
                     {...defaultProps}
-                    points={{
-                        coord: [
-                            [0, 0],
-                            [0, 1],
-                            [1, 1],
-                        ],
-                    }}
+                    points={[{coord: [0, 0]}, {coord: [0, 1]}, {coord: [1, 1]}]}
                     ariaLabel={undefined}
                     onChangeProps={onChangeProps}
                     labels={[
@@ -729,13 +691,7 @@ describe("LockedPolygonSettings", () => {
             render(
                 <LockedPolygonSettings
                     {...defaultProps}
-                    points={{
-                        coord: [
-                            [0, 0],
-                            [0, 1],
-                            [1, 1],
-                        ],
-                    }}
+                    points={[{coord: [0, 0]}, {coord: [0, 1]}, {coord: [1, 1]}]}
                     ariaLabel={undefined}
                     onChangeProps={onChangeProps}
                     labels={[

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
@@ -66,6 +66,7 @@ const LockedPolygonSettings = (props: Props) => {
         onMove,
         onRemove,
     } = props;
+    const coords = points.coord;
 
     /**
      * Generate the prepopulated aria label for the polygon,
@@ -74,11 +75,11 @@ const LockedPolygonSettings = (props: Props) => {
     async function getPrepopulatedAriaLabel() {
         const visiblelabel = await joinLabelsAsSpokenMath(labels);
 
-        let str = `Polygon${visiblelabel} with ${points.length} sides, vertices at `;
+        let str = `Polygon${visiblelabel} with ${coords.length} sides, vertices at `;
 
         // Add the coordinates of each point to the aria label
         const pointsList = await Promise.all(
-            points.map(async ([x, y]) => {
+            coords.map(async ([x, y]) => {
                 // Ensure negative values are read correctly within aria labels.
                 const spokenX = await generateSpokenMathDetails(`$${x}$`);
                 const spokenY = await generateSpokenMathDetails(`$${y}$`);
@@ -115,7 +116,7 @@ const LockedPolygonSettings = (props: Props) => {
         switch (movement) {
             case "up":
                 onChangeProps({
-                    points: points.map(([x, y]) => [x, y + 1]),
+                    points: {coord: coords.map(([x, y]) => [x, y + 1])},
                     labels: labels.map((label) => ({
                         ...label,
                         coord: [label.coord[0], label.coord[1] + 1],
@@ -124,7 +125,7 @@ const LockedPolygonSettings = (props: Props) => {
                 break;
             case "down":
                 onChangeProps({
-                    points: points.map(([x, y]) => [x, y - 1]),
+                    points: {coord: coords.map(([x, y]) => [x, y - 1])},
                     labels: labels.map((label) => ({
                         ...label,
                         coord: [label.coord[0], label.coord[1] - 1],
@@ -133,7 +134,7 @@ const LockedPolygonSettings = (props: Props) => {
                 break;
             case "left":
                 onChangeProps({
-                    points: points.map(([x, y]) => [x - 1, y]),
+                    points: {coord: coords.map(([x, y]) => [x - 1, y])},
                     labels: labels.map((label) => ({
                         ...label,
                         coord: [label.coord[0] - 1, label.coord[1]],
@@ -142,7 +143,7 @@ const LockedPolygonSettings = (props: Props) => {
                 break;
             case "right":
                 onChangeProps({
-                    points: points.map(([x, y]) => [x + 1, y]),
+                    points: {coord: coords.map(([x, y]) => [x + 1, y])},
                     labels: labels.map((label) => ({
                         ...label,
                         coord: [label.coord[0] + 1, label.coord[1]],
@@ -182,7 +183,7 @@ const LockedPolygonSettings = (props: Props) => {
                         size="medium"
                         weight="bold"
                         tag="span"
-                    >{`Polygon, ${points.length} sides`}</BodyText>
+                    >{`Polygon, ${coords.length} sides`}</BodyText>
                     <Strut size={spacing.xSmall_8} />
                     <PolygonSwatch
                         color={color}
@@ -267,7 +268,7 @@ const LockedPolygonSettings = (props: Props) => {
                 containerStyle={styles.pointAccordionContainer}
                 panelStyle={styles.pointAccordionPanel}
             >
-                {points.map((point, index) => {
+                {coords.map((point, index) => {
                     const pointLabel = String.fromCharCode(65 + index);
 
                     return (
@@ -285,26 +286,28 @@ const LockedPolygonSettings = (props: Props) => {
                                 coord={point}
                                 labels={["x", "y"]}
                                 onChange={(newValue: Coord) => {
-                                    const newPoints = [...points];
-                                    newPoints[index] = newValue;
-                                    props.onChangeProps({points: newPoints});
+                                    const newCoords = [...coords];
+                                    newCoords[index] = newValue;
+                                    props.onChangeProps({
+                                        points: {coord: newCoords},
+                                    });
                                 }}
                             />
                             {
                                 // Only show the minus (delete) buttons if there are
                                 // more than 3 points. 3 points is the minimum number
                                 // of points for a polygon (triangle).
-                                points.length > 3 && (
+                                coords.length > 3 && (
                                     <IconButton
                                         aria-label={`Delete polygon point ${pointLabel}`}
                                         icon={minusCircle}
                                         kind="tertiary"
                                         actionType="destructive"
                                         onClick={() => {
-                                            const newPoints = [...points];
-                                            newPoints.splice(index, 1);
+                                            const newCoords = [...coords];
+                                            newCoords.splice(index, 1);
                                             props.onChangeProps({
-                                                points: newPoints,
+                                                points: {coord: newCoords},
                                             });
                                         }}
                                         style={styles.icon}
@@ -320,7 +323,7 @@ const LockedPolygonSettings = (props: Props) => {
                         startIcon={plusCircle}
                         onClick={() => {
                             props.onChangeProps({
-                                points: [...points, [0, 0]],
+                                points: {coord: [...coords, [0, 0]]},
                             });
                         }}
                     >
@@ -402,10 +405,10 @@ const LockedPolygonSettings = (props: Props) => {
                     const newLabel = {
                         ...getDefaultFigureForType("label"),
                         coord: [
-                            points[0][0],
+                            coords[0][0],
                             // Additional vertical offset for each
                             // label so they don't overlap.
-                            points[0][1] - labels.length,
+                            coords[0][1] - labels.length,
                         ],
                         // Default to the same color as the ellipse
                         color: color,

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
@@ -66,7 +66,9 @@ const LockedPolygonSettings = (props: Props) => {
         onMove,
         onRemove,
     } = props;
-    const coords = points.coord;
+    const coords = points.map((point) => point.coord);
+    const coordsToPoints = (coords: Coord[]) =>
+        coords.map((coord) => ({coord}));
 
     /**
      * Generate the prepopulated aria label for the polygon,
@@ -116,7 +118,7 @@ const LockedPolygonSettings = (props: Props) => {
         switch (movement) {
             case "up":
                 onChangeProps({
-                    points: {coord: coords.map(([x, y]) => [x, y + 1])},
+                    points: coordsToPoints(coords.map(([x, y]) => [x, y + 1])),
                     labels: labels.map((label) => ({
                         ...label,
                         coord: [label.coord[0], label.coord[1] + 1],
@@ -125,7 +127,7 @@ const LockedPolygonSettings = (props: Props) => {
                 break;
             case "down":
                 onChangeProps({
-                    points: {coord: coords.map(([x, y]) => [x, y - 1])},
+                    points: coordsToPoints(coords.map(([x, y]) => [x, y - 1])),
                     labels: labels.map((label) => ({
                         ...label,
                         coord: [label.coord[0], label.coord[1] - 1],
@@ -134,7 +136,7 @@ const LockedPolygonSettings = (props: Props) => {
                 break;
             case "left":
                 onChangeProps({
-                    points: {coord: coords.map(([x, y]) => [x - 1, y])},
+                    points: coordsToPoints(coords.map(([x, y]) => [x - 1, y])),
                     labels: labels.map((label) => ({
                         ...label,
                         coord: [label.coord[0] - 1, label.coord[1]],
@@ -143,7 +145,7 @@ const LockedPolygonSettings = (props: Props) => {
                 break;
             case "right":
                 onChangeProps({
-                    points: {coord: coords.map(([x, y]) => [x + 1, y])},
+                    points: coordsToPoints(coords.map(([x, y]) => [x + 1, y])),
                     labels: labels.map((label) => ({
                         ...label,
                         coord: [label.coord[0] + 1, label.coord[1]],
@@ -289,7 +291,7 @@ const LockedPolygonSettings = (props: Props) => {
                                     const newCoords = [...coords];
                                     newCoords[index] = newValue;
                                     props.onChangeProps({
-                                        points: {coord: newCoords},
+                                        points: coordsToPoints(newCoords),
                                     });
                                 }}
                             />
@@ -307,7 +309,9 @@ const LockedPolygonSettings = (props: Props) => {
                                             const newCoords = [...coords];
                                             newCoords.splice(index, 1);
                                             props.onChangeProps({
-                                                points: {coord: newCoords},
+                                                points: coordsToPoints(
+                                                    newCoords,
+                                                ),
                                             });
                                         }}
                                         style={styles.icon}
@@ -323,7 +327,7 @@ const LockedPolygonSettings = (props: Props) => {
                         startIcon={plusCircle}
                         onClick={() => {
                             props.onChangeProps({
-                                points: {coord: [...coords, [0, 0]]},
+                                points: coordsToPoints([...coords, [0, 0]]),
                             });
                         }}
                     >

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
@@ -1,7 +1,6 @@
 import {
     getDefaultFigureForType,
     lockedFigureFillStyles,
-    type Coord,
     type LockedFigureFillType,
     type LockedPolygonType,
     type LockedFigureColor,
@@ -45,7 +44,7 @@ import type {LockedFigureSettingsCommonProps} from "./locked-figure-settings";
 export type Props = LockedFigureSettingsCommonProps &
     LockedPolygonType & {
         /**
-         * Called when the props (coords, color, etc.) are updated.
+         * Called when the props (points, color, etc.) are updated.
          */
         onChangeProps: (newProps: Partial<LockedPolygonType>) => void;
     };
@@ -66,9 +65,6 @@ const LockedPolygonSettings = (props: Props) => {
         onMove,
         onRemove,
     } = props;
-    const coords = points.map((point) => point.coord);
-    const coordsToPoints = (coords: Coord[]) =>
-        coords.map((coord) => ({coord}));
 
     /**
      * Generate the prepopulated aria label for the polygon,
@@ -77,12 +73,13 @@ const LockedPolygonSettings = (props: Props) => {
     async function getPrepopulatedAriaLabel() {
         const visiblelabel = await joinLabelsAsSpokenMath(labels);
 
-        let str = `Polygon${visiblelabel} with ${coords.length} sides, vertices at `;
+        let str = `Polygon${visiblelabel} with ${points.length} sides, vertices at `;
 
         // Add the coordinates of each point to the aria label
         const pointsList = await Promise.all(
-            coords.map(async ([x, y]) => {
+            points.map(async (point) => {
                 // Ensure negative values are read correctly within aria labels.
+                const [x, y] = point.coord;
                 const spokenX = await generateSpokenMathDetails(`$${x}$`);
                 const spokenY = await generateSpokenMathDetails(`$${y}$`);
                 return `${spokenX} comma ${spokenY}`;
@@ -118,7 +115,10 @@ const LockedPolygonSettings = (props: Props) => {
         switch (movement) {
             case "up":
                 onChangeProps({
-                    points: coordsToPoints(coords.map(([x, y]) => [x, y + 1])),
+                    points: points.map((point) => ({
+                        ...point,
+                        coord: [point.coord[0], point.coord[1] + 1],
+                    })),
                     labels: labels.map((label) => ({
                         ...label,
                         coord: [label.coord[0], label.coord[1] + 1],
@@ -127,7 +127,10 @@ const LockedPolygonSettings = (props: Props) => {
                 break;
             case "down":
                 onChangeProps({
-                    points: coordsToPoints(coords.map(([x, y]) => [x, y - 1])),
+                    points: points.map((point) => ({
+                        ...point,
+                        coord: [point.coord[0], point.coord[1] - 1],
+                    })),
                     labels: labels.map((label) => ({
                         ...label,
                         coord: [label.coord[0], label.coord[1] - 1],
@@ -136,7 +139,10 @@ const LockedPolygonSettings = (props: Props) => {
                 break;
             case "left":
                 onChangeProps({
-                    points: coordsToPoints(coords.map(([x, y]) => [x - 1, y])),
+                    points: points.map((point) => ({
+                        ...point,
+                        coord: [point.coord[0] - 1, point.coord[1]],
+                    })),
                     labels: labels.map((label) => ({
                         ...label,
                         coord: [label.coord[0] - 1, label.coord[1]],
@@ -145,7 +151,10 @@ const LockedPolygonSettings = (props: Props) => {
                 break;
             case "right":
                 onChangeProps({
-                    points: coordsToPoints(coords.map(([x, y]) => [x + 1, y])),
+                    points: points.map((point) => ({
+                        ...point,
+                        coord: [point.coord[0] + 1, point.coord[1]],
+                    })),
                     labels: labels.map((label) => ({
                         ...label,
                         coord: [label.coord[0] + 1, label.coord[1]],
@@ -185,7 +194,7 @@ const LockedPolygonSettings = (props: Props) => {
                         size="medium"
                         weight="bold"
                         tag="span"
-                    >{`Polygon, ${coords.length} sides`}</BodyText>
+                    >{`Polygon, ${points.length} sides`}</BodyText>
                     <Strut size={spacing.xSmall_8} />
                     <PolygonSwatch
                         color={color}
@@ -270,7 +279,7 @@ const LockedPolygonSettings = (props: Props) => {
                 containerStyle={styles.pointAccordionContainer}
                 panelStyle={styles.pointAccordionPanel}
             >
-                {coords.map((point, index) => {
+                {points.map((point, index) => {
                     const pointLabel = String.fromCharCode(65 + index);
 
                     return (
@@ -285,32 +294,32 @@ const LockedPolygonSettings = (props: Props) => {
                             >{`${pointLabel}:`}</BodyText>
                             <Strut size={spacing.medium_16} />
                             <CoordinatePairInput
-                                coord={point}
+                                coord={point.coord}
                                 labels={["x", "y"]}
-                                onChange={(newValue: Coord) => {
-                                    const newCoords = [...coords];
-                                    newCoords[index] = newValue;
-                                    props.onChangeProps({
-                                        points: coordsToPoints(newCoords),
-                                    });
+                                onChange={(newValue) => {
+                                    const newPoints = [...points];
+                                    newPoints[index] = {
+                                        ...point,
+                                        coord: newValue,
+                                    };
+                                    props.onChangeProps({points: newPoints});
                                 }}
                             />
                             {
                                 // Only show the minus (delete) buttons if there are
                                 // more than 3 points. 3 points is the minimum number
                                 // of points for a polygon (triangle).
-                                coords.length > 3 && (
+                                points.length > 3 && (
                                     <IconButton
                                         aria-label={`Delete polygon point ${pointLabel}`}
                                         icon={minusCircle}
                                         kind="tertiary"
                                         actionType="destructive"
                                         onClick={() => {
-                                            const newCoords = [...coords];
-                                            newCoords.splice(index, 1);
                                             props.onChangeProps({
-                                                points: coordsToPoints(
-                                                    newCoords,
+                                                points: points.filter(
+                                                    (_, pointIndex) =>
+                                                        pointIndex !== index,
                                                 ),
                                             });
                                         }}
@@ -327,7 +336,7 @@ const LockedPolygonSettings = (props: Props) => {
                         startIcon={plusCircle}
                         onClick={() => {
                             props.onChangeProps({
-                                points: coordsToPoints([...coords, [0, 0]]),
+                                points: [...points, {coord: [0, 0]}],
                             });
                         }}
                     >
@@ -409,10 +418,10 @@ const LockedPolygonSettings = (props: Props) => {
                     const newLabel = {
                         ...getDefaultFigureForType("label"),
                         coord: [
-                            coords[0][0],
+                            points[0].coord[0],
                             // Additional vertical offset for each
                             // label so they don't overlap.
-                            coords[0][1] - labels.length,
+                            points[0].coord[1] - labels.length,
                         ],
                         // Default to the same color as the ellipse
                         color: color,

--- a/packages/perseus-linter/src/rules/interactive-graph-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/interactive-graph-widget-error.test.ts
@@ -50,11 +50,13 @@ describe("interactive-graph-widget-error", () => {
                     options: generateInteractiveGraphOptions({
                         lockedFigures: [
                             generateIGLockedPolygon({
-                                points: [
-                                    [0, 0],
-                                    [0, 0],
-                                    [0, 0],
-                                ],
+                                points: {
+                                    coord: [
+                                        [0, 0],
+                                        [0, 0],
+                                        [0, 0],
+                                    ],
+                                },
                             }),
                         ],
                     }),
@@ -152,11 +154,13 @@ describe("interactive-graph-widget-error", () => {
                             ],
                         }),
                         generateIGLockedPolygon({
-                            points: [
-                                [0, 0],
-                                [0, 2],
-                                [1, 1],
-                            ],
+                            points: {
+                                coord: [
+                                    [0, 0],
+                                    [0, 2],
+                                    [1, 1],
+                                ],
+                            },
                         }),
                         generateIGLockedEllipse({radius: [2, 2]}),
                     ],

--- a/packages/perseus-linter/src/rules/interactive-graph-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/interactive-graph-widget-error.test.ts
@@ -50,13 +50,11 @@ describe("interactive-graph-widget-error", () => {
                     options: generateInteractiveGraphOptions({
                         lockedFigures: [
                             generateIGLockedPolygon({
-                                points: {
-                                    coord: [
-                                        [0, 0],
-                                        [0, 0],
-                                        [0, 0],
-                                    ],
-                                },
+                                points: [
+                                    {coord: [0, 0]},
+                                    {coord: [0, 0]},
+                                    {coord: [0, 0]},
+                                ],
                             }),
                         ],
                     }),
@@ -154,13 +152,11 @@ describe("interactive-graph-widget-error", () => {
                             ],
                         }),
                         generateIGLockedPolygon({
-                            points: {
-                                coord: [
-                                    [0, 0],
-                                    [0, 2],
-                                    [1, 1],
-                                ],
-                            },
+                            points: [
+                                {coord: [0, 0]},
+                                {coord: [0, 2]},
+                                {coord: [1, 1]},
+                            ],
                         }),
                         generateIGLockedEllipse({radius: [2, 2]}),
                     ],

--- a/packages/perseus-linter/src/rules/interactive-graph-widget-error.ts
+++ b/packages/perseus-linter/src/rules/interactive-graph-widget-error.ts
@@ -38,7 +38,7 @@ export default Rule.makeRule({
 
             // A locked polygon can't have all coordinates be the same.
             if (figure.type === "polygon") {
-                const coords = figure.points.coord;
+                const coords = figure.points.map((point) => point.coord);
                 if (
                     // If every point is the same as the first point,
                     // then all the points are the same.

--- a/packages/perseus-linter/src/rules/interactive-graph-widget-error.ts
+++ b/packages/perseus-linter/src/rules/interactive-graph-widget-error.ts
@@ -38,12 +38,11 @@ export default Rule.makeRule({
 
             // A locked polygon can't have all coordinates be the same.
             if (figure.type === "polygon") {
+                const coords = figure.points.coord;
                 if (
                     // If every point is the same as the first point,
                     // then all the points are the same.
-                    figure.points.every((point) =>
-                        kvector.equal(point, figure.points[0]),
-                    )
+                    coords.every((point) => kvector.equal(point, coords[0]))
                 ) {
                     issues.push(
                         "Locked polygon cannot have all coordinates be the same.",

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph-initial-state-regression.stories.tsx
@@ -538,12 +538,14 @@ function lockedFiguresWithWeight(
             color: "blue",
         }),
         generateIGLockedPolygon({
-            points: [
-                [-7.5, -3.5],
-                [-6.5, -2.5],
-                [-5.5, -3.5],
-                [-6.5, -4.5],
-            ],
+            points: {
+                coord: [
+                    [-7.5, -3.5],
+                    [-6.5, -2.5],
+                    [-5.5, -3.5],
+                    [-6.5, -4.5],
+                ],
+            },
             weight,
             color: "pink",
         }),

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph-initial-state-regression.stories.tsx
@@ -538,14 +538,12 @@ function lockedFiguresWithWeight(
             color: "blue",
         }),
         generateIGLockedPolygon({
-            points: {
-                coord: [
-                    [-7.5, -3.5],
-                    [-6.5, -2.5],
-                    [-5.5, -3.5],
-                    [-6.5, -4.5],
-                ],
-            },
+            points: [
+                {coord: [-7.5, -3.5]},
+                {coord: [-6.5, -2.5]},
+                {coord: [-5.5, -3.5]},
+                {coord: [-6.5, -4.5]},
+            ],
             weight,
             color: "pink",
         }),

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -1235,13 +1235,11 @@ describe("Interactive Graph", function () {
                     generateInteractiveGraphQuestion({
                         lockedFigures: [
                             generateIGLockedPolygon({
-                                points: {
-                                    coord: [
-                                        [0, 0],
-                                        [0, 1],
-                                        [1, 1],
-                                    ],
-                                },
+                                points: [
+                                    {coord: [0, 0]},
+                                    {coord: [0, 1]},
+                                    {coord: [1, 1]},
+                                ],
                                 weight: weight,
                             }),
                         ],
@@ -1353,13 +1351,11 @@ describe("Interactive Graph", function () {
                 generateInteractiveGraphQuestion({
                     lockedFigures: [
                         generateIGLockedPolygon({
-                            points: {
-                                coord: [
-                                    [0, 0],
-                                    [0, 1],
-                                    [1, 1],
-                                ],
-                            },
+                            points: [
+                                {coord: [0, 0]},
+                                {coord: [0, 1]},
+                                {coord: [1, 1]},
+                            ],
                             ariaLabel: "Polygon A",
                         }),
                     ],
@@ -1383,13 +1379,11 @@ describe("Interactive Graph", function () {
                 generateInteractiveGraphQuestion({
                     lockedFigures: [
                         generateIGLockedPolygon({
-                            points: {
-                                coord: [
-                                    [0, 0],
-                                    [0, 1],
-                                    [1, 1],
-                                ],
-                            },
+                            points: [
+                                {coord: [0, 0]},
+                                {coord: [0, 1]},
+                                {coord: [1, 1]},
+                            ],
                         }),
                     ],
                 });

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -1235,11 +1235,13 @@ describe("Interactive Graph", function () {
                     generateInteractiveGraphQuestion({
                         lockedFigures: [
                             generateIGLockedPolygon({
-                                points: [
-                                    [0, 0],
-                                    [0, 1],
-                                    [1, 1],
-                                ],
+                                points: {
+                                    coord: [
+                                        [0, 0],
+                                        [0, 1],
+                                        [1, 1],
+                                    ],
+                                },
                                 weight: weight,
                             }),
                         ],
@@ -1351,11 +1353,13 @@ describe("Interactive Graph", function () {
                 generateInteractiveGraphQuestion({
                     lockedFigures: [
                         generateIGLockedPolygon({
-                            points: [
-                                [0, 0],
-                                [0, 1],
-                                [1, 1],
-                            ],
+                            points: {
+                                coord: [
+                                    [0, 0],
+                                    [0, 1],
+                                    [1, 1],
+                                ],
+                            },
                             ariaLabel: "Polygon A",
                         }),
                     ],
@@ -1379,11 +1383,13 @@ describe("Interactive Graph", function () {
                 generateInteractiveGraphQuestion({
                     lockedFigures: [
                         generateIGLockedPolygon({
-                            points: [
-                                [0, 0],
-                                [0, 1],
-                                [1, 1],
-                            ],
+                            points: {
+                                coord: [
+                                    [0, 0],
+                                    [0, 1],
+                                    [1, 1],
+                                ],
+                            },
                         }),
                     ],
                 });

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -861,38 +861,28 @@ export const segmentWithLockedPolygons: PerseusRenderer =
         correct: generateIGSegmentGraph(),
         lockedFigures: [
             generateIGLockedPolygon({
-                points: {
-                    coord: [
-                        [-3, 4],
-                        [-5, 1],
-                        [-1, 1],
-                    ],
-                },
+                points: [{coord: [-3, 4]}, {coord: [-5, 1]}, {coord: [-1, 1]}],
             }),
             generateIGLockedPolygon({
-                points: {
-                    coord: [
-                        [1, 4],
-                        [4, 4],
-                        [4, 1],
-                        [1, 1],
-                    ],
-                },
+                points: [
+                    {coord: [1, 4]},
+                    {coord: [4, 4]},
+                    {coord: [4, 1]},
+                    {coord: [1, 1]},
+                ],
                 color: "green",
                 showVertices: true,
                 fillStyle: "translucent",
                 strokeStyle: "dashed",
             }),
             generateIGLockedPolygon({
-                points: {
-                    coord: [
-                        [0, -1],
-                        [-2, -3],
-                        [-1, -5],
-                        [1, -5],
-                        [2, -3],
-                    ],
-                },
+                points: [
+                    {coord: [0, -1]},
+                    {coord: [-2, -3]},
+                    {coord: [-1, -5]},
+                    {coord: [1, -5]},
+                    {coord: [2, -3]},
+                ],
                 color: "purple",
                 showVertices: false,
                 fillStyle: "solid",
@@ -906,24 +896,12 @@ export const segmentWithLockedPolygonWhite: PerseusRenderer =
         correct: generateIGSegmentGraph(),
         lockedFigures: [
             generateIGLockedPolygon({
-                points: {
-                    coord: [
-                        [0, 3],
-                        [-3, 0],
-                        [3, 0],
-                    ],
-                },
+                points: [{coord: [0, 3]}, {coord: [-3, 0]}, {coord: [3, 0]}],
                 color: "green",
                 fillStyle: "white",
             }),
             generateIGLockedPolygon({
-                points: {
-                    coord: [
-                        [-5, 0],
-                        [-3, -1],
-                        [3, -1],
-                    ],
-                },
+                points: [{coord: [-5, 0]}, {coord: [-3, -1]}, {coord: [3, -1]}],
                 color: "pink",
                 fillStyle: "translucent",
             }),
@@ -1021,14 +999,12 @@ export const staticGraphQuestion: PerseusRenderer =
                 color: "blue",
             }),
             generateIGLockedPolygon({
-                points: {
-                    coord: [
-                        [-9, 4],
-                        [-6, 4],
-                        [-6, 1],
-                        [-9, 1],
-                    ],
-                },
+                points: [
+                    {coord: [-9, 4]},
+                    {coord: [-6, 4]},
+                    {coord: [-6, 1]},
+                    {coord: [-9, 1]},
+                ],
                 color: "pink",
             }),
         ],
@@ -1061,14 +1037,12 @@ export const staticGraphQuestionWithAnotherWidget: () => PerseusRenderer =
                     color: "blue",
                 }),
                 generateIGLockedPolygon({
-                    points: {
-                        coord: [
-                            [-9, 4],
-                            [-6, 4],
-                            [-6, 1],
-                            [-9, 1],
-                        ],
-                    },
+                    points: [
+                        {coord: [-9, 4]},
+                        {coord: [-6, 4]},
+                        {coord: [-6, 1]},
+                        {coord: [-9, 1]},
+                    ],
                     color: "pink",
                 }),
             ],
@@ -1182,13 +1156,7 @@ export const graphWithLabeledPolygon: PerseusRenderer =
         correct: generateIGSegmentGraph(),
         lockedFigures: [
             generateIGLockedPolygon({
-                points: {
-                    coord: [
-                        [0, 0],
-                        [4, 0],
-                        [2, 4],
-                    ],
-                },
+                points: [{coord: [0, 0]}, {coord: [4, 0]}, {coord: [2, 4]}],
                 labels: [generateIGLockedLabel({text: "E", coord: [0, 0]})],
             }),
         ],

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -861,32 +861,38 @@ export const segmentWithLockedPolygons: PerseusRenderer =
         correct: generateIGSegmentGraph(),
         lockedFigures: [
             generateIGLockedPolygon({
-                points: [
-                    [-3, 4],
-                    [-5, 1],
-                    [-1, 1],
-                ],
+                points: {
+                    coord: [
+                        [-3, 4],
+                        [-5, 1],
+                        [-1, 1],
+                    ],
+                },
             }),
             generateIGLockedPolygon({
-                points: [
-                    [1, 4],
-                    [4, 4],
-                    [4, 1],
-                    [1, 1],
-                ],
+                points: {
+                    coord: [
+                        [1, 4],
+                        [4, 4],
+                        [4, 1],
+                        [1, 1],
+                    ],
+                },
                 color: "green",
                 showVertices: true,
                 fillStyle: "translucent",
                 strokeStyle: "dashed",
             }),
             generateIGLockedPolygon({
-                points: [
-                    [0, -1],
-                    [-2, -3],
-                    [-1, -5],
-                    [1, -5],
-                    [2, -3],
-                ],
+                points: {
+                    coord: [
+                        [0, -1],
+                        [-2, -3],
+                        [-1, -5],
+                        [1, -5],
+                        [2, -3],
+                    ],
+                },
                 color: "purple",
                 showVertices: false,
                 fillStyle: "solid",
@@ -900,20 +906,24 @@ export const segmentWithLockedPolygonWhite: PerseusRenderer =
         correct: generateIGSegmentGraph(),
         lockedFigures: [
             generateIGLockedPolygon({
-                points: [
-                    [0, 3],
-                    [-3, 0],
-                    [3, 0],
-                ],
+                points: {
+                    coord: [
+                        [0, 3],
+                        [-3, 0],
+                        [3, 0],
+                    ],
+                },
                 color: "green",
                 fillStyle: "white",
             }),
             generateIGLockedPolygon({
-                points: [
-                    [-5, 0],
-                    [-3, -1],
-                    [3, -1],
-                ],
+                points: {
+                    coord: [
+                        [-5, 0],
+                        [-3, -1],
+                        [3, -1],
+                    ],
+                },
                 color: "pink",
                 fillStyle: "translucent",
             }),
@@ -1011,12 +1021,14 @@ export const staticGraphQuestion: PerseusRenderer =
                 color: "blue",
             }),
             generateIGLockedPolygon({
-                points: [
-                    [-9, 4],
-                    [-6, 4],
-                    [-6, 1],
-                    [-9, 1],
-                ],
+                points: {
+                    coord: [
+                        [-9, 4],
+                        [-6, 4],
+                        [-6, 1],
+                        [-9, 1],
+                    ],
+                },
                 color: "pink",
             }),
         ],
@@ -1049,12 +1061,14 @@ export const staticGraphQuestionWithAnotherWidget: () => PerseusRenderer =
                     color: "blue",
                 }),
                 generateIGLockedPolygon({
-                    points: [
-                        [-9, 4],
-                        [-6, 4],
-                        [-6, 1],
-                        [-9, 1],
-                    ],
+                    points: {
+                        coord: [
+                            [-9, 4],
+                            [-6, 4],
+                            [-6, 1],
+                            [-9, 1],
+                        ],
+                    },
                     color: "pink",
                 }),
             ],
@@ -1168,11 +1182,13 @@ export const graphWithLabeledPolygon: PerseusRenderer =
         correct: generateIGSegmentGraph(),
         lockedFigures: [
             generateIGLockedPolygon({
-                points: [
-                    [0, 0],
-                    [4, 0],
-                    [2, 4],
-                ],
+                points: {
+                    coord: [
+                        [0, 0],
+                        [4, 0],
+                        [2, 4],
+                    ],
+                },
                 labels: [generateIGLockedLabel({text: "E", coord: [0, 0]})],
             }),
         ],

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
@@ -14,7 +14,6 @@ import type {LockedPolygonType} from "@khanacademy/perseus-core";
 
 const LockedPolygon = (props: LockedPolygonType) => {
     const {points, color, showVertices, fillStyle, strokeStyle, weight} = props;
-    const coords = points.map((point) => point.coord);
 
     const hasAria = !!props.ariaLabel;
 
@@ -26,7 +25,7 @@ const LockedPolygon = (props: LockedPolygonType) => {
             role="img"
         >
             <Polygon
-                points={[...coords]}
+                points={[...points.map(({coord}) => coord)]}
                 fillOpacity={lockedFigureFillStyles[fillStyle]}
                 strokeStyle={strokeStyle}
                 color={lockedFigureColors[color]}
@@ -44,11 +43,11 @@ const LockedPolygon = (props: LockedPolygonType) => {
                 }}
             />
             {showVertices &&
-                coords.map((point, index) => (
+                points.map((point, index) => (
                     <Point
                         key={`locked-polygon-point-${index}`}
-                        x={point[X]}
-                        y={point[Y]}
+                        x={point.coord[X]}
+                        y={point.coord[Y]}
                         color={lockedFigureColors[color]}
                     />
                 ))}

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
@@ -14,7 +14,7 @@ import type {LockedPolygonType} from "@khanacademy/perseus-core";
 
 const LockedPolygon = (props: LockedPolygonType) => {
     const {points, color, showVertices, fillStyle, strokeStyle, weight} = props;
-    const coords = points.coord;
+    const coords = points.map((point) => point.coord);
 
     const hasAria = !!props.ariaLabel;
 

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
@@ -14,6 +14,7 @@ import type {LockedPolygonType} from "@khanacademy/perseus-core";
 
 const LockedPolygon = (props: LockedPolygonType) => {
     const {points, color, showVertices, fillStyle, strokeStyle, weight} = props;
+    const coords = points.coord;
 
     const hasAria = !!props.ariaLabel;
 
@@ -25,7 +26,7 @@ const LockedPolygon = (props: LockedPolygonType) => {
             role="img"
         >
             <Polygon
-                points={[...points]}
+                points={[...coords]}
                 fillOpacity={lockedFigureFillStyles[fillStyle]}
                 strokeStyle={strokeStyle}
                 color={lockedFigureColors[color]}
@@ -43,7 +44,7 @@ const LockedPolygon = (props: LockedPolygonType) => {
                 }}
             />
             {showVertices &&
-                points.map((point, index) => (
+                coords.map((point, index) => (
                     <Point
                         key={`locked-polygon-point-${index}`}
                         x={point[X]}


### PR DESCRIPTION
## Summary

This is the first PR in a stack to enable per-vertex angle labeling in locked polygons.

- Add `LockedPolygonPointType` with shape `{coord: Coord}`
- Change `LockedPolygonType.points` from type `Coord[]` to `LockedPolygonPointType[]`
- Update rendering, editor, linter, defaults, fixtures, stories, and tests to use `points.coord`
- Keep parser backwards-compatible by accepting legacy raw `Coord[]` polygon points and normalizing to the new shape
- Add parser coverage for both new and legacy locked polygon point formats

## Next steps

- Extend `LockedPolygonPointType` with a `showAngle` field that determines whether the angle should be shown for that point (#3730)
- Extend `LockedPolygonPointType` with a `computedAngle` field that is populated during parsing with the computed angle measurement

## Test plan
- `pnpm jest packages/perseus-core/src/parse-perseus-json/regression-tests/parse-perseus-json-regression.test.ts -u --runInBand --watchman=false`
- `pnpm jest packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.test.ts packages/perseus-core/src/utils/get-default-figure-for-type.test.ts
packages/perseus-core/src/utils/generators/interactive-graph-widget-generator.test.ts packages/perseus-linter/src/rules/interactive-graph-widget-error.test.ts --runInBand --watchman=false`