### PR TITLE
[Editor] Editor label fix + editor styling/type modernization

### DIFF
--- a/.changeset/flat-news-smoke.md
+++ b/.changeset/flat-news-smoke.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+[Editor] Editor label fix + editor styling/type modernization

--- a/packages/perseus-editor/src/widgets/__tests__/__snapshots__/label-image-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/widgets/__tests__/__snapshots__/label-image-editor.test.tsx.snap
@@ -5,12 +5,12 @@ exports[`label-image-editor popover direction snapshots should render with DOWN 
   <div>
     <div>
       <div
-        class="title_dt6zj3"
+        class="title"
       >
         Image
       </div>
       <div
-        class="components_jro6t0"
+        class="image-row"
       >
         <form
           class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
@@ -22,13 +22,10 @@ exports[`label-image-editor popover direction snapshots should render with DOWN 
             value="https://example.com/test-image.png"
           />
         </form>
-        <div
-          class="spacer_1ciyl4o"
-        />
         <button
           aria-disabled="false"
           aria-label=""
-          class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1vcomhn-o_O-btn_786qd8"
+          class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1vcomhn-o_O-inlineStyles_786qd8"
           data-kind="primary"
           type="button"
         >
@@ -41,7 +38,7 @@ exports[`label-image-editor popover direction snapshots should render with DOWN 
       </div>
     </div>
     <div
-      class="smallSpacer_1y6xiyp"
+      class="small-spacer"
     />
     <form
       class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
@@ -54,7 +51,7 @@ exports[`label-image-editor popover direction snapshots should render with DOWN 
       />
     </form>
     <div
-      class="largeSpacer_xwkmkn"
+      class="large-spacer"
     />
     <div>
       <div
@@ -94,19 +91,19 @@ exports[`label-image-editor popover direction snapshots should render with DOWN 
       </div>
     </div>
     <div
-      class="largeSpacer_xwkmkn"
+      class="large-spacer"
     />
     <div>
       <div
-        class="title_dt6zj3"
+        class="title"
       >
         Answer Choices
       </div>
       <ul
-        class="answers_9pyl0r"
+        class="answers"
       >
         <li
-          class="answer_1tougex"
+          class="answer"
         >
           <a
             class="link_dwmetq"
@@ -126,9 +123,6 @@ exports[`label-image-editor popover direction snapshots should render with DOWN 
               />
             </svg>
           </a>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <form
             class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
             style="flex-grow: 1;"
@@ -138,11 +132,8 @@ exports[`label-image-editor popover direction snapshots should render with DOWN 
               value="Choice 1"
             />
           </form>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <a
-            class="link_dwmetq-o_O-disabled_14ak7oz"
+            class="link_dwmetq disabled"
             href="javascript:void(0)"
             title="Answer reordering is not implemented."
           >
@@ -191,7 +182,7 @@ exports[`label-image-editor popover direction snapshots should render with DOWN 
           </a>
         </li>
         <li
-          class="answer_1tougex"
+          class="answer"
         >
           <a
             class="link_dwmetq"
@@ -211,9 +202,6 @@ exports[`label-image-editor popover direction snapshots should render with DOWN 
               />
             </svg>
           </a>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <form
             class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
             style="flex-grow: 1;"
@@ -223,11 +211,8 @@ exports[`label-image-editor popover direction snapshots should render with DOWN 
               value="Choice 2"
             />
           </form>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <a
-            class="link_dwmetq-o_O-disabled_14ak7oz"
+            class="link_dwmetq disabled"
             href="javascript:void(0)"
             title="Answer reordering is not implemented."
           >
@@ -276,7 +261,7 @@ exports[`label-image-editor popover direction snapshots should render with DOWN 
           </a>
         </li>
         <li
-          class="answer_1tougex"
+          class="answer"
         >
           <a
             class="link_dwmetq"
@@ -296,9 +281,6 @@ exports[`label-image-editor popover direction snapshots should render with DOWN 
               />
             </svg>
           </a>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <form
             class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
             style="flex-grow: 1;"
@@ -308,11 +290,8 @@ exports[`label-image-editor popover direction snapshots should render with DOWN 
               value="Choice 3"
             />
           </form>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <a
-            class="link_dwmetq-o_O-disabled_14ak7oz"
+            class="link_dwmetq disabled"
             href="javascript:void(0)"
             title="Answer reordering is not implemented."
           >
@@ -362,7 +341,7 @@ exports[`label-image-editor popover direction snapshots should render with DOWN 
         </li>
       </ul>
       <a
-        class="link_dwmetq addAnswer_1mmlluv-o_O-addAnswer_1uy1atb"
+        class="link_dwmetq add-answer"
         href="javascript:void(0)"
       >
         <svg
@@ -378,14 +357,11 @@ exports[`label-image-editor popover direction snapshots should render with DOWN 
             fill="currentColor"
           />
         </svg>
-        <div
-          class="spacer_1ciyl4o"
-        />
         Add an answer choice
       </a>
     </div>
     <div
-      class="largeSpacer_xwkmkn"
+      class="large-spacer"
     />
     <div>
       <div
@@ -523,12 +499,12 @@ exports[`label-image-editor popover direction snapshots should render with LEFT 
   <div>
     <div>
       <div
-        class="title_dt6zj3"
+        class="title"
       >
         Image
       </div>
       <div
-        class="components_jro6t0"
+        class="image-row"
       >
         <form
           class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
@@ -540,13 +516,10 @@ exports[`label-image-editor popover direction snapshots should render with LEFT 
             value="https://example.com/test-image.png"
           />
         </form>
-        <div
-          class="spacer_1ciyl4o"
-        />
         <button
           aria-disabled="false"
           aria-label=""
-          class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1vcomhn-o_O-btn_786qd8"
+          class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1vcomhn-o_O-inlineStyles_786qd8"
           data-kind="primary"
           type="button"
         >
@@ -559,7 +532,7 @@ exports[`label-image-editor popover direction snapshots should render with LEFT 
       </div>
     </div>
     <div
-      class="smallSpacer_1y6xiyp"
+      class="small-spacer"
     />
     <form
       class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
@@ -572,7 +545,7 @@ exports[`label-image-editor popover direction snapshots should render with LEFT 
       />
     </form>
     <div
-      class="largeSpacer_xwkmkn"
+      class="large-spacer"
     />
     <div>
       <div
@@ -612,19 +585,19 @@ exports[`label-image-editor popover direction snapshots should render with LEFT 
       </div>
     </div>
     <div
-      class="largeSpacer_xwkmkn"
+      class="large-spacer"
     />
     <div>
       <div
-        class="title_dt6zj3"
+        class="title"
       >
         Answer Choices
       </div>
       <ul
-        class="answers_9pyl0r"
+        class="answers"
       >
         <li
-          class="answer_1tougex"
+          class="answer"
         >
           <a
             class="link_dwmetq"
@@ -644,9 +617,6 @@ exports[`label-image-editor popover direction snapshots should render with LEFT 
               />
             </svg>
           </a>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <form
             class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
             style="flex-grow: 1;"
@@ -656,11 +626,8 @@ exports[`label-image-editor popover direction snapshots should render with LEFT 
               value="Choice 1"
             />
           </form>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <a
-            class="link_dwmetq-o_O-disabled_14ak7oz"
+            class="link_dwmetq disabled"
             href="javascript:void(0)"
             title="Answer reordering is not implemented."
           >
@@ -709,7 +676,7 @@ exports[`label-image-editor popover direction snapshots should render with LEFT 
           </a>
         </li>
         <li
-          class="answer_1tougex"
+          class="answer"
         >
           <a
             class="link_dwmetq"
@@ -729,9 +696,6 @@ exports[`label-image-editor popover direction snapshots should render with LEFT 
               />
             </svg>
           </a>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <form
             class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
             style="flex-grow: 1;"
@@ -741,11 +705,8 @@ exports[`label-image-editor popover direction snapshots should render with LEFT 
               value="Choice 2"
             />
           </form>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <a
-            class="link_dwmetq-o_O-disabled_14ak7oz"
+            class="link_dwmetq disabled"
             href="javascript:void(0)"
             title="Answer reordering is not implemented."
           >
@@ -794,7 +755,7 @@ exports[`label-image-editor popover direction snapshots should render with LEFT 
           </a>
         </li>
         <li
-          class="answer_1tougex"
+          class="answer"
         >
           <a
             class="link_dwmetq"
@@ -814,9 +775,6 @@ exports[`label-image-editor popover direction snapshots should render with LEFT 
               />
             </svg>
           </a>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <form
             class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
             style="flex-grow: 1;"
@@ -826,11 +784,8 @@ exports[`label-image-editor popover direction snapshots should render with LEFT 
               value="Choice 3"
             />
           </form>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <a
-            class="link_dwmetq-o_O-disabled_14ak7oz"
+            class="link_dwmetq disabled"
             href="javascript:void(0)"
             title="Answer reordering is not implemented."
           >
@@ -880,7 +835,7 @@ exports[`label-image-editor popover direction snapshots should render with LEFT 
         </li>
       </ul>
       <a
-        class="link_dwmetq addAnswer_1mmlluv-o_O-addAnswer_1uy1atb"
+        class="link_dwmetq add-answer"
         href="javascript:void(0)"
       >
         <svg
@@ -896,14 +851,11 @@ exports[`label-image-editor popover direction snapshots should render with LEFT 
             fill="currentColor"
           />
         </svg>
-        <div
-          class="spacer_1ciyl4o"
-        />
         Add an answer choice
       </a>
     </div>
     <div
-      class="largeSpacer_xwkmkn"
+      class="large-spacer"
     />
     <div>
       <div
@@ -1041,12 +993,12 @@ exports[`label-image-editor popover direction snapshots should render with NONE 
   <div>
     <div>
       <div
-        class="title_dt6zj3"
+        class="title"
       >
         Image
       </div>
       <div
-        class="components_jro6t0"
+        class="image-row"
       >
         <form
           class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
@@ -1058,13 +1010,10 @@ exports[`label-image-editor popover direction snapshots should render with NONE 
             value="https://example.com/test-image.png"
           />
         </form>
-        <div
-          class="spacer_1ciyl4o"
-        />
         <button
           aria-disabled="false"
           aria-label=""
-          class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1vcomhn-o_O-btn_786qd8"
+          class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1vcomhn-o_O-inlineStyles_786qd8"
           data-kind="primary"
           type="button"
         >
@@ -1077,7 +1026,7 @@ exports[`label-image-editor popover direction snapshots should render with NONE 
       </div>
     </div>
     <div
-      class="smallSpacer_1y6xiyp"
+      class="small-spacer"
     />
     <form
       class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
@@ -1090,7 +1039,7 @@ exports[`label-image-editor popover direction snapshots should render with NONE 
       />
     </form>
     <div
-      class="largeSpacer_xwkmkn"
+      class="large-spacer"
     />
     <div>
       <div
@@ -1130,19 +1079,19 @@ exports[`label-image-editor popover direction snapshots should render with NONE 
       </div>
     </div>
     <div
-      class="largeSpacer_xwkmkn"
+      class="large-spacer"
     />
     <div>
       <div
-        class="title_dt6zj3"
+        class="title"
       >
         Answer Choices
       </div>
       <ul
-        class="answers_9pyl0r"
+        class="answers"
       >
         <li
-          class="answer_1tougex"
+          class="answer"
         >
           <a
             class="link_dwmetq"
@@ -1162,9 +1111,6 @@ exports[`label-image-editor popover direction snapshots should render with NONE 
               />
             </svg>
           </a>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <form
             class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
             style="flex-grow: 1;"
@@ -1174,11 +1120,8 @@ exports[`label-image-editor popover direction snapshots should render with NONE 
               value="Choice 1"
             />
           </form>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <a
-            class="link_dwmetq-o_O-disabled_14ak7oz"
+            class="link_dwmetq disabled"
             href="javascript:void(0)"
             title="Answer reordering is not implemented."
           >
@@ -1227,7 +1170,7 @@ exports[`label-image-editor popover direction snapshots should render with NONE 
           </a>
         </li>
         <li
-          class="answer_1tougex"
+          class="answer"
         >
           <a
             class="link_dwmetq"
@@ -1247,9 +1190,6 @@ exports[`label-image-editor popover direction snapshots should render with NONE 
               />
             </svg>
           </a>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <form
             class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
             style="flex-grow: 1;"
@@ -1259,11 +1199,8 @@ exports[`label-image-editor popover direction snapshots should render with NONE 
               value="Choice 2"
             />
           </form>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <a
-            class="link_dwmetq-o_O-disabled_14ak7oz"
+            class="link_dwmetq disabled"
             href="javascript:void(0)"
             title="Answer reordering is not implemented."
           >
@@ -1312,7 +1249,7 @@ exports[`label-image-editor popover direction snapshots should render with NONE 
           </a>
         </li>
         <li
-          class="answer_1tougex"
+          class="answer"
         >
           <a
             class="link_dwmetq"
@@ -1332,9 +1269,6 @@ exports[`label-image-editor popover direction snapshots should render with NONE 
               />
             </svg>
           </a>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <form
             class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
             style="flex-grow: 1;"
@@ -1344,11 +1278,8 @@ exports[`label-image-editor popover direction snapshots should render with NONE 
               value="Choice 3"
             />
           </form>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <a
-            class="link_dwmetq-o_O-disabled_14ak7oz"
+            class="link_dwmetq disabled"
             href="javascript:void(0)"
             title="Answer reordering is not implemented."
           >
@@ -1398,7 +1329,7 @@ exports[`label-image-editor popover direction snapshots should render with NONE 
         </li>
       </ul>
       <a
-        class="link_dwmetq addAnswer_1mmlluv-o_O-addAnswer_1uy1atb"
+        class="link_dwmetq add-answer"
         href="javascript:void(0)"
       >
         <svg
@@ -1414,14 +1345,11 @@ exports[`label-image-editor popover direction snapshots should render with NONE 
             fill="currentColor"
           />
         </svg>
-        <div
-          class="spacer_1ciyl4o"
-        />
         Add an answer choice
       </a>
     </div>
     <div
-      class="largeSpacer_xwkmkn"
+      class="large-spacer"
     />
     <div>
       <div
@@ -1559,12 +1487,12 @@ exports[`label-image-editor popover direction snapshots should render with RIGHT
   <div>
     <div>
       <div
-        class="title_dt6zj3"
+        class="title"
       >
         Image
       </div>
       <div
-        class="components_jro6t0"
+        class="image-row"
       >
         <form
           class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
@@ -1576,13 +1504,10 @@ exports[`label-image-editor popover direction snapshots should render with RIGHT
             value="https://example.com/test-image.png"
           />
         </form>
-        <div
-          class="spacer_1ciyl4o"
-        />
         <button
           aria-disabled="false"
           aria-label=""
-          class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1vcomhn-o_O-btn_786qd8"
+          class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1vcomhn-o_O-inlineStyles_786qd8"
           data-kind="primary"
           type="button"
         >
@@ -1595,7 +1520,7 @@ exports[`label-image-editor popover direction snapshots should render with RIGHT
       </div>
     </div>
     <div
-      class="smallSpacer_1y6xiyp"
+      class="small-spacer"
     />
     <form
       class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
@@ -1608,7 +1533,7 @@ exports[`label-image-editor popover direction snapshots should render with RIGHT
       />
     </form>
     <div
-      class="largeSpacer_xwkmkn"
+      class="large-spacer"
     />
     <div>
       <div
@@ -1648,19 +1573,19 @@ exports[`label-image-editor popover direction snapshots should render with RIGHT
       </div>
     </div>
     <div
-      class="largeSpacer_xwkmkn"
+      class="large-spacer"
     />
     <div>
       <div
-        class="title_dt6zj3"
+        class="title"
       >
         Answer Choices
       </div>
       <ul
-        class="answers_9pyl0r"
+        class="answers"
       >
         <li
-          class="answer_1tougex"
+          class="answer"
         >
           <a
             class="link_dwmetq"
@@ -1680,9 +1605,6 @@ exports[`label-image-editor popover direction snapshots should render with RIGHT
               />
             </svg>
           </a>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <form
             class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
             style="flex-grow: 1;"
@@ -1692,11 +1614,8 @@ exports[`label-image-editor popover direction snapshots should render with RIGHT
               value="Choice 1"
             />
           </form>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <a
-            class="link_dwmetq-o_O-disabled_14ak7oz"
+            class="link_dwmetq disabled"
             href="javascript:void(0)"
             title="Answer reordering is not implemented."
           >
@@ -1745,7 +1664,7 @@ exports[`label-image-editor popover direction snapshots should render with RIGHT
           </a>
         </li>
         <li
-          class="answer_1tougex"
+          class="answer"
         >
           <a
             class="link_dwmetq"
@@ -1765,9 +1684,6 @@ exports[`label-image-editor popover direction snapshots should render with RIGHT
               />
             </svg>
           </a>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <form
             class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
             style="flex-grow: 1;"
@@ -1777,11 +1693,8 @@ exports[`label-image-editor popover direction snapshots should render with RIGHT
               value="Choice 2"
             />
           </form>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <a
-            class="link_dwmetq-o_O-disabled_14ak7oz"
+            class="link_dwmetq disabled"
             href="javascript:void(0)"
             title="Answer reordering is not implemented."
           >
@@ -1830,7 +1743,7 @@ exports[`label-image-editor popover direction snapshots should render with RIGHT
           </a>
         </li>
         <li
-          class="answer_1tougex"
+          class="answer"
         >
           <a
             class="link_dwmetq"
@@ -1850,9 +1763,6 @@ exports[`label-image-editor popover direction snapshots should render with RIGHT
               />
             </svg>
           </a>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <form
             class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
             style="flex-grow: 1;"
@@ -1862,11 +1772,8 @@ exports[`label-image-editor popover direction snapshots should render with RIGHT
               value="Choice 3"
             />
           </form>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <a
-            class="link_dwmetq-o_O-disabled_14ak7oz"
+            class="link_dwmetq disabled"
             href="javascript:void(0)"
             title="Answer reordering is not implemented."
           >
@@ -1916,7 +1823,7 @@ exports[`label-image-editor popover direction snapshots should render with RIGHT
         </li>
       </ul>
       <a
-        class="link_dwmetq addAnswer_1mmlluv-o_O-addAnswer_1uy1atb"
+        class="link_dwmetq add-answer"
         href="javascript:void(0)"
       >
         <svg
@@ -1932,14 +1839,11 @@ exports[`label-image-editor popover direction snapshots should render with RIGHT
             fill="currentColor"
           />
         </svg>
-        <div
-          class="spacer_1ciyl4o"
-        />
         Add an answer choice
       </a>
     </div>
     <div
-      class="largeSpacer_xwkmkn"
+      class="large-spacer"
     />
     <div>
       <div
@@ -2077,12 +1981,12 @@ exports[`label-image-editor popover direction snapshots should render with UP po
   <div>
     <div>
       <div
-        class="title_dt6zj3"
+        class="title"
       >
         Image
       </div>
       <div
-        class="components_jro6t0"
+        class="image-row"
       >
         <form
           class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
@@ -2094,13 +1998,10 @@ exports[`label-image-editor popover direction snapshots should render with UP po
             value="https://example.com/test-image.png"
           />
         </form>
-        <div
-          class="spacer_1ciyl4o"
-        />
         <button
           aria-disabled="false"
           aria-label=""
-          class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1vcomhn-o_O-btn_786qd8"
+          class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1vcomhn-o_O-inlineStyles_786qd8"
           data-kind="primary"
           type="button"
         >
@@ -2113,7 +2014,7 @@ exports[`label-image-editor popover direction snapshots should render with UP po
       </div>
     </div>
     <div
-      class="smallSpacer_1y6xiyp"
+      class="small-spacer"
     />
     <form
       class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
@@ -2126,7 +2027,7 @@ exports[`label-image-editor popover direction snapshots should render with UP po
       />
     </form>
     <div
-      class="largeSpacer_xwkmkn"
+      class="large-spacer"
     />
     <div>
       <div
@@ -2166,19 +2067,19 @@ exports[`label-image-editor popover direction snapshots should render with UP po
       </div>
     </div>
     <div
-      class="largeSpacer_xwkmkn"
+      class="large-spacer"
     />
     <div>
       <div
-        class="title_dt6zj3"
+        class="title"
       >
         Answer Choices
       </div>
       <ul
-        class="answers_9pyl0r"
+        class="answers"
       >
         <li
-          class="answer_1tougex"
+          class="answer"
         >
           <a
             class="link_dwmetq"
@@ -2198,9 +2099,6 @@ exports[`label-image-editor popover direction snapshots should render with UP po
               />
             </svg>
           </a>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <form
             class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
             style="flex-grow: 1;"
@@ -2210,11 +2108,8 @@ exports[`label-image-editor popover direction snapshots should render with UP po
               value="Choice 1"
             />
           </form>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <a
-            class="link_dwmetq-o_O-disabled_14ak7oz"
+            class="link_dwmetq disabled"
             href="javascript:void(0)"
             title="Answer reordering is not implemented."
           >
@@ -2263,7 +2158,7 @@ exports[`label-image-editor popover direction snapshots should render with UP po
           </a>
         </li>
         <li
-          class="answer_1tougex"
+          class="answer"
         >
           <a
             class="link_dwmetq"
@@ -2283,9 +2178,6 @@ exports[`label-image-editor popover direction snapshots should render with UP po
               />
             </svg>
           </a>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <form
             class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
             style="flex-grow: 1;"
@@ -2295,11 +2187,8 @@ exports[`label-image-editor popover direction snapshots should render with UP po
               value="Choice 2"
             />
           </form>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <a
-            class="link_dwmetq-o_O-disabled_14ak7oz"
+            class="link_dwmetq disabled"
             href="javascript:void(0)"
             title="Answer reordering is not implemented."
           >
@@ -2348,7 +2237,7 @@ exports[`label-image-editor popover direction snapshots should render with UP po
           </a>
         </li>
         <li
-          class="answer_1tougex"
+          class="answer"
         >
           <a
             class="link_dwmetq"
@@ -2368,9 +2257,6 @@ exports[`label-image-editor popover direction snapshots should render with UP po
               />
             </svg>
           </a>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <form
             class="input_1qboe8t-o_O-container_1d6ew9d-o_O-defaultBackground_vxglvu"
             style="flex-grow: 1;"
@@ -2380,11 +2266,8 @@ exports[`label-image-editor popover direction snapshots should render with UP po
               value="Choice 3"
             />
           </form>
-          <div
-            class="spacer_1ciyl4o"
-          />
           <a
-            class="link_dwmetq-o_O-disabled_14ak7oz"
+            class="link_dwmetq disabled"
             href="javascript:void(0)"
             title="Answer reordering is not implemented."
           >
@@ -2434,7 +2317,7 @@ exports[`label-image-editor popover direction snapshots should render with UP po
         </li>
       </ul>
       <a
-        class="link_dwmetq addAnswer_1mmlluv-o_O-addAnswer_1uy1atb"
+        class="link_dwmetq add-answer"
         href="javascript:void(0)"
       >
         <svg
@@ -2450,14 +2333,11 @@ exports[`label-image-editor popover direction snapshots should render with UP po
             fill="currentColor"
           />
         </svg>
-        <div
-          class="spacer_1ciyl4o"
-        />
         Add an answer choice
       </a>
     </div>
     <div
-      class="largeSpacer_xwkmkn"
+      class="large-spacer"
     />
     <div>
       <div

--- a/packages/perseus-editor/src/widgets/expression-editor.module.css
+++ b/packages/perseus-editor/src/widgets/expression-editor.module.css
@@ -1,0 +1,42 @@
+.padded-x {
+    padding-left: var(--wb-sizing-size_080);
+    padding-right: var(--wb-sizing-size_080);
+}
+
+.padded-y {
+    padding-top: var(--wb-sizing-size_060);
+    padding-bottom: var(--wb-sizing-size_060);
+}
+
+.answer-option {
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    display: flex;
+    flex-direction: column;
+}
+
+.button-row {
+    display: flex;
+    gap: var(--wb-sizing-size_120);
+}
+
+/* TODO(LEMS-3686): Remove the !important once we don't need it anymore. */
+.button-sets {
+    text-transform: uppercase !important;
+}
+
+.answers-subtitle {
+    font-style: italic !important;
+}
+
+.answers-group {
+    gap: var(--wb-sizing-size_120) !important;
+}
+
+.answers-list {
+    gap: var(--wb-sizing-size_080) !important;
+}
+
+.delete-button {
+    padding-inline: var(--wb-sizing-size_160) !important;
+}

--- a/packages/perseus-editor/src/widgets/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor.tsx
@@ -8,17 +8,14 @@ import {
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Checkbox, LabeledTextField} from "@khanacademy/wonder-blocks-form";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {
-    semanticColor,
-    sizing,
-    spacing,
-} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {Heading, BodyText} from "@khanacademy/wonder-blocks-typography";
 import {isTruthy} from "@khanacademy/wonder-stuff-core";
-import {css, StyleSheet} from "aphrodite";
+import {StyleSheet} from "aphrodite";
 import * as React from "react";
 import _ from "underscore";
+
+import styles from "./expression-editor.module.css";
 
 import type {
     PerseusExpressionWidgetOptions,
@@ -51,11 +48,11 @@ const buttonSetsList: LegacyButtonSets = [
     "advanced relations",
 ];
 
-type State = {
+interface State {
     // this is to help the "functions" input feel natural
     // while still allowing us to store the functions as an array
     functionsInternal: string;
-};
+}
 
 // JSDoc will be shown in Storybook widget editor description
 /**
@@ -362,7 +359,7 @@ class ExpressionEditor extends React.Component<Props, State> {
             <View>
                 <Heading size="medium">Global Options</Heading>
 
-                <div className={css(styles.paddedY)}>
+                <div className={styles.paddedY}>
                     <LabeledTextField
                         label={
                             <>
@@ -380,7 +377,7 @@ class ExpressionEditor extends React.Component<Props, State> {
                     />
                 </div>
 
-                <div className={css(styles.paddedY)}>
+                <div className={styles.paddedY}>
                     <LabeledTextField
                         label={
                             <>
@@ -406,7 +403,7 @@ class ExpressionEditor extends React.Component<Props, State> {
                     />
                 </div>
 
-                <div className={css(styles.paddedY)}>
+                <div className={styles.paddedY}>
                     <LabeledTextField
                         label={
                             <>
@@ -424,7 +421,7 @@ class ExpressionEditor extends React.Component<Props, State> {
                     />
                 </div>
 
-                <div className={css(styles.paddedY)}>
+                <div className={styles.paddedY}>
                     <Checkbox
                         label={
                             <>
@@ -444,8 +441,8 @@ class ExpressionEditor extends React.Component<Props, State> {
                     />
                 </div>
 
-                <div className={css(styles.paddedY)}>
-                    <Heading size="small" style={styles.buttonSets}>
+                <div className={styles.paddedY}>
+                    <Heading size="small" className={styles.buttonSets}>
                         Button Sets
                     </Heading>
                     {buttonSetChoices}
@@ -453,17 +450,17 @@ class ExpressionEditor extends React.Component<Props, State> {
 
                 <Heading size="medium">Answers</Heading>
 
-                <BodyText size="small" style={styles.answersSubtitle}>
+                <BodyText size="small" className={styles.answersSubtitle}>
                     student responses area matched against these from top to
                     bottom
                 </BodyText>
 
-                <View style={{gap: spacing.xSmall_8}}>{answerOptions}</View>
-
-                <Strut size={spacing.small_12} />
-                <Button size="small" onClick={this.newAnswer}>
-                    Add new answer
-                </Button>
+                <View className={styles.answersGroup}>
+                    <View className={styles.answersList}>{answerOptions}</View>
+                    <Button size="small" onClick={this.newAnswer}>
+                        Add new answer
+                    </Button>
+                </View>
             </View>
         );
     }
@@ -476,7 +473,7 @@ const findNextIn = function <T>(arr: ReadonlyArray<T>, val: T) {
     return arr[ix];
 };
 
-type AnswerOptionProps = {
+interface AnswerOptionProps {
     considered: (typeof PerseusExpressionAnswerFormConsidered)[number];
     expressionProps: React.ComponentProps<typeof Expression>;
 
@@ -492,11 +489,11 @@ type AnswerOptionProps = {
     onChangeConsidered: (
         considered: (typeof PerseusExpressionAnswerFormConsidered)[number],
     ) => void;
-};
+}
 
-type AnswerOptionState = {
+interface AnswerOptionState {
     deleteFocused: boolean;
-};
+}
 
 class AnswerOption extends React.Component<
     AnswerOptionProps,
@@ -534,7 +531,6 @@ class AnswerOption extends React.Component<
                 >
                     I&apos;m sure!
                 </Button>
-                <Strut size={spacing.small_12} />
                 <Button
                     size="small"
                     onClick={this.handleCancelDelete}
@@ -549,14 +545,14 @@ class AnswerOption extends React.Component<
                 onClick={this.handleDelete}
                 actionType="destructive"
                 kind="tertiary"
-                style={styles.deleteButton}
+                className={styles.deleteButton}
             >
                 Delete
             </Button>
         );
 
         return (
-            <div className={css(styles.answerOption)}>
+            <div className={styles.answerOption}>
                 <ButtonGroup
                     onChange={this.toggleConsidered}
                     allowEmpty={false}
@@ -573,7 +569,7 @@ class AnswerOption extends React.Component<
 
                 <Expression {...this.props.expressionProps} />
 
-                <div className={css(styles.paddedY, styles.paddedX)}>
+                <div className={`${styles.paddedY} ${styles.paddedX}`}>
                     <Checkbox
                         label={
                             <>
@@ -590,7 +586,7 @@ class AnswerOption extends React.Component<
                     />
                 </div>
 
-                <div className={css(styles.paddedY, styles.paddedX)}>
+                <div className={`${styles.paddedY} ${styles.paddedX}`}>
                     <Checkbox
                         label={
                             <>
@@ -611,7 +607,7 @@ class AnswerOption extends React.Component<
                     />
                 </div>
 
-                <div className={css(styles.buttonRow, styles.paddedY)}>
+                <div className={`${styles.buttonRow} ${styles.paddedY}`}>
                     {removeButton}
                 </div>
             </div>
@@ -621,22 +617,7 @@ class AnswerOption extends React.Component<
 
 export default ExpressionEditor;
 
-const styles = StyleSheet.create({
-    paddedX: {
-        paddingLeft: spacing.xSmall_8,
-        paddingRight: spacing.xSmall_8,
-    },
-    paddedY: {
-        paddingTop: spacing.xxSmall_6,
-        paddingBottom: spacing.xxSmall_6,
-    },
-    answersSubtitle: {fontStyle: "italic"},
-    answerOption: {
-        border: "1px solid #ddd",
-        borderRadius: "3px",
-        display: "flex",
-        flexDirection: "column",
-    },
+const wbStyles = StyleSheet.create({
     answerStatusWrong: {
         backgroundColor: semanticColor.core.background.critical.subtle,
     },
@@ -646,22 +627,13 @@ const styles = StyleSheet.create({
     answerStatusUngraded: {
         backgroundColor: semanticColor.core.background.instructive.subtle,
     },
-    buttonRow: {
-        display: "flex",
-    },
-    deleteButton: {
-        paddingInline: sizing.size_160,
-    },
-    buttonSets: {
-        textTransform: "uppercase",
-    },
 });
 
 const consideredButtonStyles: Record<
     (typeof PerseusExpressionAnswerFormConsidered)[number],
     CSSProperties
 > = {
-    wrong: styles.answerStatusWrong,
-    correct: styles.answerStatusCorrect,
-    ungraded: styles.answerStatusUngraded,
+    wrong: wbStyles.answerStatusWrong,
+    correct: wbStyles.answerStatusCorrect,
+    ungraded: wbStyles.answerStatusUngraded,
 };

--- a/packages/perseus-editor/src/widgets/graded-group-editor.module.css
+++ b/packages/perseus-editor/src/widgets/graded-group-editor.module.css
@@ -1,0 +1,18 @@
+.title {
+    font-size: 18px;
+    font-weight: bold;
+}
+
+.input {
+    font-size: 18px;
+}
+
+.hints-title {
+    margin-top: var(--wb-sizing-size_100);
+    font-size: 110%;
+    font-weight: bold;
+}
+
+.add-hint-button {
+    margin-top: var(--wb-sizing-size_100);
+}

--- a/packages/perseus-editor/src/widgets/graded-group-editor.tsx
+++ b/packages/perseus-editor/src/widgets/graded-group-editor.tsx
@@ -7,12 +7,13 @@ import {
     iconTrash,
 } from "@khanacademy/perseus";
 import {gradedGroupLogic} from "@khanacademy/perseus-core";
-import {StyleSheet, css} from "aphrodite";
 import PropTypes from "prop-types";
 import * as React from "react";
 
 import Editor from "../editor";
 import {iconPlus} from "../styles/icon-paths";
+
+import styles from "./graded-group-editor.module.css";
 
 import type {
     GradedGroupDefaultWidgetOptions,
@@ -75,11 +76,11 @@ class GradedGroupEditor extends React.Component<Props> {
         return (
             <div className="perseus-group-editor">
                 <div className="perseus-widget-row">
-                    <label className={css(styles.title)}>
+                    <label className={styles.title}>
                         Title:{" "}
                         <TextInput
                             value={this.props.title}
-                            className={css(styles.input)}
+                            className={styles.input}
                             // @ts-expect-error - TS2554 - Expected 3 arguments, but got 1.
                             onChange={this.change("title")}
                         />
@@ -100,8 +101,7 @@ class GradedGroupEditor extends React.Component<Props> {
                 {!this.props.hint && (
                     <button
                         type="button"
-                        style={{marginTop: 10}}
-                        className="add-hint simple-button orange"
+                        className={`add-hint simple-button orange ${styles.addHintButton}`}
                         onClick={this.handleAddHint}
                     >
                         <InlineIcon {...iconPlus} /> Add a hint
@@ -109,7 +109,7 @@ class GradedGroupEditor extends React.Component<Props> {
                 )}
                 {this.props.hint && (
                     <div className="perseus-hint-editor">
-                        <div className={css(styles.hintsTitle)}>Hint</div>
+                        <div className={styles.hintsTitle}>Hint</div>
                         <Editor
                             ref={this.hintEditor}
                             content={
@@ -145,22 +145,5 @@ class GradedGroupEditor extends React.Component<Props> {
         );
     }
 }
-
-const styles = StyleSheet.create({
-    title: {
-        fontSize: 18,
-        fontWeight: "bold",
-    },
-
-    input: {
-        fontSize: 18,
-    },
-
-    hintsTitle: {
-        marginTop: 10,
-        fontSize: "110%",
-        fontWeight: "bold",
-    },
-});
 
 export default GradedGroupEditor;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
@@ -1,12 +1,12 @@
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
-type GraphTypeSelectorProps = {
+import styles from "../interactive-graph-editor.module.css";
+
+interface GraphTypeSelectorProps {
     graphType: string;
     onChange: (newGraphType: string) => void;
-};
+}
 
 const GraphTypeSelector = (props: GraphTypeSelectorProps) => {
     return (
@@ -14,7 +14,7 @@ const GraphTypeSelector = (props: GraphTypeSelectorProps) => {
             selectedValue={props.graphType}
             onChange={props.onChange}
             placeholder="Select an answer type"
-            style={styles.singleSelectShort}
+            className={styles.singleSelectShort}
         >
             <OptionItem value="none" label="None" />
             <OptionItem
@@ -38,11 +38,5 @@ const GraphTypeSelector = (props: GraphTypeSelectorProps) => {
         </SingleSelect>
     );
 };
-
-const styles = StyleSheet.create({
-    singleSelectShort: {
-        height: sizing.size_260,
-    },
-});
 
 export default GraphTypeSelector;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-description.module.css
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-description.module.css
@@ -1,0 +1,12 @@
+/* TODO(LEMS-3686): Remove the !important once Wonder Blocks is in the shared layer. */
+.container {
+    /* gap is for the vertical spacing between the captions and fields,
+     * while padding-top restores the space above the first caption
+     * this replaces the deprecated Strut spacing style */
+    gap: var(--wb-sizing-size_120) !important;
+    padding-top: var(--wb-sizing-size_060) !important;
+}
+
+.caption {
+    color: var(--wb-semanticColor-core-foreground-neutral-subtle) !important;
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-description.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-description.tsx
@@ -1,20 +1,20 @@
 import {View} from "@khanacademy/wonder-blocks-core";
 import {TextArea, TextField} from "@khanacademy/wonder-blocks-form";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import Heading from "../../../components/heading";
 
+import styles from "./interactive-graph-description.module.css";
+
 import type {Props as EditorProps} from "../interactive-graph-editor";
 
-type Props = {
+interface Props {
     ariaLabelValue: string;
     ariaDescriptionValue: string;
     onChange: (graphProps: Partial<EditorProps>) => void;
-};
+}
 
 export default function InteractiveGraphDescription(props: Props) {
     const {ariaLabelValue, ariaDescriptionValue, onChange} = props;
@@ -33,14 +33,14 @@ export default function InteractiveGraphDescription(props: Props) {
                 onToggle={setIsOpen}
             />
             {isOpen && (
-                <View>
-                    <BodyText size="xsmall" style={styles.caption}>
+                <View className={styles.container}>
+                    <BodyText size="xsmall" className={styles.caption}>
                         Use these fields to describe the graph as a whole. These
                         are used by screen readers to describe content to users
                         who may be visually impaired.
                     </BodyText>
 
-                    <BodyText size="xsmall" style={styles.caption}>
+                    <BodyText size="xsmall" className={styles.caption}>
                         Aria description required when using locked figures.
                         Locked figures aren't automatically described.
                     </BodyText>
@@ -57,10 +57,9 @@ export default function InteractiveGraphDescription(props: Props) {
                                         newValue || undefined,
                                 })
                             }
-                            style={styles.spaceAbove}
+                            style={{marginTop: sizing.size_040}}
                         />
                     </BodyText>
-                    <Strut size={spacing.small_12} />
                     <BodyText
                         size="medium"
                         weight="bold"
@@ -87,14 +86,3 @@ export default function InteractiveGraphDescription(props: Props) {
         </>
     );
 }
-
-const styles = StyleSheet.create({
-    caption: {
-        color: semanticColor.core.foreground.neutral.subtle,
-        paddingTop: spacing.xxSmall_6,
-        paddingBottom: spacing.xxSmall_6,
-    },
-    spaceAbove: {
-        marginTop: spacing.xxxSmall_4,
-    },
-});

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-settings.module.css
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-settings.module.css
@@ -1,0 +1,22 @@
+.background-url-input {
+    border: 1px solid var(--wb-semanticColor-core-border-neutral-subtle);
+    border-radius: var(--wb-sizing-size_040);
+    padding: var(--wb-sizing-size_040);
+}
+
+/* TODO(LEMS-3686): Remove the !important once Wonder Blocks is in the shared layer. */
+.checkbox-row {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    justify-content: space-between !important;
+    margin-bottom: var(--wb-sizing-size_080) !important;
+}
+
+.protractor-section {
+    margin-top: var(--wb-sizing-size_080) !important;
+    padding-top: var(--wb-sizing-size_080) !important;
+    padding-bottom: var(--wb-sizing-size_080) !important;
+    border-top: 1px solid var(--wb-semanticColor-core-border-neutral-subtle) !important;
+    border-bottom: 1px solid var(--wb-semanticColor-core-border-neutral-subtle) !important;
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-settings.test.tsx
@@ -97,9 +97,9 @@ describe("InteractiveGraphSettings", () => {
         // Assert
         expect(screen.getByText("x Label")).toBeInTheDocument();
         expect(screen.getByText("y Label")).toBeInTheDocument();
-        expect(screen.getByText("Markings:")).toBeInTheDocument();
+        expect(screen.getByText("Markings")).toBeInTheDocument();
         expect(screen.getByText("Snap Step")).toBeInTheDocument();
-        expect(screen.getByText("Background image URL:")).toBeInTheDocument();
+        expect(screen.getByText("Background image URL")).toBeInTheDocument();
         expect(screen.getByText("Show protractor")).toBeInTheDocument();
     });
 
@@ -143,7 +143,7 @@ describe("InteractiveGraphSettings", () => {
 
         // Act
         const input = screen.getByRole("textbox", {
-            name: "Background image URL:",
+            name: "Background image URL",
         });
         await userEvent.type(input, "https://example.com/image.png");
         await userEvent.tab();
@@ -181,7 +181,7 @@ describe("InteractiveGraphSettings", () => {
 
         // Act
         const input = screen.getByRole("textbox", {
-            name: "Background image URL:",
+            name: "Background image URL",
         });
         await userEvent.type(input, "https://example.com/image.png");
         await userEvent.tab();
@@ -214,7 +214,7 @@ describe("InteractiveGraphSettings", () => {
 
         // Act
         const input = screen.getByRole("textbox", {
-            name: "Background image URL:",
+            name: "Background image URL",
         });
         await userEvent.clear(input);
         await userEvent.tab();
@@ -247,7 +247,7 @@ describe("InteractiveGraphSettings", () => {
 
         // Act
         const input = screen.getByRole("textbox", {
-            name: "Background image URL:",
+            name: "Background image URL",
         });
         input.focus();
         // Disabling this because we need to test keypress events that are

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-settings.tsx
@@ -12,8 +12,6 @@ import Banner from "@khanacademy/wonder-blocks-banner";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
-import {css, StyleSheet} from "aphrodite";
 import * as React from "react";
 import _ from "underscore";
 
@@ -22,6 +20,7 @@ import LabeledRow from "../locked-figures/labeled-row";
 
 import AxisArrowSwitches from "./axis-arrow-switches";
 import AxisTickSwitches from "./axis-tick-switches";
+import styles from "./interactive-graph-settings.module.css";
 
 import type {APIOptionsWithDefaults} from "@khanacademy/perseus";
 import type {
@@ -48,7 +47,7 @@ function numSteps(range: any, step: any) {
 
 type Range = [min: number, max: number];
 
-type Props = {
+interface Props {
     /**
      * The size of the graph area in pixels.
      */
@@ -119,9 +118,9 @@ type Props = {
     onChange: (arg1: Partial<Props>) => void;
 
     apiOptions: APIOptionsWithDefaults;
-};
+}
 
-type State = {
+interface State {
     isExpanded: boolean;
     labelsTextbox: ReadonlyArray<string>;
     labelLocation: AxisLabelLocation;
@@ -132,7 +131,7 @@ type State = {
     showAxisArrowsSwitches: ShowAxisArrows;
     showAxisTicksSwitches: ShowAxisTicks;
     backgroundImage: PerseusImageBackground;
-};
+}
 
 class InteractiveGraphSettings extends React.Component<Props, State> {
     _isMounted = false;
@@ -706,7 +705,7 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
                                 </div>
                             </div>
                             <div className="perseus-widget-row">
-                                <LabeledRow label="Markings:">
+                                <LabeledRow label="Markings">
                                     <ButtonGroup
                                         value={this.props.markings}
                                         allowEmpty={false}
@@ -732,12 +731,12 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
                         </div>
 
                         <LabeledRow
-                            label="Background image URL:"
-                            style={styles.resetSpaceTop}
+                            label="Background image URL"
+                            style={{marginTop: 0}}
                         >
                             <input
                                 type="text"
-                                className={css(styles.backgroundUrlInput)}
+                                className={styles.backgroundUrlInput}
                                 ref={this.bgUrlRef}
                                 value={this.state.backgroundImage.url || ""}
                                 onChange={(e) => {
@@ -760,15 +759,15 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
                             </InfoTip>
                         </LabeledRow>
 
-                        <View style={styles.protractorSection}>
-                            <View style={styles.checkboxRow}>
+                        <View className={styles.protractorSection}>
+                            <View className={styles.checkboxRow}>
                                 <Checkbox
                                     label="Show protractor"
                                     checked={this.props.showProtractor}
                                     onChange={(value) => {
                                         this.change({showProtractor: value});
                                     }}
-                                    style={styles.resetSpaceTop}
+                                    style={{marginTop: 0}}
                                 />
                             </View>
                             {this.props.showProtractor && (
@@ -784,29 +783,5 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
         );
     }
 }
-
-const styles = StyleSheet.create({
-    resetSpaceTop: {
-        marginTop: 0,
-    },
-    backgroundUrlInput: {
-        border: `1px solid ${semanticColor.core.border.neutral.subtle}`,
-        borderRadius: spacing.xxxSmall_4,
-        padding: spacing.xxxSmall_4,
-    },
-    checkboxRow: {
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "space-between",
-        marginBottom: spacing.xSmall_8,
-    },
-    protractorSection: {
-        marginTop: spacing.xSmall_8,
-        borderTop: `1px solid ${semanticColor.core.border.neutral.subtle}`,
-        paddingTop: spacing.xSmall_8,
-        paddingBottom: spacing.xSmall_8,
-        borderBottom: `1px solid ${semanticColor.core.border.neutral.subtle}`,
-    },
-});
 
 export default InteractiveGraphSettings;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.module.css
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.module.css
@@ -1,0 +1,19 @@
+.tree-list {
+    list-style: revert;
+    margin-left: var(--wb-sizing-size_080);
+}
+
+.indent-list {
+    list-style: revert;
+    margin-left: var(--wb-sizing-size_120);
+}
+
+/* TODO(LEMS-3686): Remove the !important once Wonder Blocks is in the shared layer. */
+.switch-row {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    gap: var(--wb-sizing-size_080) !important;
+    margin-top: var(--wb-sizing-size_080) !important;
+    margin-bottom: var(--wb-sizing-size_080) !important;
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
@@ -1,28 +1,28 @@
 import {components} from "@khanacademy/perseus";
-import {addStyle, View} from "@khanacademy/wonder-blocks-core";
-import {Spring, Strut} from "@khanacademy/wonder-blocks-layout";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {Spring} from "@khanacademy/wonder-blocks-layout";
 import Pill from "@khanacademy/wonder-blocks-pill";
 import Switch from "@khanacademy/wonder-blocks-switch";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import Heading from "../../../components/heading";
 
-const {InfoTip} = components;
-const StyledUl = addStyle("ul");
+import styles from "./interactive-graph-sr-tree.module.css";
 
-type Attribute = {
+const {InfoTip} = components;
+
+interface Attribute {
     name: string;
     value: string;
-};
+}
 
-type AttributeMap = {
+interface AttributeMap {
     roleOrTag: string;
     className: string;
     attributes: Array<Attribute>;
-};
+}
 
 // Exported for testing
 export function getAccessibilityAttributes(graphId: string): AttributeMap[] {
@@ -90,10 +90,10 @@ export function getAccessibilityAttributes(graphId: string): AttributeMap[] {
     return elementArias;
 }
 
-type Props = {
+interface Props {
     elementArias: Array<AttributeMap>;
     showTags: boolean;
-};
+}
 
 function SRTree(props: Props) {
     const {elementArias, showTags} = props;
@@ -101,20 +101,20 @@ function SRTree(props: Props) {
     // Each list item of this ordered list is the role/rag of the element
     // followed by an unordered list of its aria attributes.
     return (
-        <ol style={{listStyle: "revert", marginLeft: 8}}>
+        <ol className={styles.treeList}>
             {elementArias.map((aria, index) => (
                 <li key={index}>
                     {showTags && (
                         <Pill
                             size="small"
                             kind="success"
-                            style={styles.smallSpaceRight}
+                            style={{marginRight: sizing.size_060}}
                         >
                             {aria.roleOrTag}
                         </Pill>
                     )}
                     {aria.className}
-                    <StyledUl style={styles.indentListLeft}>
+                    <ul className={styles.indentList}>
                         {aria.attributes.map((value, index) => (
                             <li key={index}>
                                 <Pill
@@ -124,14 +124,14 @@ function SRTree(props: Props) {
                                             ? "info"
                                             : "neutral"
                                     }
-                                    style={styles.smallSpaceRight}
+                                    style={{marginRight: sizing.size_060}}
                                 >
                                     {value.name}
                                 </Pill>
                                 {value.value}
                             </li>
                         ))}
-                    </StyledUl>
+                    </ul>
                 </li>
             ))}
         </ol>
@@ -175,13 +175,12 @@ function InteractiveGraphSRTree({
             />
             {isExpanded && (
                 <>
-                    <View style={[styles.row, styles.tagSwitch]}>
+                    <View className={styles.switchRow}>
                         <Switch
                             id={switchId}
                             checked={showTags}
                             onChange={setShowTags}
                         />
-                        <Strut size={spacing.xSmall_8} />
                         <BodyText size="small" tag="label" htmlFor={switchId}>
                             Show HTML roles/tags
                         </BodyText>
@@ -198,23 +197,5 @@ function InteractiveGraphSRTree({
         </>
     );
 }
-
-const styles = StyleSheet.create({
-    smallSpaceRight: {
-        marginRight: spacing.xxSmall_6,
-    },
-    indentListLeft: {
-        listStyle: "revert",
-        marginLeft: spacing.small_12,
-    },
-    tagSwitch: {
-        marginTop: spacing.xSmall_8,
-        marginBottom: spacing.xSmall_8,
-    },
-    row: {
-        flexDirection: "row",
-        alignItems: "center",
-    },
-});
 
 export default InteractiveGraphSRTree;

--- a/packages/perseus-editor/src/widgets/label-image-editor/answer-choices.module.css
+++ b/packages/perseus-editor/src/widgets/label-image-editor/answer-choices.module.css
@@ -1,0 +1,44 @@
+.title {
+    font-family: inherit;
+    font-size: 15px;
+    font-weight: bold;
+    line-height: 22px;
+    margin-bottom: var(--wb-sizing-size_060);
+    color: #626569; /* gray17 */
+}
+
+.answers {
+    margin-top: var(--wb-sizing-size_120);
+    margin-bottom: var(--wb-sizing-size_120);
+}
+
+.answer {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--wb-sizing-size_160);
+}
+
+.answer:not(:first-child) {
+    margin-top: var(--wb-sizing-size_120);
+}
+
+.add-answer {
+    font-family: inherit;
+    font-size: 15px;
+    font-weight: bold;
+    line-height: var(--wb-sizing-size_220);
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: var(--wb-sizing-size_160);
+    color: var(--wb-semanticColor-link-rest);
+}
+
+.add-answer:link {
+    color: var(--wb-semanticColor-link-rest);
+}
+
+.disabled {
+    cursor: not-allowed;
+}

--- a/packages/perseus-editor/src/widgets/label-image-editor/answer-choices.tsx
+++ b/packages/perseus-editor/src/widgets/label-image-editor/answer-choices.tsx
@@ -2,31 +2,32 @@
  * Controlled list of answer choices, handles adding and removing answers.
  */
 
-import {components, bodyXsmallBold} from "@khanacademy/perseus";
-import {StyleSheet, css} from "aphrodite";
+import {components} from "@khanacademy/perseus";
 import * as React from "react";
 
 import FormWrappedTextField from "../../components/form-wrapped-text-field";
 import Link from "../../components/link";
 import {gray17} from "../../styles/global-colors";
 
+import styles from "./answer-choices.module.css";
+
 const {Icon} = components;
 
-type AddAnswerProps = {
+interface AddAnswerProps {
     // Callback to add new answer choice.
     onClick: () => void;
-};
+}
 
-type AnswerProps = {
+interface AnswerProps {
     // The answer string, can be plain text or a TeX expression.
     answer: string;
     // Callback for when an answer is changed.
     onChange: (answer: string) => void;
     // Callback to remove answer from list of choices.
     onRemove: () => void;
-};
+}
 
-export type AnswerChoicesProps = {
+export interface AnswerChoicesProps {
     // The list of possible answers in a specific order.
     choices: ReadonlyArray<string>;
     // Callback for when answers change.
@@ -34,7 +35,7 @@ export type AnswerChoicesProps = {
     // Whether the editor is disabled. Can be set via API options
     // to make the editor read-only when needed.
     editingDisabled: boolean;
-};
+}
 
 const addIcon = {
     path: "M11 11V7a1 1 0 0 1 2 0v4h4a1 1 0 0 1 0 2h-4v4a1 1 0 0 1-2 0v-4H7a1 1 0 0 1 0-2h4zm1 13C5.373 24 0 18.627 0 12S5.373 0 12 0s12 5.373 12 12-5.373 12-12 12zm0-2c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z",
@@ -94,12 +95,8 @@ const DraggableGripIcon = () => (
  */
 const AddAnswer = ({onClick}: AddAnswerProps): React.ReactElement => (
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events, jsx-a11y/anchor-is-valid -- TODO(LEMS-2871): Address a11y error
-    <Link
-        className={css(styles.addAnswer, editorStyles.addAnswer)}
-        onClick={onClick}
-    >
+    <Link className={styles.addAnswer} onClick={onClick}>
         <Icon icon={addIcon} size={24} />
-        <div className={css(styles.spacer)} />
         Add an answer choice
     </Link>
 );
@@ -112,13 +109,11 @@ const Answer = ({
     onChange,
     onRemove,
 }: AnswerProps): React.ReactElement => (
-    <li className={css(styles.answer)}>
+    <li className={styles.answer}>
         {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events, jsx-a11y/anchor-is-valid -- TODO(LEMS-2871): Address a11y error, TODO(LEMS-2871): Address a11y error */}
         <Link onClick={onRemove}>
             <Icon icon={removeIcon} size={24} color="#D92916" />
         </Link>
-
-        <div className={css(styles.spacer)} />
 
         <FormWrappedTextField
             grow={1}
@@ -126,11 +121,9 @@ const Answer = ({
             value={answer}
         />
 
-        <div className={css(styles.spacer)} />
-
         {/* eslint-disable-next-line jsx-a11y/anchor-is-valid -- TODO(LEMS-2871): Address a11y error */}
         <Link
-            style={[styles.disabled]}
+            className={styles.disabled}
             title="Answer reordering is not implemented."
         >
             <DraggableGripIcon />
@@ -147,9 +140,9 @@ const AnswerChoices = ({
     onChange,
 }: AnswerChoicesProps): React.ReactElement => (
     <div>
-        <div className={css(styles.title)}>Answer Choices</div>
+        <div className={styles.title}>Answer Choices</div>
 
-        <ul className={css(styles.answers)}>
+        <ul className={styles.answers}>
             {choices.map((answer, index) => (
                 <Answer
                     answer={answer}
@@ -190,56 +183,5 @@ const AnswerChoices = ({
         />
     </div>
 );
-
-const styles = StyleSheet.create({
-    title: {
-        ...bodyXsmallBold,
-
-        marginBottom: 6,
-
-        color: gray17,
-    },
-
-    answers: {
-        marginTop: 12,
-        marginBottom: 12,
-    },
-
-    answer: {
-        display: "flex",
-        flexDirection: "row",
-        alignItems: "center",
-
-        ":not(:first-child)": {
-            marginTop: 12,
-        },
-    },
-
-    addAnswer: {
-        ...bodyXsmallBold,
-
-        display: "flex",
-        flexDirection: "row",
-        alignItems: "center",
-
-        color: "#1865f2",
-    },
-
-    spacer: {
-        width: 16,
-    },
-
-    disabled: {
-        cursor: "not-allowed",
-    },
-});
-
-const editorStyles = StyleSheet.create({
-    addAnswer: {
-        ":link": {
-            color: "#1865f2",
-        },
-    },
-});
 
 export default AnswerChoices;

--- a/packages/perseus-editor/src/widgets/label-image-editor/label-image-editor.module.css
+++ b/packages/perseus-editor/src/widgets/label-image-editor/label-image-editor.module.css
@@ -24,3 +24,11 @@
 .selectLabel {
     margin-right: var(--wb-sizing-size_080);
 }
+
+.small-spacer {
+    height: var(--wb-sizing-size_160);
+}
+
+.large-spacer {
+    height: var(--wb-sizing-size_320);
+}

--- a/packages/perseus-editor/src/widgets/label-image-editor/label-image-editor.tsx
+++ b/packages/perseus-editor/src/widgets/label-image-editor/label-image-editor.tsx
@@ -1,12 +1,12 @@
 import {EditorJsonify, Util} from "@khanacademy/perseus";
 import {labelImageLogic} from "@khanacademy/perseus-core";
-import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
 
 import FormWrappedTextField from "../../components/form-wrapped-text-field";
 
 import AnswerChoices from "./answer-choices";
 import Behavior from "./behavior";
+import styles from "./label-image-editor.module.css";
 import QuestionMarkers from "./question-markers";
 import SelectImage from "./select-image";
 
@@ -17,7 +17,7 @@ import type {
     LabelImageDefaultWidgetOptions,
 } from "@khanacademy/perseus-core";
 
-type Props = {
+interface Props {
     apiOptions: APIOptions;
     // List of answer choices to label question image with.
     choices: string[];
@@ -35,7 +35,7 @@ type Props = {
     // Callback for when a widget prop is changed.
     onChange: (options: any) => void;
     preferredPopoverDirection: PreferredPopoverDirection;
-};
+}
 
 // JSDoc will be shown in Storybook widget editor description
 /**
@@ -215,7 +215,7 @@ class LabelImageEditor extends React.Component<Props> {
             <div>
                 <SelectImage onChange={this.handleImageChange} url={imageUrl} />
 
-                <div className={css(styles.smallSpacer)} />
+                <div className={styles.smallSpacer} />
 
                 {/* eslint-disable-next-line @typescript-eslint/strict-boolean-expressions */}
                 {imageSelected && (
@@ -227,7 +227,7 @@ class LabelImageEditor extends React.Component<Props> {
                     />
                 )}
 
-                <div className={css(styles.largeSpacer)} />
+                <div className={styles.largeSpacer} />
 
                 <QuestionMarkers
                     editingDisabled={editingDisabled}
@@ -241,7 +241,7 @@ class LabelImageEditor extends React.Component<Props> {
                     ref={(node) => (this._questionMarkers = node)}
                 />
 
-                <div className={css(styles.largeSpacer)} />
+                <div className={styles.largeSpacer} />
 
                 <AnswerChoices
                     choices={choices}
@@ -249,7 +249,7 @@ class LabelImageEditor extends React.Component<Props> {
                     onChange={this.handleChoicesChange}
                 />
 
-                <div className={css(styles.largeSpacer)} />
+                <div className={styles.largeSpacer} />
 
                 <Behavior
                     preferredPopoverDirection={preferredPopoverDirection}
@@ -261,15 +261,5 @@ class LabelImageEditor extends React.Component<Props> {
         );
     }
 }
-
-const styles = StyleSheet.create({
-    largeSpacer: {
-        height: 32,
-    },
-
-    smallSpacer: {
-        height: 16,
-    },
-});
 
 export default LabelImageEditor;

--- a/packages/perseus-editor/src/widgets/label-image-editor/select-image.module.css
+++ b/packages/perseus-editor/src/widgets/label-image-editor/select-image.module.css
@@ -1,0 +1,13 @@
+.title {
+    font-family: inherit;
+    font-size: 15px;
+    font-weight: bold;
+    line-height: 22px;
+    margin-bottom: var(--wb-sizing-size_060);
+    color: #626569; /* gray17 */
+}
+
+.image-row {
+    display: flex;
+    gap: var(--wb-sizing-size_160);
+}

--- a/packages/perseus-editor/src/widgets/label-image-editor/select-image.tsx
+++ b/packages/perseus-editor/src/widgets/label-image-editor/select-image.tsx
@@ -2,34 +2,31 @@
  * Controlled component for selecting the question image, for answer labeling.
  */
 
-import {bodyXsmallBold} from "@khanacademy/perseus";
 import Button from "@khanacademy/wonder-blocks-button";
-import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
 
 import FormWrappedTextField from "../../components/form-wrapped-text-field";
-import {gray17} from "../../styles/global-colors";
 
-export type SelectImageProps = {
+import styles from "./select-image.module.css";
+
+export interface SelectImageProps {
     // Callback for when image URL is changed.
     onChange: (url: string) => void;
     // The selected image URL.
     url: string;
-};
+}
 
 const SelectImage = ({onChange, url}: SelectImageProps): React.ReactElement => (
     <div>
-        <div className={css(styles.title)}>Image</div>
+        <div className={styles.title}>Image</div>
 
-        <div className={css(styles.components)}>
+        <div className={styles.imageRow}>
             <FormWrappedTextField
                 placeholder="URL"
                 grow={1}
                 onChange={(e) => onChange(e.target.value)}
                 value={url}
             />
-
-            <div className={css(styles.spacer)} />
 
             <Button
                 disabled={!url}
@@ -40,34 +37,12 @@ const SelectImage = ({onChange, url}: SelectImageProps): React.ReactElement => (
                           "the editor to upload image, then copy the URL here."
                 }
                 onClick={() => onChange("")}
-                style={styles.btn}
+                style={{minWidth: 90}}
             >
                 {url ? "Remove" : "Upload"}
             </Button>
         </div>
     </div>
 );
-
-const styles = StyleSheet.create({
-    title: {
-        ...bodyXsmallBold,
-
-        marginBottom: 6,
-
-        color: gray17,
-    },
-
-    components: {
-        display: "flex",
-    },
-
-    spacer: {
-        width: 16,
-    },
-
-    btn: {
-        minWidth: 90,
-    },
-});
 
 export default SelectImage;

--- a/packages/perseus-editor/src/widgets/numeric-input-editor.tsx
+++ b/packages/perseus-editor/src/widgets/numeric-input-editor.tsx
@@ -66,12 +66,12 @@ type Props = Omit<PerseusNumericInputWidgetOptions, "static"> & {
     apiOptions?: APIOptionsWithDefaults;
 };
 
-type State = {
+interface State {
     lastStatus: string;
     showAnswerDetails: boolean[];
     showSettings: boolean;
     showAnswers: boolean;
-};
+}
 
 // JSDoc will be shown in Storybook widget editor description
 /**

--- a/packages/perseus-editor/src/widgets/radio/radio-editor.module.css
+++ b/packages/perseus-editor/src/widgets/radio/radio-editor.module.css
@@ -5,34 +5,34 @@
         --wb-semanticColor-core-background-instructive-subtle
     );
     border: 1px solid var(--wb-semanticColor-core-border-neutral-subtle);
-    border-radius: 12px;
-    padding-inline: 12px;
-    padding-block: 4px;
-    margin-block-end: 12px;
+    border-radius: var(--wb-sizing-size_120);
+    padding-inline: var(--wb-sizing-size_120);
+    padding-block: var(--wb-sizing-size_040);
+    margin-block-end: var(--wb-sizing-size_120);
 }
 
 .radio-option-actions-container {
     display: flex;
     flex-direction: row;
     align-items: center;
-    margin-block-start: 8px;
+    margin-block-start: var(--wb-sizing-size_080);
 }
 
 .button-row {
     display: flex;
     flex-direction: row;
     align-items: center;
-    margin-block-start: 8px;
+    margin-block-start: var(--wb-sizing-size_080);
 }
 
 .image-editor-container {
     display: flex;
     flex-direction: column;
     position: relative;
-    padding: 8px;
-    padding-block-start: 24px;
+    padding: var(--wb-sizing-size_080);
+    padding-block-start: var(--wb-sizing-size_240);
     border: 1px solid var(--wb-semanticColor-core-border-neutral-default);
-    border-radius: 8px;
-    margin-block-start: 8px;
+    border-radius: var(--wb-sizing-size_080);
+    margin-block-start: var(--wb-sizing-size_080);
     background-color: var(--wb-semanticColor-core-background-base-default);
 }

--- a/packages/perseus-editor/src/widgets/radio/radio-option-content-and-image-editor.tsx
+++ b/packages/perseus-editor/src/widgets/radio/radio-option-content-and-image-editor.tsx
@@ -13,16 +13,16 @@ import {
     setImageProxyFromMarkdownContent,
 } from "./utils";
 
-type Props = {
+interface Props {
     isNoneOfTheAbove: boolean;
     content: string;
     choiceIndex: number;
     onContentChange: (choiceIndex: number, content: string) => void;
-};
+}
 
-export type RadioOptionContentAndImageEditorHandle = {
+export interface RadioOptionContentAndImageEditorHandle {
     focus: () => void;
-};
+}
 
 export const RadioOptionContentAndImageEditor = React.forwardRef<
     RadioOptionContentAndImageEditorHandle,

--- a/packages/perseus/src/components/button-group.tsx
+++ b/packages/perseus/src/components/button-group.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 
 import type {CSSProperties} from "aphrodite";
 
-type Props = {
+interface Props {
     // the initial value of the button selected, defaults to null
     value: any;
     buttons: ReadonlyArray<{
@@ -26,12 +26,12 @@ type Props = {
      * Customizes the selected button's styling.
      */
     selectedButtonStyle?: CSSProperties;
-};
+}
 
-type DefaultProps = {
+interface DefaultProps {
     allowEmpty: Props["allowEmpty"];
     value: Props["value"];
-};
+}
 
 /**
  * ButtonGroup is an aesthetically pleasing group of buttons.
@@ -73,7 +73,6 @@ class ButtonGroup extends React.Component<Props> {
                 <button
                     title={button.title}
                     type="button"
-                    ref={"button" + i}
                     key={"" + i}
                     className={css(
                         styles.buttonStyle,


### PR DESCRIPTION
## Summary:

Improved the code by updating the editor label for consitency, and styling/type modernization, this is a prework for adding `editingDisabled` in to each editor to improve the CX UX when the editor is disabled e.g. when publish is happening.
- change (State object type alias -> interface); no runtime/behavior change
- styling & type modernization grouped per widget editor, including using gap styling instead of deprecated WB Strut, and usage of aphrodite
- change couple interactive graph settings labels

Co-Authored-By: Claude (Opus)

Issue: LEMS-4131

## Test plan:
1. Go to interactive graph editor, notice that labels are updated for `Markings:` → `Markings`, and `Background image URL` → `Background image URL`
2. Have prod storybook and znd storybook side by side, no behavior change only styling and type updates for the following editors:
- interactive graph
- radio
- label-image
- expression
- graded group
- numeric-input

## Related PRs / Follow-up work related to `editingDisabled`
| PR | Scope | Branch | Status | Notes |
|----|-------|--------|--------|-------|
| **[PR 1](https://github.com/Khan/perseus/pull/3777)** | Phase 1 (labels) + Phase 2B (modernization of touched non-locked-figures editors) | `LEMS-4131/improve-editor-labels` | ✅ |  |
| **[PR 2](https://github.com/Khan/perseus/pull/3779)** | Phase 2A (locked-figures refactor) | `LEMS-4131/editor-locked-figures-code-refactor` | ✅ | The heaviest CSS-module migration; independent of PR 1. |
| **PR 3** | Phase 3 (numeric-input label restructuring) | — | ⚪ not started, will skip | Standalone; after Phase 2B. |
| **[PR 4](https://github.com/Khan/perseus/pull/3782)** | Phase 4 (Pill → Badge / SegmentedControl) | `LEMS-4131/editor-pill-to-badge` | ✅  | Carries a UX behavior change (radio A/B/C) |
| **[PR 5](https://github.com/Khan/perseus/pull/3787)** | Phase 5 (`editingDisabled` functional fix — the actual deliverable) | `LEMS-4131/editor-add-editing-disabled` | In Review | Depends on PR 4; starts with the `button-group` `disabled` enabler. |