### PR TITLE
[Interactive Graphs] Added role="figure" to the mafs-graph

### DIFF
--- a/.changeset/green-zoos-drive.md
+++ b/.changeset/green-zoos-drive.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Added role="figure" to the mafs-graph

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -20,6 +20,7 @@ exports[`Interactive Graph A none-type graph renders predictably: first render 1
           >
             <div
               class="default_7zhre1-o_O-inlineStyles_11rziql mafs-graph"
+              role="figure"
               tabindex="0"
             >
               <div
@@ -1095,6 +1096,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
             <div
               aria-describedby="interactive-graph-interactive-elements-description-:r2: instructions-:r2:"
               class="default_7zhre1-o_O-inlineStyles_11rziql mafs-graph"
+              role="figure"
               tabindex="0"
             >
               <div
@@ -1530,6 +1532,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
             <div
               aria-describedby="interactive-graph-interactive-elements-description-:rc: instructions-:rc:"
               class="default_7zhre1-o_O-inlineStyles_11rziql mafs-graph"
+              role="figure"
               tabindex="0"
             >
               <div
@@ -1971,6 +1974,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
             <div
               aria-describedby="interactive-graph-interactive-elements-description-:rl: unlimited-graph-keyboard-prompt-:rl: instructions-:rl:"
               class="default_7zhre1-o_O-inlineStyles_11rziql mafs-graph"
+              role="figure"
               tabindex="0"
             >
               <div
@@ -2221,6 +2225,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
             <div
               aria-describedby="unlimited-graph-keyboard-prompt-:rr: instructions-:rr:"
               class="default_7zhre1-o_O-inlineStyles_11rziql mafs-graph"
+              role="figure"
               tabindex="0"
             >
               <div
@@ -2449,6 +2454,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
             <div
               aria-describedby="interactive-graph-interactive-elements-description-:r4: instructions-:r4:"
               class="default_7zhre1-o_O-inlineStyles_11rziql mafs-graph"
+              role="figure"
               tabindex="0"
             >
               <div
@@ -2857,6 +2863,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
             <div
               aria-describedby="interactive-graph-interactive-elements-description-:re: instructions-:re:"
               class="default_7zhre1-o_O-inlineStyles_11rziql mafs-graph"
+              role="figure"
               tabindex="0"
             >
               <div
@@ -3298,6 +3305,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
             <div
               aria-describedby="interactive-graph-interactive-elements-description-:rm: instructions-:rm:"
               class="default_7zhre1-o_O-inlineStyles_11rziql mafs-graph"
+              role="figure"
               tabindex="0"
             >
               <div
@@ -3655,6 +3663,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
             <div
               aria-describedby="interactive-graph-interactive-elements-description-:rt: instructions-:rt:"
               class="default_7zhre1-o_O-inlineStyles_11rziql mafs-graph"
+              role="figure"
               tabindex="0"
             >
               <div

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -224,6 +224,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
             <View className="mafs-graph-container">
                 <View
                     className="mafs-graph"
+                    role="figure"
                     style={{
                         position: "relative",
                         padding: "25px 25px 0 0",


### PR DESCRIPTION
## Summary:
Added role="figure" to the mafs-graph container in mafs-graph.tsx

Issue: LEMS-4119

## Test plan:
- Checked in local env to see if figure is mentioned instead of group when tabbed onto the graph with Voiceover