### PR TITLE
Bug fix for graded group pips on iOS mobile web

### DIFF
--- a/.changeset/fix-graded-group-set-ios-pips.md
+++ b/.changeset/fix-graded-group-set-ios-pips.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Graded group set] Fix pip indicators broken on iOS/mobile — restore `list-style:none` and add `role="list"` to the indicator `<ul>`
+
+Issue: [LEMS-4220](https://khanacademy.atlassian.net/browse/LEMS-4220)

--- a/.changeset/fix-graded-group-set-ios-pips.md
+++ b/.changeset/fix-graded-group-set-ios-pips.md
@@ -3,5 +3,3 @@
 ---
 
 [Graded group set] Fix pip indicators broken on iOS/mobile — restore `list-style:none` and add `role="list"` to the indicator `<ul>`
-
-Issue: [LEMS-4220](https://khanacademy.atlassian.net/browse/LEMS-4220)

--- a/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set.test.ts.snap
@@ -38,7 +38,8 @@ exports[`graded group set widget should snapshot 1`] = `
                 class="spacer_bc4egv"
               />
               <ul
-                class="indicatorContainer_1qvfx9i indicatorContainer"
+                class="indicatorContainer_16w94bw indicatorContainer"
+                role="list"
               >
                 <li
                   class="indicator_7k5kza"

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -53,6 +53,7 @@ class Indicators extends React.Component<IndicatorsProps> {
             <ul
                 // reduntantly add class name for use in .css files--
                 //   the styles object key gets hashed
+                role="list"
                 className={classNames(
                     css(styles.indicatorContainer),
                     "indicatorContainer",
@@ -271,7 +272,7 @@ const styles = StyleSheet.create({
     indicatorContainer: {
         display: "flex",
         flexDirection: "row",
-        listStyleType: '""',
+        listStyleType: "none",
         margin: "unset",
         paddingInlineStart: "unset",
         flexWrap: "wrap",

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -50,6 +50,7 @@ class Indicators extends React.Component<IndicatorsProps> {
 
     render(): React.ReactNode {
         return (
+            // eslint-disable-next-line jsx-a11y/no-redundant-roles -- role="list" is intentional: Safari+VoiceOver strips list semantics from <ul> with list-style:none, so explicit role restores them
             <ul
                 // reduntantly add class name for use in .css files--
                 //   the styles object key gets hashed


### PR DESCRIPTION
## Summary
Improves accessibility of the graded-group-set widget's indicator list by adding proper semantic HTML and fixing CSS list styling. Fix the pips so they stay correctly filled in on iOS mobile web. In the video below, the first site is the old way, second site is the fixed ZND:

https://github.com/user-attachments/assets/a26d4a0f-5285-4535-a114-845e548112fe


Issue: [LEMS-4220](https://khanacademy.atlassian.net/browse/LEMS-4220)

## Key Changes
- Added `role="list"` to the `<ul>` element containing indicators to ensure proper semantic meaning for assistive technologies
- Fixed `listStyleType` CSS property from invalid `'""'` string to the correct `"none"` value
- Updated snapshot to reflect the new role attribute and corrected class hash

## Implementation Details
The indicator container is a `<ul>` element that displays a list of indicators. By adding the `role="list"` attribute, we ensure that screen readers properly announce this as a list structure. The CSS fix corrects an invalid property value that was attempting to hide list bullets using an empty string instead of the standard `"none"` value.

https://claude.ai/code/session_01DjHWe3umGq5qtRv5qoEM7C

[LEMS-4220]: https://khanacademy.atlassian.net/browse/LEMS-4220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ