### PR TITLE
[Editor] Improve contrast of editor controls when editing is disabled

### DIFF
--- a/.changeset/seven-items-behave.md
+++ b/.changeset/seven-items-behave.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+[Editor] Improve contrast of editor controls when editing is disabled

--- a/packages/perseus-editor/src/components/coordinate-pair-input.tsx
+++ b/packages/perseus-editor/src/components/coordinate-pair-input.tsx
@@ -16,6 +16,7 @@ interface Props {
     style?: StyleType;
     // TODO(LEMS-3995) simplifying styling after custom label work + change deprecated WonderBlocks component / aphrodite
     labelStyle?: StyleType;
+    disabled?: boolean;
     onChange: (newCoord: Coord) => void;
 }
 
@@ -28,7 +29,15 @@ const errorFieldStyle: StyleType = {
 };
 
 const CoordinatePairInput = (props: Props) => {
-    const {coord, labels, error, style, labelStyle, onChange} = props;
+    const {
+        coord,
+        labels,
+        error,
+        style,
+        labelStyle,
+        disabled = false,
+        onChange,
+    } = props;
 
     const xLabel = labels ? labels[0] : "x coord";
     const yLabel = labels ? labels[1] : "y coord";
@@ -77,6 +86,7 @@ const CoordinatePairInput = (props: Props) => {
 
                 <ScrolllessNumberTextField
                     value={coordState[0]}
+                    disabled={disabled}
                     onChange={(newValue) => handleCoordChange(newValue, 0)}
                     style={[
                         textFieldStyle,
@@ -95,6 +105,7 @@ const CoordinatePairInput = (props: Props) => {
 
                 <ScrolllessNumberTextField
                     value={coordState[1]}
+                    disabled={disabled}
                     onChange={(newValue) => handleCoordChange(newValue, 1)}
                     style={[
                         textFieldStyle,

--- a/packages/perseus-editor/src/styles/perseus-editor.css
+++ b/packages/perseus-editor/src/styles/perseus-editor.css
@@ -1065,22 +1065,24 @@ breaks the layout depending on the widget editors used.*/
  * Targets all form controls and interactive elements within disabled editors.
  */
 .perseus-single-editor.perseus-editor-disabled input,
-.perseus-single-editor.perseus-editor-disabled textarea,
 .perseus-single-editor.perseus-editor-disabled select,
-.perseus-single-editor.perseus-editor-disabled checkbox,
 .perseus-single-editor.perseus-editor-disabled .perseus-math-input,
 .perseus-single-editor.perseus-editor-disabled .keypad-input {
-    opacity: 0.6 !important;
     background-color: var(
-        --wb-semanticColor-core-background-neutral-subtle
+        --wb-semanticColor-input-disabled-background
     ) !important;
     cursor: not-allowed !important;
-    border-color: var(--wb-semanticColor-core-border-neutral-subtle) !important;
+    border-color: var(--wb-semanticColor-input-disabled-border) !important;
 }
 
-/* We want to keep the button colors as it often helps denote correctness. */
-.perseus-single-editor.perseus-editor-disabled button {
-    opacity: 0.6 !important;
+/* The markdown field renders widget-reference highlights in a transparent
+   underlay that sits behind the textarea, so tint the container — not the
+   textarea — to keep the highlights visible while still reading as disabled. */
+.perseus-single-editor.perseus-editor-disabled .perseus-textarea-pair {
+    background-color: var(
+        --wb-semanticColor-input-disabled-background
+    ) !important;
+    border-color: var(--wb-semanticColor-input-disabled-border) !important;
     cursor: not-allowed !important;
 }
 

--- a/packages/perseus-editor/src/widgets/__tests__/numeric-input-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/numeric-input-editor.test.tsx
@@ -37,7 +37,7 @@ describe("numeric-input-editor", () => {
         render(<NumericInputEditor onChange={onChangeMock} />);
 
         await userEvent.click(
-            within(screen.getByRole("group", {name: /^Width/})).getByRole(
+            within(screen.getByRole("radiogroup", {name: /^Width/})).getByRole(
                 "radio",
                 {name: "Normal (80px)"},
             ),
@@ -55,7 +55,7 @@ describe("numeric-input-editor", () => {
         render(<NumericInputEditor onChange={onChangeMock} />);
 
         await userEvent.click(
-            within(screen.getByRole("group", {name: /^Width/})).getByRole(
+            within(screen.getByRole("radiogroup", {name: /^Width/})).getByRole(
                 "radio",
                 {name: "Small (40px)"},
             ),
@@ -73,10 +73,9 @@ describe("numeric-input-editor", () => {
         render(<NumericInputEditor onChange={onChangeMock} />);
 
         await userEvent.click(
-            within(screen.getByRole("group", {name: /^Alignment/})).getByRole(
-                "radio",
-                {name: "Right"},
-            ),
+            within(
+                screen.getByRole("radiogroup", {name: /^Alignment/}),
+            ).getByRole("radio", {name: "Right"}),
         );
 
         expect(onChangeMock).toHaveBeenCalledWith({rightAlign: true});
@@ -89,7 +88,7 @@ describe("numeric-input-editor", () => {
 
         await userEvent.click(
             within(
-                screen.getByRole("group", {name: /^Number style/}),
+                screen.getByRole("radiogroup", {name: /^Number style/}),
             ).getByRole("radio", {name: "Coefficient"}),
         );
 
@@ -103,7 +102,7 @@ describe("numeric-input-editor", () => {
 
         await userEvent.click(
             within(
-                screen.getByRole("group", {name: /^Answer formats are/}),
+                screen.getByRole("radiogroup", {name: /^Answer formats are/}),
             ).getByRole("radio", {name: "Required"}),
         );
 
@@ -156,7 +155,7 @@ describe("numeric-input-editor", () => {
         render(<StatefulNumericInputEditor />);
 
         const input = screen.getByRole("textbox", {
-            name: "User input:",
+            name: "User input",
         });
 
         await userEvent.type(input, "6/8");
@@ -171,7 +170,9 @@ describe("numeric-input-editor", () => {
 
         await userEvent.click(
             within(
-                screen.getByRole("group", {name: /^Unsimplified answers are/}),
+                screen.getByRole("radiogroup", {
+                    name: /^Unsimplified answers are/,
+                }),
             ).getByRole("radio", {name: "Ungraded"}),
         );
 
@@ -191,7 +192,9 @@ describe("numeric-input-editor", () => {
 
         await userEvent.click(
             within(
-                screen.getByRole("group", {name: /^Unsimplified answers are/}),
+                screen.getByRole("radiogroup", {
+                    name: /^Unsimplified answers are/,
+                }),
             ).getByRole("radio", {name: "Accepted"}),
         );
 
@@ -211,7 +214,9 @@ describe("numeric-input-editor", () => {
 
         await userEvent.click(
             within(
-                screen.getByRole("group", {name: /^Unsimplified answers are/}),
+                screen.getByRole("radiogroup", {
+                    name: /^Unsimplified answers are/,
+                }),
             ).getByRole("radio", {name: "Wrong"}),
         );
 

--- a/packages/perseus-editor/src/widgets/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor.tsx
@@ -1,5 +1,5 @@
 import * as KAS from "@khanacademy/kas";
-import {components, Expression} from "@khanacademy/perseus";
+import {ApiOptions, components, Expression} from "@khanacademy/perseus";
 import {
     PerseusExpressionAnswerFormConsidered,
     deriveExtraKeys,
@@ -21,7 +21,6 @@ import type {APIOptions} from "@khanacademy/perseus";
 import type {
     PerseusExpressionWidgetOptions,
     LegacyButtonSets,
-    ExpressionDefaultWidgetOptions,
     PerseusExpressionAnswerForm,
     PerseusExpressionUserInput,
 } from "@khanacademy/perseus-core";
@@ -32,7 +31,7 @@ const {ButtonGroup, InfoTip} = components;
 type Props = {
     widgetId?: string;
     value?: string;
-    apiOptions?: APIOptions;
+    apiOptions: APIOptions;
     onChange: (newValues: Partial<PerseusExpressionWidgetOptions>) => void;
 } & Omit<PerseusExpressionWidgetOptions, "buttonsVisible">;
 
@@ -63,8 +62,10 @@ interface State {
 class ExpressionEditor extends React.Component<Props, State> {
     static widgetName = "expression" as const;
 
-    static defaultProps: ExpressionDefaultWidgetOptions =
-        expressionLogic.defaultWidgetOptions;
+    static defaultProps = {
+        ...expressionLogic.defaultWidgetOptions,
+        apiOptions: ApiOptions.defaults,
+    };
 
     constructor(props: Props) {
         super(props);
@@ -287,7 +288,7 @@ class ExpressionEditor extends React.Component<Props, State> {
     };
 
     render(): React.ReactNode {
-        const editingDisabled = this.props.apiOptions?.editingDisabled ?? false;
+        const editingDisabled = this.props.apiOptions.editingDisabled ?? false;
         const answerOptions: React.JSX.Element[] = this.props.answerForms.map(
             (ans: AnswerForm, index: number) => {
                 const expressionProps: Partial<

--- a/packages/perseus-editor/src/widgets/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor.tsx
@@ -17,6 +17,7 @@ import _ from "underscore";
 
 import styles from "./expression-editor.module.css";
 
+import type {APIOptions} from "@khanacademy/perseus";
 import type {
     PerseusExpressionWidgetOptions,
     LegacyButtonSets,
@@ -31,6 +32,7 @@ const {ButtonGroup, InfoTip} = components;
 type Props = {
     widgetId?: string;
     value?: string;
+    apiOptions?: APIOptions;
     onChange: (newValues: Partial<PerseusExpressionWidgetOptions>) => void;
 } & Omit<PerseusExpressionWidgetOptions, "buttonsVisible">;
 
@@ -285,6 +287,7 @@ class ExpressionEditor extends React.Component<Props, State> {
     };
 
     render(): React.ReactNode {
+        const editingDisabled = this.props.apiOptions?.editingDisabled ?? false;
         const answerOptions: React.JSX.Element[] = this.props.answerForms.map(
             (ans: AnswerForm, index: number) => {
                 const expressionProps: Partial<
@@ -312,6 +315,7 @@ class ExpressionEditor extends React.Component<Props, State> {
                     <AnswerOption
                         key={ans.key}
                         considered={ans.considered}
+                        editingDisabled={editingDisabled}
                         // eslint-disable-next-line no-restricted-syntax
                         expressionProps={expressionProps as any}
                         form={ans.form}
@@ -457,7 +461,11 @@ class ExpressionEditor extends React.Component<Props, State> {
 
                 <View className={styles.answersGroup}>
                     <View className={styles.answersList}>{answerOptions}</View>
-                    <Button size="small" onClick={this.newAnswer}>
+                    <Button
+                        size="small"
+                        disabled={editingDisabled}
+                        onClick={this.newAnswer}
+                    >
                         Add new answer
                     </Button>
                 </View>
@@ -475,6 +483,7 @@ const findNextIn = function <T>(arr: ReadonlyArray<T>, val: T) {
 
 interface AnswerOptionProps {
     considered: (typeof PerseusExpressionAnswerFormConsidered)[number];
+    editingDisabled: boolean;
     expressionProps: React.ComponentProps<typeof Expression>;
 
     // Must the answer have the same form as this answer.
@@ -522,10 +531,12 @@ class AnswerOption extends React.Component<
     };
 
     render(): React.ReactNode {
+        const {editingDisabled} = this.props;
         const removeButton = this.state.deleteFocused ? (
             <>
                 <Button
                     size="small"
+                    disabled={editingDisabled}
                     onClick={this.handleImSure}
                     actionType="destructive"
                 >
@@ -533,6 +544,7 @@ class AnswerOption extends React.Component<
                 </Button>
                 <Button
                     size="small"
+                    disabled={editingDisabled}
                     onClick={this.handleCancelDelete}
                     kind="secondary"
                 >
@@ -542,6 +554,7 @@ class AnswerOption extends React.Component<
         ) : (
             <Button
                 size="small"
+                disabled={editingDisabled}
                 onClick={this.handleDelete}
                 actionType="destructive"
                 kind="tertiary"
@@ -556,6 +569,7 @@ class AnswerOption extends React.Component<
                 <ButtonGroup
                     onChange={this.toggleConsidered}
                     allowEmpty={false}
+                    disabled={editingDisabled}
                     value={this.props.considered}
                     selectedButtonStyle={
                         consideredButtonStyles[this.props.considered]

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -1,4 +1,4 @@
-import {Util} from "@khanacademy/perseus";
+import {ApiOptions, Util} from "@khanacademy/perseus";
 import {freeResponseLogic} from "@khanacademy/perseus-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -14,13 +14,12 @@ import * as React from "react";
 import type {APIOptions} from "@khanacademy/perseus";
 import type {
     PerseusFreeResponseWidgetOptions,
-    FreeResponseDefaultWidgetOptions,
     PerseusFreeResponseWidgetScoringCriterion,
 } from "@khanacademy/perseus-core";
 import type {ChangeEventHandler} from "react";
 
 type Props = PerseusFreeResponseWidgetOptions & {
-    apiOptions?: APIOptions;
+    apiOptions: APIOptions;
     onChange: (options: Partial<PerseusFreeResponseWidgetOptions>) => void;
 };
 
@@ -29,8 +28,10 @@ type Props = PerseusFreeResponseWidgetOptions & {
  * An editor for adding a free response widget that allows users to enter open-ended text answers.
  */
 class FreeResponseEditor extends React.Component<Props> {
-    static defaultProps: FreeResponseDefaultWidgetOptions =
-        freeResponseLogic.defaultWidgetOptions;
+    static defaultProps = {
+        ...freeResponseLogic.defaultWidgetOptions,
+        apiOptions: ApiOptions.defaults,
+    };
 
     static widgetName = "free-response" as const;
 
@@ -117,7 +118,7 @@ class FreeResponseEditor extends React.Component<Props> {
     };
 
     render(): React.ReactNode {
-        const editingDisabled = this.props.apiOptions?.editingDisabled ?? false;
+        const editingDisabled = this.props.apiOptions.editingDisabled ?? false;
         return (
             <View>
                 <LabeledField

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -11,6 +11,7 @@ import trashIcon from "@phosphor-icons/core/regular/trash.svg";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
+import type {APIOptions} from "@khanacademy/perseus";
 import type {
     PerseusFreeResponseWidgetOptions,
     FreeResponseDefaultWidgetOptions,
@@ -19,6 +20,7 @@ import type {
 import type {ChangeEventHandler} from "react";
 
 type Props = PerseusFreeResponseWidgetOptions & {
+    apiOptions?: APIOptions;
     onChange: (options: Partial<PerseusFreeResponseWidgetOptions>) => void;
 };
 
@@ -94,7 +96,9 @@ class FreeResponseEditor extends React.Component<Props> {
         });
     };
 
-    renderCriteriaList: () => React.ReactNode = () => {
+    renderCriteriaList: (editingDisabled: boolean) => React.ReactNode = (
+        editingDisabled,
+    ) => {
         const isDeletable = this.props.scoringCriteria.length > 1;
 
         return this.props.scoringCriteria.map((criterion, index) => {
@@ -103,6 +107,7 @@ class FreeResponseEditor extends React.Component<Props> {
                     criterion={criterion}
                     index={index}
                     isDeletable={isDeletable}
+                    editingDisabled={editingDisabled}
                     key={index}
                     onChange={this.handleUpdateCriterion}
                     onDelete={this.handleDeleteCriterion}
@@ -112,6 +117,7 @@ class FreeResponseEditor extends React.Component<Props> {
     };
 
     render(): React.ReactNode {
+        const editingDisabled = this.props.apiOptions?.editingDisabled ?? false;
         return (
             <View>
                 <LabeledField
@@ -171,12 +177,13 @@ class FreeResponseEditor extends React.Component<Props> {
                 <View>
                     <View style={styles.criteriaList} tag="fieldset">
                         <BodyText tag="legend">Scoring criteria</BodyText>
-                        {this.renderCriteriaList()}
+                        {this.renderCriteriaList(editingDisabled)}
                     </View>
                     <View>
                         <Button
                             onClick={this.handleAddCriterion}
                             startIcon={plusCircleIcon}
+                            disabled={editingDisabled}
                         >
                             Add an item
                         </Button>
@@ -190,6 +197,7 @@ class FreeResponseEditor extends React.Component<Props> {
 const CriterionEditor = function (props: {
     index: number;
     isDeletable: boolean;
+    editingDisabled: boolean;
     criterion: PerseusFreeResponseWidgetScoringCriterion;
     onChange: (
         index: number,
@@ -214,7 +222,7 @@ const CriterionEditor = function (props: {
                     <Button
                         aria-label={`Delete criterion ${props.index + 1}`}
                         actionType="destructive"
-                        disabled={!props.isDeletable}
+                        disabled={!props.isDeletable || props.editingDisabled}
                         kind="tertiary"
                         onClick={() => props.onDelete(props.index)}
                         size="small"

--- a/packages/perseus-editor/src/widgets/graded-group-editor.tsx
+++ b/packages/perseus-editor/src/widgets/graded-group-editor.tsx
@@ -73,6 +73,7 @@ class GradedGroupEditor extends React.Component<Props> {
     };
 
     render(): React.ReactNode {
+        const editingDisabled = this.props.apiOptions?.editingDisabled ?? false;
         return (
             <div className="perseus-group-editor">
                 <div className="perseus-widget-row">
@@ -103,6 +104,7 @@ class GradedGroupEditor extends React.Component<Props> {
                         type="button"
                         className={`add-hint simple-button orange ${styles.addHintButton}`}
                         onClick={this.handleAddHint}
+                        disabled={editingDisabled}
                     >
                         <InlineIcon {...iconPlus} /> Add a hint
                     </button>
@@ -136,6 +138,7 @@ class GradedGroupEditor extends React.Component<Props> {
                             type="button"
                             className="remove-hint simple-button orange"
                             onClick={this.handleRemoveHint}
+                            disabled={editingDisabled}
                         >
                             <InlineIcon {...iconTrash} /> Remove this hint
                         </button>

--- a/packages/perseus-editor/src/widgets/graded-group-set-editor.tsx
+++ b/packages/perseus-editor/src/widgets/graded-group-set-editor.tsx
@@ -87,10 +87,13 @@ class GradedGroupSetEditor extends React.Component<Props> {
     };
 
     render(): React.ReactNode {
+        const editingDisabled = this.props.apiOptions?.editingDisabled ?? false;
         return (
             <div className="perseus-group-editor">
                 {this.renderGroups()}
-                <button onClick={this.addGroup}>Add group</button>
+                <button onClick={this.addGroup} disabled={editingDisabled}>
+                    Add group
+                </button>
             </div>
         );
     }

--- a/packages/perseus-editor/src/widgets/image-editor/components/decorative-toggle.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/components/decorative-toggle.tsx
@@ -12,12 +12,14 @@ const {InfoTip} = components;
 interface Props {
     decorative?: boolean;
     hasPopulatedFields?: boolean;
+    editingDisabled?: boolean;
     onChange: ImageEditorProps["onChange"];
 }
 
 export default function DecorativeToggle({
     decorative,
     hasPopulatedFields,
+    editingDisabled = false,
     onChange,
 }: Props) {
     function handleDecorativeToggle(newValue: boolean) {
@@ -54,6 +56,7 @@ export default function DecorativeToggle({
                 <LabeledSwitch
                     label="Decorative"
                     checked={decorative ?? false}
+                    disabled={editingDisabled}
                     onChange={handleDecorativeToggle}
                 />
                 <InfoTip>

--- a/packages/perseus-editor/src/widgets/image-editor/components/image-scale-input.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/components/image-scale-input.tsx
@@ -20,12 +20,14 @@ const LARGE_DIMENSION_THRESHOLD = 1048576;
 interface Props {
     backgroundImage: PerseusImageBackground;
     scale: number;
+    editingDisabled?: boolean;
     onChange: ImageEditorProps["onChange"];
 }
 
 export default function ImageScaleInput({
     backgroundImage,
     scale,
+    editingDisabled = false,
     onChange,
 }: Props) {
     const width = backgroundImage.width ?? 0;
@@ -122,6 +124,7 @@ export default function ImageScaleInput({
                 kind="tertiary"
                 size="small"
                 startIcon={arrowCounterClockwise}
+                disabled={editingDisabled}
                 onClick={handleResetToOriginalSize}
             >
                 Recalculate natural size
@@ -154,7 +157,7 @@ export default function ImageScaleInput({
                         value={scale.toString()}
                         min={0}
                         onChange={handleScaleChange}
-                        disabled={hasInvalidDimensions}
+                        disabled={hasInvalidDimensions || editingDisabled}
                     />
                 }
                 styles={wbFieldStyles}
@@ -167,7 +170,7 @@ export default function ImageScaleInput({
                             value={(width * scale).toString()}
                             min={0}
                             onChange={handleScaledWidthChange}
-                            disabled={hasInvalidDimensions}
+                            disabled={hasInvalidDimensions || editingDisabled}
                         />
                     }
                     styles={wbFieldStyles}
@@ -180,7 +183,7 @@ export default function ImageScaleInput({
                             value={(height * scale).toString()}
                             min={0}
                             onChange={handleScaledHeightChange}
-                            disabled={hasInvalidDimensions}
+                            disabled={hasInvalidDimensions || editingDisabled}
                         />
                     }
                     styles={wbFieldStyles}

--- a/packages/perseus-editor/src/widgets/image-editor/components/image-settings.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/components/image-settings.tsx
@@ -24,6 +24,7 @@ const altTextTooShortError =
 
 export default function ImageSettings({
     alt,
+    apiOptions,
     backgroundImage,
     scale = 1,
     caption,
@@ -39,6 +40,8 @@ export default function ImageSettings({
     if (!backgroundImage.url) {
         return null;
     }
+
+    const editingDisabled = apiOptions?.editingDisabled ?? false;
 
     const hasPopulatedFields = Boolean(
         alt || caption || title || longDescription,
@@ -87,6 +90,7 @@ export default function ImageSettings({
             <ImageScaleInput
                 backgroundImage={backgroundImage}
                 scale={scale}
+                editingDisabled={editingDisabled}
                 onChange={onChange}
             />
 
@@ -94,6 +98,7 @@ export default function ImageSettings({
             <DecorativeToggle
                 decorative={decorative}
                 hasPopulatedFields={hasPopulatedFields}
+                editingDisabled={editingDisabled}
                 onChange={onChange}
             />
 
@@ -106,7 +111,7 @@ export default function ImageSettings({
                     <TextArea
                         value={title ?? ""}
                         onChange={(value) => onChange({title: value})}
-                        disabled={decorative}
+                        disabled={decorative || editingDisabled}
                         autoResize={true}
                     />
                 }
@@ -123,7 +128,7 @@ export default function ImageSettings({
                             value={alt ?? ""}
                             onBlur={(e) => handleAltFieldBlur(e.target.value)}
                             onChange={handleAltFieldChange}
-                            disabled={decorative}
+                            disabled={decorative || editingDisabled}
                             autoResize={true}
                         />
                     }
@@ -153,7 +158,7 @@ export default function ImageSettings({
                     <TextArea
                         value={longDescription ?? ""}
                         onChange={(value) => onChange({longDescription: value})}
-                        disabled={decorative}
+                        disabled={decorative || editingDisabled}
                         autoResize={true}
                     />
                 }
@@ -167,7 +172,7 @@ export default function ImageSettings({
                     <TextArea
                         value={caption ?? ""}
                         onChange={(value) => onChange({caption: value})}
-                        disabled={decorative}
+                        disabled={decorative || editingDisabled}
                         autoResize={true}
                     />
                 }

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/graph-type-selector.tsx
@@ -5,6 +5,7 @@ import styles from "../interactive-graph-editor.module.css";
 
 interface GraphTypeSelectorProps {
     graphType: string;
+    disabled?: boolean;
     onChange: (newGraphType: string) => void;
 }
 
@@ -15,6 +16,7 @@ const GraphTypeSelector = (props: GraphTypeSelectorProps) => {
             onChange={props.onChange}
             placeholder="Select an answer type"
             className={styles.singleSelectShort}
+            disabled={props.disabled}
         >
             <OptionItem value="none" label="None" />
             <OptionItem

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-description.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-description.tsx
@@ -13,11 +13,17 @@ import type {Props as EditorProps} from "../interactive-graph-editor";
 interface Props {
     ariaLabelValue: string;
     ariaDescriptionValue: string;
+    editingDisabled?: boolean;
     onChange: (graphProps: Partial<EditorProps>) => void;
 }
 
 export default function InteractiveGraphDescription(props: Props) {
-    const {ariaLabelValue, ariaDescriptionValue, onChange} = props;
+    const {
+        ariaLabelValue,
+        ariaDescriptionValue,
+        editingDisabled = false,
+        onChange,
+    } = props;
 
     const [isOpen, setIsOpen] = React.useState(true);
 
@@ -57,6 +63,7 @@ export default function InteractiveGraphDescription(props: Props) {
                                         newValue || undefined,
                                 })
                             }
+                            disabled={editingDisabled}
                             style={{marginTop: sizing.size_040}}
                         />
                     </BodyText>
@@ -79,6 +86,7 @@ export default function InteractiveGraphDescription(props: Props) {
                                     newValue || undefined,
                             })
                         }
+                        disabled={editingDisabled}
                         autoResize={true}
                     />
                 </View>

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-settings.tsx
@@ -537,6 +537,7 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
     };
 
     render() {
+        const editingDisabled = this.props.apiOptions?.editingDisabled ?? false;
         return (
             <>
                 <Heading
@@ -566,6 +567,7 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
                                             },
                                         ]}
                                         onChange={this.change("labelLocation")}
+                                        disabled={editingDisabled}
                                     />
                                 </LabeledRow>
                             </div>
@@ -684,6 +686,7 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
                                         onClick={() => {
                                             this.changeStepsBasedOnRange();
                                         }}
+                                        disabled={editingDisabled}
                                     >
                                         Auto-adjust steps
                                     </Button>
@@ -716,6 +719,7 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
                                             {value: "none", content: "None"},
                                         ]}
                                         onChange={this.change("markings")}
+                                        disabled={editingDisabled}
                                     />
                                 </LabeledRow>
                             </div>
@@ -726,6 +730,7 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
                                     onChange={(value) => {
                                         this.change({showTooltips: value});
                                     }}
+                                    disabled={editingDisabled}
                                 />
                             </div>
                         </div>
@@ -767,6 +772,7 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
                                     onChange={(value) => {
                                         this.change({showProtractor: value});
                                     }}
+                                    disabled={editingDisabled}
                                     style={{marginTop: 0}}
                                 />
                             </View>

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-sr-tree.tsx
@@ -167,6 +167,7 @@ function InteractiveGraphSRTree({
     fullGraphAriaLabel,
     fullGraphAriaDescription,
     lockedFigures,
+    editingDisabled = false,
 }) {
     const [isExpanded, setIsExpanded] = React.useState(true);
     const [showTags, setShowTags] = React.useState(false);
@@ -200,6 +201,7 @@ function InteractiveGraphSRTree({
                             id={switchId}
                             checked={showTags}
                             onChange={setShowTags}
+                            disabled={editingDisabled}
                         />
                         <BodyText size="small" tag="label" htmlFor={switchId}>
                             Show HTML roles/tags

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -438,6 +438,10 @@ class InteractiveGraphEditor extends React.Component<Props> {
                     <View>
                         <LabeledRow label="Answer type" labelSize="medium">
                             <GraphTypeSelector
+                                disabled={
+                                    this.props.apiOptions?.editingDisabled ??
+                                    false
+                                }
                                 graphType={
                                     this.props.graph?.type ??
                                     InteractiveGraph.defaultProps.userInput.type
@@ -460,6 +464,9 @@ class InteractiveGraphEditor extends React.Component<Props> {
                             ariaLabelValue={this.props.fullGraphAriaLabel ?? ""}
                             ariaDescriptionValue={
                                 this.props.fullGraphAriaDescription ?? ""
+                            }
+                            editingDisabled={
+                                this.props.apiOptions?.editingDisabled ?? false
                             }
                             onChange={this.props.onChange}
                         />
@@ -514,6 +521,10 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                     {...this.props.graph}
                                     range={this.props.range}
                                     step={this.props.step}
+                                    editingDisabled={
+                                        this.props.apiOptions
+                                            ?.editingDisabled ?? false
+                                    }
                                     onChange={this.changeStartCoords}
                                     onChangePointLabels={this.changePointLabels}
                                 />
@@ -527,6 +538,9 @@ class InteractiveGraphEditor extends React.Component<Props> {
                                 this.props.fullGraphAriaDescription
                             }
                             lockedFigures={this.props.lockedFigures}
+                            editingDisabled={
+                                this.props.apiOptions?.editingDisabled ?? false
+                            }
                         />
                         <InteractiveGraphSettings
                             box={getInteractiveBoxFromSizeClass(sizeClass)}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/color-select.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/color-select.tsx
@@ -13,11 +13,12 @@ import type {StyleType} from "@khanacademy/wonder-blocks-core";
 interface Props {
     selectedValue: LockedFigureColor;
     style?: StyleType;
+    editingDisabled?: boolean;
     onChange: (newColor: LockedFigureColor) => void;
 }
 
 const ColorSelect = (props: Props) => {
-    const {selectedValue, style, onChange} = props;
+    const {selectedValue, style, editingDisabled = false, onChange} = props;
 
     return (
         <View className={styles.row} style={style}>
@@ -25,6 +26,7 @@ const ColorSelect = (props: Props) => {
                 color
                 <SingleSelect
                     selectedValue={selectedValue}
+                    disabled={editingDisabled}
                     // TODO(LEMS-2656): remove TS suppression
                     // eslint-disable-next-line no-restricted-syntax
                     onChange={onChange as any}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/line-stroke-select.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/line-stroke-select.tsx
@@ -11,10 +11,16 @@ interface Props {
     selectedValue: StyleOptions;
     onChange: (newValue: StyleOptions) => void;
     containerStyle?: StyleType;
+    editingDisabled?: boolean;
 }
 
 const LineStrokeSelect = (props: Props) => {
-    const {selectedValue, containerStyle, onChange} = props;
+    const {
+        selectedValue,
+        containerStyle,
+        editingDisabled = false,
+        onChange,
+    } = props;
 
     return (
         <BodyText
@@ -25,6 +31,7 @@ const LineStrokeSelect = (props: Props) => {
             stroke
             <SingleSelect
                 selectedValue={selectedValue}
+                disabled={editingDisabled}
                 // eslint-disable-next-line no-restricted-syntax
                 onChange={onChange as any}
                 // Placeholder is required, but never gets used.

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/line-weight-select.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/line-weight-select.tsx
@@ -11,10 +11,16 @@ interface Props {
     selectedValue: StrokeWeight;
     onChange: (newValue: StrokeWeight) => void;
     containerStyle?: StyleType;
+    editingDisabled?: boolean;
 }
 
 const LineWeightSelect = (props: Props) => {
-    const {selectedValue, containerStyle, onChange} = props;
+    const {
+        selectedValue,
+        containerStyle,
+        editingDisabled = false,
+        onChange,
+    } = props;
 
     return (
         <BodyText
@@ -25,6 +31,7 @@ const LineWeightSelect = (props: Props) => {
             weight
             <SingleSelect
                 selectedValue={selectedValue}
+                disabled={editingDisabled}
                 // eslint-disable-next-line no-restricted-syntax
                 onChange={(value) => onChange(value as StrokeWeight)}
                 // Placeholder is required, but never gets used.

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-ellipse-settings.tsx
@@ -73,6 +73,7 @@ const LockedEllipseSettings = (props: Props) => {
         strokeStyle,
         weight,
         expanded,
+        editingDisabled = false,
         onToggle,
         onChangeProps,
         onMove,
@@ -192,6 +193,7 @@ const LockedEllipseSettings = (props: Props) => {
                 <CoordinatePairInput
                     coord={center}
                     style={spaceUnderStyle}
+                    disabled={editingDisabled}
                     onChange={handleCenterChange}
                 />
                 <View className={styles.spaceUnder}>
@@ -206,6 +208,7 @@ const LockedEllipseSettings = (props: Props) => {
                 coord={radius}
                 labels={["x radius", "y radius"]}
                 style={spaceUnderStyle}
+                disabled={editingDisabled}
                 onChange={(newCoords: Coord) =>
                     onChangeProps({radius: newCoords})
                 }
@@ -223,6 +226,7 @@ const LockedEllipseSettings = (props: Props) => {
                 {/* Color */}
                 <ColorSelect
                     selectedValue={color}
+                    editingDisabled={editingDisabled}
                     onChange={handleColorChange}
                 />
 
@@ -234,6 +238,7 @@ const LockedEllipseSettings = (props: Props) => {
                     fill
                     <SingleSelect
                         selectedValue={fillStyle}
+                        disabled={editingDisabled}
                         // TODO(LEMS-2656): remove TS suppression
                         onChange={
                             // eslint-disable-next-line no-restricted-syntax
@@ -257,6 +262,7 @@ const LockedEllipseSettings = (props: Props) => {
             {/* Stroke style */}
             <LineStrokeSelect
                 selectedValue={strokeStyle}
+                editingDisabled={editingDisabled}
                 onChange={(value) => onChangeProps({strokeStyle: value})}
                 containerStyle={{marginBottom: sizing.size_080}}
             />
@@ -264,6 +270,7 @@ const LockedEllipseSettings = (props: Props) => {
             {/* Weight */}
             <LineWeightSelect
                 selectedValue={weight}
+                editingDisabled={editingDisabled}
                 onChange={(value) => onChangeProps({weight: value})}
             />
 
@@ -272,6 +279,7 @@ const LockedEllipseSettings = (props: Props) => {
             <LockedFigureAria
                 ariaLabel={ariaLabel}
                 getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
+                editingDisabled={editingDisabled}
                 onChangeProps={(newProps) => {
                     onChangeProps(newProps);
                 }}
@@ -286,6 +294,7 @@ const LockedEllipseSettings = (props: Props) => {
                 <LockedLabelSettings
                     {...label}
                     key={labelIndex}
+                    editingDisabled={editingDisabled}
                     expanded={true}
                     onChangeProps={(newLabel) => {
                         handleLabelChange(newLabel, labelIndex);
@@ -299,6 +308,7 @@ const LockedEllipseSettings = (props: Props) => {
             <Button
                 kind="tertiary"
                 startIcon={plusCircle}
+                disabled={editingDisabled}
                 onClick={() => {
                     const newLabel = {
                         ...getDefaultFigureForType("label"),
@@ -324,6 +334,7 @@ const LockedEllipseSettings = (props: Props) => {
             {/* Actions */}
             <LockedFigureSettingsActions
                 figureType={props.type}
+                editingDisabled={editingDisabled}
                 onMove={onMove}
                 onRemove={onRemove}
             />

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-aria.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-aria.tsx
@@ -18,11 +18,17 @@ interface Props {
      * for the locked figure with math details converted to spoken words.
      */
     getPrepopulatedAriaLabel: () => Promise<string>;
+    editingDisabled?: boolean;
     onChangeProps: (props: {ariaLabel?: string | undefined}) => void;
 }
 
 function LockedFigureAria(props: Props) {
-    const {ariaLabel, getPrepopulatedAriaLabel, onChangeProps} = props;
+    const {
+        ariaLabel,
+        getPrepopulatedAriaLabel,
+        editingDisabled = false,
+        onChangeProps,
+    } = props;
     const id = React.useId();
     const ariaLabelId = `aria-label-${id}`;
 
@@ -56,6 +62,7 @@ function LockedFigureAria(props: Props) {
             <TextArea
                 id={ariaLabelId}
                 value={loading ? "Loading..." : ariaLabel ?? ""}
+                disabled={editingDisabled}
                 onChange={(newValue) => {
                     onChangeProps({
                         // Save as undefined if the field is empty.
@@ -70,6 +77,7 @@ function LockedFigureAria(props: Props) {
             <Button
                 kind="tertiary"
                 startIcon={pencilCircle}
+                disabled={editingDisabled}
                 className={styles.button}
                 onClick={() => {
                     setLoading(true);

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-select.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-select.tsx
@@ -15,11 +15,12 @@ import type {LockedFigureType} from "@khanacademy/perseus-core";
 
 interface Props {
     id: string;
+    editingDisabled?: boolean;
     onChange: (value: LockedFigureType) => void;
 }
 
 const LockedFigureSelect = (props: Props) => {
-    const {id, onChange} = props;
+    const {id, editingDisabled, onChange} = props;
 
     const figureTypes: ReadonlyArray<LockedFigureType> = [
         "point",
@@ -35,6 +36,7 @@ const LockedFigureSelect = (props: Props) => {
         <View className={styles.container}>
             <ActionMenu
                 menuText="Add locked figure"
+                disabled={editingDisabled}
                 className={styles.addElementSelect}
             >
                 {figureTypes.map((figureType) => (

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-settings-actions.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-settings-actions.tsx
@@ -26,12 +26,13 @@ export type LockedFigureSettingsMovementType =
 
 interface Props {
     figureType: LockedFigureType;
+    editingDisabled?: boolean;
     onMove?: (movement: LockedFigureSettingsMovementType) => void;
     onRemove: () => void;
 }
 
 const LockedFigureSettingsActions = (props: Props) => {
-    const {figureType, onMove, onRemove} = props;
+    const {figureType, editingDisabled = false, onMove, onRemove} = props;
 
     return (
         <View className={styles.container}>
@@ -40,6 +41,7 @@ const LockedFigureSettingsActions = (props: Props) => {
                 aria-label={`Delete locked ${figureType}`}
                 onClick={onRemove}
                 kind="tertiary"
+                disabled={editingDisabled}
                 className={styles.deleteButton}
             >
                 Delete
@@ -54,6 +56,7 @@ const LockedFigureSettingsActions = (props: Props) => {
                         kind="tertiary"
                         size="small"
                         aria-label={`Move locked ${figureType} to the back`}
+                        disabled={editingDisabled}
                         onClick={() => onMove("back")}
                     />
                     <IconButton
@@ -61,6 +64,7 @@ const LockedFigureSettingsActions = (props: Props) => {
                         kind="tertiary"
                         size="small"
                         aria-label={`Move locked ${figureType} backward`}
+                        disabled={editingDisabled}
                         onClick={() => onMove("backward")}
                     />
                     <IconButton
@@ -68,6 +72,7 @@ const LockedFigureSettingsActions = (props: Props) => {
                         kind="tertiary"
                         size="small"
                         aria-label={`Move locked ${figureType} forward`}
+                        disabled={editingDisabled}
                         onClick={() => onMove("forward")}
                     />
                     <IconButton
@@ -75,6 +80,7 @@ const LockedFigureSettingsActions = (props: Props) => {
                         kind="tertiary"
                         size="small"
                         aria-label={`Move locked ${figureType} to the front`}
+                        disabled={editingDisabled}
                         onClick={() => onMove("front")}
                     />
                 </>

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figure-settings.tsx
@@ -26,6 +26,11 @@ import type {Props as LockedPolygonProps} from "./locked-polygon-settings";
 import type {Props as LockedVectorProps} from "./locked-vector-settings";
 
 export interface LockedFigureSettingsCommonProps {
+    /**
+     * Whether editing is disabled for this figure's controls.
+     */
+    editingDisabled?: boolean;
+
     // Movement props
     /**
      * Called when a movement button (top, up, down, bottom) is pressed.

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figures-section.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-figures-section.tsx
@@ -30,9 +30,9 @@ const LockedFiguresSection = (props: Props) => {
     // Keep track of all figures' accordions' expanded states for the
     // expand/collapse all button. When editing is disabled, default to
     // all open so content can still be reviewed. Otherwise, default to closed.
-    const defaultState = props.apiOptions?.editingDisabled ?? false;
+    const editingDisabled = props.apiOptions?.editingDisabled ?? false;
     const collapsedStateArray = Array((props.figures ?? []).length).fill(
-        defaultState,
+        editingDisabled,
     );
     const [expandedStates, setExpandedStates] =
         React.useState(collapsedStateArray);
@@ -170,6 +170,7 @@ const LockedFiguresSection = (props: Props) => {
                                     setExpandedStates(newExpanded);
                                 }}
                                 {...figure}
+                                editingDisabled={editingDisabled}
                                 onChangeProps={(newProps) =>
                                     changeProps(index, newProps)
                                 }
@@ -183,11 +184,13 @@ const LockedFiguresSection = (props: Props) => {
                     <View className={styles.buttonContainer}>
                         <LockedFigureSelect
                             id={`${uniqueId}-select`}
+                            editingDisabled={editingDisabled}
                             onChange={addLockedFigure}
                         />
                         {showExpandButton && (
                             <Button
                                 kind="secondary"
+                                disabled={editingDisabled}
                                 onClick={() => toggleExpanded(allCollapsed)}
                                 className={styles.button}
                             >

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-function-settings.tsx
@@ -58,6 +58,7 @@ const LockedFunctionSettings = (props: Props) => {
         domain,
         weight,
         ariaLabel,
+        editingDisabled = false,
         onChangeProps,
         onMove,
         onRemove,
@@ -203,12 +204,14 @@ const LockedFunctionSettings = (props: Props) => {
                 {/* Line color settings */}
                 <ColorSelect
                     selectedValue={lineColor}
+                    editingDisabled={editingDisabled}
                     onChange={handleColorChange}
                 />
 
                 {/* Line style settings */}
                 <LineStrokeSelect
                     selectedValue={strokeStyle}
+                    editingDisabled={editingDisabled}
                     onChange={(newValue) => {
                         handlePropChange("strokeStyle", newValue);
                     }}
@@ -218,6 +221,7 @@ const LockedFunctionSettings = (props: Props) => {
             {/* Line weight settings */}
             <LineWeightSelect
                 selectedValue={weight}
+                editingDisabled={editingDisabled}
                 onChange={(value) => onChangeProps({weight: value})}
             />
 
@@ -227,6 +231,7 @@ const LockedFunctionSettings = (props: Props) => {
                 {/* Directional axis (x or y) */}
                 <SingleSelect
                     selectedValue={directionalAxis}
+                    disabled={editingDisabled}
                     onChange={(newValue) => {
                         handlePropChange("directionalAxis", newValue);
                     }}
@@ -243,6 +248,7 @@ const LockedFunctionSettings = (props: Props) => {
                     type="text"
                     aria-label="equation"
                     value={equation}
+                    disabled={editingDisabled}
                     onChange={(newValue) => {
                         handlePropChange("equation", newValue);
                     }}
@@ -265,6 +271,7 @@ const LockedFunctionSettings = (props: Props) => {
                         // make room for the label
                         style={{width: "calc(100% - 88.7px)"}}
                         value={domainEntries[0]}
+                        disabled={editingDisabled}
                         onChange={(newValue) => {
                             handleDomainChange(0, newValue);
                         }}
@@ -281,6 +288,7 @@ const LockedFunctionSettings = (props: Props) => {
                         type="number"
                         style={{width: "calc(100% - 36.2px)"}}
                         value={domainEntries[1]}
+                        disabled={editingDisabled}
                         onChange={(newValue) => {
                             handleDomainChange(1, newValue);
                         }}
@@ -310,6 +318,7 @@ const LockedFunctionSettings = (props: Props) => {
                     {"Choose a category"}
                     <SingleSelect
                         selectedValue={exampleCategory}
+                        disabled={editingDisabled}
                         onChange={setExampleCategory}
                         placeholder="examples"
                     >
@@ -332,6 +341,7 @@ const LockedFunctionSettings = (props: Props) => {
                                 category={exampleCategory}
                                 example={example}
                                 index={index}
+                                editingDisabled={editingDisabled}
                                 pasteEquationFn={handlePropChange}
                             />
                         ))}
@@ -344,6 +354,7 @@ const LockedFunctionSettings = (props: Props) => {
             <LockedFigureAria
                 ariaLabel={ariaLabel}
                 getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
+                editingDisabled={editingDisabled}
                 onChangeProps={(newProps) => {
                     onChangeProps(newProps);
                 }}
@@ -358,6 +369,7 @@ const LockedFunctionSettings = (props: Props) => {
                 <LockedLabelSettings
                     key={labelIndex}
                     {...label}
+                    editingDisabled={editingDisabled}
                     expanded={true}
                     onChangeProps={(newLabel) => {
                         handleLabelChange(newLabel, labelIndex);
@@ -374,6 +386,7 @@ const LockedFunctionSettings = (props: Props) => {
             <Button
                 kind="tertiary"
                 startIcon={plusCircle}
+                disabled={editingDisabled}
                 onClick={() => {
                     const newLabel = {
                         ...getDefaultFigureForType("label"),
@@ -396,6 +409,7 @@ const LockedFunctionSettings = (props: Props) => {
             {/* Actions */}
             <LockedFigureSettingsActions
                 figureType={props.type}
+                editingDisabled={editingDisabled}
                 onMove={onMove}
                 onRemove={onRemove}
             />
@@ -407,11 +421,12 @@ interface ItemProps {
     category: string;
     example: string;
     index: number;
+    editingDisabled?: boolean;
     pasteEquationFn: (property: string, newValue: string) => void;
 }
 
 const ExampleItem = (props: ItemProps): React.ReactElement => {
-    const {category, example, index, pasteEquationFn} = props;
+    const {category, example, index, editingDisabled, pasteEquationFn} = props;
     const exampleId = useId();
 
     return (
@@ -421,6 +436,7 @@ const ExampleItem = (props: ItemProps): React.ReactElement => {
                 kind="tertiary"
                 aria-label="paste example"
                 aria-describedby={exampleId}
+                disabled={editingDisabled}
                 onClick={() => pasteEquationFn("equation", example)}
                 size="medium"
                 className={styles.copyPasteButton}
@@ -430,6 +446,7 @@ const ExampleItem = (props: ItemProps): React.ReactElement => {
                 kind="tertiary"
                 aria-label="copy example"
                 aria-describedby={exampleId}
+                disabled={editingDisabled}
                 onClick={() => navigator.clipboard.writeText(example)}
                 size="medium"
                 className={styles.copyPasteButton}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-label-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-label-settings.tsx
@@ -35,6 +35,10 @@ const spaceUnderStyle: StyleType = {marginBottom: sizing.size_080};
 
 export type Props = LockedLabelType & {
     /**
+     * Whether editing is disabled for this label's controls.
+     */
+    editingDisabled?: boolean;
+    /**
      * Called when the props (coord, color, etc.) are updated.
      */
     onChangeProps: (newProps: Partial<LockedLabelType>) => void;
@@ -75,6 +79,7 @@ export default function LockedLabelSettings(props: Props) {
         size,
         text,
         expanded,
+        editingDisabled = false,
         onChangeProps,
         onMove,
         onRemove,
@@ -113,6 +118,7 @@ export default function LockedLabelSettings(props: Props) {
             {/* Coord settings */}
             <CoordinatePairInput
                 coord={coord}
+                disabled={editingDisabled}
                 onChange={(newCoords) => {
                     onChangeProps({coord: newCoords});
                 }}
@@ -129,6 +135,7 @@ export default function LockedLabelSettings(props: Props) {
                     <TextField
                         value={text}
                         placeholder="ex. $x^2$ or $\frac{1}{2}$"
+                        disabled={editingDisabled}
                         onChange={(newValue) =>
                             onChangeProps({
                                 text: newValue,
@@ -151,6 +158,7 @@ export default function LockedLabelSettings(props: Props) {
             <View className={`${styles.row} ${styles.colorRow}`}>
                 <ColorSelect
                     selectedValue={color}
+                    editingDisabled={editingDisabled}
                     onChange={(newColor) => {
                         onChangeProps({color: newColor});
                     }}
@@ -165,6 +173,7 @@ export default function LockedLabelSettings(props: Props) {
                     size
                     <SingleSelect
                         selectedValue={size}
+                        disabled={editingDisabled}
                         // TODO(LEMS-2656): remove TS suppression
                         onChange={
                             // eslint-disable-next-line no-restricted-syntax
@@ -187,6 +196,7 @@ export default function LockedLabelSettings(props: Props) {
             {/* Actions */}
             <LockedFigureSettingsActions
                 figureType={type}
+                editingDisabled={editingDisabled}
                 onMove={onMove}
                 onRemove={onRemove}
             />

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.tsx
@@ -72,6 +72,7 @@ const LockedLineSettings = (props: Props) => {
         weight,
         labels,
         ariaLabel,
+        editingDisabled = false,
         onChangeProps,
         onMove,
         onRemove,
@@ -243,6 +244,7 @@ const LockedLineSettings = (props: Props) => {
                 kind
                 <SingleSelect
                     selectedValue={kind}
+                    disabled={editingDisabled}
                     // TODO(LEMS-2656): remove TS suppression
                     onChange={
                         // eslint-disable-next-line no-restricted-syntax
@@ -264,12 +266,14 @@ const LockedLineSettings = (props: Props) => {
                 {/* Line color settings */}
                 <ColorSelect
                     selectedValue={lineColor}
+                    editingDisabled={editingDisabled}
                     onChange={handleColorChange}
                 />
 
                 {/* Line style settings */}
                 <LineStrokeSelect
                     selectedValue={lineStyle}
+                    editingDisabled={editingDisabled}
                     onChange={
                         // eslint-disable-next-line no-restricted-syntax
                         ((value: "solid" | "dashed") =>
@@ -279,6 +283,7 @@ const LockedLineSettings = (props: Props) => {
             </View>
             <LineWeightSelect
                 selectedValue={weight}
+                editingDisabled={editingDisabled}
                 onChange={(value: StrokeWeight) =>
                     onChangeProps({weight: value})
                 }
@@ -298,6 +303,7 @@ const LockedLineSettings = (props: Props) => {
                 showPoint={showPoint1}
                 error={isInvalid ? lengthZeroStr : null}
                 {...point1}
+                editingDisabled={editingDisabled}
                 onTogglePoint={(newValue) =>
                     onChangeProps({showPoint1: newValue})
                 }
@@ -309,6 +315,7 @@ const LockedLineSettings = (props: Props) => {
                 showPoint={showPoint2}
                 error={isInvalid ? lengthZeroStr : null}
                 {...point2}
+                editingDisabled={editingDisabled}
                 onTogglePoint={(newValue) =>
                     onChangeProps({showPoint2: newValue})
                 }
@@ -320,6 +327,7 @@ const LockedLineSettings = (props: Props) => {
             <LockedFigureAria
                 ariaLabel={ariaLabel}
                 getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
+                editingDisabled={editingDisabled}
                 onChangeProps={(newProps) => {
                     onChangeProps(newProps);
                 }}
@@ -335,6 +343,7 @@ const LockedLineSettings = (props: Props) => {
                 <LockedLabelSettings
                     {...label}
                     key={labelIndex}
+                    editingDisabled={editingDisabled}
                     expanded={true}
                     onChangeProps={(newLabel) => {
                         handleLabelChange(newLabel, labelIndex);
@@ -348,6 +357,7 @@ const LockedLineSettings = (props: Props) => {
             <Button
                 kind="tertiary"
                 startIcon={plusCircle}
+                disabled={editingDisabled}
                 onClick={() => {
                     // Additional vertical offset for each label so
                     // they don't overlap.
@@ -376,6 +386,7 @@ const LockedLineSettings = (props: Props) => {
             {/* Actions */}
             <LockedFigureSettingsActions
                 figureType={props.type}
+                editingDisabled={editingDisabled}
                 onMove={onMove}
                 onRemove={onRemove}
             />

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-point-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-point-settings.tsx
@@ -45,6 +45,10 @@ export type Props = LockedPointType & {
      */
     headerLabel?: string;
     /**
+     * Whether editing is disabled for this figure's controls.
+     */
+    editingDisabled?: boolean;
+    /**
      * Whether the extra point settings are toggled open.
      */
     showPoint?: boolean;
@@ -86,6 +90,7 @@ export type Props = LockedPointType & {
 const LockedPointSettings = (props: Props) => {
     const {
         headerLabel,
+        editingDisabled = false,
         coord,
         color: pointColor,
         filled = true,
@@ -219,6 +224,7 @@ const LockedPointSettings = (props: Props) => {
             <CoordinatePairInput
                 coord={coord}
                 style={spaceUnderStyle}
+                disabled={editingDisabled}
                 onChange={handleCoordChange}
                 error={!!error}
             />
@@ -229,6 +235,7 @@ const LockedPointSettings = (props: Props) => {
                     label="show point on graph"
                     checked={!!showPoint}
                     style={showPoint && spaceUnderStyle}
+                    disabled={editingDisabled}
                     onChange={onTogglePoint}
                 />
             )}
@@ -240,10 +247,12 @@ const LockedPointSettings = (props: Props) => {
                         selectedValue={pointColor}
                         onChange={handleColorChange}
                         style={spaceUnderStyle}
+                        editingDisabled={editingDisabled}
                     />
                     <LabeledSwitch
                         label="open point"
                         checked={!filled}
+                        disabled={editingDisabled}
                         onChange={(newValue) => {
                             onChangeProps({filled: !newValue});
                         }}
@@ -260,6 +269,7 @@ const LockedPointSettings = (props: Props) => {
                     <LockedFigureAria
                         ariaLabel={ariaLabel}
                         getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
+                        editingDisabled={editingDisabled}
                         onChangeProps={(newProps) => {
                             onChangeProps(newProps);
                         }}
@@ -276,6 +286,7 @@ const LockedPointSettings = (props: Props) => {
                 <LockedLabelSettings
                     {...label}
                     key={labelIndex}
+                    editingDisabled={editingDisabled}
                     containerStyle={
                         !isDefiningPoint && {
                             backgroundColor:
@@ -294,6 +305,7 @@ const LockedPointSettings = (props: Props) => {
             <Button
                 kind="tertiary"
                 startIcon={plusCircle}
+                disabled={editingDisabled}
                 onClick={() => {
                     const newLabel = {
                         ...getDefaultFigureForType("label"),
@@ -322,6 +334,7 @@ const LockedPointSettings = (props: Props) => {
             {onRemove && (
                 <LockedFigureSettingsActions
                     figureType={props.type}
+                    editingDisabled={editingDisabled}
                     onMove={onMove}
                     onRemove={onRemove}
                 />

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
@@ -76,6 +76,7 @@ const LockedPolygonSettings = (props: Props) => {
         labels,
         ariaLabel,
         expanded,
+        editingDisabled = false,
         onToggle,
         onChangeProps,
         onMove,
@@ -210,6 +211,7 @@ const LockedPolygonSettings = (props: Props) => {
                 {/* Color */}
                 <ColorSelect
                     selectedValue={color}
+                    editingDisabled={editingDisabled}
                     onChange={handleColorChange}
                 />
 
@@ -221,6 +223,7 @@ const LockedPolygonSettings = (props: Props) => {
                     fill
                     <SingleSelect
                         selectedValue={fillStyle}
+                        disabled={editingDisabled}
                         // TODO(LEMS-2656): remove TS suppression
                         onChange={
                             // eslint-disable-next-line no-restricted-syntax
@@ -244,6 +247,7 @@ const LockedPolygonSettings = (props: Props) => {
             {/* Stroke style */}
             <LineStrokeSelect
                 selectedValue={strokeStyle}
+                editingDisabled={editingDisabled}
                 onChange={(value) => onChangeProps({strokeStyle: value})}
                 containerStyle={spaceUnderStyle}
             />
@@ -251,6 +255,7 @@ const LockedPolygonSettings = (props: Props) => {
             {/* Weight */}
             <LineWeightSelect
                 selectedValue={weight}
+                editingDisabled={editingDisabled}
                 onChange={(value) =>
                     onChangeProps({
                         weight: value,
@@ -263,6 +268,7 @@ const LockedPolygonSettings = (props: Props) => {
             <LabeledSwitch
                 label="show vertices"
                 checked={showVertices}
+                disabled={editingDisabled}
                 onChange={(newValue: boolean) =>
                     onChangeProps({showVertices: newValue})
                 }
@@ -296,6 +302,7 @@ const LockedPolygonSettings = (props: Props) => {
                                 coord={point}
                                 labels={["x", "y"]}
                                 style={{marginInlineStart: sizing.size_160}}
+                                disabled={editingDisabled}
                                 onChange={(newValue: Coord) => {
                                     const newPoints = [...points];
                                     newPoints[index] = newValue;
@@ -312,6 +319,7 @@ const LockedPolygonSettings = (props: Props) => {
                                         icon={minusCircle}
                                         kind="tertiary"
                                         actionType="destructive"
+                                        disabled={editingDisabled}
                                         onClick={() => {
                                             const newPoints = [...points];
                                             newPoints.splice(index, 1);
@@ -332,6 +340,7 @@ const LockedPolygonSettings = (props: Props) => {
                     <Button
                         kind="tertiary"
                         startIcon={plusCircle}
+                        disabled={editingDisabled}
                         onClick={() => {
                             props.onChangeProps({
                                 points: [...points, [0, 0]],
@@ -350,6 +359,7 @@ const LockedPolygonSettings = (props: Props) => {
                             size="small"
                             icon={arrowFatUp}
                             kind="tertiary"
+                            disabled={editingDisabled}
                             onClick={() => handlePolygonMove("up")}
                         />
                         <View className={styles.row}>
@@ -358,6 +368,7 @@ const LockedPolygonSettings = (props: Props) => {
                                 size="small"
                                 icon={arrowFatLeft}
                                 kind="tertiary"
+                                disabled={editingDisabled}
                                 onClick={() => handlePolygonMove("left")}
                             />
                             <IconButton
@@ -365,6 +376,7 @@ const LockedPolygonSettings = (props: Props) => {
                                 size="small"
                                 icon={arrowFatDown}
                                 kind="tertiary"
+                                disabled={editingDisabled}
                                 onClick={() => handlePolygonMove("down")}
                             />
                             <IconButton
@@ -372,6 +384,7 @@ const LockedPolygonSettings = (props: Props) => {
                                 size="small"
                                 icon={arrowFatRight}
                                 kind="tertiary"
+                                disabled={editingDisabled}
                                 onClick={() => handlePolygonMove("right")}
                             />
                         </View>
@@ -384,6 +397,7 @@ const LockedPolygonSettings = (props: Props) => {
             <LockedFigureAria
                 ariaLabel={ariaLabel}
                 getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
+                editingDisabled={editingDisabled}
                 onChangeProps={(newProps) => {
                     onChangeProps(newProps);
                 }}
@@ -398,6 +412,7 @@ const LockedPolygonSettings = (props: Props) => {
                 <LockedLabelSettings
                     {...label}
                     key={labelIndex}
+                    editingDisabled={editingDisabled}
                     expanded={true}
                     onChangeProps={(newLabel) => {
                         handleLabelChange(newLabel, labelIndex);
@@ -411,6 +426,7 @@ const LockedPolygonSettings = (props: Props) => {
             <Button
                 kind="tertiary"
                 startIcon={plusCircle}
+                disabled={editingDisabled}
                 onClick={() => {
                     const newLabel = {
                         ...getDefaultFigureForType("label"),
@@ -436,6 +452,7 @@ const LockedPolygonSettings = (props: Props) => {
             {/* Actions */}
             <LockedFigureSettingsActions
                 figureType={props.type}
+                editingDisabled={editingDisabled}
                 onMove={onMove}
                 onRemove={onRemove}
             />

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.tsx
@@ -75,6 +75,7 @@ const LockedVectorSettings = (props: Props) => {
         weight,
         labels,
         ariaLabel,
+        editingDisabled = false,
         onChangeProps,
         onMove,
         onRemove,
@@ -180,6 +181,7 @@ const LockedVectorSettings = (props: Props) => {
             {/* Line color settings */}
             <ColorSelect
                 selectedValue={lineColor}
+                editingDisabled={editingDisabled}
                 onChange={handleColorChange}
                 style={{marginBottom: sizing.size_080}}
             />
@@ -187,6 +189,7 @@ const LockedVectorSettings = (props: Props) => {
             {/* Line weight settings */}
             <LineWeightSelect
                 selectedValue={weight}
+                editingDisabled={editingDisabled}
                 onChange={(value: StrokeWeight) =>
                     onChangeProps({weight: value})
                 }
@@ -217,6 +220,7 @@ const LockedVectorSettings = (props: Props) => {
                 <CoordinatePairInput
                     coord={tail}
                     error={isInvalid}
+                    disabled={editingDisabled}
                     onChange={(newProps) => {
                         handleChangePoint(newProps, 0);
                     }}
@@ -240,6 +244,7 @@ const LockedVectorSettings = (props: Props) => {
                 <CoordinatePairInput
                     coord={tip}
                     error={isInvalid}
+                    disabled={editingDisabled}
                     onChange={(newProps) => {
                         handleChangePoint(newProps, 1);
                     }}
@@ -251,6 +256,7 @@ const LockedVectorSettings = (props: Props) => {
             <LockedFigureAria
                 ariaLabel={ariaLabel}
                 getPrepopulatedAriaLabel={getPrepopulatedAriaLabel}
+                editingDisabled={editingDisabled}
                 onChangeProps={(newProps) => {
                     onChangeProps(newProps);
                 }}
@@ -265,6 +271,7 @@ const LockedVectorSettings = (props: Props) => {
                 <LockedLabelSettings
                     {...label}
                     key={labelIndex}
+                    editingDisabled={editingDisabled}
                     expanded={true}
                     onChangeProps={(newLabel) => {
                         handleLabelChange(newLabel, labelIndex);
@@ -278,6 +285,7 @@ const LockedVectorSettings = (props: Props) => {
             <Button
                 kind="tertiary"
                 startIcon={plusCircle}
+                disabled={editingDisabled}
                 onClick={() => {
                     // Additional vertical offset for each label so
                     // they don't overlap.
@@ -306,6 +314,7 @@ const LockedVectorSettings = (props: Props) => {
             {/* Actions */}
             <LockedFigureSettingsActions
                 figureType={props.type}
+                editingDisabled={editingDisabled}
                 onMove={onMove}
                 onRemove={onRemove}
             />

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-settings.tsx
@@ -43,6 +43,7 @@ interface StartCoordsSettingsProps {
     range: [x: Range, y: Range];
     step: [x: number, y: number];
     allowReflexAngles?: boolean;
+    editingDisabled?: boolean;
     onChange: (startCoords: StartCoords) => void;
     onChangePointLabels: (pointLabels: ReadonlyArray<string>) => void;
 }
@@ -229,7 +230,7 @@ const StartCoordsSettingsInner = (props: Props) => {
 };
 
 const StartCoordsSettings = (props: Props) => {
-    const {range, step, onChange} = props;
+    const {range, step, editingDisabled, onChange} = props;
     const [isOpen, setIsOpen] = React.useState(true);
 
     return (
@@ -254,6 +255,7 @@ const StartCoordsSettings = (props: Props) => {
                             startIcon={arrowCounterClockwise}
                             kind="tertiary"
                             size="small"
+                            disabled={editingDisabled}
                             onClick={() => {
                                 onChange(
                                     getDefaultGraphStartCoords(

--- a/packages/perseus-editor/src/widgets/label-image-editor/answer-choices.module.css
+++ b/packages/perseus-editor/src/widgets/label-image-editor/answer-choices.module.css
@@ -42,3 +42,8 @@
 .disabled {
     cursor: not-allowed;
 }
+
+.disabled-link {
+    cursor: not-allowed;
+    opacity: 0.5;
+}

--- a/packages/perseus-editor/src/widgets/label-image-editor/answer-choices.tsx
+++ b/packages/perseus-editor/src/widgets/label-image-editor/answer-choices.tsx
@@ -16,6 +16,8 @@ const {Icon} = components;
 interface AddAnswerProps {
     // Callback to add new answer choice.
     onClick: () => void;
+    // Whether the editor is disabled (read-only).
+    editingDisabled: boolean;
 }
 
 interface AnswerProps {
@@ -25,6 +27,8 @@ interface AnswerProps {
     onChange: (answer: string) => void;
     // Callback to remove answer from list of choices.
     onRemove: () => void;
+    // Whether the editor is disabled (read-only).
+    editingDisabled: boolean;
 }
 
 export interface AnswerChoicesProps {
@@ -93,9 +97,20 @@ const DraggableGripIcon = () => (
 /**
  * A button link to add a new answer.
  */
-const AddAnswer = ({onClick}: AddAnswerProps): React.ReactElement => (
+const AddAnswer = ({
+    onClick,
+    editingDisabled,
+}: AddAnswerProps): React.ReactElement => (
     // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events, jsx-a11y/anchor-is-valid -- TODO(LEMS-2871): Address a11y error
-    <Link className={styles.addAnswer} onClick={onClick}>
+    <Link
+        className={
+            editingDisabled
+                ? `${styles.addAnswer} ${styles.disabledLink}`
+                : styles.addAnswer
+        }
+        aria-disabled={editingDisabled || undefined}
+        onClick={onClick}
+    >
         <Icon icon={addIcon} size={24} />
         Add an answer choice
     </Link>
@@ -108,10 +123,15 @@ const Answer = ({
     answer,
     onChange,
     onRemove,
+    editingDisabled,
 }: AnswerProps): React.ReactElement => (
     <li className={styles.answer}>
         {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events, jsx-a11y/anchor-is-valid -- TODO(LEMS-2871): Address a11y error, TODO(LEMS-2871): Address a11y error */}
-        <Link onClick={onRemove}>
+        <Link
+            onClick={onRemove}
+            className={editingDisabled ? styles.disabledLink : undefined}
+            aria-disabled={editingDisabled || undefined}
+        >
             <Icon icon={removeIcon} size={24} color="#D92916" />
         </Link>
 
@@ -147,6 +167,7 @@ const AnswerChoices = ({
                 <Answer
                     answer={answer}
                     key={index}
+                    editingDisabled={editingDisabled}
                     // Update answer for choice.
                     onChange={(answer) => {
                         if (editingDisabled) {
@@ -173,6 +194,7 @@ const AnswerChoices = ({
         </ul>
 
         <AddAnswer
+            editingDisabled={editingDisabled}
             // Append a new empty answer to choices.
             onClick={() => {
                 if (editingDisabled) {

--- a/packages/perseus-editor/src/widgets/label-image-editor/answer-choices.tsx
+++ b/packages/perseus-editor/src/widgets/label-image-editor/answer-choices.tsx
@@ -16,7 +16,6 @@ const {Icon} = components;
 interface AddAnswerProps {
     // Callback to add new answer choice.
     onClick: () => void;
-    // Whether the editor is disabled (read-only).
     editingDisabled: boolean;
 }
 
@@ -27,7 +26,6 @@ interface AnswerProps {
     onChange: (answer: string) => void;
     // Callback to remove answer from list of choices.
     onRemove: () => void;
-    // Whether the editor is disabled (read-only).
     editingDisabled: boolean;
 }
 

--- a/packages/perseus-editor/src/widgets/label-image-editor/label-image-editor.tsx
+++ b/packages/perseus-editor/src/widgets/label-image-editor/label-image-editor.tsx
@@ -213,7 +213,11 @@ class LabelImageEditor extends React.Component<Props> {
 
         return (
             <div>
-                <SelectImage onChange={this.handleImageChange} url={imageUrl} />
+                <SelectImage
+                    onChange={this.handleImageChange}
+                    url={imageUrl}
+                    editingDisabled={editingDisabled}
+                />
 
                 <div className={styles.smallSpacer} />
 

--- a/packages/perseus-editor/src/widgets/label-image-editor/select-image.tsx
+++ b/packages/perseus-editor/src/widgets/label-image-editor/select-image.tsx
@@ -14,9 +14,14 @@ export interface SelectImageProps {
     onChange: (url: string) => void;
     // The selected image URL.
     url: string;
+    editingDisabled?: boolean;
 }
 
-const SelectImage = ({onChange, url}: SelectImageProps): React.ReactElement => (
+const SelectImage = ({
+    onChange,
+    url,
+    editingDisabled = false,
+}: SelectImageProps): React.ReactElement => (
     <div>
         <div className={styles.title}>Image</div>
 
@@ -29,7 +34,7 @@ const SelectImage = ({onChange, url}: SelectImageProps): React.ReactElement => (
             />
 
             <Button
-                disabled={!url}
+                disabled={!url || editingDisabled}
                 aria-label={
                     url
                         ? ""

--- a/packages/perseus-editor/src/widgets/numeric-input-editor.module.css
+++ b/packages/perseus-editor/src/widgets/numeric-input-editor.module.css
@@ -1,0 +1,21 @@
+/* TODO(LEMS-3686): Remove the !important once Wonder Blocks is in the shared layer. */
+
+.field {
+    margin-block: var(--wb-sizing-size_120) !important;
+    gap: var(--wb-sizing-size_080) !important;
+    align-items: flex-start !important;
+}
+
+/* Label + InfoTip on one line. */
+.label-row {
+    flex-direction: row !important;
+    align-items: center !important;
+    gap: var(--wb-sizing-size_040) !important;
+}
+
+/* A label whose control sits inline beside it (e.g. "User input"). */
+.inline-field {
+    flex-direction: row !important;
+    align-items: center !important;
+    gap: var(--wb-sizing-size_080) !important;
+}

--- a/packages/perseus-editor/src/widgets/numeric-input-editor.tsx
+++ b/packages/perseus-editor/src/widgets/numeric-input-editor.tsx
@@ -1,5 +1,6 @@
 import {KhanMath} from "@khanacademy/kmath";
 import {
+    ApiOptions,
     components,
     Changeable,
     EditorJsonify,
@@ -7,7 +8,6 @@ import {
 } from "@khanacademy/perseus";
 import {
     numericInputLogic,
-    type NumericInputDefaultWidgetOptions,
     type PerseusNumericInputWidgetOptions,
 } from "@khanacademy/perseus-core";
 import Button from "@khanacademy/wonder-blocks-button";
@@ -62,7 +62,7 @@ const initAnswer = (status: string) => {
 // The "static" property is not used in this widget (per the type definition comments)
 type Props = Omit<PerseusNumericInputWidgetOptions, "static"> & {
     onChange: (results: any) => any;
-    apiOptions?: APIOptionsWithDefaults;
+    apiOptions: APIOptionsWithDefaults;
 };
 
 interface State {
@@ -81,8 +81,10 @@ class NumericInputEditor extends React.Component<Props, State> {
     static widgetName = "numeric-input";
     static displayName = "NumericInputEditor";
 
-    static defaultProps: NumericInputDefaultWidgetOptions =
-        numericInputLogic.defaultWidgetOptions;
+    static defaultProps = {
+        ...numericInputLogic.defaultWidgetOptions,
+        apiOptions: ApiOptions.defaults,
+    };
 
     constructor(props: Props) {
         super(props);
@@ -230,7 +232,7 @@ class NumericInputEditor extends React.Component<Props, State> {
 
     render() {
         const answers = this.props.answers;
-        const editingDisabled = this.props.apiOptions?.editingDisabled ?? false;
+        const editingDisabled = this.props.apiOptions.editingDisabled;
 
         const unsimplifiedAnswers = (i: any) => (
             <View className={styles.field}>

--- a/packages/perseus-editor/src/widgets/numeric-input-editor.tsx
+++ b/packages/perseus-editor/src/widgets/numeric-input-editor.tsx
@@ -7,12 +7,11 @@ import {
 } from "@khanacademy/perseus";
 import {
     numericInputLogic,
-    type MathFormat,
     type NumericInputDefaultWidgetOptions,
     type PerseusNumericInputWidgetOptions,
 } from "@khanacademy/perseus-core";
 import Button from "@khanacademy/wonder-blocks-button";
-import Pill from "@khanacademy/wonder-blocks-pill";
+import {View} from "@khanacademy/wonder-blocks-core";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import trashIcon from "@phosphor-icons/core/bold/trash-bold.svg";
 import * as React from "react";
@@ -20,15 +19,15 @@ import _ from "underscore";
 
 import Heading from "../components/heading";
 import PerseusEditorAccordion from "../components/perseus-editor-accordion";
+import {
+    SegmentedControl,
+    ToggleButtonGroup,
+} from "../components/segmented-control";
 import Editor from "../editor";
 
+import styles from "./numeric-input-editor.module.css";
+
 import type {APIOptionsWithDefaults} from "@khanacademy/perseus";
-import type {ClickableRole} from "@khanacademy/wonder-blocks-clickable";
-import type {StyleType} from "@khanacademy/wonder-blocks-core";
-import type {
-    PillSize,
-    PillKind,
-} from "@khanacademy/wonder-blocks-pill/dist/components/pill";
 
 type ChangeFn = typeof Changeable.change;
 
@@ -231,75 +230,21 @@ class NumericInputEditor extends React.Component<Props, State> {
 
     render() {
         const answers = this.props.answers;
-        const commonOptionProps: {
-            size: PillSize;
-            role: ClickableRole;
-            style: StyleType;
-        } = {
-            size: "medium",
-            role: "radio",
-            style: {marginRight: "8px"},
-        };
-
-        const SettingOption = (props: {
-            kind: "accent" | "transparent";
-            role?: "radio" | "checkbox";
-            ariaLabel?: string;
-            onClick: () => void;
-            children: any;
-        }): React.ReactElement => {
-            const {kind, onClick, ariaLabel, children} = props;
-            const role = props.role ?? "radio";
-            const pillProps = {
-                ...commonOptionProps,
-                "aria-label": ariaLabel,
-                kind: kind satisfies PillKind,
-                role: role satisfies ClickableRole,
-                onClick: onClick,
-            };
-            return <Pill {...pillProps}>{children}</Pill>;
-        };
-
-        const RadioOption = (props: {
-            answerIndex: number;
-            answerProperty: string;
-            value: string | boolean;
-            onClick?: () => void;
-            children: any;
-        }): React.ReactElement => {
-            const {answerIndex, answerProperty, value, children} = props;
-            const isSelected = answers[answerIndex][answerProperty] === value;
-            const kind = isSelected ? "accent" : "transparent";
-            const newState = {};
-            newState[answerProperty] = value;
-            const onClick =
-                props.onClick ??
-                (() => {
-                    this.updateAnswer(answerIndex, newState);
-                });
-
-            return (
-                <SettingOption kind={kind} onClick={onClick}>
-                    {children}
-                </SettingOption>
-            );
-        };
+        const editingDisabled = this.props.apiOptions?.editingDisabled ?? false;
 
         const unsimplifiedAnswers = (i: any) => (
-            <fieldset className="perseus-widget-row unsimplified-options">
+            <View className={styles.field}>
                 {answers[i]["status"] !== "correct" && (
-                    <>
-                        <legend className="inline-options">
-                            Unsimplified answers are irrelevant for this status
-                        </legend>
-                    </>
+                    <BodyText weight="semi">
+                        Unsimplified answers are irrelevant for this status
+                    </BodyText>
                 )}
                 {answers[i]["status"] === "correct" && (
                     <>
-                        <legend className="inline-options">
-                            Unsimplified answers are
-                        </legend>
-                        <span className="tooltip-for-legend">
+                        <View className={styles.labelRow}>
+                            <BodyText weight="semi">
+                                Unsimplified answers are
+                            </BodyText>
                             <InfoTip>
                                 <p>
                                     Normally select "ungraded". This will give
@@ -319,215 +264,182 @@ class NumericInputEditor extends React.Component<Props, State> {
                                     simplify.
                                 </p>
                             </InfoTip>
-                        </span>
-                        <br />
-                        <RadioOption
-                            answerIndex={i}
-                            answerProperty="simplify"
-                            value="required"
-                        >
-                            Ungraded
-                        </RadioOption>
-                        <RadioOption
-                            answerIndex={i}
-                            answerProperty="simplify"
-                            value="optional"
-                        >
-                            Accepted
-                        </RadioOption>
-                        <RadioOption
-                            answerIndex={i}
-                            answerProperty="simplify"
-                            value="enforced"
-                        >
-                            Wrong
-                        </RadioOption>
+                        </View>
+                        <SegmentedControl
+                            aria-label="Unsimplified answers are"
+                            disabled={editingDisabled}
+                            selectedValue={answers[i]["simplify"]}
+                            onChange={(value) =>
+                                this.updateAnswer(i, {simplify: value})
+                            }
+                            options={[
+                                {value: "required", label: "Ungraded"},
+                                {value: "optional", label: "Accepted"},
+                                {value: "enforced", label: "Wrong"},
+                            ]}
+                        />
                     </>
                 )}
-            </fieldset>
+            </View>
         );
 
         const suggestedAnswerTypes = (i: any) => (
             <>
-                <div className="perseus-widget-row">
-                    {/* eslint-disable-next-line jsx-a11y/label-has-associated-control -- TODO(LEMS-2871): Address a11y error */}
-                    <label>Possible answer formats&ensp;</label>
-                    <InfoTip>
-                        <p>
-                            Formats will be autoselected for you based on the
-                            given answer; to show no suggested formats and
-                            accept all types, simply have a decimal/integer be
-                            the answer. Values with &pi; will have format "pi",
-                            and values that are fractions will have some subset
-                            (mixed will be "mixed" and "proper"; improper/proper
-                            will both be "improper" and "proper"). If you would
-                            like to specify that it is only a proper fraction
-                            (or only a mixed/improper fraction), deselect the
-                            other format. Except for specific cases, you should
-                            not need to change the autoselected formats.
-                        </p>
-                        <p>
-                            To restrict the answer to <em>only</em> an improper
-                            fraction (i.e. 7/4), select the improper fraction
-                            and toggle "strict" to true. This <b>will not</b>{" "}
-                            accept 1.75 as an answer.{" "}
-                        </p>
-                        <p>
-                            Unless you are testing that specific skill, please
-                            do not restrict the answer format.
-                        </p>
-                    </InfoTip>
-                    <br />
-                    {answerFormButtons.map((format) => {
-                        const isSelected = answers[i]["answerForms"]?.includes(
-                            // eslint-disable-next-line no-restricted-syntax
-                            format.value as MathFormat,
-                        );
-                        const kind = isSelected ? "accent" : "transparent";
-                        const onClick = () => {
-                            this.onToggleAnswerForm(i, format.value);
-                        };
-
-                        return (
-                            <SettingOption
-                                key={format.value}
-                                ariaLabel={format.title}
-                                kind={kind}
-                                role="checkbox"
-                                onClick={onClick}
-                            >
-                                {format.content}
-                            </SettingOption>
-                        );
-                    })}
-                </div>
-                <fieldset className="perseus-widget-row">
-                    <legend>Answer formats are: </legend>
-                    <RadioOption
-                        answerIndex={i}
-                        answerProperty="strict"
-                        value={false}
-                    >
-                        Suggested
-                    </RadioOption>
-                    <RadioOption
-                        answerIndex={i}
-                        answerProperty="strict"
-                        value={true}
-                    >
-                        Required
-                    </RadioOption>
-                </fieldset>
+                <View className={styles.field}>
+                    <View className={styles.labelRow}>
+                        <BodyText weight="semi">
+                            Possible answer formats
+                        </BodyText>
+                        <InfoTip>
+                            <p>
+                                Formats will be autoselected for you based on
+                                the given answer; to show no suggested formats
+                                and accept all types, simply have a
+                                decimal/integer be the answer. Values with &pi;
+                                will have format "pi", and values that are
+                                fractions will have some subset (mixed will be
+                                "mixed" and "proper"; improper/proper will both
+                                be "improper" and "proper"). If you would like
+                                to specify that it is only a proper fraction (or
+                                only a mixed/improper fraction), deselect the
+                                other format. Except for specific cases, you
+                                should not need to change the autoselected
+                                formats.
+                            </p>
+                            <p>
+                                To restrict the answer to <em>only</em> an
+                                improper fraction (i.e. 7/4), select the
+                                improper fraction and toggle "strict" to true.
+                                This <b>will not</b> accept 1.75 as an answer.{" "}
+                            </p>
+                            <p>
+                                Unless you are testing that specific skill,
+                                please do not restrict the answer format.
+                            </p>
+                        </InfoTip>
+                    </View>
+                    <ToggleButtonGroup
+                        aria-label="Possible answer formats"
+                        disabled={editingDisabled}
+                        selectedValues={answers[i]["answerForms"] ?? []}
+                        onToggle={(value) => this.onToggleAnswerForm(i, value)}
+                        options={answerFormButtons.map((format) => ({
+                            value: format.value,
+                            label: format.content,
+                            ariaLabel: format.title,
+                        }))}
+                    />
+                </View>
+                <View className={styles.field}>
+                    <BodyText weight="semi">Answer formats are</BodyText>
+                    <SegmentedControl
+                        aria-label="Answer formats are"
+                        disabled={editingDisabled}
+                        selectedValue={
+                            answers[i]["strict"] ? "required" : "suggested"
+                        }
+                        onChange={(value) =>
+                            this.updateAnswer(i, {strict: value === "required"})
+                        }
+                        options={[
+                            {value: "suggested", label: "Suggested"},
+                            {value: "required", label: "Required"},
+                        ]}
+                    />
+                </View>
             </>
         );
 
         const inputSize = (
-            <fieldset className="perseus-widget-row">
-                <legend className="inline-options">Width: </legend>
-                <Pill
-                    {...commonOptionProps}
-                    kind={
-                        this.props.size === "normal" ? "accent" : "transparent"
-                    }
-                    onClick={() => {
-                        this.change("size")("normal");
-                    }}
-                >
-                    Normal (80px)
-                </Pill>
-                <Pill
-                    {...commonOptionProps}
-                    kind={
-                        this.props.size === "small" ? "accent" : "transparent"
-                    }
-                    onClick={() => {
-                        this.change("size")("small");
-                    }}
-                >
-                    Small (40px)
-                </Pill>
-                <InfoTip>
-                    <p>
-                        Use size "Normal" for all text boxes, unless there are
-                        multiple text boxes in one line and the answer area is
-                        too narrow to fit them.
-                    </p>
-                </InfoTip>
-            </fieldset>
+            <View className={styles.field}>
+                <View className={styles.labelRow}>
+                    <BodyText weight="semi">Width</BodyText>
+                    <InfoTip>
+                        <p>
+                            Use size "Normal" for all text boxes, unless there
+                            are multiple text boxes in one line and the answer
+                            area is too narrow to fit them.
+                        </p>
+                    </InfoTip>
+                </View>
+                <SegmentedControl
+                    aria-label="Width"
+                    disabled={editingDisabled}
+                    selectedValue={this.props.size}
+                    onChange={(value) => this.change("size")(value)}
+                    options={[
+                        {value: "normal", label: "Normal (80px)"},
+                        {value: "small", label: "Small (40px)"},
+                    ]}
+                />
+            </View>
         );
 
         const rightAlign = (
-            <fieldset className="perseus-widget-row">
-                <legend className="inline-options">Alignment: </legend>
-                <Pill
-                    {...commonOptionProps}
-                    kind={this.props.rightAlign ? "transparent" : "accent"}
-                    onClick={() => {
-                        this.props.onChange({rightAlign: false});
-                    }}
-                >
-                    Left
-                </Pill>
-                <Pill
-                    {...commonOptionProps}
-                    kind={this.props.rightAlign ? "accent" : "transparent"}
-                    onClick={() => {
-                        this.props.onChange({rightAlign: true});
-                    }}
-                >
-                    Right
-                </Pill>
-            </fieldset>
+            <View className={styles.field}>
+                <BodyText weight="semi">Alignment</BodyText>
+                <SegmentedControl
+                    aria-label="Alignment"
+                    disabled={editingDisabled}
+                    selectedValue={this.props.rightAlign ? "right" : "left"}
+                    onChange={(value) =>
+                        this.props.onChange({rightAlign: value === "right"})
+                    }
+                    options={[
+                        {value: "left", label: "Left"},
+                        {value: "right", label: "Right"},
+                    ]}
+                />
+            </View>
         );
 
         const labelText = (
-            <>
-                <div className="perseus-widget-row">
-                    {/* eslint-disable-next-line jsx-a11y/label-has-associated-control -- TODO(LEMS-2871): Address a11y error */}
-                    <label>Answer Field Aria label</label>
+            <View className={styles.field}>
+                <View className={styles.labelRow}>
+                    <BodyText weight="semi">Answer Field Aria label</BodyText>
                     <InfoTip>
                         <p>
                             Text to describe the Answer Field for screenreader
                             users.
                         </p>
                     </InfoTip>
-                </div>
+                </View>
                 <TextInput
                     labelText="aria label"
                     value={this.props.labelText}
                     onChange={this.change("labelText")}
                 />
-            </>
+            </View>
         );
 
         const coefficientCheck = (
-            <fieldset className="perseus-widget-row">
-                <legend className="inline-options">Number style: </legend>
-                <Pill
-                    {...commonOptionProps}
-                    kind={this.props.coefficient ? "transparent" : "accent"}
-                    onClick={() => {
-                        this.props.onChange({coefficient: false});
-                    }}
-                >
-                    Standard
-                </Pill>
-                <Pill
-                    {...commonOptionProps}
-                    kind={this.props.coefficient ? "accent" : "transparent"}
-                    onClick={() => {
-                        this.props.onChange({coefficient: true});
-                    }}
-                >
-                    Coefficient
-                </Pill>
-                <InfoTip>
-                    <p>
-                        A coefficient style number allows the student to use -
-                        for -1 and an empty string to mean 1.
-                    </p>
-                </InfoTip>
-            </fieldset>
+            <View className={styles.field}>
+                <View className={styles.labelRow}>
+                    <BodyText weight="semi">Number style</BodyText>
+                    <InfoTip>
+                        <p>
+                            A coefficient style number allows the student to use
+                            - for -1 and an empty string to mean 1.
+                        </p>
+                    </InfoTip>
+                </View>
+                <SegmentedControl
+                    aria-label="Number style"
+                    disabled={editingDisabled}
+                    selectedValue={
+                        this.props.coefficient ? "coefficient" : "standard"
+                    }
+                    onChange={(value) =>
+                        this.props.onChange({
+                            coefficient: value === "coefficient",
+                        })
+                    }
+                    options={[
+                        {value: "standard", label: "Standard"},
+                        {value: "coefficient", label: "Coefficient"},
+                    ]}
+                />
+            </View>
         );
 
         const instructions = {
@@ -583,11 +495,7 @@ class NumericInputEditor extends React.Component<Props, State> {
                                 this.onToggleAnswers(i);
                             }}
                             header={
-                                <BodyText
-                                    size="medium"
-                                    weight="bold"
-                                    tag="span"
-                                >
+                                <BodyText weight="bold" tag="span">
                                     {answerHeading}
                                 </BodyText>
                             }
@@ -598,8 +506,13 @@ class NumericInputEditor extends React.Component<Props, State> {
                                     (answer.maxError ? " with-max-error" : "")
                                 }
                             >
-                                <label>
-                                    User input:
+                                <View
+                                    tag="label"
+                                    className={styles.inlineField}
+                                >
+                                    <BodyText weight="semi">
+                                        User input
+                                    </BodyText>
                                     <NumberInput
                                         value={answer.value}
                                         className="numeric-input-value"
@@ -647,7 +560,7 @@ class NumericInputEditor extends React.Component<Props, State> {
                                             });
                                         }}
                                     />
-                                </label>
+                                </View>
                                 <span className="max-error-plusmn">
                                     &plusmn;
                                 </span>
@@ -659,51 +572,35 @@ class NumericInputEditor extends React.Component<Props, State> {
                                     onChange={this.updateAnswer(i, "maxError")}
                                 />
                             </div>
-                            <fieldset className="perseus-widget-row">
-                                <legend className="inline-options">
-                                    Status:
-                                </legend>
-                                <RadioOption
-                                    answerIndex={i}
-                                    answerProperty="status"
-                                    value="correct"
-                                    onClick={() => {
-                                        this.onEvaluationChange(i, "correct");
-                                    }}
-                                >
-                                    Correct
-                                </RadioOption>
-                                <RadioOption
-                                    answerIndex={i}
-                                    answerProperty="status"
-                                    value="wrong"
-                                    onClick={() => {
-                                        this.onEvaluationChange(i, "wrong");
-                                    }}
-                                >
-                                    Wrong
-                                </RadioOption>
-                                <RadioOption
-                                    answerIndex={i}
-                                    answerProperty="status"
-                                    value="ungraded"
-                                    onClick={() => {
-                                        this.onEvaluationChange(i, "ungraded");
-                                    }}
-                                >
-                                    Ungraded
-                                </RadioOption>
-                            </fieldset>
+                            <View className={styles.field}>
+                                <BodyText weight="semi">Status</BodyText>
+                                <SegmentedControl
+                                    aria-label="Status"
+                                    disabled={editingDisabled}
+                                    selectedValue={answers[i]["status"]}
+                                    onChange={(value) =>
+                                        this.onEvaluationChange(i, value)
+                                    }
+                                    options={[
+                                        {value: "correct", label: "Correct"},
+                                        {value: "wrong", label: "Wrong"},
+                                        {value: "ungraded", label: "Ungraded"},
+                                    ]}
+                                />
+                            </View>
                             {unsimplifiedAnswers(i)}
-                            <div className="perseus-widget-row">
-                                (Articles only) Message shown to user:
-                            </div>
-                            {editor}
+                            <View className={styles.field}>
+                                <BodyText weight="semi">
+                                    (Articles only) Message shown to user
+                                </BodyText>
+                                {editor}
+                            </View>
                             {suggestedAnswerTypes(i)}
                             <Button
                                 startIcon={trashIcon}
                                 aria-label={`Delete ${answerHeading}`}
                                 className="delete-item-button"
+                                disabled={editingDisabled}
                                 onClick={() => {
                                     this.onTrashAnswer(i);
                                 }}
@@ -745,7 +642,11 @@ class NumericInputEditor extends React.Component<Props, State> {
                 >
                     <div className="perseus-editor-accordion-content">
                         {generateInputAnswerEditors()}
-                        <Button kind="tertiary" onClick={this.addAnswer}>
+                        <Button
+                            kind="tertiary"
+                            disabled={editingDisabled}
+                            onClick={this.addAnswer}
+                        >
                             Add new answer
                         </Button>
                     </div>

--- a/packages/perseus-editor/src/widgets/radio/editor.tsx
+++ b/packages/perseus-editor/src/widgets/radio/editor.tsx
@@ -322,7 +322,8 @@ class RadioEditor extends React.Component<RadioEditorProps> {
 
     render(): React.ReactNode {
         const numCorrect = deriveNumCorrect(this.props.choices);
-        const isEditingDisabled = this.props.apiOptions.editingDisabled;
+        const isEditingDisabled =
+            this.props.apiOptions.editingDisabled ?? false;
 
         return (
             <div>
@@ -384,6 +385,7 @@ class RadioEditor extends React.Component<RadioEditorProps> {
                         }
                         onDelete={() => this.onDelete(index)}
                         onMove={this.handleMove}
+                        editingDisabled={isEditingDisabled}
                     />
                 ))}
 
@@ -394,6 +396,7 @@ class RadioEditor extends React.Component<RadioEditorProps> {
                         startIcon={plusIcon}
                         onClick={this.addChoice.bind(this, false)}
                         style={{marginInlineEnd: "2.4rem"}}
+                        disabled={isEditingDisabled}
                     >
                         Add a choice
                     </Button>
@@ -403,6 +406,7 @@ class RadioEditor extends React.Component<RadioEditorProps> {
                             kind="tertiary"
                             startIcon={plusIcon}
                             onClick={this.addChoice.bind(this, true)}
+                            disabled={isEditingDisabled}
                         >
                             None of the above
                         </Button>

--- a/packages/perseus-editor/src/widgets/radio/radio-image-editor.tsx
+++ b/packages/perseus-editor/src/widgets/radio/radio-image-editor.tsx
@@ -18,7 +18,6 @@ interface RadioImageEditorProps {
     imageAltText: string;
     onSave: (imageUrl: string, imageAltText: string) => void;
     onDelete: () => void;
-    // Whether the whole editor is disabled (apiOptions.editingDisabled).
     editingDisabled?: boolean;
 }
 

--- a/packages/perseus-editor/src/widgets/radio/radio-image-editor.tsx
+++ b/packages/perseus-editor/src/widgets/radio/radio-image-editor.tsx
@@ -18,6 +18,8 @@ interface RadioImageEditorProps {
     imageAltText: string;
     onSave: (imageUrl: string, imageAltText: string) => void;
     onDelete: () => void;
+    // Whether the whole editor is disabled (apiOptions.editingDisabled).
+    editingDisabled?: boolean;
 }
 
 export default function RadioImageEditor({
@@ -25,6 +27,7 @@ export default function RadioImageEditor({
     imageAltText,
     onSave,
     onDelete,
+    editingDisabled = false,
 }: RadioImageEditorProps): React.ReactElement {
     const uniqueId = React.useId();
     const imageUrlTextAreaId = `${uniqueId}-image-url-textarea`;
@@ -142,6 +145,7 @@ export default function RadioImageEditor({
                 onBlur={() => onSave(stateImageUrl, imageAltText)}
                 style={{marginBlockEnd: sizing.size_080}}
                 autoResize={true}
+                disabled={editingDisabled}
             />
 
             {/* Image Alt Text textarea */}
@@ -160,6 +164,7 @@ export default function RadioImageEditor({
                 placeholder="Example: Graph of a linear function..."
                 onChange={(value) => onSave(imageUrl, value)}
                 autoResize={true}
+                disabled={editingDisabled}
             />
 
             {/* Delete button */}
@@ -170,6 +175,7 @@ export default function RadioImageEditor({
                     startIcon={trashIcon}
                     style={{alignSelf: "flex-start"}}
                     onClick={onDelete}
+                    disabled={editingDisabled}
                 >
                     Delete this image
                 </Button>

--- a/packages/perseus-editor/src/widgets/radio/radio-option-content-and-image-editor.tsx
+++ b/packages/perseus-editor/src/widgets/radio/radio-option-content-and-image-editor.tsx
@@ -18,7 +18,6 @@ interface Props {
     content: string;
     choiceIndex: number;
     onContentChange: (choiceIndex: number, content: string) => void;
-    // Whether the whole editor is disabled (apiOptions.editingDisabled).
     editingDisabled?: boolean;
 }
 

--- a/packages/perseus-editor/src/widgets/radio/radio-option-content-and-image-editor.tsx
+++ b/packages/perseus-editor/src/widgets/radio/radio-option-content-and-image-editor.tsx
@@ -18,6 +18,8 @@ interface Props {
     content: string;
     choiceIndex: number;
     onContentChange: (choiceIndex: number, content: string) => void;
+    // Whether the whole editor is disabled (apiOptions.editingDisabled).
+    editingDisabled?: boolean;
 }
 
 export interface RadioOptionContentAndImageEditorHandle {
@@ -28,7 +30,13 @@ export const RadioOptionContentAndImageEditor = React.forwardRef<
     RadioOptionContentAndImageEditorHandle,
     Props
 >(function RadioOptionContentAndImageEditor(props, ref) {
-    const {content, choiceIndex, onContentChange, isNoneOfTheAbove} = props;
+    const {
+        content,
+        choiceIndex,
+        onContentChange,
+        isNoneOfTheAbove,
+        editingDisabled = false,
+    } = props;
     const uniqueId = React.useId();
     const contentTextAreaId = `${uniqueId}-content-textarea`;
     const textAreaRef = React.useRef<HTMLTextAreaElement>(null);
@@ -173,6 +181,7 @@ export const RadioOptionContentAndImageEditor = React.forwardRef<
                 }}
                 onPaste={handlePaste}
                 autoResize={true}
+                disabled={editingDisabled}
             />
 
             {/* Add image button */}
@@ -184,6 +193,7 @@ export const RadioOptionContentAndImageEditor = React.forwardRef<
                 onClick={() => {
                     handleAddImage(choiceIndex, "", "");
                 }}
+                disabled={editingDisabled}
             >
                 Add image
             </Button>
@@ -219,6 +229,7 @@ export const RadioOptionContentAndImageEditor = React.forwardRef<
                         onDelete={() => {
                             handleDeleteImageConfirmation(imageIndex);
                         }}
+                        editingDisabled={editingDisabled}
                     />
                 </PerseusEditorAccordion>
             )) ?? null}

--- a/packages/perseus-editor/src/widgets/radio/radio-option-settings-actions.tsx
+++ b/packages/perseus-editor/src/widgets/radio/radio-option-settings-actions.tsx
@@ -18,6 +18,8 @@ interface RadioOptionSettingsActionsProps {
     showMove: boolean;
     onDelete: () => void;
     onMove: (movement: ChoiceMovementType) => void;
+    // Whether the whole editor is disabled (apiOptions.editingDisabled).
+    editingDisabled: boolean;
 }
 
 export function RadioOptionSettingsActions({
@@ -26,6 +28,7 @@ export function RadioOptionSettingsActions({
     showMove,
     onDelete,
     onMove,
+    editingDisabled,
 }: RadioOptionSettingsActionsProps) {
     return (
         <div className={styles.radioOptionActionsContainer}>
@@ -44,6 +47,7 @@ export function RadioOptionSettingsActions({
                             onDelete();
                         }
                     }}
+                    disabled={editingDisabled}
                 >
                     Remove
                 </Button>
@@ -59,6 +63,7 @@ export function RadioOptionSettingsActions({
                         size="xsmall"
                         aria-label="Move choice to the top"
                         onClick={() => onMove("top")}
+                        disabled={editingDisabled}
                     />
                     <IconButton
                         icon={caretUpIcon}
@@ -66,6 +71,7 @@ export function RadioOptionSettingsActions({
                         size="xsmall"
                         aria-label="Move choice up"
                         onClick={() => onMove("up")}
+                        disabled={editingDisabled}
                     />
                     <IconButton
                         icon={caretDownIcon}
@@ -73,6 +79,7 @@ export function RadioOptionSettingsActions({
                         size="xsmall"
                         aria-label="Move choice down"
                         onClick={() => onMove("down")}
+                        disabled={editingDisabled}
                     />
                     <IconButton
                         icon={caretDoubleDownIcon}
@@ -80,6 +87,7 @@ export function RadioOptionSettingsActions({
                         size="xsmall"
                         aria-label="Move choice to the bottom"
                         onClick={() => onMove("bottom")}
+                        disabled={editingDisabled}
                     />
                 </>
             )}

--- a/packages/perseus-editor/src/widgets/radio/radio-option-settings-actions.tsx
+++ b/packages/perseus-editor/src/widgets/radio/radio-option-settings-actions.tsx
@@ -18,7 +18,6 @@ interface RadioOptionSettingsActionsProps {
     showMove: boolean;
     onDelete: () => void;
     onMove: (movement: ChoiceMovementType) => void;
-    // Whether the whole editor is disabled (apiOptions.editingDisabled).
     editingDisabled: boolean;
 }
 

--- a/packages/perseus-editor/src/widgets/radio/radio-option-settings.tsx
+++ b/packages/perseus-editor/src/widgets/radio/radio-option-settings.tsx
@@ -29,7 +29,6 @@ interface RadioOptionSettingsProps {
     showMove: boolean;
     onDelete: () => void;
     onMove: (choiceIndex: number, movement: ChoiceMovementType) => void;
-    // Whether the whole editor is disabled (apiOptions.editingDisabled).
     editingDisabled: boolean;
 }
 

--- a/packages/perseus-editor/src/widgets/radio/radio-option-settings.tsx
+++ b/packages/perseus-editor/src/widgets/radio/radio-option-settings.tsx
@@ -29,6 +29,8 @@ interface RadioOptionSettingsProps {
     showMove: boolean;
     onDelete: () => void;
     onMove: (choiceIndex: number, movement: ChoiceMovementType) => void;
+    // Whether the whole editor is disabled (apiOptions.editingDisabled).
+    editingDisabled: boolean;
 }
 
 export const RadioOptionSettings = React.forwardRef<
@@ -46,6 +48,7 @@ export const RadioOptionSettings = React.forwardRef<
         showMove,
         onDelete,
         onMove,
+        editingDisabled,
     },
     ref,
 ) {
@@ -85,6 +88,7 @@ export const RadioOptionSettings = React.forwardRef<
                             {value: "correct", label: "Correct"},
                             {value: "incorrect", label: "Incorrect"},
                         ]}
+                        disabled={editingDisabled}
                     />
                 </div>
             </fieldset>
@@ -96,6 +100,7 @@ export const RadioOptionSettings = React.forwardRef<
                 choiceIndex={index}
                 isNoneOfTheAbove={isNoneOfTheAbove ?? false}
                 onContentChange={onContentChange}
+                editingDisabled={editingDisabled}
             />
 
             <BodyText
@@ -118,6 +123,7 @@ export const RadioOptionSettings = React.forwardRef<
                     onRationaleChange(index, value);
                 }}
                 autoResize={true}
+                disabled={editingDisabled}
             />
 
             {/* Delete & reorder button */}
@@ -127,6 +133,7 @@ export const RadioOptionSettings = React.forwardRef<
                 showMove={showMove}
                 onDelete={onDelete}
                 onMove={(movement) => onMove(index, movement)}
+                editingDisabled={editingDisabled}
             />
         </div>
     );

--- a/packages/perseus/src/components/button-group.tsx
+++ b/packages/perseus/src/components/button-group.tsx
@@ -1,3 +1,4 @@
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {css, StyleSheet} from "aphrodite";
 import * as React from "react";
 
@@ -26,6 +27,11 @@ interface Props {
      * Customizes the selected button's styling.
      */
     selectedButtonStyle?: CSSProperties;
+
+    /**
+     * When true, all buttons are disabled (non-interactive and visually muted).
+     */
+    disabled?: boolean;
 }
 
 interface DefaultProps {
@@ -74,11 +80,13 @@ class ButtonGroup extends React.Component<Props> {
                     title={button.title}
                     type="button"
                     key={"" + i}
+                    disabled={this.props.disabled}
                     className={css(
                         styles.buttonStyle,
                         button.value === value && styles.selectedStyle,
                         button.value === value &&
                             this.props.selectedButtonStyle,
+                        this.props.disabled && styles.disabledStyle,
                     )}
                     onClick={() => this.toggleSelect(button.value)}
                 >
@@ -134,6 +142,15 @@ const styles = StyleSheet.create({
 
     selectedStyle: {
         backgroundColor: "#ddd",
+    },
+
+    disabledStyle: {
+        cursor: "not-allowed",
+        backgroundColor: semanticColor.core.background.disabled.default,
+        color: semanticColor.core.foreground.disabled.strong,
+        ":hover": {
+            backgroundColor: semanticColor.core.background.disabled.default,
+        },
     },
 });
 


### PR DESCRIPTION
## Summary:
This PR uses the WB props `disabled` to disable the editor components so it will be uneditable when the `apiOptions.editingDisabled` is true. This allows the content publisher to pause content editing while doing a publish. This also includes numeric input updates on removing the deprecated Pill component which was not covered in the previous PR.

Issue: LEMS-4131

## Test plan:
Have the storybook in this PR side by side with Prod storybook to easily see the difference
1. Check if the Editor still works as expected
2. Check in the Editor page's "When Editing Disabled" story confirm that editor is disabled as expected

See detailed comparison in [Improve contrast of editor controls when the whole editor is disabled](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4810375321/Improve+contrast+of+editor+controls+when+the+whole+editor+is+disabled) page

## Related PRs / Follow-up work related to `editingDisabled`
| PR | Scope | Branch | Status | Notes |
|----|-------|--------|--------|-------|
| **[PR 1](https://github.com/Khan/perseus/pull/3777)** | Phase 1 (labels) + Phase 2B (modernization of touched non-locked-figures editors) | `LEMS-4131/improve-editor-labels` | ✅ |  |
| **[PR 2](https://github.com/Khan/perseus/pull/3779)** | Phase 2A (locked-figures refactor) | `LEMS-4131/editor-locked-figures-code-refactor` | ✅ | The heaviest CSS-module migration; independent of PR 1. |
| **PR 3** | Phase 3 (numeric-input label restructuring) | — | ⚪ not started, will skip | Standalone; after Phase 2B. |
| **[PR 4](https://github.com/Khan/perseus/pull/3782)** | Phase 4 (Pill → Badge / SegmentedControl) | `LEMS-4131/editor-pill-to-badge` | ✅  | Carries a UX behavior change (radio A/B/C) |
| **[PR 5](https://github.com/Khan/perseus/pull/3787)** | Phase 5 (`editingDisabled` functional fix — the actual deliverable) | `LEMS-4131/editor-add-editing-disabled` | In Review | Depends on PR 4; starts with the `button-group` `disabled` enabler. |