### PR TITLE
Remove `it` from `expectWarning` and `expectPass`

### DIFF
--- a/.changeset/small-turtles-think.md
+++ b/.changeset/small-turtles-think.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-linter": patch
+---
+
+Replace how expectWarning and expectPass work so that they no longer contain `it` blocks

--- a/packages/perseus-linter/src/__tests__/test-utils.ts
+++ b/packages/perseus-linter/src/__tests__/test-utils.ts
@@ -61,17 +61,29 @@ export function expectWarning(
     }
 
     it.each(strings)(`Rule ${rule.name} warns with: %s`, (string) => {
-        const result = testRule(rule, string, context);
-        expect(result).not.toBeNull();
-
-        if (options?.message) {
-            expect(result?.[0]?.message).toBe(options.message);
-        }
-
-        if (options?.severity) {
-            expect(result?.[0]?.severity).toBe(options.severity);
-        }
+        expectWarningSingle(rule, string, context, options);
     });
+}
+
+export function expectWarningSingle(
+    rule,
+    string: string,
+    context?,
+    options?: {
+        message?: string;
+        severity?: number;
+    },
+) {
+    const result = testRule(rule, string, context);
+    expect(result).not.toBeNull();
+
+    if (options?.message) {
+        expect(result?.[0]?.message).toBe(options.message);
+    }
+
+    if (options?.severity) {
+        expect(result?.[0]?.severity).toBe(options.severity);
+    }
 }
 
 export function expectPass(rule, string: string, context?) {

--- a/packages/perseus-linter/src/__tests__/test-utils.ts
+++ b/packages/perseus-linter/src/__tests__/test-utils.ts
@@ -74,16 +74,6 @@ export function expectWarning(
     });
 }
 
-export function expectPass(rule, strings: string | Array<string>, context?) {
-    if (typeof strings === "string") {
-        strings = [strings];
-    }
-
-    it.each(strings)(`Rule ${rule.name} passes with: %s`, (string) => {
-        expectPassSingle(rule, string, context);
-    });
-}
-
-export function expectPassSingle(rule, string: string, context?) {
+export function expectPass(rule, string: string, context?) {
     expect(testRule(rule, string, context)).toBeNull();
 }

--- a/packages/perseus-linter/src/__tests__/test-utils.ts
+++ b/packages/perseus-linter/src/__tests__/test-utils.ts
@@ -80,6 +80,10 @@ export function expectPass(rule, strings: string | Array<string>, context?) {
     }
 
     it.each(strings)(`Rule ${rule.name} passes with: %s`, (string) => {
-        expect(testRule(rule, string, context)).toBeNull();
+        expectPassSingle(rule, string, context);
     });
+}
+
+export function expectPassSingle(rule, string: string, context?) {
+    expect(testRule(rule, string, context)).toBeNull();
 }

--- a/packages/perseus-linter/src/__tests__/test-utils.ts
+++ b/packages/perseus-linter/src/__tests__/test-utils.ts
@@ -49,24 +49,6 @@ export function testRule(
 
 export function expectWarning(
     rule,
-    strings: string | Array<string>,
-    context?,
-    options?: {
-        message?: string;
-        severity?: number;
-    },
-) {
-    if (typeof strings === "string") {
-        strings = [strings];
-    }
-
-    it.each(strings)(`Rule ${rule.name} warns with: %s`, (string) => {
-        expectWarningSingle(rule, string, context, options);
-    });
-}
-
-export function expectWarningSingle(
-    rule,
     string: string,
     context?,
     options?: {

--- a/packages/perseus-linter/src/rules/absolute-url.test.ts
+++ b/packages/perseus-linter/src/rules/absolute-url.test.ts
@@ -1,4 +1,4 @@
-import {expectPass, expectWarningSingle} from "../__tests__/test-utils";
+import {expectPass, expectWarning} from "../__tests__/test-utils";
 
 import absoluteUrlRule from "./absolute-url";
 
@@ -19,7 +19,7 @@ describe("absolute-url", () => {
         "![alt text](https://www.khanacademy.org/about)",
         "![alt text](https://es.khanacademy.org/about)",
     ])("absoluteUrlRule warns with: %s", (str: string) => {
-        expectWarningSingle(absoluteUrlRule, str);
+        expectWarning(absoluteUrlRule, str);
     });
 
     it.each([

--- a/packages/perseus-linter/src/rules/absolute-url.test.ts
+++ b/packages/perseus-linter/src/rules/absolute-url.test.ts
@@ -19,7 +19,7 @@ describe("absolute-url", () => {
         "![alt text](https://www.khanacademy.org/about)",
         "![alt text](https://es.khanacademy.org/about)",
     ]);
-    expectPass(absoluteUrlRule, [
+    it.each([
         "[target](/about)", // relative URLs okay
         "[target](https://kasandbox.org/path)",
         "[target](https://fastly.kastatic.org/path)",
@@ -31,5 +31,7 @@ describe("absolute-url", () => {
         "![alt text](/about)",
         "![alt text](https://cdn.kastatic.org/path)",
         "![alt text](https://ka-perseus-images.s3.amazonaws.com/path)",
-    ]);
+    ])("absoluteUrlRule passes with: %s", (str: string) => {
+        expectPass(absoluteUrlRule, str);
+    });
 });

--- a/packages/perseus-linter/src/rules/absolute-url.test.ts
+++ b/packages/perseus-linter/src/rules/absolute-url.test.ts
@@ -1,9 +1,9 @@
-import {expectWarning, expectPass} from "../__tests__/test-utils";
+import {expectPass, expectWarningSingle} from "../__tests__/test-utils";
 
 import absoluteUrlRule from "./absolute-url";
 
 describe("absolute-url", () => {
-    expectWarning(absoluteUrlRule, [
+    it.each([
         // Warn about absolute khanacademy.org urls
         "[target](http://khanacademy.org/about)",
         "[target](https://khanacademy.org/about)",
@@ -18,7 +18,10 @@ describe("absolute-url", () => {
         "![alt text](http://khanacademy.org/about)",
         "![alt text](https://www.khanacademy.org/about)",
         "![alt text](https://es.khanacademy.org/about)",
-    ]);
+    ])("absoluteUrlRule warns with: %s", (str: string) => {
+        expectWarningSingle(absoluteUrlRule, str);
+    });
+
     it.each([
         "[target](/about)", // relative URLs okay
         "[target](https://kasandbox.org/path)",

--- a/packages/perseus-linter/src/rules/double-spacing-after-terminal.test.ts
+++ b/packages/perseus-linter/src/rules/double-spacing-after-terminal.test.ts
@@ -1,13 +1,14 @@
-import {expectWarning, expectPass} from "../__tests__/test-utils";
+import {expectPass, expectWarning} from "../__tests__/test-utils";
 
 import doubleSpacingAfterTerminalRule from "./double-spacing-after-terminal";
 
 describe("double-spacing-after-terminal", () => {
-    expectWarning(doubleSpacingAfterTerminalRule, [
-        "Good times.  Great oldies.",
-        "End of the line!  ",
-        "You?  Me!",
-    ]);
+    it.each(["Good times.  Great oldies.", "End of the line!  ", "You?  Me!"])(
+        "doubleSpacingAfterTerminalRule warns with: %s",
+        (str: string) => {
+            expectWarning(doubleSpacingAfterTerminalRule, str);
+        },
+    );
     it.each([
         "This is okay.",
         "This is definitely okay. Yeah.",

--- a/packages/perseus-linter/src/rules/double-spacing-after-terminal.test.ts
+++ b/packages/perseus-linter/src/rules/double-spacing-after-terminal.test.ts
@@ -9,6 +9,7 @@ describe("double-spacing-after-terminal", () => {
             expectWarning(doubleSpacingAfterTerminalRule, str);
         },
     );
+
     it.each([
         "This is okay.",
         "This is definitely okay. Yeah.",

--- a/packages/perseus-linter/src/rules/double-spacing-after-terminal.test.ts
+++ b/packages/perseus-linter/src/rules/double-spacing-after-terminal.test.ts
@@ -8,9 +8,11 @@ describe("double-spacing-after-terminal", () => {
         "End of the line!  ",
         "You?  Me!",
     ]);
-    expectPass(doubleSpacingAfterTerminalRule, [
+    it.each([
         "This is okay.",
         "This is definitely okay. Yeah.",
         "$a == 3.  125$",
-    ]);
+    ])("doubleSpacingAfterTerminalRule passes with: %s", (str: string) => {
+        expectPass(doubleSpacingAfterTerminalRule, str);
+    });
 });

--- a/packages/perseus-linter/src/rules/expression-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/expression-widget-error.test.ts
@@ -3,88 +3,93 @@ import {expectPass, expectWarning} from "../__tests__/test-utils";
 import expressionWidgetErrorRule from "./expression-widget-error";
 
 describe("expression-widget-error", () => {
-    // Error when no answers are specified
-    expectWarning(expressionWidgetErrorRule, "[[☃ expression 1]]", {
-        widgets: {
-            "expression 1": {
-                options: {
-                    answerForms: [],
+    it("warns when no answers are specified", () => {
+        expectWarning(expressionWidgetErrorRule, "[[☃ expression 1]]", {
+            widgets: {
+                "expression 1": {
+                    options: {
+                        answerForms: [],
+                    },
                 },
             },
-        },
+        });
     });
 
-    // Error when no correct answer is specified
-    expectWarning(expressionWidgetErrorRule, "[[☃ expression 1]]", {
-        widgets: {
-            "expression 1": {
-                options: {
-                    answerForms: [
-                        {
-                            value: "1",
-                            form: false,
-                            simplify: false,
-                            considered: "wrong",
-                        },
-                    ],
+    it("warns when no correct answer is specified", () => {
+        expectWarning(expressionWidgetErrorRule, "[[☃ expression 1]]", {
+            widgets: {
+                "expression 1": {
+                    options: {
+                        answerForms: [
+                            {
+                                value: "1",
+                                form: false,
+                                simplify: false,
+                                considered: "wrong",
+                            },
+                        ],
+                    },
                 },
             },
-        },
+        });
     });
 
-    // Error when an answer is empty
-    expectWarning(expressionWidgetErrorRule, "[[☃ expression 1]]", {
-        widgets: {
-            "expression 1": {
-                options: {
-                    answerForms: [
-                        {
-                            value: "",
-                            form: false,
-                            simplify: false,
-                            considered: "correct",
-                        },
-                    ],
+    it("warns when an answer is empty", () => {
+        expectWarning(expressionWidgetErrorRule, "[[☃ expression 1]]", {
+            widgets: {
+                "expression 1": {
+                    options: {
+                        answerForms: [
+                            {
+                                value: "",
+                                form: false,
+                                simplify: false,
+                                considered: "correct",
+                            },
+                        ],
+                    },
                 },
             },
-        },
+        });
     });
 
-    // Error when value could not be parsed
-    expectWarning(expressionWidgetErrorRule, "[[☃ expression 1]]", {
-        widgets: {
-            "expression 1": {
-                options: {
-                    answerForms: [
-                        {
-                            // Unparsable value
-                            value: "2.4.r",
-                            form: false,
-                            simplify: false,
-                            considered: "correct",
-                        },
-                    ],
+    it("warns when value could not be parsed", () => {
+        expectWarning(expressionWidgetErrorRule, "[[☃ expression 1]]", {
+            widgets: {
+                "expression 1": {
+                    options: {
+                        answerForms: [
+                            {
+                                // Unparsable value
+                                value: "2.4.r",
+                                form: false,
+                                simplify: false,
+                                considered: "correct",
+                            },
+                        ],
+                    },
                 },
             },
-        },
+        });
     });
 
-    // Error when value is not simplified but is required to be
-    expectWarning(expressionWidgetErrorRule, "[[☃ expression 1]]", {
-        widgets: {
-            "expression 1": {
-                options: {
-                    answerForms: [
-                        {
-                            value: "2/1",
-                            form: false,
-                            simplify: true,
-                            considered: "correct",
-                        },
-                    ],
+    it("warns when value is not simplified but is required to be", () => {
+        expectWarning(expressionWidgetErrorRule, "[[☃ expression 1]]", {
+            widgets: {
+                "expression 1": {
+                    options: {
+                        answerForms: [
+                            {
+                                value: "2/1",
+                                form: false,
+                                simplify: true,
+                                considered: "correct",
+                            },
+                        ],
+                    },
                 },
             },
-        },
+        });
     });
 
     it("passes when no errors are detected", () => {

--- a/packages/perseus-linter/src/rules/expression-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/expression-widget-error.test.ts
@@ -87,21 +87,22 @@ describe("expression-widget-error", () => {
         },
     });
 
-    // Pass when no errors are detected
-    expectPass(expressionWidgetErrorRule, "[[☃ expression 1]]", {
-        widgets: {
-            "expression 1": {
-                options: {
-                    answerForms: [
-                        {
-                            value: "2",
-                            form: false,
-                            simplify: false,
-                            considered: "correct",
-                        },
-                    ],
+    it("passes when no errors are detected", () => {
+        expectPass(expressionWidgetErrorRule, "[[☃ expression 1]]", {
+            widgets: {
+                "expression 1": {
+                    options: {
+                        answerForms: [
+                            {
+                                value: "2",
+                                form: false,
+                                simplify: false,
+                                considered: "correct",
+                            },
+                        ],
+                    },
                 },
             },
-        },
+        });
     });
 });

--- a/packages/perseus-linter/src/rules/expression-widget.test.ts
+++ b/packages/perseus-linter/src/rules/expression-widget.test.ts
@@ -1,8 +1,4 @@
-import {
-    expectWarning,
-    expectPass,
-    expectPassSingle,
-} from "../__tests__/test-utils";
+import {expectWarning, expectPass} from "../__tests__/test-utils";
 
 import expressionWidgetRule from "./expression-widget";
 
@@ -28,7 +24,7 @@ describe("expression-widget", () => {
     });
 
     it("passes for sqrt with the prealgebra button set", () => {
-        expectPassSingle(expressionWidgetRule, "[[☃ expression 1]]", {
+        expectPass(expressionWidgetRule, "[[☃ expression 1]]", {
             widgets: {
                 "expression 1": {
                     options: {
@@ -68,24 +64,25 @@ describe("expression-widget", () => {
         },
     });
 
-    // Pass for ^ with the prealgebra button set
-    expectPass(expressionWidgetRule, "[[☃ expression 1]]", {
-        widgets: {
-            "expression 1": {
-                options: {
-                    answerForms: [
-                        {
-                            value: "2^{2x}",
-                            form: true,
-                            simplify: true,
-                            considered: "correct",
-                            key: "0",
-                        },
-                    ],
-                    buttonSets: ["basic", "prealgebra"],
+    it("passes for ^ with the prealgebra button set", () => {
+        expectPass(expressionWidgetRule, "[[☃ expression 1]]", {
+            widgets: {
+                "expression 1": {
+                    options: {
+                        answerForms: [
+                            {
+                                value: "2^{2x}",
+                                form: true,
+                                simplify: true,
+                                considered: "correct",
+                                key: "0",
+                            },
+                        ],
+                        buttonSets: ["basic", "prealgebra"],
+                    },
                 },
             },
-        },
+        });
     });
 
     // Warning for sin without the trig button set
@@ -108,24 +105,25 @@ describe("expression-widget", () => {
         },
     });
 
-    // Pass for sin with the trig button set
-    expectPass(expressionWidgetRule, "[[☃ expression 1]]", {
-        widgets: {
-            "expression 1": {
-                options: {
-                    answerForms: [
-                        {
-                            value: "\\sin\\left(42\\right)",
-                            form: true,
-                            simplify: true,
-                            considered: "correct",
-                            key: "0",
-                        },
-                    ],
-                    buttonSets: ["basic", "trig"],
+    it("passes for sin with the trig button set", () => {
+        expectPass(expressionWidgetRule, "[[☃ expression 1]]", {
+            widgets: {
+                "expression 1": {
+                    options: {
+                        answerForms: [
+                            {
+                                value: "\\sin\\left(42\\right)",
+                                form: true,
+                                simplify: true,
+                                considered: "correct",
+                                key: "0",
+                            },
+                        ],
+                        buttonSets: ["basic", "trig"],
+                    },
                 },
             },
-        },
+        });
     });
 
     // Warning for log without the logarithms button set
@@ -148,23 +146,24 @@ describe("expression-widget", () => {
         },
     });
 
-    // Pass for log with the logarithms button set
-    expectPass(expressionWidgetRule, "[[☃ expression 1]]", {
-        widgets: {
-            "expression 1": {
-                options: {
-                    answerForms: [
-                        {
-                            value: "\\log\\left(5\\right)",
-                            form: true,
-                            simplify: true,
-                            considered: "correct",
-                            key: "0",
-                        },
-                    ],
-                    buttonSets: ["basic", "logarithms"],
+    it("passes for log with the logarithms button set", () => {
+        expectPass(expressionWidgetRule, "[[☃ expression 1]]", {
+            widgets: {
+                "expression 1": {
+                    options: {
+                        answerForms: [
+                            {
+                                value: "\\log\\left(5\\right)",
+                                form: true,
+                                simplify: true,
+                                considered: "correct",
+                                key: "0",
+                            },
+                        ],
+                        buttonSets: ["basic", "logarithms"],
+                    },
                 },
             },
-        },
+        });
     });
 });

--- a/packages/perseus-linter/src/rules/expression-widget.test.ts
+++ b/packages/perseus-linter/src/rules/expression-widget.test.ts
@@ -1,26 +1,31 @@
-import {expectWarning, expectPass} from "../__tests__/test-utils";
+import {
+    expectWarning,
+    expectPass,
+    expectWarningSingle,
+} from "../__tests__/test-utils";
 
 import expressionWidgetRule from "./expression-widget";
 
 describe("expression-widget", () => {
-    // Warning for sqrt without the prealgebra button set
-    expectWarning(expressionWidgetRule, "[[☃ expression 1]]", {
-        widgets: {
-            "expression 1": {
-                options: {
-                    answerForms: [
-                        {
-                            value: "\\sqrt{42}",
-                            form: true,
-                            simplify: true,
-                            considered: "correct",
-                            key: "0",
-                        },
-                    ],
-                    buttonSets: ["basic"],
+    it("warns for sqrt without the prealgebra button set", () => {
+        expectWarningSingle(expressionWidgetRule, "[[☃ expression 1]]", {
+            widgets: {
+                "expression 1": {
+                    options: {
+                        answerForms: [
+                            {
+                                value: "\\sqrt{42}",
+                                form: true,
+                                simplify: true,
+                                considered: "correct",
+                                key: "0",
+                            },
+                        ],
+                        buttonSets: ["basic"],
+                    },
                 },
             },
-        },
+        });
     });
 
     it("passes for sqrt with the prealgebra button set", () => {

--- a/packages/perseus-linter/src/rules/expression-widget.test.ts
+++ b/packages/perseus-linter/src/rules/expression-widget.test.ts
@@ -1,4 +1,8 @@
-import {expectWarning, expectPass} from "../__tests__/test-utils";
+import {
+    expectWarning,
+    expectPass,
+    expectPassSingle,
+} from "../__tests__/test-utils";
 
 import expressionWidgetRule from "./expression-widget";
 
@@ -23,24 +27,25 @@ describe("expression-widget", () => {
         },
     });
 
-    // Pass for sqrt with the prealgebra button set
-    expectPass(expressionWidgetRule, "[[☃ expression 1]]", {
-        widgets: {
-            "expression 1": {
-                options: {
-                    answerForms: [
-                        {
-                            value: "\\sqrt{42}",
-                            form: true,
-                            simplify: true,
-                            considered: "correct",
-                            key: "0",
-                        },
-                    ],
-                    buttonSets: ["basic", "prealgebra"],
+    it("passes for sqrt with the prealgebra button set", () => {
+        expectPassSingle(expressionWidgetRule, "[[☃ expression 1]]", {
+            widgets: {
+                "expression 1": {
+                    options: {
+                        answerForms: [
+                            {
+                                value: "\\sqrt{42}",
+                                form: true,
+                                simplify: true,
+                                considered: "correct",
+                                key: "0",
+                            },
+                        ],
+                        buttonSets: ["basic", "prealgebra"],
+                    },
                 },
             },
-        },
+        });
     });
 
     // Warning for ^ without the prealgebra button set

--- a/packages/perseus-linter/src/rules/expression-widget.test.ts
+++ b/packages/perseus-linter/src/rules/expression-widget.test.ts
@@ -1,14 +1,10 @@
-import {
-    expectWarning,
-    expectPass,
-    expectWarningSingle,
-} from "../__tests__/test-utils";
+import {expectPass, expectWarning} from "../__tests__/test-utils";
 
 import expressionWidgetRule from "./expression-widget";
 
 describe("expression-widget", () => {
     it("warns for sqrt without the prealgebra button set", () => {
-        expectWarningSingle(expressionWidgetRule, "[[☃ expression 1]]", {
+        expectWarning(expressionWidgetRule, "[[☃ expression 1]]", {
             widgets: {
                 "expression 1": {
                     options: {
@@ -49,24 +45,25 @@ describe("expression-widget", () => {
         });
     });
 
-    // Warning for ^ without the prealgebra button set
-    expectWarning(expressionWidgetRule, "[[☃ expression 1]]", {
-        widgets: {
-            "expression 1": {
-                options: {
-                    answerForms: [
-                        {
-                            value: "2^{2x}",
-                            form: true,
-                            simplify: true,
-                            considered: "correct",
-                            key: "0",
-                        },
-                    ],
-                    buttonSets: ["basic"],
+    it("warns for ^ without the prealgebra button set", () => {
+        expectWarning(expressionWidgetRule, "[[☃ expression 1]]", {
+            widgets: {
+                "expression 1": {
+                    options: {
+                        answerForms: [
+                            {
+                                value: "2^{2x}",
+                                form: true,
+                                simplify: true,
+                                considered: "correct",
+                                key: "0",
+                            },
+                        ],
+                        buttonSets: ["basic"],
+                    },
                 },
             },
-        },
+        });
     });
 
     it("passes for ^ with the prealgebra button set", () => {
@@ -90,24 +87,25 @@ describe("expression-widget", () => {
         });
     });
 
-    // Warning for sin without the trig button set
-    expectWarning(expressionWidgetRule, "[[☃ expression 1]]", {
-        widgets: {
-            "expression 1": {
-                options: {
-                    answerForms: [
-                        {
-                            value: "\\sin\\left(42\\right)",
-                            form: true,
-                            simplify: true,
-                            considered: "correct",
-                            key: "0",
-                        },
-                    ],
-                    buttonSets: ["basic"],
+    it("warns for sin without the trig button set", () => {
+        expectWarning(expressionWidgetRule, "[[☃ expression 1]]", {
+            widgets: {
+                "expression 1": {
+                    options: {
+                        answerForms: [
+                            {
+                                value: "\\sin\\left(42\\right)",
+                                form: true,
+                                simplify: true,
+                                considered: "correct",
+                                key: "0",
+                            },
+                        ],
+                        buttonSets: ["basic"],
+                    },
                 },
             },
-        },
+        });
     });
 
     it("passes for sin with the trig button set", () => {
@@ -131,24 +129,25 @@ describe("expression-widget", () => {
         });
     });
 
-    // Warning for log without the logarithms button set
-    expectWarning(expressionWidgetRule, "[[☃ expression 1]]", {
-        widgets: {
-            "expression 1": {
-                options: {
-                    answerForms: [
-                        {
-                            value: "\\log\\left(5\\right)",
-                            form: true,
-                            simplify: true,
-                            considered: "correct",
-                            key: "0",
-                        },
-                    ],
-                    buttonSets: ["basic"],
+    it("warns for log without the logarithms button set", () => {
+        expectWarning(expressionWidgetRule, "[[☃ expression 1]]", {
+            widgets: {
+                "expression 1": {
+                    options: {
+                        answerForms: [
+                            {
+                                value: "\\log\\left(5\\right)",
+                                form: true,
+                                simplify: true,
+                                considered: "correct",
+                                key: "0",
+                            },
+                        ],
+                        buttonSets: ["basic"],
+                    },
                 },
             },
-        },
+        });
     });
 
     it("passes for log with the logarithms button set", () => {

--- a/packages/perseus-linter/src/rules/extra-content-spacing.test.ts
+++ b/packages/perseus-linter/src/rules/extra-content-spacing.test.ts
@@ -10,6 +10,7 @@ describe("extra-content-spacing", () => {
     ])("extraContentSpacingRule warns with: %s", (str: string) => {
         expectWarning(extraContentSpacingRule, str);
     });
+
     it.each([
         "This is okay.",
         "This is definitely okay. Yeah.",

--- a/packages/perseus-linter/src/rules/extra-content-spacing.test.ts
+++ b/packages/perseus-linter/src/rules/extra-content-spacing.test.ts
@@ -8,9 +8,11 @@ describe("extra-content-spacing", () => {
         "There's extra spaces here    ",
         "  ",
     ]);
-    expectPass(extraContentSpacingRule, [
+    it.each([
         "This is okay.",
         "This is definitely okay. Yeah.",
         "$a == 3.  125$",
-    ]);
+    ])("extraContentSpacingRule passes with: %s", (str: string) => {
+        expectPass(extraContentSpacingRule, str);
+    });
 });

--- a/packages/perseus-linter/src/rules/extra-content-spacing.test.ts
+++ b/packages/perseus-linter/src/rules/extra-content-spacing.test.ts
@@ -1,13 +1,15 @@
-import {expectWarning, expectPass} from "../__tests__/test-utils";
+import {expectPass, expectWarning} from "../__tests__/test-utils";
 
 import extraContentSpacingRule from "./extra-content-spacing";
 
 describe("extra-content-spacing", () => {
-    expectWarning(extraContentSpacingRule, [
+    it.each([
         "There's extra spaces here.     ",
         "There's extra spaces here    ",
         "  ",
-    ]);
+    ])("extraContentSpacingRule warns with: %s", (str: string) => {
+        expectWarning(extraContentSpacingRule, str);
+    });
     it.each([
         "This is okay.",
         "This is definitely okay. Yeah.",

--- a/packages/perseus-linter/src/rules/free-response-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/free-response-widget-error.test.ts
@@ -3,48 +3,52 @@ import {expectPass, expectWarning} from "../__tests__/test-utils";
 import freeResponseWidgetErrorRule from "./free-response-widget-error";
 
 describe("radio-widget-error", () => {
-    // Error for free response widget with no question (undefined)
-    expectWarning(freeResponseWidgetErrorRule, "[[☃ free-response 1]]", {
-        widgets: {
-            "free-response 1": {
-                options: {
-                    question: undefined,
+    it("warns for free response widget with no question (undefined)", () => {
+        expectWarning(freeResponseWidgetErrorRule, "[[☃ free-response 1]]", {
+            widgets: {
+                "free-response 1": {
+                    options: {
+                        question: undefined,
+                    },
                 },
             },
-        },
+        });
     });
 
-    // Error for free response widget with no question (empty string)
-    expectWarning(freeResponseWidgetErrorRule, "[[☃ free-response 1]]", {
-        widgets: {
-            "free-response 1": {
-                options: {
-                    question: "",
+    it("warns for free response widget with no question (empty string)", () => {
+        expectWarning(freeResponseWidgetErrorRule, "[[☃ free-response 1]]", {
+            widgets: {
+                "free-response 1": {
+                    options: {
+                        question: "",
+                    },
                 },
             },
-        },
+        });
     });
 
-    // Error for free response widget with question that contains a widget placeholder
-    expectWarning(freeResponseWidgetErrorRule, "[[☃ free-response 1]]", {
-        widgets: {
-            "free-response 1": {
-                options: {
-                    question: "[[☃ radio 1]]",
+    it("warns for free response widget with question that contains a widget placeholder", () => {
+        expectWarning(freeResponseWidgetErrorRule, "[[☃ free-response 1]]", {
+            widgets: {
+                "free-response 1": {
+                    options: {
+                        question: "[[☃ radio 1]]",
+                    },
                 },
             },
-        },
+        });
     });
 
-    // Error for free response widget with question that contains a widget placeholder plus other text
-    expectWarning(freeResponseWidgetErrorRule, "[[☃ free-response 1]]", {
-        widgets: {
-            "free-response 1": {
-                options: {
-                    question: "abc [[☃ radio 1]] def",
+    it("warns for free response widget with question that contains a widget placeholder plus other text", () => {
+        expectWarning(freeResponseWidgetErrorRule, "[[☃ free-response 1]]", {
+            widgets: {
+                "free-response 1": {
+                    options: {
+                        question: "abc [[☃ radio 1]] def",
+                    },
                 },
             },
-        },
+        });
     });
 
     it("passes for free response widget with no issues", () => {

--- a/packages/perseus-linter/src/rules/free-response-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/free-response-widget-error.test.ts
@@ -47,14 +47,15 @@ describe("radio-widget-error", () => {
         },
     });
 
-    // Pass for free response widget with no issues
-    expectPass(freeResponseWidgetErrorRule, "[[☃ free-response 1]]", {
-        widgets: {
-            "free-response 1": {
-                options: {
-                    question: "Hello world!",
+    it("passes for free response widget with no issues", () => {
+        expectPass(freeResponseWidgetErrorRule, "[[☃ free-response 1]]", {
+            widgets: {
+                "free-response 1": {
+                    options: {
+                        question: "Hello world!",
+                    },
                 },
             },
-        },
+        });
     });
 });

--- a/packages/perseus-linter/src/rules/heading-level-1.test.ts
+++ b/packages/perseus-linter/src/rules/heading-level-1.test.ts
@@ -4,5 +4,10 @@ import headingLevel1Rule from "./heading-level-1";
 
 describe("heading-level-1", () => {
     expectWarning(headingLevel1Rule, "# Level 1 heading");
-    expectPass(headingLevel1Rule, "## Level 1 heading\n\n### Level 3 heading");
+    it("passes for level 2 and level 3 headings", () => {
+        expectPass(
+            headingLevel1Rule,
+            "## Level 1 heading\n\n### Level 3 heading",
+        );
+    });
 });

--- a/packages/perseus-linter/src/rules/heading-level-1.test.ts
+++ b/packages/perseus-linter/src/rules/heading-level-1.test.ts
@@ -1,9 +1,11 @@
-import {expectWarning, expectPass} from "../__tests__/test-utils";
+import {expectPass, expectWarning} from "../__tests__/test-utils";
 
 import headingLevel1Rule from "./heading-level-1";
 
 describe("heading-level-1", () => {
-    expectWarning(headingLevel1Rule, "# Level 1 heading");
+    it("warns for a level 1 heading", () => {
+        expectWarning(headingLevel1Rule, "# Level 1 heading");
+    });
     it("passes for level 2 and level 3 headings", () => {
         expectPass(
             headingLevel1Rule,

--- a/packages/perseus-linter/src/rules/heading-level-1.test.ts
+++ b/packages/perseus-linter/src/rules/heading-level-1.test.ts
@@ -10,7 +10,7 @@ describe("heading-level-1", () => {
     it("passes for level 2 and level 3 headings", () => {
         expectPass(
             headingLevel1Rule,
-            "## Level 1 heading\n\n### Level 3 heading",
+            "## Level 2 heading\n\n### Level 3 heading",
         );
     });
 });

--- a/packages/perseus-linter/src/rules/heading-level-1.test.ts
+++ b/packages/perseus-linter/src/rules/heading-level-1.test.ts
@@ -6,6 +6,7 @@ describe("heading-level-1", () => {
     it("warns for a level 1 heading", () => {
         expectWarning(headingLevel1Rule, "# Level 1 heading");
     });
+
     it("passes for level 2 and level 3 headings", () => {
         expectPass(
             headingLevel1Rule,

--- a/packages/perseus-linter/src/rules/heading-level-skip.test.ts
+++ b/packages/perseus-linter/src/rules/heading-level-skip.test.ts
@@ -6,6 +6,7 @@ describe("heading-level-skip", () => {
     it("warns when a heading level is skipped", () => {
         expectWarning(headingLevelSkipRule, "## heading 1\n\n#### heading 2");
     });
+
     it.each([
         "## heading 1\n\n### heading 2\n\n#### heading 3\n\n### heading 4",
         "## heading 1\n\n##heading 2\n\n##heading3",

--- a/packages/perseus-linter/src/rules/heading-level-skip.test.ts
+++ b/packages/perseus-linter/src/rules/heading-level-skip.test.ts
@@ -3,7 +3,9 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import headingLevelSkipRule from "./heading-level-skip";
 
 describe("heading-level-skip", () => {
-    expectWarning(headingLevelSkipRule, "## heading 1\n\n#### heading 2");
+    it("warns when a heading level is skipped", () => {
+        expectWarning(headingLevelSkipRule, "## heading 1\n\n#### heading 2");
+    });
     it.each([
         "## heading 1\n\n### heading 2\n\n#### heading 3\n\n### heading 4",
         "## heading 1\n\n##heading 2\n\n##heading3",

--- a/packages/perseus-linter/src/rules/heading-level-skip.test.ts
+++ b/packages/perseus-linter/src/rules/heading-level-skip.test.ts
@@ -4,8 +4,10 @@ import headingLevelSkipRule from "./heading-level-skip";
 
 describe("heading-level-skip", () => {
     expectWarning(headingLevelSkipRule, "## heading 1\n\n#### heading 2");
-    expectPass(headingLevelSkipRule, [
+    it.each([
         "## heading 1\n\n### heading 2\n\n#### heading 3\n\n### heading 4",
         "## heading 1\n\n##heading 2\n\n##heading3",
-    ]);
+    ])("headingLevelSkipRule passes with: %s", (str: string) => {
+        expectPass(headingLevelSkipRule, str);
+    });
 });

--- a/packages/perseus-linter/src/rules/heading-sentence-case.test.ts
+++ b/packages/perseus-linter/src/rules/heading-sentence-case.test.ts
@@ -10,6 +10,7 @@ describe("heading-sentence-case", () => {
     ])("headingSentenceCaseRule warns with: %s", (str: string) => {
         expectWarning(headingSentenceCaseRule, str);
     });
+
     it.each([
         "## This heading is in sentence case",
         "## 'This heading too'",

--- a/packages/perseus-linter/src/rules/heading-sentence-case.test.ts
+++ b/packages/perseus-linter/src/rules/heading-sentence-case.test.ts
@@ -8,9 +8,11 @@ describe("heading-sentence-case", () => {
         "## 'this' heading is uncapitalized",
         "##   this heading is uncapitalized",
     ]);
-    expectPass(headingSentenceCaseRule, [
+    it.each([
         "## This heading is in sentence case",
         "## 'This heading too'",
         "## 2 + 2 = 4",
-    ]);
+    ])("headingSentenceCaseRule passes with: %s", (str: string) => {
+        expectPass(headingSentenceCaseRule, str);
+    });
 });

--- a/packages/perseus-linter/src/rules/heading-sentence-case.test.ts
+++ b/packages/perseus-linter/src/rules/heading-sentence-case.test.ts
@@ -3,11 +3,13 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import headingSentenceCaseRule from "./heading-sentence-case";
 
 describe("heading-sentence-case", () => {
-    expectWarning(headingSentenceCaseRule, [
+    it.each([
         "## this heading is uncapitalized",
         "## 'this' heading is uncapitalized",
         "##   this heading is uncapitalized",
-    ]);
+    ])("headingSentenceCaseRule warns with: %s", (str: string) => {
+        expectWarning(headingSentenceCaseRule, str);
+    });
     it.each([
         "## This heading is in sentence case",
         "## 'This heading too'",

--- a/packages/perseus-linter/src/rules/heading-sentence-case.test.ts
+++ b/packages/perseus-linter/src/rules/heading-sentence-case.test.ts
@@ -7,7 +7,7 @@ describe("heading-sentence-case", () => {
         "## this heading is uncapitalized",
         "## 'this' heading is uncapitalized",
         "##   this heading is uncapitalized",
-    ])("headingSentenceCaseRule warns with: %s", (str: string) => {
+    ])("warns with: %s", (str: string) => {
         expectWarning(headingSentenceCaseRule, str);
     });
 
@@ -15,7 +15,7 @@ describe("heading-sentence-case", () => {
         "## This heading is in sentence case",
         "## 'This heading too'",
         "## 2 + 2 = 4",
-    ])("headingSentenceCaseRule passes with: %s", (str: string) => {
+    ])("passes with: %s", (str: string) => {
         expectPass(headingSentenceCaseRule, str);
     });
 });

--- a/packages/perseus-linter/src/rules/heading-title-case.test.ts
+++ b/packages/perseus-linter/src/rules/heading-title-case.test.ts
@@ -14,7 +14,7 @@ describe("heading-title-case", () => {
         "## This heading is in sentence case",
         "## Acronyms: The CIA, NSA, DNI, and FBI",
         "## The Great War",
-    ])("headingTitleCaseRule passes with: %s", (str: string) => {
+    ])("passes with: %s", (str: string) => {
         expectPass(headingTitleCaseRule, str);
     });
 });

--- a/packages/perseus-linter/src/rules/heading-title-case.test.ts
+++ b/packages/perseus-linter/src/rules/heading-title-case.test.ts
@@ -9,6 +9,7 @@ describe("heading-title-case", () => {
             "## This Heading is in Title Case and the but nor for Too",
         );
     });
+
     it.each([
         "## This heading is in sentence case",
         "## Acronyms: The CIA, NSA, DNI, and FBI",

--- a/packages/perseus-linter/src/rules/heading-title-case.test.ts
+++ b/packages/perseus-linter/src/rules/heading-title-case.test.ts
@@ -7,9 +7,11 @@ describe("heading-title-case", () => {
         headingTitleCaseRule,
         "## This Heading is in Title Case and the but nor for Too",
     );
-    expectPass(headingTitleCaseRule, [
+    it.each([
         "## This heading is in sentence case",
         "## Acronyms: The CIA, NSA, DNI, and FBI",
         "## The Great War",
-    ]);
+    ])("headingTitleCaseRule passes with: %s", (str: string) => {
+        expectPass(headingTitleCaseRule, str);
+    });
 });

--- a/packages/perseus-linter/src/rules/heading-title-case.test.ts
+++ b/packages/perseus-linter/src/rules/heading-title-case.test.ts
@@ -3,10 +3,12 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import headingTitleCaseRule from "./heading-title-case";
 
 describe("heading-title-case", () => {
-    expectWarning(
-        headingTitleCaseRule,
-        "## This Heading is in Title Case and the but nor for Too",
-    );
+    it("warns when a heading is in title case", () => {
+        expectWarning(
+            headingTitleCaseRule,
+            "## This Heading is in Title Case and the but nor for Too",
+        );
+    });
     it.each([
         "## This heading is in sentence case",
         "## Acronyms: The CIA, NSA, DNI, and FBI",

--- a/packages/perseus-linter/src/rules/image-alt-text.test.ts
+++ b/packages/perseus-linter/src/rules/image-alt-text.test.ts
@@ -12,9 +12,11 @@ describe("image-alt-text", () => {
         "![blah](http://google.com/)", // too short to be meaningful
     ]);
 
-    expectPass(imageAltTextRule, [
+    it.each([
         "![alt-text](http://google.com)",
         '![alternative text](http://google.com/ "title")',
         "![alt alt alt][url-ref]",
-    ]);
+    ])("imageAltTextRule passes with: %s", (str: string) => {
+        expectPass(imageAltTextRule, str);
+    });
 });

--- a/packages/perseus-linter/src/rules/image-alt-text.test.ts
+++ b/packages/perseus-linter/src/rules/image-alt-text.test.ts
@@ -3,14 +3,16 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import imageAltTextRule from "./image-alt-text";
 
 describe("image-alt-text", () => {
-    expectWarning(imageAltTextRule, [
+    it.each([
         "![](http://google.com/)",
         '![](http://google.com/ "title")',
         "![][url-ref]",
         "![ ](http://google.com/)",
         "![ \t\n ](http://google.com/)", // all whitespace
         "![blah](http://google.com/)", // too short to be meaningful
-    ]);
+    ])("imageAltTextRule warns with: %s", (str: string) => {
+        expectWarning(imageAltTextRule, str);
+    });
 
     it.each([
         "![alt-text](http://google.com)",

--- a/packages/perseus-linter/src/rules/image-in-table.test.ts
+++ b/packages/perseus-linter/src/rules/image-in-table.test.ts
@@ -3,9 +3,12 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import imageInTableRule from "./image-in-table";
 
 describe("image-in-table", () => {
-    expectWarning(imageInTableRule, [
-        "|col1|col2|\n|----|----|\n|![alt-text](/link.gif)|cell2|",
-    ]);
+    it.each(["|col1|col2|\n|----|----|\n|![alt-text](/link.gif)|cell2|"])(
+        "imageInTableRule warns with: %s",
+        (str: string) => {
+            expectWarning(imageInTableRule, str);
+        },
+    );
     it.each([
         "![alt-text](/link.gif)\n|col1|col2|\n|----|----|\n|cell1|cell2|",
     ])("imageInTableRule passes with: %s", (str: string) => {

--- a/packages/perseus-linter/src/rules/image-in-table.test.ts
+++ b/packages/perseus-linter/src/rules/image-in-table.test.ts
@@ -6,7 +6,9 @@ describe("image-in-table", () => {
     expectWarning(imageInTableRule, [
         "|col1|col2|\n|----|----|\n|![alt-text](/link.gif)|cell2|",
     ]);
-    expectPass(imageInTableRule, [
+    it.each([
         "![alt-text](/link.gif)\n|col1|col2|\n|----|----|\n|cell1|cell2|",
-    ]);
+    ])("imageInTableRule passes with: %s", (str: string) => {
+        expectPass(imageInTableRule, str);
+    });
 });

--- a/packages/perseus-linter/src/rules/image-in-table.test.ts
+++ b/packages/perseus-linter/src/rules/image-in-table.test.ts
@@ -3,16 +3,17 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import imageInTableRule from "./image-in-table";
 
 describe("image-in-table", () => {
-    it.each(["|col1|col2|\n|----|----|\n|![alt-text](/link.gif)|cell2|"])(
-        "imageInTableRule warns with: %s",
-        (str: string) => {
-            expectWarning(imageInTableRule, str);
-        },
-    );
+    it("warns when an image is inside a table", () => {
+        expectWarning(
+            imageInTableRule,
+            "|col1|col2|\n|----|----|\n|![alt-text](/link.gif)|cell2|",
+        );
+    });
 
-    it.each([
-        "![alt-text](/link.gif)\n|col1|col2|\n|----|----|\n|cell1|cell2|",
-    ])("imageInTableRule passes with: %s", (str: string) => {
-        expectPass(imageInTableRule, str);
+    it("passes when an image is outside a table", () => {
+        expectPass(
+            imageInTableRule,
+            "![alt-text](/link.gif)\n|col1|col2|\n|----|----|\n|cell1|cell2|",
+        );
     });
 });

--- a/packages/perseus-linter/src/rules/image-in-table.test.ts
+++ b/packages/perseus-linter/src/rules/image-in-table.test.ts
@@ -9,6 +9,7 @@ describe("image-in-table", () => {
             expectWarning(imageInTableRule, str);
         },
     );
+
     it.each([
         "![alt-text](/link.gif)\n|col1|col2|\n|----|----|\n|cell1|cell2|",
     ])("imageInTableRule passes with: %s", (str: string) => {

--- a/packages/perseus-linter/src/rules/image-markdown.test.ts
+++ b/packages/perseus-linter/src/rules/image-markdown.test.ts
@@ -5,7 +5,7 @@ import imageMarkdownRule from "./image-markdown";
 describe("image-markdown", () => {
     // All markdown images (format ![alt](url)) should result in a warning
     // when NOT inside a widget
-    expectWarning(imageMarkdownRule, [
+    it.each([
         "![]()",
         "![](  )",
         "![](\n)",
@@ -20,7 +20,9 @@ describe("image-markdown", () => {
         "![blah](http://google.com/)",
         "![alt alt alt][url-ref]", // Reference image
         "![][url-ref]", // Reference image
-    ]);
+    ])("imageMarkdownRule warns with: %s", (str: string) => {
+        expectWarning(imageMarkdownRule, str);
+    });
 
     // Text that does not contain markdown images should pass
     it.each([
@@ -74,11 +76,12 @@ describe("image-markdown", () => {
         },
     );
 
-    expectWarning(
-        imageMarkdownRule,
-        ["![test image](http://test.com/img.jpg)"],
-        {
-            stack: ["image"],
+    it.each(["![test image](http://test.com/img.jpg)"])(
+        "imageMarkdownRule warns with: %s",
+        (str: string) => {
+            expectWarning(imageMarkdownRule, str, {
+                stack: ["image"],
+            });
         },
     );
 });

--- a/packages/perseus-linter/src/rules/image-markdown.test.ts
+++ b/packages/perseus-linter/src/rules/image-markdown.test.ts
@@ -23,7 +23,7 @@ describe("image-markdown", () => {
     ]);
 
     // Text that does not contain markdown images should pass
-    expectPass(imageMarkdownRule, [
+    it.each([
         "!",
         "![",
         "![]",
@@ -38,31 +38,41 @@ describe("image-markdown", () => {
         "[]()", // link markdown, not image
         "[link text](http://google.com)", // link markdown, not image
         "![][", // Incomplete reference image
-    ]);
+    ])("imageMarkdownRule passes with: %s", (str: string) => {
+        expectPass(imageMarkdownRule, str);
+    });
 
     // Markdown images should pass when inside a widget (e.g., Radio widget)
-    expectPass(
-        imageMarkdownRule,
-        [
-            "![](http://google.com/)",
-            "![alt text](http://example.com/image.png)",
-            "![]()",
-            "![ ](http://google.com/)",
-            "![blah](http://google.com/)",
-        ],
-        {
+    it.each([
+        "![](http://google.com/)",
+        "![alt text](http://example.com/image.png)",
+        "![]()",
+        "![ ](http://google.com/)",
+        "![blah](http://google.com/)",
+    ])("imageMarkdownRule passes with: %s", (str: string) => {
+        expectPass(imageMarkdownRule, str, {
             stack: ["root", "paragraph", "widget", "text", "image"],
+        });
+    });
+
+    // Additional test to ensure stack checking works correctly
+    it.each(["![test image](http://test.com/img.jpg)"])(
+        "imageMarkdownRule passes with: %s",
+        (str: string) => {
+            expectPass(imageMarkdownRule, str, {
+                stack: ["widget", "image"],
+            });
         },
     );
 
-    // Additional test to ensure stack checking works correctly
-    expectPass(imageMarkdownRule, ["![test image](http://test.com/img.jpg)"], {
-        stack: ["widget", "image"],
-    });
-
-    expectPass(imageMarkdownRule, ["![test image](http://test.com/img.jpg)"], {
-        stack: ["widget"],
-    });
+    it.each(["![test image](http://test.com/img.jpg)"])(
+        "imageMarkdownRule passes with: %s",
+        (str: string) => {
+            expectPass(imageMarkdownRule, str, {
+                stack: ["widget"],
+            });
+        },
+    );
 
     expectWarning(
         imageMarkdownRule,

--- a/packages/perseus-linter/src/rules/image-markdown.test.ts
+++ b/packages/perseus-linter/src/rules/image-markdown.test.ts
@@ -57,31 +57,33 @@ describe("image-markdown", () => {
         });
     });
 
-    // Additional test to ensure stack checking works correctly
-    it.each(["![test image](http://test.com/img.jpg)"])(
-        "imageMarkdownRule passes with: %s",
-        (str: string) => {
-            expectPass(imageMarkdownRule, str, {
+    it("passes for a markdown image when the stack is widget then image", () => {
+        expectPass(
+            imageMarkdownRule,
+            "![test image](http://test.com/img.jpg)",
+            {
                 stack: ["widget", "image"],
-            });
-        },
-    );
+            },
+        );
+    });
 
-    it.each(["![test image](http://test.com/img.jpg)"])(
-        "imageMarkdownRule passes with: %s",
-        (str: string) => {
-            expectPass(imageMarkdownRule, str, {
+    it("passes for a markdown image when the stack is just a widget", () => {
+        expectPass(
+            imageMarkdownRule,
+            "![test image](http://test.com/img.jpg)",
+            {
                 stack: ["widget"],
-            });
-        },
-    );
+            },
+        );
+    });
 
-    it.each(["![test image](http://test.com/img.jpg)"])(
-        "imageMarkdownRule warns with: %s",
-        (str: string) => {
-            expectWarning(imageMarkdownRule, str, {
+    it("warns for a markdown image when the stack is just an image", () => {
+        expectWarning(
+            imageMarkdownRule,
+            "![test image](http://test.com/img.jpg)",
+            {
                 stack: ["image"],
-            });
-        },
-    );
+            },
+        );
+    });
 });

--- a/packages/perseus-linter/src/rules/image-spaces-around-urls.test.ts
+++ b/packages/perseus-linter/src/rules/image-spaces-around-urls.test.ts
@@ -3,7 +3,7 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import imageSpacesAroundUrlsRule from "./image-spaces-around-urls";
 
 describe("image-spaces-around-urls", () => {
-    expectWarning(imageSpacesAroundUrlsRule, [
+    it.each([
         "![alternative]( http://example.com/image.jpg )",
         "![alternative]( http://example.com/image.jpg)",
         "![alternative](http://example.com/image.jpg )",
@@ -11,7 +11,9 @@ describe("image-spaces-around-urls", () => {
         "![alternative](http://example.com/image.jpg\t)",
         "![alternative](\nhttp://example.com/image.jpg)",
         "![alternative](http://example.com/image.jpg\n)",
-    ]);
+    ])("imageSpacesAroundUrlsRule warns with: %s", (str: string) => {
+        expectWarning(imageSpacesAroundUrlsRule, str);
+    });
     it.each([
         "![alternative](http://example.com/image.jpg)",
         "![alternative](image.jpg)",

--- a/packages/perseus-linter/src/rules/image-spaces-around-urls.test.ts
+++ b/packages/perseus-linter/src/rules/image-spaces-around-urls.test.ts
@@ -12,9 +12,11 @@ describe("image-spaces-around-urls", () => {
         "![alternative](\nhttp://example.com/image.jpg)",
         "![alternative](http://example.com/image.jpg\n)",
     ]);
-    expectPass(imageSpacesAroundUrlsRule, [
+    it.each([
         "![alternative](http://example.com/image.jpg)",
         "![alternative](image.jpg)",
         "![alternative](--image.jpg--)",
-    ]);
+    ])("imageSpacesAroundUrlsRule passes with: %s", (str: string) => {
+        expectPass(imageSpacesAroundUrlsRule, str);
+    });
 });

--- a/packages/perseus-linter/src/rules/image-spaces-around-urls.test.ts
+++ b/packages/perseus-linter/src/rules/image-spaces-around-urls.test.ts
@@ -14,6 +14,7 @@ describe("image-spaces-around-urls", () => {
     ])("imageSpacesAroundUrlsRule warns with: %s", (str: string) => {
         expectWarning(imageSpacesAroundUrlsRule, str);
     });
+
     it.each([
         "![alternative](http://example.com/image.jpg)",
         "![alternative](image.jpg)",

--- a/packages/perseus-linter/src/rules/image-url-empty.test.ts
+++ b/packages/perseus-linter/src/rules/image-url-empty.test.ts
@@ -10,6 +10,7 @@ describe("image-url-empty", () => {
     ])("imageUrlEmptyRule warns with: %s", (str: string) => {
         expectWarning(imageUrlEmptyRule, str);
     });
+
     it.each([
         "![alt-text]('something')", // text should pass, though not a valid URL
         "![alt-text]('www.test.com')", // example URL

--- a/packages/perseus-linter/src/rules/image-url-empty.test.ts
+++ b/packages/perseus-linter/src/rules/image-url-empty.test.ts
@@ -8,9 +8,11 @@ describe("image-url-empty", () => {
         "![alt-text](  )", // empty URL with spaces
         "![alt-text](\n)", // empty URL with newline
     ]);
-    expectPass(imageUrlEmptyRule, [
+    it.each([
         "![alt-text]('something')", // text should pass, though not a valid URL
         "![alt-text]('www.test.com')", // example URL
         "![alt-text](56)", // example number should pass, though not a valid URL
-    ]);
+    ])("imageUrlEmptyRule passes with: %s", (str: string) => {
+        expectPass(imageUrlEmptyRule, str);
+    });
 });

--- a/packages/perseus-linter/src/rules/image-url-empty.test.ts
+++ b/packages/perseus-linter/src/rules/image-url-empty.test.ts
@@ -3,11 +3,13 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import imageUrlEmptyRule from "./image-url-empty";
 
 describe("image-url-empty", () => {
-    expectWarning(imageUrlEmptyRule, [
+    it.each([
         "![alt-text]()", // empty URL
         "![alt-text](  )", // empty URL with spaces
         "![alt-text](\n)", // empty URL with newline
-    ]);
+    ])("imageUrlEmptyRule warns with: %s", (str: string) => {
+        expectWarning(imageUrlEmptyRule, str);
+    });
     it.each([
         "![alt-text]('something')", // text should pass, though not a valid URL
         "![alt-text]('www.test.com')", // example URL

--- a/packages/perseus-linter/src/rules/image-widget-alt-text.test.ts
+++ b/packages/perseus-linter/src/rules/image-widget-alt-text.test.ts
@@ -34,14 +34,15 @@ describe("image-widget", () => {
         },
     });
 
-    // Pass for image widget with sufficiently long alt text
-    expectPass(imageWidgetAltTextRule, "[[☃ image 1]]", {
-        widgets: {
-            "image 1": {
-                options: {
-                    alt: "1234567890",
+    it("passes for image widget with sufficiently long alt text", () => {
+        expectPass(imageWidgetAltTextRule, "[[☃ image 1]]", {
+            widgets: {
+                "image 1": {
+                    options: {
+                        alt: "1234567890",
+                    },
                 },
             },
-        },
+        });
     });
 });

--- a/packages/perseus-linter/src/rules/image-widget-alt-text.test.ts
+++ b/packages/perseus-linter/src/rules/image-widget-alt-text.test.ts
@@ -3,35 +3,38 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import imageWidgetAltTextRule from "./image-widget-alt-text";
 
 describe("image-widget", () => {
-    // Warn for image widget with no alt text
-    expectWarning(imageWidgetAltTextRule, "[[☃ image 1]]", {
-        widgets: {
-            "image 1": {
-                options: {},
-            },
-        },
-    });
-
-    // Warn for image widget with short alt text
-    expectWarning(imageWidgetAltTextRule, "[[☃ image 1]]", {
-        widgets: {
-            "image 1": {
-                options: {
-                    alt: "1234567",
+    it("warns for image widget with no alt text", () => {
+        expectWarning(imageWidgetAltTextRule, "[[☃ image 1]]", {
+            widgets: {
+                "image 1": {
+                    options: {},
                 },
             },
-        },
+        });
     });
 
-    // Warn for image widget with excessively long alt text
-    expectWarning(imageWidgetAltTextRule, "[[☃ image 1]]", {
-        widgets: {
-            "image 1": {
-                options: {
-                    alt: "a".repeat(151), // string length 151 characters
+    it("warns for image widget with short alt text", () => {
+        expectWarning(imageWidgetAltTextRule, "[[☃ image 1]]", {
+            widgets: {
+                "image 1": {
+                    options: {
+                        alt: "1234567",
+                    },
                 },
             },
-        },
+        });
+    });
+
+    it("warns for image widget with excessively long alt text", () => {
+        expectWarning(imageWidgetAltTextRule, "[[☃ image 1]]", {
+            widgets: {
+                "image 1": {
+                    options: {
+                        alt: "a".repeat(151), // string length 151 characters
+                    },
+                },
+            },
+        });
     });
 
     it("passes for image widget with sufficiently long alt text", () => {

--- a/packages/perseus-linter/src/rules/image-widget-empty-size.test.ts
+++ b/packages/perseus-linter/src/rules/image-widget-empty-size.test.ts
@@ -61,18 +61,19 @@ describe("image-widget-empty-size", () => {
         },
     });
 
-    // Pass for image widget with defined width and height
-    expectPass(imageWidgetEmptySizeRule, "[[☃ image 1]]", {
-        widgets: {
-            "image 1": {
-                options: {
-                    backgroundImage: {
-                        url: "https://example.com/image.png",
-                        width: 100,
-                        height: 100,
+    it("passes for image widget with defined width and height", () => {
+        expectPass(imageWidgetEmptySizeRule, "[[☃ image 1]]", {
+            widgets: {
+                "image 1": {
+                    options: {
+                        backgroundImage: {
+                            url: "https://example.com/image.png",
+                            width: 100,
+                            height: 100,
+                        },
                     },
                 },
             },
-        },
+        });
     });
 });

--- a/packages/perseus-linter/src/rules/image-widget-empty-size.test.ts
+++ b/packages/perseus-linter/src/rules/image-widget-empty-size.test.ts
@@ -3,62 +3,66 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import imageWidgetEmptySizeRule from "./image-widget-empty-size";
 
 describe("image-widget-empty-size", () => {
-    // Warn for image widget with undefined width
-    expectWarning(imageWidgetEmptySizeRule, "[[☃ image 1]]", {
-        widgets: {
-            "image 1": {
-                options: {
-                    backgroundImage: {
-                        url: "https://example.com/image.png",
-                        height: 100,
+    it("warns for image widget with undefined width", () => {
+        expectWarning(imageWidgetEmptySizeRule, "[[☃ image 1]]", {
+            widgets: {
+                "image 1": {
+                    options: {
+                        backgroundImage: {
+                            url: "https://example.com/image.png",
+                            height: 100,
+                        },
                     },
                 },
             },
-        },
+        });
     });
 
-    // Warn for image widget with undefined height
-    expectWarning(imageWidgetEmptySizeRule, "[[☃ image 1]]", {
-        widgets: {
-            "image 1": {
-                options: {
-                    backgroundImage: {
-                        url: "https://example.com/image.png",
-                        width: 100,
+    it("warns for image widget with undefined height", () => {
+        expectWarning(imageWidgetEmptySizeRule, "[[☃ image 1]]", {
+            widgets: {
+                "image 1": {
+                    options: {
+                        backgroundImage: {
+                            url: "https://example.com/image.png",
+                            width: 100,
+                        },
                     },
                 },
             },
-        },
+        });
     });
 
-    // Warn for image widget with 0 width
-    expectWarning(imageWidgetEmptySizeRule, "[[☃ image 1]]", {
-        widgets: {
-            "image 1": {
-                options: {
-                    backgroundImage: {
-                        url: "https://example.com/image.png",
-                        height: 100,
-                        width: 0,
+    it("warns for image widget with 0 width", () => {
+        expectWarning(imageWidgetEmptySizeRule, "[[☃ image 1]]", {
+            widgets: {
+                "image 1": {
+                    options: {
+                        backgroundImage: {
+                            url: "https://example.com/image.png",
+                            height: 100,
+                            width: 0,
+                        },
                     },
                 },
             },
-        },
+        });
     });
 
-    // Warn for image widget with 0 height
-    expectWarning(imageWidgetEmptySizeRule, "[[☃ image 1]]", {
-        widgets: {
-            "image 1": {
-                options: {
-                    backgroundImage: {
-                        url: "https://example.com/image.png",
-                        width: 100,
-                        height: 0,
+    it("warns for image widget with 0 height", () => {
+        expectWarning(imageWidgetEmptySizeRule, "[[☃ image 1]]", {
+            widgets: {
+                "image 1": {
+                    options: {
+                        backgroundImage: {
+                            url: "https://example.com/image.png",
+                            width: 100,
+                            height: 0,
+                        },
                     },
                 },
             },
-        },
+        });
     });
 
     it("passes for image widget with defined width and height", () => {

--- a/packages/perseus-linter/src/rules/interactive-graph-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/interactive-graph-widget-error.test.ts
@@ -14,189 +14,198 @@ import Rule from "../rule";
 import interactiveGraphWidgetErrorRule from "./interactive-graph-widget-error";
 
 describe("interactive-graph-widget-error", () => {
-    // Error when locked line has length 0
-    expectWarning(
-        interactiveGraphWidgetErrorRule,
-        "[[☃ interactive-graph 1]]",
-        {
-            widgets: {
-                "interactive-graph 1": generateInteractiveGraphWidget({
-                    options: generateInteractiveGraphOptions({
-                        lockedFigures: [
-                            generateIGLockedLine({
-                                points: [
-                                    generateIGLockedPoint({coord: [0, 0]}),
-                                    generateIGLockedPoint({coord: [0, 0]}),
-                                ],
+    it("warns when locked line has length 0", () => {
+        expectWarning(
+            interactiveGraphWidgetErrorRule,
+            "[[☃ interactive-graph 1]]",
+            {
+                widgets: {
+                    "interactive-graph 1": generateInteractiveGraphWidget({
+                        options: generateInteractiveGraphOptions({
+                            lockedFigures: [
+                                generateIGLockedLine({
+                                    points: [
+                                        generateIGLockedPoint({coord: [0, 0]}),
+                                        generateIGLockedPoint({coord: [0, 0]}),
+                                    ],
+                                }),
+                            ],
+                        }),
+                    }),
+                },
+            },
+            {
+                message: "Locked line cannot have length 0.",
+                severity: Rule.Severity.ERROR,
+            },
+        );
+    });
+
+    it("warns when locked polygon has all coordinates be the same", () => {
+        expectWarning(
+            interactiveGraphWidgetErrorRule,
+            "[[☃ interactive-graph 1]]",
+            {
+                widgets: {
+                    "interactive-graph 1": generateInteractiveGraphWidget({
+                        options: generateInteractiveGraphOptions({
+                            lockedFigures: [
+                                generateIGLockedPolygon({
+                                    points: [
+                                        [0, 0],
+                                        [0, 0],
+                                        [0, 0],
+                                    ],
+                                }),
+                            ],
+                        }),
+                    }),
+                },
+            },
+            {
+                message:
+                    "Locked polygon cannot have all coordinates be the same.",
+                severity: Rule.Severity.ERROR,
+            },
+        );
+    });
+
+    it("warns when locked ellipse has negative radius", () => {
+        expectWarning(
+            interactiveGraphWidgetErrorRule,
+            "[[☃ interactive-graph 1]]",
+            {
+                widgets: {
+                    "interactive-graph 1": generateInteractiveGraphWidget({
+                        options: generateInteractiveGraphOptions({
+                            lockedFigures: [
+                                generateIGLockedEllipse({radius: [-1, -1]}),
+                            ],
+                        }),
+                    }),
+                },
+            },
+            {
+                message: "Locked ellipse must have positive radius values.",
+                severity: Rule.Severity.ERROR,
+            },
+        );
+    });
+
+    it("warns when locked ellipse has zero radius", () => {
+        expectWarning(
+            interactiveGraphWidgetErrorRule,
+            "[[☃ interactive-graph 1]]",
+            {
+                widgets: {
+                    "interactive-graph 1": generateInteractiveGraphWidget({
+                        options: generateInteractiveGraphOptions({
+                            lockedFigures: [
+                                generateIGLockedEllipse({radius: [0, 0]}),
+                            ],
+                        }),
+                    }),
+                },
+            },
+            {
+                message: "Locked ellipse must have positive radius values.",
+                severity: Rule.Severity.ERROR,
+            },
+        );
+    });
+
+    it("warns when unlimited polygon is open", () => {
+        expectWarning(
+            interactiveGraphWidgetErrorRule,
+            "[[☃ interactive-graph 1]]",
+            {
+                widgets: {
+                    "interactive-graph 1": generateInteractiveGraphWidget({
+                        options: generateInteractiveGraphOptions({
+                            correct: generateIGPolygonGraph({
+                                numSides: "unlimited",
+                                coords: undefined,
                             }),
-                        ],
+                        }),
                     }),
-                }),
+                },
             },
-        },
-        {
-            message: "Locked line cannot have length 0.",
-            severity: Rule.Severity.ERROR,
-        },
-    );
+            {
+                message: "Polygon must be closed.",
+                severity: Rule.Severity.ERROR,
+            },
+        );
+    });
 
-    // Error when locked polygon has all coordinates be the same
-    expectWarning(
-        interactiveGraphWidgetErrorRule,
-        "[[☃ interactive-graph 1]]",
-        {
-            widgets: {
-                "interactive-graph 1": generateInteractiveGraphWidget({
-                    options: generateInteractiveGraphOptions({
-                        lockedFigures: [
-                            generateIGLockedPolygon({
-                                points: [
-                                    [0, 0],
-                                    [0, 0],
-                                    [0, 0],
-                                ],
+    it("warns when showPointLabels is true but pointLabels is missing (correct graph)", () => {
+        expectWarning(
+            interactiveGraphWidgetErrorRule,
+            "[[☃ interactive-graph 1]]",
+            {
+                widgets: {
+                    "interactive-graph 1": generateInteractiveGraphWidget({
+                        options: generateInteractiveGraphOptions({
+                            correct: generateIGPolygonGraph({
+                                showPointLabels: true,
                             }),
-                        ],
-                    }),
-                }),
-            },
-        },
-        {
-            message: "Locked polygon cannot have all coordinates be the same.",
-            severity: Rule.Severity.ERROR,
-        },
-    );
-
-    // Error when locked ellipse has negative radius
-    expectWarning(
-        interactiveGraphWidgetErrorRule,
-        "[[☃ interactive-graph 1]]",
-        {
-            widgets: {
-                "interactive-graph 1": generateInteractiveGraphWidget({
-                    options: generateInteractiveGraphOptions({
-                        lockedFigures: [
-                            generateIGLockedEllipse({radius: [-1, -1]}),
-                        ],
-                    }),
-                }),
-            },
-        },
-        {
-            message: "Locked ellipse must have positive radius values.",
-            severity: Rule.Severity.ERROR,
-        },
-    );
-
-    // Error when locked ellipse has zero radius
-    expectWarning(
-        interactiveGraphWidgetErrorRule,
-        "[[☃ interactive-graph 1]]",
-        {
-            widgets: {
-                "interactive-graph 1": generateInteractiveGraphWidget({
-                    options: generateInteractiveGraphOptions({
-                        lockedFigures: [
-                            generateIGLockedEllipse({radius: [0, 0]}),
-                        ],
-                    }),
-                }),
-            },
-        },
-        {
-            message: "Locked ellipse must have positive radius values.",
-            severity: Rule.Severity.ERROR,
-        },
-    );
-
-    // Error when unlimited polygon is open
-    expectWarning(
-        interactiveGraphWidgetErrorRule,
-        "[[☃ interactive-graph 1]]",
-        {
-            widgets: {
-                "interactive-graph 1": generateInteractiveGraphWidget({
-                    options: generateInteractiveGraphOptions({
-                        correct: generateIGPolygonGraph({
-                            numSides: "unlimited",
-                            coords: undefined,
                         }),
                     }),
-                }),
+                },
             },
-        },
-        {
-            message: "Polygon must be closed.",
-            severity: Rule.Severity.ERROR,
-        },
-    );
+            {
+                message:
+                    "showPointLabels is true but pointLabels is missing. Provide a label for every point.",
+                severity: Rule.Severity.ERROR,
+            },
+        );
+    });
 
-    // Error when showPointLabels is true but pointLabels is missing (correct graph)
-    expectWarning(
-        interactiveGraphWidgetErrorRule,
-        "[[☃ interactive-graph 1]]",
-        {
-            widgets: {
-                "interactive-graph 1": generateInteractiveGraphWidget({
-                    options: generateInteractiveGraphOptions({
-                        correct: generateIGPolygonGraph({
-                            showPointLabels: true,
+    it("warns when showPointLabels is true but pointLabels has an empty entry", () => {
+        expectWarning(
+            interactiveGraphWidgetErrorRule,
+            "[[☃ interactive-graph 1]]",
+            {
+                widgets: {
+                    "interactive-graph 1": generateInteractiveGraphWidget({
+                        options: generateInteractiveGraphOptions({
+                            correct: generateIGPolygonGraph({
+                                showPointLabels: true,
+                                pointLabels: ["A", "", "C"],
+                            }),
                         }),
                     }),
-                }),
+                },
             },
-        },
-        {
-            message:
-                "showPointLabels is true but pointLabels is missing. Provide a label for every point.",
-            severity: Rule.Severity.ERROR,
-        },
-    );
+            {
+                message:
+                    "showPointLabels is true but pointLabels has empty entries. Provide a label for every point.",
+                severity: Rule.Severity.ERROR,
+            },
+        );
+    });
 
-    // Error when showPointLabels is true but pointLabels has an empty entry
-    expectWarning(
-        interactiveGraphWidgetErrorRule,
-        "[[☃ interactive-graph 1]]",
-        {
-            widgets: {
-                "interactive-graph 1": generateInteractiveGraphWidget({
-                    options: generateInteractiveGraphOptions({
-                        correct: generateIGPolygonGraph({
-                            showPointLabels: true,
-                            pointLabels: ["A", "", "C"],
+    it("warns when showPointLabels is true on the starting (`graph`) graph too", () => {
+        expectWarning(
+            interactiveGraphWidgetErrorRule,
+            "[[☃ interactive-graph 1]]",
+            {
+                widgets: {
+                    "interactive-graph 1": generateInteractiveGraphWidget({
+                        options: generateInteractiveGraphOptions({
+                            graph: generateIGPolygonGraph({
+                                showPointLabels: true,
+                            }),
                         }),
                     }),
-                }),
+                },
             },
-        },
-        {
-            message:
-                "showPointLabels is true but pointLabels has empty entries. Provide a label for every point.",
-            severity: Rule.Severity.ERROR,
-        },
-    );
-
-    // Error when showPointLabels is true on the starting (`graph`) graph too
-    expectWarning(
-        interactiveGraphWidgetErrorRule,
-        "[[☃ interactive-graph 1]]",
-        {
-            widgets: {
-                "interactive-graph 1": generateInteractiveGraphWidget({
-                    options: generateInteractiveGraphOptions({
-                        graph: generateIGPolygonGraph({
-                            showPointLabels: true,
-                        }),
-                    }),
-                }),
+            {
+                message:
+                    "showPointLabels is true but pointLabels is missing. Provide a label for every point.",
+                severity: Rule.Severity.ERROR,
             },
-        },
-        {
-            message:
-                "showPointLabels is true but pointLabels is missing. Provide a label for every point.",
-            severity: Rule.Severity.ERROR,
-        },
-    );
+        );
+    });
 
     it("passes when showPointLabels is true and pointLabels is fully provided", () => {
         expectPass(

--- a/packages/perseus-linter/src/rules/interactive-graph-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/interactive-graph-widget-error.test.ts
@@ -198,110 +198,143 @@ describe("interactive-graph-widget-error", () => {
         },
     );
 
-    // Pass when showPointLabels is true and pointLabels is fully provided
-    expectPass(interactiveGraphWidgetErrorRule, "[[☃ interactive-graph 1]]", {
-        widgets: {
-            "interactive-graph 1": generateInteractiveGraphWidget({
-                options: generateInteractiveGraphOptions({
-                    correct: generateIGPolygonGraph({
-                        showPointLabels: true,
-                        pointLabels: ["A", "B", "C"],
+    it("passes when showPointLabels is true and pointLabels is fully provided", () => {
+        expectPass(
+            interactiveGraphWidgetErrorRule,
+            "[[☃ interactive-graph 1]]",
+            {
+                widgets: {
+                    "interactive-graph 1": generateInteractiveGraphWidget({
+                        options: generateInteractiveGraphOptions({
+                            correct: generateIGPolygonGraph({
+                                showPointLabels: true,
+                                pointLabels: ["A", "B", "C"],
+                            }),
+                        }),
                     }),
-                }),
-            }),
-        },
+                },
+            },
+        );
     });
 
-    // Pass when showPointLabels is false (no requirement on pointLabels)
-    expectPass(interactiveGraphWidgetErrorRule, "[[☃ interactive-graph 1]]", {
-        widgets: {
-            "interactive-graph 1": generateInteractiveGraphWidget({
-                options: generateInteractiveGraphOptions({
-                    correct: generateIGPolygonGraph({
-                        showPointLabels: false,
+    it("passes when showPointLabels is false (no requirement on pointLabels)", () => {
+        expectPass(
+            interactiveGraphWidgetErrorRule,
+            "[[☃ interactive-graph 1]]",
+            {
+                widgets: {
+                    "interactive-graph 1": generateInteractiveGraphWidget({
+                        options: generateInteractiveGraphOptions({
+                            correct: generateIGPolygonGraph({
+                                showPointLabels: false,
+                            }),
+                        }),
                     }),
-                }),
-            }),
-        },
+                },
+            },
+        );
     });
 
-    // Pass when showPointLabels is absent on the `graph` field
-    expectPass(interactiveGraphWidgetErrorRule, "[[☃ interactive-graph 1]]", {
-        widgets: {
-            "interactive-graph 1": generateInteractiveGraphWidget({
-                options: generateInteractiveGraphOptions({
-                    graph: generateIGPolygonGraph({
-                        pointLabels: ["A", "B", "C"],
+    it("passes when showPointLabels is absent on the `graph` field", () => {
+        expectPass(
+            interactiveGraphWidgetErrorRule,
+            "[[☃ interactive-graph 1]]",
+            {
+                widgets: {
+                    "interactive-graph 1": generateInteractiveGraphWidget({
+                        options: generateInteractiveGraphOptions({
+                            graph: generateIGPolygonGraph({
+                                pointLabels: ["A", "B", "C"],
+                            }),
+                        }),
                     }),
-                }),
-            }),
-        },
+                },
+            },
+        );
     });
 
-    // Pass when graph type is "none" — even with showPointLabels true via a
-    // cast, the rule must skip rather than error (defense-in-depth: the
-    // schema disallows showPointLabels on `none`, but the rule is the
-    // backstop).
-    expectPass(interactiveGraphWidgetErrorRule, "[[☃ interactive-graph 1]]", {
-        widgets: {
-            "interactive-graph 1": generateInteractiveGraphWidget({
-                options: generateInteractiveGraphOptions({
-                    // The schema disallows showPointLabels on `none`, so we
-                    // cast to assert the defensive guard fires when the
-                    // backstop is asked to look at this shape.
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-restricted-syntax
-                    correct: {type: "none", showPointLabels: true} as any,
-                }),
-            }),
-        },
-    });
-
-    // Pass when graph type is "vector" — same rationale as "none".
-    expectPass(interactiveGraphWidgetErrorRule, "[[☃ interactive-graph 1]]", {
-        widgets: {
-            "interactive-graph 1": generateInteractiveGraphWidget({
-                options: generateInteractiveGraphOptions({
-                    // The schema disallows showPointLabels on `vector`, so we
-                    // cast to assert the defensive guard fires when the
-                    // backstop is asked to look at this shape.
-                    // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-restricted-syntax
-                    correct: {type: "vector", showPointLabels: true} as any,
-                }),
-            }),
-        },
-    });
-
-    // Pass when no errors are detected
-    expectPass(interactiveGraphWidgetErrorRule, "[[☃ interactive-graph 1]]", {
-        widgets: {
-            "interactive-graph 1": generateInteractiveGraphWidget({
-                options: generateInteractiveGraphOptions({
-                    correct: generateIGPolygonGraph({
-                        numSides: "unlimited",
-                        coords: [
-                            [0, 0],
-                            [2, 0],
-                            [1, 1],
-                        ],
+    it('passes when graph type is "none" even with showPointLabels true via a cast (defense-in-depth backstop)', () => {
+        expectPass(
+            interactiveGraphWidgetErrorRule,
+            "[[☃ interactive-graph 1]]",
+            {
+                widgets: {
+                    "interactive-graph 1": generateInteractiveGraphWidget({
+                        options: generateInteractiveGraphOptions({
+                            // The schema disallows showPointLabels on `none`, so we
+                            // cast to assert the defensive guard fires when the
+                            // backstop is asked to look at this shape.
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-restricted-syntax
+                            correct: {
+                                type: "none",
+                                showPointLabels: true,
+                            } as any,
+                        }),
                     }),
-                    lockedFigures: [
-                        generateIGLockedLine({
-                            points: [
-                                generateIGLockedPoint({coord: [0, 0]}),
-                                generateIGLockedPoint({coord: [2, 3]}),
+                },
+            },
+        );
+    });
+
+    it('passes when graph type is "vector" (same rationale as "none")', () => {
+        expectPass(
+            interactiveGraphWidgetErrorRule,
+            "[[☃ interactive-graph 1]]",
+            {
+                widgets: {
+                    "interactive-graph 1": generateInteractiveGraphWidget({
+                        options: generateInteractiveGraphOptions({
+                            // The schema disallows showPointLabels on `vector`, so we
+                            // cast to assert the defensive guard fires when the
+                            // backstop is asked to look at this shape.
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-restricted-syntax
+                            correct: {
+                                type: "vector",
+                                showPointLabels: true,
+                            } as any,
+                        }),
+                    }),
+                },
+            },
+        );
+    });
+
+    it("passes when no errors are detected", () => {
+        expectPass(
+            interactiveGraphWidgetErrorRule,
+            "[[☃ interactive-graph 1]]",
+            {
+                widgets: {
+                    "interactive-graph 1": generateInteractiveGraphWidget({
+                        options: generateInteractiveGraphOptions({
+                            correct: generateIGPolygonGraph({
+                                numSides: "unlimited",
+                                coords: [
+                                    [0, 0],
+                                    [2, 0],
+                                    [1, 1],
+                                ],
+                            }),
+                            lockedFigures: [
+                                generateIGLockedLine({
+                                    points: [
+                                        generateIGLockedPoint({coord: [0, 0]}),
+                                        generateIGLockedPoint({coord: [2, 3]}),
+                                    ],
+                                }),
+                                generateIGLockedPolygon({
+                                    points: [
+                                        [0, 0],
+                                        [0, 2],
+                                        [1, 1],
+                                    ],
+                                }),
+                                generateIGLockedEllipse({radius: [2, 2]}),
                             ],
                         }),
-                        generateIGLockedPolygon({
-                            points: [
-                                [0, 0],
-                                [0, 2],
-                                [1, 1],
-                            ],
-                        }),
-                        generateIGLockedEllipse({radius: [2, 2]}),
-                    ],
-                }),
-            }),
-        },
+                    }),
+                },
+            },
+        );
     });
 });

--- a/packages/perseus-linter/src/rules/label-image-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/label-image-widget-error.test.ts
@@ -170,24 +170,25 @@ describe("label-image-widget-error", () => {
         },
     );
 
-    // Pass when no errors are detected
-    expectPass(labelImageWidgetErrorRule, "[[☃ label-image 1]]", {
-        widgets: {
-            "label-image 1": {
-                options: {
-                    choices: ["Choice 1", "Choice 2"],
-                    imageUrl: "example-url",
-                    imageAlt: "example-alt",
-                    markers: [
-                        {
-                            label: "Label 1",
-                            answers: ["Choice 1"],
-                            x: 10,
-                            y: 10,
-                        },
-                    ],
+    it("passes when no errors are detected", () => {
+        expectPass(labelImageWidgetErrorRule, "[[☃ label-image 1]]", {
+            widgets: {
+                "label-image 1": {
+                    options: {
+                        choices: ["Choice 1", "Choice 2"],
+                        imageUrl: "example-url",
+                        imageAlt: "example-alt",
+                        markers: [
+                            {
+                                label: "Label 1",
+                                answers: ["Choice 1"],
+                                x: 10,
+                                y: 10,
+                            },
+                        ],
+                    },
                 },
             },
-        },
+        });
     });
 });

--- a/packages/perseus-linter/src/rules/label-image-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/label-image-widget-error.test.ts
@@ -4,171 +4,178 @@ import Rule from "../rule";
 import labelImageWidgetErrorRule from "./label-image-widget-error";
 
 describe("label-image-widget-error", () => {
-    // Error when question has fewer than two answer choices
-    expectWarning(
-        labelImageWidgetErrorRule,
-        "[[☃ label-image 1]]",
-        {
-            widgets: {
-                "label-image 1": {
-                    options: {
-                        choices: ["Choice 1"],
-                        imageUrl: "example-url",
-                        imageAlt: "example-alt",
-                        markers: [
-                            {
-                                label: "Label 1",
-                                answers: ["Choice 1"],
-                                x: 10,
-                                y: 10,
-                            },
-                        ],
+    it("warns when question has fewer than two answer choices", () => {
+        expectWarning(
+            labelImageWidgetErrorRule,
+            "[[☃ label-image 1]]",
+            {
+                widgets: {
+                    "label-image 1": {
+                        options: {
+                            choices: ["Choice 1"],
+                            imageUrl: "example-url",
+                            imageAlt: "example-alt",
+                            markers: [
+                                {
+                                    label: "Label 1",
+                                    answers: ["Choice 1"],
+                                    x: 10,
+                                    y: 10,
+                                },
+                            ],
+                        },
                     },
                 },
             },
-        },
-        {
-            message: "label-image widget must have at least two answer choices",
-            severity: Rule.Severity.ERROR,
-        },
-    );
+            {
+                message:
+                    "label-image widget must have at least two answer choices",
+                severity: Rule.Severity.ERROR,
+            },
+        );
+    });
 
-    // Error when there's no image URL
-    expectWarning(
-        labelImageWidgetErrorRule,
-        "[[☃ label-image 1]]",
-        {
-            widgets: {
-                "label-image 1": {
-                    options: {
-                        choices: ["Choice 1", "Choice 2"],
-                        imageAlt: "example-alt",
-                        markers: [
-                            {
-                                label: "Label 1",
-                                answers: ["Choice 1"],
-                                x: 10,
-                                y: 10,
-                            },
-                        ],
+    it("warns when there's no image URL", () => {
+        expectWarning(
+            labelImageWidgetErrorRule,
+            "[[☃ label-image 1]]",
+            {
+                widgets: {
+                    "label-image 1": {
+                        options: {
+                            choices: ["Choice 1", "Choice 2"],
+                            imageAlt: "example-alt",
+                            markers: [
+                                {
+                                    label: "Label 1",
+                                    answers: ["Choice 1"],
+                                    x: 10,
+                                    y: 10,
+                                },
+                            ],
+                        },
                     },
                 },
             },
-        },
-        {
-            message: "No image url provided",
-            severity: Rule.Severity.ERROR,
-        },
-    );
+            {
+                message: "No image url provided",
+                severity: Rule.Severity.ERROR,
+            },
+        );
+    });
 
-    // Error when there's no image alt text
-    expectWarning(
-        labelImageWidgetErrorRule,
-        "[[☃ label-image 1]]",
-        {
-            widgets: {
-                "label-image 1": {
-                    options: {
-                        choices: ["Choice 1", "Choice 2"],
-                        imageUrl: "example-url",
-                        markers: [
-                            {
-                                label: "Label 1",
-                                answers: ["Choice 1"],
-                                x: 10,
-                                y: 10,
-                            },
-                        ],
+    it("warns when there's no image alt text", () => {
+        expectWarning(
+            labelImageWidgetErrorRule,
+            "[[☃ label-image 1]]",
+            {
+                widgets: {
+                    "label-image 1": {
+                        options: {
+                            choices: ["Choice 1", "Choice 2"],
+                            imageUrl: "example-url",
+                            markers: [
+                                {
+                                    label: "Label 1",
+                                    answers: ["Choice 1"],
+                                    x: 10,
+                                    y: 10,
+                                },
+                            ],
+                        },
                     },
                 },
             },
-        },
-        {
-            message: "No image alt text provided",
-            severity: Rule.Severity.ERROR,
-        },
-    );
+            {
+                message: "No image alt text provided",
+                severity: Rule.Severity.ERROR,
+            },
+        );
+    });
 
-    // Error when there are no markers
-    expectWarning(
-        labelImageWidgetErrorRule,
-        "[[☃ label-image 1]]",
-        {
-            widgets: {
-                "label-image 1": {
-                    options: {
-                        choices: ["Choice 1", "Choice 2"],
-                        imageUrl: "example-url",
-                        imageAlt: "example-alt",
-                        markers: [],
+    it("warns when there are no markers", () => {
+        expectWarning(
+            labelImageWidgetErrorRule,
+            "[[☃ label-image 1]]",
+            {
+                widgets: {
+                    "label-image 1": {
+                        options: {
+                            choices: ["Choice 1", "Choice 2"],
+                            imageUrl: "example-url",
+                            imageAlt: "example-alt",
+                            markers: [],
+                        },
                     },
                 },
             },
-        },
-        {
-            message: "label-image widget requires at least one marker",
-            severity: Rule.Severity.ERROR,
-        },
-    );
+            {
+                message: "label-image widget requires at least one marker",
+                severity: Rule.Severity.ERROR,
+            },
+        );
+    });
 
-    // Error when there are markers with no answers
-    expectWarning(
-        labelImageWidgetErrorRule,
-        "[[☃ label-image 1]]",
-        {
-            widgets: {
-                "label-image 1": {
-                    options: {
-                        choices: ["Choice 1", "Choice 2"],
-                        imageUrl: "example-url",
-                        imageAlt: "example-alt",
-                        markers: [
-                            {
-                                label: "Label 1",
-                                answers: [],
-                                x: 10,
-                                y: 10,
-                            },
-                        ],
+    it("warns when there are markers with no answers", () => {
+        expectWarning(
+            labelImageWidgetErrorRule,
+            "[[☃ label-image 1]]",
+            {
+                widgets: {
+                    "label-image 1": {
+                        options: {
+                            choices: ["Choice 1", "Choice 2"],
+                            imageUrl: "example-url",
+                            imageAlt: "example-alt",
+                            markers: [
+                                {
+                                    label: "Label 1",
+                                    answers: [],
+                                    x: 10,
+                                    y: 10,
+                                },
+                            ],
+                        },
                     },
                 },
             },
-        },
-        {
-            message:
-                "label-image widget has 1 markers with no answers selected",
-            severity: Rule.Severity.ERROR,
-        },
-    );
+            {
+                message:
+                    "label-image widget has 1 markers with no answers selected",
+                severity: Rule.Severity.ERROR,
+            },
+        );
+    });
 
-    // Error when there are markers with no ARIA label
-    expectWarning(
-        labelImageWidgetErrorRule,
-        "[[☃ label-image 1]]",
-        {
-            widgets: {
-                "label-image 1": {
-                    options: {
-                        choices: ["Choice 1", "Choice 2"],
-                        imageUrl: "example-url",
-                        imageAlt: "example-alt",
-                        markers: [
-                            {
-                                label: "", // empty string
-                                answers: ["Choice 1"],
-                                x: 10,
-                                y: 10,
-                            },
-                        ],
+    it("warns when there are markers with no ARIA label", () => {
+        expectWarning(
+            labelImageWidgetErrorRule,
+            "[[☃ label-image 1]]",
+            {
+                widgets: {
+                    "label-image 1": {
+                        options: {
+                            choices: ["Choice 1", "Choice 2"],
+                            imageUrl: "example-url",
+                            imageAlt: "example-alt",
+                            markers: [
+                                {
+                                    label: "", // empty string
+                                    answers: ["Choice 1"],
+                                    x: 10,
+                                    y: 10,
+                                },
+                            ],
+                        },
                     },
                 },
             },
-        },
-        {
-            message: "label-image widget has 1 markers with no ARIA label",
-            severity: Rule.Severity.ERROR,
-        },
-    );
+            {
+                message: "label-image widget has 1 markers with no ARIA label",
+                severity: Rule.Severity.ERROR,
+            },
+        );
+    });
 
     it("passes when no errors are detected", () => {
         expectPass(labelImageWidgetErrorRule, "[[☃ label-image 1]]", {

--- a/packages/perseus-linter/src/rules/legacy-gif-url.test.ts
+++ b/packages/perseus-linter/src/rules/legacy-gif-url.test.ts
@@ -29,38 +29,41 @@ describe("legacy-gif-url", () => {
         },
     });
 
-    // Pass for a legacy S3 image that isn't a gif
-    expectPass(legacyGifUrlRule, "[[☃ image 1]]", {
-        widgets: {
-            "image 1": {
-                options: {
-                    backgroundImage: {
-                        url: "https://ka-perseus-images.s3.amazonaws.com/abc123.png",
+    it("passes for a legacy S3 image that isn't a gif", () => {
+        expectPass(legacyGifUrlRule, "[[☃ image 1]]", {
+            widgets: {
+                "image 1": {
+                    options: {
+                        backgroundImage: {
+                            url: "https://ka-perseus-images.s3.amazonaws.com/abc123.png",
+                        },
                     },
                 },
             },
-        },
+        });
     });
 
-    // Pass for a gif hosted on the CDN
-    expectPass(legacyGifUrlRule, "[[☃ image 1]]", {
-        widgets: {
-            "image 1": {
-                options: {
-                    backgroundImage: {
-                        url: "https://cdn.kastatic.org/ka-perseus-images/abc123.gif",
+    it("passes for a gif hosted on the CDN", () => {
+        expectPass(legacyGifUrlRule, "[[☃ image 1]]", {
+            widgets: {
+                "image 1": {
+                    options: {
+                        backgroundImage: {
+                            url: "https://cdn.kastatic.org/ka-perseus-images/abc123.gif",
+                        },
                     },
                 },
             },
-        },
+        });
     });
 
-    // Pass for an image widget with no background image URL
-    expectPass(legacyGifUrlRule, "[[☃ image 1]]", {
-        widgets: {
-            "image 1": {
-                options: {},
+    it("passes for an image widget with no background image URL", () => {
+        expectPass(legacyGifUrlRule, "[[☃ image 1]]", {
+            widgets: {
+                "image 1": {
+                    options: {},
+                },
             },
-        },
+        });
     });
 });

--- a/packages/perseus-linter/src/rules/legacy-gif-url.test.ts
+++ b/packages/perseus-linter/src/rules/legacy-gif-url.test.ts
@@ -3,30 +3,32 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import legacyGifUrlRule from "./legacy-gif-url";
 
 describe("legacy-gif-url", () => {
-    // Warn for a legacy S3 gif URL
-    expectWarning(legacyGifUrlRule, "[[☃ image 1]]", {
-        widgets: {
-            "image 1": {
-                options: {
-                    backgroundImage: {
-                        url: "https://ka-perseus-images.s3.amazonaws.com/abc123.gif",
+    it("warns for a legacy S3 gif URL", () => {
+        expectWarning(legacyGifUrlRule, "[[☃ image 1]]", {
+            widgets: {
+                "image 1": {
+                    options: {
+                        backgroundImage: {
+                            url: "https://ka-perseus-images.s3.amazonaws.com/abc123.gif",
+                        },
                     },
                 },
             },
-        },
+        });
     });
 
-    // Warn regardless of the gif extension's casing
-    expectWarning(legacyGifUrlRule, "[[☃ image 1]]", {
-        widgets: {
-            "image 1": {
-                options: {
-                    backgroundImage: {
-                        url: "https://ka-perseus-images.s3.amazonaws.com/abc123.GIF",
+    it("warns regardless of the gif extension's casing", () => {
+        expectWarning(legacyGifUrlRule, "[[☃ image 1]]", {
+            widgets: {
+                "image 1": {
+                    options: {
+                        backgroundImage: {
+                            url: "https://ka-perseus-images.s3.amazonaws.com/abc123.GIF",
+                        },
                     },
                 },
             },
-        },
+        });
     });
 
     it("passes for a legacy S3 image that isn't a gif", () => {

--- a/packages/perseus-linter/src/rules/link-click-here.test.ts
+++ b/packages/perseus-linter/src/rules/link-click-here.test.ts
@@ -8,7 +8,10 @@ describe("link-click-here", () => {
         "[Click here, please](http://google.com)",
         "[For a good time, Click Here](http://google.com)",
     ]);
-    expectPass(linkClickHereRule, [
-        "[click to activate this link here](http://google.com)",
-    ]);
+    it.each(["[click to activate this link here](http://google.com)"])(
+        "linkClickHereRule passes with: %s",
+        (str: string) => {
+            expectPass(linkClickHereRule, str);
+        },
+    );
 });

--- a/packages/perseus-linter/src/rules/link-click-here.test.ts
+++ b/packages/perseus-linter/src/rules/link-click-here.test.ts
@@ -11,10 +11,10 @@ describe("link-click-here", () => {
         expectWarning(linkClickHereRule, str);
     });
 
-    it.each(["[click to activate this link here](http://google.com)"])(
-        "linkClickHereRule passes with: %s",
-        (str: string) => {
-            expectPass(linkClickHereRule, str);
-        },
-    );
+    it("passes when the link text is not 'click here'", () => {
+        expectPass(
+            linkClickHereRule,
+            "[click to activate this link here](http://google.com)",
+        );
+    });
 });

--- a/packages/perseus-linter/src/rules/link-click-here.test.ts
+++ b/packages/perseus-linter/src/rules/link-click-here.test.ts
@@ -3,11 +3,13 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import linkClickHereRule from "./link-click-here";
 
 describe("link-click-here", () => {
-    expectWarning(linkClickHereRule, [
+    it.each([
         "[click here](http://google.com)",
         "[Click here, please](http://google.com)",
         "[For a good time, Click Here](http://google.com)",
-    ]);
+    ])("linkClickHereRule warns with: %s", (str: string) => {
+        expectWarning(linkClickHereRule, str);
+    });
     it.each(["[click to activate this link here](http://google.com)"])(
         "linkClickHereRule passes with: %s",
         (str: string) => {

--- a/packages/perseus-linter/src/rules/link-click-here.test.ts
+++ b/packages/perseus-linter/src/rules/link-click-here.test.ts
@@ -10,6 +10,7 @@ describe("link-click-here", () => {
     ])("linkClickHereRule warns with: %s", (str: string) => {
         expectWarning(linkClickHereRule, str);
     });
+
     it.each(["[click to activate this link here](http://google.com)"])(
         "linkClickHereRule passes with: %s",
         (str: string) => {

--- a/packages/perseus-linter/src/rules/long-paragraph.test.ts
+++ b/packages/perseus-linter/src/rules/long-paragraph.test.ts
@@ -9,6 +9,7 @@ describe("long-paragraph", () => {
     it("warns about paragraphs over 500 characters", () => {
         expectWarning(longParagraphRule, sentence + sentence);
     });
+
     it.each([sentence, sentence + "\n\n" + sentence])(
         "longParagraphRule passes with: %s",
         (str: string) => {

--- a/packages/perseus-linter/src/rules/long-paragraph.test.ts
+++ b/packages/perseus-linter/src/rules/long-paragraph.test.ts
@@ -6,8 +6,9 @@ describe("long-paragraph", () => {
     // 299 characters
     const sentence = new Array(25).fill("lorem ipsum").join(" ");
 
-    // long-paragraph rule warns about paragraphs over 500 characters
-    expectWarning(longParagraphRule, sentence + sentence);
+    it("warns about paragraphs over 500 characters", () => {
+        expectWarning(longParagraphRule, sentence + sentence);
+    });
     it.each([sentence, sentence + "\n\n" + sentence])(
         "longParagraphRule passes with: %s",
         (str: string) => {

--- a/packages/perseus-linter/src/rules/long-paragraph.test.ts
+++ b/packages/perseus-linter/src/rules/long-paragraph.test.ts
@@ -8,5 +8,10 @@ describe("long-paragraph", () => {
 
     // long-paragraph rule warns about paragraphs over 500 characters
     expectWarning(longParagraphRule, sentence + sentence);
-    expectPass(longParagraphRule, [sentence, sentence + "\n\n" + sentence]);
+    it.each([sentence, sentence + "\n\n" + sentence])(
+        "longParagraphRule passes with: %s",
+        (str: string) => {
+            expectPass(longParagraphRule, str);
+        },
+    );
 });

--- a/packages/perseus-linter/src/rules/matcher-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/matcher-widget-error.test.ts
@@ -3,28 +3,30 @@ import {expectPass, expectWarning} from "../__tests__/test-utils";
 import matcherWidgetErrorRule from "./matcher-widget-error";
 
 describe("radio-widget-error", () => {
-    // Error for matcher widget with more left cards than right cards
-    expectWarning(matcherWidgetErrorRule, "[[☃ matcher 1]]", {
-        widgets: {
-            "matcher 1": {
-                options: {
-                    left: ["1", "2", "3"],
-                    right: ["4", "5"],
+    it("warns for matcher widget with more left cards than right cards", () => {
+        expectWarning(matcherWidgetErrorRule, "[[☃ matcher 1]]", {
+            widgets: {
+                "matcher 1": {
+                    options: {
+                        left: ["1", "2", "3"],
+                        right: ["4", "5"],
+                    },
                 },
             },
-        },
+        });
     });
 
-    // Error for matcher widget with more right cards than left cards
-    expectWarning(matcherWidgetErrorRule, "[[☃ matcher 1]]", {
-        widgets: {
-            "matcher 1": {
-                options: {
-                    left: ["1", "2"],
-                    right: ["3", "4", "5"],
+    it("warns for matcher widget with more right cards than left cards", () => {
+        expectWarning(matcherWidgetErrorRule, "[[☃ matcher 1]]", {
+            widgets: {
+                "matcher 1": {
+                    options: {
+                        left: ["1", "2"],
+                        right: ["3", "4", "5"],
+                    },
                 },
             },
-        },
+        });
     });
 
     it("passes for matcher widget with the same number of cards in the left and right columns", () => {

--- a/packages/perseus-linter/src/rules/matcher-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/matcher-widget-error.test.ts
@@ -27,27 +27,29 @@ describe("radio-widget-error", () => {
         },
     });
 
-    // Pass for matcher widget with the same number of cards in the left and right columns
-    expectPass(matcherWidgetErrorRule, "[[☃ matcher 1]]", {
-        widgets: {
-            "matcher 1": {
-                options: {
-                    left: ["1", "2", "3"],
-                    right: ["4", "5", "6"],
+    it("passes for matcher widget with the same number of cards in the left and right columns", () => {
+        expectPass(matcherWidgetErrorRule, "[[☃ matcher 1]]", {
+            widgets: {
+                "matcher 1": {
+                    options: {
+                        left: ["1", "2", "3"],
+                        right: ["4", "5", "6"],
+                    },
                 },
             },
-        },
+        });
     });
 
-    // Pass for matcher widget with no cards
-    expectPass(matcherWidgetErrorRule, "[[☃ matcher 1]]", {
-        widgets: {
-            "matcher 1": {
-                options: {
-                    left: [],
-                    right: [],
+    it("passes for matcher widget with no cards", () => {
+        expectPass(matcherWidgetErrorRule, "[[☃ matcher 1]]", {
+            widgets: {
+                "matcher 1": {
+                    options: {
+                        left: [],
+                        right: [],
+                    },
                 },
             },
-        },
+        });
     });
 });

--- a/packages/perseus-linter/src/rules/math-adjacent.test.ts
+++ b/packages/perseus-linter/src/rules/math-adjacent.test.ts
@@ -3,17 +3,11 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import mathAdjacentRule from "./math-adjacent";
 
 describe("math-adjacent", () => {
-    it.each(["$x=b+c$\n\n$x-b=c$"])(
-        "mathAdjacentRule warns with: %s",
-        (str: string) => {
-            expectWarning(mathAdjacentRule, str);
-        },
-    );
+    it("warns for adjacent math blocks", () => {
+        expectWarning(mathAdjacentRule, "$x=b+c$\n\n$x-b=c$");
+    });
 
-    it.each(["$x=b+c$\n\nnew paragraph\n\n$x-b=c$"])(
-        "mathAdjacentRule passes with: %s",
-        (str: string) => {
-            expectPass(mathAdjacentRule, str);
-        },
-    );
+    it("passes when math blocks are separated by a paragraph", () => {
+        expectPass(mathAdjacentRule, "$x=b+c$\n\nnew paragraph\n\n$x-b=c$");
+    });
 });

--- a/packages/perseus-linter/src/rules/math-adjacent.test.ts
+++ b/packages/perseus-linter/src/rules/math-adjacent.test.ts
@@ -4,5 +4,10 @@ import mathAdjacentRule from "./math-adjacent";
 
 describe("math-adjacent", () => {
     expectWarning(mathAdjacentRule, ["$x=b+c$\n\n$x-b=c$"]);
-    expectPass(mathAdjacentRule, ["$x=b+c$\n\nnew paragraph\n\n$x-b=c$"]);
+    it.each(["$x=b+c$\n\nnew paragraph\n\n$x-b=c$"])(
+        "mathAdjacentRule passes with: %s",
+        (str: string) => {
+            expectPass(mathAdjacentRule, str);
+        },
+    );
 });

--- a/packages/perseus-linter/src/rules/math-adjacent.test.ts
+++ b/packages/perseus-linter/src/rules/math-adjacent.test.ts
@@ -3,7 +3,12 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import mathAdjacentRule from "./math-adjacent";
 
 describe("math-adjacent", () => {
-    expectWarning(mathAdjacentRule, ["$x=b+c$\n\n$x-b=c$"]);
+    it.each(["$x=b+c$\n\n$x-b=c$"])(
+        "mathAdjacentRule warns with: %s",
+        (str: string) => {
+            expectWarning(mathAdjacentRule, str);
+        },
+    );
     it.each(["$x=b+c$\n\nnew paragraph\n\n$x-b=c$"])(
         "mathAdjacentRule passes with: %s",
         (str: string) => {

--- a/packages/perseus-linter/src/rules/math-adjacent.test.ts
+++ b/packages/perseus-linter/src/rules/math-adjacent.test.ts
@@ -9,6 +9,7 @@ describe("math-adjacent", () => {
             expectWarning(mathAdjacentRule, str);
         },
     );
+
     it.each(["$x=b+c$\n\nnew paragraph\n\n$x-b=c$"])(
         "mathAdjacentRule passes with: %s",
         (str: string) => {

--- a/packages/perseus-linter/src/rules/math-align-extra-break.test.ts
+++ b/packages/perseus-linter/src/rules/math-align-extra-break.test.ts
@@ -10,10 +10,10 @@ describe("math-align-extra-break", () => {
         expectWarning(mathAlignExtraBreakRule, str);
     });
 
-    it.each(["$\\begin{align} x \\\\\\\\ y  \\end{align}$"])(
-        "mathAlignExtraBreakRule passes with: %s",
-        (str: string) => {
-            expectPass(mathAlignExtraBreakRule, str);
-        },
-    );
+    it("passes for an align block without an extra break", () => {
+        expectPass(
+            mathAlignExtraBreakRule,
+            "$\\begin{align} x \\\\\\\\ y  \\end{align}$",
+        );
+    });
 });

--- a/packages/perseus-linter/src/rules/math-align-extra-break.test.ts
+++ b/packages/perseus-linter/src/rules/math-align-extra-break.test.ts
@@ -7,7 +7,10 @@ describe("math-align-extra-break", () => {
         "$\\begin{align}x \\\\\\\\ y \\\\ \\end{align}$",
         "$\\begin{align}x \\\\\\\\ y \\\\\\\\ \\end{align}$",
     ]);
-    expectPass(mathAlignExtraBreakRule, [
-        "$\\begin{align} x \\\\\\\\ y  \\end{align}$",
-    ]);
+    it.each(["$\\begin{align} x \\\\\\\\ y  \\end{align}$"])(
+        "mathAlignExtraBreakRule passes with: %s",
+        (str: string) => {
+            expectPass(mathAlignExtraBreakRule, str);
+        },
+    );
 });

--- a/packages/perseus-linter/src/rules/math-align-extra-break.test.ts
+++ b/packages/perseus-linter/src/rules/math-align-extra-break.test.ts
@@ -3,10 +3,12 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import mathAlignExtraBreakRule from "./math-align-extra-break";
 
 describe("math-align-extra-break", () => {
-    expectWarning(mathAlignExtraBreakRule, [
+    it.each([
         "$\\begin{align}x \\\\\\\\ y \\\\ \\end{align}$",
         "$\\begin{align}x \\\\\\\\ y \\\\\\\\ \\end{align}$",
-    ]);
+    ])("mathAlignExtraBreakRule warns with: %s", (str: string) => {
+        expectWarning(mathAlignExtraBreakRule, str);
+    });
     it.each(["$\\begin{align} x \\\\\\\\ y  \\end{align}$"])(
         "mathAlignExtraBreakRule passes with: %s",
         (str: string) => {

--- a/packages/perseus-linter/src/rules/math-align-extra-break.test.ts
+++ b/packages/perseus-linter/src/rules/math-align-extra-break.test.ts
@@ -9,6 +9,7 @@ describe("math-align-extra-break", () => {
     ])("mathAlignExtraBreakRule warns with: %s", (str: string) => {
         expectWarning(mathAlignExtraBreakRule, str);
     });
+
     it.each(["$\\begin{align} x \\\\\\\\ y  \\end{align}$"])(
         "mathAlignExtraBreakRule passes with: %s",
         (str: string) => {

--- a/packages/perseus-linter/src/rules/math-align-linebreaks.test.ts
+++ b/packages/perseus-linter/src/rules/math-align-linebreaks.test.ts
@@ -9,10 +9,12 @@ describe("math-align-linebreaks", () => {
         "$\\begin{align}x\\\\\\\\\\\\y\\end{align}$",
         "$\\begin{align}\nx\\\\\n\\\\\\\\\ny\n\\end{align}$",
     ]);
-    expectPass(mathAlignLinebreaksRule, [
+    it.each([
         "$\\begin{align}x\\sqrty\\end{align}$",
         "$\\begin{align}x\\\\\\\\y\\end{align}$",
         "$\\begin{align}x\\\\\n\\\\y\\end{align}$",
         "$\\begin{align}x \\\\  \\\\ y\\end{align}$",
-    ]);
+    ])("mathAlignLinebreaksRule passes with: %s", (str: string) => {
+        expectPass(mathAlignLinebreaksRule, str);
+    });
 });

--- a/packages/perseus-linter/src/rules/math-align-linebreaks.test.ts
+++ b/packages/perseus-linter/src/rules/math-align-linebreaks.test.ts
@@ -3,12 +3,14 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import mathAlignLinebreaksRule from "./math-align-linebreaks";
 
 describe("math-align-linebreaks", () => {
-    expectWarning(mathAlignLinebreaksRule, [
+    it.each([
         "$\\begin{align}x\\\\y\\end{align}$",
         "$\\begin{align} x \\\\ y \\end{align}$",
         "$\\begin{align}x\\\\\\\\\\\\y\\end{align}$",
         "$\\begin{align}\nx\\\\\n\\\\\\\\\ny\n\\end{align}$",
-    ]);
+    ])("mathAlignLinebreaksRule warns with: %s", (str: string) => {
+        expectWarning(mathAlignLinebreaksRule, str);
+    });
     it.each([
         "$\\begin{align}x\\sqrty\\end{align}$",
         "$\\begin{align}x\\\\\\\\y\\end{align}$",

--- a/packages/perseus-linter/src/rules/math-align-linebreaks.test.ts
+++ b/packages/perseus-linter/src/rules/math-align-linebreaks.test.ts
@@ -11,6 +11,7 @@ describe("math-align-linebreaks", () => {
     ])("mathAlignLinebreaksRule warns with: %s", (str: string) => {
         expectWarning(mathAlignLinebreaksRule, str);
     });
+
     it.each([
         "$\\begin{align}x\\sqrty\\end{align}$",
         "$\\begin{align}x\\\\\\\\y\\end{align}$",

--- a/packages/perseus-linter/src/rules/math-empty.test.ts
+++ b/packages/perseus-linter/src/rules/math-empty.test.ts
@@ -10,6 +10,7 @@ describe("math-empty", () => {
     ])("mathEmptyRule warns with: %s", (str: string) => {
         expectWarning(mathEmptyRule, str);
     });
+
     it.each([
         "foo $x$ bar",
         "foo\n\n$x$\n\nbar",

--- a/packages/perseus-linter/src/rules/math-empty.test.ts
+++ b/packages/perseus-linter/src/rules/math-empty.test.ts
@@ -8,9 +8,11 @@ describe("math-empty", () => {
         "foo\n\n$$\n\nbar",
         "$$ | $$ | $$\n- | - | -\ndata 1 | data 2 | data 3",
     ]);
-    expectPass(mathEmptyRule, [
+    it.each([
         "foo $x$ bar",
         "foo\n\n$x$\n\nbar",
         "$x$ | $y$ | $z$\n- | - | -\ndata 1 | data 2 | data 3",
-    ]);
+    ])("mathEmptyRule passes with: %s", (str: string) => {
+        expectPass(mathEmptyRule, str);
+    });
 });

--- a/packages/perseus-linter/src/rules/math-empty.test.ts
+++ b/packages/perseus-linter/src/rules/math-empty.test.ts
@@ -3,11 +3,13 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import mathEmptyRule from "./math-empty";
 
 describe("math-empty", () => {
-    expectWarning(mathEmptyRule, [
+    it.each([
         "foo $$ bar",
         "foo\n\n$$\n\nbar",
         "$$ | $$ | $$\n- | - | -\ndata 1 | data 2 | data 3",
-    ]);
+    ])("mathEmptyRule warns with: %s", (str: string) => {
+        expectWarning(mathEmptyRule, str);
+    });
     it.each([
         "foo $x$ bar",
         "foo\n\n$x$\n\nbar",

--- a/packages/perseus-linter/src/rules/math-frac.test.ts
+++ b/packages/perseus-linter/src/rules/math-frac.test.ts
@@ -4,9 +4,10 @@ import mathFracRule from "./math-frac";
 
 describe("math-frac", () => {
     expectWarning(mathFracRule, ["$\\frac 12$", "$\\frac{1}{2}$"]);
-    expectPass(mathFracRule, [
-        "$\\dfrac 12$",
-        "$\\dfrac{1}{2}$",
-        "$\\fraction 12$",
-    ]);
+    it.each(["$\\dfrac 12$", "$\\dfrac{1}{2}$", "$\\fraction 12$"])(
+        "mathFracRule passes with: %s",
+        (str: string) => {
+            expectPass(mathFracRule, str);
+        },
+    );
 });

--- a/packages/perseus-linter/src/rules/math-frac.test.ts
+++ b/packages/perseus-linter/src/rules/math-frac.test.ts
@@ -3,7 +3,12 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import mathFracRule from "./math-frac";
 
 describe("math-frac", () => {
-    expectWarning(mathFracRule, ["$\\frac 12$", "$\\frac{1}{2}$"]);
+    it.each(["$\\frac 12$", "$\\frac{1}{2}$"])(
+        "mathFracRule warns with: %s",
+        (str: string) => {
+            expectWarning(mathFracRule, str);
+        },
+    );
     it.each(["$\\dfrac 12$", "$\\dfrac{1}{2}$", "$\\fraction 12$"])(
         "mathFracRule passes with: %s",
         (str: string) => {

--- a/packages/perseus-linter/src/rules/math-frac.test.ts
+++ b/packages/perseus-linter/src/rules/math-frac.test.ts
@@ -9,6 +9,7 @@ describe("math-frac", () => {
             expectWarning(mathFracRule, str);
         },
     );
+
     it.each(["$\\dfrac 12$", "$\\dfrac{1}{2}$", "$\\fraction 12$"])(
         "mathFracRule passes with: %s",
         (str: string) => {

--- a/packages/perseus-linter/src/rules/math-nested.test.ts
+++ b/packages/perseus-linter/src/rules/math-nested.test.ts
@@ -9,6 +9,7 @@ describe("math-nested", () => {
             expectWarning(mathNestedRule, str);
         },
     );
+
     it.each(["$\\text{4}x$", "inline $\\text{4}x$ math"])(
         "mathNestedRule passes with: %s",
         (str: string) => {

--- a/packages/perseus-linter/src/rules/math-nested.test.ts
+++ b/packages/perseus-linter/src/rules/math-nested.test.ts
@@ -8,5 +8,10 @@ describe("math-nested", () => {
         "inline $\\text{4$x$}$ math",
         "$\\text{$$}$",
     ]);
-    expectPass(mathNestedRule, ["$\\text{4}x$", "inline $\\text{4}x$ math"]);
+    it.each(["$\\text{4}x$", "inline $\\text{4}x$ math"])(
+        "mathNestedRule passes with: %s",
+        (str: string) => {
+            expectPass(mathNestedRule, str);
+        },
+    );
 });

--- a/packages/perseus-linter/src/rules/math-nested.test.ts
+++ b/packages/perseus-linter/src/rules/math-nested.test.ts
@@ -3,11 +3,12 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import mathNestedRule from "./math-nested";
 
 describe("math-nested", () => {
-    expectWarning(mathNestedRule, [
-        "$\\text{4$x$}$",
-        "inline $\\text{4$x$}$ math",
-        "$\\text{$$}$",
-    ]);
+    it.each(["$\\text{4$x$}$", "inline $\\text{4$x$}$ math", "$\\text{$$}$"])(
+        "mathNestedRule warns with: %s",
+        (str: string) => {
+            expectWarning(mathNestedRule, str);
+        },
+    );
     it.each(["$\\text{4}x$", "inline $\\text{4}x$ math"])(
         "mathNestedRule passes with: %s",
         (str: string) => {

--- a/packages/perseus-linter/src/rules/math-starts-with-space.test.ts
+++ b/packages/perseus-linter/src/rules/math-starts-with-space.test.ts
@@ -15,7 +15,7 @@ describe("math-starts-with-space", () => {
         "$\\enspace x$",
         "$\\phantom{xyz} x$",
     ]);
-    expectPass(mathStartsWithSpaceRule, [
+    it.each([
         "$a~ x$",
         "$a\\qquad x$",
         "$a\\quad x$",
@@ -26,5 +26,7 @@ describe("math-starts-with-space", () => {
         "$a\\! x$",
         "$a\\enspace x$",
         "$a\\phantom{xyz} x$",
-    ]);
+    ])("mathStartsWithSpaceRule passes with: %s", (str: string) => {
+        expectPass(mathStartsWithSpaceRule, str);
+    });
 });

--- a/packages/perseus-linter/src/rules/math-starts-with-space.test.ts
+++ b/packages/perseus-linter/src/rules/math-starts-with-space.test.ts
@@ -17,6 +17,7 @@ describe("math-starts-with-space", () => {
     ])("mathStartsWithSpaceRule warns with: %s", (str: string) => {
         expectWarning(mathStartsWithSpaceRule, str);
     });
+
     it.each([
         "$a~ x$",
         "$a\\qquad x$",

--- a/packages/perseus-linter/src/rules/math-starts-with-space.test.ts
+++ b/packages/perseus-linter/src/rules/math-starts-with-space.test.ts
@@ -3,7 +3,7 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import mathStartsWithSpaceRule from "./math-starts-with-space";
 
 describe("math-starts-with-space", () => {
-    expectWarning(mathStartsWithSpaceRule, [
+    it.each([
         "foo$~ x$bar",
         "$\\qquad x$",
         "$\\quad x$",
@@ -14,7 +14,9 @@ describe("math-starts-with-space", () => {
         "$\\! x$",
         "$\\enspace x$",
         "$\\phantom{xyz} x$",
-    ]);
+    ])("mathStartsWithSpaceRule warns with: %s", (str: string) => {
+        expectWarning(mathStartsWithSpaceRule, str);
+    });
     it.each([
         "$a~ x$",
         "$a\\qquad x$",

--- a/packages/perseus-linter/src/rules/math-text-empty.test.ts
+++ b/packages/perseus-linter/src/rules/math-text-empty.test.ts
@@ -11,6 +11,7 @@ describe("math-text-empty", () => {
     ])("mathTextEmptyRule warns with: %s", (str: string) => {
         expectWarning(mathTextEmptyRule, str);
     });
+
     it.each(["$x\\text{z}y$"])(
         "mathTextEmptyRule passes with: %s",
         (str: string) => {

--- a/packages/perseus-linter/src/rules/math-text-empty.test.ts
+++ b/packages/perseus-linter/src/rules/math-text-empty.test.ts
@@ -9,5 +9,10 @@ describe("math-text-empty", () => {
         "$x\\text{\n}y$",
         "$x\\text{\t}y$",
     ]);
-    expectPass(mathTextEmptyRule, ["$x\\text{z}y$"]);
+    it.each(["$x\\text{z}y$"])(
+        "mathTextEmptyRule passes with: %s",
+        (str: string) => {
+            expectPass(mathTextEmptyRule, str);
+        },
+    );
 });

--- a/packages/perseus-linter/src/rules/math-text-empty.test.ts
+++ b/packages/perseus-linter/src/rules/math-text-empty.test.ts
@@ -12,10 +12,7 @@ describe("math-text-empty", () => {
         expectWarning(mathTextEmptyRule, str);
     });
 
-    it.each(["$x\\text{z}y$"])(
-        "mathTextEmptyRule passes with: %s",
-        (str: string) => {
-            expectPass(mathTextEmptyRule, str);
-        },
-    );
+    it("passes for non-empty text in math", () => {
+        expectPass(mathTextEmptyRule, "$x\\text{z}y$");
+    });
 });

--- a/packages/perseus-linter/src/rules/math-text-empty.test.ts
+++ b/packages/perseus-linter/src/rules/math-text-empty.test.ts
@@ -3,12 +3,14 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import mathTextEmptyRule from "./math-text-empty";
 
 describe("math-text-empty", () => {
-    expectWarning(mathTextEmptyRule, [
+    it.each([
         "$x\\text{}y$",
         "$x\\text{ }y$",
         "$x\\text{\n}y$",
         "$x\\text{\t}y$",
-    ]);
+    ])("mathTextEmptyRule warns with: %s", (str: string) => {
+        expectWarning(mathTextEmptyRule, str);
+    });
     it.each(["$x\\text{z}y$"])(
         "mathTextEmptyRule passes with: %s",
         (str: string) => {

--- a/packages/perseus-linter/src/rules/math-without-dollars.test.ts
+++ b/packages/perseus-linter/src/rules/math-without-dollars.test.ts
@@ -1,14 +1,16 @@
-import {expectWarning, expectPass} from "../__tests__/test-utils";
+import {expectPass, expectWarning} from "../__tests__/test-utils";
 
 import mathWithoutDollarsRule from "./math-without-dollars";
 
 describe("math-without-dollars", () => {
-    expectWarning(mathWithoutDollarsRule, [
+    it.each([
         "One half: \\frac{1}{2}!",
         "\\Large{BIG}!",
         "This looks like someone's ear: {",
         "Here's the other ear: }. Weird!",
-    ]);
+    ])("mathWithoutDollarsRule warns with: %s", (str: string) => {
+        expectWarning(mathWithoutDollarsRule, str);
+    });
 
     it.each([
         "One half: $\\frac{1}{2}$",

--- a/packages/perseus-linter/src/rules/math-without-dollars.test.ts
+++ b/packages/perseus-linter/src/rules/math-without-dollars.test.ts
@@ -1,4 +1,4 @@
-import {expectWarning, expectPassSingle} from "../__tests__/test-utils";
+import {expectWarning, expectPass} from "../__tests__/test-utils";
 
 import mathWithoutDollarsRule from "./math-without-dollars";
 
@@ -20,6 +20,6 @@ describe("math-without-dollars", () => {
         "~~~\n\\frac{1}{2}\n~~~",
         "\n    \\frac{1}{2}\n    {\n    }\n",
     ])("mathWithoutDollarsRule passes with: %s", (str: string) => {
-        expectPassSingle(mathWithoutDollarsRule, str);
+        expectPass(mathWithoutDollarsRule, str);
     });
 });

--- a/packages/perseus-linter/src/rules/math-without-dollars.test.ts
+++ b/packages/perseus-linter/src/rules/math-without-dollars.test.ts
@@ -1,4 +1,4 @@
-import {expectWarning, expectPass} from "../__tests__/test-utils";
+import {expectWarning, expectPassSingle} from "../__tests__/test-utils";
 
 import mathWithoutDollarsRule from "./math-without-dollars";
 
@@ -9,7 +9,8 @@ describe("math-without-dollars", () => {
         "This looks like someone's ear: {",
         "Here's the other ear: }. Weird!",
     ]);
-    expectPass(mathWithoutDollarsRule, [
+
+    it.each([
         "One half: $\\frac{1}{2}$",
         "$\\Large{BIG}$!",
         "`{`",
@@ -18,5 +19,7 @@ describe("math-without-dollars", () => {
         "```\n\\frac{1}{2}\n```",
         "~~~\n\\frac{1}{2}\n~~~",
         "\n    \\frac{1}{2}\n    {\n    }\n",
-    ]);
+    ])("mathWithoutDollarsRule passes with: %s", (str: string) => {
+        expectPassSingle(mathWithoutDollarsRule, str);
+    });
 });

--- a/packages/perseus-linter/src/rules/nested-lists.test.ts
+++ b/packages/perseus-linter/src/rules/nested-lists.test.ts
@@ -3,10 +3,12 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import nestedListsRule from "./nested-lists";
 
 describe("nested-lists", () => {
-    expectWarning(nestedListsRule, [
-        "1. outer\n  * nested\n  *nested",
-        " + outer\n\n   1. nested",
-    ]);
+    it.each(["1. outer\n  * nested\n  *nested", " + outer\n\n   1. nested"])(
+        "nestedListsRule warns with: %s",
+        (str: string) => {
+            expectWarning(nestedListsRule, str);
+        },
+    );
     it.each([
         "-one\n-two\n-three",
         "1. one\n 2. two\n3. three",

--- a/packages/perseus-linter/src/rules/nested-lists.test.ts
+++ b/packages/perseus-linter/src/rules/nested-lists.test.ts
@@ -7,9 +7,11 @@ describe("nested-lists", () => {
         "1. outer\n  * nested\n  *nested",
         " + outer\n\n   1. nested",
     ]);
-    expectPass(nestedListsRule, [
+    it.each([
         "-one\n-two\n-three",
         "1. one\n 2. two\n3. three",
         " * one\n\n * two\n\n * three",
-    ]);
+    ])("nestedListsRule passes with: %s", (str: string) => {
+        expectPass(nestedListsRule, str);
+    });
 });

--- a/packages/perseus-linter/src/rules/nested-lists.test.ts
+++ b/packages/perseus-linter/src/rules/nested-lists.test.ts
@@ -9,6 +9,7 @@ describe("nested-lists", () => {
             expectWarning(nestedListsRule, str);
         },
     );
+
     it.each([
         "-one\n-two\n-three",
         "1. one\n 2. two\n3. three",

--- a/packages/perseus-linter/src/rules/numeric-input-missing-label.test.ts
+++ b/packages/perseus-linter/src/rules/numeric-input-missing-label.test.ts
@@ -26,15 +26,16 @@ describe("numeric-input-missing-label", () => {
         },
     });
 
-    // Pass when labelText is set
-    expectPass(numericInputMissingLabelRule, "[[☃ numeric-input 1]]", {
-        widgets: {
-            "numeric-input 1": {
-                options: {
-                    answers: [{value: 42}],
-                    labelText: "What's the answer?",
+    it("passes when labelText is set", () => {
+        expectPass(numericInputMissingLabelRule, "[[☃ numeric-input 1]]", {
+            widgets: {
+                "numeric-input 1": {
+                    options: {
+                        answers: [{value: 42}],
+                        labelText: "What's the answer?",
+                    },
                 },
             },
-        },
+        });
     });
 });

--- a/packages/perseus-linter/src/rules/numeric-input-missing-label.test.ts
+++ b/packages/perseus-linter/src/rules/numeric-input-missing-label.test.ts
@@ -3,27 +3,29 @@ import {expectPass, expectWarning} from "../__tests__/test-utils";
 import numericInputMissingLabelRule from "./numeric-input-missing-label";
 
 describe("numeric-input-missing-label", () => {
-    // Warning when labelText is empty
-    expectWarning(numericInputMissingLabelRule, "[[☃ numeric-input 1]]", {
-        widgets: {
-            "numeric-input 1": {
-                options: {
-                    answers: [{value: 42}],
-                    labelText: "",
+    it("warns when labelText is empty", () => {
+        expectWarning(numericInputMissingLabelRule, "[[☃ numeric-input 1]]", {
+            widgets: {
+                "numeric-input 1": {
+                    options: {
+                        answers: [{value: 42}],
+                        labelText: "",
+                    },
                 },
             },
-        },
+        });
     });
 
-    // Warning when labelText is undefined
-    expectWarning(numericInputMissingLabelRule, "[[☃ numeric-input 1]]", {
-        widgets: {
-            "numeric-input 1": {
-                options: {
-                    answers: [{value: 42}],
+    it("warns when labelText is undefined", () => {
+        expectWarning(numericInputMissingLabelRule, "[[☃ numeric-input 1]]", {
+            widgets: {
+                "numeric-input 1": {
+                    options: {
+                        answers: [{value: 42}],
+                    },
                 },
             },
-        },
+        });
     });
 
     it("passes when labelText is set", () => {

--- a/packages/perseus-linter/src/rules/numeric-input-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/numeric-input-widget-error.test.ts
@@ -56,18 +56,19 @@ describe("radio-widget-error", () => {
         },
     });
 
-    // Pass for numeric input widget with all non-empty answers
-    expectPass(numericInputWidgetErrorRule, "[[☃ numeric-input 1]]", {
-        widgets: {
-            "numeric-input 1": {
-                options: {
-                    answers: [
-                        {
-                            value: 0,
-                        },
-                    ],
+    it("passes for numeric input widget with all non-empty answers", () => {
+        expectPass(numericInputWidgetErrorRule, "[[☃ numeric-input 1]]", {
+            widgets: {
+                "numeric-input 1": {
+                    options: {
+                        answers: [
+                            {
+                                value: 0,
+                            },
+                        ],
+                    },
                 },
             },
-        },
+        });
     });
 });

--- a/packages/perseus-linter/src/rules/numeric-input-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/numeric-input-widget-error.test.ts
@@ -3,57 +3,60 @@ import {expectPass, expectWarning} from "../__tests__/test-utils";
 import numericInputWidgetErrorRule from "./numeric-input-widget-error";
 
 describe("radio-widget-error", () => {
-    // Error for numeric input widget with all empty answers
-    expectWarning(numericInputWidgetErrorRule, "[[☃ numeric-input 1]]", {
-        widgets: {
-            "numeric-input 1": {
-                options: {
-                    answers: [
-                        {
-                            value: null,
-                        },
-                        {
-                            value: null,
-                        },
-                    ],
+    it("warns for numeric input widget with all empty answers", () => {
+        expectWarning(numericInputWidgetErrorRule, "[[☃ numeric-input 1]]", {
+            widgets: {
+                "numeric-input 1": {
+                    options: {
+                        answers: [
+                            {
+                                value: null,
+                            },
+                            {
+                                value: null,
+                            },
+                        ],
+                    },
                 },
             },
-        },
+        });
     });
 
-    // Error for numeric input widget with some empty answers
-    expectWarning(numericInputWidgetErrorRule, "[[☃ numeric-input 1]]", {
-        widgets: {
-            "numeric-input 1": {
-                options: {
-                    answers: [
-                        {
-                            value: 2,
-                        },
-                        {
-                            value: null,
-                        },
-                    ],
+    it("warns for numeric input widget with some empty answers", () => {
+        expectWarning(numericInputWidgetErrorRule, "[[☃ numeric-input 1]]", {
+            widgets: {
+                "numeric-input 1": {
+                    options: {
+                        answers: [
+                            {
+                                value: 2,
+                            },
+                            {
+                                value: null,
+                            },
+                        ],
+                    },
                 },
             },
-        },
+        });
     });
 
-    // Error for numeric input with required format but no format selected
-    expectWarning(numericInputWidgetErrorRule, "[[☃ numeric-input 1]]", {
-        widgets: {
-            "numeric-input 1": {
-                options: {
-                    answers: [
-                        {
-                            value: 2,
-                            answerForms: [],
-                            strict: true,
-                        },
-                    ],
+    it("warns for numeric input with required format but no format selected", () => {
+        expectWarning(numericInputWidgetErrorRule, "[[☃ numeric-input 1]]", {
+            widgets: {
+                "numeric-input 1": {
+                    options: {
+                        answers: [
+                            {
+                                value: 2,
+                                answerForms: [],
+                                strict: true,
+                            },
+                        ],
+                    },
                 },
             },
-        },
+        });
     });
 
     it("passes for numeric input widget with all non-empty answers", () => {

--- a/packages/perseus-linter/src/rules/phet-simulation-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/phet-simulation-widget-error.test.ts
@@ -10,26 +10,36 @@ describe("radio-widget-error", () => {
         global.URL.canParse = jest.fn(() => true) as jest.Mock;
     });
 
-    // Error for phet simulation widget with non-PhET URL
-    expectWarning(phetSimulationWidgetErrorRule, "[[☃ phet-simulation 1]]", {
-        widgets: {
-            "phet-simulation 1": {
-                options: {
-                    url: "https://google.com",
+    it("warns for phet simulation widget with non-PhET URL", () => {
+        expectWarning(
+            phetSimulationWidgetErrorRule,
+            "[[☃ phet-simulation 1]]",
+            {
+                widgets: {
+                    "phet-simulation 1": {
+                        options: {
+                            url: "https://google.com",
+                        },
+                    },
                 },
             },
-        },
+        );
     });
 
-    // Error for phet simulation widget with nonsensical URL
-    expectWarning(phetSimulationWidgetErrorRule, "[[☃ phet-simulation 1]]", {
-        widgets: {
-            "phet-simulation 1": {
-                options: {
-                    url: "abcdefghijklmnopqrstuvwxyz",
+    it("warns for phet simulation widget with nonsensical URL", () => {
+        expectWarning(
+            phetSimulationWidgetErrorRule,
+            "[[☃ phet-simulation 1]]",
+            {
+                widgets: {
+                    "phet-simulation 1": {
+                        options: {
+                            url: "abcdefghijklmnopqrstuvwxyz",
+                        },
+                    },
                 },
             },
-        },
+        );
     });
 
     it("passes for phet simulation widget with PhET URL", () => {

--- a/packages/perseus-linter/src/rules/phet-simulation-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/phet-simulation-widget-error.test.ts
@@ -32,14 +32,15 @@ describe("radio-widget-error", () => {
         },
     });
 
-    // Pass for phet simulation widget with PhET URL
-    expectPass(phetSimulationWidgetErrorRule, "[[☃ phet-simulation 1]]", {
-        widgets: {
-            "phet-simulation 1": {
-                options: {
-                    url: "https://phet.colorado.edu/sims/html/projectile-data-lab/latest/projectile-data-lab_all.html",
+    it("passes for phet simulation widget with PhET URL", () => {
+        expectPass(phetSimulationWidgetErrorRule, "[[☃ phet-simulation 1]]", {
+            widgets: {
+                "phet-simulation 1": {
+                    options: {
+                        url: "https://phet.colorado.edu/sims/html/projectile-data-lab/latest/projectile-data-lab_all.html",
+                    },
                 },
             },
-        },
+        });
     });
 });

--- a/packages/perseus-linter/src/rules/python-program-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/python-program-widget-error.test.ts
@@ -36,15 +36,16 @@ describe("python-program-widget-error", () => {
         },
     });
 
-    // Pass when no errors are detected
-    expectPass(pythonProgramWidgetErrorRule, "[[☃ python-program 1]]", {
-        widgets: {
-            "python-program 1": {
-                options: {
-                    programID: "123",
-                    height: 100,
+    it("passes when no errors are detected", () => {
+        expectPass(pythonProgramWidgetErrorRule, "[[☃ python-program 1]]", {
+            widgets: {
+                "python-program 1": {
+                    options: {
+                        programID: "123",
+                        height: 100,
+                    },
                 },
             },
-        },
+        });
     });
 });

--- a/packages/perseus-linter/src/rules/python-program-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/python-program-widget-error.test.ts
@@ -3,37 +3,40 @@ import {expectPass, expectWarning} from "../__tests__/test-utils";
 import pythonProgramWidgetErrorRule from "./python-program-widget-error";
 
 describe("python-program-widget-error", () => {
-    // Error when no program ID is specified
-    expectWarning(pythonProgramWidgetErrorRule, "[[☃ python-program 1]]", {
-        widgets: {
-            "python-program 1": {
-                options: {
-                    programID: "",
+    it("warns when no program ID is specified", () => {
+        expectWarning(pythonProgramWidgetErrorRule, "[[☃ python-program 1]]", {
+            widgets: {
+                "python-program 1": {
+                    options: {
+                        programID: "",
+                    },
                 },
             },
-        },
+        });
     });
 
-    // Error when the height is not a positive integer (0)
-    expectWarning(pythonProgramWidgetErrorRule, "[[☃ python-program 1]]", {
-        widgets: {
-            "python-program 1": {
-                options: {
-                    height: 0,
+    it("warns when the height is not a positive integer (0)", () => {
+        expectWarning(pythonProgramWidgetErrorRule, "[[☃ python-program 1]]", {
+            widgets: {
+                "python-program 1": {
+                    options: {
+                        height: 0,
+                    },
                 },
             },
-        },
+        });
     });
 
-    // Error when the height is not a positive integer (negative)
-    expectWarning(pythonProgramWidgetErrorRule, "[[☃ python-program 1]]", {
-        widgets: {
-            "python-program 1": {
-                options: {
-                    height: -1,
+    it("warns when the height is not a positive integer (negative)", () => {
+        expectWarning(pythonProgramWidgetErrorRule, "[[☃ python-program 1]]", {
+            widgets: {
+                "python-program 1": {
+                    options: {
+                        height: -1,
+                    },
                 },
             },
-        },
+        });
     });
 
     it("passes when no errors are detected", () => {

--- a/packages/perseus-linter/src/rules/radio-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/radio-widget-error.test.ts
@@ -26,15 +26,16 @@ describe("radio-widget-error", () => {
             },
         });
 
-        // Pass for radio widget with correct choices
-        expectPass(radioWidgetErrorRule, "[[☃ radio 1]]", {
-            widgets: {
-                "radio 1": {
-                    options: {
-                        choices: [{content: "Correct", correct: true}],
+        it("passes for radio widget with correct choices", () => {
+            expectPass(radioWidgetErrorRule, "[[☃ radio 1]]", {
+                widgets: {
+                    "radio 1": {
+                        options: {
+                            choices: [{content: "Correct", correct: true}],
+                        },
                     },
                 },
-            },
+            });
         });
     });
 
@@ -56,38 +57,42 @@ describe("radio-widget-error", () => {
             },
         });
 
-        expectPass(radioWidgetErrorRule, "[[☃ radio 1]]", {
-            widgets: {
-                "radio 1": {
-                    options: {
-                        choices: [
-                            {content: "Correct", correct: true},
-                            {
-                                content: "None Of the Above",
-                                isNoneOfTheAbove: true,
-                                correct: false,
-                            },
-                        ],
+        it("passes when None of the Above is not marked correct alongside another correct choice", () => {
+            expectPass(radioWidgetErrorRule, "[[☃ radio 1]]", {
+                widgets: {
+                    "radio 1": {
+                        options: {
+                            choices: [
+                                {content: "Correct", correct: true},
+                                {
+                                    content: "None Of the Above",
+                                    isNoneOfTheAbove: true,
+                                    correct: false,
+                                },
+                            ],
+                        },
                     },
                 },
-            },
+            });
         });
 
-        expectPass(radioWidgetErrorRule, "[[☃ radio 1]]", {
-            widgets: {
-                "radio 1": {
-                    options: {
-                        choices: [
-                            {content: "Correct", correct: false},
-                            {
-                                content: "None Of the Above",
-                                isNoneOfTheAbove: true,
-                                correct: true,
-                            },
-                        ],
+        it("passes when only None of the Above is marked correct", () => {
+            expectPass(radioWidgetErrorRule, "[[☃ radio 1]]", {
+                widgets: {
+                    "radio 1": {
+                        options: {
+                            choices: [
+                                {content: "Correct", correct: false},
+                                {
+                                    content: "None Of the Above",
+                                    isNoneOfTheAbove: true,
+                                    correct: true,
+                                },
+                            ],
+                        },
                     },
                 },
-            },
+            });
         });
     });
 });

--- a/packages/perseus-linter/src/rules/radio-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/radio-widget-error.test.ts
@@ -4,26 +4,28 @@ import radioWidgetErrorRule from "./radio-widget-error";
 
 describe("radio-widget-error", () => {
     describe("No choice is marked as correct.", () => {
-        // Error for radio widget with no choices
-        expectWarning(radioWidgetErrorRule, "[[☃ radio 1]]", {
-            widgets: {
-                "radio 1": {
-                    options: {
-                        choices: [],
+        it("warns for radio widget with no choices", () => {
+            expectWarning(radioWidgetErrorRule, "[[☃ radio 1]]", {
+                widgets: {
+                    "radio 1": {
+                        options: {
+                            choices: [],
+                        },
                     },
                 },
-            },
+            });
         });
 
-        // Error for radio widget with no correct choices
-        expectWarning(radioWidgetErrorRule, "[[☃ radio 1]]", {
-            widgets: {
-                "radio 1": {
-                    options: {
-                        choices: [{content: "Incorrect", correct: false}],
+        it("warns for radio widget with no correct choices", () => {
+            expectWarning(radioWidgetErrorRule, "[[☃ radio 1]]", {
+                widgets: {
+                    "radio 1": {
+                        options: {
+                            choices: [{content: "Incorrect", correct: false}],
+                        },
                     },
                 },
-            },
+            });
         });
 
         it("passes for radio widget with correct choices", () => {
@@ -40,21 +42,23 @@ describe("radio-widget-error", () => {
     });
 
     describe("Cannot mark both None of the Above and another choice as correct.", () => {
-        expectWarning(radioWidgetErrorRule, "[[☃ radio 1]]", {
-            widgets: {
-                "radio 1": {
-                    options: {
-                        choices: [
-                            {content: "I'm marked correct", correct: true},
-                            {
-                                content: "None Of the Above",
-                                isNoneOfTheAbove: true,
-                                correct: true,
-                            },
-                        ],
+        it("warns when None of the Above is marked correct alongside another correct choice", () => {
+            expectWarning(radioWidgetErrorRule, "[[☃ radio 1]]", {
+                widgets: {
+                    "radio 1": {
+                        options: {
+                            choices: [
+                                {content: "I'm marked correct", correct: true},
+                                {
+                                    content: "None Of the Above",
+                                    isNoneOfTheAbove: true,
+                                    correct: true,
+                                },
+                            ],
+                        },
                     },
                 },
-            },
+            });
         });
 
         it("passes when None of the Above is not marked correct alongside another correct choice", () => {

--- a/packages/perseus-linter/src/rules/table-missing-cells.test.ts
+++ b/packages/perseus-linter/src/rules/table-missing-cells.test.ts
@@ -3,13 +3,15 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import tableMissingCellsRule from "./table-missing-cells";
 
 describe("table-missing-cells", () => {
-    expectWarning(tableMissingCellsRule, [
+    it.each([
         "|col1|col2|col3|\n|----|----|----|\n|col1|col2|col3|\n|cell1|cell2|",
         "|col1|col2|col3|\n|----|----|----|\n|col1|col2|\n|cell1|cell2|",
         "|col1|col2|\n|----|----|\n|cell1|cell2|\n|cell1|cell2|cell3|",
         "|col1|\n|----|----|\n|col1|\n|cell1|cell2|",
         "|col1|col2|\n|----|----|\n|col1|\n|cell1|cell2|",
-    ]);
+    ])("tableMissingCellsRule warns with: %s", (str: string) => {
+        expectWarning(tableMissingCellsRule, str);
+    });
     it.each([
         "|col1|col2|\n|----|----|\n|cell1|cell2|\n|cell1|cell2|",
         "|cell1|\n|----|\n|cell2|\n|cell3|",

--- a/packages/perseus-linter/src/rules/table-missing-cells.test.ts
+++ b/packages/perseus-linter/src/rules/table-missing-cells.test.ts
@@ -10,8 +10,10 @@ describe("table-missing-cells", () => {
         "|col1|\n|----|----|\n|col1|\n|cell1|cell2|",
         "|col1|col2|\n|----|----|\n|col1|\n|cell1|cell2|",
     ]);
-    expectPass(tableMissingCellsRule, [
+    it.each([
         "|col1|col2|\n|----|----|\n|cell1|cell2|\n|cell1|cell2|",
         "|cell1|\n|----|\n|cell2|\n|cell3|",
-    ]);
+    ])("tableMissingCellsRule passes with: %s", (str: string) => {
+        expectPass(tableMissingCellsRule, str);
+    });
 });

--- a/packages/perseus-linter/src/rules/table-missing-cells.test.ts
+++ b/packages/perseus-linter/src/rules/table-missing-cells.test.ts
@@ -12,6 +12,7 @@ describe("table-missing-cells", () => {
     ])("tableMissingCellsRule warns with: %s", (str: string) => {
         expectWarning(tableMissingCellsRule, str);
     });
+
     it.each([
         "|col1|col2|\n|----|----|\n|cell1|cell2|\n|cell1|cell2|",
         "|cell1|\n|----|\n|cell2|\n|cell3|",

--- a/packages/perseus-linter/src/rules/unbalanced-code-delimiters.test.ts
+++ b/packages/perseus-linter/src/rules/unbalanced-code-delimiters.test.ts
@@ -9,7 +9,7 @@ describe("unbalanced-code-delimiters", () => {
         "```code\n",
         "~~~\ncode\n~~",
     ]);
-    expectPass(unbalancedCodeDelimitersRule, [
+    it.each([
         "`code`",
         "``code``",
         "```code```",
@@ -18,5 +18,7 @@ describe("unbalanced-code-delimiters", () => {
         "``co`de``",
         "`co~de`",
         "$`~$",
-    ]);
+    ])("unbalancedCodeDelimitersRule passes with: %s", (str: string) => {
+        expectPass(unbalancedCodeDelimitersRule, str);
+    });
 });

--- a/packages/perseus-linter/src/rules/unbalanced-code-delimiters.test.ts
+++ b/packages/perseus-linter/src/rules/unbalanced-code-delimiters.test.ts
@@ -3,12 +3,12 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import unbalancedCodeDelimitersRule from "./unbalanced-code-delimiters";
 
 describe("unbalanced-code-delimiters", () => {
-    expectWarning(unbalancedCodeDelimitersRule, [
-        "`code``",
-        "``code```",
-        "```code\n",
-        "~~~\ncode\n~~",
-    ]);
+    it.each(["`code``", "``code```", "```code\n", "~~~\ncode\n~~"])(
+        "unbalancedCodeDelimitersRule warns with: %s",
+        (str: string) => {
+            expectWarning(unbalancedCodeDelimitersRule, str);
+        },
+    );
     it.each([
         "`code`",
         "``code``",

--- a/packages/perseus-linter/src/rules/unbalanced-code-delimiters.test.ts
+++ b/packages/perseus-linter/src/rules/unbalanced-code-delimiters.test.ts
@@ -9,6 +9,7 @@ describe("unbalanced-code-delimiters", () => {
             expectWarning(unbalancedCodeDelimitersRule, str);
         },
     );
+
     it.each([
         "`code`",
         "``code``",

--- a/packages/perseus-linter/src/rules/unescaped-dollar.test.ts
+++ b/packages/perseus-linter/src/rules/unescaped-dollar.test.ts
@@ -3,7 +3,12 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import unescapedDollarRule from "./unescaped-dollar";
 
 describe("unescaped-dollar", () => {
-    expectWarning(unescapedDollarRule, ["It costs $10", "It costs $$10$"]);
+    it.each(["It costs $10", "It costs $$10$"])(
+        "unescapedDollarRule warns with: %s",
+        (str: string) => {
+            expectWarning(unescapedDollarRule, str);
+        },
+    );
 
     it.each(["It costs \\$10", "It costs $10x$"])(
         "unescapedDollarRule passes with: %s",

--- a/packages/perseus-linter/src/rules/unescaped-dollar.test.ts
+++ b/packages/perseus-linter/src/rules/unescaped-dollar.test.ts
@@ -5,5 +5,10 @@ import unescapedDollarRule from "./unescaped-dollar";
 describe("unescaped-dollar", () => {
     expectWarning(unescapedDollarRule, ["It costs $10", "It costs $$10$"]);
 
-    expectPass(unescapedDollarRule, ["It costs \\$10", "It costs $10x$"]);
+    it.each(["It costs \\$10", "It costs $10x$"])(
+        "unescapedDollarRule passes with: %s",
+        (str: string) => {
+            expectPass(unescapedDollarRule, str);
+        },
+    );
 });

--- a/packages/perseus-linter/src/rules/widget-in-table.test.ts
+++ b/packages/perseus-linter/src/rules/widget-in-table.test.ts
@@ -3,17 +3,17 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import widgetInTableRule from "./widget-in-table";
 
 describe("widget-in-table", () => {
-    it.each(["|col1|col2|\n|----|----|\n|[[☃ image 1]]|cell2|"])(
-        "widgetInTableRule warns with: %s",
-        (str: string) => {
-            expectWarning(widgetInTableRule, str);
-        },
-    );
+    it("warns when a widget is inside a table", () => {
+        expectWarning(
+            widgetInTableRule,
+            "|col1|col2|\n|----|----|\n|[[☃ image 1]]|cell2|",
+        );
+    });
 
-    it.each(["[[☃ image 1]]\n|col1|col2|\n|----|----|\n|cell1|cell2|"])(
-        "widgetInTableRule passes with: %s",
-        (str: string) => {
-            expectPass(widgetInTableRule, str);
-        },
-    );
+    it("passes when a widget is outside a table", () => {
+        expectPass(
+            widgetInTableRule,
+            "[[☃ image 1]]\n|col1|col2|\n|----|----|\n|cell1|cell2|",
+        );
+    });
 });

--- a/packages/perseus-linter/src/rules/widget-in-table.test.ts
+++ b/packages/perseus-linter/src/rules/widget-in-table.test.ts
@@ -3,9 +3,12 @@ import {expectWarning, expectPass} from "../__tests__/test-utils";
 import widgetInTableRule from "./widget-in-table";
 
 describe("widget-in-table", () => {
-    expectWarning(widgetInTableRule, [
-        "|col1|col2|\n|----|----|\n|[[☃ image 1]]|cell2|",
-    ]);
+    it.each(["|col1|col2|\n|----|----|\n|[[☃ image 1]]|cell2|"])(
+        "widgetInTableRule warns with: %s",
+        (str: string) => {
+            expectWarning(widgetInTableRule, str);
+        },
+    );
     it.each(["[[☃ image 1]]\n|col1|col2|\n|----|----|\n|cell1|cell2|"])(
         "widgetInTableRule passes with: %s",
         (str: string) => {

--- a/packages/perseus-linter/src/rules/widget-in-table.test.ts
+++ b/packages/perseus-linter/src/rules/widget-in-table.test.ts
@@ -9,6 +9,7 @@ describe("widget-in-table", () => {
             expectWarning(widgetInTableRule, str);
         },
     );
+
     it.each(["[[☃ image 1]]\n|col1|col2|\n|----|----|\n|cell1|cell2|"])(
         "widgetInTableRule passes with: %s",
         (str: string) => {

--- a/packages/perseus-linter/src/rules/widget-in-table.test.ts
+++ b/packages/perseus-linter/src/rules/widget-in-table.test.ts
@@ -6,7 +6,10 @@ describe("widget-in-table", () => {
     expectWarning(widgetInTableRule, [
         "|col1|col2|\n|----|----|\n|[[☃ image 1]]|cell2|",
     ]);
-    expectPass(widgetInTableRule, [
-        "[[☃ image 1]]\n|col1|col2|\n|----|----|\n|cell1|cell2|",
-    ]);
+    it.each(["[[☃ image 1]]\n|col1|col2|\n|----|----|\n|cell1|cell2|"])(
+        "widgetInTableRule passes with: %s",
+        (str: string) => {
+            expectPass(widgetInTableRule, str);
+        },
+    );
 });


### PR DESCRIPTION
## Summary:
See the ticket for more detail, but the goal is just to remove `it` from `expectWarning` and `expectPass` for more idiomatic Jest tests and also to make test names read easier.

**Highly recommended to "Hide whitespace" when reviewing this PR.**

This PR ideally will not contain any functional changes besides pulling `it` blocks (and array support) from `expectWarning` and `expectPass` and wrapping tests in `it` blocks (or `it.each` blocks if data is an array).

Issue: LEMS-4140