### PR TITLE
Require the `sinusoid` and `tangent` subtypes of interactive graphs to have exactly two points.

### DIFF
--- a/.changeset/spotty-ads-rescue.md
+++ b/.changeset/spotty-ads-rescue.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+In the data-schema types, clarify that `sinusoid` and `tangent` interactive graphs have exactly two movable points.

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1275,9 +1275,9 @@ export type PerseusGraphTypeSegment = {
 export type PerseusGraphTypeSinusoid = {
     type: "sinusoid";
     /** Expects a list of 2 Coords */
-    coords?: Coord[] | null;
+    coords?: [Coord, Coord] | null;
     /** The initial coordinates the graph renders with. */
-    startCoords?: Coord[];
+    startCoords?: [Coord, Coord];
     /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
     /** Opt-in: render a visible label next to each interactive point. */
@@ -1287,9 +1287,9 @@ export type PerseusGraphTypeSinusoid = {
 export type PerseusGraphTypeTangent = {
     type: "tangent";
     // Expects a list of 2 Coords
-    coords?: Coord[] | null;
+    coords?: [Coord, Coord] | null;
     // The initial coordinates the graph renders with.
-    startCoords?: Coord[];
+    startCoords?: [Coord, Coord];
     /** Custom label for each interactive point that will help with the screen reader. */
     pointLabels?: string[];
     /** Opt-in: render a visible label next to each interactive point. */

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interactive-graph-widget.ts
@@ -128,8 +128,8 @@ const parsePerseusGraphTypeSegment = object({
 
 const parsePerseusGraphTypeSinusoid = object({
     type: constant("sinusoid"),
-    coords: optional(nullable(array(pairOfNumbers))),
-    startCoords: optional(array(pairOfNumbers)),
+    coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
+    startCoords: optional(pair(pairOfNumbers, pairOfNumbers)),
     pointLabels: optional(array(string)),
     showPointLabels: optional(boolean),
 });
@@ -158,8 +158,8 @@ const parsePerseusGraphTypeAbsoluteValue = object({
 
 const parsePerseusGraphTypeTangent = object({
     type: constant("tangent"),
-    coords: optional(nullable(array(pairOfNumbers))),
-    startCoords: optional(array(pairOfNumbers)),
+    coords: optional(nullable(pair(pairOfNumbers, pairOfNumbers))),
+    startCoords: optional(pair(pairOfNumbers, pairOfNumbers)),
     pointLabels: optional(array(string)),
     showPointLabels: optional(boolean),
 });

--- a/packages/perseus-core/src/utils/generators/interactive-graph-widget-generator.test.ts
+++ b/packages/perseus-core/src/utils/generators/interactive-graph-widget-generator.test.ts
@@ -784,12 +784,10 @@ describe("generateIGSinusoidGraph", () => {
             coords: [
                 [0, 0],
                 [1, 1],
-                [2, 2],
             ],
             startCoords: [
                 [0, 0],
                 [1, 1],
-                [2, 2],
             ],
         });
 
@@ -799,12 +797,10 @@ describe("generateIGSinusoidGraph", () => {
             coords: [
                 [0, 0],
                 [1, 1],
-                [2, 2],
             ],
             startCoords: [
                 [0, 0],
                 [1, 1],
-                [2, 2],
             ],
         });
     });


### PR DESCRIPTION
## Summary:
This will make it slightly easier to adapt the Grapher widget to the
Interactive Graph UI. Grapher uses tuple types for its point coordinates.

Issue: LEMS-4252

## Test plan:

Search the content for interactive graphs, and verify that all sinusoid
and tangent graphs have exactly two points.

```
rg -l '"type":"interactive-graph"' \
  | xargs jq --indent 0 '
      ..
      | objects
      | select(.type == "sinusoid" or .type == "tangent")
      | {
          coords: (if .coords == null then null else .coords | length end),
          startCoords: (if .startCoords == null then .startCoords else .startCoords | length end)
        }' \
  | sort \
  | uniq -c

8455 {"coords":2,"startCoords":null}
 102 {"coords":null,"startCoords":2}
3443 {"coords":null,"startCoords":null}
```