### PR TITLE
[Preview NG] Export PreviewContent and PreviewWithIframe from perseus-editor

### DIFF
--- a/.changeset/thirty-pumpkins-sleep.md
+++ b/.changeset/thirty-pumpkins-sleep.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Export PreviewContent type and PreviewWithIframe component

--- a/.changeset/weak-horses-fetch.md
+++ b/.changeset/weak-horses-fetch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Export `PreviewContent` and `PreviewWithIframe` from `@khanacademy/perseus-editor` so the Frontend can drive the typed preview protocol. Purely additive — both symbols already existed internally; this only adds them to the package's public entry point.

--- a/packages/perseus-editor/src/index.ts
+++ b/packages/perseus-editor/src/index.ts
@@ -14,6 +14,8 @@ export type {Issue} from "./components/issues-panel";
 // Preview system hooks and utilities
 export {usePreviewController} from "./preview/use-preview-controller";
 export {usePreviewPresenter} from "./preview/use-preview-presenter";
+export {default as PreviewWithIframe} from "./preview-with-iframe";
+export type {PreviewContent} from "./preview/message-types";
 
 import "./styles/perseus-editor.css";
 


### PR DESCRIPTION
## Summary

Exports two symbols from `@khanacademy/perseus-editor` that are needed by consumers: 

  * `PreviewWithIframe` — the component that hosts the preview iframe and the parent↔iframe message bridge.
  * `PreviewContent` — the discriminated-union type describing what a preview renders (question, hint, article-section, article-all, exercise).

Both already lived in the package; this just adds them to the public entry point (src/index.ts). No behavior change.

Issue: LEMS-3741 

## Test plan

  * `pnpm typecheck` passes — the new re-exports resolve.
  * No runtime change; nothing to exercise manually.