### PR TITLE
Editor `Pill` → `SegmentedControl`/`Badge`

### DIFF
--- a/.changeset/tidy-glasses-laugh.md
+++ b/.changeset/tidy-glasses-laugh.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Editor `Pill` → `SegmentedControl`/`Badge` migration

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -114,6 +114,6 @@
     },
     "keywords": [],
     "khan": {
-        "catalogHash": "a7ee0170a1dee778"
+        "catalogHash": "1fab6704d94ffe20"
     }
 }

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -51,6 +51,7 @@
     "devDependencies": {
         "@khanacademy/mathjax-renderer": "catalog:devDeps",
         "@khanacademy/wonder-blocks-accordion": "catalog:devDeps",
+        "@khanacademy/wonder-blocks-badge": "catalog:devDeps",
         "@khanacademy/wonder-blocks-banner": "catalog:devDeps",
         "@khanacademy/wonder-blocks-button": "catalog:devDeps",
         "@khanacademy/wonder-blocks-clickable": "catalog:devDeps",
@@ -83,6 +84,7 @@
     "peerDependencies": {
         "@khanacademy/mathjax-renderer": "catalog:peerDeps",
         "@khanacademy/wonder-blocks-accordion": "catalog:peerDeps",
+        "@khanacademy/wonder-blocks-badge": "catalog:peerDeps",
         "@khanacademy/wonder-blocks-banner": "catalog:peerDeps",
         "@khanacademy/wonder-blocks-button": "catalog:peerDeps",
         "@khanacademy/wonder-blocks-clickable": "catalog:peerDeps",

--- a/packages/perseus-editor/src/components/__docs__/segmented-control.stories.tsx
+++ b/packages/perseus-editor/src/components/__docs__/segmented-control.stories.tsx
@@ -1,0 +1,78 @@
+import * as React from "react";
+
+import {SegmentedControl, ToggleButtonGroup} from "../segmented-control";
+
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+const meta: Meta<typeof SegmentedControl> = {
+    component: SegmentedControl,
+    title: "Editors/Components/Segmented Control",
+};
+
+export default meta;
+type Story = StoryObj<typeof SegmentedControl>;
+
+const statusOptions = [
+    {value: "correct", label: "Correct"},
+    {value: "incorrect", label: "Incorrect"},
+];
+
+const formatOptions = [
+    {value: "integer", label: "integer"},
+    {value: "proper", label: "proper fraction"},
+    {value: "improper", label: "improper fraction"},
+    {value: "mixed", label: "mixed number"},
+    {value: "decimal", label: "decimal"},
+];
+
+/** Single-select segmented control (role="radiogroup"). */
+export const SingleSelect: Story = {
+    render: function Render() {
+        const [value, setValue] = React.useState<string>("correct");
+        return (
+            <SegmentedControl
+                aria-label="Choice status"
+                options={statusOptions}
+                selectedValue={value}
+                onChange={setValue}
+            />
+        );
+    },
+};
+
+/** Disabled single-select (e.g. when the whole editor is disabled). */
+export const Disabled: Story = {
+    render: () => (
+        <SegmentedControl
+            aria-label="Choice status"
+            options={statusOptions}
+            selectedValue="correct"
+            onChange={() => {}}
+            disabled={true}
+        />
+    ),
+};
+
+/** Multi-select group (role="group", checkboxes) that wraps onto rows. */
+export const MultiSelect: Story = {
+    render: function Render() {
+        const [values, setValues] = React.useState<ReadonlyArray<string>>([
+            "integer",
+            "decimal",
+        ]);
+        return (
+            <ToggleButtonGroup
+                aria-label="Answer formats"
+                options={formatOptions}
+                selectedValues={values}
+                onToggle={(value) =>
+                    setValues((prev) =>
+                        prev.includes(value)
+                            ? prev.filter((v) => v !== value)
+                            : [...prev, value],
+                    )
+                }
+            />
+        );
+    },
+};

--- a/packages/perseus-editor/src/components/segmented-control.module.css
+++ b/packages/perseus-editor/src/components/segmented-control.module.css
@@ -25,21 +25,15 @@
     gap: var(--wb-sizing-size_080) !important;
 }
 
-/* Reset the Clickable's native <button> chrome; the visual lives on the inner
- * View so it can react to hovered/pressed state. The keyboard focus ring is a
- * rounded box-shadow (follows the border radius, unlike `outline`) shown only on
- * `:focus-visible` so it doesn't appear after a mouse click. */
-.reset {
-    border-radius: var(--wb-border-radius-radius_040) !important;
-}
-
-.reset:focus-visible {
-    outline: none !important;
-    box-shadow: 0 0 0 var(--wb-border-width-medium)
-        var(--wb-semanticColor-focus-outer) !important;
-}
-
+/* The segment IS the Clickable's <button>. Clickable already inherits the font,
+ * resets the text decoration, and sets the cursor (pointer / not-allowed when
+ * disabled); here we add the visual box. Its variants are driven by selectors
+ * below — selected via `[aria-checked="true"]`, disabled via `[aria-disabled]`,
+ * hover via `:hover` — so the markup needs only this one static class. The
+ * keyboard focus ring is a rounded box-shadow (follows the border radius, unlike
+ * `outline`) shown only on `:focus-visible` so it doesn't appear after a click. */
 .segment {
+    display: flex !important;
     flex-direction: row !important;
     align-items: center !important;
     justify-content: center !important;
@@ -57,7 +51,23 @@
     white-space: nowrap !important;
 }
 
-.segment-selected {
+.segment:focus-visible {
+    outline: none !important;
+    box-shadow: 0 0 0 var(--wb-border-width-medium)
+        var(--wb-semanticColor-focus-outer) !important;
+}
+
+/* Hover only when interactive and not already selected. */
+.segment:not([aria-disabled="true"]):not([aria-checked="true"]):hover {
+    border-color: var(
+        --wb-semanticColor-core-border-neutral-default
+    ) !important;
+    background-color: var(
+        --wb-semanticColor-core-background-neutral-subtle
+    ) !important;
+}
+
+.segment[aria-checked="true"] {
     background-color: var(
         --wb-semanticColor-core-background-instructive-default
     ) !important;
@@ -67,16 +77,7 @@
     color: var(--wb-semanticColor-core-foreground-knockout-default) !important;
 }
 
-.segment-hovered {
-    border-color: var(
-        --wb-semanticColor-core-border-neutral-default
-    ) !important;
-    background-color: var(
-        --wb-semanticColor-core-background-neutral-subtle
-    ) !important;
-}
-
-.segment-disabled {
+.segment[aria-disabled="true"] {
     background-color: var(
         --wb-semanticColor-core-background-disabled-subtle
     ) !important;
@@ -84,10 +85,9 @@
         --wb-semanticColor-core-border-disabled-default
     ) !important;
     color: var(--wb-semanticColor-core-foreground-disabled-default) !important;
-    cursor: not-allowed !important;
 }
 
-.segment-disabled-selected {
+.segment[aria-disabled="true"][aria-checked="true"] {
     background-color: var(
         --wb-semanticColor-core-background-disabled-strong
     ) !important;

--- a/packages/perseus-editor/src/components/segmented-control.module.css
+++ b/packages/perseus-editor/src/components/segmented-control.module.css
@@ -1,0 +1,98 @@
+/* TODO(LEMS-3686): Remove the !important once Wonder Blocks is in the shared layer. */
+
+/* inline-flex so the (single-select) group flows inline with adjacent
+ * labels/badges (e.g. the "Status" label) instead of wrapping onto its own
+ * line. It stays cohesive — its segments never split across lines; the whole
+ * group wraps below the label as a unit if there isn't room. */
+.group {
+    display: inline-flex !important;
+    flex-direction: row !important;
+    align-items: center !important;
+    vertical-align: middle !important;
+    gap: var(--wb-sizing-size_080) !important;
+}
+
+/* Multi-select group: wraps onto multiple rows as an aligned grid with
+ * consistent row + column gaps. Stretch to the full available width so it only
+ * wraps when the segments genuinely don't fit on one line (not because a flex
+ * parent shrank it to content width). */
+.wrap-group {
+    display: flex !important;
+    flex-direction: row !important;
+    flex-wrap: wrap !important;
+    align-items: center !important;
+    align-self: stretch !important;
+    gap: var(--wb-sizing-size_080) !important;
+}
+
+/* Reset the Clickable's native <button> chrome; the visual lives on the inner
+ * View so it can react to hovered/pressed state. The keyboard focus ring is a
+ * rounded box-shadow (follows the border radius, unlike `outline`) shown only on
+ * `:focus-visible` so it doesn't appear after a mouse click. */
+.reset {
+    border-radius: var(--wb-border-radius-radius_040) !important;
+}
+
+.reset:focus-visible {
+    outline: none !important;
+    box-shadow: 0 0 0 var(--wb-border-width-medium)
+        var(--wb-semanticColor-focus-outer) !important;
+}
+
+.segment {
+    flex-direction: row !important;
+    align-items: center !important;
+    justify-content: center !important;
+    padding-block: var(--wb-sizing-size_040) !important;
+    padding-inline: var(--wb-sizing-size_120) !important;
+    border-radius: var(--wb-border-radius-radius_040) !important;
+    border: var(--wb-border-width-thin) solid
+        var(--wb-semanticColor-core-border-neutral-subtle) !important;
+    background-color: var(
+        --wb-semanticColor-core-background-base-default
+    ) !important;
+    color: var(--wb-semanticColor-core-foreground-neutral-strong) !important;
+    font-size: var(--wb-font-body-size-small) !important;
+    line-height: var(--wb-font-body-lineHeight-small) !important;
+    white-space: nowrap !important;
+}
+
+.segment-selected {
+    background-color: var(
+        --wb-semanticColor-core-background-instructive-default
+    ) !important;
+    border-color: var(
+        --wb-semanticColor-core-background-instructive-default
+    ) !important;
+    color: var(--wb-semanticColor-core-foreground-knockout-default) !important;
+}
+
+.segment-hovered {
+    border-color: var(
+        --wb-semanticColor-core-border-neutral-default
+    ) !important;
+    background-color: var(
+        --wb-semanticColor-core-background-neutral-subtle
+    ) !important;
+}
+
+.segment-disabled {
+    background-color: var(
+        --wb-semanticColor-core-background-disabled-subtle
+    ) !important;
+    border-color: var(
+        --wb-semanticColor-core-border-disabled-default
+    ) !important;
+    color: var(--wb-semanticColor-core-foreground-disabled-default) !important;
+    cursor: not-allowed !important;
+}
+
+.segment-disabled-selected {
+    background-color: var(
+        --wb-semanticColor-core-background-disabled-strong
+    ) !important;
+    border-color: var(
+        --wb-semanticColor-core-background-disabled-strong
+    ) !important;
+    color: var(--wb-semanticColor-core-foreground-disabled-strong) !important;
+}

--- a/packages/perseus-editor/src/components/segmented-control.test.tsx
+++ b/packages/perseus-editor/src/components/segmented-control.test.tsx
@@ -1,0 +1,158 @@
+import {render, screen} from "@testing-library/react";
+import {userEvent as userEventLib} from "@testing-library/user-event";
+import * as React from "react";
+
+import {SegmentedControl, ToggleButtonGroup} from "./segmented-control";
+
+import type {UserEvent} from "@testing-library/user-event";
+
+const options = [
+    {value: "a", label: "A"},
+    {value: "b", label: "B"},
+    {value: "c", label: "C"},
+];
+
+describe("SegmentedControl", () => {
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+    });
+
+    it("renders each option as a radio in a radiogroup", () => {
+        // Arrange, Act
+        render(
+            <SegmentedControl
+                aria-label="Letter"
+                options={options}
+                selectedValue="a"
+                onChange={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("radiogroup", {name: "Letter"}),
+        ).toBeInTheDocument();
+        expect(screen.getAllByRole("radio")).toHaveLength(3);
+    });
+
+    it("marks the selected option as checked", () => {
+        // Arrange, Act
+        render(
+            <SegmentedControl
+                options={options}
+                selectedValue="b"
+                onChange={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(screen.getByRole("radio", {name: "B"})).toBeChecked();
+        expect(screen.getByRole("radio", {name: "A"})).not.toBeChecked();
+    });
+
+    it("calls onChange with the value when an option is clicked", async () => {
+        // Arrange
+        const onChange = jest.fn();
+        render(
+            <SegmentedControl
+                options={options}
+                selectedValue="a"
+                onChange={onChange}
+            />,
+        );
+
+        // Act
+        await userEvent.click(screen.getByRole("radio", {name: "C"}));
+
+        // Assert
+        expect(onChange).toHaveBeenCalledWith("c");
+    });
+
+    it("does not call onChange when disabled", async () => {
+        // Arrange
+        const onChange = jest.fn();
+        render(
+            <SegmentedControl
+                options={options}
+                selectedValue="a"
+                onChange={onChange}
+                disabled={true}
+            />,
+        );
+
+        // Act
+        await userEvent.click(screen.getByRole("radio", {name: "B"}));
+
+        // Assert
+        expect(onChange).not.toHaveBeenCalled();
+    });
+});
+
+describe("ToggleButtonGroup", () => {
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+    });
+
+    it("renders each option as a checkbox in a group", () => {
+        // Arrange, Act
+        render(
+            <ToggleButtonGroup
+                aria-label="Letters"
+                options={options}
+                selectedValues={["a", "c"]}
+                onToggle={() => {}}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("group", {name: "Letters"}),
+        ).toBeInTheDocument();
+        expect(screen.getByRole("checkbox", {name: "A"})).toBeChecked();
+        expect(screen.getByRole("checkbox", {name: "B"})).not.toBeChecked();
+        expect(screen.getByRole("checkbox", {name: "C"})).toBeChecked();
+    });
+
+    it("calls onToggle with the value when an option is clicked", async () => {
+        // Arrange
+        const onToggle = jest.fn();
+        render(
+            <ToggleButtonGroup
+                options={options}
+                selectedValues={["a"]}
+                onToggle={onToggle}
+            />,
+        );
+
+        // Act
+        await userEvent.click(screen.getByRole("checkbox", {name: "B"}));
+
+        // Assert
+        expect(onToggle).toHaveBeenCalledWith("b");
+    });
+
+    it("does not call onToggle when disabled", async () => {
+        // Arrange
+        const onToggle = jest.fn();
+        render(
+            <ToggleButtonGroup
+                options={options}
+                selectedValues={[]}
+                onToggle={onToggle}
+                disabled={true}
+            />,
+        );
+
+        // Act
+        await userEvent.click(screen.getByRole("checkbox", {name: "A"}));
+
+        // Assert
+        expect(onToggle).not.toHaveBeenCalled();
+    });
+});

--- a/packages/perseus-editor/src/components/segmented-control.tsx
+++ b/packages/perseus-editor/src/components/segmented-control.tsx
@@ -1,0 +1,147 @@
+import Clickable from "@khanacademy/wonder-blocks-clickable";
+import {View} from "@khanacademy/wonder-blocks-core";
+import classNames from "classnames";
+import * as React from "react";
+
+import styles from "./segmented-control.module.css";
+
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
+
+interface ToggleButtonProps {
+    selected: boolean;
+    onClick: () => void;
+    disabled?: boolean;
+    role?: "radio" | "checkbox";
+    "aria-label"?: string;
+    children: React.ReactNode;
+    style?: StyleType;
+}
+
+/**
+ * A single selectable segment. Built on Wonder Blocks `Clickable` (the same
+ * primitive `Pill` uses) so it gets focus handling and a real `disabled` /
+ * `aria-disabled` state for free, while letting us render arbitrary children
+ * (math, icons) and set a `radio`/`checkbox` role.
+ *
+ * Disabled styling intentionally uses the WB disabled tokens so it reads as
+ * disabled consistently with the rest of the design system (no opacity hack).
+ */
+export function ToggleButton({
+    selected,
+    onClick,
+    disabled = false,
+    role = "radio",
+    children,
+    style,
+    "aria-label": ariaLabel,
+}: ToggleButtonProps): React.ReactElement {
+    return (
+        <Clickable
+            role={role}
+            aria-checked={selected}
+            aria-label={ariaLabel}
+            disabled={disabled}
+            onClick={onClick}
+            className={styles.reset}
+            style={style}
+        >
+            {({hovered, pressed}) => (
+                <View
+                    className={classNames(styles.segment, {
+                        [styles.segmentSelected]: selected,
+                        [styles.segmentHovered]:
+                            !disabled && !selected && (hovered || pressed),
+                        [styles.segmentDisabled]: disabled,
+                        [styles.segmentDisabledSelected]: disabled && selected,
+                    })}
+                >
+                    {children}
+                </View>
+            )}
+        </Clickable>
+    );
+}
+
+interface Option {
+    value: string;
+    label: React.ReactNode;
+    ariaLabel?: string;
+}
+
+interface SegmentedControlProps {
+    options: ReadonlyArray<Option>;
+    selectedValue: string | null | undefined;
+    onChange: (value: string) => void;
+    disabled?: boolean;
+    "aria-label"?: string;
+}
+
+/**
+ * A row of mutually-exclusive (single-select) segments — a segmented control.
+ * Replaces the deprecated `Pill`-as-button pattern. Pass `disabled` to disable
+ * the whole group (e.g. `editingDisabled`).
+ */
+export function SegmentedControl({
+    options,
+    selectedValue,
+    onChange,
+    disabled = false,
+    "aria-label": ariaLabel,
+}: SegmentedControlProps): React.ReactElement {
+    return (
+        <View role="radiogroup" aria-label={ariaLabel} className={styles.group}>
+            {options.map((option) => (
+                <ToggleButton
+                    key={option.value}
+                    role="radio"
+                    selected={option.value === selectedValue}
+                    aria-label={option.ariaLabel}
+                    disabled={disabled}
+                    onClick={() => onChange(option.value)}
+                >
+                    {option.label}
+                </ToggleButton>
+            ))}
+        </View>
+    );
+}
+
+interface ToggleButtonGroupProps {
+    options: ReadonlyArray<Option>;
+    selectedValues: ReadonlyArray<string>;
+    onToggle: (value: string) => void;
+    disabled?: boolean;
+    "aria-label"?: string;
+}
+
+/**
+ * A group of independent (multi-select) toggles — i.e. a set of checkboxes
+ * styled as buttons. Unlike `SegmentedControl`, more than one can be selected,
+ * and the group wraps onto multiple rows as an aligned grid (consistent row and
+ * column gaps) when it doesn't fit on one line. `onToggle` is called with the
+ * value that was clicked; the caller flips it in/out of `selectedValues`.
+ */
+export function ToggleButtonGroup({
+    options,
+    selectedValues,
+    onToggle,
+    disabled = false,
+    "aria-label": ariaLabel,
+}: ToggleButtonGroupProps): React.ReactElement {
+    return (
+        <View role="group" aria-label={ariaLabel} className={styles.wrapGroup}>
+            {options.map((option) => (
+                <ToggleButton
+                    key={option.value}
+                    role="checkbox"
+                    selected={selectedValues.includes(option.value)}
+                    aria-label={option.ariaLabel}
+                    disabled={disabled}
+                    onClick={() => onToggle(option.value)}
+                >
+                    {option.label}
+                </ToggleButton>
+            ))}
+        </View>
+    );
+}

--- a/packages/perseus-editor/src/components/segmented-control.tsx
+++ b/packages/perseus-editor/src/components/segmented-control.tsx
@@ -26,7 +26,7 @@ interface ToggleButtonProps {
  * Disabled styling intentionally uses the WB disabled tokens so it reads as
  * disabled consistently with the rest of the design system (no opacity hack).
  */
-export function ToggleButton({
+function ToggleButton({
     selected,
     onClick,
     disabled = false,

--- a/packages/perseus-editor/src/components/segmented-control.tsx
+++ b/packages/perseus-editor/src/components/segmented-control.tsx
@@ -1,6 +1,5 @@
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 import {View} from "@khanacademy/wonder-blocks-core";
-import classNames from "classnames";
 import * as React from "react";
 
 import styles from "./segmented-control.module.css";
@@ -42,22 +41,10 @@ function ToggleButton({
             aria-label={ariaLabel}
             disabled={disabled}
             onClick={onClick}
-            className={styles.reset}
+            className={styles.segment}
             style={style}
         >
-            {({hovered, pressed}) => (
-                <View
-                    className={classNames(styles.segment, {
-                        [styles.segmentSelected]: selected,
-                        [styles.segmentHovered]:
-                            !disabled && !selected && (hovered || pressed),
-                        [styles.segmentDisabled]: disabled,
-                        [styles.segmentDisabledSelected]: disabled && selected,
-                    })}
-                >
-                    {children}
-                </View>
-            )}
+            {() => children}
         </Clickable>
     );
 }

--- a/packages/perseus-editor/src/widgets/__tests__/radio-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/radio-editor.test.tsx
@@ -389,17 +389,7 @@ describe("radio-editor", () => {
             {wrapper: RenderStateRoot},
         );
 
-        /**
-         * This was super annoying to figure out.
-         * When in "edit" mode (which the editor is obviously)
-         * the only way to select an option from the radio
-         * is to click the A/B/C/etc icons themselves.
-         * We have a `elem.getAttribute("data-is-radio-icon")` check
-         * to make sure that what we're clicking is the icon and
-         * not some other part of the radio choice.
-         * It's just a div, hence the test ID.
-         */
-        const choices = screen.getAllByRole("button", {name: "Correct"});
+        const choices = screen.getAllByRole("radio", {name: "Correct"});
 
         // switch an incorrect answer into a correct answer
         await userEvent.click(choices[0]);
@@ -412,14 +402,14 @@ describe("radio-editor", () => {
         );
     });
 
-    it("calls onChange when the correct choice is picked (status badges)", async () => {
+    it("calls onChange when the correct choice is picked", async () => {
         const onChangeMock = jest.fn();
 
         renderRadioEditor(onChangeMock, {
             choices: fourChoices,
         });
 
-        const choices = screen.getAllByRole("button", {name: "Correct"});
+        const choices = screen.getAllByRole("radio", {name: "Correct"});
 
         await userEvent.click(choices[0]);
 
@@ -430,32 +420,14 @@ describe("radio-editor", () => {
         );
     });
 
-    it("calls onChange when the correct choice is picked (indicator pill)", async () => {
-        const onChangeMock = jest.fn();
-
-        renderRadioEditor(onChangeMock, {
-            choices: fourChoices,
-        });
-
-        const choice = screen.getByRole("button", {name: "A"});
-
-        await userEvent.click(choice);
-
-        expect(onChangeMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                choices: fourChoicesWithFirstCorrect,
-            }),
-        );
-    });
-
-    it("calls onChange when the correct choice is changed (status badges)", async () => {
+    it("calls onChange when the correct choice is changed", async () => {
         const onChangeMock = jest.fn();
 
         renderRadioEditor(onChangeMock, {
             choices: fourChoicesWithFirstCorrect,
         });
 
-        const choices = screen.getAllByRole("button", {name: "Correct"});
+        const choices = screen.getAllByRole("radio", {name: "Correct"});
 
         await userEvent.click(choices[1]);
 
@@ -467,58 +439,20 @@ describe("radio-editor", () => {
         );
     });
 
-    it("calls onChange when the correct choice is changed (indicator pill)", async () => {
+    it("calls onChange when the previously correct choice is marked wrong", async () => {
         const onChangeMock = jest.fn();
 
         renderRadioEditor(onChangeMock, {
             choices: fourChoicesWithFirstCorrect,
         });
 
-        const choice = screen.getByRole("button", {name: "B"});
-
-        await userEvent.click(choice);
-
-        expect(onChangeMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                // Automatically change the previous correct choice to incorrect
-                choices: fourChoicesWithSecondCorrect,
-            }),
-        );
-    });
-
-    it("calls onChange when the previously correct choice is marked wrong (status badges)", async () => {
-        const onChangeMock = jest.fn();
-
-        renderRadioEditor(onChangeMock, {
-            choices: fourChoicesWithFirstCorrect,
-        });
-
-        const choices = screen.getAllByRole("button", {name: "Incorrect"});
+        const choices = screen.getAllByRole("radio", {name: "Incorrect"});
 
         await userEvent.click(choices[0]);
 
         expect(onChangeMock).toHaveBeenCalledWith(
             expect.objectContaining({
                 // All choices are now incorrect
-                choices: fourChoicesWithAllIncorrect,
-            }),
-        );
-    });
-
-    it("calls onChange when the previously correct choice is marked wrong (indicator pill)", async () => {
-        const onChangeMock = jest.fn();
-
-        renderRadioEditor(onChangeMock, {
-            choices: fourChoicesWithFirstCorrect,
-        });
-
-        const choice = screen.getByRole("button", {name: "A"});
-
-        await userEvent.click(choice);
-
-        expect(onChangeMock).toHaveBeenCalledWith(
-            expect.objectContaining({
-                // All choices are now incorrect.
                 choices: fourChoicesWithAllIncorrect,
             }),
         );
@@ -532,7 +466,7 @@ describe("radio-editor", () => {
             multipleSelect: true,
         });
 
-        const choices = screen.getAllByRole("button", {name: "Correct"});
+        const choices = screen.getAllByRole("radio", {name: "Correct"});
 
         await userEvent.click(choices[1]);
 

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
@@ -1,9 +1,9 @@
 import {components} from "@khanacademy/perseus";
+import {NeutralBadge, StatusBadge} from "@khanacademy/wonder-blocks-badge";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Spring} from "@khanacademy/wonder-blocks-layout";
-import Pill from "@khanacademy/wonder-blocks-pill";
 import Switch from "@khanacademy/wonder-blocks-switch";
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {font, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import * as React from "react";
 
@@ -11,7 +11,16 @@ import Heading from "../../../components/heading";
 
 import styles from "./interactive-graph-sr-tree.module.css";
 
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
+
 const {InfoTip} = components;
+
+// Passed to the Badge `styles` prop, which is typed as Wonder Blocks `StyleType`
+// (per-part: root/label) and does not accept a className.
+const badgeSpacingStyle: StyleType = {marginInlineEnd: sizing.size_060};
+// Badges default to a bold label, but these decorative role/tag indicators
+// should read at the regular body weight (matching the old Pill look).
+const badgeLabelStyle: StyleType = {fontWeight: font.weight.regular};
 
 interface Attribute {
     name: string;
@@ -105,29 +114,40 @@ function SRTree(props: Props) {
             {elementArias.map((aria, index) => (
                 <li key={index}>
                     {showTags && (
-                        <Pill
-                            size="small"
+                        <StatusBadge
                             kind="success"
-                            style={{marginRight: sizing.size_060}}
-                        >
-                            {aria.roleOrTag}
-                        </Pill>
+                            label={aria.roleOrTag}
+                            showBorder={false}
+                            styles={{
+                                root: badgeSpacingStyle,
+                                label: badgeLabelStyle,
+                            }}
+                        />
                     )}
                     {aria.className}
                     <ul className={styles.indentList}>
                         {aria.attributes.map((value, index) => (
                             <li key={index}>
-                                <Pill
-                                    size="small"
-                                    kind={
-                                        value.name === "label"
-                                            ? "info"
-                                            : "neutral"
-                                    }
-                                    style={{marginRight: sizing.size_060}}
-                                >
-                                    {value.name}
-                                </Pill>
+                                {value.name === "label" ? (
+                                    <StatusBadge
+                                        kind="info"
+                                        label={value.name}
+                                        showBorder={false}
+                                        styles={{
+                                            root: badgeSpacingStyle,
+                                            label: badgeLabelStyle,
+                                        }}
+                                    />
+                                ) : (
+                                    <NeutralBadge
+                                        label={value.name}
+                                        showBorder={false}
+                                        styles={{
+                                            root: badgeSpacingStyle,
+                                            label: badgeLabelStyle,
+                                        }}
+                                    />
+                                )}
                                 {value.value}
                             </li>
                         ))}

--- a/packages/perseus-editor/src/widgets/radio/radio-editor.module.css
+++ b/packages/perseus-editor/src/widgets/radio/radio-editor.module.css
@@ -11,6 +11,14 @@
     margin-block-end: var(--wb-sizing-size_120);
 }
 
+.status-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: var(--wb-sizing-size_080);
+}
+
 .radio-option-actions-container {
     display: flex;
     flex-direction: row;

--- a/packages/perseus-editor/src/widgets/radio/radio-editor.module.css
+++ b/packages/perseus-editor/src/widgets/radio/radio-editor.module.css
@@ -7,7 +7,8 @@
     border: 1px solid var(--wb-semanticColor-core-border-neutral-subtle);
     border-radius: var(--wb-sizing-size_120);
     padding-inline: var(--wb-sizing-size_120);
-    padding-block: var(--wb-sizing-size_040);
+    padding-block: var(--wb-sizing-size_080);
+    margin-block-start: var(--wb-sizing-size_120);
     margin-block-end: var(--wb-sizing-size_120);
 }
 
@@ -17,6 +18,7 @@
     align-items: center;
     flex-wrap: wrap;
     gap: var(--wb-sizing-size_080);
+    margin-block-end: var(--wb-sizing-size_080);
 }
 
 .radio-option-actions-container {

--- a/packages/perseus-editor/src/widgets/radio/radio-option-settings.tsx
+++ b/packages/perseus-editor/src/widgets/radio/radio-option-settings.tsx
@@ -1,8 +1,9 @@
 import {TextArea} from "@khanacademy/wonder-blocks-form";
-import Pill from "@khanacademy/wonder-blocks-pill";
-import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import * as React from "react";
+
+import {SegmentedControl} from "../../components/segmented-control";
 
 import styles from "./radio-editor.module.css";
 import {RadioOptionContentAndImageEditor} from "./radio-option-content-and-image-editor";
@@ -65,57 +66,27 @@ export const RadioOptionSettings = React.forwardRef<
         <div className={styles.tile}>
             {/* Correct / Incorrect status selection */}
             <fieldset className="perseus-widget-row">
-                <RadioStatusPill
-                    index={index}
-                    correct={correct}
-                    multipleSelect={multipleSelect}
-                    onClick={() => {
-                        onStatusChange(index, !correct);
-                    }}
-                />
-                <BodyText
-                    size="small"
-                    weight="bold"
-                    tag="span"
-                    style={{
-                        display: "inline",
-                        marginInlineEnd: sizing.size_080,
-                    }}
-                >
-                    Status
-                </BodyText>
-                <Pill
-                    kind={correct ? "accent" : "transparent"}
-                    onClick={() => {
-                        onStatusChange(index, true);
-                    }}
-                    style={{
-                        marginInlineEnd: sizing.size_080,
-                        // Higher contrast on the default outline for
-                        // secondary pills
-                        outlineColor: correct
-                            ? semanticColor.core.background.instructive.default
-                            : semanticColor.core.border.neutral.default,
-                    }}
-                >
-                    Correct
-                </Pill>
-                <Pill
-                    kind={correct ? "transparent" : "accent"}
-                    onClick={() => {
-                        onStatusChange(index, false);
-                    }}
-                    style={{
-                        marginInlineEnd: sizing.size_080,
-                        // Higher contrast on the default outline for
-                        // secondary pills
-                        outlineColor: !correct
-                            ? semanticColor.core.background.instructive.default
-                            : semanticColor.core.border.neutral.default,
-                    }}
-                >
-                    Incorrect
-                </Pill>
+                <div className={styles.statusRow}>
+                    <RadioStatusPill
+                        index={index}
+                        correct={correct}
+                        multipleSelect={multipleSelect}
+                    />
+                    <BodyText size="small" weight="bold" tag="span">
+                        Status
+                    </BodyText>
+                    <SegmentedControl
+                        aria-label="Choice status"
+                        selectedValue={correct ? "correct" : "incorrect"}
+                        onChange={(value) => {
+                            onStatusChange(index, value === "correct");
+                        }}
+                        options={[
+                            {value: "correct", label: "Correct"},
+                            {value: "incorrect", label: "Incorrect"},
+                        ]}
+                    />
+                </div>
             </fieldset>
 
             {/* Content and rationale text areas */}

--- a/packages/perseus-editor/src/widgets/radio/radio-status-pill.tsx
+++ b/packages/perseus-editor/src/widgets/radio/radio-status-pill.tsx
@@ -13,11 +13,9 @@ interface RadioStatusPillProps {
     multipleSelect: boolean;
 }
 
-// Passed to StatusBadge's `styles` prop, which is typed as Wonder Blocks
-// `StyleType` (per-part: root/icon/label) and does not accept a className.
-// Match the original Pill's compact, fixed-width box so the A/B/C indicators
-// stay aligned; `cursor: default` since the badge is read-only (status is set
-// via the adjacent segmented control), not clickable.
+// Passed to StatusBadge's `styles` prop.
+// Uses a fixed-width box so the A/B/C indicators
+// stay aligned; `cursor: default` since the badge is read-only.
 const boxStyle: StyleType = {
     width: sizing.size_560,
     justifyContent: "center",
@@ -26,9 +24,7 @@ const boxStyle: StyleType = {
 };
 const roundStyle: StyleType = {borderRadius: sizing.size_240};
 const squareStyle: StyleType = {borderRadius: border.radius.radius_040};
-// Correct uses the strong (dark green) fill with knockout (white) content,
-// matching the runtime choice indicator. Incorrect keeps StatusBadge's default
-// subtle critical (light red) styling.
+// Styles matching the runtime choice indicator.
 const correctStrongStyle: StyleType = {
     backgroundColor: semanticColor.core.background.success.strong,
     borderColor: semanticColor.core.border.success.strong,
@@ -38,10 +34,9 @@ const knockoutForegroundStyle: StyleType = {
 };
 
 /**
- * A read-only status indicator showing whether a choice is correct (a green
- * check) or incorrect (a red minus), labelled with the choice letter (A, B,
- * C...). Status is changed via the adjacent segmented control, so this is no
- * longer interactive — it is a Wonder Blocks `StatusBadge`.
+ * * A read-only status indicator showing whether a choice is correct or incorrect,
+ * labeled with the choice letter (A, B, C...). Status is changed via the
+ * adjacent segmented control.
  */
 export function RadioStatusPill({
     index,
@@ -65,8 +60,8 @@ export function RadioStatusPill({
                     multipleSelect ? squareStyle : roundStyle,
                     correct && correctStrongStyle,
                 ],
-                label: correct ? knockoutForegroundStyle : undefined,
-                icon: correct ? knockoutForegroundStyle : undefined,
+                label: correct && knockoutForegroundStyle,
+                icon: correct && knockoutForegroundStyle,
             }}
         />
     );

--- a/packages/perseus-editor/src/widgets/radio/radio-status-pill.tsx
+++ b/packages/perseus-editor/src/widgets/radio/radio-status-pill.tsx
@@ -1,60 +1,73 @@
+import {StatusBadge} from "@khanacademy/wonder-blocks-badge";
 import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
-import Pill from "@khanacademy/wonder-blocks-pill";
-import {semanticColor, sizing, border} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import checkIcon from "@phosphor-icons/core/bold/check-bold.svg";
 import minusCircleIcon from "@phosphor-icons/core/bold/minus-circle-bold.svg";
 import * as React from "react";
+
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 interface RadioStatusPillProps {
     index: number;
     correct?: boolean;
     multipleSelect: boolean;
-    onClick: () => void;
 }
 
+// Passed to StatusBadge's `styles` prop, which is typed as Wonder Blocks
+// `StyleType` (per-part: root/icon/label) and does not accept a className.
+// Match the original Pill's compact, fixed-width box so the A/B/C indicators
+// stay aligned; `cursor: default` since the badge is read-only (status is set
+// via the adjacent segmented control), not clickable.
+const boxStyle: StyleType = {
+    width: sizing.size_560,
+    justifyContent: "center",
+    boxSizing: "border-box",
+    cursor: "default",
+};
+const roundStyle: StyleType = {borderRadius: sizing.size_240};
+const squareStyle: StyleType = {borderRadius: border.radius.radius_040};
+// Correct uses the strong (dark green) fill with knockout (white) content,
+// matching the runtime choice indicator. Incorrect keeps StatusBadge's default
+// subtle critical (light red) styling.
+const correctStrongStyle: StyleType = {
+    backgroundColor: semanticColor.core.background.success.strong,
+    borderColor: semanticColor.core.border.success.strong,
+};
+const knockoutForegroundStyle: StyleType = {
+    color: semanticColor.core.foreground.knockout.default,
+};
+
+/**
+ * A read-only status indicator showing whether a choice is correct (a green
+ * check) or incorrect (a red minus), labelled with the choice letter (A, B,
+ * C...). Status is changed via the adjacent segmented control, so this is no
+ * longer interactive — it is a Wonder Blocks `StatusBadge`.
+ */
 export function RadioStatusPill({
     index,
     correct,
     multipleSelect,
-    onClick,
 }: RadioStatusPillProps) {
     return (
-        <Pill
-            size="large"
-            // TODO(LEMS-3686): Update to use CSS modules when we can
-            // use them with Wonder Blocks.
-            style={{
-                // Space between the pill and the text
-                marginInlineEnd: sizing.size_080,
-                color: correct
-                    ? semanticColor.core.foreground.knockout.default
-                    : semanticColor.core.foreground.critical.default,
-                backgroundColor: correct
-                    ? semanticColor.core.background.success.strong
-                    : semanticColor.core.background.critical.subtle,
-                // Round for single select, square for multiple select
-                borderRadius: multipleSelect
-                    ? border.radius.radius_040
-                    : sizing.size_240,
-                border: `1px solid ${correct ? semanticColor.core.border.success.strong : semanticColor.core.border.critical.default}`,
-                width: sizing.size_560,
-                flexDirection: "row",
-            }}
-            onClick={onClick}
-        >
-            <>
+        <StatusBadge
+            kind={correct ? "success" : "critical"}
+            icon={
                 <PhosphorIcon
                     size="small"
                     icon={correct ? checkIcon : minusCircleIcon}
-                    style={{marginInlineEnd: sizing.size_060}}
-                    color={
-                        correct
-                            ? semanticColor.core.foreground.knockout.default
-                            : semanticColor.core.foreground.critical.default
-                    }
                 />
-                {String.fromCharCode(65 + index)}
-            </>
-        </Pill>
+            }
+            label={String.fromCharCode(65 + index)}
+            styles={{
+                // Round for single select, square for multiple select.
+                root: [
+                    boxStyle,
+                    multipleSelect ? squareStyle : roundStyle,
+                    correct && correctStrongStyle,
+                ],
+                label: correct ? knockoutForegroundStyle : undefined,
+                icon: correct ? knockoutForegroundStyle : undefined,
+            }}
+        />
     );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@khanacademy/wonder-blocks-announcer':
       specifier: 1.1.1
       version: 1.1.1
+    '@khanacademy/wonder-blocks-badge':
+      specifier: 1.1.15
+      version: 1.1.15
     '@khanacademy/wonder-blocks-banner':
       specifier: 5.1.3
       version: 5.1.3
@@ -798,6 +801,9 @@ importers:
       '@khanacademy/wonder-blocks-accordion':
         specifier: catalog:devDeps
         version: 3.1.62(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-badge':
+        specifier: catalog:devDeps
+        version: 1.1.15(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-banner':
         specifier: catalog:devDeps
         version: 5.1.3(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -2385,6 +2391,13 @@ packages:
       aphrodite: ^1.2.5
       react: 18.2.0
 
+  '@khanacademy/wonder-blocks-badge@1.1.15':
+    resolution: {integrity: sha512-oN3lZ1HniE5JYpRbOZ7KKKjPWtJStU847QqYrw+cX7iS5V0bcHujJ21g/9xTrNQwCjFIZ08mcr5/IhF9MPKvkw==}
+    peerDependencies:
+      '@phosphor-icons/core': ^2.0.2
+      aphrodite: ^1.2.5
+      react: 18.2.0
+
   '@khanacademy/wonder-blocks-banner@5.1.3':
     resolution: {integrity: sha512-2dTtUPeCnUKACQvErBjsRRHvR8FfFz84g9yd2qlpRXtCjzqon6KdhTPLSjtQhHnGugjiMq1XAUmXvy++g38ReA==}
     peerDependencies:
@@ -2476,6 +2489,13 @@ packages:
       aphrodite: ^1.2.5
       react: 18.2.0
 
+  '@khanacademy/wonder-blocks-icon@5.3.17':
+    resolution: {integrity: sha512-HUArSUS/f189u26DaQ6VPiMFvzHMRHXUe+dzBT4Jug9+kdnmwjVJr8MxPZV+13loFdCT2UTlT/jtzJ8wSOkErw==}
+    peerDependencies:
+      '@phosphor-icons/core': ^2.0.2
+      aphrodite: ^1.2.5
+      react: 18.2.0
+
   '@khanacademy/wonder-blocks-labeled-field@4.1.2':
     resolution: {integrity: sha512-qfWUz7p27pocNNPbwzz0/lDgpOgteTKYs9PtixCATeLEfVniALGvP2my7rBP8g1GZ0vIddzcPztoiPSIjn/kaA==}
     peerDependencies:
@@ -2539,6 +2559,9 @@ packages:
   '@khanacademy/wonder-blocks-styles@0.2.46':
     resolution: {integrity: sha512-9osaWx2Nvi7/Xy65VyfkSH+8qGKLw7Ng2xa5JE2Mpd6SKAr7OPwnrPeft0pbKX9uJzHaGBcMI/1htb7j36OC0g==}
 
+  '@khanacademy/wonder-blocks-styles@0.2.47':
+    resolution: {integrity: sha512-ZNi2BOPfsvGO69G2J94UfbbsyaxQw86AwE8tNIAdfowYs7t/AQFslNoOO7OPqFb3TapU0vD7exjuzhyqYZBXcQ==}
+
   '@khanacademy/wonder-blocks-switch@3.4.2':
     resolution: {integrity: sha512-1ReZj9Wfq3AsRNxQXeGFj2xpKeSy/7ZFpKEx+Jfez6/1npY9+c5W/0EYxeombXjSJsv8A5pL5qV5L5oBeagltw==}
     peerDependencies:
@@ -2567,6 +2590,10 @@ packages:
     resolution: {integrity: sha512-1NlZpfTDhxUdPqVrD+qfvNFPJdSyOXVTnXXMiJXRoJYXpqUoIMdqdq3NS8CsRgkeRPVAcY4trRf1pEKh1I94MA==}
     hasBin: true
 
+  '@khanacademy/wonder-blocks-tokens@16.7.0':
+    resolution: {integrity: sha512-RM9q/agsNrmv7jc63nYugA0dgcCVxprOe/wD+0iDDRO7En/fMiK2isXmTW/r+0KYAvQNo3TKdpTlSRf3jkBYfQ==}
+    hasBin: true
+
   '@khanacademy/wonder-blocks-tooltip@4.1.78':
     resolution: {integrity: sha512-QtBHquX5iRjZbwx4BCDZa8o0JV1KODJMAAhgO/dCHlSaKIUEwfFKX0oJDsZgvlRtz6bRc63Y/JWwrJZPo0GQIg==}
     peerDependencies:
@@ -2578,6 +2605,12 @@ packages:
 
   '@khanacademy/wonder-blocks-typography@4.3.6':
     resolution: {integrity: sha512-hMw1h40Ef6jcy+6cSZ8K0u73rXzvGcFl5puI6eF4iAIyqkteXlOz2IB+2vMgCMK5FDvo9Qq4jq45VupOo+Z2Kw==}
+    peerDependencies:
+      aphrodite: ^1.2.5
+      react: 18.2.0
+
+  '@khanacademy/wonder-blocks-typography@4.3.7':
+    resolution: {integrity: sha512-lHLso2XBQGn6J8RlzICHKrDyHCot7v3KnBwX8amg+XQ1DWbomO7InYlsuh5EGXLEOHkzv1vHevxSHig/FsaJGA==}
     peerDependencies:
       aphrodite: ^1.2.5
       react: 18.2.0
@@ -11437,6 +11470,22 @@ snapshots:
       - react-router-dom
       - react-router-dom-v5-compat
 
+  '@khanacademy/wonder-blocks-badge@1.1.15(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@khanacademy/wonder-blocks-core': 12.4.4(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-icon': 5.3.17(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-styles': 0.2.47(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-tokens': 16.7.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-typography': 4.3.7(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@phosphor-icons/core': 2.0.2
+      aphrodite: 1.2.5
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-router
+      - react-router-dom
+      - react-router-dom-v5-compat
+
   '@khanacademy/wonder-blocks-banner@5.1.3(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@khanacademy/wonder-blocks-button': 11.7.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -11634,6 +11683,19 @@ snapshots:
       - react-router-dom
       - react-router-dom-v5-compat
 
+  '@khanacademy/wonder-blocks-icon@5.3.17(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@khanacademy/wonder-blocks-core': 12.4.4(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-tokens': 16.7.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@phosphor-icons/core': 2.0.2
+      aphrodite: 1.2.5
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-router
+      - react-router-dom
+      - react-router-dom-v5-compat
+
   '@khanacademy/wonder-blocks-labeled-field@4.1.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@khanacademy/wonder-blocks-core': 12.4.4(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -11792,6 +11854,14 @@ snapshots:
       - react
       - react-dom
 
+  '@khanacademy/wonder-blocks-styles@0.2.47(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@khanacademy/wonder-blocks-tokens': 16.7.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+    transitivePeerDependencies:
+      - aphrodite
+      - react
+      - react-dom
+
   '@khanacademy/wonder-blocks-switch@3.4.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@khanacademy/wonder-blocks-core': 12.4.4(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -11847,6 +11917,14 @@ snapshots:
       - react
       - react-dom
 
+  '@khanacademy/wonder-blocks-tokens@16.7.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@khanacademy/wonder-blocks-theming': 4.1.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+    transitivePeerDependencies:
+      - aphrodite
+      - react
+      - react-dom
+
   '@khanacademy/wonder-blocks-tooltip@4.1.78(@phosphor-icons/core@2.0.2)(@popperjs/core@2.10.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.10.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@khanacademy/wonder-blocks-core': 12.4.4(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -11887,6 +11965,18 @@ snapshots:
     dependencies:
       '@khanacademy/wonder-blocks-core': 12.4.4(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 16.6.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      aphrodite: 1.2.5
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-router
+      - react-router-dom
+      - react-router-dom-v5-compat
+
+  '@khanacademy/wonder-blocks-typography@4.3.7(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@khanacademy/wonder-blocks-core': 12.4.4(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-tokens': 16.7.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       aphrodite: 1.2.5
       react: 18.2.0
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -65,6 +65,7 @@ catalogs:
         "@khanacademy/mathjax-renderer": ^3.0.0
         "@khanacademy/wonder-blocks-accordion": ^3.1.62
         "@khanacademy/wonder-blocks-announcer": ^1.1.1
+        "@khanacademy/wonder-blocks-badge": ^1.1.15
         "@khanacademy/wonder-blocks-banner": ^5.1.3
         "@khanacademy/wonder-blocks-button": ^11.7.0
         "@khanacademy/wonder-blocks-clickable": ^8.2.2
@@ -106,6 +107,7 @@ catalogs:
         "@khanacademy/mathjax-renderer": 3.0.0
         "@khanacademy/wonder-blocks-accordion": 3.1.62
         "@khanacademy/wonder-blocks-announcer": 1.1.1
+        "@khanacademy/wonder-blocks-badge": 1.1.15
         "@khanacademy/wonder-blocks-banner": 5.1.3
         "@khanacademy/wonder-blocks-button": 11.7.0
         "@khanacademy/wonder-blocks-clickable": 8.2.2


### PR DESCRIPTION
## Summary:
This PR change the usage of the deprecated WB `Pill` component to recommended WB `Badge` component.
- Added package for WB Badge v1.1.15 in Perseus
- Created components that will retain the same look of the Pill used in Radio Widget Editor and Interactive Graph Editor (screen reader tree)

Issue: LEMS-4131

## Test plan:
1. Confirm the Radio Widget Editor still works as expected
2. Confirm the radio status for correct and incorrect now uses the Badge and not the Pill component
3. Confirm the Interactive Graph Editor still works as expected
4. Confirm that the Interactive Graph Editor screen reader tree now uses Badge and not the Pill component

## Related PRs / Follow-up work related to `editingDisabled`
| PR | Scope | Branch | Status | Notes |
|----|-------|--------|--------|-------|
| **[PR 1](https://github.com/Khan/perseus/pull/3777)** | Phase 1 (labels) + Phase 2B (modernization of touched non-locked-figures editors) | `LEMS-4131/improve-editor-labels` | ✅ |  |
| **[PR 2](https://github.com/Khan/perseus/pull/3779)** | Phase 2A (locked-figures refactor) | `LEMS-4131/editor-locked-figures-code-refactor` | ✅ | The heaviest CSS-module migration; independent of PR 1. |
| **PR 3** | Phase 3 (numeric-input label restructuring) | — | ⚪ not started, will skip | Standalone; after Phase 2B. |
| **[PR 4](https://github.com/Khan/perseus/pull/3782)** | Phase 4 (Pill → Badge / SegmentedControl) | `LEMS-4131/editor-pill-to-badge` | ✅  | Carries a UX behavior change (radio A/B/C) |
| **[PR 5](https://github.com/Khan/perseus/pull/3787)** | Phase 5 (`editingDisabled` functional fix — the actual deliverable) | `LEMS-4131/editor-add-editing-disabled` | In Review | Depends on PR 4; starts with the `button-group` `disabled` enabler. |