### PR TITLE
[LockedFigures] Locked-figures editor styling/type modernization

### DIFF
--- a/.changeset/clever-doors-care.md
+++ b/.changeset/clever-doors-care.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Locked-figures editor styling/type modernization

--- a/packages/perseus-editor/src/components/coordinate-pair-input.module.css
+++ b/packages/perseus-editor/src/components/coordinate-pair-input.module.css
@@ -1,0 +1,14 @@
+/* TODO(LEMS-3686): Remove the !important once Wonder Blocks is in the shared layer. */
+.container {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    gap: var(--wb-sizing-size_160) !important;
+}
+
+.label {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    gap: var(--wb-sizing-size_060) !important;
+}

--- a/packages/perseus-editor/src/components/coordinate-pair-input.tsx
+++ b/packages/perseus-editor/src/components/coordinate-pair-input.tsx
@@ -1,16 +1,15 @@
 import {View} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
+import styles from "./coordinate-pair-input.module.css";
 import ScrolllessNumberTextField from "./scrollless-number-text-field";
 
 import type {Coord} from "@khanacademy/perseus";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-type Props = {
+interface Props {
     coord: [number, number];
     labels?: [string, string];
     error?: boolean;
@@ -18,6 +17,14 @@ type Props = {
     // TODO(LEMS-3995) simplifying styling after custom label work + change deprecated WonderBlocks component / aphrodite
     labelStyle?: StyleType;
     onChange: (newCoord: Coord) => void;
+}
+
+// Passed to ScrolllessNumberTextField's `style` prop, which is typed as Wonder
+// Blocks `StyleType` and does not accept a CSS-module className.
+const textFieldStyle: StyleType = {width: sizing.size_640};
+const errorFieldStyle: StyleType = {
+    borderColor: semanticColor.core.border.critical.default,
+    backgroundColor: semanticColor.core.background.critical.subtle,
 };
 
 const CoordinatePairInput = (props: Props) => {
@@ -59,8 +66,8 @@ const CoordinatePairInput = (props: Props) => {
     }
 
     return (
-        <View style={[styles.row, style]}>
-            <BodyText tag="label" style={styles.row}>
+        <View className={styles.container} style={style}>
+            <BodyText tag="label" className={styles.label}>
                 {/* TODO(LEMS-3995) simplifying styling after custom label work + change deprecated WonderBlocks component / aphrodite */}
                 {labelStyle != null ? (
                     <View style={labelStyle}>{xLabel}</View>
@@ -68,19 +75,17 @@ const CoordinatePairInput = (props: Props) => {
                     xLabel
                 )}
 
-                <Strut size={spacing.xxSmall_6} />
                 <ScrolllessNumberTextField
                     value={coordState[0]}
                     onChange={(newValue) => handleCoordChange(newValue, 0)}
                     style={[
-                        styles.textField,
-                        error ? styles.errorField : undefined,
+                        textFieldStyle,
+                        error ? errorFieldStyle : undefined,
                     ]}
                 />
             </BodyText>
-            <Strut size={spacing.medium_16} />
 
-            <BodyText tag="label" style={styles.row}>
+            <BodyText tag="label" className={styles.label}>
                 {/* TODO(LEMS-3995) simplifying styling after custom label work + change deprecated WonderBlocks component / aphrodite */}
                 {labelStyle != null ? (
                     <View style={labelStyle}>{yLabel}</View>
@@ -88,33 +93,17 @@ const CoordinatePairInput = (props: Props) => {
                     yLabel
                 )}
 
-                <Strut size={spacing.xxSmall_6} />
                 <ScrolllessNumberTextField
                     value={coordState[1]}
                     onChange={(newValue) => handleCoordChange(newValue, 1)}
                     style={[
-                        styles.textField,
-                        error ? styles.errorField : undefined,
+                        textFieldStyle,
+                        error ? errorFieldStyle : undefined,
                     ]}
                 />
             </BodyText>
         </View>
     );
 };
-
-const styles = StyleSheet.create({
-    row: {
-        display: "flex",
-        flexDirection: "row",
-        alignItems: "center",
-    },
-    textField: {
-        width: spacing.xxxLarge_64,
-    },
-    errorField: {
-        borderColor: semanticColor.core.border.critical.default,
-        backgroundColor: semanticColor.core.background.critical.subtle,
-    },
-});
 
 export default CoordinatePairInput;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/color-select.module.css
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/color-select.module.css
@@ -1,0 +1,10 @@
+/* TODO(LEMS-3686): Remove the !important once Wonder Blocks is in the shared layer. */
+.row {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    gap: var(--wb-sizing-size_060) !important;
+    /* Set minWidth to "auto" to prevent the component from bleeding */
+    /* into the margins. (minWidth is 0 by default.) */
+    min-width: auto !important;
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/color-select.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/color-select.tsx
@@ -1,31 +1,28 @@
 import {lockedFigureColorNames} from "@khanacademy/perseus-core";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
+import styles from "./color-select.module.css";
 import ColorSwatch from "./color-swatch";
 
 import type {LockedFigureColor} from "@khanacademy/perseus-core";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-type Props = {
+interface Props {
     selectedValue: LockedFigureColor;
     style?: StyleType;
     onChange: (newColor: LockedFigureColor) => void;
-};
+}
 
 const ColorSelect = (props: Props) => {
     const {selectedValue, style, onChange} = props;
 
     return (
-        <View style={[styles.row, style]}>
-            <BodyText tag="label" style={styles.row}>
+        <View className={styles.row} style={style}>
+            <BodyText tag="label" className={styles.row}>
                 color
-                <Strut size={spacing.xxSmall_6} />
                 <SingleSelect
                     selectedValue={selectedValue}
                     // TODO(LEMS-2656): remove TS suppression
@@ -52,16 +49,5 @@ const ColorSelect = (props: Props) => {
         </View>
     );
 };
-
-const styles = StyleSheet.create({
-    row: {
-        display: "flex",
-        flexDirection: "row",
-        alignItems: "center",
-        // Set minWidth to "auto" to prevent the component from bleeding
-        // into the margins. (minWidth is 0 by default.)
-        minWidth: "auto",
-    },
-});
 
 export default ColorSelect;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/line-stroke-select.module.css
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/line-stroke-select.module.css
@@ -1,0 +1,9 @@
+/* TODO(LEMS-3686): Remove the !important once Wonder Blocks is in the shared layer. */
+.line-stroke-select {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    gap: var(--wb-sizing-size_040) !important;
+    /* Allow truncation, stop bleeding over the edge. */
+    min-width: 0 !important;
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/line-stroke-select.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/line-stroke-select.tsx
@@ -1,26 +1,28 @@
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
+
+import styles from "./line-stroke-select.module.css";
 
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 type StyleOptions = "solid" | "dashed";
-type Props = {
+interface Props {
     selectedValue: StyleOptions;
     onChange: (newValue: StyleOptions) => void;
     containerStyle?: StyleType;
-};
+}
 
 const LineStrokeSelect = (props: Props) => {
     const {selectedValue, containerStyle, onChange} = props;
 
     return (
-        <BodyText tag="label" style={[styles.lineStrokeSelect, containerStyle]}>
+        <BodyText
+            tag="label"
+            className={styles.lineStrokeSelect}
+            style={containerStyle}
+        >
             stroke
-            <Strut size={spacing.xxxSmall_4} />
             <SingleSelect
                 selectedValue={selectedValue}
                 // eslint-disable-next-line no-restricted-syntax
@@ -34,15 +36,5 @@ const LineStrokeSelect = (props: Props) => {
         </BodyText>
     );
 };
-
-const styles = StyleSheet.create({
-    lineStrokeSelect: {
-        display: "flex",
-        flexDirection: "row",
-        alignItems: "center",
-        // Allow truncation, stop bleeding over the edge.
-        minWidth: 0,
-    },
-});
 
 export default LineStrokeSelect;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/line-weight-select.module.css
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/line-weight-select.module.css
@@ -1,0 +1,9 @@
+/* TODO(LEMS-3686): Remove the !important once Wonder Blocks is in the shared layer. */
+.line-weight-select {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    gap: var(--wb-sizing-size_040) !important;
+    /* Allow truncation, stop bleeding over the edge. */
+    min-width: 0 !important;
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/line-weight-select.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/line-weight-select.tsx
@@ -1,17 +1,17 @@
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import * as React from "react";
+
+import styles from "./line-weight-select.module.css";
 
 import type {StrokeWeight} from "@khanacademy/perseus-core";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
-type Props = {
+interface Props {
     selectedValue: StrokeWeight;
     onChange: (newValue: StrokeWeight) => void;
     containerStyle?: StyleType;
-};
+}
 
 const LineWeightSelect = (props: Props) => {
     const {selectedValue, containerStyle, onChange} = props;
@@ -19,19 +19,10 @@ const LineWeightSelect = (props: Props) => {
     return (
         <BodyText
             tag="label"
-            style={[
-                {
-                    display: "flex",
-                    flexDirection: "row",
-                    alignItems: "center",
-                    // Allow truncation, stop bleeding over the edge.
-                    minWidth: 0,
-                },
-                containerStyle,
-            ]}
+            className={styles.lineWeightSelect}
+            style={containerStyle}
         >
             weight
-            <Strut size={spacing.xxxSmall_4} />
             <SingleSelect
                 selectedValue={selectedValue}
                 // eslint-disable-next-line no-restricted-syntax

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.module.css
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.module.css
@@ -1,0 +1,54 @@
+/* We have to use !important until wonder blocks is in the shared layer. */
+/* TODO(LEMS-3686): Remove the !important once we don't need it anymore. */
+.row {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+}
+
+/* gap replaces the spacer that separated the header label from its swatch. */
+.header {
+    gap: var(--wb-sizing-size_080) !important;
+}
+
+.space-under {
+    margin-bottom: var(--wb-sizing-size_080) !important;
+}
+
+.color-row {
+    margin-top: var(--wb-sizing-size_080) !important;
+    margin-bottom: var(--wb-sizing-size_080) !important;
+    /* gap replaces the spacer between the color select and the fill control. */
+    gap: var(--wb-sizing-size_160) !important;
+}
+
+/* gap replaces the spacer between the "fill" label and its select. */
+.fill-label {
+    gap: var(--wb-sizing-size_060) !important;
+}
+
+.truncated-width {
+    /* Allow truncation, stop bleeding over the edge. */
+    min-width: 0 !important;
+}
+
+.add-button {
+    align-self: start !important;
+}
+
+.horizontal-rule {
+    height: 1px !important;
+    background-color: var(
+        --wb-semanticColor-core-border-neutral-subtle
+    ) !important;
+}
+
+/* Top spacing for a section start (a divider opening a section, or a heading). */
+.section-top {
+    margin-top: var(--wb-sizing-size_120) !important;
+}
+
+/* A divider that hugs the content directly above it. */
+.divider-tight {
+    margin-top: var(--wb-sizing-size_040) !important;
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.tsx
@@ -7,15 +7,9 @@ import {
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {
-    sizing,
-    spacing,
-    semanticColor,
-} from "@khanacademy/wonder-blocks-tokens";
+import {sizing, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import plusCircle from "@phosphor-icons/core/regular/plus-circle.svg";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import AngleInput from "../../../components/angle-input";
@@ -26,6 +20,7 @@ import ColorSelect from "./color-select";
 import EllipseSwatch from "./ellipse-swatch";
 import LineStrokeSelect from "./line-stroke-select";
 import LineWeightSelect from "./line-weight-select";
+import styles from "./locked-ellipse-settings.module.css";
 import LockedFigureAria from "./locked-figure-aria";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 import LockedLabelSettings from "./locked-label-settings";
@@ -43,9 +38,20 @@ import type {
     LockedFigureColor,
     LockedLabelType,
 } from "@khanacademy/perseus-core";
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 const {convertRadiansToDegrees} = angles;
 const {InfoTip} = components;
+
+// Passed to CoordinatePairInput's/View's `style` and LockedLabelSettings'
+// `containerStyle`, which are typed as Wonder Blocks `StyleType` and do not
+// accept a CSS-module className.
+const spaceUnderStyle: StyleType = {
+    marginBottom: sizing.size_080,
+};
+const labelContainerStyle: StyleType = {
+    backgroundColor: semanticColor.core.background.base.default,
+};
 
 export type Props = LockedFigureSettingsCommonProps &
     LockedEllipseType & {
@@ -167,13 +173,12 @@ const LockedEllipseSettings = (props: Props) => {
             onToggle={onToggle}
             header={
                 // Summary: Ellipse, center, radius, color (opacity, dashed)
-                <View style={styles.row}>
+                <View className={`${styles.row} ${styles.header}`}>
                     <BodyText
                         size="medium"
                         tag="span"
                         weight="bold"
                     >{`Ellipse (${center[0]}, ${center[1]}), radius ${radius[0]}, ${radius[1]}`}</BodyText>
-                    <Strut size={spacing.xSmall_8} />
                     <EllipseSwatch
                         color={props.color}
                         fillStyle={fillStyle}
@@ -183,13 +188,13 @@ const LockedEllipseSettings = (props: Props) => {
             }
         >
             {/* Center point */}
-            <View style={styles.row}>
+            <View className={styles.row}>
                 <CoordinatePairInput
                     coord={center}
-                    style={styles.spaceUnder}
+                    style={spaceUnderStyle}
                     onChange={handleCenterChange}
                 />
-                <View style={styles.spaceUnder}>
+                <View className={styles.spaceUnder}>
                     <InfoTip>
                         The coordinates for the center of the ellipse.
                     </InfoTip>
@@ -200,7 +205,7 @@ const LockedEllipseSettings = (props: Props) => {
             <CoordinatePairInput
                 coord={radius}
                 labels={["x radius", "y radius"]}
-                style={styles.spaceUnder}
+                style={spaceUnderStyle}
                 onChange={(newCoords: Coord) =>
                     onChangeProps({radius: newCoords})
                 }
@@ -213,23 +218,20 @@ const LockedEllipseSettings = (props: Props) => {
                     onChangeProps({angle: newAngle})
                 }
             />
-            <Strut size={spacing.xSmall_8} />
 
-            <View style={[styles.row, styles.spaceUnder]}>
+            <View className={`${styles.row} ${styles.colorRow}`}>
                 {/* Color */}
                 <ColorSelect
                     selectedValue={color}
                     onChange={handleColorChange}
                 />
-                <Strut size={spacing.medium_16} />
 
                 {/* Fill opacity */}
                 <BodyText
                     tag="label"
-                    style={[styles.row, styles.truncatedWidth]}
+                    className={`${styles.row} ${styles.truncatedWidth} ${styles.fillLabel}`}
                 >
                     fill
-                    <Strut size={spacing.xxSmall_6} />
                     <SingleSelect
                         selectedValue={fillStyle}
                         // TODO(LEMS-2656): remove TS suppression
@@ -266,8 +268,7 @@ const LockedEllipseSettings = (props: Props) => {
             />
 
             {/* Aria label */}
-            <Strut size={spacing.small_12} />
-            <View style={styles.horizontalRule} />
+            <View className={`${styles.horizontalRule} ${styles.sectionTop}`} />
             <LockedFigureAria
                 ariaLabel={ariaLabel}
                 getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
@@ -277,10 +278,10 @@ const LockedEllipseSettings = (props: Props) => {
             />
 
             {/* Visible Labels */}
-            <Strut size={spacing.xxxSmall_4} />
-            <View style={styles.horizontalRule} />
-            <Strut size={spacing.small_12} />
-            <BodyText>Visible labels</BodyText>
+            <View
+                className={`${styles.horizontalRule} ${styles.dividerTight}`}
+            />
+            <BodyText className={styles.sectionTop}>Visible labels</BodyText>
             {labels.map((label, labelIndex) => (
                 <LockedLabelSettings
                     {...label}
@@ -292,7 +293,7 @@ const LockedEllipseSettings = (props: Props) => {
                     onRemove={() => {
                         handleLabelRemove(labelIndex);
                     }}
-                    containerStyle={styles.labelContainer}
+                    containerStyle={labelContainerStyle}
                 />
             ))}
             <Button
@@ -315,7 +316,7 @@ const LockedEllipseSettings = (props: Props) => {
                         labels: [...labels, newLabel],
                     });
                 }}
-                style={styles.addButton}
+                className={styles.addButton}
             >
                 Add visible label
             </Button>
@@ -329,30 +330,5 @@ const LockedEllipseSettings = (props: Props) => {
         </PerseusEditorAccordion>
     );
 };
-
-const styles = StyleSheet.create({
-    row: {
-        display: "flex",
-        flexDirection: "row",
-        alignItems: "center",
-    },
-    spaceUnder: {
-        marginBottom: spacing.xSmall_8,
-    },
-    truncatedWidth: {
-        // Allow truncation, stop bleeding over the edge.
-        minWidth: 0,
-    },
-    addButton: {
-        alignSelf: "start",
-    },
-    labelContainer: {
-        backgroundColor: semanticColor.core.background.base.default,
-    },
-    horizontalRule: {
-        height: 1,
-        backgroundColor: semanticColor.core.border.neutral.subtle,
-    },
-});
 
 export default LockedEllipseSettings;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-aria.module.css
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-aria.module.css
@@ -1,0 +1,21 @@
+/* TODO(LEMS-3686): Remove the !important once Wonder Blocks is in the shared layer. */
+.container {
+    display: flex !important;
+    flex-direction: column !important;
+    gap: var(--wb-sizing-size_060) !important;
+    padding-top: var(--wb-sizing-size_080) !important;
+}
+
+.row {
+    flex-direction: row !important;
+    align-items: center !important;
+}
+
+.button {
+    align-self: start !important;
+    margin-top: calc(-1 * var(--wb-sizing-size_060)) !important;
+}
+
+.caption {
+    color: var(--wb-semanticColor-core-foreground-neutral-subtle) !important;
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-aria.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-aria.tsx
@@ -2,16 +2,16 @@ import {components} from "@khanacademy/perseus";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {TextArea} from "@khanacademy/wonder-blocks-form";
-import {Spring, Strut} from "@khanacademy/wonder-blocks-layout";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {Spring} from "@khanacademy/wonder-blocks-layout";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import pencilCircle from "@phosphor-icons/core/regular/pencil-circle.svg";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
+
+import styles from "./locked-figure-aria.module.css";
 
 const {InfoTip} = components;
 
-type Props = {
+interface Props {
     ariaLabel: string | undefined;
     /**
      * The async function that generates the prepopulated aria label
@@ -19,7 +19,7 @@ type Props = {
      */
     getPrepopulatedAriaLabel: () => Promise<string>;
     onChangeProps: (props: {ariaLabel?: string | undefined}) => void;
-};
+}
 
 function LockedFigureAria(props: Props) {
     const {ariaLabel, getPrepopulatedAriaLabel, onChangeProps} = props;
@@ -29,9 +29,8 @@ function LockedFigureAria(props: Props) {
     const [loading, setLoading] = React.useState(false);
 
     return (
-        <View>
-            <Strut size={spacing.xSmall_8} />
-            <View style={styles.row}>
+        <View className={styles.container}>
+            <View className={styles.row}>
                 <BodyText tag="label" htmlFor={ariaLabelId}>
                     Aria label
                 </BodyText>
@@ -50,12 +49,10 @@ function LockedFigureAria(props: Props) {
                     point using a screen reader.
                 </InfoTip>
             </View>
-            <Strut size={spacing.xxSmall_6} />
-            <BodyText size="xsmall" style={styles.caption}>
+            <BodyText size="xsmall" className={styles.caption}>
                 The figure is hidden from screen readers if this field is left
                 blank.
             </BodyText>
-            <Strut size={spacing.xxSmall_6} />
             <TextArea
                 id={ariaLabelId}
                 value={loading ? "Loading..." : ariaLabel ?? ""}
@@ -73,7 +70,7 @@ function LockedFigureAria(props: Props) {
             <Button
                 kind="tertiary"
                 startIcon={pencilCircle}
-                style={styles.button}
+                className={styles.button}
                 onClick={() => {
                     setLoading(true);
                     getPrepopulatedAriaLabel().then((ariaLabel) => {
@@ -87,18 +84,5 @@ function LockedFigureAria(props: Props) {
         </View>
     );
 }
-
-const styles = StyleSheet.create({
-    row: {
-        flexDirection: "row",
-        alignItems: "center",
-    },
-    button: {
-        alignSelf: "start",
-    },
-    caption: {
-        color: semanticColor.core.foreground.neutral.subtle,
-    },
-});
 
 export default LockedFigureAria;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-select.module.css
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-select.module.css
@@ -1,0 +1,11 @@
+/* TODO(LEMS-3686): Remove the !important once Wonder Blocks is in the shared layer. */
+.container {
+    margin-top: var(--wb-sizing-size_080) !important;
+}
+
+.add-element-select {
+    background-color: var(
+        --wb-semanticColor-core-background-instructive-subtle
+    ) !important;
+    border-radius: var(--wb-sizing-size_040) !important;
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-select.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-select.tsx
@@ -7,16 +7,16 @@
  */
 import {View} from "@khanacademy/wonder-blocks-core";
 import {ActionItem, ActionMenu} from "@khanacademy/wonder-blocks-dropdown";
-import {spacing, semanticColor} from "@khanacademy/wonder-blocks-tokens";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
+
+import styles from "./locked-figure-select.module.css";
 
 import type {LockedFigureType} from "@khanacademy/perseus-core";
 
-type Props = {
+interface Props {
     id: string;
     onChange: (value: LockedFigureType) => void;
-};
+}
 
 const LockedFigureSelect = (props: Props) => {
     const {id, onChange} = props;
@@ -32,10 +32,10 @@ const LockedFigureSelect = (props: Props) => {
     ];
 
     return (
-        <View style={styles.container}>
+        <View className={styles.container}>
             <ActionMenu
                 menuText="Add locked figure"
-                style={styles.addElementSelect}
+                className={styles.addElementSelect}
             >
                 {figureTypes.map((figureType) => (
                     <ActionItem
@@ -48,15 +48,5 @@ const LockedFigureSelect = (props: Props) => {
         </View>
     );
 };
-
-const styles = StyleSheet.create({
-    container: {
-        marginTop: spacing.xSmall_8,
-    },
-    addElementSelect: {
-        backgroundColor: semanticColor.core.background.instructive.subtle,
-        borderRadius: spacing.xxxSmall_4,
-    },
-});
 
 export default LockedFigureSelect;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-settings-actions.module.css
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-settings-actions.module.css
@@ -1,0 +1,12 @@
+/* TODO(LEMS-3686): Remove the !important once Wonder Blocks is in the shared layer. */
+.container {
+    width: 100% !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    margin-top: var(--wb-sizing-size_040) !important;
+}
+
+.delete-button {
+    /* Line up the delete icon with the rest of the content. */
+    margin-inline-start: calc(-1 * var(--wb-sizing-size_040)) !important;
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-settings-actions.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-settings-actions.tsx
@@ -7,14 +7,14 @@ import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {Spring} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import caretDoubleDownIcon from "@phosphor-icons/core/bold/caret-double-down-bold.svg";
 import caretDoubleUpIcon from "@phosphor-icons/core/bold/caret-double-up-bold.svg";
 import caretDownIcon from "@phosphor-icons/core/bold/caret-down-bold.svg";
 import caretUpIcon from "@phosphor-icons/core/bold/caret-up-bold.svg";
 import trashIcon from "@phosphor-icons/core/bold/trash-bold.svg";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
+
+import styles from "./locked-figure-settings-actions.module.css";
 
 import type {LockedFigureType} from "@khanacademy/perseus-core";
 
@@ -24,23 +24,23 @@ export type LockedFigureSettingsMovementType =
     | "forward"
     | "front";
 
-type Props = {
+interface Props {
     figureType: LockedFigureType;
     onMove?: (movement: LockedFigureSettingsMovementType) => void;
     onRemove: () => void;
-};
+}
 
 const LockedFigureSettingsActions = (props: Props) => {
     const {figureType, onMove, onRemove} = props;
 
     return (
-        <View style={styles.container}>
+        <View className={styles.container}>
             <Button
                 startIcon={trashIcon}
                 aria-label={`Delete locked ${figureType}`}
                 onClick={onRemove}
                 kind="tertiary"
-                style={styles.deleteButton}
+                className={styles.deleteButton}
             >
                 Delete
             </Button>
@@ -82,18 +82,5 @@ const LockedFigureSettingsActions = (props: Props) => {
         </View>
     );
 };
-
-const styles = StyleSheet.create({
-    container: {
-        width: "100%",
-        flexDirection: "row",
-        alignItems: "center",
-        marginTop: spacing.xxxSmall_4,
-    },
-    deleteButton: {
-        // Line up the delete icon with the rest of the content.
-        marginInlineStart: -spacing.xxxSmall_4,
-    },
-});
 
 export default LockedFigureSettingsActions;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-settings.tsx
@@ -25,7 +25,7 @@ import type {Props as LockedPointProps} from "./locked-point-settings";
 import type {Props as LockedPolygonProps} from "./locked-polygon-settings";
 import type {Props as LockedVectorProps} from "./locked-vector-settings";
 
-export type LockedFigureSettingsCommonProps = {
+export interface LockedFigureSettingsCommonProps {
     // Movement props
     /**
      * Called when a movement button (top, up, down, bottom) is pressed.
@@ -45,7 +45,7 @@ export type LockedFigureSettingsCommonProps = {
      * Called when the accordion is expanded or collapsed.
      */
     onToggle?: (expanded: boolean) => void;
-};
+}
 
 // Union this type with other locked figure types when they are added.
 type Props = LockedFigureSettingsCommonProps &

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figures-section.module.css
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figures-section.module.css
@@ -1,0 +1,11 @@
+/* TODO(LEMS-3686): Remove the !important once Wonder Blocks is in the shared layer. */
+.button-container {
+    flex-direction: row !important;
+    align-items: center !important;
+    gap: var(--wb-sizing-size_120) !important;
+}
+
+.button {
+    margin-top: var(--wb-sizing-size_080) !important;
+    flex-grow: 1 !important;
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figures-section.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figures-section.tsx
@@ -6,9 +6,6 @@
 import {getDefaultFigureForType} from "@khanacademy/perseus-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
 import {useId} from "react";
 
@@ -16,17 +13,18 @@ import Heading from "../../../components/heading";
 
 import LockedFigureSelect from "./locked-figure-select";
 import LockedFigureSettings from "./locked-figure-settings";
+import styles from "./locked-figures-section.module.css";
 
 import type {LockedFigureSettingsMovementType} from "./locked-figure-settings-actions";
 import type {Props as InteractiveGraphEditorProps} from "../interactive-graph-editor";
 import type {APIOptionsWithDefaults} from "@khanacademy/perseus";
 import type {LockedFigure, LockedFigureType} from "@khanacademy/perseus-core";
 
-type Props = {
+interface Props {
     figures?: Array<LockedFigure>;
     onChange: (props: Partial<InteractiveGraphEditorProps>) => void;
     apiOptions: APIOptionsWithDefaults;
-};
+}
 
 const LockedFiguresSection = (props: Props) => {
     // Keep track of all figures' accordions' expanded states for the
@@ -182,17 +180,16 @@ const LockedFiguresSection = (props: Props) => {
                             />
                         );
                     })}
-                    <View style={styles.buttonContainer}>
+                    <View className={styles.buttonContainer}>
                         <LockedFigureSelect
                             id={`${uniqueId}-select`}
                             onChange={addLockedFigure}
                         />
-                        <Strut size={spacing.small_12} />
                         {showExpandButton && (
                             <Button
                                 kind="secondary"
                                 onClick={() => toggleExpanded(allCollapsed)}
-                                style={styles.button}
+                                className={styles.button}
                             >
                                 {buttonLabel}
                             </Button>
@@ -203,16 +200,5 @@ const LockedFiguresSection = (props: Props) => {
         </>
     );
 };
-
-const styles = StyleSheet.create({
-    buttonContainer: {
-        flexDirection: "row",
-        alignItems: "center",
-    },
-    button: {
-        marginTop: spacing.xSmall_8,
-        flexGrow: 1,
-    },
-});
 
 export default LockedFiguresSection;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.module.css
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.module.css
@@ -1,0 +1,135 @@
+/* We have to use !important until wonder blocks is in the shared layer. */
+/* TODO(LEMS-3686): Remove the !important once we don't need it anymore. */
+
+.accordion-header {
+    text-overflow: ellipsis !important;
+    /* A maximum width needs to be specified in order for the ellipsis to work. */
+    /* The 64px in the calculation accounts for the line swatch (56px) and the preceding strut (8px). */
+    /* Margin and padding won't work here because they would create space between the header text and the swatch. */
+    max-width: calc(100% - 64px) !important;
+    overflow: hidden !important;
+    white-space: nowrap !important;
+}
+
+.axis-menu {
+    min-width: auto !important;
+}
+
+.copy-paste-button {
+    flex-shrink: 0 !important;
+    margin: 0 2px !important;
+}
+
+.domain-min {
+    justify-content: space-between !important;
+    /* The 'width' property is applied to the label, which wraps the text and the input field. */
+    /* The width of the input fields (min/max) should be the same (to have a consistent look), */
+    /*     so the following calculation distributes the space accordingly. */
+    /* For the "domain/range min" block, the text is 82.7px, and the strut is 6px (88.7px total). */
+    /* The "domain/range max" block is 30.23px, and the strut is 6px (36.23px total). */
+    /* The calculation takes the remain space after the text & struts (141px total) are removed, */
+    /*     and divides it between the two input fields equally. */
+    /* The calculation reads: "Take 1/2 of the non-text space, and add the required space for this label's text" */
+    width: calc(((100% - 141px) / 2) + 88.7px) !important;
+    text-wrap: nowrap !important;
+}
+
+.domain-max {
+    /* See explanation for "domainMin" for the calculation below. */
+    width: calc(((100% - 141px) / 2) + 36.2px) !important;
+}
+
+.dropdown-label {
+    align-items: center !important;
+    display: flex !important;
+    /* gap replaces the spacer between the label text and its control. */
+    gap: var(--wb-sizing-size_060) !important;
+}
+
+/* Plain <ul> element, no !important needed. */
+.example-container {
+    background: white;
+    border: 1px solid var(--wb-semanticColor-core-border-neutral-subtle);
+    border-radius: 4px;
+    flex-grow: 1;
+    list-style-type: none;
+    /* Nothing special about the maxHeight value, */
+    /*    just a good height to partially show a 3rd example in the list */
+    /*    to hint at scrollable content. */
+    max-height: 88px;
+    margin: 8px 0 0 0;
+    overflow-y: scroll;
+    padding: 4px 12px 4px 4px;
+}
+
+.example-content {
+    font-family: "Lato", sans-serif !important;
+    flex-grow: 1 !important;
+    color: var(--wb-semanticColor-core-foreground-neutral-strong) !important;
+}
+
+/* Plain <li> element, no !important needed. */
+.example-row {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    min-height: 44px;
+}
+
+.row-space {
+    margin-top: var(--wb-sizing-size_080) !important;
+}
+
+.row {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+}
+
+/* gap replaces the spacer that separated the header label from its swatch. */
+.header {
+    gap: var(--wb-sizing-size_080) !important;
+}
+
+/* Color/stroke row: gap between controls, with spacing below the row. */
+.color-row {
+    margin-bottom: var(--wb-sizing-size_080) !important;
+    gap: var(--wb-sizing-size_120) !important;
+}
+
+/* gap between the directional-axis dropdown and the equation field. */
+.axis-row {
+    gap: var(--wb-sizing-size_080) !important;
+}
+
+/* gap between the domain min and max controls. */
+.domain-row {
+    gap: var(--wb-sizing-size_160) !important;
+}
+
+/* Label settings styles */
+.add-button {
+    align-self: start !important;
+}
+
+.horizontal-rule {
+    height: 1px !important;
+    background-color: var(
+        --wb-semanticColor-core-border-neutral-subtle
+    ) !important;
+}
+
+/* Top spacing for a section start (a divider opening a section, or a heading). */
+.section-top {
+    margin-top: var(--wb-sizing-size_120) !important;
+}
+
+/* A divider that hugs the content directly above it. */
+.divider-tight {
+    margin-top: var(--wb-sizing-size_040) !important;
+}
+
+/* Indent for the example content text beside the copy/paste buttons. */
+.example-content-indent {
+    margin-inline-start: var(--wb-sizing-size_040) !important;
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.tsx
@@ -10,17 +10,11 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {
-    semanticColor,
-    sizing,
-    spacing,
-} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import copyIcon from "@phosphor-icons/core/assets/regular/copy.svg";
 import autoPasteIcon from "@phosphor-icons/core/assets/regular/note-pencil.svg";
 import plusCircle from "@phosphor-icons/core/regular/plus-circle.svg";
-import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
 import {useEffect, useId, useState} from "react";
 
@@ -33,6 +27,7 @@ import LineWeightSelect from "./line-weight-select";
 import LockedFigureAria from "./locked-figure-aria";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 import examples from "./locked-function-examples";
+import styles from "./locked-function-settings.module.css";
 import LockedLabelSettings from "./locked-label-settings";
 import {
     generateLockedFigureAppearanceDescription,
@@ -191,27 +186,25 @@ const LockedFunctionSettings = (props: Props) => {
             expanded={props.expanded}
             onToggle={props.onToggle}
             header={
-                <View style={styles.row}>
+                <View className={`${styles.row} ${styles.header}`}>
                     <BodyText
                         size="medium"
                         weight="bold"
                         tag="span"
-                        style={styles.accordionHeader}
+                        className={styles.accordionHeader}
                     >
                         {lineLabel}
                     </BodyText>
-                    <Strut size={spacing.xSmall_8} />
                     <LineSwatch color={lineColor} lineStyle={strokeStyle} />
                 </View>
             }
         >
-            <View style={[styles.row, {marginBottom: sizing.size_080}]}>
+            <View className={`${styles.row} ${styles.colorRow}`}>
                 {/* Line color settings */}
                 <ColorSelect
                     selectedValue={lineColor}
                     onChange={handleColorChange}
                 />
-                <Strut size={spacing.small_12} />
 
                 {/* Line style settings */}
                 <LineStrokeSelect
@@ -228,7 +221,9 @@ const LockedFunctionSettings = (props: Props) => {
                 onChange={(value) => onChangeProps({weight: value})}
             />
 
-            <View style={[styles.row, styles.rowSpace]}>
+            <View
+                className={`${styles.row} ${styles.rowSpace} ${styles.axisRow}`}
+            >
                 {/* Directional axis (x or y) */}
                 <SingleSelect
                     selectedValue={directionalAxis}
@@ -236,14 +231,13 @@ const LockedFunctionSettings = (props: Props) => {
                         handlePropChange("directionalAxis", newValue);
                     }}
                     aria-label="equation prefix"
-                    style={[styles.dropdownLabel, styles.axisMenu]}
+                    className={`${styles.dropdownLabel} ${styles.axisMenu}`}
                     // Placeholder is required, but never gets used.
                     placeholder=""
                 >
                     <OptionItem value="x" label="y =" />
                     <OptionItem value="y" label="x =" />
                 </SingleSelect>
-                <Strut size={spacing.xSmall_8} />
                 {/* Equation entry */}
                 <TextField
                     type="text"
@@ -252,40 +246,40 @@ const LockedFunctionSettings = (props: Props) => {
                     onChange={(newValue) => {
                         handlePropChange("equation", newValue);
                     }}
-                    style={[styles.textField]}
+                    style={{flexGrow: 1}}
                 />
             </View>
 
             {/* Domain/Range restrictions */}
-            <View style={[styles.row, styles.rowSpace]}>
+            <View
+                className={`${styles.row} ${styles.rowSpace} ${styles.domainRow}`}
+            >
                 <BodyText
                     tag="label"
-                    style={[styles.dropdownLabel, styles.domainMin]}
+                    className={`${styles.dropdownLabel} ${styles.domainMin}`}
                 >
                     {"domain min"}
 
-                    <Strut size={spacing.xxSmall_6} />
                     <TextField
                         type="number"
-                        style={styles.domainMinField}
+                        // make room for the label
+                        style={{width: "calc(100% - 88.7px)"}}
                         value={domainEntries[0]}
                         onChange={(newValue) => {
                             handleDomainChange(0, newValue);
                         }}
                     />
                 </BodyText>
-                <Strut size={spacing.medium_16} />
                 <BodyText
                     tag="label"
                     aria-label="domain max"
-                    style={[styles.dropdownLabel, styles.domainMax]}
+                    className={`${styles.dropdownLabel} ${styles.domainMax}`}
                 >
                     {"max"}
 
-                    <Strut size={spacing.xxSmall_6} />
                     <TextField
                         type="number"
-                        style={styles.domainMaxField}
+                        style={{width: "calc(100% - 36.2px)"}}
                         value={domainEntries[1]}
                         onChange={(newValue) => {
                             handleDomainChange(1, newValue);
@@ -302,12 +296,18 @@ const LockedFunctionSettings = (props: Props) => {
                     </BodyText>
                 }
                 expanded={false}
-                containerStyle={styles.exampleWorkspace}
-                panelStyle={styles.exampleAccordionPanel}
+                containerStyle={{
+                    background: semanticColor.core.background.base.subtle,
+                }}
+                panelStyle={{
+                    alignItems: "start",
+                    paddingBottom: sizing.size_120,
+                    flexDirection: "row",
+                    flexWrap: "wrap",
+                }}
             >
-                <BodyText tag="label" style={styles.dropdownLabel}>
+                <BodyText tag="label" className={styles.dropdownLabel}>
                     {"Choose a category"}
-                    <Strut size={spacing.xxSmall_6} />
                     <SingleSelect
                         selectedValue={exampleCategory}
                         onChange={setExampleCategory}
@@ -325,7 +325,7 @@ const LockedFunctionSettings = (props: Props) => {
                     </SingleSelect>
                 </BodyText>
                 {exampleCategorySelected && (
-                    <ul className={css(styles.exampleContainer)}>
+                    <ul className={styles.exampleContainer}>
                         {exampleContent.map((example, index) => (
                             <ExampleItem
                                 key={index}
@@ -340,8 +340,7 @@ const LockedFunctionSettings = (props: Props) => {
             </PerseusEditorAccordion>
 
             {/* Aria label */}
-            <Strut size={spacing.small_12} />
-            <View style={styles.horizontalRule} />
+            <View className={`${styles.horizontalRule} ${styles.sectionTop}`} />
             <LockedFigureAria
                 ariaLabel={ariaLabel}
                 getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
@@ -351,10 +350,10 @@ const LockedFunctionSettings = (props: Props) => {
             />
 
             {/* Visible Labels */}
-            <Strut size={spacing.xxxSmall_4} />
-            <View style={styles.horizontalRule} />
-            <Strut size={spacing.small_12} />
-            <BodyText>Visible labels</BodyText>
+            <View
+                className={`${styles.horizontalRule} ${styles.dividerTight}`}
+            />
+            <BodyText className={styles.sectionTop}>Visible labels</BodyText>
             {labels.map((label, labelIndex) => (
                 <LockedLabelSettings
                     key={labelIndex}
@@ -366,7 +365,10 @@ const LockedFunctionSettings = (props: Props) => {
                     onRemove={() => {
                         handleLabelRemove(labelIndex);
                     }}
-                    containerStyle={styles.labelContainer}
+                    containerStyle={{
+                        backgroundColor:
+                            semanticColor.core.background.base.default,
+                    }}
                 />
             ))}
             <Button
@@ -386,7 +388,7 @@ const LockedFunctionSettings = (props: Props) => {
                         labels: [...labels, newLabel],
                     });
                 }}
-                style={styles.addButton}
+                className={styles.addButton}
             >
                 Add visible label
             </Button>
@@ -401,19 +403,19 @@ const LockedFunctionSettings = (props: Props) => {
     );
 };
 
-type ItemProps = {
+interface ItemProps {
     category: string;
     example: string;
     index: number;
     pasteEquationFn: (property: string, newValue: string) => void;
-};
+}
 
 const ExampleItem = (props: ItemProps): React.ReactElement => {
     const {category, example, index, pasteEquationFn} = props;
     const exampleId = useId();
 
     return (
-        <li key={`${category}-${index}`} className={css(styles.exampleRow)}>
+        <li key={`${category}-${index}`} className={styles.exampleRow}>
             <IconButton
                 icon={autoPasteIcon}
                 kind="tertiary"
@@ -421,7 +423,7 @@ const ExampleItem = (props: ItemProps): React.ReactElement => {
                 aria-describedby={exampleId}
                 onClick={() => pasteEquationFn("equation", example)}
                 size="medium"
-                style={styles.copyPasteButton}
+                className={styles.copyPasteButton}
             />
             <IconButton
                 icon={copyIcon}
@@ -430,117 +432,16 @@ const ExampleItem = (props: ItemProps): React.ReactElement => {
                 aria-describedby={exampleId}
                 onClick={() => navigator.clipboard.writeText(example)}
                 size="medium"
-                style={styles.copyPasteButton}
+                className={styles.copyPasteButton}
             />
-            <Strut size={spacing.xxxSmall_4} />
-            <View style={styles.exampleContent} id={exampleId}>
+            <View
+                className={`${styles.exampleContent} ${styles.exampleContentIndent}`}
+                id={exampleId}
+            >
                 {example}
             </View>
         </li>
     );
 };
-
-const styles = StyleSheet.create({
-    accordionHeader: {
-        textOverflow: "ellipsis",
-        // A maximum width needs to be specified in order for the ellipsis to work.
-        // The 64px in the calculation accounts for the line swatch (56px) and the preceding strut (8px).
-        // Margin and padding won't work here because they would create space between the header text and the swatch.
-        maxWidth: "calc(100% - 64px)",
-        overflow: "hidden",
-        whiteSpace: "nowrap",
-    },
-    axisMenu: {
-        minWidth: "auto",
-    },
-    copyPasteButton: {
-        flexShrink: "0",
-        margin: "0 2px",
-    },
-    domainMin: {
-        justifyContent: "space-between",
-        // The 'width' property is applied to the label, which wraps the text and the input field.
-        // The width of the input fields (min/max) should be the same (to have a consistent look),
-        //     so the following calculation distributes the space accordingly.
-        // For the "domain/range min" block, the text is 82.7px, and the strut is 6px (88.7px total).
-        // The "domain/range max" block is 30.23px, and the strut is 6px (36.23px total).
-        // The calculation takes the remain space after the text & struts (141px total) are removed,
-        //     and divides it between the two input fields equally.
-        // The calculation reads: "Take 1/2 of the non-text space, and add the required space for this label's text"
-        width: "calc(((100% - 141px) / 2) + 88.7px)",
-        textWrap: "nowrap",
-    },
-    domainMinField: {
-        width: "calc(100% - 88.7px)", // make room for the label
-    },
-    domainMax: {
-        // See explanation for "domainMin" for the calculation below.
-        width: "calc(((100% - 141px) / 2) + 36.2px)",
-    },
-    domainMaxField: {
-        width: "calc(100% - 36.2px)", // make room for the label
-    },
-    dropdownLabel: {
-        alignItems: "center",
-        display: "flex",
-    },
-    exampleAccordionPanel: {
-        alignItems: "start",
-        paddingBottom: "12px",
-        flexDirection: "row",
-        flexWrap: "wrap",
-    },
-    exampleContainer: {
-        background: "white",
-        border: `1px solid ${semanticColor.core.border.neutral.subtle}`,
-        borderRadius: "4px",
-        flexGrow: "1",
-        listStyleType: "none",
-        // Nothing special about the maxHeight value,
-        //    just a good height to partially show a 3rd example in the list
-        //    to hint at scrollable content.
-        maxHeight: "88px",
-        margin: "8px 0 0 0",
-        overflowY: "scroll",
-        padding: "4px 12px 4px 4px",
-    },
-    exampleContent: {
-        fontFamily: `"Lato", sans-serif`,
-        flexGrow: "1",
-        color: semanticColor.core.foreground.neutral.strong,
-    },
-    exampleRow: {
-        alignItems: "center",
-        display: "flex",
-        flexDirection: "row",
-        minHeight: "44px",
-    },
-    exampleWorkspace: {
-        background: semanticColor.core.background.base.subtle,
-    },
-    rowSpace: {
-        marginTop: spacing.xSmall_8,
-    },
-    row: {
-        display: "flex",
-        flexDirection: "row",
-        alignItems: "center",
-    },
-    textField: {
-        flexGrow: "1",
-    },
-
-    // Label settings styles
-    addButton: {
-        alignSelf: "start",
-    },
-    horizontalRule: {
-        height: 1,
-        backgroundColor: semanticColor.core.border.neutral.subtle,
-    },
-    labelContainer: {
-        backgroundColor: semanticColor.core.background.base.default,
-    },
-});
 
 export default LockedFunctionSettings;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-label-settings.module.css
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-label-settings.module.css
@@ -1,0 +1,47 @@
+/* We have to use !important until wonder blocks is in the shared layer. */
+/* TODO(LEMS-3686): Remove the !important once we don't need it anymore. */
+.accordion-header-container {
+    /* Stop the label summary from wrapping. */
+    white-space: nowrap !important;
+}
+
+.accordion-header {
+    padding: var(--wb-sizing-size_040) !important;
+    margin-inline-end: var(--wb-sizing-size_080) !important;
+    border-radius: var(--wb-sizing-size_040) !important;
+    text-overflow: ellipsis !important;
+    overflow: hidden !important;
+    background-color: var(
+        --wb-semanticColor-core-background-base-default
+    ) !important;
+}
+
+.row {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    /* Allow truncation, stop bleeding over the edge. */
+    min-width: 0 !important;
+}
+
+/* gap replaces the spacer that separated the header label from its swatch. */
+.header {
+    gap: var(--wb-sizing-size_080) !important;
+}
+
+/* The "text" label row: grow to fill, with a gap before the text field. */
+.text-label {
+    margin-bottom: var(--wb-sizing-size_080) !important;
+    flex-grow: 1 !important;
+    gap: var(--wb-sizing-size_080) !important;
+}
+
+/* gap between the color select and the size control. */
+.color-row {
+    gap: var(--wb-sizing-size_160) !important;
+}
+
+/* gap replaces the spacer between the "size" label and its select. */
+.size-label {
+    gap: var(--wb-sizing-size_080) !important;
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-label-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-label-settings.tsx
@@ -13,10 +13,8 @@ import {
 import {View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import {TextField} from "@khanacademy/wonder-blocks-form";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing, semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import CoordinatePairInput from "../../../components/coordinate-pair-input";
@@ -24,11 +22,16 @@ import PerseusEditorAccordion from "../../../components/perseus-editor-accordion
 
 import ColorSelect from "./color-select";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
+import styles from "./locked-label-settings.module.css";
 
 import type {LockedFigureSettingsMovementType} from "./locked-figure-settings-actions";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 const {InfoTip} = components;
+
+// Passed to Wonder Blocks `StyleType`-only props (CoordinatePairInput,
+// ColorSelect) which don't accept a CSS-module className.
+const spaceUnderStyle: StyleType = {marginBottom: sizing.size_080};
 
 export type Props = LockedLabelType & {
     /**
@@ -84,25 +87,21 @@ export default function LockedLabelSettings(props: Props) {
             expanded={expanded}
             onToggle={onToggle}
             header={
-                <View style={[styles.row, styles.accordionHeaderContainer]}>
+                <View
+                    className={`${styles.row} ${styles.accordionHeaderContainer} ${styles.header}`}
+                >
                     <BodyText size="medium" weight="bold" tag="span">
                         Label ({coord[0]}, {coord[1]})
                     </BodyText>
-                    <Strut size={spacing.xSmall_8} />
                     {text !== "" && (
                         <BodyText
                             size="medium"
                             weight="bold"
                             tag="span"
-                            style={[
-                                {
-                                    backgroundColor:
-                                        semanticColor.core.background.base
-                                            .default,
-                                    color: lockedFigureColors[color],
-                                },
-                                styles.accordionHeader,
-                            ]}
+                            className={styles.accordionHeader}
+                            style={{
+                                color: lockedFigureColors[color],
+                            }}
                         >
                             {text}
                         </BodyText>
@@ -117,17 +116,16 @@ export default function LockedLabelSettings(props: Props) {
                 onChange={(newCoords) => {
                     onChangeProps({coord: newCoords});
                 }}
-                style={styles.spaceUnder}
+                style={spaceUnderStyle}
             />
 
             {/* Text settings */}
-            <View style={styles.row}>
+            <View className={styles.row}>
                 <BodyText
                     tag="label"
-                    style={[styles.row, styles.spaceUnder, {flexGrow: 1}]}
+                    className={`${styles.row} ${styles.textLabel}`}
                 >
                     text
-                    <Strut size={spacing.xSmall_8} />
                     <TextField
                         value={text}
                         placeholder="ex. $x^2$ or $\frac{1}{2}$"
@@ -150,20 +148,21 @@ export default function LockedLabelSettings(props: Props) {
                 </InfoTip>
             </View>
 
-            <View style={styles.row}>
+            <View className={`${styles.row} ${styles.colorRow}`}>
                 <ColorSelect
                     selectedValue={color}
                     onChange={(newColor) => {
                         onChangeProps({color: newColor});
                     }}
-                    style={styles.spaceUnder}
+                    style={spaceUnderStyle}
                 />
-                <Strut size={spacing.medium_16} />
 
                 {/* Size settings */}
-                <BodyText tag="label" style={styles.row}>
+                <BodyText
+                    tag="label"
+                    className={`${styles.row} ${styles.sizeLabel}`}
+                >
                     size
-                    <Strut size={spacing.xSmall_8} />
                     <SingleSelect
                         selectedValue={size}
                         // TODO(LEMS-2656): remove TS suppression
@@ -194,26 +193,3 @@ export default function LockedLabelSettings(props: Props) {
         </PerseusEditorAccordion>
     );
 }
-const styles = StyleSheet.create({
-    accordionHeaderContainer: {
-        // Stop the label summary from wrapping.
-        whiteSpace: "nowrap",
-    },
-    accordionHeader: {
-        padding: spacing.xxxSmall_4,
-        marginInlineEnd: spacing.xSmall_8,
-        borderRadius: spacing.xxxSmall_4,
-        textOverflow: "ellipsis",
-        overflow: "hidden",
-    },
-    row: {
-        display: "flex",
-        flexDirection: "row",
-        alignItems: "center",
-        // Allow truncation, stop bleeding over the edge.
-        minWidth: 0,
-    },
-    spaceUnder: {
-        marginBottom: spacing.xSmall_8,
-    },
-});

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.module.css
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.module.css
@@ -1,0 +1,51 @@
+/* We have to use !important until wonder blocks is in the shared layer. */
+/* TODO(LEMS-3686): Remove the !important once we don't need it anymore. */
+.row {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+}
+
+/* gap replaces the spacer that separated the header label from its swatch. */
+.header {
+    gap: var(--wb-sizing-size_080) !important;
+}
+
+.space-under {
+    margin-bottom: var(--wb-sizing-size_080) !important;
+}
+
+/* gap between the "kind" label and its select. */
+.kind-label {
+    gap: var(--wb-sizing-size_040) !important;
+}
+
+/* gap between the color select and the line style select. */
+.color-row {
+    gap: var(--wb-sizing-size_120) !important;
+}
+
+.error-text {
+    color: var(--wb-semanticColor-core-foreground-critical-default) !important;
+}
+
+.add-button {
+    align-self: start !important;
+}
+
+.horizontal-rule {
+    height: 1px !important;
+    background-color: var(
+        --wb-semanticColor-core-border-neutral-subtle
+    ) !important;
+}
+
+/* Top spacing for a section start (a divider opening a section, or a heading). */
+.section-top {
+    margin-top: var(--wb-sizing-size_120) !important;
+}
+
+/* A divider that hugs the content directly above it. */
+.divider-tight {
+    margin-top: var(--wb-sizing-size_040) !important;
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.tsx
@@ -9,12 +9,10 @@ import {getDefaultFigureForType} from "@khanacademy/perseus-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {semanticColor, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 import plusCircle from "@phosphor-icons/core/regular/plus-circle.svg";
-import {StyleSheet} from "aphrodite";
 import {vec} from "mafs";
 import * as React from "react";
 
@@ -27,6 +25,7 @@ import LineWeightSelect from "./line-weight-select";
 import LockedFigureAria from "./locked-figure-aria";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 import LockedLabelSettings from "./locked-label-settings";
+import styles from "./locked-line-settings.module.css";
 import LockedPointSettings from "./locked-point-settings";
 import {
     generateLockedFigureAppearanceDescription,
@@ -44,8 +43,15 @@ import type {
     LockedLineType,
     LockedPointType,
 } from "@khanacademy/perseus-core";
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 const lengthZeroStr = "The line cannot have length 0.";
+
+// Passed to LockedLabelSettings' `containerStyle`, which is typed as a
+// Wonder Blocks `StyleType` and does not accept a CSS-module className.
+const labelContainerStyle: StyleType = {
+    backgroundColor: semanticColor.core.background.base.default,
+};
 
 export type Props = LockedLineType &
     LockedFigureSettingsCommonProps & {
@@ -221,19 +227,20 @@ const LockedLineSettings = (props: Props) => {
             expanded={props.expanded}
             onToggle={props.onToggle}
             header={
-                <View style={styles.row}>
+                <View className={`${styles.row} ${styles.header}`}>
                     <BodyText size="medium" weight="bold" tag="span">
                         {lineLabel}
                     </BodyText>
-                    <Strut size={spacing.xSmall_8} />
                     <LineSwatch color={lineColor} lineStyle={lineStyle} />
                 </View>
             }
         >
             {/* Line kind settings */}
-            <BodyText tag="label" style={[styles.row, styles.spaceUnder]}>
+            <BodyText
+                tag="label"
+                className={`${styles.row} ${styles.spaceUnder} ${styles.kindLabel}`}
+            >
                 kind
-                <Strut size={spacing.xxxSmall_4} />
                 <SingleSelect
                     selectedValue={kind}
                     // TODO(LEMS-2656): remove TS suppression
@@ -251,13 +258,14 @@ const LockedLineSettings = (props: Props) => {
                 </SingleSelect>
             </BodyText>
 
-            <View style={[styles.row, styles.spaceUnder]}>
+            <View
+                className={`${styles.row} ${styles.spaceUnder} ${styles.colorRow}`}
+            >
                 {/* Line color settings */}
                 <ColorSelect
                     selectedValue={lineColor}
                     onChange={handleColorChange}
                 />
-                <Strut size={spacing.small_12} />
 
                 {/* Line style settings */}
                 <LineStrokeSelect
@@ -278,7 +286,9 @@ const LockedLineSettings = (props: Props) => {
 
             {/* Points error message */}
             {isInvalid && (
-                <BodyText style={styles.errorText}>{lengthZeroStr}</BodyText>
+                <BodyText className={styles.errorText}>
+                    {lengthZeroStr}
+                </BodyText>
             )}
 
             {/* Defining points settings */}
@@ -306,8 +316,7 @@ const LockedLineSettings = (props: Props) => {
             />
 
             {/* Aria label */}
-            <Strut size={spacing.small_12} />
-            <View style={styles.horizontalRule} />
+            <View className={`${styles.horizontalRule} ${styles.sectionTop}`} />
             <LockedFigureAria
                 ariaLabel={ariaLabel}
                 getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
@@ -317,10 +326,10 @@ const LockedLineSettings = (props: Props) => {
             />
 
             {/* Visible labels */}
-            <Strut size={spacing.xxxSmall_4} />
-            <View style={styles.horizontalRule} />
-            <Strut size={spacing.small_12} />
-            <BodyText>Visible labels</BodyText>
+            <View
+                className={`${styles.horizontalRule} ${styles.dividerTight}`}
+            />
+            <BodyText className={styles.sectionTop}>Visible labels</BodyText>
 
             {labels.map((label, labelIndex) => (
                 <LockedLabelSettings
@@ -333,7 +342,7 @@ const LockedLineSettings = (props: Props) => {
                     onRemove={() => {
                         handleLabelRemove(labelIndex);
                     }}
-                    containerStyle={styles.labelContainer}
+                    containerStyle={labelContainerStyle}
                 />
             ))}
             <Button
@@ -359,7 +368,7 @@ const LockedLineSettings = (props: Props) => {
                         labels: [...labels, newLabel],
                     });
                 }}
-                style={styles.addButton}
+                className={styles.addButton}
             >
                 Add visible label
             </Button>
@@ -373,29 +382,5 @@ const LockedLineSettings = (props: Props) => {
         </PerseusEditorAccordion>
     );
 };
-
-const styles = StyleSheet.create({
-    row: {
-        display: "flex",
-        flexDirection: "row",
-        alignItems: "center",
-    },
-    spaceUnder: {
-        marginBottom: spacing.xSmall_8,
-    },
-    errorText: {
-        color: semanticColor.core.foreground.critical.default,
-    },
-    addButton: {
-        alignSelf: "start",
-    },
-    horizontalRule: {
-        height: 1,
-        backgroundColor: semanticColor.core.border.neutral.subtle,
-    },
-    labelContainer: {
-        backgroundColor: semanticColor.core.background.base.default,
-    },
-});
 
 export default LockedLineSettings;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-point-settings.module.css
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-point-settings.module.css
@@ -1,0 +1,29 @@
+/* We have to use !important until wonder blocks is in the shared layer. */
+/* TODO(LEMS-3686): Remove the !important once we don't need it anymore. */
+.row {
+    flex-direction: row !important;
+    align-items: center !important;
+    /* gap replaces the Strut that separated the header label from its swatch. */
+    gap: var(--wb-sizing-size_080) !important;
+}
+
+.add-button {
+    align-self: start !important;
+}
+
+.horizontal-rule {
+    height: 1px !important;
+    background-color: var(
+        --wb-semanticColor-core-border-neutral-subtle
+    ) !important;
+}
+
+/* Top spacing for a section start (a divider opening a section, or a heading). */
+.section-top {
+    margin-top: var(--wb-sizing-size_120) !important;
+}
+
+/* A divider that hugs the content directly above it. */
+.divider-tight {
+    margin-top: var(--wb-sizing-size_040) !important;
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-point-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-point-settings.tsx
@@ -7,11 +7,9 @@
 import {getDefaultFigureForType} from "@khanacademy/perseus-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing, semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {sizing, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import plusCircle from "@phosphor-icons/core/regular/plus-circle.svg";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import CoordinatePairInput from "../../../components/coordinate-pair-input";
@@ -23,6 +21,7 @@ import ColorSwatch from "./color-swatch";
 import LockedFigureAria from "./locked-figure-aria";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 import LockedLabelSettings from "./locked-label-settings";
+import styles from "./locked-point-settings.module.css";
 import {
     generateSpokenMathDetails,
     generateLockedFigureAppearanceDescription,
@@ -31,6 +30,13 @@ import {
 
 import type {LockedFigureSettingsMovementType} from "./locked-figure-settings-actions";
 import type {LockedLabelType, LockedPointType} from "@khanacademy/perseus-core";
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
+
+// Passed to Wonder Blocks `style`/`containerStyle` props (typed as
+// `StyleType`), which do not accept a CSS-module className.
+const spaceUnderStyle: StyleType = {
+    marginBottom: sizing.size_080,
+};
 
 export type Props = LockedPointType & {
     /**
@@ -181,23 +187,38 @@ const LockedPointSettings = (props: Props) => {
             expanded={expanded}
             onToggle={onToggle}
             containerStyle={
-                isDefiningPoint ? styles.definingContainer : undefined
+                isDefiningPoint
+                    ? {
+                          marginTop: sizing.size_080,
+                          marginBottom: 0,
+                          marginLeft: -sizing.size_040,
+                          marginRight: -sizing.size_040,
+                          backgroundColor:
+                              semanticColor.core.background.base.default,
+                      }
+                    : undefined
             }
-            panelStyle={isDefiningPoint ? styles.definingPanel : undefined}
+            panelStyle={
+                isDefiningPoint
+                    ? {
+                          // Need more space since we don't have the actions' margins.
+                          paddingBottom: sizing.size_060,
+                      }
+                    : undefined
+            }
             header={
                 // Summary: Point, coords, color (filled/open)
-                <View style={styles.row}>
+                <View className={styles.row}>
                     <BodyText size="medium" weight="bold" tag="span">
                         {`${headerLabel || "Point"} (${coord[0]}, ${coord[1]})`}
                     </BodyText>
-                    <Strut size={spacing.xSmall_8} />
                     <ColorSwatch color={pointColor} filled={filled} />
                 </View>
             }
         >
             <CoordinatePairInput
                 coord={coord}
-                style={styles.spaceUnder}
+                style={spaceUnderStyle}
                 onChange={handleCoordChange}
                 error={!!error}
             />
@@ -207,7 +228,7 @@ const LockedPointSettings = (props: Props) => {
                 <LabeledSwitch
                     label="show point on graph"
                     checked={!!showPoint}
-                    style={showPoint && styles.spaceUnder}
+                    style={showPoint && spaceUnderStyle}
                     onChange={onTogglePoint}
                 />
             )}
@@ -218,7 +239,7 @@ const LockedPointSettings = (props: Props) => {
                     <ColorSelect
                         selectedValue={pointColor}
                         onChange={handleColorChange}
-                        style={styles.spaceUnder}
+                        style={spaceUnderStyle}
                     />
                     <LabeledSwitch
                         label="open point"
@@ -232,8 +253,9 @@ const LockedPointSettings = (props: Props) => {
 
             {!isDefiningPoint && (
                 <>
-                    <Strut size={spacing.small_12} />
-                    <View style={styles.horizontalRule} />
+                    <View
+                        className={`${styles.horizontalRule} ${styles.sectionTop}`}
+                    />
 
                     <LockedFigureAria
                         ariaLabel={ariaLabel}
@@ -246,16 +268,19 @@ const LockedPointSettings = (props: Props) => {
             )}
 
             {/* Visible labels */}
-            <Strut size={spacing.xxxSmall_4} />
-            <View style={styles.horizontalRule} />
-            <Strut size={spacing.small_12} />
-            <BodyText>Visible labels</BodyText>
+            <View
+                className={`${styles.horizontalRule} ${styles.dividerTight}`}
+            />
+            <BodyText className={styles.sectionTop}>Visible labels</BodyText>
             {labels.map((label, labelIndex) => (
                 <LockedLabelSettings
                     {...label}
                     key={labelIndex}
                     containerStyle={
-                        !isDefiningPoint && styles.lockedPointLabelContainer
+                        !isDefiningPoint && {
+                            backgroundColor:
+                                semanticColor.core.background.base.default,
+                        }
                     }
                     expanded={true}
                     onChangeProps={(newLabel) => {
@@ -289,7 +314,7 @@ const LockedPointSettings = (props: Props) => {
                         labels: [...labels, newLabel],
                     });
                 }}
-                style={styles.addButton}
+                className={styles.addButton}
             >
                 Add visible label
             </Button>
@@ -304,38 +329,5 @@ const LockedPointSettings = (props: Props) => {
         </PerseusEditorAccordion>
     );
 };
-
-const styles = StyleSheet.create({
-    definingContainer: {
-        marginTop: spacing.xSmall_8,
-        marginBottom: 0,
-        marginLeft: -spacing.xxxSmall_4,
-        marginRight: -spacing.xxxSmall_4,
-        backgroundColor: semanticColor.core.background.base.default,
-    },
-    definingPanel: {
-        // Need more space since we don't have the actions' margins.
-        paddingBottom: spacing.xxSmall_6,
-    },
-    // A regular point (NOT a defining point) has label
-    // accordions with white backgrounds.
-    lockedPointLabelContainer: {
-        backgroundColor: semanticColor.core.background.base.default,
-    },
-    row: {
-        flexDirection: "row",
-        alignItems: "center",
-    },
-    spaceUnder: {
-        marginBottom: spacing.xSmall_8,
-    },
-    addButton: {
-        alignSelf: "start",
-    },
-    horizontalRule: {
-        height: 1,
-        backgroundColor: semanticColor.core.border.neutral.subtle,
-    },
-});
 
 export default LockedPointSettings;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.module.css
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.module.css
@@ -1,0 +1,68 @@
+/* We have to use !important until wonder blocks is in the shared layer. */
+/* TODO(LEMS-3686): Remove the !important once we don't need it anymore. */
+.row {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+}
+
+/* gap replaces the spacer that separated the header label from its swatch. */
+.header {
+    gap: var(--wb-sizing-size_080) !important;
+}
+
+.space-under {
+    margin-bottom: var(--wb-sizing-size_080) !important;
+}
+
+.color-row {
+    margin-bottom: var(--wb-sizing-size_080) !important;
+    /* gap replaces the spacer between the color select and the fill control. */
+    gap: var(--wb-sizing-size_160) !important;
+}
+
+/* gap replaces the spacer between the "fill" label and its select. */
+.fill-label {
+    gap: var(--wb-sizing-size_060) !important;
+}
+
+.icon {
+    margin-inline-start: var(--wb-sizing-size_040) !important;
+}
+
+.polygon-actions-container {
+    width: 100% !important;
+}
+
+.movement-buttons-container {
+    display: flex !important;
+    flex-direction: column !important;
+    align-items: center !important;
+    min-width: fit-content !important;
+}
+
+.truncated-width {
+    /* Allow truncation, stop bleeding over the edge. */
+    min-width: 0 !important;
+}
+
+.add-button {
+    align-self: start !important;
+}
+
+.horizontal-rule {
+    height: 1px !important;
+    background-color: var(
+        --wb-semanticColor-core-border-neutral-subtle
+    ) !important;
+}
+
+/* Top spacing for a section start (a divider opening a section, or a heading). */
+.section-top {
+    margin-top: var(--wb-sizing-size_120) !important;
+}
+
+/* A divider that hugs the content directly above it. */
+.divider-tight {
+    margin-top: var(--wb-sizing-size_040) !important;
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
@@ -11,8 +11,8 @@ import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {OptionItem, SingleSelect} from "@khanacademy/wonder-blocks-dropdown";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
-import {Spring, Strut} from "@khanacademy/wonder-blocks-layout";
-import {spacing, semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {Spring} from "@khanacademy/wonder-blocks-layout";
+import {sizing, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import arrowFatDown from "@phosphor-icons/core/regular/arrow-fat-down.svg";
 import arrowFatLeft from "@phosphor-icons/core/regular/arrow-fat-left.svg";
@@ -20,7 +20,6 @@ import arrowFatRight from "@phosphor-icons/core/regular/arrow-fat-right.svg";
 import arrowFatUp from "@phosphor-icons/core/regular/arrow-fat-up.svg";
 import minusCircle from "@phosphor-icons/core/regular/minus-circle.svg";
 import plusCircle from "@phosphor-icons/core/regular/plus-circle.svg";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import CoordinatePairInput from "../../../components/coordinate-pair-input";
@@ -33,6 +32,7 @@ import LineWeightSelect from "./line-weight-select";
 import LockedFigureAria from "./locked-figure-aria";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 import LockedLabelSettings from "./locked-label-settings";
+import styles from "./locked-polygon-settings.module.css";
 import PolygonSwatch from "./polygon-swatch";
 import {
     generateLockedFigureAppearanceDescription,
@@ -41,6 +41,21 @@ import {
 } from "./util";
 
 import type {LockedFigureSettingsCommonProps} from "./locked-figure-settings";
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
+
+// Passed to Wonder Blocks `StyleType`-only props (PerseusEditorAccordion's
+// `containerStyle`/`panelStyle`, child `style`/`containerStyle`), which do not
+// accept a CSS-module className.
+const spaceUnderStyle: StyleType = {marginBottom: sizing.size_080};
+const pointAccordionContainerStyle: StyleType = {
+    backgroundColor: semanticColor.core.background.base.default,
+};
+const pointAccordionPanelStyle: StyleType = {
+    alignItems: "start",
+};
+const labelContainerStyle: StyleType = {
+    backgroundColor: semanticColor.core.background.base.default,
+};
 
 export type Props = LockedFigureSettingsCommonProps &
     LockedPolygonType & {
@@ -177,13 +192,12 @@ const LockedPolygonSettings = (props: Props) => {
             onToggle={onToggle}
             header={
                 // Summary: Polygon, number of sides, style swatch
-                <View style={styles.row}>
+                <View className={`${styles.row} ${styles.header}`}>
                     <BodyText
                         size="medium"
                         weight="bold"
                         tag="span"
                     >{`Polygon, ${points.length} sides`}</BodyText>
-                    <Strut size={spacing.xSmall_8} />
                     <PolygonSwatch
                         color={color}
                         fillStyle={fillStyle}
@@ -192,21 +206,19 @@ const LockedPolygonSettings = (props: Props) => {
                 </View>
             }
         >
-            <View style={[styles.row, styles.spaceUnder]}>
+            <View className={`${styles.row} ${styles.colorRow}`}>
                 {/* Color */}
                 <ColorSelect
                     selectedValue={color}
                     onChange={handleColorChange}
                 />
-                <Strut size={spacing.medium_16} />
 
                 {/* Fill opacity */}
                 <BodyText
                     tag="label"
-                    style={[styles.row, styles.truncatedWidth]}
+                    className={`${styles.row} ${styles.truncatedWidth} ${styles.fillLabel}`}
                 >
                     fill
-                    <Strut size={spacing.xxSmall_6} />
                     <SingleSelect
                         selectedValue={fillStyle}
                         // TODO(LEMS-2656): remove TS suppression
@@ -233,7 +245,7 @@ const LockedPolygonSettings = (props: Props) => {
             <LineStrokeSelect
                 selectedValue={strokeStyle}
                 onChange={(value) => onChangeProps({strokeStyle: value})}
-                containerStyle={styles.spaceUnder}
+                containerStyle={spaceUnderStyle}
             />
 
             {/* Weight */}
@@ -244,7 +256,7 @@ const LockedPolygonSettings = (props: Props) => {
                         weight: value,
                     })
                 }
-                containerStyle={styles.spaceUnder}
+                containerStyle={spaceUnderStyle}
             />
 
             {/* Show vertices switch */}
@@ -254,7 +266,7 @@ const LockedPolygonSettings = (props: Props) => {
                 onChange={(newValue: boolean) =>
                     onChangeProps({showVertices: newValue})
                 }
-                style={styles.spaceUnder}
+                style={spaceUnderStyle}
             />
 
             <PerseusEditorAccordion
@@ -264,8 +276,8 @@ const LockedPolygonSettings = (props: Props) => {
                     </BodyText>
                 }
                 expanded={true}
-                containerStyle={styles.pointAccordionContainer}
-                panelStyle={styles.pointAccordionPanel}
+                containerStyle={pointAccordionContainerStyle}
+                panelStyle={pointAccordionPanelStyle}
             >
                 {points.map((point, index) => {
                     const pointLabel = String.fromCharCode(65 + index);
@@ -273,17 +285,17 @@ const LockedPolygonSettings = (props: Props) => {
                     return (
                         <View
                             key={`locked-polygon-point-index-${index}`}
-                            style={[styles.row, styles.spaceUnder]}
+                            className={`${styles.row} ${styles.spaceUnder}`}
                         >
                             {/* Give the points alphabet labels */}
                             <BodyText
                                 size="medium"
                                 weight="bold"
                             >{`${pointLabel}:`}</BodyText>
-                            <Strut size={spacing.medium_16} />
                             <CoordinatePairInput
                                 coord={point}
                                 labels={["x", "y"]}
+                                style={{marginInlineStart: sizing.size_160}}
                                 onChange={(newValue: Coord) => {
                                     const newPoints = [...points];
                                     newPoints[index] = newValue;
@@ -307,14 +319,16 @@ const LockedPolygonSettings = (props: Props) => {
                                                 points: newPoints,
                                             });
                                         }}
-                                        style={styles.icon}
+                                        className={styles.icon}
                                     />
                                 )
                             }
                         </View>
                     );
                 })}
-                <View style={[styles.row, styles.polygonActionsContainer]}>
+                <View
+                    className={`${styles.row} ${styles.polygonActionsContainer}`}
+                >
                     <Button
                         kind="tertiary"
                         startIcon={plusCircle}
@@ -330,7 +344,7 @@ const LockedPolygonSettings = (props: Props) => {
                     <Spring />
 
                     {/* Buttons to move the entire polygon */}
-                    <View style={styles.movementButtonsContainer}>
+                    <View className={styles.movementButtonsContainer}>
                         <IconButton
                             aria-label="Move polygon up"
                             size="small"
@@ -338,7 +352,7 @@ const LockedPolygonSettings = (props: Props) => {
                             kind="tertiary"
                             onClick={() => handlePolygonMove("up")}
                         />
-                        <View style={styles.row}>
+                        <View className={styles.row}>
                             <IconButton
                                 aria-label="Move polygon left"
                                 size="small"
@@ -366,8 +380,7 @@ const LockedPolygonSettings = (props: Props) => {
             </PerseusEditorAccordion>
 
             {/* Aria label */}
-            <Strut size={spacing.small_12} />
-            <View style={styles.horizontalRule} />
+            <View className={`${styles.horizontalRule} ${styles.sectionTop}`} />
             <LockedFigureAria
                 ariaLabel={ariaLabel}
                 getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
@@ -377,10 +390,10 @@ const LockedPolygonSettings = (props: Props) => {
             />
 
             {/* Visible Labels */}
-            <Strut size={spacing.xxxSmall_4} />
-            <View style={styles.horizontalRule} />
-            <Strut size={spacing.small_12} />
-            <BodyText>Visible labels</BodyText>
+            <View
+                className={`${styles.horizontalRule} ${styles.dividerTight}`}
+            />
+            <BodyText className={styles.sectionTop}>Visible labels</BodyText>
             {labels.map((label, labelIndex) => (
                 <LockedLabelSettings
                     {...label}
@@ -392,7 +405,7 @@ const LockedPolygonSettings = (props: Props) => {
                     onRemove={() => {
                         handleLabelRemove(labelIndex);
                     }}
-                    containerStyle={styles.labelContainer}
+                    containerStyle={labelContainerStyle}
                 />
             ))}
             <Button
@@ -415,7 +428,7 @@ const LockedPolygonSettings = (props: Props) => {
                         labels: [...labels, newLabel],
                     });
                 }}
-                style={styles.addButton}
+                className={styles.addButton}
             >
                 Add visible label
             </Button>
@@ -429,50 +442,5 @@ const LockedPolygonSettings = (props: Props) => {
         </PerseusEditorAccordion>
     );
 };
-
-const styles = StyleSheet.create({
-    row: {
-        display: "flex",
-        flexDirection: "row",
-        alignItems: "center",
-    },
-    pointAccordionContainer: {
-        backgroundColor: semanticColor.core.background.base.default,
-    },
-    pointAccordionPanel: {
-        alignItems: "start",
-    },
-    icon: {
-        marginInlineStart: spacing.xxxSmall_4,
-    },
-    polygonActionsContainer: {
-        width: "100%",
-    },
-    movementButtonsContainer: {
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        minWidth: "fit-content",
-    },
-    spaceUnder: {
-        marginBottom: spacing.xSmall_8,
-    },
-    truncatedWidth: {
-        // Allow truncation, stop bleeding over the edge.
-        minWidth: 0,
-    },
-
-    // Styles for the visible labels section
-    addButton: {
-        alignSelf: "start",
-    },
-    labelContainer: {
-        backgroundColor: semanticColor.core.background.base.default,
-    },
-    horizontalRule: {
-        height: 1,
-        backgroundColor: semanticColor.core.border.neutral.subtle,
-    },
-});
 
 export default LockedPolygonSettings;

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.module.css
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.module.css
@@ -1,0 +1,34 @@
+/* We have to use !important until wonder blocks is in the shared layer. */
+/* TODO(LEMS-3686): Remove the !important once we don't need it anymore. */
+.row {
+    flex-direction: row !important;
+    align-items: center !important;
+    /* gap replaces the Strut that separated the header label from its swatch. */
+    gap: var(--wb-sizing-size_080) !important;
+}
+
+.error-text {
+    color: var(--wb-semanticColor-core-foreground-critical-default) !important;
+    margin-top: var(--wb-sizing-size_080) !important;
+}
+
+.add-button {
+    align-self: start !important;
+}
+
+.horizontal-rule {
+    height: 1px !important;
+    background-color: var(
+        --wb-semanticColor-core-border-neutral-subtle
+    ) !important;
+}
+
+/* Top spacing for a section start (a divider opening a section, or a heading). */
+.section-top {
+    margin-top: var(--wb-sizing-size_120) !important;
+}
+
+/* A divider that hugs the content directly above it. */
+.divider-tight {
+    margin-top: var(--wb-sizing-size_040) !important;
+}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.tsx
@@ -8,15 +8,9 @@ import {vector as kvector} from "@khanacademy/kmath";
 import {getDefaultFigureForType} from "@khanacademy/perseus-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {Strut} from "@khanacademy/wonder-blocks-layout";
-import {
-    sizing,
-    spacing,
-    semanticColor,
-} from "@khanacademy/wonder-blocks-tokens";
+import {sizing, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import plusCircle from "@phosphor-icons/core/regular/plus-circle.svg";
-import {StyleSheet} from "aphrodite";
 import {vec} from "mafs";
 import * as React from "react";
 
@@ -29,6 +23,7 @@ import LineWeightSelect from "./line-weight-select";
 import LockedFigureAria from "./locked-figure-aria";
 import LockedFigureSettingsActions from "./locked-figure-settings-actions";
 import LockedLabelSettings from "./locked-label-settings";
+import styles from "./locked-vector-settings.module.css";
 import {
     generateLockedFigureAppearanceDescription,
     generateSpokenMathDetails,
@@ -44,8 +39,26 @@ import type {
     LockedVectorType,
     StrokeWeight,
 } from "@khanacademy/perseus-core";
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 const lengthErrorMessage = "The vector cannot have length 0.";
+
+// Passed to PerseusEditorAccordion's `containerStyle`/`panelStyle` and
+// LockedLabelSettings' `containerStyle`, which are typed as Wonder Blocks
+// `StyleType` and do not accept a CSS-module className.
+const coordsAccordionContainerStyle: StyleType = {
+    marginTop: sizing.size_080,
+    marginBottom: 0,
+    marginLeft: -sizing.size_040,
+    marginRight: -sizing.size_040,
+    backgroundColor: semanticColor.core.background.base.default,
+};
+const coordsAccordionPanelStyle: StyleType = {
+    paddingBottom: sizing.size_160,
+};
+const labelContainerStyle: StyleType = {
+    backgroundColor: semanticColor.core.background.base.default,
+};
 
 export type Props = LockedVectorType &
     LockedFigureSettingsCommonProps & {
@@ -156,11 +169,10 @@ const LockedVectorSettings = (props: Props) => {
             expanded={props.expanded}
             onToggle={props.onToggle}
             header={
-                <View style={styles.row}>
+                <View className={styles.row}>
                     <BodyText size="medium" weight="bold" tag="span">
                         {lineLabel}
                     </BodyText>
-                    <Strut size={spacing.xSmall_8} />
                     <LineSwatch color={lineColor} lineStyle="solid" />
                 </View>
             }
@@ -182,7 +194,7 @@ const LockedVectorSettings = (props: Props) => {
 
             {/* Zero length error message */}
             {isInvalid && (
-                <BodyText style={styles.errorText}>
+                <BodyText className={styles.errorText}>
                     {lengthErrorMessage}
                 </BodyText>
             )}
@@ -190,10 +202,10 @@ const LockedVectorSettings = (props: Props) => {
             {/* Coordinates */}
             <PerseusEditorAccordion
                 expanded={true} // Initial state is expanded
-                containerStyle={styles.container}
-                panelStyle={styles.accordionPanel}
+                containerStyle={coordsAccordionContainerStyle}
+                panelStyle={coordsAccordionPanelStyle}
                 header={
-                    <View style={styles.row}>
+                    <View className={styles.row}>
                         <BodyText
                             size="medium"
                             weight="bold"
@@ -213,10 +225,10 @@ const LockedVectorSettings = (props: Props) => {
 
             <PerseusEditorAccordion
                 expanded={true} // Initial state is expanded
-                containerStyle={styles.container}
-                panelStyle={styles.accordionPanel}
+                containerStyle={coordsAccordionContainerStyle}
+                panelStyle={coordsAccordionPanelStyle}
                 header={
-                    <View style={styles.row}>
+                    <View className={styles.row}>
                         <BodyText
                             size="medium"
                             weight="bold"
@@ -235,8 +247,7 @@ const LockedVectorSettings = (props: Props) => {
             </PerseusEditorAccordion>
 
             {/* Aria label */}
-            <Strut size={spacing.small_12} />
-            <View style={styles.horizontalRule} />
+            <View className={`${styles.horizontalRule} ${styles.sectionTop}`} />
             <LockedFigureAria
                 ariaLabel={ariaLabel}
                 getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
@@ -246,10 +257,10 @@ const LockedVectorSettings = (props: Props) => {
             />
 
             {/* Visible labels */}
-            <Strut size={spacing.xxxSmall_4} />
-            <View style={styles.horizontalRule} />
-            <Strut size={spacing.small_12} />
-            <BodyText>Visible labels</BodyText>
+            <View
+                className={`${styles.horizontalRule} ${styles.dividerTight}`}
+            />
+            <BodyText className={styles.sectionTop}>Visible labels</BodyText>
             {labels.map((label, labelIndex) => (
                 <LockedLabelSettings
                     {...label}
@@ -261,7 +272,7 @@ const LockedVectorSettings = (props: Props) => {
                     onRemove={() => {
                         handleLabelRemove(labelIndex);
                     }}
-                    containerStyle={styles.labelContainer}
+                    containerStyle={labelContainerStyle}
                 />
             ))}
             <Button
@@ -287,7 +298,7 @@ const LockedVectorSettings = (props: Props) => {
                         labels: [...labels, newLabel],
                     });
                 }}
-                style={styles.addButton}
+                className={styles.addButton}
             >
                 Add visible label
             </Button>
@@ -301,36 +312,5 @@ const LockedVectorSettings = (props: Props) => {
         </PerseusEditorAccordion>
     );
 };
-
-const styles = StyleSheet.create({
-    accordionPanel: {
-        paddingBottom: spacing.medium_16,
-    },
-    container: {
-        marginTop: spacing.xSmall_8,
-        marginBottom: 0,
-        marginLeft: -spacing.xxxSmall_4,
-        marginRight: -spacing.xxxSmall_4,
-        backgroundColor: semanticColor.core.background.base.default,
-    },
-    errorText: {
-        color: semanticColor.core.foreground.critical.default,
-        marginTop: spacing.xSmall_8,
-    },
-    row: {
-        flexDirection: "row",
-        alignItems: "center",
-    },
-    addButton: {
-        alignSelf: "start",
-    },
-    horizontalRule: {
-        height: 1,
-        backgroundColor: semanticColor.core.border.neutral.subtle,
-    },
-    labelContainer: {
-        backgroundColor: semanticColor.core.background.base.default,
-    },
-});
 
 export default LockedVectorSettings;


### PR DESCRIPTION
## Summary:
A pure refactor of **16 files** (15 new colocated `*.module.css`), applying the same modernization rules
to each:
- No more deprecated aphrodite
- No more deprecated `Strut`, use `gap`
- No more deprecated `spacing`, use `sizing`
- Use CSS module

Issue: LEMS-4131

## Test plan:
- no behavior or visual change, locked figure editor still works as expected

## Related PRs / Follow-up work related to `editingDisabled`
| PR | Scope | Branch | Status | Notes |
|----|-------|--------|--------|-------|
| **[PR 1](https://github.com/Khan/perseus/pull/3777)** | Phase 1 (labels) + Phase 2B (modernization of touched non-locked-figures editors) | `LEMS-4131/improve-editor-labels` | ✅ |  |
| **[PR 2](https://github.com/Khan/perseus/pull/3779)** | Phase 2A (locked-figures refactor) | `LEMS-4131/editor-locked-figures-code-refactor` | ✅ | The heaviest CSS-module migration; independent of PR 1. |
| **PR 3** | Phase 3 (numeric-input label restructuring) | — | ⚪ not started, will skip | Standalone; after Phase 2B. |
| **[PR 4](https://github.com/Khan/perseus/pull/3782)** | Phase 4 (Pill → Badge / SegmentedControl) | `LEMS-4131/editor-pill-to-badge` | ✅  | Carries a UX behavior change (radio A/B/C) |
| **[PR 5](https://github.com/Khan/perseus/pull/3787)** | Phase 5 (`editingDisabled` functional fix — the actual deliverable) | `LEMS-4131/editor-add-editing-disabled` | In Review | Depends on PR 4; starts with the `button-group` `disabled` enabler. |