### PR TITLE
[Interactive Graph] Fixed issue where sinusoid and logartihm identifiers were renamed

### DIFF
--- a/.changeset/short-worms-press.md
+++ b/.changeset/short-worms-press.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Fixed issue with dropdown graph identifier, sinusoid and logarithm

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
@@ -23,9 +23,9 @@ const GraphTypeSelector = (props: GraphTypeSelectorProps) => {
             />
             <OptionItem value="exponential" label="Exponential function" />
             <OptionItem value="linear" label="Linear function" />
-            <OptionItem value="logarithmic" label="Logarithmic function" />
+            <OptionItem value="logarithm" label="Logarithmic function" />
             <OptionItem value="quadratic" label="Quadratic function" />
-            <OptionItem value="sinusoidal" label="Sinusoidal function" />
+            <OptionItem value="sinusoid" label="Sinusoidal function" />
             <OptionItem value="tangent" label="Tangent function" />
             <OptionItem value="angle" label="Angle" />
             <OptionItem value="circle" label="Circle" />


### PR DESCRIPTION
## Summary:
Reverted identifier change from LEMS-4208 to fix interactive graph type choosing

Issue: https://khanacademy.atlassian.net/browse/LEMS-4208

## Test plan:
- Checked on storybook editor to ensure selecting a sinusoidal and logarithmic graph both worked