### PR TITLE
Delete magic comment

### DIFF
--- a/.changeset/warm-moose-unite.md
+++ b/.changeset/warm-moose-unite.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: a magical comment that was once needed to make the build work is no longer needed and has been removed.

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -1,14 +1,6 @@
 import type {ILogger} from "./logging/log";
 import type {SizeClass} from "./util/sizing-utils";
 import type {WidgetPromptJSON} from "./widget-ai-utils/prompt-types";
-// MAGIC: Removal of this comment may cause `tsc --build` to output a syntax
-// error in packages/perseus/dist/server-item-renderer.d.ts and then fail. This
-// appears to be a bug introduced in TS 5.6. If you are curious about this, try
-// deleting this comment and running:
-//     rm -rf packages/*/{dist,tsconfig-build.tsbuildinfo} && yarn build:types
-// If that succeeds, maybe the bug has been fixed.
-// For more information, see:
-// https://khanacademy.slack.com/archives/C01AZ9H8TTQ/p1738883377389969
 import type {
     Hint,
     PerseusAnswerArea,


### PR DESCRIPTION
## Summary:
I'm almost sorry to see this go. It was pretty funny, and [the linked
slack thread] documents one of the most outlandish "war stories" of my
career. But the "magic" comment doesn't do anything anymore.

The compiler bug was in TS 5.6; we're now on 5.9.3. I hope it's really
fixed.

[the linked slack thread]: https://khanacademy.slack.com/archives/C01AZ9H8TTQ/p1738883377389969

Issue: none

## Test plan:

CI should pass.