### PR TITLE
[Interactive Graph] Re-order graph instructions so screen readers hear them first

### DIFF
--- a/.changeset/ninety-brooms-type.md
+++ b/.changeset/ninety-brooms-type.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Re-order graph instructions so screen readers hear them first

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/a11y.mdx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/a11y.mdx
@@ -18,6 +18,7 @@ The Interactive Graph widget is designed to be accessible for all users, includi
 -   The widget provides ARIA labels and descriptions via the `fullGraphAriaLabel` and `fullGraphAriaDescription` props.
 -   Graph elements are described for screen readers, including coordinates and types of shapes.
 -   Equation strings and graph state can be programmatically accessed and announced.
+-   Keyboard instructions are intentionally ordered first—both as the first sr-only child of the graph figure and first in the figure's `aria-describedby`—so screen reader users hear how to interact with the graph before its description and interactive-element descriptions.
 
 ## Visible Labels and Markings
 

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -1094,24 +1094,24 @@ exports[`Interactive Graph question Should render blank predictably: first rende
             class="default_7zhre1 mafs-graph-container"
           >
             <div
-              aria-describedby="interactive-graph-interactive-elements-description-:r2: instructions-:r2:"
+              aria-describedby="instructions-:r2: interactive-graph-interactive-elements-description-:r2:"
               class="default_7zhre1-o_O-inlineStyles_11rziql mafs-graph"
               role="figure"
               tabindex="0"
             >
               <div
                 class="default_7zhre1 mafs-sr-only"
-                id="interactive-graph-interactive-elements-description-:r2:"
-                tabindex="-1"
-              >
-                Interactive elements: A polygon with 3 points. 
-              </div>
-              <div
-                class="default_7zhre1 mafs-sr-only"
                 id="instructions-:r2:"
                 tabindex="-1"
               >
                 Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it.
+              </div>
+              <div
+                class="default_7zhre1 mafs-sr-only"
+                id="interactive-graph-interactive-elements-description-:r2:"
+                tabindex="-1"
+              >
+                Interactive elements: A polygon with 3 points. 
               </div>
               <div
                 class="default_7zhre1-o_O-inlineStyles_16155wj"
@@ -1527,24 +1527,24 @@ exports[`Interactive Graph question Should render blank predictably: first rende
             class="default_7zhre1 mafs-graph-container"
           >
             <div
-              aria-describedby="interactive-graph-interactive-elements-description-:rc: instructions-:rc:"
+              aria-describedby="instructions-:rc: interactive-graph-interactive-elements-description-:rc:"
               class="default_7zhre1-o_O-inlineStyles_11rziql mafs-graph"
               role="figure"
               tabindex="0"
             >
               <div
                 class="default_7zhre1 mafs-sr-only"
-                id="interactive-graph-interactive-elements-description-:rc:"
-                tabindex="-1"
-              >
-                Interactive elements: A polygon with 3 points. 
-              </div>
-              <div
-                class="default_7zhre1 mafs-sr-only"
                 id="instructions-:rc:"
                 tabindex="-1"
               >
                 Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it.
+              </div>
+              <div
+                class="default_7zhre1 mafs-sr-only"
+                id="interactive-graph-interactive-elements-description-:rc:"
+                tabindex="-1"
+              >
+                Interactive elements: A polygon with 3 points. 
               </div>
               <div
                 class="default_7zhre1-o_O-inlineStyles_16155wj"
@@ -1966,24 +1966,24 @@ exports[`Interactive Graph question Should render blank predictably: first rende
             class="default_7zhre1 mafs-graph-container"
           >
             <div
-              aria-describedby="interactive-graph-interactive-elements-description-:rl: unlimited-graph-keyboard-prompt-:rl: instructions-:rl:"
+              aria-describedby="instructions-:rl: interactive-graph-interactive-elements-description-:rl: unlimited-graph-keyboard-prompt-:rl:"
               class="default_7zhre1-o_O-inlineStyles_11rziql mafs-graph"
               role="figure"
               tabindex="0"
             >
               <div
                 class="default_7zhre1 mafs-sr-only"
-                id="interactive-graph-interactive-elements-description-:rl:"
-                tabindex="-1"
-              >
-                No interactive elements
-              </div>
-              <div
-                class="default_7zhre1 mafs-sr-only"
                 id="instructions-:rl:"
                 tabindex="-1"
               >
                 Press Shift + Enter to interact with the graph. Use the Tab key to move through the interactive elements in the graph and access the graph Action Bar. When an interactive element has focus, use Control + Shift + Arrows to move it or use the Delete key to remove it from the graph. Use the buttons in the Action Bar to add or adjust elements within the graph.
+              </div>
+              <div
+                class="default_7zhre1 mafs-sr-only"
+                id="interactive-graph-interactive-elements-description-:rl:"
+                tabindex="-1"
+              >
+                No interactive elements
               </div>
               <div
                 class="default_7zhre1-o_O-inlineStyles_16155wj"
@@ -2217,7 +2217,7 @@ exports[`Interactive Graph question Should render blank predictably: first rende
             class="default_7zhre1 mafs-graph-container"
           >
             <div
-              aria-describedby="unlimited-graph-keyboard-prompt-:rr: instructions-:rr:"
+              aria-describedby="instructions-:rr: unlimited-graph-keyboard-prompt-:rr:"
               class="default_7zhre1-o_O-inlineStyles_11rziql mafs-graph"
               role="figure"
               tabindex="0"
@@ -2446,24 +2446,24 @@ exports[`Interactive Graph question Should render user input predictably: with u
             class="default_7zhre1 mafs-graph-container"
           >
             <div
-              aria-describedby="interactive-graph-interactive-elements-description-:r4: instructions-:r4:"
+              aria-describedby="instructions-:r4: interactive-graph-interactive-elements-description-:r4:"
               class="default_7zhre1-o_O-inlineStyles_11rziql mafs-graph"
               role="figure"
               tabindex="0"
             >
               <div
                 class="default_7zhre1 mafs-sr-only"
-                id="interactive-graph-interactive-elements-description-:r4:"
-                tabindex="-1"
-              >
-                Interactive elements: A polygon with 3 points. 
-              </div>
-              <div
-                class="default_7zhre1 mafs-sr-only"
                 id="instructions-:r4:"
                 tabindex="-1"
               >
                 Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it.
+              </div>
+              <div
+                class="default_7zhre1 mafs-sr-only"
+                id="interactive-graph-interactive-elements-description-:r4:"
+                tabindex="-1"
+              >
+                Interactive elements: A polygon with 3 points. 
               </div>
               <div
                 class="default_7zhre1-o_O-inlineStyles_16155wj"
@@ -2852,24 +2852,24 @@ exports[`Interactive Graph question Should render user input predictably: with u
             class="default_7zhre1 mafs-graph-container"
           >
             <div
-              aria-describedby="interactive-graph-interactive-elements-description-:re: instructions-:re:"
+              aria-describedby="instructions-:re: interactive-graph-interactive-elements-description-:re:"
               class="default_7zhre1-o_O-inlineStyles_11rziql mafs-graph"
               role="figure"
               tabindex="0"
             >
               <div
                 class="default_7zhre1 mafs-sr-only"
-                id="interactive-graph-interactive-elements-description-:re:"
-                tabindex="-1"
-              >
-                Interactive elements: A polygon with 3 points. 
-              </div>
-              <div
-                class="default_7zhre1 mafs-sr-only"
                 id="instructions-:re:"
                 tabindex="-1"
               >
                 Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it.
+              </div>
+              <div
+                class="default_7zhre1 mafs-sr-only"
+                id="interactive-graph-interactive-elements-description-:re:"
+                tabindex="-1"
+              >
+                Interactive elements: A polygon with 3 points. 
               </div>
               <div
                 class="default_7zhre1-o_O-inlineStyles_16155wj"
@@ -3291,24 +3291,24 @@ exports[`Interactive Graph question Should render user input predictably: with u
             class="default_7zhre1 mafs-graph-container"
           >
             <div
-              aria-describedby="interactive-graph-interactive-elements-description-:rm: instructions-:rm:"
+              aria-describedby="instructions-:rm: interactive-graph-interactive-elements-description-:rm:"
               class="default_7zhre1-o_O-inlineStyles_11rziql mafs-graph"
               role="figure"
               tabindex="0"
             >
               <div
                 class="default_7zhre1 mafs-sr-only"
-                id="interactive-graph-interactive-elements-description-:rm:"
-                tabindex="-1"
-              >
-                Interactive elements: Point 1 at 0 comma 0. Point 2 at -2.5 comma 0. Point 3 at -1 comma 0.
-              </div>
-              <div
-                class="default_7zhre1 mafs-sr-only"
                 id="instructions-:rm:"
                 tabindex="-1"
               >
                 Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it.
+              </div>
+              <div
+                class="default_7zhre1 mafs-sr-only"
+                id="interactive-graph-interactive-elements-description-:rm:"
+                tabindex="-1"
+              >
+                Interactive elements: Point 1 at 0 comma 0. Point 2 at -2.5 comma 0. Point 3 at -1 comma 0.
               </div>
               <div
                 class="default_7zhre1-o_O-inlineStyles_16155wj"
@@ -3646,24 +3646,24 @@ exports[`Interactive Graph question Should render user input predictably: with u
             class="default_7zhre1 mafs-graph-container"
           >
             <div
-              aria-describedby="interactive-graph-interactive-elements-description-:rt: instructions-:rt:"
+              aria-describedby="instructions-:rt: interactive-graph-interactive-elements-description-:rt:"
               class="default_7zhre1-o_O-inlineStyles_11rziql mafs-graph"
               role="figure"
               tabindex="0"
             >
               <div
                 class="default_7zhre1 mafs-sr-only"
-                id="interactive-graph-interactive-elements-description-:rt:"
-                tabindex="-1"
-              >
-                Interactive elements: A polygon with 4 points. 
-              </div>
-              <div
-                class="default_7zhre1 mafs-sr-only"
                 id="instructions-:rt:"
                 tabindex="-1"
               >
                 Use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Control + Shift + Arrows to move it.
+              </div>
+              <div
+                class="default_7zhre1 mafs-sr-only"
+                id="interactive-graph-interactive-elements-description-:rt:"
+                tabindex="-1"
+              >
+                Interactive elements: A polygon with 4 points. 
               </div>
               <div
                 class="default_7zhre1-o_O-inlineStyles_16155wj"

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -954,7 +954,7 @@ describe("MafsGraph", () => {
             ],
         };
 
-        it("renders the instructions as the first sr-only child of the figure", () => {
+        it("renders the instructions before the graph description so screen readers encounter them first", () => {
             // Arrange, Act
             render(
                 <MafsGraph
@@ -966,15 +966,23 @@ describe("MafsGraph", () => {
             );
 
             // Assert
-            const figure = screen.getByRole("figure");
-            // eslint-disable-next-line testing-library/no-node-access
-            const srOnlyChildren = figure.querySelectorAll(
-                ":scope > .mafs-sr-only",
+            const instructions = screen.getByText(
+                /^Use the Tab key to move through/,
             );
-            expect(srOnlyChildren[0].id).toMatch(/^instructions-/);
+            const description = screen.getByText("A graph description.");
+
+            // The instructions block must come before the description in the
+            // DOM so a screen reader reading the figure's contents in order
+            // hears how to interact with the graph before the graph
+            // description. If this fails, the instructions are rendered after
+            // the description.
+            // eslint-disable-next-line testing-library/no-node-access
+            expect(description.compareDocumentPosition(instructions)).toBe(
+                Node.DOCUMENT_POSITION_PRECEDING,
+            );
         });
 
-        it("lists the instructions first in aria-describedby so they are read first on focus", () => {
+        it("orders aria-describedby as instructions, then graph description, then element details", () => {
             // Arrange, Act
             render(
                 <MafsGraph
@@ -989,7 +997,32 @@ describe("MafsGraph", () => {
             const figure = screen.getByRole("figure");
             const describedByIds =
                 figure.getAttribute("aria-describedby")?.split(" ") ?? [];
-            expect(describedByIds[0]).toMatch(/^instructions-/);
+
+            // Screen readers announce these in order, so the sequence itself is
+            // the behavior under test: how-to-interact first, then the graph
+            // description, then the interactive-element details.
+            const order = describedByIds.map((id) => {
+                if (id.startsWith("instructions-")) {
+                    return "instructions";
+                }
+                // Check the more specific prefix before the description prefix.
+                if (
+                    id.startsWith(
+                        "interactive-graph-interactive-elements-description-",
+                    )
+                ) {
+                    return "element-details";
+                }
+                if (id.startsWith("interactive-graph-description-")) {
+                    return "description";
+                }
+                return id;
+            });
+            expect(order).toEqual([
+                "instructions",
+                "description",
+                "element-details",
+            ]);
         });
     });
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -937,6 +937,62 @@ describe("MafsGraph", () => {
         expect(state.coords).toEqual(expectedCoords);
     });
 
+    describe("screen reader instructions ordering", () => {
+        const orderingState: InteractiveGraphState = {
+            type: "segment",
+            hasBeenInteractedWith: true,
+            range: [
+                [-10, 10],
+                [-10, 10],
+            ],
+            snapStep: [0.5, 0.5],
+            coords: [
+                [
+                    [0, 0],
+                    [-7, 0.5],
+                ],
+            ],
+        };
+
+        it("renders the instructions as the first sr-only child of the figure", () => {
+            // Arrange, Act
+            render(
+                <MafsGraph
+                    {...baseMafsProps}
+                    state={orderingState}
+                    fullGraphAriaDescription="A graph description."
+                    dispatch={() => {}}
+                />,
+            );
+
+            // Assert
+            const figure = screen.getByRole("figure");
+            // eslint-disable-next-line testing-library/no-node-access
+            const srOnlyChildren = figure.querySelectorAll(
+                ":scope > .mafs-sr-only",
+            );
+            expect(srOnlyChildren[0].id).toMatch(/^instructions-/);
+        });
+
+        it("lists the instructions first in aria-describedby so they are read first on focus", () => {
+            // Arrange, Act
+            render(
+                <MafsGraph
+                    {...baseMafsProps}
+                    state={orderingState}
+                    fullGraphAriaDescription="A graph description."
+                    dispatch={() => {}}
+                />,
+            );
+
+            // Assert
+            const figure = screen.getByRole("figure");
+            const describedByIds =
+                figure.getAttribute("aria-describedby")?.split(" ") ?? [];
+            expect(describedByIds[0]).toMatch(/^instructions-/);
+        });
+    });
+
     describe("with an unlimited graph", () => {
         it("point - shows a remove point button when a point is focused", async () => {
             // Arrange

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -247,7 +247,6 @@ export const MafsGraph = (props: MafsGraphProps) => {
                     aria-describedby={describedByIds(
                         // Instructions read first on focus so screen reader
                         // users hear how to interact before the descriptions
-                        // (LEMS-4121).
                         state.type !== "none" &&
                             !disableInteraction &&
                             instructionsId,
@@ -270,7 +269,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                     {/*
                       Instructions render first so screen reader users
                       encounter how to interact with the graph before the
-                      graph and interactive-element descriptions (LEMS-4121).
+                      graph and interactive-element descriptions
                     */}
                     {state.type !== "none" && (
                         <View

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -245,15 +245,18 @@ export const MafsGraph = (props: MafsGraphProps) => {
                     }}
                     aria-label={fullGraphAriaLabel}
                     aria-describedby={describedByIds(
+                        // Instructions read first on focus so screen reader
+                        // users hear how to interact before the descriptions
+                        // (LEMS-4121).
+                        state.type !== "none" &&
+                            !disableInteraction &&
+                            instructionsId,
                         fullGraphAriaDescription && descriptionId,
                         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
                         interactiveElementsDescription &&
                             interactiveElementsDescriptionId,
                         isUnlimitedGraphState(state) &&
                             unlimitedGraphKeyboardPromptId,
-                        state.type !== "none" &&
-                            !disableInteraction &&
-                            instructionsId,
                     )}
                     ref={graphRef}
                     tabIndex={0}
@@ -264,6 +267,22 @@ export const MafsGraph = (props: MafsGraphProps) => {
                         handleBlurEvent(event, state, dispatch);
                     }}
                 >
+                    {/*
+                      Instructions render first so screen reader users
+                      encounter how to interact with the graph before the
+                      graph and interactive-element descriptions (LEMS-4121).
+                    */}
+                    {state.type !== "none" && (
+                        <View
+                            id={instructionsId}
+                            tabIndex={-1}
+                            className="mafs-sr-only"
+                        >
+                            {isUnlimitedGraphState(state)
+                                ? strings.srUnlimitedGraphInstructions
+                                : strings.srGraphInstructions}
+                        </View>
+                    )}
                     {fullGraphAriaDescription && (
                         <View
                             id={descriptionId}
@@ -283,17 +302,6 @@ export const MafsGraph = (props: MafsGraphProps) => {
                             className="mafs-sr-only"
                         >
                             {interactiveElementsDescription}
-                        </View>
-                    )}
-                    {state.type !== "none" && (
-                        <View
-                            id={instructionsId}
-                            tabIndex={-1}
-                            className="mafs-sr-only"
-                        >
-                            {isUnlimitedGraphState(state)
-                                ? strings.srUnlimitedGraphInstructions
-                                : strings.srGraphInstructions}
                         </View>
                     )}
 


### PR DESCRIPTION
## Summary:
The interactive-graph wrapper (`<View role="figure">`) exposes three screen-reader-only descriptions: the keyboard **instructions**, the graph **description** (`fullGraphAriaDescription`), and the **interactive-elements** description. Until now the instructions came *last* — both in DOM order and in the figure's `aria-describedby` — so a screen reader user heard the graph and element descriptions before learning how to interact with the graph.

Issue: LEMS-4121

## Test plan:
- Confirm the screen reader reads in the order: instructions → description → interactiveElements