### PR TITLE
Render Grapher axis labels as TeX when the Interactive Graph UI components are used

### DIFF
--- a/.changeset/loud-poets-appear.md
+++ b/.changeset/loud-poets-appear.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+When the `grapher-to-interactive-graph` feature flag is on, Grapher axis labels are now interpreted as TeX. This preserves the existing behavior of Grapher.

--- a/packages/perseus-core/src/widgets/grapher/to-interactive-graph.test.ts
+++ b/packages/perseus-core/src/widgets/grapher/to-interactive-graph.test.ts
@@ -54,4 +54,18 @@ describe("convertGrapherOptionsToInteractiveGraph", () => {
             type: "sinusoid",
         });
     });
+
+    it("wraps axis labels in $...$ delimiters so they are interpreted as TeX", () => {
+        const grapher = generateGrapherWidgetOptions({
+            availableTypes: ["sinusoid"],
+            graph: {
+                ...generateGrapherWidgetOptions().graph,
+                labels: ["x", "f(x)"],
+            },
+        });
+
+        const ig = convertGrapherOptionsToInteractiveGraph(grapher);
+
+        expect(ig?.labels).toEqual(["$x$", "$f(x)$"]);
+    });
 });

--- a/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
+++ b/packages/perseus-core/src/widgets/grapher/to-interactive-graph.ts
@@ -40,7 +40,7 @@ export function convertGrapherOptionsToInteractiveGraph(
         snapStep: grapherOptions.graph.snapStep,
         backgroundImage: grapherOptions.graph.backgroundImage,
         markings: grapherOptions.graph.markings,
-        labels: grapherOptions.graph.labels,
+        labels: grapherOptions.graph.labels.map(wrapTexInDelimitersForMarkdown),
         labelLocation: "onAxis",
         showAxisArrows: {
             xMin: true,
@@ -186,4 +186,8 @@ function grapherAnswerTypesToPerseusGraphType(
 
 function grapherFunctionTypeToInteractiveGraphType(type: GrapherFunctionType) {
     return type === "absolute_value" ? "absolute-value" : type;
+}
+
+function wrapTexInDelimitersForMarkdown(tex): string {
+    return `$${tex}$`;
 }


### PR DESCRIPTION
## Summary:
The old Grapher UI assumed axis labels were formatted as bare TeX. Interactive
Graph assumes they are text which may contain TeX surrounded by `$...$`
delimiters. This means we have to adapt the label format when rendering a
Grapher using the Interactive Graph components.

Issue: LEMS-4285

## Test plan:

View this exercise with the `grapher-to-interactive-graph` feature flag turned
on for your account:

- https://www.khanacademy.org/internal-courses/test-everything/test-everything-1/te-grapher/e/grapher-exercise

The graph axis labels (`x`, `y`) should be italicized.