### PR TITLE
[Definition] Fix typo in translation

### DIFF
--- a/.changeset/popular-walls-give.md
+++ b/.changeset/popular-walls-give.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Definition] Fix typo in translation

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -1385,7 +1385,7 @@ export const strings = {
     imageResetZoomAriaLabel: "Close image.",
     gifPlayButtonLabel: "Play Animation",
     gifPauseButtonLabel: "Pause Animation",
-    definitionIdentifier: "Definition of: %(word)",
+    definitionIdentifier: "Definition of: %(word)s",
 } satisfies {
     [key in keyof PerseusStrings]:
         | string


### PR DESCRIPTION
## Summary:
[Definition] Fix typo in translation

This will fix the CI issue in frontend
```
@khan/classroom-builders:typecheck
cache miss, executing 4e7062bac8b2b037

> @khan/classroom-builders@0.0.1 typecheck /home/github/work/frontend/frontend/libs/classroom/builders
> tsc --noEmit

Error: ../../component/perseus/src/perseus-strings-lingui.tsx(579,5): error TS2322: Type 'string' is not assignable to type '({ word }: { word: string; }) => string'.
```

Issue: LEMS-4104

## Test plan: