### PR TITLE
[TEST] Add changes to both data-schema and item-splitting

### DIFF
--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1828,6 +1828,10 @@ export type PerseusRadioChoice = {
 /** Options for the sorter widget. Cards to arrange into the correct order. */
 export type PerseusSorterWidgetOptions = {
     /**
+     * Test Change
+     */
+    name: string;
+    /**
      * Translatable Text; The correct answer (in the correct order). The user
      * will see the cards in a randomized order.
      */

--- a/packages/perseus-core/src/utils/split-perseus-item.ts
+++ b/packages/perseus-core/src/utils/split-perseus-item.ts
@@ -14,8 +14,6 @@ import type {PerseusItem} from "../data-schema";
 export default function splitPerseusItem(original: PerseusItem): PerseusItem {
     const item = deepClone(original);
 
-    console.log("Test affecting item splitting");
-
     return {
         ...item,
         question: splitPerseusRenderer(item.question),

--- a/packages/perseus-core/src/utils/split-perseus-item.ts
+++ b/packages/perseus-core/src/utils/split-perseus-item.ts
@@ -14,6 +14,8 @@ import type {PerseusItem} from "../data-schema";
 export default function splitPerseusItem(original: PerseusItem): PerseusItem {
     const item = deepClone(original);
 
+    console.log("Test affecting item splitting");
+
     return {
         ...item,
         question: splitPerseusRenderer(item.question),


### PR DESCRIPTION
## Summary:

A PR to test data-schema and item-splitting detection.  

### Update 1 - data-schema and item-splitting triggered

| success? | check | url | screenshot |
| --- | --- | --- | --- |
| ✅ | data-schema | https://github.com/Khan/perseus/pull/3714/checks?check_run_id=79386966500 | <img width="500" src="https://github.com/user-attachments/assets/9f672687-8f07-4b03-a3c2-3ea4bb7a5ff8" /> |
| ✅ | item-splitting | https://github.com/Khan/perseus/pull/3714/checks?check_run_id=79386966500 | <img width="500" src="https://github.com/user-attachments/assets/f24c8ff8-90db-44ad-82c7-52716e2621e3" />  | 

PR Status panel showing the two blocking comparison checks 

<img width="500" src="https://github.com/user-attachments/assets/15ef14aa-8598-4c35-9671-8daff7430982" />

### Update 2 - data-schema "ack'd"



Issue: LEMS-XXXX

## Test plan: