### PR TITLE
[Image] Remove gif flag, make gif controls permanent

### DIFF
--- a/.changeset/gold-rabbits-design.md
+++ b/.changeset/gold-rabbits-design.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus-editor": patch
+---
+
+[Image] Remove gif flag, make gif controls permanent

--- a/packages/perseus-core/src/feature-flags.ts
+++ b/packages/perseus-core/src/feature-flags.ts
@@ -10,7 +10,6 @@
  * 4. Also update the testing/feature-flags-util.ts for testing purpose
  */
 const PerseusFeatureFlags = [
-    "image-widget-upgrade-gif-controls", // TODO(LEMS-3914): clean up feature flag
     "input-number-to-numeric-input", // TODO(LEMS-4085): clean up feature flag
 ] as const;
 

--- a/packages/perseus-editor/src/testing/feature-flags-util.ts
+++ b/packages/perseus-editor/src/testing/feature-flags-util.ts
@@ -3,7 +3,6 @@ const DEFAULT_FEATURE_FLAGS = {
     "perseus-test-flag-1": false,
     "perseus-test-flag-2": false,
     // Real production flags.
-    "image-widget-upgrade-gif-controls": false,
     "interactive-graph-vector": false,
     "interactive-graph-not-scored": false,
     "input-number-to-numeric-input": false,

--- a/packages/perseus/src/testing/feature-flags-util.ts
+++ b/packages/perseus/src/testing/feature-flags-util.ts
@@ -3,7 +3,6 @@ const DEFAULT_FEATURE_FLAGS = {
     "perseus-test-flag-1": false,
     "perseus-test-flag-2": false,
     // Real production flags.
-    "image-widget-upgrade-gif-controls": false,
     "interactive-graph-vector": false,
     "interactive-graph-not-scored": false,
     "input-number-to-numeric-input": false,

--- a/packages/perseus/src/widgets/image/__docs__/image-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/image/__docs__/image-initial-state-regression.stories.tsx
@@ -343,9 +343,6 @@ export const ImageWithoutWidthOrHeightLarge: Story = {
 
 export const TallAnimatedGif: Story = {
     decorators: [imageRendererDecorator],
-    globals: {
-        featureFlags: ["image-widget-upgrade-gif-controls"],
-    },
     args: {
         backgroundImage: animatedGifPortrait,
         alt: animatedGifPortraitAlt,
@@ -414,9 +411,6 @@ export const PngImage: Story = {
 
 export const MobileAnimatedGif: Story = {
     decorators: [imageRendererDecorator, mobileDecorator],
-    globals: {
-        featureFlags: ["image-widget-upgrade-gif-controls"],
-    },
     args: {
         backgroundImage: animatedGifLandscape,
         alt: animatedGifLandscapeAlt,
@@ -426,9 +420,6 @@ export const MobileAnimatedGif: Story = {
 
 export const NonAnimatedGif: Story = {
     decorators: [imageRendererDecorator],
-    globals: {
-        featureFlags: ["image-widget-upgrade-gif-controls"],
-    },
     args: {
         backgroundImage: nonAnimatedGif,
         alt: nonAnimatedGifAlt,

--- a/packages/perseus/src/widgets/image/__docs__/image-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/image/__docs__/image-interactions-regression.stories.tsx
@@ -182,9 +182,6 @@ export const ZoomClickedLargePortraitImage: Story = {
 
 export const LongDescriptionClickedStateWithTallAnimatedGif: Story = {
     decorators: [imageRendererDecorator],
-    globals: {
-        featureFlags: ["image-widget-upgrade-gif-controls"],
-    },
     args: {
         backgroundImage: animatedGifPortrait,
         alt: animatedGifPortraitAlt,

--- a/packages/perseus/src/widgets/image/components/explore-image-modal-content.tsx
+++ b/packages/perseus/src/widgets/image/components/explore-image-modal-content.tsx
@@ -1,4 +1,3 @@
-import {isFeatureOn} from "@khanacademy/perseus-core";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {Heading} from "@khanacademy/wonder-blocks-typography";
 import * as React from "react";
@@ -42,11 +41,6 @@ export default function ExploreImageModalContent({
     if (!backgroundImage.url) {
         return null;
     }
-
-    const gifControlsFF = isFeatureOn(
-        {apiOptions},
-        "image-widget-upgrade-gif-controls",
-    );
 
     const imageIsGif = isGif(backgroundImage.url);
     const imageIsSvg = isSvg(backgroundImage.url);
@@ -109,13 +103,9 @@ export default function ExploreImageModalContent({
                             constrainHeight={apiOptions.isMobile}
                             allowFullBleed={apiOptions.isMobile}
                             setAssetStatus={setAssetStatus}
-                            isGifPlaying={
-                                gifControlsFF && imageIsGif
-                                    ? isGifPlaying
-                                    : undefined
-                            }
+                            isGifPlaying={imageIsGif ? isGifPlaying : undefined}
                             onGifLoop={
-                                gifControlsFF && imageIsGif
+                                imageIsGif
                                     ? () => setIsGifPlaying(false)
                                     : undefined
                             }
@@ -126,7 +116,7 @@ export default function ExploreImageModalContent({
             <div
                 className={`perseus-image-modal-description ${styles.modalDescriptionContainer}`}
             >
-                {gifControlsFF && imageIsGif && (
+                {imageIsGif && (
                     <>
                         <GifControlsButton
                             isPlaying={isGifPlaying}

--- a/packages/perseus/src/widgets/image/components/explore-image-modal.test.tsx
+++ b/packages/perseus/src/widgets/image/components/explore-image-modal.test.tsx
@@ -5,7 +5,6 @@ import * as React from "react";
 import * as Dependencies from "../../../dependencies";
 import {DependenciesContext} from "../../../dependencies";
 import {ApiOptions} from "../../../perseus-api";
-import {getFeatureFlags} from "../../../testing/feature-flags-util";
 import {mockImageLoading} from "../../../testing/image-loader-utils";
 import {
     testDependencies,
@@ -53,13 +52,6 @@ const defaultProps = {
     apiOptions: ApiOptions.defaults,
     isGifPlaying: false,
     setIsGifPlaying: () => {},
-};
-
-const apiOptionsWithGifControls = {
-    ...ApiOptions.defaults,
-    flags: getFeatureFlags({
-        "image-widget-upgrade-gif-controls": true,
-    }),
 };
 
 describe("ExploreImageModal", () => {
@@ -272,7 +264,6 @@ describe("ExploreImageModal", () => {
             renderModal({
                 ...defaultProps,
                 backgroundImage: animatedGifLandscape,
-                apiOptions: apiOptionsWithGifControls,
             });
 
             // Assert
@@ -306,7 +297,6 @@ describe("ExploreImageModal", () => {
             renderModal({
                 ...defaultProps,
                 backgroundImage: animatedGifLandscape,
-                apiOptions: apiOptionsWithGifControls,
             });
 
             // Act — the modal starts paused, so click Play first
@@ -328,7 +318,6 @@ describe("ExploreImageModal", () => {
                 ...defaultProps,
                 backgroundImage: animatedGifLandscape,
                 isGifPlaying: false,
-                apiOptions: apiOptionsWithGifControls,
             });
 
             // Act
@@ -345,7 +334,6 @@ describe("ExploreImageModal", () => {
             renderModal({
                 ...defaultProps,
                 backgroundImage: animatedGifLandscape,
-                apiOptions: apiOptionsWithGifControls,
             });
 
             // Act — modal starts paused, click Play
@@ -365,7 +353,6 @@ describe("ExploreImageModal", () => {
             renderModal({
                 ...defaultProps,
                 backgroundImage: animatedGifLandscape,
-                apiOptions: apiOptionsWithGifControls,
             });
 
             // Act — click Play then Pause
@@ -380,58 +367,6 @@ describe("ExploreImageModal", () => {
             expect(
                 screen.getByRole("button", {name: "Play Animation"}),
             ).toBeVisible();
-        });
-    });
-
-    describe("flags", () => {
-        it("should render gif controls when the feature flag is enabled", () => {
-            // Arrange
-
-            const apiOptionsWithFeatureFlag = {
-                ...ApiOptions.defaults,
-                flags: getFeatureFlags({
-                    "image-widget-upgrade-gif-controls": true,
-                }),
-            };
-
-            renderModal({
-                ...defaultProps,
-                backgroundImage: animatedGifLandscape,
-                apiOptions: apiOptionsWithFeatureFlag,
-            });
-
-            // Assert
-            const playButton = screen.getByRole("button", {
-                name: "Play Animation",
-            });
-            expect(playButton).toBeVisible();
-        });
-
-        it("should not render gif controls when the feature flag is disabled", () => {
-            // Arrange
-
-            const apiOptionsWithFeatureFlag = {
-                ...ApiOptions.defaults,
-                flags: getFeatureFlags({
-                    "image-widget-upgrade-gif-controls": false,
-                }),
-            };
-
-            renderModal({
-                ...defaultProps,
-                backgroundImage: animatedGifLandscape,
-                apiOptions: apiOptionsWithFeatureFlag,
-            });
-
-            // Assert
-            const playButton = screen.queryByRole("button", {
-                name: "Play Animation",
-            });
-            const pauseButton = screen.queryByRole("button", {
-                name: "Pause Animation",
-            });
-            expect(playButton).not.toBeInTheDocument();
-            expect(pauseButton).not.toBeInTheDocument();
         });
     });
 });

--- a/packages/perseus/src/widgets/image/components/image-info-area.tsx
+++ b/packages/perseus/src/widgets/image/components/image-info-area.tsx
@@ -1,5 +1,4 @@
 import {
-    isFeatureOn,
     type Interval,
     type PerseusImageBackground,
     type PerseusImageLabel,
@@ -59,11 +58,6 @@ export const ImageInfoArea = (props: Props) => {
 
     const context = React.useContext(PerseusI18nContext);
 
-    const gifControlsFF = isFeatureOn(
-        {apiOptions},
-        "image-widget-upgrade-gif-controls",
-    );
-
     if (!backgroundImage.url) {
         return null;
     }
@@ -73,7 +67,7 @@ export const ImageInfoArea = (props: Props) => {
     return (
         <div className={styles.infoAreaContainer}>
             {/* GIF controls */}
-            {gifControlsFF && imageIsGif && (
+            {imageIsGif && (
                 <GifControlsIcon
                     isPlaying={isGifPlaying}
                     onToggle={() => setIsGifPlaying(!isGifPlaying)}
@@ -81,7 +75,7 @@ export const ImageInfoArea = (props: Props) => {
             )}
 
             {/* Spacer if both GIF controls and description are shown */}
-            {gifControlsFF && imageIsGif && longDescription && (
+            {imageIsGif && longDescription && (
                 <div className={styles.spacerHorizontal} />
             )}
 

--- a/packages/perseus/src/widgets/image/image.test.ts
+++ b/packages/perseus/src/widgets/image/image.test.ts
@@ -8,7 +8,6 @@ import {userEvent as userEventLib} from "@testing-library/user-event";
 import invariant from "tiny-invariant";
 
 import * as Dependencies from "../../dependencies";
-import {getFeatureFlags} from "../../testing/feature-flags-util";
 import {mockImageLoading} from "../../testing/image-loader-utils";
 import {
     testDependenciesV2,
@@ -29,13 +28,6 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
 
     const apiOptions: APIOptions = {
         isMobile,
-    };
-
-    const apiOptionsWithGifControlsFlag = {
-        ...apiOptions,
-        flags: getFeatureFlags({
-            "image-widget-upgrade-gif-controls": true,
-        }),
     };
 
     beforeEach(() => {
@@ -547,7 +539,7 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
             });
 
             // Act
-            renderQuestion(gifImageQuestion, apiOptionsWithGifControlsFlag);
+            renderQuestion(gifImageQuestion, apiOptions);
 
             // Assert
             const zoomButton = screen.queryByRole("button", {
@@ -1088,7 +1080,7 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
                     }),
                 },
             });
-            renderQuestion(gifImageQuestion, apiOptionsWithGifControlsFlag);
+            renderQuestion(gifImageQuestion, apiOptions);
 
             // Assert
             const playButton = screen.getByRole("button", {
@@ -1109,7 +1101,7 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
                     }),
                 },
             });
-            renderQuestion(imageQuestion, apiOptionsWithGifControlsFlag);
+            renderQuestion(imageQuestion, apiOptions);
 
             // Assert
             const playButton = screen.queryByRole("button", {
@@ -1134,7 +1126,7 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
                     }),
                 },
             });
-            renderQuestion(gifImageQuestion, apiOptionsWithGifControlsFlag);
+            renderQuestion(gifImageQuestion, apiOptions);
 
             // Act - gif is paused by default, click play button
             const playButton = screen.getByRole("button", {
@@ -1161,7 +1153,7 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
                     }),
                 },
             });
-            renderQuestion(gifImageQuestion, apiOptionsWithGifControlsFlag);
+            renderQuestion(gifImageQuestion, apiOptions);
 
             // Act - gif is paused by default, click play button
             const playButton = screen.getByRole("button", {
@@ -1183,91 +1175,6 @@ describe.each([[true], [false]])("image widget - isMobile(%j)", (isMobile) => {
                 name: "Play Animation",
             });
             expect(playButtonAgain).toBeVisible();
-        });
-
-        it("does not render a canvas overlay when the feature flag is disabled", () => {
-            // Arrange, Act
-            const gifImageQuestion = generateTestPerseusRenderer({
-                content: "[[☃ image 1]]",
-                widgets: {
-                    "image 1": generateImageWidget({
-                        options: generateImageOptions({
-                            backgroundImage: animatedGifLandscape,
-                        }),
-                    }),
-                },
-            });
-            renderQuestion(gifImageQuestion, apiOptions);
-            act(() => {
-                jest.runAllTimers();
-            });
-
-            // Assert
-            expect(screen.queryByTestId("gif-canvas")).not.toBeInTheDocument();
-        });
-    });
-
-    describe("flags", () => {
-        it("should render gif controls when the feature flag is enabled", () => {
-            // Arrange
-            const imageQuestion = generateTestPerseusRenderer({
-                content: "[[☃ image 1]]",
-                widgets: {
-                    "image 1": generateImageWidget({
-                        options: generateImageOptions({
-                            backgroundImage: animatedGifLandscape,
-                        }),
-                    }),
-                },
-            });
-
-            const apiOptionsWithFeatureFlag = {
-                ...apiOptions,
-                flags: getFeatureFlags({
-                    "image-widget-upgrade-gif-controls": true,
-                }),
-            };
-
-            renderQuestion(imageQuestion, apiOptionsWithFeatureFlag);
-
-            // Assert
-            const playButton = screen.getByRole("button", {
-                name: "Play Animation",
-            });
-            expect(playButton).toBeVisible();
-        });
-
-        it("should not render gif controls when the feature flag is disabled", () => {
-            // Arrange
-            const imageQuestion = generateTestPerseusRenderer({
-                content: "[[☃ image 1]]",
-                widgets: {
-                    "image 1": generateImageWidget({
-                        options: generateImageOptions({
-                            backgroundImage: animatedGifLandscape,
-                        }),
-                    }),
-                },
-            });
-
-            const apiOptionsWithFeatureFlag = {
-                ...apiOptions,
-                flags: getFeatureFlags({
-                    "image-widget-upgrade-gif-controls": false,
-                }),
-            };
-
-            renderQuestion(imageQuestion, apiOptionsWithFeatureFlag);
-
-            // Assert
-            const playButton = screen.queryByRole("button", {
-                name: "Play Animation",
-            });
-            const pauseButton = screen.queryByRole("button", {
-                name: "Pause Animation",
-            });
-            expect(playButton).not.toBeInTheDocument();
-            expect(pauseButton).not.toBeInTheDocument();
         });
     });
 });

--- a/packages/perseus/src/widgets/image/image.tsx
+++ b/packages/perseus/src/widgets/image/image.tsx
@@ -152,7 +152,7 @@ export const ImageComponent = (props: ImageWidgetProps) => {
             {/* Image */}
             {svgImage}
 
-            {/* Gif Controls, Description & Caption */}
+            {/* Gif Controls, Description, and Caption */}
             {(imageIsGif || caption || longDescription) && (
                 <ImageInfoArea
                     isGifPlaying={isGifPlaying}

--- a/packages/perseus/src/widgets/image/image.tsx
+++ b/packages/perseus/src/widgets/image/image.tsx
@@ -152,7 +152,7 @@ export const ImageComponent = (props: ImageWidgetProps) => {
             {/* Image */}
             {svgImage}
 
-            {/* Gif Controls,Description & Caption */}
+            {/* Gif Controls, Description & Caption */}
             {(imageIsGif || caption || longDescription) && (
                 <ImageInfoArea
                     isGifPlaying={isGifPlaying}

--- a/packages/perseus/src/widgets/image/image.tsx
+++ b/packages/perseus/src/widgets/image/image.tsx
@@ -1,4 +1,3 @@
-import {isFeatureOn} from "@khanacademy/perseus-core";
 import {useOnMountEffect} from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
 
@@ -32,10 +31,6 @@ export const ImageComponent = (props: ImageWidgetProps) => {
     } = props;
     const context = React.useContext(PerseusI18nContext);
     const {analytics} = useDependencies();
-    const gifControlsFF = isFeatureOn(
-        {apiOptions},
-        "image-widget-upgrade-gif-controls",
-    );
 
     // Gif should be paused on initial render for a11y.
     const [isGifPlaying, setIsGifPlaying] = React.useState<boolean>(false);
@@ -95,13 +90,9 @@ export const ImageComponent = (props: ImageWidgetProps) => {
                     allowZoom={!decorative && !imageIsGif}
                     alt={decorative || caption === alt ? "" : alt}
                     setAssetStatus={setAssetStatus}
-                    isGifPlaying={
-                        gifControlsFF && imageIsGif ? isGifPlaying : undefined
-                    }
+                    isGifPlaying={imageIsGif ? isGifPlaying : undefined}
                     onGifLoop={
-                        gifControlsFF && imageIsGif
-                            ? () => setIsGifPlaying(false)
-                            : undefined
+                        imageIsGif ? () => setIsGifPlaying(false) : undefined
                     }
                 />
             )}
@@ -161,8 +152,8 @@ export const ImageComponent = (props: ImageWidgetProps) => {
             {/* Image */}
             {svgImage}
 
-            {/* Description & Caption */}
-            {((gifControlsFF && imageIsGif) || caption || longDescription) && (
+            {/* Gif Controls,Description & Caption */}
+            {(imageIsGif || caption || longDescription) && (
                 <ImageInfoArea
                     isGifPlaying={isGifPlaying}
                     setIsGifPlaying={setIsGifPlaying}


### PR DESCRIPTION
## Summary:
Now that the feature has been on for a while without issues, we can remove the
`image-widget-upgrade-gif-controls` flag from the codebase and make the gif
controls feature permanent.

Issue: https://khanacademy.atlassian.net/browse/LEMS-3914

## Test plan:
`pnpm jest`

Do an IDE search and confirm `image-widget-upgrade-gif-controls` has no matches.

Storybook
- `/?path=/story/widgets-image-widget-demo--gif-image`