### PR TITLE
[Image] Update flakey regression story

### DIFF
--- a/packages/perseus/src/widgets/image/__docs__/image-demo.stories.tsx
+++ b/packages/perseus/src/widgets/image/__docs__/image-demo.stories.tsx
@@ -307,8 +307,8 @@ export const MarkdownTableWithImageWidgets: Story = {
                             }),
                             "image 2": generateImageWidget({
                                 options: generateImageOptions({
-                                    backgroundImage: earthMoonImage,
-                                    alt: "Earth and Moon",
+                                    backgroundImage: scienceImage,
+                                    alt: scienceImageAlt,
                                 }),
                             }),
                             "image 3": generateImageWidget({
@@ -335,7 +335,7 @@ export const MarkdownTableWithMarkdownImages: Story = {
             <div style={{width: 600}}>
                 <QuestionRendererForStories
                     question={generateTestPerseusRenderer({
-                        content: `| col 1 | col 2 | col 3 |\n| --- | --- | --- |\n| ![Fresco painting](${frescoImage.url}) | ![Earth and Moon](${earthMoonImage.url}) | ![Graphie image](${graphieImage.url}) |`,
+                        content: `| col 1 | col 2 | col 3 |\n| --- | --- | --- |\n| ![Fresco painting](${frescoImage.url}) | ![${scienceImageAlt}](${scienceImage.url}) | ![Graphie image](${graphieImage.url}) |`,
                         widgets: {},
                     })}
                 />

--- a/packages/perseus/src/widgets/image/__docs__/image-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/image/__docs__/image-initial-state-regression.stories.tsx
@@ -466,7 +466,7 @@ export const MarkdownTableWithImageWidgets: Story = {
                             }),
                             "image 2": generateImageWidget({
                                 options: generateImageOptions({
-                                    backgroundImage: earthMoonImage,
+                                    backgroundImage: scienceImage,
                                     alt: "Earth and Moon",
                                 }),
                             }),
@@ -494,7 +494,7 @@ export const MarkdownTableWithMarkdownImages: Story = {
             <div style={{width: 600}}>
                 <QuestionRendererForStories
                     question={generateTestPerseusRenderer({
-                        content: `| col 1 | col 2 | col 3 |\n| --- | --- | --- |\n| ![Fresco painting](${frescoImage.url}) | ![Earth and Moon](${earthMoonImage.url}) | ![Graphie image](${graphieImage.url}) |`,
+                        content: `| col 1 | col 2 | col 3 |\n| --- | --- | --- |\n| ![Fresco painting](${frescoImage.url}) | ![${scienceImageAlt}](${scienceImage.url}) | ![Graphie image](${graphieImage.url}) |`,
                         widgets: {},
                     })}
                 />


### PR DESCRIPTION
## Summary:
There's a 1px difference in the MarkdownTableWithImageWidgets regression story that
happens with no DOM difference.

Theoretically, this could be happening because of how the image decompression + antialiasing
happens on this JPEG at the edge of the moon.

In order to adequately test this case but avoid the flakiness, I'm changing the image used
in the middle part of the table.

Here's the full explanation from Claude:

```
⏺ I found it. Here's what's going on.

  The diagnosis

  The zoomed-in circle isn't showing empty space with a stray green pixel — it's showing the 
  actual content of the col-2 image. That image is earthMoonImage:
  
  packages/perseus/src/widgets/image/utils.ts:16
  earthMoonImage = {
      url:
  "https://cdn.kastatic.org/ka-content-images/61831c1329dbc32036d7dd0d03e06e7e2c622718.jpg",
      width: 400,
      height: 225,
  }

  It's the NASA "Moon above Earth's horizon" photo — mostly pure black space with one tiny, very
  bright Moon. At the story's scale the whole image just reads as gray/dark next to the gray
  background, so you don't notice it. But zoom in and you see black space + a bright dot. The
  green dot Chromatic drew is sitting right on the edge of that bright Moon, against the black
  background. (The green is Chromatic's diff-highlight color, not the pixel's real color.)

  That location is the entire explanation. A single high-contrast edge being downscaled is the
  textbook source of a 1px Chromatic flake.

  ★ Insight ─────────────────────────────────────
  - A 1px diff with an identical DOM is almost always a rasterization difference, not a 
  layout/content difference. Chromatic compares rendered pixels; the DOM diff only catches
  structural changes. Antialiasing, image resampling, and subpixel positioning all change pixels
  without changing a single DOM node.
  - High-contrast edge + downscaling = flake magnet. This image is 400×225 natural, but the
  table puts it in a ~200px-wide column (width: 600 ÷ 3 columns), so the browser is resampling
  it to ~0.5×. Where a hard black→white boundary lands between two destination pixels depends on
  sub-pixel box geometry, and the resampler can round one boundary pixel either way between
  runs.
  - It's a bright edge, which makes it visible to the diff. The diff threshold is a
  color-distance check; a black↔bright-Moon flip is a huge color delta, so even one flipped
  pixel clears the threshold and gets flagged — whereas the same sub-pixel wobble in the muted
  fresco (col 1) produces deltas too small to report.
  ─────────────────────────────────────────────────
  
  Why it's non-deterministic between runs

  Several things can nudge that one boundary pixel:
  - Remote JPEG fetch + decode timing. These images load from cdn.kastatic.org at snapshot time.
  The decoded bytes are deterministic, but the downscale-to-paint step can vary with GPU vs CPU
  rasterization path and decode-vs-paint timing.
  - Sub-pixel layout of the table cell. Table column widths frequently resolve to fractional
  pixels. A 0.3px shift in where the image box lands re-maps source→device pixels and flips the
  edge.
  - JPEG lossiness on a hard edge. The compression artifacts around the Moon's rim are already
  noisy; downscaling amplifies which of those near-edge samples wins.
  
  The white rounded rectangle you see around a figure in col 1 is unrelated — that's in the
  fresco image, a different column from the dot.

  What I'd do about it
  
  The cleanest fix is to stop testing a downscaled hard edge. In order of preference:

  1. Tell Chromatic to ignore antialiased/edge pixels for this story via a story-level
  parameter, e.g. bumping diffThreshold (Chromatic's per-pixel color-distance tolerance, ~0.063
  default) on just MarkdownTableWithImageWidgets. Targeted and low-risk, but raising the
  threshold slightly reduces sensitivity for that one story. (Confirm the exact param name 
  against current Chromatic docs before committing — their config has churned.)
  2. Swap the col-2 image for one without a tiny bright-on-black feature (e.g. reuse the fresco
  or science image). The story is about table layout, not this specific photo, so the content of
  col 2 is incidental — and a low-contrast image won't produce a threshold-clearing 1px delta.
  3. Render col-2's image closer to 1× so there's no aggressive downscale, though that fights
  the story's "limit width so zoom becomes possible" intent.

  I'd lean toward option 2 — it removes the flake at the source (no hard edge to wobble) without
  weakening the diff sensitivity of the whole story, and it keeps the test honest.
  ```

Issue: none

## Test plan:
Storybook
- /?path=/story/widgets-image-visual-regression-tests-initial-state--markdown-table-with-image-widgets

The flakiness can't be checked here since the story has changed. We'll have to continue
monitoring in future PRs.

## Screenshots:

### Issue
<img width="312" height="212" alt="Screenshot 2026-06-08 at 10 08 30 AM" src="https://github.com/user-attachments/assets/fdba4bdf-7fc4-4545-ab8f-263a881224ac" />

### Before
<img width="661" height="282" alt="Screenshot 2026-06-08 at 10 08 03 AM" src="https://github.com/user-attachments/assets/e4e5c3fc-5bc5-4063-b285-2a06d96168c4" />

### After
<img width="661" height="283" alt="Screenshot 2026-06-08 at 10 08 07 AM" src="https://github.com/user-attachments/assets/096b8214-1eb1-4472-a879-9ae16201f202" />
