### PR TITLE
[Interactive Graph] Improve graph instruction and add repeat shortcut

### DIFF
--- a/.changeset/stupid-bees-sip.md
+++ b/.changeset/stupid-bees-sip.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Interactive Graph] Improve graph instruction and add repeat shortcut

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -125,8 +125,10 @@ export type PerseusStrings = {
     simulationLoadFail: string;
     simulationLocaleWarning: string;
     selectAnAnswer: string;
+    srGraphFocusModeWarning: string;
     srGraphInstructions: string;
     srUnlimitedGraphInstructions: string;
+    srGraphInstructionsRepeatHint: string;
     addPoint: string;
     removePoint: string;
     graphKeyboardPrompt: string;
@@ -822,6 +824,12 @@ export const strings = {
             "Button label for the button that opens a closed polygon created by the user in the interactive graph widget.",
         message: "Re-open shape",
     },
+    srGraphFocusModeWarning: {
+        context:
+            "Leading screen reader-only warning that prefixes the interactive graph instructions, telling the user to switch their screen reader to focus mode so that the graph's keyboard commands are not intercepted.",
+        message:
+            "Set your screen reader to focus mode to interact with this graph.",
+    },
     srGraphInstructions: {
         context:
             "Screen reader-only instructions for using the keyboard to move through the interactive elements in the interactive graph widget.",
@@ -833,6 +841,12 @@ export const strings = {
             "Screen reader-only instructions for using the keyboard to move through the 'unlimited' (addable/deletable by the user) interactive elements in the interactive graph widget.",
         message:
             "Press Shift + Enter to interact with the graph. Use the Tab key to move through the interactive elements in the graph and access the graph Action Bar. When an interactive element has focus, use Control + Shift + Arrows to move it or use the Delete key to remove it from the graph. Use the buttons in the Action Bar to add or adjust elements within the graph.",
+    },
+    srGraphInstructionsRepeatHint: {
+        context:
+            "Trailing screen reader-only hint appended to the interactive graph instructions, telling the user which keyboard shortcut repeats the instructions on demand.",
+        message:
+            "Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.",
     },
     srPointAtCoordinates: {
         context:
@@ -1544,10 +1558,14 @@ export const mockStrings: PerseusStrings = {
     simulationLocaleWarning:
         "Sorry, this simulation isn't available in your language.",
     selectAnAnswer: "Select an answer",
+    srGraphFocusModeWarning:
+        "Set your screen reader to focus mode to interact with this graph.",
     srGraphInstructions:
         "Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it.",
     srUnlimitedGraphInstructions:
         "Press Shift + Enter to interact with the graph. Use the Tab key to move through the interactive elements in the graph and access the graph Action Bar. When an interactive element has focus, use Control + Shift + Arrows to move it or use the Delete key to remove it from the graph. Use the buttons in the Action Bar to add or adjust elements within the graph.",
+    srGraphInstructionsRepeatHint:
+        "Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.",
     graphKeyboardPrompt: "Press Shift + Enter to interact with the graph",
     addPoint: "Add Point",
     removePoint: "Remove Point",

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -845,8 +845,7 @@ export const strings = {
     srGraphInstructionsRepeatHint: {
         context:
             "Trailing screen reader-only hint appended to the interactive graph instructions, telling the user which keyboard shortcut repeats the instructions on demand.",
-        message:
-            "Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.",
+        message: "Press Insert + I to repeat these instructions.",
     },
     srPointAtCoordinates: {
         context:
@@ -1565,7 +1564,7 @@ export const mockStrings: PerseusStrings = {
     srUnlimitedGraphInstructions:
         "Press Shift + Enter to interact with the graph. Use the Tab key to move through the interactive elements in the graph and access the graph Action Bar. When an interactive element has focus, use Control + Shift + Arrows to move it or use the Delete key to remove it from the graph. Use the buttons in the Action Bar to add or adjust elements within the graph.",
     srGraphInstructionsRepeatHint:
-        "Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.",
+        "Press Insert + I to repeat these instructions.",
     graphKeyboardPrompt: "Press Shift + Enter to interact with the graph",
     addPoint: "Add Point",
     removePoint: "Remove Point",

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
@@ -17,6 +17,7 @@ import {
     rayQuestion,
     rayWithCustomLabelsQuestion,
     segmentQuestion,
+    segmentWithAriaLabelQuestion,
     segmentWithCustomLabelsQuestion,
     segmentWithLockedPointsQuestion,
     segmentWithLockedLineQuestion,
@@ -241,6 +242,20 @@ export const Vector: Story = {
 export const Segment: Story = {
     args: {
         item: generateTestPerseusItem({question: segmentQuestion}),
+    },
+};
+
+/**
+ * A segment graph that sets `fullGraphAriaLabel` and
+ * `fullGraphAriaDescription`, giving the focusable figure an accessible name
+ * and description. Use this story to test the screen reader experience: on
+ * focus it announces the label, description, interactive elements, and the
+ * graph instructions (including the focus-mode warning and the Insert + I
+ * repeat-instructions hint).
+ */
+export const SegmentWithAriaLabel: Story = {
+    args: {
+        item: generateTestPerseusItem({question: segmentWithAriaLabelQuestion}),
     },
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/notes/screen-reader.md
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/notes/screen-reader.md
@@ -285,7 +285,7 @@ Since this implementation is an improvement on existing functionality no QE is n
 - `role="figure"` on the outer focusable `mafs-graph` View (LEMS-4119; OQ6a primary, OQ6b decision A).
 - DOM reorder so the instructions `<View>` is the first sr-only child inside the graph wrapper (LEMS-4121; OQ4).
 - Bounded vs. unlimited instruction-string split (LEMS-4120; OQ2a decision B), including the leading mode-toggle warning (OQ2b decision A) and the on-demand-shortcut sentence (OQ2c decision A).
-- Insert + I (Windows) / Fn + Enter + I (macOS) keyboard shortcut to repeat the instruction string on demand (LEMS-4120; OQ2c decision A). Platform-detected dual binding.
+- Insert + I keyboard shortcut to repeat the instruction string on demand (LEMS-4120; OQ2c). **Windows-only** — the originally-planned Fn + Enter + I macOS binding was dropped during implementation: Macs have no Insert key (Fn + Return reports as `key: "Enter"`, never "Insert") and macOS VoiceOver doesn't use Insert as a modifier, so the chord can't fire on a Mac. Mac SR users re-focus the graph to re-hear the instructions. No platform detection needed.
 - Explicit "nothing to move" SR-only label for none-type graphs and locked-figure traversability prefix in the on-entry description (LEMS-3205).
 - Instruction-level guidance for keyboard command conflict with screen readers (LEMS-4003); the mode-toggle warning in the instruction text addresses this directly per OQ2b.
 - Per-graph instruction polish for Exponent (LEMS-4122), Logarithm (LEMS-4123), and Vector (LEMS-4124) graph types — audit and update all SR strings for overall graph description and interactive element descriptions.
@@ -328,13 +328,12 @@ Since this implementation is an improvement on existing functionality no QE is n
 
 #### 2.3.3 Update instruction strings and Insert + I shortcut (LEMS-4120; OQ2a, OQ2b, OQ2c)
 
-- Replace `srGraphInstructions` and `srUnlimitedGraphInstructions` with two new strings that share a leading **mode-toggle warning** sentence ("Set your Screen Reader to Focus mode…") and end with the **instruction-repeat hint** ("Use Insert + I (Windows) or Fn + Enter + I (Mac) to repeat these instructions").
-- Bounded variant trims out Action Bar / add-point / close-shape language. Unlimited variant uses the designer's full text.
-- Add a keydown handler on the outer View for Insert + I (Windows) / Fn + Enter + I (macOS). The handler is **focus-scoped** — only runs when the graph is focused (WCAG 2.1.4 compliant). Detect the platform (`navigator.platform` or `navigator.userAgentData` with fallback chain).
-- On match: call `announce(...)` via WB Announcer with the same instruction string the user heard on entry. (No reducer round-trip needed — use `useGraphAnnouncer` directly.)
+- Add a leading **mode-toggle warning** sentence (`srGraphFocusModeWarning`, "Set your Screen Reader to Focus mode…") and a trailing **instruction-repeat hint** (`srGraphInstructionsRepeatHint`, "Press Insert + I to repeat these instructions"), composed with the existing bounded/unlimited bodies via a `getGraphInstructions(state, strings)` selector. (Implemented: the bodies `srGraphInstructions` / `srUnlimitedGraphInstructions` were kept unchanged rather than replaced.)
+- Add a keydown handler on the outer View for Insert + I. The handler is **focus-scoped** — only runs when the graph is focused (WCAG 2.1.4 compliant). **Windows-only, no platform detection:** Macs have no Insert key (Fn + Return reports as `key: "Enter"`) and VoiceOver doesn't use Insert, so the shortcut can't fire on a Mac — the hint copy names only Insert + I.
+- On match: call `announceMessage(...)` via WB Announcer with the same instruction string the user heard on entry (no reducer round-trip).
 - Coordinate final wording with Caitlyn, with Darrell as final sign-off — see [Cross-Cutting → Copy Review Process](#copy-review-process).
 
-**Done when:** bounded and unlimited instruction strings ship with the mode-toggle warning and repeat hint; Insert + I / Fn + Enter + I repeats instructions when the graph is focused; chord is not intercepted when focus is outside the graph.
+**Done when:** bounded and unlimited instruction strings ship with the mode-toggle warning and repeat hint; Insert + I repeats instructions when the graph is focused; chord is not intercepted when focus is outside the graph.
 
 #### 2.3.4 None-type / locked-figure messaging (LEMS-3205)
 
@@ -368,7 +367,7 @@ One PR per graph type is preferred; bundle if trivially the same shape.
 - `role="figure"` is present on the outer View and survives state changes.
 - DOM order: assert the `instructions` `<View>` is the first sr-only child after the new reorder.
 - Instruction strings: round-trip through the i18n harness; assert bounded/unlimited branches produce the expected substrings (mode-toggle warning, on-demand hint).
-- Insert + I / Fn + Enter + I: simulate each keydown on each platform, assert `announceMessage` is called with the instruction string. Assert the chord is **not** intercepted when focus is outside the graph.
+- Insert + I: simulate the keydown, assert `announceMessage` is called with the instruction string; assert I alone does not announce and blur disarms the shortcut.
 - None-type: assert renders `srGraphNothingToMove` in the sr-only description.
 - Locked-figure-bearing graphs: assert the traversability prefix is rendered.
 - Per-graph polish: snapshot-style assertions that updated strings are used.
@@ -400,15 +399,15 @@ Each PR is independently revertible via `git revert` if regressions appear.
 - **`role="figure"` may suppress child announcements on some SRs** (documented on focusable widgets in OQ6a). Mitigation: cross-SR test before merging; documented fallback to `role="application"` if needed.
 - **i18n copy churn**: the instruction strings are long. Late copy changes could ripple through translation files. Mitigation: complete Caitlyn-led iteration, then get Darrell's final sign-off **before** translation kicks off.
 - **"Nothing to move" copy may be misleading** for graph-as-image cases — coordinate with Content team.
-- **Platform detection brittleness** for Insert + I vs. Fn + Enter + I — `navigator.platform` is deprecated in some browsers; use `navigator.userAgentData` with fallback chain.
+- ~~**Platform detection brittleness** for Insert + I vs. Fn + Enter + I~~ — moot: the shortcut shipped Windows-only with no platform detection (see 2.3.3).
 
 ### 2.7 Open Implementation-time Questions
 
 - Final wording of all new strings, especially the mode-toggle warning sentence and whether it names specific SR toggle keys (JAWS: Insert + Z, NVDA: Insert + Space). Owner: Caitlyn, with Darrell as final sign-off.
-- Whether on-entry instructions list both Insert + I **and** Fn + Enter + I, or only the platform-relevant one.
+- ~~Whether on-entry instructions list both Insert + I and Fn + Enter + I~~ — RESOLVED: Insert + I only (Windows-only; see 2.3.3).
 - Whether static graphs get the "nothing to move" treatment. Pending design from Caitlyn.
 - Exact wording of the locked-figure traversability prefix — Caitlyn & Darrell.
-- Final platform-detection signal for Insert + I vs. Fn + Enter + I.
+- ~~Final platform-detection signal for Insert + I vs. Fn + Enter + I~~ — RESOLVED: none needed (Windows-only).
 
 ### 2.8 QE Strategy
 
@@ -816,9 +815,9 @@ Aggregated from per-phase subsections — living list, not a roadblock to starti
 - **Phase 1 (1.2):** Do `linear-system.tsx` and `ray.tsx` carry source-side aria-live toggles, or only test-side assertions? Decides whether they're paired-migration targets in Phase 1 or copy fixes in Phase 5.
 - **Phase 1 (1.3.7):** Do graph-entered / graph-exited announcements route through reducer actions or directly via `useGraphAnnouncer` from the focus handler? Phase 4 picks at the start of implementation.
 - **Phase 2 (2.7):** Final wording of all new strings, especially the mode-toggle warning sentence and whether it names specific SR toggle keys (JAWS Insert + Z, NVDA Insert + Space). Owner: Caitlyn & Darrell.
-- **Phase 2 (2.7):** Whether on-entry instructions list both Insert + I and Fn + Enter + I, or only the platform-relevant one.
+- ~~**Phase 2 (2.7):** Whether on-entry instructions list both Insert + I and Fn + Enter + I~~ — RESOLVED: Insert + I only (Windows-only).
 - **Phase 2 (2.7):** Whether static graphs get the "nothing to move" treatment. Pending design.
-- **Phase 2 (2.7):** Final platform-detection signal for the Insert + I vs. Fn + Enter + I dual binding.
+- ~~**Phase 2 (2.7):** Final platform-detection signal for the Insert + I vs. Fn + Enter + I dual binding~~ — RESOLVED: none needed (Windows-only).
 - **Phase 4 (4.7):** Whether to additionally announce the disabled-button hint on click attempt, or rely on the focus-time announcement.
 - **Phase 5 (5.6):** Whether to expose sinusoid extremum / midline / max / min labels for SR users at all. Pending design from Caitlyn.
 - **Cross-cutting:** Final feature-flag names confirmed with platform team during Phase 4.
@@ -832,7 +831,7 @@ Mirror of `screen-reader-research.md` "Decisions Recorded" — one-line restatem
 - **OQ1 → A.** Focus trap on all graphs (bounded + unlimited).
 - **OQ2a → B.** Two instruction strings (bounded vs. unlimited).
 - **OQ2b → A.** Keep Ctrl + Shift + Arrow; on-entry mode-toggle warning in the instruction text.
-- **OQ2c → A.** Insert + I (Windows) / Fn + Enter + I (macOS), platform-detected dual binding.
+- **OQ2c → A (revised during implementation to Windows-only).** Insert + I, no platform detection. The Fn + Enter + I macOS half of the dual binding was dropped: Macs emit `key: "Enter"` (not "Insert") for Fn + Return and VoiceOver doesn't use Insert, so it can't fire on a Mac.
 - **OQ3 → C.** Hybrid Announcer (central pure-function handler + `useGraphAnnouncer` per-graph escape hatch).
 - **OQ4 → A.** Reorder DOM so instructions render first.
 - **OQ5 → A.** Optional `pointLabels?: string[]` schema field with per-index fallback to "Point N".

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -1104,7 +1104,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                 id="instructions-:r2:"
                 tabindex="-1"
               >
-                Set your screen reader to focus mode to interact with this graph. Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it. Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.
+                Set your screen reader to focus mode to interact with this graph. Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it. Press Insert + I to repeat these instructions.
               </div>
               <div
                 class="default_7zhre1 mafs-sr-only"
@@ -1537,7 +1537,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                 id="instructions-:rc:"
                 tabindex="-1"
               >
-                Set your screen reader to focus mode to interact with this graph. Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it. Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.
+                Set your screen reader to focus mode to interact with this graph. Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it. Press Insert + I to repeat these instructions.
               </div>
               <div
                 class="default_7zhre1 mafs-sr-only"
@@ -1976,7 +1976,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                 id="instructions-:rl:"
                 tabindex="-1"
               >
-                Set your screen reader to focus mode to interact with this graph. Press Shift + Enter to interact with the graph. Use the Tab key to move through the interactive elements in the graph and access the graph Action Bar. When an interactive element has focus, use Control + Shift + Arrows to move it or use the Delete key to remove it from the graph. Use the buttons in the Action Bar to add or adjust elements within the graph. Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.
+                Set your screen reader to focus mode to interact with this graph. Press Shift + Enter to interact with the graph. Use the Tab key to move through the interactive elements in the graph and access the graph Action Bar. When an interactive element has focus, use Control + Shift + Arrows to move it or use the Delete key to remove it from the graph. Use the buttons in the Action Bar to add or adjust elements within the graph. Press Insert + I to repeat these instructions.
               </div>
               <div
                 class="default_7zhre1 mafs-sr-only"
@@ -2227,7 +2227,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                 id="instructions-:rr:"
                 tabindex="-1"
               >
-                Set your screen reader to focus mode to interact with this graph. Press Shift + Enter to interact with the graph. Use the Tab key to move through the interactive elements in the graph and access the graph Action Bar. When an interactive element has focus, use Control + Shift + Arrows to move it or use the Delete key to remove it from the graph. Use the buttons in the Action Bar to add or adjust elements within the graph. Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.
+                Set your screen reader to focus mode to interact with this graph. Press Shift + Enter to interact with the graph. Use the Tab key to move through the interactive elements in the graph and access the graph Action Bar. When an interactive element has focus, use Control + Shift + Arrows to move it or use the Delete key to remove it from the graph. Use the buttons in the Action Bar to add or adjust elements within the graph. Press Insert + I to repeat these instructions.
               </div>
               <div
                 class="default_7zhre1-o_O-inlineStyles_16155wj"
@@ -2456,7 +2456,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
                 id="instructions-:r4:"
                 tabindex="-1"
               >
-                Set your screen reader to focus mode to interact with this graph. Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it. Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.
+                Set your screen reader to focus mode to interact with this graph. Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it. Press Insert + I to repeat these instructions.
               </div>
               <div
                 class="default_7zhre1 mafs-sr-only"
@@ -2862,7 +2862,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
                 id="instructions-:re:"
                 tabindex="-1"
               >
-                Set your screen reader to focus mode to interact with this graph. Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it. Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.
+                Set your screen reader to focus mode to interact with this graph. Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it. Press Insert + I to repeat these instructions.
               </div>
               <div
                 class="default_7zhre1 mafs-sr-only"
@@ -3301,7 +3301,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
                 id="instructions-:rm:"
                 tabindex="-1"
               >
-                Set your screen reader to focus mode to interact with this graph. Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it. Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.
+                Set your screen reader to focus mode to interact with this graph. Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it. Press Insert + I to repeat these instructions.
               </div>
               <div
                 class="default_7zhre1 mafs-sr-only"
@@ -3656,7 +3656,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
                 id="instructions-:rt:"
                 tabindex="-1"
               >
-                Set your screen reader to focus mode to interact with this graph. Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it. Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.
+                Set your screen reader to focus mode to interact with this graph. Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it. Press Insert + I to repeat these instructions.
               </div>
               <div
                 class="default_7zhre1 mafs-sr-only"

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -1104,7 +1104,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                 id="instructions-:r2:"
                 tabindex="-1"
               >
-                Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it.
+                Set your screen reader to focus mode to interact with this graph. Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it. Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.
               </div>
               <div
                 class="default_7zhre1 mafs-sr-only"
@@ -1537,7 +1537,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                 id="instructions-:rc:"
                 tabindex="-1"
               >
-                Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it.
+                Set your screen reader to focus mode to interact with this graph. Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it. Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.
               </div>
               <div
                 class="default_7zhre1 mafs-sr-only"
@@ -1976,7 +1976,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                 id="instructions-:rl:"
                 tabindex="-1"
               >
-                Press Shift + Enter to interact with the graph. Use the Tab key to move through the interactive elements in the graph and access the graph Action Bar. When an interactive element has focus, use Control + Shift + Arrows to move it or use the Delete key to remove it from the graph. Use the buttons in the Action Bar to add or adjust elements within the graph.
+                Set your screen reader to focus mode to interact with this graph. Press Shift + Enter to interact with the graph. Use the Tab key to move through the interactive elements in the graph and access the graph Action Bar. When an interactive element has focus, use Control + Shift + Arrows to move it or use the Delete key to remove it from the graph. Use the buttons in the Action Bar to add or adjust elements within the graph. Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.
               </div>
               <div
                 class="default_7zhre1 mafs-sr-only"
@@ -2227,7 +2227,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                 id="instructions-:rr:"
                 tabindex="-1"
               >
-                Press Shift + Enter to interact with the graph. Use the Tab key to move through the interactive elements in the graph and access the graph Action Bar. When an interactive element has focus, use Control + Shift + Arrows to move it or use the Delete key to remove it from the graph. Use the buttons in the Action Bar to add or adjust elements within the graph.
+                Set your screen reader to focus mode to interact with this graph. Press Shift + Enter to interact with the graph. Use the Tab key to move through the interactive elements in the graph and access the graph Action Bar. When an interactive element has focus, use Control + Shift + Arrows to move it or use the Delete key to remove it from the graph. Use the buttons in the Action Bar to add or adjust elements within the graph. Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.
               </div>
               <div
                 class="default_7zhre1-o_O-inlineStyles_16155wj"
@@ -2456,7 +2456,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
                 id="instructions-:r4:"
                 tabindex="-1"
               >
-                Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it.
+                Set your screen reader to focus mode to interact with this graph. Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it. Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.
               </div>
               <div
                 class="default_7zhre1 mafs-sr-only"
@@ -2862,7 +2862,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
                 id="instructions-:re:"
                 tabindex="-1"
               >
-                Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it.
+                Set your screen reader to focus mode to interact with this graph. Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it. Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.
               </div>
               <div
                 class="default_7zhre1 mafs-sr-only"
@@ -3301,7 +3301,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
                 id="instructions-:rm:"
                 tabindex="-1"
               >
-                Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it.
+                Set your screen reader to focus mode to interact with this graph. Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it. Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.
               </div>
               <div
                 class="default_7zhre1 mafs-sr-only"
@@ -3656,7 +3656,7 @@ exports[`Interactive Graph question Should render user input predictably: with u
                 id="instructions-:rt:"
                 tabindex="-1"
               >
-                Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it.
+                Set your screen reader to focus mode to interact with this graph. Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it. Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.
               </div>
               <div
                 class="default_7zhre1 mafs-sr-only"

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -89,10 +89,14 @@ import type {
 } from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
 
+const focusModeWarning =
+    "Set your screen reader to focus mode to interact with this graph.";
 const commonInstructions =
     "Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it.";
 const unlimitedInstructions =
     "Press Shift + Enter to interact with the graph. Use the Tab key to move through the interactive elements in the graph and access the graph Action Bar. When an interactive element has focus, use Control + Shift + Arrows to move it or use the Delete key to remove it from the graph. Use the buttons in the Action Bar to add or adjust elements within the graph.";
+const repeatHint =
+    "Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.";
 
 const blankOptions: APIOptions = Object.freeze(ApiOptions.defaults);
 
@@ -1848,6 +1852,20 @@ describe("Interactive Graph", function () {
             },
         );
 
+        it.each(Object.entries(limitedGraphQuestionRenderers))(
+            "graph type %s prefixes the focus mode warning and ends with the repeat hint",
+            (_type, question) => {
+                const {container} = renderQuestion(question, blankOptions);
+
+                // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+                const graph = container.querySelector(".mafs-graph");
+
+                expect(graph).toHaveTextContent(
+                    `${focusModeWarning} ${commonInstructions} ${repeatHint}`,
+                );
+            },
+        );
+
         it.each(Object.entries(unlimitedGraphQuestionRenderers))(
             "graph type %s has SR instructions for interacting with the graph",
             (_type, question) => {
@@ -1857,6 +1875,20 @@ describe("Interactive Graph", function () {
                 const graph = container.querySelector(".mafs-graph");
 
                 expect(graph).toHaveTextContent(unlimitedInstructions);
+            },
+        );
+
+        it.each(Object.entries(unlimitedGraphQuestionRenderers))(
+            "graph type %s prefixes the focus mode warning and ends with the repeat hint",
+            (_type, question) => {
+                const {container} = renderQuestion(question, blankOptions);
+
+                // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+                const graph = container.querySelector(".mafs-graph");
+
+                expect(graph).toHaveTextContent(
+                    `${focusModeWarning} ${unlimitedInstructions} ${repeatHint}`,
+                );
             },
         );
 

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -95,8 +95,7 @@ const commonInstructions =
     "Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it.";
 const unlimitedInstructions =
     "Press Shift + Enter to interact with the graph. Use the Tab key to move through the interactive elements in the graph and access the graph Action Bar. When an interactive element has focus, use Control + Shift + Arrows to move it or use the Delete key to remove it from the graph. Use the buttons in the Action Bar to add or adjust elements within the graph.";
-const repeatHint =
-    "Press Insert + I, or Function + Enter + I on a Mac, to repeat these instructions.";
+const repeatHint = "Press Insert + I to repeat these instructions.";
 
 const blankOptions: APIOptions = Object.freeze(ApiOptions.defaults);
 

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -290,6 +290,27 @@ export const segmentQuestion: PerseusRenderer =
         }),
     });
 
+// A segment graph that sets both `fullGraphAriaLabel` and
+// `fullGraphAriaDescription`, so the focusable figure has an accessible name
+// and description. Useful for screen reader testing of the on-focus
+// announcement (label → description → interactive elements → instructions) and
+// the Insert + I repeat-instructions shortcut.
+export const segmentWithAriaLabelQuestion: PerseusRenderer =
+    generateInteractiveGraphQuestion({
+        correct: generateIGSegmentGraph({
+            numSegments: 1,
+            coords: [
+                [
+                    [-5, 5],
+                    [5, 5],
+                ],
+            ],
+        }),
+        fullGraphAriaLabel: "Segment graph",
+        fullGraphAriaDescription:
+            "A line segment on a coordinate plane. Move its endpoints to draw your answer.",
+    });
+
 export const segmentQuestionDefaultCorrect: PerseusRenderer =
     generateInteractiveGraphQuestion({
         correct: generateIGSegmentGraph({

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -972,8 +972,11 @@ describe("MafsGraph", () => {
             );
 
             // Assert
+            // The instructions block now leads with a focus-mode warning
+            // (see getGraphInstructions), so match the body text as a substring
+            // rather than anchoring at the start of the string.
             const instructions = screen.getByText(
-                /^Use the Tab key to move through/,
+                /Use the Tab key to move through/,
             );
             const description = screen.getByText("A graph description.");
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -1,3 +1,4 @@
+import {announceMessage} from "@khanacademy/wonder-blocks-announcer";
 import {screen, render, act} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import {vec} from "mafs";
@@ -5,12 +6,13 @@ import React from "react";
 import invariant from "tiny-invariant";
 
 import * as Dependencies from "../../dependencies";
+import {mockStrings} from "../../strings";
 import {
     testDependencies,
     testDependenciesV2,
 } from "../../testing/test-dependencies";
 
-import {MafsGraph} from "./mafs-graph";
+import {getGraphInstructions, MafsGraph} from "./mafs-graph";
 import {actions, REMOVE_POINT} from "./reducer/interactive-graph-action";
 import {interactiveGraphReducer} from "./reducer/interactive-graph-reducer";
 import {calculateNestedSVGCoords, getBaseMafsGraphPropsForTests} from "./utils";
@@ -20,6 +22,10 @@ import type {InteractiveGraphState} from "./types";
 import type {PerseusDependenciesV2} from "../../types";
 import type {GraphRange} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
+
+jest.mock("@khanacademy/wonder-blocks-announcer", () => ({
+    announceMessage: jest.fn(),
+}));
 
 const baseMafsProps = getBaseMafsGraphPropsForTests();
 
@@ -1294,6 +1300,87 @@ describe("MafsGraph", () => {
             });
             // Make sure the button is disabled
             expect(closeShapeButton).toHaveAttribute("aria-disabled", "true");
+        });
+    });
+
+    describe("instructions shortcut (Insert + I)", () => {
+        const segmentState: InteractiveGraphState = {
+            type: "segment",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [0.5, 0.5],
+            coords: [
+                [
+                    [0, 0],
+                    [-7, 0.5],
+                ],
+            ],
+        };
+
+        beforeEach(() => {
+            jest.mocked(announceMessage).mockClear();
+        });
+
+        it("announces the instructions when Insert + I is pressed while the graph is focused", async () => {
+            // Arrange
+            render(
+                <MafsGraph
+                    {...baseMafsProps}
+                    state={segmentState}
+                    dispatch={jest.fn()}
+                />,
+            );
+            act(() => screen.getByRole("figure").focus());
+
+            // Act
+            await userEvent.keyboard("{Insert>}i{/Insert}");
+
+            // Assert
+            expect(jest.mocked(announceMessage)).toHaveBeenCalledWith({
+                message: getGraphInstructions(segmentState, mockStrings),
+            });
+        });
+
+        it("does not announce when I is pressed without Insert held", async () => {
+            // Arrange
+            render(
+                <MafsGraph
+                    {...baseMafsProps}
+                    state={segmentState}
+                    dispatch={jest.fn()}
+                />,
+            );
+            act(() => screen.getByRole("figure").focus());
+
+            // Act
+            await userEvent.keyboard("i");
+
+            // Assert
+            expect(jest.mocked(announceMessage)).not.toHaveBeenCalled();
+        });
+
+        it("does not stay armed after the graph loses focus", async () => {
+            // Arrange
+            render(
+                <MafsGraph
+                    {...baseMafsProps}
+                    state={segmentState}
+                    dispatch={jest.fn()}
+                />,
+            );
+            const figure = screen.getByRole("figure");
+            act(() => figure.focus());
+
+            // Act: hold Insert, blur the graph, then press I
+            await userEvent.keyboard("{Insert>}");
+            act(() => figure.blur());
+            await userEvent.keyboard("i{/Insert}");
+
+            // Assert
+            expect(jest.mocked(announceMessage)).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -121,11 +121,11 @@ export const MafsGraph = (props: MafsGraphProps) => {
     const unlimitedGraphKeyboardPromptId = `unlimited-graph-keyboard-prompt-${uniqueId}`;
     const instructionsId = `instructions-${uniqueId}`;
     const graphRef = React.useRef<HTMLElement>(null);
-    // Tracks whether the Insert key (the SR modifier, also emulated by
-    // Fn + Enter on Mac) is currently held, so we can detect the Insert + I
-    // shortcut that repeats the graph instructions. Insert is not a standard
-    // keyboard modifier, so it can't be read via getModifierState and must be
-    // tracked manually across keydown/keyup.
+    // Tracks whether the Insert key is held, so we can detect the Insert + I
+    // shortcut that repeats the graph instructions. Insert isn't a standard
+    // modifier (no getModifierState), so we track it manually across keydown/up.
+    // Windows-only: Macs have no Insert key, the Fn + Return reports as
+    // `key: "Enter"` (never "Insert"), so this shortcut can't fire on a Mac.
     const insertKeyHeld = React.useRef(false);
     const {analytics} = useDependencies();
 
@@ -298,9 +298,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                             tabIndex={-1}
                             className="mafs-sr-only"
                         >
-                            {isUnlimitedGraphState(state)
-                                ? strings.srUnlimitedGraphInstructions
-                                : strings.srGraphInstructions}
+                            {getGraphInstructions(state, strings)}
                         </View>
                     )}
                     {fullGraphAriaDescription && (
@@ -742,13 +740,17 @@ export function getGraphInstructions(
 }
 
 /**
- * Repeat the graph instructions on demand via the Insert + I shortcut
- * (Fn + Enter + I on Mac, which the OS emulates as the Insert key).
+ * Repeat the graph instructions on demand via the Insert + I shortcut.
  *
  * This handler lives on the graph wrapper, so it is inherently focus-scoped to
  * the graph (WCAG 2.1.4) — it only fires while focus is on the graph or one of
  * its interactive children. Insert is not a standard keyboard modifier, so its
  * held state is tracked manually in `insertKeyHeld` across keydown/keyup/blur.
+ *
+ * Windows-only by decision (LEMS-4120): Insert is the NVDA/JAWS modifier. Macs
+ * have no Insert key (Fn + Return reports as "Enter", not "Insert") and macOS
+ * VoiceOver doesn't use Insert, so the shortcut intentionally does not fire on
+ * Mac — the repeat-hint copy omits any Mac chord to match.
  */
 function handleInstructionsShortcut(
     event: React.KeyboardEvent,

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -9,6 +9,7 @@
  * - Protractor
  * - Interactive Graph Elements
  */
+import {announceMessage} from "@khanacademy/wonder-blocks-announcer";
 import Button from "@khanacademy/wonder-blocks-button";
 import {useOnMountEffect, View} from "@khanacademy/wonder-blocks-core";
 import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
@@ -120,6 +121,12 @@ export const MafsGraph = (props: MafsGraphProps) => {
     const unlimitedGraphKeyboardPromptId = `unlimited-graph-keyboard-prompt-${uniqueId}`;
     const instructionsId = `instructions-${uniqueId}`;
     const graphRef = React.useRef<HTMLElement>(null);
+    // Tracks whether the Insert key (the SR modifier, also emulated by
+    // Fn + Enter on Mac) is currently held, so we can detect the Insert + I
+    // shortcut that repeats the graph instructions. Insert is not a standard
+    // keyboard modifier, so it can't be read via getModifierState and must be
+    // tracked manually across keydown/keyup.
+    const insertKeyHeld = React.useRef(false);
     const {analytics} = useDependencies();
 
     const i18n = usePerseusI18n();
@@ -240,7 +247,18 @@ export const MafsGraph = (props: MafsGraphProps) => {
                         width,
                         height,
                     }}
+                    onKeyDown={(event) => {
+                        handleInstructionsShortcut(
+                            event,
+                            state,
+                            strings,
+                            insertKeyHeld,
+                        );
+                    }}
                     onKeyUp={(event) => {
+                        if (event.key === "Insert") {
+                            insertKeyHeld.current = false;
+                        }
                         handleKeyboardEvent(event, state, dispatch);
                     }}
                     aria-label={fullGraphAriaLabel}
@@ -263,6 +281,9 @@ export const MafsGraph = (props: MafsGraphProps) => {
                         handleFocusEvent(event, state, dispatch);
                     }}
                     onBlur={(event) => {
+                        // Reset the Insert-held flag if focus leaves the graph,
+                        // so a missed keyup can't leave the shortcut "armed".
+                        insertKeyHeld.current = false;
                         handleBlurEvent(event, state, dispatch);
                     }}
                 >
@@ -693,6 +714,56 @@ function handleBlurEvent(
 ) {
     if (isUnlimitedGraphState(state)) {
         dispatch(actions.global.changeKeyboardInvitationVisibility(false));
+    }
+}
+
+/**
+ * Build the screen reader-only instruction string for the graph.
+ *
+ * Composed from three parts so the shared pieces stay in sync and the
+ * churn-prone copy is isolated: a leading focus-mode warning, the
+ * bounded/unlimited instruction body, and a trailing repeat-shortcut hint.
+ *
+ * Used both by the rendered sr-only instructions View and (in a follow-up) by
+ * the Insert + I repeat-instructions shortcut, so the two can't drift.
+ */
+export function getGraphInstructions(
+    state: InteractiveGraphState,
+    strings: PerseusStrings,
+): string {
+    const body = isUnlimitedGraphState(state)
+        ? strings.srUnlimitedGraphInstructions
+        : strings.srGraphInstructions;
+    return [
+        strings.srGraphFocusModeWarning,
+        body,
+        strings.srGraphInstructionsRepeatHint,
+    ].join(" ");
+}
+
+/**
+ * Repeat the graph instructions on demand via the Insert + I shortcut
+ * (Fn + Enter + I on Mac, which the OS emulates as the Insert key).
+ *
+ * This handler lives on the graph wrapper, so it is inherently focus-scoped to
+ * the graph (WCAG 2.1.4) — it only fires while focus is on the graph or one of
+ * its interactive children. Insert is not a standard keyboard modifier, so its
+ * held state is tracked manually in `insertKeyHeld` across keydown/keyup/blur.
+ */
+function handleInstructionsShortcut(
+    event: React.KeyboardEvent,
+    state: InteractiveGraphState,
+    strings: PerseusStrings,
+    insertKeyHeld: React.MutableRefObject<boolean>,
+) {
+    if (event.key === "Insert") {
+        insertKeyHeld.current = true;
+        return;
+    }
+
+    if (insertKeyHeld.current && event.key.toLowerCase() === "i") {
+        event.preventDefault();
+        announceMessage({message: getGraphInstructions(state, strings)});
     }
 }
 


### PR DESCRIPTION
## Summary:
Reworks the screen reader-only interactive-graph instructions to lead with a focus-mode warning and end with an on-demand repeat hint, and adds the Insert + I shortcut that repeats the instructions while the graph is focused.

<img width="1013" height="702" alt="Screenshot 2026-06-12 at 2 31 51 PM" src="https://github.com/user-attachments/assets/0edcf457-58ca-49ea-9d14-05ba232c0249" />

Issue: LEMS-4120

## Test plan: