### PR TITLE
Convert Grapher widgets to Interactive Graph

### DIFF
--- a/.changeset/forty-terms-help.md
+++ b/.changeset/forty-terms-help.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": minor
+"@khanacademy/perseus-core": minor
+---
+
+When the `grapher-to-interactive-graph` feature flag is on, render Grapher widgets using the Interactive Graph UI components.

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -785,23 +785,28 @@ export type GrapherAnswerTypes =
           coords: null | [Coord, Coord];
       };
 
+/** The functions that can be graphed in a Grapher widget */
+export type GrapherFunctionType =
+    | "absolute_value"
+    | "exponential"
+    | "linear"
+    | "logarithm"
+    | "quadratic"
+    | "sinusoid"
+    | "tangent";
+
 /**
  * Options for the Grapher widget. Defines the available function
  * types, the correct answer, and the visual graph configuration.
  */
 export type PerseusGrapherWidgetOptions = {
     /** The set of function types the learner can choose from when plotting. */
-    availableTypes: Array<
-        | "absolute_value"
-        | "exponential"
-        | "linear"
-        | "logarithm"
-        | "quadratic"
-        | "sinusoid"
-        | "tangent"
-    >;
-    /** The correct answer; used to score the learner's plotted function. */
-    correct: GrapherAnswerTypes;
+    availableTypes: GrapherFunctionType[];
+    /**
+     * The correct answer; used to score the learner's plotted function.
+     * Undefined in answerless data.
+     */
+    correct?: GrapherAnswerTypes;
     /** Visual configuration for the coordinate plane. */
     graph: {
         /** An optional background image displayed behind the graph. */

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1296,7 +1296,7 @@ export type PerseusGraphTypeTangent = {
 export type PerseusGraphTypeExponential = {
     type: "exponential";
     /** Two points along the exponential curve. */
-    coords?: Coord[] | null;
+    coords?: [Coord, Coord] | null;
     /**
      * The y-value of the horizontal asymptote (the line y = asymptote).
      * Corresponds to the coefficient c in f(x) = a·eᵇˣ + c.

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1313,7 +1313,7 @@ export type PerseusGraphTypeExponential = {
 export type PerseusGraphTypeLogarithm = {
     type: "logarithm";
     /** Two points along the logarithmic curve. */
-    coords?: Coord[] | null;
+    coords?: [Coord, Coord] | null;
     /**
      * The x-value of the vertical asymptote (the line x = asymptote).
      * The curve is defined on only one side of this line.

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -208,6 +208,12 @@ export type {VideoDefaultWidgetOptions} from "./widgets/video";
 
 /** @hidden */
 export {convertInputNumberOptionsToNumericInput} from "./widgets/input-number/to-numeric-input";
+/** @hidden */
+export {
+    convertGrapherOptionsToInteractiveGraph,
+    convertGrapherUserInputToInteractiveGraph,
+    convertInteractiveGraphUserInputToGrapher,
+} from "./widgets/grapher/to-interactive-graph";
 
 /** @hidden */
 export {

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/grapher-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/grapher-widget.ts
@@ -113,7 +113,7 @@ export const parseGrapherWidget = parseWidget(
                 "tangent",
             ),
         ),
-        correct: parseCorrect,
+        correct: optional(parseCorrect),
         graph: object({
             backgroundImage: object({
                 bottom: optional(number),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -136,7 +136,7 @@ const parsePerseusGraphTypeSinusoid = object({
 
 const parsePerseusGraphTypeExponential = object({
     type: constant("exponential"),
-    coords: optional(nullable(array(pairOfNumbers))),
+    coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
     asymptote: optional(nullable(number)),
     startCoords: optional(
         object({

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -166,7 +166,7 @@ const parsePerseusGraphTypeTangent = object({
 
 const parsePerseusGraphTypeLogarithm = object({
     type: constant("logarithm"),
-    coords: optional(nullable(array(pairOfNumbers))),
+    coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
     asymptote: optional(nullable(number)),
     startCoords: optional(
         object({

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -3204,10 +3204,6 @@ exports[`parseAndMigratePerseusItem given grapher-with-empty-coords.ts returns t
           "availableTypes": [
             "linear",
           ],
-          "correct": {
-            "coords": null,
-            "type": "linear",
-          },
           "graph": {
             "backgroundImage": {
               "url": null,
@@ -3387,10 +3383,6 @@ exports[`parseAndMigratePerseusItem given grapher-with-null-coords.ts returns th
             "logarithm",
             "exponential",
           ],
-          "correct": {
-            "coords": null,
-            "type": "linear",
-          },
           "graph": {
             "backgroundImage": {
               "height": 0,

--- a/packages/perseus-core/src/utils/generators/grapher-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/grapher-widget-generator.ts
@@ -1,0 +1,24 @@
+import grapherWidgetLogic from "../../widgets/grapher";
+
+import type {
+    GrapherWidget,
+    PerseusGrapherWidgetOptions,
+} from "../../data-schema";
+
+export function generateGrapherWidget(
+    options: Partial<PerseusGrapherWidgetOptions> = {},
+): GrapherWidget {
+    return {
+        type: "grapher",
+        options: generateGrapherWidgetOptions(options),
+    };
+}
+
+export function generateGrapherWidgetOptions(
+    options: Partial<PerseusGrapherWidgetOptions> = {},
+): PerseusGrapherWidgetOptions {
+    return {
+        ...grapherWidgetLogic.defaultWidgetOptions,
+        ...options,
+    };
+}

--- a/packages/perseus-core/src/utils/generators/grapher-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/grapher-widget-generator.ts
@@ -1,18 +1,6 @@
 import grapherWidgetLogic from "../../widgets/grapher";
 
-import type {
-    GrapherWidget,
-    PerseusGrapherWidgetOptions,
-} from "../../data-schema";
-
-export function generateGrapherWidget(
-    options: Partial<PerseusGrapherWidgetOptions> = {},
-): GrapherWidget {
-    return {
-        type: "grapher",
-        options: generateGrapherWidgetOptions(options),
-    };
-}
+import type {PerseusGrapherWidgetOptions} from "../../data-schema";
 
 export function generateGrapherWidgetOptions(
     options: Partial<PerseusGrapherWidgetOptions> = {},

--- a/packages/perseus-core/src/widgets/grapher/grapher-util.typetest.ts
+++ b/packages/perseus-core/src/widgets/grapher/grapher-util.typetest.ts
@@ -1,0 +1,10 @@
+import {describe, it, expect} from "tstyche";
+
+import type {GrapherPublicWidgetOptions} from "./grapher-util";
+import type {PerseusGrapherWidgetOptions} from "../../data-schema";
+
+describe("GrapherPublicWidgetOptions", () => {
+    it("is assignable to PerseusGrapherWidgetOptions", () => {
+        expect<GrapherPublicWidgetOptions>().type.toBeAssignableTo<PerseusGrapherWidgetOptions>();
+    });
+});

--- a/packages/perseus-core/src/widgets/grapher/to-interactive-graph.test.ts
+++ b/packages/perseus-core/src/widgets/grapher/to-interactive-graph.test.ts
@@ -1,0 +1,57 @@
+import {describe, it, expect} from "@jest/globals";
+
+import {generateGrapherWidgetOptions} from "../../utils/generators/grapher-widget-generator";
+
+import {convertGrapherOptionsToInteractiveGraph} from "./to-interactive-graph";
+
+describe("convertGrapherOptionsToInteractiveGraph", () => {
+    it("returns null given a graph with multiple available function types", () => {
+        const grapher = generateGrapherWidgetOptions({
+            availableTypes: ["sinusoid", "linear"],
+        });
+        expect(convertGrapherOptionsToInteractiveGraph(grapher)).toBe(null);
+    });
+
+    it("returns null given a quadratic graph", () => {
+        const grapher = generateGrapherWidgetOptions({
+            availableTypes: ["quadratic"],
+        });
+        expect(convertGrapherOptionsToInteractiveGraph(grapher)).toBe(null);
+    });
+
+    it("converts the 'correct' field if present", () => {
+        const grapher = generateGrapherWidgetOptions({
+            availableTypes: ["sinusoid"],
+            correct: {
+                type: "sinusoid",
+                coords: [
+                    [1, 2],
+                    [3, 4],
+                ],
+            },
+        });
+
+        const ig = convertGrapherOptionsToInteractiveGraph(grapher);
+
+        expect(ig?.correct).toEqual({
+            type: "sinusoid",
+            coords: [
+                [1, 2],
+                [3, 4],
+            ],
+        });
+    });
+
+    it("defaults the 'correct' field if missing", () => {
+        const grapher = generateGrapherWidgetOptions({
+            availableTypes: ["sinusoid"],
+            correct: undefined,
+        });
+
+        const ig = convertGrapherOptionsToInteractiveGraph(grapher);
+
+        expect(ig?.correct).toEqual({
+            type: "sinusoid",
+        });
+    });
+});

--- a/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
+++ b/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
@@ -3,6 +3,7 @@ import invariant from "tiny-invariant";
 
 import type {
     GrapherAnswerTypes,
+    GrapherFunctionType,
     PerseusGrapherWidgetOptions,
     PerseusGraphType,
     PerseusInteractiveGraphWidgetOptions,
@@ -29,6 +30,10 @@ export function convertGrapherOptionsToInteractiveGraph(
         return null;
     }
 
+    const graph: PerseusGraphType = {
+        type: grapherFunctionTypeToInteractiveGraphType(type),
+    };
+
     return {
         step: grapherOptions.graph.step,
         gridStep: grapherOptions.graph.gridStep,
@@ -47,10 +52,10 @@ export function convertGrapherOptionsToInteractiveGraph(
         showProtractor: grapherOptions.graph.showProtractor ?? false,
         showTooltips: grapherOptions.graph.showTooltips,
         range: grapherOptions.graph.range,
-        graph: {type: type === "absolute_value" ? "absolute-value" : type},
+        graph,
         correct: grapherOptions.correct
             ? grapherAnswerTypesToPerseusGraphType(grapherOptions.correct)
-            : {type: type === "absolute_value" ? "absolute-value" : type},
+            : graph,
         lockedFigures: [],
     };
 }
@@ -177,4 +182,8 @@ function grapherAnswerTypesToPerseusGraphType(
         default:
             throw new UnreachableCaseError(grapherAnswerTypes);
     }
+}
+
+function grapherFunctionTypeToInteractiveGraphType(type: GrapherFunctionType) {
+    return type === "absolute_value" ? "absolute-value" : type;
 }

--- a/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
+++ b/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
@@ -10,7 +10,7 @@ import type {
 import type {
     PerseusGrapherUserInput,
     PerseusInteractiveGraphUserInput,
-} from "@khanacademy/perseus-core";
+} from "../../validation.types";
 
 export function convertGrapherOptionsToInteractiveGraph(
     grapherOptions: PerseusGrapherWidgetOptions,
@@ -91,20 +91,12 @@ export function convertInteractiveGraphUserInputToGrapher(
                 ],
             };
         }
-        // FIXME: we can't convert interactive graph quadratic coords to
-        //  grapher, because that conversion is lossy. We might need to create
-        //  a new interactive graph subtype that uses the two-point quadratic form.
-        // case "quadratic": {
-        //     return {
-        //         type: "quadratic",
-        //         coords: interactiveGraphUserInput.coords ?? null,
-        //     }
-        // }
         case "sinusoid":
             return {
                 type: "sinusoid",
                 // FIXME: avoid casting, use the parser.
                 coords:
+                    // eslint-disable-next-line no-restricted-syntax
                     (interactiveGraphUserInput.coords as [Coord, Coord]) ??
                     null,
             };
@@ -113,10 +105,14 @@ export function convertInteractiveGraphUserInputToGrapher(
                 type: "tangent",
                 // FIXME: avoid casting, use the parser.
                 coords:
+                    // eslint-disable-next-line no-restricted-syntax
                     (interactiveGraphUserInput.coords as [Coord, Coord]) ??
                     null,
             };
         default:
+            // This branch includes "quadratic"
+            // NOTE: we can't convert interactive graph quadratic coords to
+            // grapher, because that conversion is lossy (3 points -> 2 points).
             throw Error(
                 "Can't convert interactive-graph user input to grapher user input. Type: " +
                     interactiveGraphUserInput.type,

--- a/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
+++ b/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
@@ -176,8 +176,7 @@ function grapherQuadraticCoordsToInteractiveGraphCoords([vertex, secondPoint]: [
     Coord,
 ]): [Coord, Coord, Coord] {
     const thirdPoint: Coord = [
-        // Reflect the x-coordinate of the second point across a vertical line
-        // through the vertex.
+        // Reflect the second point across a vertical line through the vertex.
         vertex[0] - (secondPoint[0] - vertex[0]),
         secondPoint[1],
     ];

--- a/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
+++ b/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
@@ -1,4 +1,5 @@
 import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
+import invariant from "tiny-invariant";
 
 import type {
     GrapherAnswerTypes,
@@ -71,8 +72,11 @@ export function convertInteractiveGraphUserInputToGrapher(
                 coords: interactiveGraphUserInput.coords ?? null,
             };
         case "exponential": {
-            // FIXME: assert asymptote is not nullish here.
-            const asymptoteY = interactiveGraphUserInput.asymptote ?? 0;
+            invariant(
+                interactiveGraphUserInput.asymptote != null,
+                "exponential graph asymptote must not be nullish in user input",
+            );
+            const asymptoteY = interactiveGraphUserInput.asymptote;
             return {
                 type: "exponential",
                 coords: interactiveGraphUserInput.coords ?? null,
@@ -88,8 +92,11 @@ export function convertInteractiveGraphUserInputToGrapher(
                 coords: interactiveGraphUserInput.coords ?? null,
             };
         case "logarithm": {
-            // FIXME: assert asymptote is not nullish here.
-            const asymptoteX = interactiveGraphUserInput.asymptote ?? 0;
+            invariant(
+                interactiveGraphUserInput.asymptote != null,
+                "logarithm graph asymptote must not be nullish in user input",
+            );
+            const asymptoteX = interactiveGraphUserInput.asymptote;
             return {
                 type: "logarithm",
                 coords: interactiveGraphUserInput.coords ?? null,

--- a/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
+++ b/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
@@ -15,7 +15,7 @@ import type {
 export function convertGrapherOptionsToInteractiveGraph(
     grapherOptions: PerseusGrapherWidgetOptions,
 ): PerseusInteractiveGraphWidgetOptions | null {
-    if (grapherOptions.availableTypes.length === 1) {
+    if (grapherOptions.availableTypes.length !== 1) {
         // Only grapher widgets with a single available graph type can be
         // converted to interactive-graph widgets.
         return null;
@@ -42,7 +42,9 @@ export function convertGrapherOptionsToInteractiveGraph(
         showTooltips: grapherOptions.graph.showTooltips,
         range: grapherOptions.graph.range,
         graph: {type: type === "absolute_value" ? "absolute-value" : type},
-        correct: grapherAnswerTypesToPerseusGraphType(grapherOptions.correct),
+        correct: grapherOptions.correct
+            ? grapherAnswerTypesToPerseusGraphType(grapherOptions.correct)
+            : {type: type === "absolute_value" ? "absolute-value" : type},
         lockedFigures: [],
     };
 }

--- a/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
+++ b/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
@@ -1,5 +1,189 @@
-import {PerseusGrapherWidgetOptions, PerseusInteractiveGraphWidgetOptions} from "@khanacademy/perseus-core";
+import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 
-export function convertGrapherOptionsToInteractiveGraph(grapherOptions: PerseusGrapherWidgetOptions): PerseusInteractiveGraphWidgetOptions {
+import type {
+    GrapherAnswerTypes,
+    PerseusGrapherWidgetOptions,
+    PerseusGraphType,
+    PerseusInteractiveGraphWidgetOptions,
+    Coord,
+} from "../../data-schema";
+import type {
+    PerseusGrapherUserInput,
+    PerseusInteractiveGraphUserInput,
+} from "@khanacademy/perseus-core";
 
+export function convertGrapherOptionsToInteractiveGraph(
+    grapherOptions: PerseusGrapherWidgetOptions,
+): PerseusInteractiveGraphWidgetOptions | null {
+    if (grapherOptions.availableTypes.length === 1) {
+        // Only grapher widgets with a single available graph type can be
+        // converted to interactive-graph widgets.
+        return null;
+    }
+
+    const type = grapherOptions.availableTypes[0];
+
+    return {
+        step: grapherOptions.graph.step,
+        gridStep: grapherOptions.graph.gridStep,
+        snapStep: grapherOptions.graph.snapStep,
+        backgroundImage: grapherOptions.graph.backgroundImage,
+        markings: grapherOptions.graph.markings,
+        labels: grapherOptions.graph.labels,
+        labelLocation: "onAxis",
+        showAxisArrows: {
+            xMin: true,
+            xMax: true,
+            yMin: true,
+            yMax: true,
+        },
+        showAxisTicks: {x: true, y: true},
+        showProtractor: grapherOptions.graph.showProtractor ?? false,
+        showTooltips: grapherOptions.graph.showTooltips,
+        range: grapherOptions.graph.range,
+        graph: {type: type === "absolute_value" ? "absolute-value" : type},
+        correct: grapherAnswerTypesToPerseusGraphType(grapherOptions.correct),
+        lockedFigures: [],
+    };
+}
+
+export function convertGrapherUserInputToInteractiveGraph(
+    grapherUserInput: PerseusGrapherUserInput,
+): PerseusInteractiveGraphUserInput {
+    return grapherAnswerTypesToPerseusGraphType(grapherUserInput);
+}
+
+export function convertInteractiveGraphUserInputToGrapher(
+    interactiveGraphUserInput: PerseusInteractiveGraphUserInput,
+): PerseusGrapherUserInput {
+    switch (interactiveGraphUserInput.type) {
+        case "absolute-value":
+            return {
+                type: "absolute_value",
+                coords: interactiveGraphUserInput.coords ?? null,
+            };
+        case "exponential": {
+            // FIXME: assert asymptote is not nullish here.
+            const asymptoteY = interactiveGraphUserInput.asymptote ?? 0;
+            return {
+                type: "exponential",
+                coords: interactiveGraphUserInput.coords ?? null,
+                asymptote: [
+                    [0, asymptoteY],
+                    [1, asymptoteY],
+                ],
+            };
+        }
+        case "linear":
+            return {
+                type: "linear",
+                coords: interactiveGraphUserInput.coords ?? null,
+            };
+        case "logarithm": {
+            // FIXME: assert asymptote is not nullish here.
+            const asymptoteX = interactiveGraphUserInput.asymptote ?? 0;
+            return {
+                type: "logarithm",
+                coords: interactiveGraphUserInput.coords ?? null,
+                asymptote: [
+                    [asymptoteX, 0],
+                    [asymptoteX, 1],
+                ],
+            };
+        }
+        // FIXME: we can't convert interactive graph quadratic coords to
+        //  grapher, because that conversion is lossy. We might need to create
+        //  a new interactive graph subtype that uses the two-point quadratic form.
+        // case "quadratic": {
+        //     return {
+        //         type: "quadratic",
+        //         coords: interactiveGraphUserInput.coords ?? null,
+        //     }
+        // }
+        case "sinusoid":
+            return {
+                type: "sinusoid",
+                // FIXME: avoid casting, use the parser.
+                coords:
+                    (interactiveGraphUserInput.coords as [Coord, Coord]) ??
+                    null,
+            };
+        case "tangent":
+            return {
+                type: "tangent",
+                // FIXME: avoid casting, use the parser.
+                coords:
+                    (interactiveGraphUserInput.coords as [Coord, Coord]) ??
+                    null,
+            };
+        default:
+            throw Error(
+                "Can't convert interactive-graph user input to grapher user input. Type: " +
+                    interactiveGraphUserInput.type,
+            );
+    }
+}
+
+function grapherAnswerTypesToPerseusGraphType(
+    grapherAnswerTypes: GrapherAnswerTypes,
+): PerseusGraphType {
+    switch (grapherAnswerTypes.type) {
+        case "absolute_value":
+            return {
+                type: "absolute-value",
+                coords: grapherAnswerTypes.coords,
+            };
+        case "exponential":
+            return {
+                type: "exponential",
+                coords: grapherAnswerTypes.coords,
+                asymptote: grapherAnswerTypes.asymptote[0][1],
+            };
+        case "linear":
+            return {
+                type: "linear",
+                coords: grapherAnswerTypes.coords,
+            };
+        case "logarithm":
+            return {
+                type: "logarithm",
+                coords: grapherAnswerTypes.coords,
+                asymptote: grapherAnswerTypes.asymptote[0][0],
+            };
+        case "quadratic":
+            return {
+                type: "quadratic",
+                coords:
+                    grapherAnswerTypes.coords == null
+                        ? null
+                        : grapherQuadraticCoordsToInteractiveGraphCoords(
+                              grapherAnswerTypes.coords,
+                          ),
+            };
+        case "sinusoid":
+            return {
+                type: "sinusoid",
+                coords: grapherAnswerTypes.coords,
+            };
+        case "tangent":
+            return {
+                type: "tangent",
+                coords: grapherAnswerTypes.coords,
+            };
+        default:
+            throw new UnreachableCaseError(grapherAnswerTypes);
+    }
+}
+
+function grapherQuadraticCoordsToInteractiveGraphCoords([vertex, secondPoint]: [
+    Coord,
+    Coord,
+]): [Coord, Coord, Coord] {
+    const thirdPoint: Coord = [
+        // Reflect the x-coordinate of the second point across a vertical line
+        // through the vertex.
+        vertex[0] - (secondPoint[0] - vertex[0]),
+        secondPoint[1],
+    ];
+    return [vertex, secondPoint, thirdPoint];
 }

--- a/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
+++ b/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
@@ -21,7 +21,13 @@ export function convertGrapherOptionsToInteractiveGraph(
         return null;
     }
 
-    const type = grapherOptions.availableTypes[0];
+    const [type] = grapherOptions.availableTypes;
+    if (type === "quadratic") {
+        // Quadratic graphers cannot be converted to interactive-graph,
+        // because the 3-point user input from the interactive-graph cannot be
+        // losslessly converted back to the 2-point user input for Grapher.
+        return null;
+    }
 
     return {
         step: grapherOptions.graph.step,
@@ -111,14 +117,22 @@ export function convertInteractiveGraphUserInputToGrapher(
                     (interactiveGraphUserInput.coords as [Coord, Coord]) ??
                     null,
             };
-        default:
-            // This branch includes "quadratic"
-            // NOTE: we can't convert interactive graph quadratic coords to
-            // grapher, because that conversion is lossy (3 points -> 2 points).
+        case "angle":
+        case "circle":
+        case "linear-system":
+        case "none":
+        case "point":
+        case "polygon":
+        case "quadratic":
+        case "ray":
+        case "segment":
+        case "vector":
             throw Error(
                 "Can't convert interactive-graph user input to grapher user input. Type: " +
                     interactiveGraphUserInput.type,
             );
+        default:
+            throw new UnreachableCaseError(interactiveGraphUserInput);
     }
 }
 
@@ -149,15 +163,9 @@ function grapherAnswerTypesToPerseusGraphType(
                 asymptote: grapherAnswerTypes.asymptote[0][0],
             };
         case "quadratic":
-            return {
-                type: "quadratic",
-                coords:
-                    grapherAnswerTypes.coords == null
-                        ? null
-                        : grapherQuadraticCoordsToInteractiveGraphCoords(
-                              grapherAnswerTypes.coords,
-                          ),
-            };
+            throw Error(
+                "Can't convert GrapherAnswerTypes to interactive graph. Type: quadratic",
+            );
         case "sinusoid":
             return {
                 type: "sinusoid",
@@ -171,16 +179,4 @@ function grapherAnswerTypesToPerseusGraphType(
         default:
             throw new UnreachableCaseError(grapherAnswerTypes);
     }
-}
-
-function grapherQuadraticCoordsToInteractiveGraphCoords([vertex, secondPoint]: [
-    Coord,
-    Coord,
-]): [Coord, Coord, Coord] {
-    const thirdPoint: Coord = [
-        // Reflect the second point across a vertical line through the vertex.
-        vertex[0] - (secondPoint[0] - vertex[0]),
-        secondPoint[1],
-    ];
-    return [vertex, secondPoint, thirdPoint];
 }

--- a/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
+++ b/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
@@ -6,7 +6,6 @@ import type {
     PerseusGrapherWidgetOptions,
     PerseusGraphType,
     PerseusInteractiveGraphWidgetOptions,
-    Coord,
 } from "../../data-schema";
 import type {
     PerseusGrapherUserInput,
@@ -109,20 +108,12 @@ export function convertInteractiveGraphUserInputToGrapher(
         case "sinusoid":
             return {
                 type: "sinusoid",
-                // FIXME: avoid casting, use the parser.
-                coords:
-                    // eslint-disable-next-line no-restricted-syntax
-                    (interactiveGraphUserInput.coords as [Coord, Coord]) ??
-                    null,
+                coords: interactiveGraphUserInput.coords ?? null,
             };
         case "tangent":
             return {
                 type: "tangent",
-                // FIXME: avoid casting, use the parser.
-                coords:
-                    // eslint-disable-next-line no-restricted-syntax
-                    (interactiveGraphUserInput.coords as [Coord, Coord]) ??
-                    null,
+                coords: interactiveGraphUserInput.coords ?? null,
             };
         case "angle":
         case "circle":

--- a/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
+++ b/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
@@ -1,0 +1,5 @@
+import {PerseusGrapherWidgetOptions, PerseusInteractiveGraphWidgetOptions} from "@khanacademy/perseus-core";
+
+export function convertGrapherOptionsToInteractiveGraph(grapherOptions: PerseusGrapherWidgetOptions): PerseusInteractiveGraphWidgetOptions {
+
+}

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -626,6 +626,10 @@ class Grapher extends React.Component<Props> implements Widget {
     }
 
     render(): React.ReactNode {
+        if (!this.props.apiOptions.flags?.["grapher-to-interactive-graph"]) {
+            return this.renderLegacyGrapher();
+        }
+
         const interactiveGraphOptions = convertGrapherOptionsToInteractiveGraph(
             this.props,
         );

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -3,7 +3,13 @@ import {
     vector as kvector,
     point as kpoint,
 } from "@khanacademy/kmath";
-import {deepClone, GrapherUtil} from "@khanacademy/perseus-core";
+import {
+    convertGrapherOptionsToInteractiveGraph,
+    convertGrapherUserInputToInteractiveGraph,
+    convertInteractiveGraphUserInputToGrapher,
+    deepClone,
+    GrapherUtil,
+} from "@khanacademy/perseus-core";
 import * as React from "react";
 
 import ButtonGroup from "../../components/button-group";
@@ -19,6 +25,7 @@ import {getInteractiveBoxFromSizeClass} from "../../util/sizing-utils";
 /* Graphie and relevant components. */
 /* Mixins. */
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/grapher/grapher-ai-utils";
+import InteractiveGraph from "../interactive-graphs/interactive-graph";
 
 import {
     DEFAULT_GRAPHER_PROPS,
@@ -534,7 +541,7 @@ class Grapher extends React.Component<Props> implements Widget {
         };
     }
 
-    render(): React.ReactNode {
+    renderLegacyGrapher() {
         const availableTypes = this.props.static
             ? [this.props.correct.type]
             : this.props.availableTypes;
@@ -604,6 +611,32 @@ class Grapher extends React.Component<Props> implements Widget {
                 <FunctionGrapher {...grapherProps} />
                 {availableTypes.length > 1 && typeSelector}
             </div>
+        );
+    }
+
+    render(): React.ReactNode {
+        const interactiveGraphOptions = convertGrapherOptionsToInteractiveGraph(
+            this.props,
+        );
+        if (interactiveGraphOptions == null) {
+            return this.renderLegacyGrapher();
+        }
+        const interactiveGraphUserInput =
+            convertGrapherUserInputToInteractiveGraph(this.props.userInput);
+
+        return (
+            <InteractiveGraph.widget
+                {...this.props}
+                {...interactiveGraphOptions}
+                userInput={interactiveGraphUserInput}
+                handleUserInput={(interactiveGraphUserInput) =>
+                    this.props.handleUserInput(
+                        convertInteractiveGraphUserInputToGrapher(
+                            interactiveGraphUserInput,
+                        ),
+                    )
+                }
+            />
         );
     }
 }

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -11,6 +11,7 @@ import {
     GrapherUtil,
 } from "@khanacademy/perseus-core";
 import * as React from "react";
+import invariant from "tiny-invariant";
 
 import ButtonGroup from "../../components/button-group";
 import Graphie from "../../components/graphie";
@@ -50,6 +51,7 @@ import type {
     PerseusGrapherWidgetOptions,
     PerseusGrapherUserInput,
     GrapherPublicWidgetOptions,
+    GrapherFunctionType,
 } from "@khanacademy/perseus-core";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
@@ -541,10 +543,19 @@ class Grapher extends React.Component<Props> implements Widget {
         };
     }
 
+    getAvailableTypes(): GrapherFunctionType[] {
+        if (this.props.static) {
+            invariant(
+                this.props.correct,
+                "static widgets must have a correct answer",
+            );
+            return [this.props.correct.type];
+        }
+        return this.props.availableTypes;
+    }
+
     renderLegacyGrapher() {
-        const availableTypes = this.props.static
-            ? [this.props.correct.type]
-            : this.props.availableTypes;
+        const availableTypes = this.getAvailableTypes();
 
         const type = this.props.userInput.type;
         const coords = this.props.userInput.coords;
@@ -669,6 +680,10 @@ function getStartUserInput(
 function getCorrectUserInput(
     options: PerseusGrapherWidgetOptions,
 ): PerseusGrapherUserInput {
+    invariant(
+        options.correct,
+        "getCorrectUserInput should only be called for static widgets",
+    );
     return options.correct;
 }
 


### PR DESCRIPTION
This PR makes it so when the `grapher-to-interactive-graph` feature flag
is on, we render Grapher widgets with the interactive graph components.
From the learner's perspective, the Grapher widget appears to have been
replaced by Interactive Graph.

There are two cases where we can't convert Grapher to Interactive Graph:

- Quadratic graphs. The Grapher data and UI use two movable points (the
  vertex and a second point) to determine the quadratic function.
  IG uses three arbitrary points to determine the quadratic function. This
  makes it impossible to losslessly convert IG user input to Grapher user
  input.
- Choose-your-own-function graphs. IG has no equivalent for this case.

Issue: LEMS-4258

## Test plan:

Review Grapher widgets in Test Everything and elsewhere. When the feature
flag is on, they should display as Interactive Graphs. Validation and
scoring should work.