### PR TITLE
Fix PhET widget fullscreen support on Safari/iOS

### DIFF
--- a/.changeset/phet-accompli-fixes.md
+++ b/.changeset/phet-accompli-fixes.md
@@ -3,4 +3,4 @@
 "@khanacademy/perseus": patch
 ---
 
-PhET widget: remove `URL.canParse` so simulations load on Safari/iOS < 17, and hide the fullscreen button on web browsers without Fullscreen API support (e.g. Safari on iPhone)
+PhET widget: remove `URL.canParse` so simulations load on Safari/iOS < 17, and on web browsers without Fullscreen API support (e.g. Safari on iPhone) replace the non-functional fullscreen button with a link that opens the simulation on PhET's site in a new tab

--- a/.changeset/phet-accompli-fixes.md
+++ b/.changeset/phet-accompli-fixes.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus": patch
+---
+
+PhET widget: remove `URL.canParse` so simulations load on Safari/iOS < 17, and hide the fullscreen button on web browsers without Fullscreen API support (e.g. Safari on iPhone)

--- a/packages/perseus-core/src/utils/make-safe-url.test.ts
+++ b/packages/perseus-core/src/utils/make-safe-url.test.ts
@@ -4,19 +4,8 @@ const phetOriginForTests = "https://phet.colorado.edu";
 const enLocaleForTests = "en";
 
 describe("makeSafeUrl", () => {
-    beforeEach(() => {
-        // We need to mock URL.canParse() because it is not available
-        // in our testing environment.
-        // eslint-disable-next-line no-restricted-syntax
-        global.URL.canParse = jest.fn(() => true) as jest.Mock;
-    });
-
-    it("should return null if the URL is not valid", () => {
+    it("returns null if the URL is not valid", () => {
         // Arrange
-        // Update the mock to return false for canParse, since we're testing
-        // an invalid URL that should not be parseable.
-        // eslint-disable-next-line no-restricted-syntax
-        global.URL.canParse = jest.fn(() => false) as jest.Mock;
         const invalidUrl = "some-invalid-url";
 
         // Act

--- a/packages/perseus-core/src/utils/make-safe-url.ts
+++ b/packages/perseus-core/src/utils/make-safe-url.ts
@@ -15,10 +15,14 @@ export const makeSafeUrl = (
     locale: string,
     expectedOrigin: string,
 ): URL | null => {
-    if (!URL.canParse(urlString)) {
+    // Note: we intentionally avoid URL.canParse() here because it isn't
+    // available before Safari 17 / iOS 17 and throws on older devices.
+    let url: URL;
+    try {
+        url = new URL(urlString);
+    } catch {
         return null;
     }
-    const url = new URL(urlString);
     if (url.origin !== expectedOrigin) {
         return null;
     }

--- a/packages/perseus-linter/src/rules/phet-simulation-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/phet-simulation-widget-error.test.ts
@@ -3,13 +3,6 @@ import {expectPass, expectWarning} from "../__tests__/test-utils";
 import phetSimulationWidgetErrorRule from "./phet-simulation-widget-error";
 
 describe("radio-widget-error", () => {
-    beforeEach(() => {
-        // We need to mock URL.canParse() because it is not available
-        // in our testing environment.
-        // eslint-disable-next-line no-restricted-syntax
-        global.URL.canParse = jest.fn(() => true) as jest.Mock;
-    });
-
     it("warns for phet simulation widget with non-PhET URL", () => {
         expectWarning(
             phetSimulationWidgetErrorRule,

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -124,6 +124,7 @@ export type PerseusStrings = {
     tan: string;
     simulationLoadFail: string;
     simulationLocaleWarning: string;
+    openSimulationInNewTab: string;
     selectAnAnswer: string;
     srGraphInstructions: string;
     srUnlimitedGraphInstructions: string;
@@ -1075,6 +1076,7 @@ export const strings = {
     simulationLoadFail: "Sorry, this simulation cannot load.",
     simulationLocaleWarning:
         "Sorry, this simulation isn't available in your language.",
+    openSimulationInNewTab: "Open simulation in a new tab",
     selectAnAnswer: "Select an answer",
     addPoint: "Add Point",
     removePoint: "Remove Point",
@@ -2004,6 +2006,7 @@ export const mockStrings: PerseusStrings = {
     simulationLoadFail: "Sorry, this simulation cannot load.",
     simulationLocaleWarning:
         "Sorry, this simulation isn't available in your language.",
+    openSimulationInNewTab: "Open simulation in a new tab",
     selectAnAnswer: "Select an answer",
     srGraphInstructions:
         "Enable Forms or Focus mode and use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Arrow keys to move it.",

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -125,6 +125,8 @@ export type PerseusStrings = {
     simulationLoadFail: string;
     simulationLocaleWarning: string;
     openSimulationInNewTab: string;
+    fullscreen: string;
+    exitFullscreen: string;
     selectAnAnswer: string;
     srGraphInstructions: string;
     srUnlimitedGraphInstructions: string;
@@ -1077,6 +1079,8 @@ export const strings = {
     simulationLocaleWarning:
         "Sorry, this simulation isn't available in your language.",
     openSimulationInNewTab: "Open simulation in a new tab",
+    fullscreen: "Fullscreen",
+    exitFullscreen: "Exit fullscreen",
     selectAnAnswer: "Select an answer",
     addPoint: "Add Point",
     removePoint: "Remove Point",
@@ -2007,6 +2011,8 @@ export const mockStrings: PerseusStrings = {
     simulationLocaleWarning:
         "Sorry, this simulation isn't available in your language.",
     openSimulationInNewTab: "Open simulation in a new tab",
+    fullscreen: "Fullscreen",
+    exitFullscreen: "Exit fullscreen",
     selectAnAnswer: "Select an answer",
     srGraphInstructions:
         "Enable Forms or Focus mode and use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Arrow keys to move it.",

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -124,7 +124,7 @@ export type PerseusStrings = {
     tan: string;
     simulationLoadFail: string;
     simulationLocaleWarning: string;
-    openSimulationInNewTab: string;
+    openInNewTab: string;
     fullscreen: string;
     exitFullscreen: string;
     selectAnAnswer: string;
@@ -1078,7 +1078,7 @@ export const strings = {
     simulationLoadFail: "Sorry, this simulation cannot load.",
     simulationLocaleWarning:
         "Sorry, this simulation isn't available in your language.",
-    openSimulationInNewTab: "Open simulation in a new tab",
+    openInNewTab: "Open simulation in a new tab",
     fullscreen: "Fullscreen",
     exitFullscreen: "Exit fullscreen",
     selectAnAnswer: "Select an answer",
@@ -2010,7 +2010,7 @@ export const mockStrings: PerseusStrings = {
     simulationLoadFail: "Sorry, this simulation cannot load.",
     simulationLocaleWarning:
         "Sorry, this simulation isn't available in your language.",
-    openSimulationInNewTab: "Open simulation in a new tab",
+    openInNewTab: "Open simulation in a new tab",
     fullscreen: "Fullscreen",
     exitFullscreen: "Exit fullscreen",
     selectAnAnswer: "Select an answer",

--- a/packages/perseus/src/widget-ai-utils/phet-simulation/prompt-utils.test.ts
+++ b/packages/perseus/src/widget-ai-utils/phet-simulation/prompt-utils.test.ts
@@ -35,8 +35,6 @@ describe("PhET Simulation AI utils", () => {
                 ok: true,
             }),
         ) as jest.Mock;
-        // eslint-disable-next-line no-restricted-syntax
-        global.URL.canParse = jest.fn(() => true) as jest.Mock;
     });
 
     it("it returns JSON with the expected format and fields", () => {

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.test.ts
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.test.ts
@@ -154,7 +154,7 @@ describe("phet-simulation widget", () => {
         expect(url).toBe(null);
     });
 
-    it("hides the fullscreen button on web when the Fullscreen API is unsupported", async () => {
+    it("links out to the simulation instead of showing the fullscreen button when the Fullscreen API is unsupported", async () => {
         // Arrange
         // Simulate a browser without any Fullscreen API support
         // (e.g. Safari on iPhone).
@@ -170,13 +170,34 @@ describe("phet-simulation widget", () => {
         renderQuestion(question1, apiOptions);
 
         // Assert
+        const link = await screen.findByRole("link", {
+            name: "Open simulation in a new tab",
+        });
+        expect(link).toHaveAttribute(
+            "href",
+            "https://phet.colorado.edu/sims/html/projectile-data-lab/latest/projectile-data-lab_all.html?locale=en",
+        );
+        expect(link).toHaveAttribute("target", "_blank");
+        expect(
+            screen.queryByRole("button", {name: "Fullscreen"}),
+        ).not.toBeInTheDocument();
+    });
+
+    it("does not show the open-in-new-tab link when fullscreen is supported", async () => {
+        // Arrange, Act
+        // The default beforeEach marks the Fullscreen API as supported.
+        renderQuestion(question1, {isMobile: false});
+
+        // Assert
         await waitFor(() => {
             expect(
-                screen.getByTitle("Projectile Data Lab"),
+                screen.getByRole("button", {name: "Fullscreen"}),
             ).toBeInTheDocument();
         });
         expect(
-            screen.queryByRole("button", {name: "Fullscreen"}),
+            screen.queryByRole("link", {
+                name: "Open simulation in a new tab",
+            }),
         ).not.toBeInTheDocument();
     });
 

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.test.ts
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.test.ts
@@ -34,8 +34,12 @@ describe("phet-simulation widget", () => {
                 ok: true,
             }),
         ) as jest.Mock;
-        // eslint-disable-next-line no-restricted-syntax
-        global.URL.canParse = jest.fn(() => true) as jest.Mock;
+        // jsdom doesn't implement the Fullscreen API, so we mark it as
+        // supported to keep the fullscreen button visible in these tests.
+        Object.defineProperty(document, "fullscreenEnabled", {
+            value: true,
+            configurable: true,
+        });
     });
 
     it("should display with valid PhET URL", async () => {
@@ -148,6 +152,55 @@ describe("phet-simulation widget", () => {
 
         // Assert
         expect(url).toBe(null);
+    });
+
+    it("hides the fullscreen button on web when the Fullscreen API is unsupported", async () => {
+        // Arrange
+        // Simulate a browser without any Fullscreen API support
+        // (e.g. Safari on iPhone).
+        Object.defineProperty(document, "fullscreenEnabled", {
+            value: undefined,
+            configurable: true,
+        });
+        const apiOptions: APIOptions = {
+            isMobile: true,
+        };
+
+        // Act
+        renderQuestion(question1, apiOptions);
+
+        // Assert
+        await waitFor(() => {
+            expect(
+                screen.getByTitle("Projectile Data Lab"),
+            ).toBeInTheDocument();
+        });
+        expect(
+            screen.queryByRole("button", {name: "Fullscreen"}),
+        ).not.toBeInTheDocument();
+    });
+
+    it("shows the fullscreen button in the mobile app even when the Fullscreen API is unsupported", async () => {
+        // Arrange
+        // The mobile app uses its own fullscreen implementation, so the
+        // button should show regardless of browser API support.
+        Object.defineProperty(document, "fullscreenEnabled", {
+            value: undefined,
+            configurable: true,
+        });
+        const apiOptions: APIOptions = {
+            isMobileApp: true,
+        };
+
+        // Act
+        renderQuestion(question1, apiOptions);
+
+        // Assert
+        await waitFor(() => {
+            expect(
+                screen.getByRole("button", {name: "Fullscreen"}),
+            ).toBeInTheDocument();
+        });
     });
 
     it("should use the mobile app fullscreen logic when rendered in a mobile app", async () => {

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.test.ts
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.test.ts
@@ -203,6 +203,40 @@ describe("phet-simulation widget", () => {
         });
     });
 
+    it("requests browser fullscreen when the fullscreen button is clicked on web", async () => {
+        // Arrange
+        const requestFullscreen = jest.fn(() => Promise.resolve());
+        renderQuestion(question1, {isMobile: false});
+        const iframe = await screen.findByTitle("Projectile Data Lab");
+        iframe.requestFullscreen = requestFullscreen;
+
+        // Act
+        await userEvent.click(
+            await screen.findByRole("button", {name: "Fullscreen"}),
+        );
+
+        // Assert
+        expect(requestFullscreen).toHaveBeenCalledTimes(1);
+    });
+
+    it("falls back to webkitRequestFullscreen when the standard API is unavailable", async () => {
+        // Arrange
+        const webkitRequestFullscreen = jest.fn();
+        renderQuestion(question1, {isMobile: false});
+        const iframe = await screen.findByTitle("Projectile Data Lab");
+        // jsdom doesn't implement requestFullscreen, so only the prefixed
+        // variant exists on the element in this test.
+        Object.assign(iframe, {webkitRequestFullscreen});
+
+        // Act
+        await userEvent.click(
+            await screen.findByRole("button", {name: "Fullscreen"}),
+        );
+
+        // Assert
+        expect(webkitRequestFullscreen).toHaveBeenCalledTimes(1);
+    });
+
     it("should use the mobile app fullscreen logic when rendered in a mobile app", async () => {
         // Arrange
         const apiOptions: APIOptions = {

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -252,7 +252,7 @@ export class PhetSimulation
                     }
                     kind="tertiary"
                     actionType="neutral"
-                    aria-label={"Fullscreen"}
+                    aria-label={this.context.strings.fullscreen}
                     style={styles.cornerButton}
                 />
             );
@@ -320,7 +320,7 @@ export class PhetSimulation
                             onClick={this.toggleFullScreen}
                             kind="tertiary"
                             actionType="neutral"
-                            aria-label={"Exit fullscreen"}
+                            aria-label={this.context.strings.exitFullscreen}
                             style={styles.closeButton}
                         />
                     </View>

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -32,6 +32,24 @@ type State = {
     isFullScreen: boolean;
 };
 
+// Safari still exposes the Fullscreen API behind a webkit prefix in some
+// versions, so we check for both the standard and prefixed variants.
+// Notably, Safari on iPhone supports neither: Apple deliberately omits
+// fullscreen support there, so this returns false and we hide the
+// fullscreen button instead of rendering one that silently fails.
+export const isFullscreenApiSupported = (): boolean => {
+    const doc: DocumentWithWebkitFullscreen = document;
+    return Boolean(doc.fullscreenEnabled || doc.webkitFullscreenEnabled);
+};
+
+type DocumentWithWebkitFullscreen = Document & {
+    webkitFullscreenEnabled?: boolean;
+};
+
+type IframeWithWebkitFullscreen = HTMLIFrameElement & {
+    webkitRequestFullscreen?: () => void;
+};
+
 // A constant for the bottom bar height in the mobile app.
 // This is a little hacky, but seems to be the best way to make sure the
 // simulation is not cut off by the bottom bar.
@@ -195,6 +213,19 @@ export class PhetSimulation
         }));
     };
 
+    requestIframeFullscreen = () => {
+        const iframe: IframeWithWebkitFullscreen | null =
+            this.iframeRef.current;
+        if (!iframe) {
+            return;
+        }
+        if (typeof iframe.requestFullscreen === "function") {
+            iframe.requestFullscreen();
+        } else {
+            iframe.webkitRequestFullscreen?.();
+        }
+    };
+
     render(): React.ReactNode {
         // Extract state and props we'll use
         const {isFullScreen, banner, url} = this.state;
@@ -259,27 +290,29 @@ export class PhetSimulation
                     />
                 </View>
 
-                {/* Fullscreen button (only shown when not in mobile app fullscreen) */}
-                {url !== null && !isMobileAppFullscreen && (
-                    <IconButton
-                        icon={cornersOutIcon}
-                        onClick={
-                            isMobileApp
-                                ? this.toggleFullScreen
-                                : () => {
-                                      this.iframeRef.current?.requestFullscreen();
-                                  }
-                        }
-                        kind="tertiary"
-                        actionType="neutral"
-                        aria-label={"Fullscreen"}
-                        style={{
-                            marginTop: 5,
-                            marginBottom: 5,
-                            alignSelf: "flex-end",
-                        }}
-                    />
-                )}
+                {/* Fullscreen button (only shown when not in mobile app
+                    fullscreen, and hidden on web browsers that don't support
+                    the Fullscreen API, e.g. Safari on iPhone) */}
+                {url !== null &&
+                    !isMobileAppFullscreen &&
+                    (isMobileApp || isFullscreenApiSupported()) && (
+                        <IconButton
+                            icon={cornersOutIcon}
+                            onClick={
+                                isMobileApp
+                                    ? this.toggleFullScreen
+                                    : this.requestIframeFullscreen
+                            }
+                            kind="tertiary"
+                            actionType="neutral"
+                            aria-label={"Fullscreen"}
+                            style={{
+                                marginTop: 5,
+                                marginBottom: 5,
+                                alignSelf: "flex-end",
+                            }}
+                        />
+                    )}
             </View>
         );
     }

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -37,7 +37,11 @@ type State = {
 // Notably, Safari on iPhone supports neither: Apple deliberately omits
 // fullscreen support there, so this returns false and we hide the
 // fullscreen button instead of rendering one that silently fails.
-export const isFullscreenApiSupported = (): boolean => {
+const isFullscreenApiSupported = (): boolean => {
+    // Guard against non-DOM environments (e.g. server-side rendering)
+    if (typeof document === "undefined") {
+        return false;
+    }
     const doc: DocumentWithWebkitFullscreen = document;
     return Boolean(doc.fullscreenEnabled || doc.webkitFullscreenEnabled);
 };
@@ -220,7 +224,11 @@ export class PhetSimulation
             return;
         }
         if (typeof iframe.requestFullscreen === "function") {
-            iframe.requestFullscreen();
+            // The browser can reject the fullscreen request (e.g. denied
+            // permission, or the call wasn't triggered by a user gesture);
+            // there's nothing actionable for us to do, so swallow it rather
+            // than surface an unhandled promise rejection.
+            iframe.requestFullscreen().catch(() => {});
         } else {
             iframe.webkitRequestFullscreen?.();
         }

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -268,7 +268,7 @@ export class PhetSimulation
                 target="_blank"
                 kind="tertiary"
                 actionType="neutral"
-                aria-label={this.context.strings.openSimulationInNewTab}
+                aria-label={this.context.strings.openInNewTab}
                 style={styles.cornerButton}
             />
         );

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -8,6 +8,7 @@ import Banner from "@khanacademy/wonder-blocks-banner";
 import {View} from "@khanacademy/wonder-blocks-core";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import arrowSquareOutIcon from "@phosphor-icons/core/regular/arrow-square-out.svg";
 import cornersOutIcon from "@phosphor-icons/core/regular/corners-out.svg";
 import xIcon from "@phosphor-icons/core/regular/x.svg";
 import {StyleSheet, css} from "aphrodite";
@@ -234,6 +235,45 @@ export class PhetSimulation
         }
     };
 
+    renderCornerButton(
+        url: URL,
+        isMobileApp: boolean | undefined,
+    ): React.ReactNode {
+        // The mobile app uses its own fullscreen implementation, and web
+        // browsers that support the Fullscreen API can go fullscreen in place.
+        if (isMobileApp || isFullscreenApiSupported()) {
+            return (
+                <IconButton
+                    icon={cornersOutIcon}
+                    onClick={
+                        isMobileApp
+                            ? this.toggleFullScreen
+                            : this.requestIframeFullscreen
+                    }
+                    kind="tertiary"
+                    actionType="neutral"
+                    aria-label={"Fullscreen"}
+                    style={styles.cornerButton}
+                />
+            );
+        }
+
+        // Otherwise the simulation can't be enlarged in place (e.g. Safari on
+        // iPhone, which doesn't support the Fullscreen API), so link out to the
+        // full-size simulation on PhET's site in a new tab instead.
+        return (
+            <IconButton
+                icon={arrowSquareOutIcon}
+                href={url.toString()}
+                target="_blank"
+                kind="tertiary"
+                actionType="neutral"
+                aria-label={this.context.strings.openSimulationInNewTab}
+                style={styles.cornerButton}
+            />
+        );
+    }
+
     render(): React.ReactNode {
         // Extract state and props we'll use
         const {isFullScreen, banner, url} = this.state;
@@ -298,29 +338,14 @@ export class PhetSimulation
                     />
                 </View>
 
-                {/* Fullscreen button (only shown when not in mobile app
-                    fullscreen, and hidden on web browsers that don't support
-                    the Fullscreen API, e.g. Safari on iPhone) */}
+                {/* Corner action button, shown when not already in mobile-app
+                    fullscreen: either a fullscreen toggle (when fullscreen is
+                    available) or, when the browser can't go fullscreen (e.g.
+                    Safari on iPhone), a link to open the simulation on PhET's
+                    site. */}
                 {url !== null &&
                     !isMobileAppFullscreen &&
-                    (isMobileApp || isFullscreenApiSupported()) && (
-                        <IconButton
-                            icon={cornersOutIcon}
-                            onClick={
-                                isMobileApp
-                                    ? this.toggleFullScreen
-                                    : this.requestIframeFullscreen
-                            }
-                            kind="tertiary"
-                            actionType="neutral"
-                            aria-label={"Fullscreen"}
-                            style={{
-                                marginTop: 5,
-                                marginBottom: 5,
-                                alignSelf: "flex-end",
-                            }}
-                        />
-                    )}
+                    this.renderCornerButton(url, isMobileApp)}
             </View>
         );
     }
@@ -333,6 +358,11 @@ const styles = StyleSheet.create({
         borderColor: "#CCC",
         padding: spacing.medium_16,
         paddingBottom: 0,
+    },
+    cornerButton: {
+        marginTop: 5,
+        marginBottom: 5,
+        alignSelf: "flex-end",
     },
     iframeContainer: {
         position: "relative",


### PR DESCRIPTION
## Summary
Users on older (but still supported) versions of iOS devices will now be able to load PhET Simulations on both mobile web and the mobile app. Older iOS devices on mobile web will also see a different button that takes them directly to the simulation on PhET, as Apple has specifically blocked the ability to make elements full screen under these conditions. 

## Key Changes

- **Removed `URL.canParse()` usage**: Replaced with try-catch pattern in `makeSafeUrl()` since `URL.canParse()` is not available before Safari 17/iOS 17, which was preventing simulations from loading on older Apple devices
- **Added Fullscreen API detection**: Implemented `isFullscreenApiSupported()` function that checks for both standard (`fullscreenEnabled`) and webkit-prefixed (`webkitFullscreenEnabled`) variants
- **Conditional fullscreen button visibility**: The fullscreen button now only renders on web when the Fullscreen API is supported, preventing broken buttons on Safari/iPhone where Apple deliberately omits fullscreen support
- **Improved fullscreen request handling**: Added `requestIframeFullscreen()` method that attempts standard `requestFullscreen()` first, then falls back to `webkitRequestFullscreen()` for older Safari versions
- **Mobile app exception**: The fullscreen button still shows in the mobile app even without Fullscreen API support, since the app uses its own fullscreen implementation
- **Removed test mocks**: Cleaned up `URL.canParse()` mocks from test files since the implementation no longer depends on this API

## Implementation Details

- Added TypeScript types for webkit-prefixed APIs: `DocumentWithWebkitFullscreen` and `IframeWithWebkitFullscreen`
- Fullscreen request errors are silently caught to avoid unhandled promise rejections when permission is denied or gesture requirement isn't met
- Added comprehensive test coverage for fullscreen behavior across web and mobile app contexts, including fallback scenarios

## Test Plan

- Manual testing using QR Code snapshot in app, and navigating to znd link manually in Safari. Please let me know if you would like the QR Code / ZND link 
- Tests pass