### PR TITLE
[Preview NG] Add exercise content variant to typed preview protocol

### DIFF
--- a/.changeset/friendly-lemons-destroy.md
+++ b/.changeset/friendly-lemons-destroy.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Add an `"exercise"` variant to the typed preview protocol (`ExercisePreviewData`: `{item, apiOptions, showRationales}`) so the interactive exercise preview can move onto the new hook-based message passing. Purely additive — the existing content variants and hooks are unchanged.

--- a/packages/perseus-editor/src/preview/message-types.ts
+++ b/packages/perseus-editor/src/preview/message-types.ts
@@ -4,7 +4,11 @@
  */
 
 import type {SerializableApiOptions} from "./sanitize-api-options";
-import type {Hint, PerseusRenderer} from "@khanacademy/perseus-core";
+import type {
+    Hint,
+    PerseusItem,
+    PerseusRenderer,
+} from "@khanacademy/perseus-core";
 
 /**
  * The subset of `LinterContextProps` that's meaningful to send across the
@@ -75,13 +79,30 @@ export type ArticleAllPreviewData = {
 };
 
 /**
+ * Data for the interactive exercise preview (drives the exercise editor's
+ * "Preview" tab in khan/frontend).
+ *
+ * Unlike the read-only `question` preview, this signals the iframe to mount the
+ * full interactive `ExercisePreview` component (hint controls, answer checking,
+ * scoring) rather than a `ServerItemRenderer`. All of that interactivity lives
+ * inside the iframe — the parent only sends these fields and never observes or
+ * controls the exercise state.
+ */
+export type ExercisePreviewData = {
+    item: PerseusItem;
+    apiOptions: SerializableApiOptions;
+    showRationales: boolean;
+};
+
+/**
  * Union of all preview content types
  */
 export type PreviewContent =
     | {type: "question"; data: QuestionPreviewData}
     | {type: "hint"; data: HintPreviewData}
     | {type: "article-section"; data: ArticleSectionPreviewData}
-    | {type: "article-all"; data: ArticleAllPreviewData};
+    | {type: "article-all"; data: ArticleAllPreviewData}
+    | {type: "exercise"; data: ExercisePreviewData};
 
 // ---- Parent → Iframe messages ----
 

--- a/packages/perseus-editor/src/preview/message-validators.test.ts
+++ b/packages/perseus-editor/src/preview/message-validators.test.ts
@@ -112,6 +112,23 @@ describe("message-validators", () => {
             expect(isParentToIframeMessage(message)).toBe(true);
         });
 
+        it("returns true for valid exercise content-data message", () => {
+            const message = {
+                source: PREVIEW_MESSAGE_SOURCE,
+                type: "content-data" as const,
+                content: {
+                    type: "exercise" as const,
+                    data: {
+                        item: {question: {content: "test"}},
+                        apiOptions: {},
+                        showRationales: true,
+                    },
+                },
+            };
+
+            expect(isParentToIframeMessage(message)).toBe(true);
+        });
+
         it("returns false for null", () => {
             expect(isParentToIframeMessage(null)).toBe(false);
         });

--- a/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
+++ b/packages/perseus-editor/src/preview/preview-data-sanitizer.test.ts
@@ -1,3 +1,4 @@
+import {getDefaultAnswerArea} from "@khanacademy/perseus-core";
 import invariant from "tiny-invariant";
 
 import {sanitizePreviewData} from "./preview-data-sanitizer";
@@ -5,6 +6,7 @@ import {sanitizePreviewData} from "./preview-data-sanitizer";
 import type {
     ArticleAllPreviewData,
     ArticleSectionPreviewData,
+    ExercisePreviewData,
     HintPreviewData,
     PreviewContent,
     QuestionPreviewData,
@@ -297,6 +299,66 @@ describe("sanitizePreviewData", () => {
         });
     });
 
+    describe("exercise preview data", () => {
+        it("sanitizes apiOptions in exercise data", () => {
+            const exerciseData: ExercisePreviewData = {
+                item: {
+                    question: {
+                        content: "What is 2+2?",
+                        widgets: {},
+                        images: {},
+                    },
+                    answerArea: getDefaultAnswerArea(),
+                    hints: [],
+                },
+                apiOptions: createMockApiOptions(),
+                showRationales: true,
+            };
+
+            const previewContent: PreviewContent = {
+                type: "exercise",
+                data: exerciseData,
+            };
+
+            const result = sanitizePreviewData(previewContent);
+
+            invariant(result.type === "exercise");
+            // Serializable options should remain
+            expect(result.data.apiOptions.readOnly).toBe(true);
+
+            // Non-serializable functions should be removed
+            expect("onFocusChange" in result.data.apiOptions).toBe(false);
+            expect("trackInteraction" in result.data.apiOptions).toBe(false);
+
+            // Other properties should remain unchanged
+            expect(result.data.item).toBe(exerciseData.item);
+            expect(result.data.showRationales).toBe(true);
+        });
+
+        it("handles exercise data with null apiOptions", () => {
+            const exerciseData: ExercisePreviewData = {
+                item: {
+                    question: {content: "Test", widgets: {}, images: {}},
+                    answerArea: getDefaultAnswerArea(),
+                    hints: [],
+                },
+                // eslint-disable-next-line no-restricted-syntax
+                apiOptions: null as any,
+                showRationales: false,
+            };
+
+            const previewContent: PreviewContent = {
+                type: "exercise",
+                data: exerciseData,
+            };
+
+            const result = sanitizePreviewData(previewContent);
+
+            // Should return unchanged when apiOptions is null
+            expect(result).toEqual(previewContent);
+        });
+    });
+
     describe("edge cases", () => {
         it("preserves data structure for all content types", () => {
             const types: PreviewContent["type"][] = [
@@ -304,6 +366,7 @@ describe("sanitizePreviewData", () => {
                 "hint",
                 "article-section",
                 "article-all",
+                "exercise",
             ];
 
             types.forEach((type) => {
@@ -370,6 +433,24 @@ describe("sanitizePreviewData", () => {
                                     },
                                 ],
                                 apiOptions: {},
+                            },
+                        };
+                        break;
+                    case "exercise":
+                        previewContent = {
+                            type: "exercise",
+                            data: {
+                                item: {
+                                    question: {
+                                        content: "Q",
+                                        widgets: {},
+                                        images: {},
+                                    },
+                                    answerArea: getDefaultAnswerArea(),
+                                    hints: [],
+                                },
+                                apiOptions: {},
+                                showRationales: false,
                             },
                         };
                         break;

--- a/packages/perseus-editor/src/preview/preview-data-sanitizer.ts
+++ b/packages/perseus-editor/src/preview/preview-data-sanitizer.ts
@@ -55,6 +55,14 @@ export function sanitizePreviewData(
                     apiOptions: sanitizedApiOptions,
                 },
             };
+        case "exercise":
+            return {
+                type: content.type,
+                data: {
+                    ...content.data,
+                    apiOptions: sanitizedApiOptions,
+                },
+            };
         default:
             throw new UnreachableCaseError(content);
     }


### PR DESCRIPTION
## Summary:

Adds an `"exercise"` variant to the typed preview protocol to support the full-exercise preview view.

Note that there is no preview rendering of this new type as that is (and will continue to be) handled by the consuming apps. This just plumbs the value through for use. 

Issue: LEMS-3741

## Test plan:

- `pnpm test`
- `pnpm tsc`