### PR TITLE
Add test to catch typo in translation e.g. %(word) -> $(word)s

### DIFF
--- a/.changeset/pretty-cheetahs-draw.md
+++ b/.changeset/pretty-cheetahs-draw.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Add test to catch typo in translation e.g. %(word) -> \$(word)s

--- a/packages/perseus/src/strings.test.ts
+++ b/packages/perseus/src/strings.test.ts
@@ -1,5 +1,43 @@
-import {mapErrorToString, mockStrings} from "./strings";
+import {mapErrorToString, mockStrings, strings} from "./strings";
 import {clone} from "./testing/object-utils";
+
+describe("strings", () => {
+    // Iterate every translatable string in the `strings` export, including the
+    // `message` field of objects with translator context and the `one`/`other`
+    // fields of plural entries.
+    function* translatableStrings(): Iterable<{key: string; value: string}> {
+        for (const [key, val] of Object.entries(strings)) {
+            if (typeof val === "string") {
+                yield {key, value: val};
+            } else if (typeof val === "object") {
+                if ("message" in val && typeof val.message === "string") {
+                    yield {key, value: val.message};
+                }
+                if ("one" in val && typeof val.one === "string") {
+                    yield {key: `${key}.one`, value: val.one};
+                }
+                if ("other" in val && typeof val.other === "string") {
+                    yield {key: `${key}.other`, value: val.other};
+                }
+            }
+        }
+    }
+
+    it("has an `s` format specifier on every %(name) placeholder", () => {
+        // A `%(name)` placeholder must be followed by the `s` format specifier
+        // (the codebase uses `s` exclusively). Catches typos like `%(word)`
+        // missing the trailing `s`, which silently break interpolation.
+        const malformed: Array<{key: string; value: string; bad: string}> = [];
+
+        for (const {key, value} of translatableStrings()) {
+            for (const match of value.matchAll(/%\([^)]+\)(?!s)/g)) {
+                malformed.push({key, value, bad: match[0]});
+            }
+        }
+
+        expect(malformed).toEqual([]);
+    });
+});
 
 describe("mapErrorToString", () => {
     it("handles translated strings", () => {

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -1385,7 +1385,7 @@ export const strings = {
     imageResetZoomAriaLabel: "Close image.",
     gifPlayButtonLabel: "Play Animation",
     gifPauseButtonLabel: "Pause Animation",
-    definitionIdentifier: "Definition of: %(word)",
+    definitionIdentifier: "Definition of: %(word)s",
 } satisfies {
     [key in keyof PerseusStrings]:
         | string


### PR DESCRIPTION
## Summary:
Add test to catch typo in translation e.g. %(word) -> $(word)s

Issue: LEMS-XXXX

## Test plan: