### PR TITLE
Mark input-number widget as accessible (LEMS-4184)

### DIFF
--- a/.changeset/input-number-accessible.md
+++ b/.changeset/input-number-accessible.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus-core": patch
 ---
 
-Mark the input-number widget as accessible. Items using input-number are no longer reported as inaccessible, since input-number now renders and scores as a NumericInput.
+Mark the input-number widget as accessible. Items using input-number are no longer reported as inaccessible, as input-number now renders and scores as a NumericInput.

--- a/.changeset/input-number-accessible.md
+++ b/.changeset/input-number-accessible.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+Mark the input-number widget as accessible. Items using input-number are no longer reported as inaccessible, since input-number now renders and scores as a NumericInput.

--- a/packages/perseus-core/src/accessibility.test.ts
+++ b/packages/perseus-core/src/accessibility.test.ts
@@ -7,6 +7,7 @@ import {
     generateImageOptions,
     generateImageWidget,
 } from "./utils/generators/image-widget-generator";
+import {generateInputNumberWidget} from "./utils/generators/input-number-widget-generator";
 import {
     generateIGPointGraph,
     generateInteractiveGraphOptions,
@@ -104,6 +105,21 @@ describe("isItemAccessible", () => {
                 }),
             });
 
+            expect(isItemAccessible(itemData)).toBe(true);
+        });
+
+        it("returns true for an item whose only widget is input-number", () => {
+            // Arrange
+            const itemData: PerseusItem = generateTestPerseusItem({
+                question: generateTestPerseusRenderer({
+                    content: "Enter a number: [[☃ input-number 1]]",
+                    widgets: {
+                        "input-number 1": generateInputNumberWidget(),
+                    },
+                }),
+            });
+
+            // Act, Assert
             expect(isItemAccessible(itemData)).toBe(true);
         });
 

--- a/packages/perseus-core/src/widgets/input-number/index.ts
+++ b/packages/perseus-core/src/widgets/input-number/index.ts
@@ -31,7 +31,7 @@ const inputNumberWidgetLogic: WidgetLogic<
     version: {major: 1, minor: 0},
     defaultWidgetOptions,
     defaultAlignment: "inline-block",
-    accessible: false,
+    accessible: true,
     getPublicWidgetOptions: getInputNumberPublicWidgetOptions,
 };
 


### PR DESCRIPTION
## Summary:
input-number now renders and scores as a NumericInput, so items using it
should no longer be reported as inaccessible. Flip the widget's accessible
flag to true and add a test covering the item-level behavior.

Issue: LEMS-4184

## Test plan:
- Tests pass