### PR TITLE
[ColorSync][Interactive Graph] Use the parser to convert orange to gold

### DIFF
--- a/.changeset/empty-icons-act.md
+++ b/.changeset/empty-icons-act.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-core": minor
+"@khanacademy/perseus-editor": minor
+---
+
+[ColorSync][interactive graph] Use the parser to convert orange to gold

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -990,8 +990,6 @@ export const lockedFigureColorNames = [
     "purple",
     "pink",
     "red",
-    // deprecated
-    "orange",
 ] as const;
 
 export type LockedFigureColor = (typeof lockedFigureColorNames)[number];
@@ -1004,9 +1002,6 @@ export const lockedFigureColors: Record<LockedFigureColor, string> = {
     pink: "var(--wb-semanticColor-learning-math-foreground-pink)",
     purple: "var(--wb-semanticColor-learning-math-foreground-purple)",
     red: "var(--wb-semanticColor-learning-math-foreground-red)",
-    // Deprecated: "orange" is the old name for the current "gold" color.
-    // We still have to support this in existing content.
-    orange: "var(--wb-semanticColor-learning-math-foreground-gold)",
 } as const;
 
 export type StrokeWeight = "thin" | "medium" | "thick";

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.test.ts
@@ -312,7 +312,7 @@ describe("parseInteractiveGraphWidget", () => {
         );
     });
 
-    it("accepts the deprecated 'orange' color on locked figures so existing content keeps rendering", () => {
+    it("parses the deprecated 'orange' color on locked figures to 'gold'", () => {
         const result = parse(
             {
                 type: "interactive-graph",
@@ -375,7 +375,7 @@ describe("parseInteractiveGraphWidget", () => {
                         {
                             type: "point",
                             coord: [0, 0],
-                            color: "orange",
+                            color: "gold",
                             filled: true,
                             labels: [],
                         },

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -1,4 +1,3 @@
-import {lockedFigureColorNames} from "../../data-schema";
 import {
     array,
     boolean,
@@ -188,7 +187,20 @@ export const parsePerseusGraphType = discriminatedUnionOn("type")
     .withBranch("logarithm", parsePerseusGraphTypeLogarithm)
     .withBranch("vector", parsePerseusGraphTypeVector).parser;
 
-const parseLockedFigureColor = enumeration(...lockedFigureColorNames);
+const parseLockedFigureColor = pipeParsers(
+    enumeration(
+        // Same as lockedFigureColorNames in data-schema.ts
+        "blue",
+        "gold",
+        "green",
+        "grayH",
+        "purple",
+        "pink",
+        "red",
+        // deprecated name - "orange" is now "gold"
+        "orange",
+    ),
+).then(convert((color) => (color === "orange" ? "gold" : color))).parser;
 
 const parseLockedFigureFillType = enumeration(
     "none",

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -6778,6 +6778,340 @@ $3$ | $8$
 }
 `;
 
+exports[`parseAndMigratePerseusItem given interactive-graph-locked-figure-colors.ts returns the same result as before 1`] = `
+{
+  "answerArea": {
+    "calculator": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTimeToPayOff": false,
+    "financialCalculatorTotalAmount": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+  },
+  "hints": [],
+  "question": {
+    "content": "A graph with locked figures of different colors.
+
+[[☃ interactive-graph 1]]
+
+",
+    "images": {},
+    "widgets": {
+      "interactive-graph 1": {
+        "alignment": "default",
+        "graded": true,
+        "options": {
+          "backgroundImage": {
+            "url": null,
+          },
+          "correct": {
+            "type": "none",
+          },
+          "graph": {
+            "type": "none",
+          },
+          "gridStep": [
+            0.5,
+            0.1,
+          ],
+          "labelLocation": "onAxis",
+          "labels": [
+            "$x$",
+            "$y$",
+          ],
+          "lockedFigures": [
+            {
+              "color": "blue",
+              "coord": [
+                1,
+                1,
+              ],
+              "filled": true,
+              "labels": [],
+              "type": "point",
+            },
+            {
+              "color": "gold",
+              "coord": [
+                2,
+                1,
+              ],
+              "filled": true,
+              "labels": [],
+              "type": "point",
+            },
+            {
+              "color": "green",
+              "coord": [
+                3,
+                1,
+              ],
+              "filled": true,
+              "labels": [],
+              "type": "point",
+            },
+            {
+              "color": "grayH",
+              "coord": [
+                4,
+                1,
+              ],
+              "filled": true,
+              "labels": [],
+              "type": "point",
+            },
+            {
+              "color": "purple",
+              "coord": [
+                5,
+                1,
+              ],
+              "filled": true,
+              "labels": [],
+              "type": "point",
+            },
+            {
+              "color": "pink",
+              "coord": [
+                5,
+                1,
+              ],
+              "filled": true,
+              "labels": [],
+              "type": "point",
+            },
+            {
+              "color": "red",
+              "coord": [
+                6,
+                1,
+              ],
+              "filled": true,
+              "labels": [],
+              "type": "point",
+            },
+            {
+              "color": "gold",
+              "coord": [
+                7,
+                1,
+              ],
+              "filled": true,
+              "labels": [],
+              "type": "point",
+            },
+          ],
+          "markings": "graph",
+          "range": [
+            [
+              0,
+              8,
+            ],
+            [
+              0,
+              2,
+            ],
+          ],
+          "showAxisArrows": {
+            "xMax": true,
+            "xMin": true,
+            "yMax": true,
+            "yMin": true,
+          },
+          "showAxisTicks": {
+            "x": true,
+            "y": true,
+          },
+          "showProtractor": false,
+          "showTooltips": false,
+          "snapStep": [
+            0.25,
+            0.05,
+          ],
+          "step": [
+            1,
+            0.5,
+          ],
+        },
+        "static": false,
+        "type": "interactive-graph",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`parseAndMigratePerseusItem given interactive-graph-locked-figure-colors.ts returns the same result as before with answer information removed 1`] = `
+{
+  "answerArea": {
+    "calculator": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTimeToPayOff": false,
+    "financialCalculatorTotalAmount": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+  },
+  "hints": [],
+  "question": {
+    "content": "A graph with locked figures of different colors.
+
+[[☃ interactive-graph 1]]
+
+",
+    "images": {},
+    "widgets": {
+      "interactive-graph 1": {
+        "alignment": "default",
+        "graded": true,
+        "options": {
+          "backgroundImage": {
+            "url": null,
+          },
+          "correct": {
+            "type": "linear",
+          },
+          "graph": {
+            "type": "none",
+          },
+          "gridStep": [
+            0.5,
+            0.1,
+          ],
+          "labelLocation": "onAxis",
+          "labels": [
+            "$x$",
+            "$y$",
+          ],
+          "lockedFigures": [
+            {
+              "color": "blue",
+              "coord": [
+                1,
+                1,
+              ],
+              "filled": true,
+              "labels": [],
+              "type": "point",
+            },
+            {
+              "color": "gold",
+              "coord": [
+                2,
+                1,
+              ],
+              "filled": true,
+              "labels": [],
+              "type": "point",
+            },
+            {
+              "color": "green",
+              "coord": [
+                3,
+                1,
+              ],
+              "filled": true,
+              "labels": [],
+              "type": "point",
+            },
+            {
+              "color": "grayH",
+              "coord": [
+                4,
+                1,
+              ],
+              "filled": true,
+              "labels": [],
+              "type": "point",
+            },
+            {
+              "color": "purple",
+              "coord": [
+                5,
+                1,
+              ],
+              "filled": true,
+              "labels": [],
+              "type": "point",
+            },
+            {
+              "color": "pink",
+              "coord": [
+                5,
+                1,
+              ],
+              "filled": true,
+              "labels": [],
+              "type": "point",
+            },
+            {
+              "color": "red",
+              "coord": [
+                6,
+                1,
+              ],
+              "filled": true,
+              "labels": [],
+              "type": "point",
+            },
+            {
+              "color": "gold",
+              "coord": [
+                7,
+                1,
+              ],
+              "filled": true,
+              "labels": [],
+              "type": "point",
+            },
+          ],
+          "markings": "graph",
+          "range": [
+            [
+              0,
+              8,
+            ],
+            [
+              0,
+              2,
+            ],
+          ],
+          "showAxisArrows": {
+            "xMax": true,
+            "xMin": true,
+            "yMax": true,
+            "yMin": true,
+          },
+          "showAxisTicks": {
+            "x": true,
+            "y": true,
+          },
+          "showProtractor": false,
+          "showTooltips": false,
+          "snapStep": [
+            0.25,
+            0.05,
+          ],
+          "step": [
+            1,
+            0.5,
+          ],
+        },
+        "static": false,
+        "type": "interactive-graph",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`parseAndMigratePerseusItem given interactive-graph-locked-figures-missing-weights.ts returns the same result as before 1`] = `
 {
   "answerArea": {

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/interactive-graph-locked-figure-colors.ts
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/interactive-graph-locked-figure-colors.ts
@@ -1,0 +1,123 @@
+// WARNING: Do not change or delete this file! If you do, Perseus might become
+// unable to parse the current data format, which will break clients.
+// If you need to add more regression tests, add a new file to this directory.
+export default {
+    question: {
+        content:
+            "A graph with locked figures of different colors.\n\n[[☃ interactive-graph 1]]\n\n",
+        images: {},
+        widgets: {
+            "interactive-graph 1": {
+                type: "interactive-graph",
+                alignment: "default",
+                static: false,
+                graded: true,
+                options: {
+                    step: [1, 0.5],
+                    backgroundImage: {
+                        url: null,
+                    },
+                    markings: "graph",
+                    labels: ["$x$", "$y$"],
+                    labelLocation: "onAxis",
+                    showProtractor: false,
+                    showTooltips: false,
+                    range: [
+                        [0, 8],
+                        [0, 2],
+                    ],
+                    showAxisArrows: {
+                        xMin: true,
+                        xMax: true,
+                        yMin: true,
+                        yMax: true,
+                    },
+                    showAxisTicks: {
+                        x: true,
+                        y: true,
+                    },
+                    gridStep: [0.5, 0.1],
+                    snapStep: [0.25, 0.05],
+                    lockedFigures: [
+                        {
+                            type: "point",
+                            coord: [1, 1],
+                            color: "blue",
+                            filled: true,
+                            labels: [],
+                        },
+                        {
+                            type: "point",
+                            coord: [2, 1],
+                            color: "gold",
+                            filled: true,
+                            labels: [],
+                        },
+                        {
+                            type: "point",
+                            coord: [3, 1],
+                            color: "green",
+                            filled: true,
+                            labels: [],
+                        },
+                        {
+                            type: "point",
+                            coord: [4, 1],
+                            color: "grayH",
+                            filled: true,
+                            labels: [],
+                        },
+                        {
+                            type: "point",
+                            coord: [5, 1],
+                            color: "purple",
+                            filled: true,
+                            labels: [],
+                        },
+                        {
+                            type: "point",
+                            coord: [5, 1],
+                            color: "pink",
+                            filled: true,
+                            labels: [],
+                        },
+                        {
+                            type: "point",
+                            coord: [6, 1],
+                            color: "red",
+                            filled: true,
+                            labels: [],
+                        },
+                        {
+                            type: "point",
+                            coord: [7, 1],
+                            // deprecated color
+                            color: "orange",
+                            filled: true,
+                            labels: [],
+                        },
+                    ],
+                    graph: {
+                        type: "none",
+                    },
+                    correct: {
+                        type: "none",
+                    },
+                },
+                version: {
+                    major: 0,
+                    minor: 0,
+                },
+            },
+        },
+    },
+    answerArea: {
+        calculator: false,
+        financialCalculatorMonthlyPayment: false,
+        financialCalculatorTotalAmount: false,
+        financialCalculatorTimeToPayOff: false,
+        periodicTable: false,
+        periodicTableWithKey: false,
+    },
+    hints: [],
+};

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/color-select.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/color-select.tsx
@@ -12,11 +12,6 @@ import ColorSwatch from "./color-swatch";
 import type {LockedFigureColor} from "@khanacademy/perseus-core";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-// Get all the possible colors to put in the dropdown,
-// except for the deprecated "orange" color.
-const possibleColors: Exclude<LockedFigureColor, "orange">[] =
-    lockedFigureColorNames.filter((color) => color !== "orange");
-
 type Props = {
     selectedValue: LockedFigureColor;
     style?: StyleType;
@@ -32,16 +27,14 @@ const ColorSelect = (props: Props) => {
                 color
                 <Strut size={spacing.xxSmall_6} />
                 <SingleSelect
-                    selectedValue={
-                        selectedValue === "orange" ? "gold" : selectedValue
-                    }
+                    selectedValue={selectedValue}
                     // TODO(LEMS-2656): remove TS suppression
                     // eslint-disable-next-line no-restricted-syntax
                     onChange={onChange as any}
                     // Placeholder is required, but never gets used.
                     placeholder=""
                 >
-                    {possibleColors.map((colorName) => (
+                    {lockedFigureColorNames.map((colorName) => (
                         <OptionItem
                             key={colorName}
                             value={colorName}


### PR DESCRIPTION
## Summary:
When we updated the colors to the math learning tokens, orange got updated to gold.
There was an issue and the quick fix involved manually handling old "orange" values in the code.

However, the best practice would be to assume "gold" is the only valid value in the data schema,
and have the parser handle any "orange" values that may come through. 

Implementing that here.

Issue: https://khanacademy.atlassian.net/browse/LEMS-4219

## Test plan:
- `pnpm jest packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.test.ts`
- Confirm that the new regression test has TWO instances of "gold" for the item data that has one "gold" and one "orange"

Storybook
- Go to `/?path=/story/editors-editorpage--demo`
- Add a new interactive graph
- Add a new locked figure and set it to be gold
- Go to Developer JSON mode
- Update "gold" to "orange"
- Exit Developer JSON mode
- Confirm that the editor still shows "gold"
- Go back to Devloper JSON mode
- Confirm that the JSON says "gold" again


https://github.com/user-attachments/assets/7db877ad-c7cd-41d4-9187-7e5f4461add8

