### PR TITLE
[Interactive Graph] Fix line ends bending in for Linear / Ray interactive graphs

### DIFF
--- a/.changeset/stale-fishes-rest.md
+++ b/.changeset/stale-fishes-rest.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Interactive Graph] Fix line ends bending in for Linear / Ray interactive graphs

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.tsx
@@ -84,11 +84,15 @@ describe("insetTipAlongRay", () => {
 
     it("pulls tip 4px back toward tail along a horizontal ray", () => {
         // Arrange, Act: 1 graph unit = 20 px, so 4 px ≈ 0.2 graph units
-        const result = insetTipAlongRay([5, 3], [10, 3], range400, dims400);
+        const tail = [5, 3]
+        const tip = [10, 3]
+        const result = insetTipAlongRay(tail, tip, range400, dims400);
 
         // Assert
-        expect(result[0]).toBeCloseTo(9.8);
-        expect(result[1]).toBeCloseTo(3);
+        const expectedSomethingX = 9.8
+        const expectedSomethingY = 3
+        expect(result[0]).toBeCloseTo(expectedSomethingX);
+        expect(result[1]).toBeCloseTo(expectedSomethingY);
     });
 
     it("keeps a horizontal extension straight when tail sits on an edge (LEMS-4203)", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.tsx
@@ -84,13 +84,13 @@ describe("insetTipAlongRay", () => {
 
     it("pulls tip 4px back toward tail along a horizontal ray", () => {
         // Arrange, Act: 1 graph unit = 20 px, so 4 px ≈ 0.2 graph units
-        const tail = [5, 3]
-        const tip = [10, 3]
+        const tail: vec.Vector2 = [5, 3];
+        const tip: vec.Vector2 = [10, 3];
         const result = insetTipAlongRay(tail, tip, range400, dims400);
 
         // Assert
-        const expectedSomethingX = 9.8
-        const expectedSomethingY = 3
+        const expectedSomethingX = 9.8;
+        const expectedSomethingY = 3;
         expect(result[0]).toBeCloseTo(expectedSomethingX);
         expect(result[1]).toBeCloseTo(expectedSomethingY);
     });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.test.tsx
@@ -6,6 +6,7 @@ import * as UseDraggableModule from "../use-draggable";
 
 import {
     getMovableLineKeyboardConstraint,
+    insetTipAlongRay,
     MovableLine,
     trimRange,
 } from "./movable-line";
@@ -71,6 +72,58 @@ describe("trimRange", () => {
             [-9.6, 9.6],
             [-0.98, 0.98],
         ]);
+    });
+});
+
+describe("insetTipAlongRay", () => {
+    const range400: [Interval, Interval] = [
+        [-10, 10],
+        [-10, 10],
+    ];
+    const dims400: vec.Vector2 = [400, 400];
+
+    it("pulls tip 4px back toward tail along a horizontal ray", () => {
+        // Arrange, Act: 1 graph unit = 20 px, so 4 px ≈ 0.2 graph units
+        const result = insetTipAlongRay([5, 3], [10, 3], range400, dims400);
+
+        // Assert
+        expect(result[0]).toBeCloseTo(9.8);
+        expect(result[1]).toBeCloseTo(3);
+    });
+
+    it("keeps a horizontal extension straight when tail sits on an edge (LEMS-4203)", () => {
+        const result = insetTipAlongRay([5, -10], [10, -10], range400, dims400);
+
+        // Assert
+        expect(result[0]).toBeCloseTo(9.8);
+        expect(result[1]).toBe(-10);
+    });
+
+    it("returns tip unchanged when tail and tip coincide", () => {
+        // Arrange, Act
+        const result = insetTipAlongRay([2, 2], [2, 2], range400, dims400);
+
+        // Assert
+        expect(result).toEqual([2, 2]);
+    });
+
+    it("measures inset distance in pixel space when axes have different scales", () => {
+        // Arrange: x-axis is 10 px/unit, y-axis is 100 px/unit
+        const range: [Interval, Interval] = [
+            [-10, 10],
+            [-1, 1],
+        ];
+        const dims: vec.Vector2 = [200, 200];
+
+        // Act: diagonal ray of equal graph-unit components — but in pixel
+        // space the y-component is 10x longer, so the inset is dominated
+        // by the y direction.
+        const result = insetTipAlongRay([0, 0], [1, 1], range, dims);
+
+        // Assert: pixel-space length = √(10² + 100²) ≈ 100.5, so 4 px
+        // back ≈ 0.0398 of the way toward tail.
+        expect(result[0]).toBeCloseTo(0.9602, 3);
+        expect(result[1]).toBeCloseTo(0.9602, 3);
     });
 });
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -308,27 +308,27 @@ export const getMovableLineKeyboardConstraint = (
     };
 };
 
+// Inset extensions from the graph edge so the arrowhead isn't clipped.
+const GRAPH_EDGE_INSET_PX = 4;
+
 export function trimRange(
     range: [Interval, Interval],
     graphDimensionsInPixels: vec.Vector2,
 ): [Interval, Interval] {
-    const pixelsToTrim = 4;
     const [xRange, yRange] = range;
     const [pixelsWide, pixelsTall] = graphDimensionsInPixels;
     const graphUnitsPerPixelX = size(xRange) / pixelsWide;
     const graphUnitsPerPixelY = size(yRange) / pixelsTall;
-    const graphUnitsToTrimX = pixelsToTrim * graphUnitsPerPixelX;
-    const graphUnitsToTrimY = pixelsToTrim * graphUnitsPerPixelY;
+    const graphUnitsToTrimX = GRAPH_EDGE_INSET_PX * graphUnitsPerPixelX;
+    const graphUnitsToTrimY = GRAPH_EDGE_INSET_PX * graphUnitsPerPixelY;
     return inset([graphUnitsToTrimX, graphUnitsToTrimY], range);
 }
 
-// Matches `pixelsToTrim` in trimRange above so extension arrows keep the
-// same visual length
-const EXTENSION_TIP_INSET_PX = 4;
-
 /**
- * Without this inset the arrow tip sits exactly on the graph edge, where
- * the arrowhead glyph is half-clipped by the viewport.
+ * Returns `tip` pulled back toward `tail` by GRAPH_EDGE_INSET_PX, measured
+ * in pixel space (not graph units) so the inset looks the same regardless
+ * of axis scale. Used to keep arrowhead glyphs from being clipped by the
+ * viewport edge.
  */
 export function insetTipAlongRay(
     tail: vec.Vector2,
@@ -336,15 +336,26 @@ export function insetTipAlongRay(
     range: [Interval, Interval],
     graphDimensionsInPixels: vec.Vector2,
 ): vec.Vector2 {
+    // Direction from tail to tip, in graph units.
     const dx = tip[0] - tail[0];
     const dy = tip[1] - tail[1];
+
+    // Conversion factors from graph units to pixels on each axis. These
+    // can differ when the x and y axes have different scales.
     const [pixelsWide, pixelsTall] = graphDimensionsInPixels;
     const pxPerUnitX = pixelsWide / size(range[0]);
     const pxPerUnitY = pixelsTall / size(range[1]);
+
+    // Length of the ray in pixel space. We measure in pixels (not graph
+    // units) so the inset is a fixed visual distance regardless of scale.
     const lenPx = Math.hypot(dx * pxPerUnitX, dy * pxPerUnitY);
     if (lenPx === 0) {
+        // tail and tip coincide; no direction to inset along.
         return tip;
     }
-    const scale = EXTENSION_TIP_INSET_PX / lenPx;
+
+    // Fraction of the ray that equals GRAPH_EDGE_INSET_PX in pixel space.
+    // Subtract that fraction of the (graph-unit) direction from `tip`.
+    const scale = GRAPH_EDGE_INSET_PX / lenPx;
     return [tip[0] - dx * scale, tip[1] - dy * scale];
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line.tsx
@@ -169,18 +169,18 @@ const Line = (props: LineProps) => {
         interactiveColor,
     } = useGraphConfig();
 
-    let startExtend: vec.Vector2 | undefined = undefined;
-    let endExtend: vec.Vector2 | undefined = undefined;
+    const computeExtensionTip = (tail: vec.Vector2, source: vec.Vector2) =>
+        insetTipAlongRay(
+            tail,
+            getIntersectionOfRayWithBox(source, tail, range),
+            range,
+            graphDimensionsInPixels,
+        );
 
-    if (extend) {
-        const trimmedRange = trimRange(range, graphDimensionsInPixels);
-        startExtend = extend.start
-            ? getIntersectionOfRayWithBox(end, start, trimmedRange)
-            : undefined;
-        endExtend = extend.end
-            ? getIntersectionOfRayWithBox(start, end, trimmedRange)
-            : undefined;
-    }
+    const startExtend = extend?.start
+        ? computeExtensionTip(start, end)
+        : undefined;
+    const endExtend = extend?.end ? computeExtensionTip(end, start) : undefined;
 
     const line = useRef<SVGGElement>(null);
     const {dragging} = useDraggable({
@@ -320,4 +320,31 @@ export function trimRange(
     const graphUnitsToTrimX = pixelsToTrim * graphUnitsPerPixelX;
     const graphUnitsToTrimY = pixelsToTrim * graphUnitsPerPixelY;
     return inset([graphUnitsToTrimX, graphUnitsToTrimY], range);
+}
+
+// Matches `pixelsToTrim` in trimRange above so extension arrows keep the
+// same visual length
+const EXTENSION_TIP_INSET_PX = 4;
+
+/**
+ * Without this inset the arrow tip sits exactly on the graph edge, where
+ * the arrowhead glyph is half-clipped by the viewport.
+ */
+export function insetTipAlongRay(
+    tail: vec.Vector2,
+    tip: vec.Vector2,
+    range: [Interval, Interval],
+    graphDimensionsInPixels: vec.Vector2,
+): vec.Vector2 {
+    const dx = tip[0] - tail[0];
+    const dy = tip[1] - tail[1];
+    const [pixelsWide, pixelsTall] = graphDimensionsInPixels;
+    const pxPerUnitX = pixelsWide / size(range[0]);
+    const pxPerUnitY = pixelsTall / size(range[1]);
+    const lenPx = Math.hypot(dx * pxPerUnitX, dy * pxPerUnitY);
+    if (lenPx === 0) {
+        return tip;
+    }
+    const scale = EXTENSION_TIP_INSET_PX / lenPx;
+    return [tip[0] - dx * scale, tip[1] - dy * scale];
 }


### PR DESCRIPTION
## Summary:
Fix line ends bending in for Linear / Ray interactive graphs.

### Issue
When both control points of a Linear (or Ray) interactive graph are dragged to the same edge of the graph (most visible on the bottom or left edge), the extension arrows render sharply diagonal toward a corner instead of continuing straight along the edge.

### Root cause
`getIntersectionOfRayWithBox` in `packages/perseus/src/widgets/interactive-graphs/graphs/utils.ts` requires its source point (`initialPoint`) to lie **inside** the box. The call site in `movable-line.tsx` was passing a `trimRange`-shrunk box (4 px inset on each edge) so the arrowhead could clear the graph viewport. When an endpoint sat exactly on the graph edge, it fell **outside** the shrunk box, violating the precondition: both `isBetween` branches in the algorithm failed and it fell through to its default return — the opposite corner of the trimmed box. That's the bend the user sees.

Issue: LEMS-4203

## Test plan:
1. Navigate to Point Graph story
2. Confirm that when the points are dragged to the edge of the graph the arrow remain with it