### PR TITLE
Fix flaky Matcher TeX Chromatic snapshot with increased delay

### DIFF
--- a/.changeset/proud-rules-wash.md
+++ b/.changeset/proud-rules-wash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Increase delay on flaky TeX Chromatic snapshot for Matcher

--- a/packages/perseus/src/widgets/matcher/__docs__/matcher-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/matcher/__docs__/matcher-initial-state-regression.stories.tsx
@@ -57,30 +57,29 @@ export const WithoutLabels: Story = {
     },
 };
 
-// TODO: Test flaky, commenting until it's fixed
 // Verifies TeX rendering in both column labels and item cards. The 500ms delay
 // gives MathJax time to finish rendering and onMeasure to settle before
 // Chromatic takes its snapshot.
-// export const WithTeX: Story = {
-//     decorators: [matcherRendererDecorator],
-//     parameters: {
-//         chromatic: {delay: 1000},
-//     },
-//     args: {
-//         ...sharedArgs,
-//         labels: ["$f(x)$", "$f'(x)$"],
-//         left: [
-//             "$f(x) = \\dfrac{1}{x}$",
-//             "$f(x) = \\dfrac{1}{x^2}$",
-//             "$f(x) = \\dfrac{1}{x^3}$",
-//         ],
-//         right: [
-//             "$f'(x) = -\\dfrac{1}{x^2}$",
-//             "$f'(x) = -\\dfrac{2}{x^3}$",
-//             "$f'(x) = -\\dfrac{3}{x^4}$",
-//         ],
-//     },
-// };
+export const WithTeX: Story = {
+    decorators: [matcherRendererDecorator],
+    parameters: {
+        chromatic: {delay: 5000},
+    },
+    args: {
+        ...sharedArgs,
+        labels: ["$f(x)$", "$f'(x)$"],
+        left: [
+            "$f(x) = \\dfrac{1}{x}$",
+            "$f(x) = \\dfrac{1}{x^2}$",
+            "$f(x) = \\dfrac{1}{x^3}$",
+        ],
+        right: [
+            "$f'(x) = -\\dfrac{1}{x^2}$",
+            "$f'(x) = -\\dfrac{2}{x^3}$",
+            "$f'(x) = -\\dfrac{3}{x^4}$",
+        ],
+    },
+};
 
 // Verifies the orderMatters state: both columns render as draggable cards
 // (white background, visible border) rather than the left column appearing


### PR DESCRIPTION
## Summary:
After converting colors and fonts in Matcher and creating visual regression tests, we noticed one of the tests was still flaky. Attempted to fix with a delay, but that wasn't robust enough.

After reviewing a more robust solution though (see ticket for relevant PRs), we decided to just increase the delay even more and not pursue something more in-depth at this time, especially since Sorter is currently being redone (same mechanics apply to Matcher through Sortable). 

Issue: LEMS-4117

## Test plan:
- Confirm the snapshot appears
- Keep track of the test in future PRs to see if it is still flaky