### PR TITLE
Make `WidgetLogic.version` the source of truth for widget versions

### DIFF
--- a/.changeset/friendly-gorillas-serve.md
+++ b/.changeset/friendly-gorillas-serve.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Internal: `WidgetLogic.version` is now the source of truth for widget versions.

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/measurer-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/measurer-widget.ts
@@ -41,9 +41,6 @@ const parseMeasurerWidgetV1 = parseWidgetWithVersion(
 const parseMeasurerWidgetV0 = parseWidget(
     constant("measurer"),
     object({
-        // The default value for image comes from measurer.tsx.
-        // See parse-perseus-json/README.md for why we want to duplicate the
-        // defaults here.
         imageTop: number,
         imageLeft: number,
         imageUrl: optional(nullable(string)),

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/measurer-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/measurer-widget.ts
@@ -1,17 +1,20 @@
 import {
     boolean,
-    constant, nullable,
+    constant,
+    nullable,
     number,
-    object, optional,
+    object,
+    optional,
     pair,
     string,
 } from "../general-purpose-parsers";
 import {defaulted} from "../general-purpose-parsers/defaulted";
-import type {ParsedValue} from "../parser-types";
 
 import {parsePerseusImageBackground} from "./perseus-image-background";
-import {parseWidget, parseWidgetWithVersion} from "./widget";
 import {versionedWidgetOptions} from "./versioned-widget-options";
+import {parseWidget, parseWidgetWithVersion} from "./widget";
+
+import type {ParsedValue} from "../parser-types";
 
 const parseMeasurerWidgetV1 = parseWidgetWithVersion(
     object({major: constant(1), minor: number}),
@@ -52,9 +55,11 @@ const parseMeasurerWidgetV0 = parseWidget(
         rulerLength: number,
         box: pair(number, number),
     }),
-)
+);
 
-function migrateV0ToV1(v0: ParsedValue<typeof parseMeasurerWidgetV0>): ParsedValue<typeof parseMeasurerWidgetV1> {
+function migrateV0ToV1(
+    v0: ParsedValue<typeof parseMeasurerWidgetV0>,
+): ParsedValue<typeof parseMeasurerWidgetV1> {
     const {imageTop, imageLeft, imageUrl, ...v1Options} = v0.options;
     return {
         ...v0,
@@ -66,8 +71,11 @@ function migrateV0ToV1(v0: ParsedValue<typeof parseMeasurerWidgetV0>): ParsedVal
                 url: imageUrl,
             },
             ...v1Options,
-        }
+        },
     };
 }
 
-export const parseMeasurerWidget = versionedWidgetOptions(1, parseMeasurerWidgetV1).withMigrationFrom(0, parseMeasurerWidgetV0, migrateV0ToV1).parser;
+export const parseMeasurerWidget = versionedWidgetOptions(
+    1,
+    parseMeasurerWidgetV1,
+).withMigrationFrom(0, parseMeasurerWidgetV0, migrateV0ToV1).parser;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/measurer-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/measurer-widget.ts
@@ -1,17 +1,20 @@
 import {
     boolean,
-    constant,
+    constant, nullable,
     number,
-    object,
+    object, optional,
     pair,
     string,
 } from "../general-purpose-parsers";
 import {defaulted} from "../general-purpose-parsers/defaulted";
+import type {ParsedValue} from "../parser-types";
 
 import {parsePerseusImageBackground} from "./perseus-image-background";
-import {parseWidget} from "./widget";
+import {parseWidget, parseWidgetWithVersion} from "./widget";
+import {versionedWidgetOptions} from "./versioned-widget-options";
 
-export const parseMeasurerWidget = parseWidget(
+const parseMeasurerWidgetV1 = parseWidgetWithVersion(
+    object({major: constant(1), minor: number}),
     constant("measurer"),
     object({
         // The default value for image comes from measurer.tsx.
@@ -31,3 +34,40 @@ export const parseMeasurerWidget = parseWidget(
         box: pair(number, number),
     }),
 );
+
+const parseMeasurerWidgetV0 = parseWidget(
+    constant("measurer"),
+    object({
+        // The default value for image comes from measurer.tsx.
+        // See parse-perseus-json/README.md for why we want to duplicate the
+        // defaults here.
+        imageTop: number,
+        imageLeft: number,
+        imageUrl: optional(nullable(string)),
+        showProtractor: boolean,
+        showRuler: boolean,
+        rulerLabel: string,
+        rulerTicks: number,
+        rulerPixels: number,
+        rulerLength: number,
+        box: pair(number, number),
+    }),
+)
+
+function migrateV0ToV1(v0: ParsedValue<typeof parseMeasurerWidgetV0>): ParsedValue<typeof parseMeasurerWidgetV1> {
+    const {imageTop, imageLeft, imageUrl, ...v1Options} = v0.options;
+    return {
+        ...v0,
+        version: {major: 1, minor: 0},
+        options: {
+            image: {
+                top: imageTop,
+                left: imageLeft,
+                url: imageUrl,
+            },
+            ...v1Options,
+        }
+    };
+}
+
+export const parseMeasurerWidget = versionedWidgetOptions(1, parseMeasurerWidgetV1).withMigrationFrom(0, parseMeasurerWidgetV0, migrateV0ToV1).parser;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -501,7 +501,7 @@ describe("parseWidgetsMap", () => {
         const widgetsMap: unknown = {
             "measurer 1": {
                 type: "measurer",
-                version: {major: 0, minor: 0},
+                version: {major: 1, minor: 0},
                 options: {
                     image: {},
                     showProtractor: false,

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -13007,7 +13007,7 @@ exports[`parseAndMigratePerseusItem given measurer-missing-image.ts returns the 
           "image": {
             "left": 0,
             "top": 0,
-            "url": null,
+            "url": "crwdns6514084:0crwdne6514084:0",
           },
           "rulerLabel": "",
           "rulerLength": 10,
@@ -13017,6 +13017,10 @@ exports[`parseAndMigratePerseusItem given measurer-missing-image.ts returns the 
           "showRuler": false,
         },
         "type": "measurer",
+        "version": {
+          "major": 1,
+          "minor": 0,
+        },
       },
     },
   },
@@ -13114,7 +13118,7 @@ exports[`parseAndMigratePerseusItem given measurer-missing-image.ts returns the 
           "image": {
             "left": 0,
             "top": 0,
-            "url": null,
+            "url": "crwdns6514084:0crwdne6514084:0",
           },
           "rulerLabel": "",
           "rulerLength": 10,
@@ -13210,6 +13214,231 @@ exports[`parseAndMigratePerseusItem given measurer-missing-static.ts returns the
           "rulerTicks": 10,
           "showProtractor": true,
           "showRuler": true,
+        },
+        "static": false,
+        "type": "measurer",
+        "version": {
+          "major": 1,
+          "minor": 0,
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`parseAndMigratePerseusItem given measurer-missing-version.ts returns the same result as before 1`] = `
+{
+  "answerArea": {
+    "calculator": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTimeToPayOff": false,
+    "financialCalculatorTotalAmount": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+  },
+  "hints": [
+    {
+      "content": "We should be able to approach the base of the mountain. Measure it angle of the base using the protractor.",
+      "images": {},
+      "widgets": {},
+    },
+    {
+      "content": "In the training course built for the earthbound version of Curiosity, they had a number obstacles and hills set out. For example, the **smallest** of these hills had an incline of 5 degrees.",
+      "images": {},
+      "widgets": {},
+    },
+    {
+      "content": "Curiosity is expected to have the ability to ascend inclines as large as 20 degrees.",
+      "images": {},
+      "widgets": {},
+    },
+  ],
+  "question": {
+    "content": "Curiosity's landing site is Gale Crater; a location notable for having a large mountain of layered rock in the center known as Aeolis Mons (*Mount Sharp*). This prevents Curiosity from traveling **directly across** due to the steep incline towards the top. Instead, it was designed to drive up and along the shallower base.
+
+**How steep of an incline was Curiosity designed for?**
+
+*Click and drag the protractor to help you!*
+[[☃ measurer 1]]
+
+[[☃ dropdown 1]]",
+    "images": {},
+    "widgets": {
+      "dropdown 1": {
+        "graded": true,
+        "options": {
+          "choices": [
+            {
+              "content": "5",
+              "correct": false,
+            },
+            {
+              "content": "10",
+              "correct": false,
+            },
+            {
+              "content": "20",
+              "correct": true,
+            },
+            {
+              "content": "30",
+              "correct": false,
+            },
+            {
+              "content": "45",
+              "correct": false,
+            },
+            {
+              "content": "60",
+              "correct": false,
+            },
+            {
+              "content": "90",
+              "correct": false,
+            },
+          ],
+          "placeholder": "",
+          "static": false,
+        },
+        "type": "dropdown",
+      },
+      "measurer 1": {
+        "graded": true,
+        "options": {
+          "box": [
+            480,
+            480,
+          ],
+          "image": {
+            "left": 0,
+            "top": 0,
+            "url": "https://ka-perseus-images.s3.amazonaws.com/32d7ebe969c7ce5b241873ac172d50992ca79de3.jpeg",
+          },
+          "rulerLabel": "",
+          "rulerLength": 10,
+          "rulerPixels": 40,
+          "rulerTicks": 10,
+          "showProtractor": true,
+          "showRuler": false,
+        },
+        "type": "measurer",
+        "version": {
+          "major": 1,
+          "minor": 0,
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`parseAndMigratePerseusItem given measurer-missing-version.ts returns the same result as before with answer information removed 1`] = `
+{
+  "answerArea": {
+    "calculator": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTimeToPayOff": false,
+    "financialCalculatorTotalAmount": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+  },
+  "hints": [
+    {
+      "content": "",
+      "images": {},
+      "placeholder": true,
+      "widgets": {},
+    },
+    {
+      "content": "",
+      "images": {},
+      "placeholder": true,
+      "widgets": {},
+    },
+    {
+      "content": "",
+      "images": {},
+      "placeholder": true,
+      "widgets": {},
+    },
+  ],
+  "question": {
+    "content": "Curiosity's landing site is Gale Crater; a location notable for having a large mountain of layered rock in the center known as Aeolis Mons (*Mount Sharp*). This prevents Curiosity from traveling **directly across** due to the steep incline towards the top. Instead, it was designed to drive up and along the shallower base.
+
+**How steep of an incline was Curiosity designed for?**
+
+*Click and drag the protractor to help you!*
+[[☃ measurer 1]]
+
+[[☃ dropdown 1]]",
+    "images": {},
+    "widgets": {
+      "dropdown 1": {
+        "alignment": "default",
+        "graded": true,
+        "options": {
+          "ariaLabel": undefined,
+          "choices": [
+            {
+              "content": "5",
+              "correct": false,
+            },
+            {
+              "content": "10",
+              "correct": false,
+            },
+            {
+              "content": "20",
+              "correct": false,
+            },
+            {
+              "content": "30",
+              "correct": false,
+            },
+            {
+              "content": "45",
+              "correct": false,
+            },
+            {
+              "content": "60",
+              "correct": false,
+            },
+            {
+              "content": "90",
+              "correct": false,
+            },
+          ],
+          "placeholder": "",
+          "static": false,
+          "visibleLabel": undefined,
+        },
+        "static": false,
+        "type": "dropdown",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+      "measurer 1": {
+        "alignment": "default",
+        "graded": true,
+        "options": {
+          "box": [
+            480,
+            480,
+          ],
+          "image": {
+            "left": 0,
+            "top": 0,
+            "url": "https://ka-perseus-images.s3.amazonaws.com/32d7ebe969c7ce5b241873ac172d50992ca79de3.jpeg",
+          },
+          "rulerLabel": "",
+          "rulerLength": 10,
+          "rulerPixels": 40,
+          "rulerTicks": 10,
+          "showProtractor": true,
+          "showRuler": false,
         },
         "static": false,
         "type": "measurer",

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/measurer-missing-version.ts
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/measurer-missing-version.ts
@@ -1,0 +1,92 @@
+// WARNING: Do not change or delete this file! If you do, Perseus might become
+// unable to parse the current data format, which will break clients.
+// If you need to add more regression tests, add a new file to this directory.
+export default {
+    "answerArea": {
+        "calculator": false,
+        "options": {
+            "content": "",
+            "images": {},
+            "widgets": {}
+        },
+        "type": "multiple"
+    },
+    "hints": [
+        {
+            "content": "We should be able to approach the base of the mountain. Measure it angle of the base using the protractor.",
+            "images": {},
+            "widgets": {}
+        },
+        {
+            "content": "In the training course built for the earthbound version of Curiosity, they had a number obstacles and hills set out. For example, the **smallest** of these hills had an incline of 5 degrees.",
+            "images": {},
+            "widgets": {}
+        },
+        {
+            "content": "Curiosity is expected to have the ability to ascend inclines as large as 20 degrees.",
+            "images": {},
+            "widgets": {}
+        }
+    ],
+    "question": {
+        "content": "Curiosity's landing site is Gale Crater; a location notable for having a large mountain of layered rock in the center known as Aeolis Mons (*Mount Sharp*). This prevents Curiosity from traveling **directly across** due to the steep incline towards the top. Instead, it was designed to drive up and along the shallower base.\n\n**How steep of an incline was Curiosity designed for?**\n\n*Click and drag the protractor to help you!*\n[[☃ measurer 1]]\n\n[[☃ dropdown 1]]",
+        "images": {},
+        "widgets": {
+            "dropdown 1": {
+                "graded": true,
+                "options": {
+                    "choices": [
+                        {
+                            "content": "5",
+                            "correct": false
+                        },
+                        {
+                            "content": "10",
+                            "correct": false
+                        },
+                        {
+                            "content": "20",
+                            "correct": true
+                        },
+                        {
+                            "content": "30",
+                            "correct": false
+                        },
+                        {
+                            "content": "45",
+                            "correct": false
+                        },
+                        {
+                            "content": "60",
+                            "correct": false
+                        },
+                        {
+                            "content": "90",
+                            "correct": false
+                        }
+                    ]
+                },
+                "type": "dropdown"
+            },
+            "measurer 1": {
+                "graded": true,
+                "options": {
+                    "box": [
+                        480,
+                        480
+                    ],
+                    "imageLeft": 0,
+                    "imageTop": 0,
+                    "imageUrl": "https://ka-perseus-images.s3.amazonaws.com/32d7ebe969c7ce5b241873ac172d50992ca79de3.jpeg",
+                    "rulerLabel": "",
+                    "rulerLength": 10,
+                    "rulerPixels": 40,
+                    "rulerTicks": 10,
+                    "showProtractor": true,
+                    "showRuler": false
+                },
+                "type": "measurer"
+            }
+        }
+    }
+}

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/measurer-missing-version.ts
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/measurer-missing-version.ts
@@ -2,91 +2,93 @@
 // unable to parse the current data format, which will break clients.
 // If you need to add more regression tests, add a new file to this directory.
 export default {
-    "answerArea": {
-        "calculator": false,
-        "options": {
-            "content": "",
-            "images": {},
-            "widgets": {}
+    answerArea: {
+        calculator: false,
+        options: {
+            content: "",
+            images: {},
+            widgets: {},
         },
-        "type": "multiple"
+        type: "multiple",
     },
-    "hints": [
+    hints: [
         {
-            "content": "We should be able to approach the base of the mountain. Measure it angle of the base using the protractor.",
-            "images": {},
-            "widgets": {}
+            content:
+                "We should be able to approach the base of the mountain. Measure it angle of the base using the protractor.",
+            images: {},
+            widgets: {},
         },
         {
-            "content": "In the training course built for the earthbound version of Curiosity, they had a number obstacles and hills set out. For example, the **smallest** of these hills had an incline of 5 degrees.",
-            "images": {},
-            "widgets": {}
+            content:
+                "In the training course built for the earthbound version of Curiosity, they had a number obstacles and hills set out. For example, the **smallest** of these hills had an incline of 5 degrees.",
+            images: {},
+            widgets: {},
         },
         {
-            "content": "Curiosity is expected to have the ability to ascend inclines as large as 20 degrees.",
-            "images": {},
-            "widgets": {}
-        }
+            content:
+                "Curiosity is expected to have the ability to ascend inclines as large as 20 degrees.",
+            images: {},
+            widgets: {},
+        },
     ],
-    "question": {
-        "content": "Curiosity's landing site is Gale Crater; a location notable for having a large mountain of layered rock in the center known as Aeolis Mons (*Mount Sharp*). This prevents Curiosity from traveling **directly across** due to the steep incline towards the top. Instead, it was designed to drive up and along the shallower base.\n\n**How steep of an incline was Curiosity designed for?**\n\n*Click and drag the protractor to help you!*\n[[☃ measurer 1]]\n\n[[☃ dropdown 1]]",
-        "images": {},
-        "widgets": {
+    question: {
+        content:
+            "Curiosity's landing site is Gale Crater; a location notable for having a large mountain of layered rock in the center known as Aeolis Mons (*Mount Sharp*). This prevents Curiosity from traveling **directly across** due to the steep incline towards the top. Instead, it was designed to drive up and along the shallower base.\n\n**How steep of an incline was Curiosity designed for?**\n\n*Click and drag the protractor to help you!*\n[[☃ measurer 1]]\n\n[[☃ dropdown 1]]",
+        images: {},
+        widgets: {
             "dropdown 1": {
-                "graded": true,
-                "options": {
-                    "choices": [
+                graded: true,
+                options: {
+                    choices: [
                         {
-                            "content": "5",
-                            "correct": false
+                            content: "5",
+                            correct: false,
                         },
                         {
-                            "content": "10",
-                            "correct": false
+                            content: "10",
+                            correct: false,
                         },
                         {
-                            "content": "20",
-                            "correct": true
+                            content: "20",
+                            correct: true,
                         },
                         {
-                            "content": "30",
-                            "correct": false
+                            content: "30",
+                            correct: false,
                         },
                         {
-                            "content": "45",
-                            "correct": false
+                            content: "45",
+                            correct: false,
                         },
                         {
-                            "content": "60",
-                            "correct": false
+                            content: "60",
+                            correct: false,
                         },
                         {
-                            "content": "90",
-                            "correct": false
-                        }
-                    ]
+                            content: "90",
+                            correct: false,
+                        },
+                    ],
                 },
-                "type": "dropdown"
+                type: "dropdown",
             },
             "measurer 1": {
-                "graded": true,
-                "options": {
-                    "box": [
-                        480,
-                        480
-                    ],
-                    "imageLeft": 0,
-                    "imageTop": 0,
-                    "imageUrl": "https://ka-perseus-images.s3.amazonaws.com/32d7ebe969c7ce5b241873ac172d50992ca79de3.jpeg",
-                    "rulerLabel": "",
-                    "rulerLength": 10,
-                    "rulerPixels": 40,
-                    "rulerTicks": 10,
-                    "showProtractor": true,
-                    "showRuler": false
+                graded: true,
+                options: {
+                    box: [480, 480],
+                    imageLeft: 0,
+                    imageTop: 0,
+                    imageUrl:
+                        "https://ka-perseus-images.s3.amazonaws.com/32d7ebe969c7ce5b241873ac172d50992ca79de3.jpeg",
+                    rulerLabel: "",
+                    rulerLength: 10,
+                    rulerPixels: 40,
+                    rulerTicks: 10,
+                    showProtractor: true,
+                    showRuler: false,
                 },
-                "type": "measurer"
-            }
-        }
-    }
-}
+                type: "measurer",
+            },
+        },
+    },
+};

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/parse-perseus-json-regression.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/parse-perseus-json-regression.test.ts
@@ -1,8 +1,13 @@
 import * as fs from "fs";
 import {join} from "path";
 
+import _ from "underscore";
+
 import splitPerseusItem from "../../utils/split-perseus-item";
-import {getCurrentVersion, registerCoreWidgets} from "../../widgets/core-widget-registry";
+import {
+    getCurrentVersion,
+    registerCoreWidgets,
+} from "../../widgets/core-widget-registry";
 import {anySuccess} from "../general-purpose-parsers/test-helpers";
 import {
     parseAndMigratePerseusArticle,
@@ -16,9 +21,16 @@ import {parsePerseusItem} from "../perseus-parsers/perseus-item";
 import {parsePerseusRenderer} from "../perseus-parsers/perseus-renderer";
 import {parseUserInputMap} from "../perseus-parsers/user-input-map";
 import {assertSuccess, mapFailure} from "../result";
-import type {ExplanationWidget, GradedGroupSetWidget, GradedGroupWidget, PerseusItem, PerseusRenderer, PerseusWidget} from "../../data-schema";
-import {PerseusGradedGroupWidgetOptions} from "../../data-schema";
-import _ from "underscore";
+
+import type {
+    PerseusGradedGroupWidgetOptions,
+    ExplanationWidget,
+    GradedGroupSetWidget,
+    GradedGroupWidget,
+    PerseusItem,
+    PerseusRenderer,
+    PerseusWidget,
+} from "../../data-schema";
 
 const itemDataDir = join(__dirname, "item-data");
 const itemDataFiles = fs.readdirSync(itemDataDir);
@@ -152,7 +164,9 @@ describe("parseAndMigratePerseusItem", () => {
                     }
                 }
                 if (!_.isEqual(expectedVersion, widget.version)) {
-                    throw Error(`Expected ${widget.type} widget to have version ${JSON.stringify(expectedVersion)}, but got ${widget.version}`);
+                    throw Error(
+                        `Expected ${widget.type} widget to have version ${JSON.stringify(expectedVersion)}, but got ${widget.version}`,
+                    );
                 }
             }
         });
@@ -347,21 +361,29 @@ function getWidgetsFromRenderer(renderer: PerseusRenderer): PerseusWidget[] {
     const topLevelWidgets = Object.values(renderer.widgets);
     return [
         ...topLevelWidgets,
-        ...topLevelWidgets.filter(isExplanation).flatMap(getWidgetsFromExplanation),
-        ...topLevelWidgets.filter(isGradedGroup).flatMap(getWidgetsFromGradedGroup),
-        ...topLevelWidgets.filter(isGradedGroupSet).flatMap(getWidgetsFromGradedGroupSet),
+        ...topLevelWidgets
+            .filter(isExplanation)
+            .flatMap(getWidgetsFromExplanation),
+        ...topLevelWidgets
+            .filter(isGradedGroup)
+            .flatMap(getWidgetsFromGradedGroup),
+        ...topLevelWidgets
+            .filter(isGradedGroupSet)
+            .flatMap(getWidgetsFromGradedGroupSet),
     ];
 }
 
 function isExplanation(widget: PerseusWidget): widget is ExplanationWidget {
-    return widget.type === "explanation"
+    return widget.type === "explanation";
 }
 
 function isGradedGroup(widget: PerseusWidget): widget is GradedGroupWidget {
     return widget.type === "graded-group";
 }
 
-function isGradedGroupSet(widget: PerseusWidget): widget is GradedGroupSetWidget {
+function isGradedGroupSet(
+    widget: PerseusWidget,
+): widget is GradedGroupSetWidget {
     return widget.type === "graded-group-set";
 }
 
@@ -373,10 +395,16 @@ function getWidgetsFromGradedGroup(widget: GradedGroupWidget): PerseusWidget[] {
     return getWidgetsFromGradedGroupOptions(widget.options);
 }
 
-function getWidgetsFromGradedGroupOptions(options: PerseusGradedGroupWidgetOptions): PerseusWidget[] {
+function getWidgetsFromGradedGroupOptions(
+    options: PerseusGradedGroupWidgetOptions,
+): PerseusWidget[] {
     return Object.values(options.widgets);
 }
 
-function getWidgetsFromGradedGroupSet(widget: GradedGroupSetWidget): PerseusWidget[] {
-    return widget.options.gradedGroups.flatMap(getWidgetsFromGradedGroupOptions);
+function getWidgetsFromGradedGroupSet(
+    widget: GradedGroupSetWidget,
+): PerseusWidget[] {
+    return widget.options.gradedGroups.flatMap(
+        getWidgetsFromGradedGroupOptions,
+    );
 }

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/parse-perseus-json-regression.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/parse-perseus-json-regression.test.ts
@@ -30,6 +30,9 @@ import type {
     PerseusItem,
     PerseusRenderer,
     PerseusWidget,
+    GroupWidget,
+    OrdererWidget,
+    PerseusWidgetsMap,
 } from "../../data-schema";
 
 const itemDataDir = join(__dirname, "item-data");
@@ -358,7 +361,13 @@ function getWidgetsFromItem(item: PerseusItem): PerseusWidget[] {
 }
 
 function getWidgetsFromRenderer(renderer: PerseusRenderer): PerseusWidget[] {
-    const topLevelWidgets = Object.values(renderer.widgets);
+    return getWidgetsFromPerseusWidgetsMap(renderer.widgets);
+}
+
+function getWidgetsFromPerseusWidgetsMap(
+    widgets: PerseusWidgetsMap,
+): PerseusWidget[] {
+    const topLevelWidgets = Object.values(widgets);
     return [
         ...topLevelWidgets,
         ...topLevelWidgets
@@ -370,6 +379,8 @@ function getWidgetsFromRenderer(renderer: PerseusRenderer): PerseusWidget[] {
         ...topLevelWidgets
             .filter(isGradedGroupSet)
             .flatMap(getWidgetsFromGradedGroupSet),
+        ...topLevelWidgets.filter(isGroup).flatMap(getWidgetsFromGroup),
+        ...topLevelWidgets.filter(isOrderer).flatMap(getWidgetsFromOrderer),
     ];
 }
 
@@ -387,18 +398,31 @@ function isGradedGroupSet(
     return widget.type === "graded-group-set";
 }
 
+function isGroup(widget: PerseusWidget): widget is GroupWidget {
+    return widget.type === "group";
+}
+
+function isOrderer(widget: PerseusWidget): widget is OrdererWidget {
+    return widget.type === "orderer";
+}
+
 function getWidgetsFromExplanation(widget: ExplanationWidget): PerseusWidget[] {
-    return Object.values(widget.options.widgets);
+    return getWidgetsFromPerseusWidgetsMap(widget.options.widgets);
 }
 
 function getWidgetsFromGradedGroup(widget: GradedGroupWidget): PerseusWidget[] {
-    return getWidgetsFromGradedGroupOptions(widget.options);
+    return [
+        ...getWidgetsFromGradedGroupOptions(widget.options),
+        ...(widget.options.hint
+            ? getWidgetsFromRenderer(widget.options.hint)
+            : []),
+    ];
 }
 
 function getWidgetsFromGradedGroupOptions(
     options: PerseusGradedGroupWidgetOptions,
 ): PerseusWidget[] {
-    return Object.values(options.widgets);
+    return getWidgetsFromPerseusWidgetsMap(options.widgets);
 }
 
 function getWidgetsFromGradedGroupSet(
@@ -407,4 +431,16 @@ function getWidgetsFromGradedGroupSet(
     return widget.options.gradedGroups.flatMap(
         getWidgetsFromGradedGroupOptions,
     );
+}
+
+function getWidgetsFromGroup(widget: GroupWidget): PerseusWidget[] {
+    return getWidgetsFromRenderer(widget.options);
+}
+
+function getWidgetsFromOrderer(widget: OrdererWidget): PerseusWidget[] {
+    return [
+        ...widget.options.correctOptions.flatMap(getWidgetsFromRenderer),
+        ...widget.options.options.flatMap(getWidgetsFromRenderer),
+        ...widget.options.otherOptions.flatMap(getWidgetsFromRenderer),
+    ];
 }

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/parse-perseus-json-regression.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/parse-perseus-json-regression.test.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import {join} from "path";
 
 import splitPerseusItem from "../../utils/split-perseus-item";
-import {registerCoreWidgets} from "../../widgets/core-widget-registry";
+import {getCurrentVersion, registerCoreWidgets} from "../../widgets/core-widget-registry";
 import {anySuccess} from "../general-purpose-parsers/test-helpers";
 import {
     parseAndMigratePerseusArticle,
@@ -16,6 +16,9 @@ import {parsePerseusItem} from "../perseus-parsers/perseus-item";
 import {parsePerseusRenderer} from "../perseus-parsers/perseus-renderer";
 import {parseUserInputMap} from "../perseus-parsers/user-input-map";
 import {assertSuccess, mapFailure} from "../result";
+import type {ExplanationWidget, GradedGroupSetWidget, GradedGroupWidget, PerseusItem, PerseusRenderer, PerseusWidget} from "../../data-schema";
+import {PerseusGradedGroupWidgetOptions} from "../../data-schema";
+import _ from "underscore";
 
 const itemDataDir = join(__dirname, "item-data");
 const itemDataFiles = fs.readdirSync(itemDataDir);
@@ -132,6 +135,26 @@ describe("parseAndMigratePerseusItem", () => {
             expect(answerlessParseResult2.value).toEqual(
                 answerlessParseResult1.value,
             );
+        });
+
+        it("stamps each widget with the current version number", async () => {
+            const result = await getParseResult();
+            assertSuccess(result);
+
+            const widgets = getWidgetsFromItem(result.value);
+
+            for (const widget of widgets) {
+                const expectedVersion = getCurrentVersion(widget.type);
+                if (_.isEqual(expectedVersion, {major: 0, minor: 0})) {
+                    // An undefined version is equivalent to 0.0.
+                    if (widget.version === undefined) {
+                        continue;
+                    }
+                }
+                if (!_.isEqual(expectedVersion, widget.version)) {
+                    throw Error(`Expected ${widget.type} widget to have version ${JSON.stringify(expectedVersion)}, but got ${widget.version}`);
+                }
+            }
         });
     });
 });
@@ -311,4 +334,49 @@ describe("the regression test data", () => {
 
 function getMessage(obj: {message: string}): string {
     return obj.message;
+}
+
+function getWidgetsFromItem(item: PerseusItem): PerseusWidget[] {
+    return [
+        ...getWidgetsFromRenderer(item.question),
+        ...item.hints.flatMap(getWidgetsFromRenderer),
+    ];
+}
+
+function getWidgetsFromRenderer(renderer: PerseusRenderer): PerseusWidget[] {
+    const topLevelWidgets = Object.values(renderer.widgets);
+    return [
+        ...topLevelWidgets,
+        ...topLevelWidgets.filter(isExplanation).flatMap(getWidgetsFromExplanation),
+        ...topLevelWidgets.filter(isGradedGroup).flatMap(getWidgetsFromGradedGroup),
+        ...topLevelWidgets.filter(isGradedGroupSet).flatMap(getWidgetsFromGradedGroupSet),
+    ];
+}
+
+function isExplanation(widget: PerseusWidget): widget is ExplanationWidget {
+    return widget.type === "explanation"
+}
+
+function isGradedGroup(widget: PerseusWidget): widget is GradedGroupWidget {
+    return widget.type === "graded-group";
+}
+
+function isGradedGroupSet(widget: PerseusWidget): widget is GradedGroupSetWidget {
+    return widget.type === "graded-group-set";
+}
+
+function getWidgetsFromExplanation(widget: ExplanationWidget): PerseusWidget[] {
+    return Object.values(widget.options.widgets);
+}
+
+function getWidgetsFromGradedGroup(widget: GradedGroupWidget): PerseusWidget[] {
+    return getWidgetsFromGradedGroupOptions(widget.options);
+}
+
+function getWidgetsFromGradedGroupOptions(options: PerseusGradedGroupWidgetOptions): PerseusWidget[] {
+    return Object.values(options.widgets);
+}
+
+function getWidgetsFromGradedGroupSet(widget: GradedGroupSetWidget): PerseusWidget[] {
+    return widget.options.gradedGroups.flatMap(getWidgetsFromGradedGroupOptions);
 }

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/parse-perseus-json-regression.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/parse-perseus-json-regression.test.ts
@@ -165,7 +165,7 @@ describe("parseAndMigratePerseusItem", () => {
                 }
                 if (!_.isEqual(expectedVersion, widget.version)) {
                     throw Error(
-                        `Expected ${widget.type} widget to have version ${JSON.stringify(expectedVersion)}, but got ${widget.version}`,
+                        `Expected ${widget.type} widget to have version ${JSON.stringify(expectedVersion)}, but got ${JSON.stringify(widget.version)}`,
                     );
                 }
             }

--- a/packages/perseus-core/src/widgets/logic-export.types.ts
+++ b/packages/perseus-core/src/widgets/logic-export.types.ts
@@ -59,6 +59,14 @@ export type WidgetLogic<
     TPublicWidgetOptions = never,
 > = {
     name: string;
+    /**
+     * The widget version. Any time the _major_ version changes, the widget
+     * should provide a new entry in the widget parser to migrate from the
+     * older version to the current (new) version. Minor version changes must
+     * be backwards compatible with previous minor versions widget options.
+     *
+     * This key defaults to `{major: 0, minor: 0}` if not provided.
+     */
     version?: Version;
     defaultWidgetOptions?: any;
     supportedAlignments?: ReadonlyArray<Alignment>;

--- a/packages/perseus-core/src/widgets/logic-export.types.ts
+++ b/packages/perseus-core/src/widgets/logic-export.types.ts
@@ -62,8 +62,9 @@ export type WidgetLogic<
     /**
      * The widget version. Any time the _major_ version changes, the widget
      * should provide a new entry in the widget parser to migrate from the
-     * older version to the current (new) version. Minor version changes must
-     * be backwards compatible with previous minor versions widget options.
+     * older version to the current (new) version.
+     *
+     * The minor version is not used.
      *
      * This key defaults to `{major: 0, minor: 0}` if not provided.
      */

--- a/packages/perseus-core/src/widgets/measurer/index.ts
+++ b/packages/perseus-core/src/widgets/measurer/index.ts
@@ -1,8 +1,6 @@
 import type {PerseusMeasurerWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-const currentVersion = {major: 1, minor: 0};
-
 export type MeasurerDefaultWidgetOptions = Pick<
     PerseusMeasurerWidgetOptions,
     | "box"
@@ -29,7 +27,7 @@ const defaultWidgetOptions: MeasurerDefaultWidgetOptions = {
 
 const measurerWidgetLogic: WidgetLogic = {
     name: "measurer",
-    version: currentVersion,
+    version: {major: 1, minor: 0},
     defaultWidgetOptions: defaultWidgetOptions,
     accessible: false,
 };

--- a/packages/perseus-editor/src/__tests__/hint-editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/hint-editor.test.tsx
@@ -3,10 +3,15 @@ import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
 import CombinedHintsEditor from "../hint-editor";
+import {registerAllWidgetsAndEditorsForTesting} from "../util/register-all-widgets-and-editors-for-testing";
 
 import type {UserEvent} from "@testing-library/user-event";
 
 describe("CombinedHintsEditor", () => {
+    beforeAll(() => {
+        registerAllWidgetsAndEditorsForTesting();
+    });
+
     let userEvent: UserEvent;
     beforeEach(() => {
         userEvent = userEventLib.setup({

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -684,7 +684,7 @@ class Editor extends React.Component<Props, State> {
             // Track widget version on creation, so that a widget editor
             // without a valid version prop can only possibly refer to a
             // pre-versioning creation time.
-            version: Widgets.getVersion(widgetType),
+            version: CoreWidgetRegistry.getCurrentVersion(widgetType),
         };
 
         // See componentDidUpdate() for how this flag is used

--- a/packages/perseus/src/__tests__/extract-perseus-data.test.ts
+++ b/packages/perseus/src/__tests__/extract-perseus-data.test.ts
@@ -19,6 +19,7 @@ import {
     isWrongAnswerSupported,
     shouldHaveIndividualAnswer,
 } from "../util/extract-perseus-data";
+import {registerAllWidgetsForTesting} from "../util/register-all-widgets-for-testing";
 import {generateTestCategorizerWidget} from "../util/test-utils";
 
 const stub: jest.MockedFunction<any> = jest.fn();
@@ -28,6 +29,10 @@ beforeEach(() => {
 });
 
 describe("ExtractPerseusData", () => {
+    beforeAll(() => {
+        registerAllWidgetsForTesting();
+    });
+
     describe("isWrongAnswerSupported", () => {
         it("returns true if all the widgets are wrong answers supported widgets", () => {
             expect(

--- a/packages/perseus/src/__tests__/widgets-pre-registration.test.ts
+++ b/packages/perseus/src/__tests__/widgets-pre-registration.test.ts
@@ -9,7 +9,6 @@ describe("widgets pre-registration", () => {
         test.each([
             "getWidget",
             "getWidgetExport",
-            "getVersion",
             "supportsStaticMode",
             "getTracking",
             "isLintable",

--- a/packages/perseus/src/__tests__/widgets.test.ts
+++ b/packages/perseus/src/__tests__/widgets.test.ts
@@ -6,43 +6,6 @@ describe("Widget API support", () => {
         registerAllWidgetsForTesting();
     });
 
-    describe("getVersionVector", () => {
-        it("creates a map of all widget versions", () => {
-            expect(Widgets.getVersionVector()).toEqual(
-                // skipping the 0.0 widgets for brevity
-                expect.objectContaining({
-                    expression: {
-                        major: 2,
-                        minor: 0,
-                    },
-                    measurer: {
-                        major: 1,
-                        minor: 0,
-                    },
-                    radio: {
-                        major: 3,
-                        minor: 0,
-                    },
-                    transformer: {
-                        major: 0,
-                        minor: 0,
-                    },
-                }),
-            );
-        });
-
-        it("defaults to 0.0 for widgets without a version", () => {
-            expect(Widgets.getVersionVector()).toEqual(
-                expect.objectContaining({
-                    "numeric-input": {
-                        major: 0,
-                        minor: 0,
-                    },
-                }),
-            );
-        });
-    });
-
     describe("replaceWidget", () => {
         it("replaces an existing widget", () => {
             Widgets.replaceWidget("transformer", "radio");

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -12,8 +12,6 @@ export {ClassNames} from "./perseus-api";
 export {libVersion} from "./version";
 /** @hidden */
 export {apiVersion} from "./perseus-version";
-/** @hidden */
-export {default as itemVersion} from "./item-version";
 
 /**
  * Renderers

--- a/packages/perseus/src/item-version.ts
+++ b/packages/perseus/src/item-version.ts
@@ -1,8 +1,0 @@
-import allWidgets from "./all-widgets";
-import * as Widgets from "./widgets";
-
-Widgets.registerWidgets(allWidgets);
-
-const ItemVersion = Widgets.getVersionVector();
-
-export default ItemVersion;

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -16,7 +16,6 @@ import type {
     PerseusWidget,
     PerseusWidgetsMap,
     AnalyticsEventHandlerFn,
-    Version,
     LabelImageMarkerPublicData,
     PerseusLabelImageMarker,
     ShowSolutions,

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -425,15 +425,6 @@ export type WidgetExports<
 
     /** Supresses widget from showing up in the dropdown in the content editor */
     hidden?: boolean;
-    /**
-     * The widget version. Any time the _major_ version changes, the widget
-     * should provide a new entry in the widget parser to migrate from the
-     * older version to the current (new) version. Minor version changes must
-     * be backwards compatible with previous minor versions widget options.
-     *
-     * This key defaults to `{major: 0, minor: 0}` if not provided.
-     */
-    version?: Version;
     isLintable?: boolean;
     tracking?: Tracking;
     /** When true, the widget editor shows a "Graded" toggle. */

--- a/packages/perseus/src/widgets.ts
+++ b/packages/perseus/src/widgets.ts
@@ -1,9 +1,8 @@
-import {Errors, CoreWidgetRegistry, PerseusError, Registry} from "@khanacademy/perseus-core";
+import {Errors, PerseusError, Registry} from "@khanacademy/perseus-core";
 
 import {Log} from "./logging/log";
 
 import type {Tracking, WidgetExports} from "./types";
-import type {Version} from "@khanacademy/perseus-core";
 import type * as React from "react";
 
 const DEFAULT_TRACKING = "";

--- a/packages/perseus/src/widgets.ts
+++ b/packages/perseus/src/widgets.ts
@@ -1,4 +1,4 @@
-import {Errors, PerseusError, Registry} from "@khanacademy/perseus-core";
+import {Errors, CoreWidgetRegistry, PerseusError, Registry} from "@khanacademy/perseus-core";
 
 import {Log} from "./logging/log";
 
@@ -129,25 +129,6 @@ export const getWidgetExport = (type: string): WidgetExports | null => {
 
 export const getEditor = (type: string): Editor | null => {
     return editors.get(type) ?? null;
-};
-
-export const getVersion = (type: string): Version | undefined => {
-    const widget = widgets.get(type);
-    if (widget != null) {
-        return widget.version || {major: 0, minor: 0};
-    }
-
-    return;
-};
-
-export const getVersionVector = (): {
-    [key: string]: Version;
-} => {
-    const version: Record<string, any> = {};
-    widgets.keys().forEach((type) => {
-        version[type] = getVersion(type);
-    });
-    return version;
 };
 
 export const getPublicWidgets = (): Record<string, WidgetExports> => {

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -1,6 +1,5 @@
 import {KeypadContext} from "@khanacademy/keypad-context";
 import {KeypadInput} from "@khanacademy/math-input";
-import {expressionLogic} from "@khanacademy/perseus-core";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import {StyleSheet} from "aphrodite";

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -421,7 +421,6 @@ export default {
     name: "expression",
     displayName: "Expression / Equation",
     widget: Expression,
-    version: expressionLogic.version,
 
     // For use by the editor
     isLintable: true,

--- a/packages/perseus/src/widgets/measurer/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.tsx
@@ -1,7 +1,4 @@
-import {
-    measurerLogic,
-    type PerseusMeasurerWidgetOptions,
-} from "@khanacademy/perseus-core";
+import {type PerseusMeasurerWidgetOptions} from "@khanacademy/perseus-core";
 import $ from "jquery";
 import * as React from "react";
 import ReactDOM from "react-dom";

--- a/packages/perseus/src/widgets/measurer/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.tsx
@@ -184,5 +184,4 @@ export default {
     displayName: "Measurer",
     hidden: true,
     widget: Measurer,
-    version: measurerLogic.version,
 } satisfies WidgetExports<typeof Measurer>;

--- a/packages/perseus/src/widgets/radio/index.ts
+++ b/packages/perseus/src/widgets/radio/index.ts
@@ -17,7 +17,6 @@ export default {
     displayName: "Radio / Multiple choice",
     widget: Radio,
     getStartUserInput,
-    version: radioLogic.version,
     isLintable: true,
 
     // TODO(LEMS-3185): remove serializedState

--- a/packages/perseus/src/widgets/radio/index.ts
+++ b/packages/perseus/src/widgets/radio/index.ts
@@ -1,5 +1,3 @@
-import {radioLogic} from "@khanacademy/perseus-core";
-
 import Radio from "./radio-widget";
 import {getUserInputFromSerializedState} from "./util";
 


### PR DESCRIPTION
## Summary:
Previously, widget versions were encoded in three different places:

- In the `perseus` package, [on the WidgetExports type]. This version used to
  be used for widget prop upgrades (the data migration strategy that preceded
  the parsers, now removed). It is now used by the editors to determine the
  version number that gets stamped on newly-created widgets.
- In `perseus-core`, [in the parser code].
- In `perseus-core`, [on the WidgetLogic type].

These three sources of truth could get out of sync. Also, not every package can
import `perseus` (for example, in the backend perseus service, we can't import
React code at all, so we can't use the `perseus` package) which means that some
code could not get a runtime representation of the current version of a widget
if the `WidgetLogic` didn't have the version.

This PR makes `WidgetLogic.version` the single source of truth for widget
versions, and adds tests for the parsers to make sure that they output the
correct version number. `WidgetExports.version` has been deleted, and the
editors now use `WidgetLogic.version` instead.

In the process of making this change, I noticed a bug in the Measurer widget
parser where it did not parse version 0 options correctly: it zeroed out the
image properties. This PR also fixes that bug. Only one widget in our content
corpus was affected.

[on the WidgetExports type]: https://github.com/Khan/perseus/blob/4a130c0367d9e83953c4b37c19881f81437bca39/packages/perseus/src/types.ts#L436
[in the parser code]: https://github.com/Khan/perseus/blob/449a085f7d7136fba5ba198e291b2d44f1f2cd74/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.ts#L54
[on the WidgetLogic type]: https://github.com/Khan/perseus/blob/135eaf6c330bd3b5092bda458d2b90d450e7d9a5/packages/perseus-core/src/widgets/logic-export.types.ts#L62

Issue: none

## Test plan:

CI checks should pass.