### PR TITLE
Fix Safari freeze when positioning graphie labels during font loading

### DIFF
--- a/.changeset/lucky-pianos-wave.md
+++ b/.changeset/lucky-pianos-wave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix a Safari hard-freeze when rendering graphie images with TeX labels: graphie label positioning now waits for `document.fonts.ready` at most once instead of re-checking `document.fonts.status`, which Safari can leave at "loading" while `ready` is already resolved (WebKit bugs 174030, 225790), causing an infinite microtask loop

--- a/packages/perseus/src/util/graphie.test.ts
+++ b/packages/perseus/src/util/graphie.test.ts
@@ -1059,6 +1059,51 @@ describe("Graphie drawing tools", () => {
             expect($span[0].style.padding).toBe("7px");
         });
 
+        describe("when fonts are loading", () => {
+            afterEach(() => {
+                Reflect.deleteProperty(document, "fonts");
+            });
+
+            it("applies label margins after fonts.ready resolves even when fonts.status remains 'loading'", async () => {
+                // Arrange: simulate Safari (WebKit bugs 174030, 225790),
+                // where fonts.ready can already be resolved while
+                // fonts.status still reports "loading". Re-checking the
+                // status after awaiting ready would loop forever.
+                let readyReads = 0;
+                Object.defineProperty(document, "fonts", {
+                    configurable: true,
+                    value: {
+                        status: "loading",
+                        get ready() {
+                            readyReads++;
+                            return Promise.resolve();
+                        },
+                    },
+                });
+                jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+                    testDependencies,
+                );
+                const graphie = createAndInitGraphie();
+
+                // Act
+                const $span = graphie.label(
+                    [0, 0],
+                    "this is the text",
+                    "center",
+                    false,
+                );
+                // Margins are deferred until fonts.ready resolves.
+                expect($span[0].style.marginLeft).toBe("");
+                // Flush microtasks so the fonts.ready callback runs.
+                await Promise.resolve();
+                await Promise.resolve();
+
+                // Assert
+                expect($span[0].style.marginLeft).not.toBe("");
+                expect(readyReads).toBe(1);
+            });
+        });
+
         it("resets the padding to the default after each call", () => {
             jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
                 testDependencies,

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1702,11 +1702,19 @@ const SVG_SPECIFIC_STYLE_MASK = {
 const setLabelMargins = function (span: HTMLElement, size: Coord): void {
     // Wait for fonts to load before setting label margins,
     // so that the margins are not flakey.
+    // We wait at most once and then apply the margins unconditionally:
+    // Safari can report fonts.status === "loading" while fonts.ready is
+    // already resolved (WebKit bugs 174030, 225790), so re-checking the
+    // status after the wait would re-queue on a resolved promise forever —
+    // an infinite microtask loop that hard-freezes the tab.
     if (document.fonts?.status === "loading") {
-        document.fonts.ready.then(() => setLabelMargins(span, size));
+        document.fonts.ready.then(() => applyLabelMargins(span, size));
         return;
     }
+    applyLabelMargins(span, size);
+};
 
+const applyLabelMargins = function (span: HTMLElement, size: Coord): void {
     const $span = $(span);
     const direction = $span.data("labelDirection");
     let [width, height] = size;

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -1702,7 +1702,7 @@ const SVG_SPECIFIC_STYLE_MASK = {
 const setLabelMargins = function (span: HTMLElement, size: Coord): void {
     // Wait for fonts to load before setting label margins,
     // so that the margins are not flakey.
-    // We wait at most once and then apply the margins unconditionally:
+    // We wait only once and then apply the margins unconditionally:
     // Safari can report fonts.status === "loading" while fonts.ready is
     // already resolved (WebKit bugs 174030, 225790), so re-checking the
     // status after the wait would re-queue on a resolved promise forever —


### PR DESCRIPTION
## Summary:
Graphies with TeX labels (e.g. labeled numberlines) hard-froze Safari. setLabelMargins waits for fonts by re-checking document.fonts.status after each fonts.ready wait — but Safari can report status === "loading" while ready is already resolved ([WebKit #174030](https://bugs.webkit.org/show_bug.cgi?id=174030), [#225790](https://bugs.webkit.org/show_bug.cgi?id=225790)). `.then()` on a resolved promise fires on the next microtask, so the re-check spun in an infinite microtask loop that never yielded the main thread. Confirmed in Safari: fonts.ready was read 2000+ times with status stuck at "loading".

Fix: wait on fonts.ready only _once_, then apply margins without re-checking status. Any slightly-early measurement is corrected by the existing ResizeObserver recalculation.

Issue: LEMS-4283

## Test plan:
- Tests pass 
- Manual testing 