### PR TITLE
[Interactive Graph] Vector graph description polish.

### DIFF
--- a/.changeset/vector-sr-description-polish.md
+++ b/.changeset/vector-sr-description-polish.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Interactive Graph] Update screen reader descriptions for vector graph

--- a/packages/perseus/src/strings.ts
+++ b/packages/perseus/src/strings.ts
@@ -399,25 +399,32 @@ export type PerseusStrings = {
     srVectorPoints: ({
         tailX,
         tailY,
-        tipX,
-        tipY,
+        headX,
+        headY,
     }: {
         tailX: string;
         tailY: string;
-        tipX: string;
-        tipY: string;
+        headX: string;
+        headY: string;
     }) => string;
-    srVectorTipPoint: ({x, y}: {x: string; y: string}) => string;
+    srVectorHeadPoint: ({x, y}: {x: string; y: string}) => string;
+    srVectorMagnitudeDirection: ({
+        magnitude,
+        direction,
+    }: {
+        magnitude: string;
+        direction: string;
+    }) => string;
     srVectorGrabHandle: ({
         tailX,
         tailY,
-        tipX,
-        tipY,
+        headX,
+        headY,
     }: {
         tailX: string;
         tailY: string;
-        tipX: string;
-        tipY: string;
+        headX: string;
+        headY: string;
     }) => string;
     srQuadraticGraph: string;
     srQuadraticFaceUp: string;
@@ -1075,20 +1082,26 @@ export const strings = {
     },
     srVectorPoints: {
         context:
-            "Screen reader description for the tail and tip of a vector in the interactive graph widget.",
+            "Screen reader description for the tail and head of a vector in the interactive graph widget.",
         message:
-            "The tail is at %(tailX)s comma %(tailY)s and the tip is at %(tipX)s comma %(tipY)s.",
+            "The tail is at %(tailX)s comma %(tailY)s and the head is at %(headX)s comma %(headY)s.",
     },
-    srVectorTipPoint: {
+    srVectorHeadPoint: {
         context:
-            "Aria label for the tip point of a Vector (the point with the arrowhead) in the interactive graph widget.",
-        message: "Tip point at %(x)s comma %(y)s.",
+            "Aria label for the head point of a Vector (the point with the arrowhead) in the interactive graph widget.",
+        message: "Vector head at %(x)s comma %(y)s.",
+    },
+    srVectorMagnitudeDirection: {
+        context:
+            "Screen reader description of a vector's magnitude (length) and direction (angle in degrees, measured counterclockwise from the positive x-axis) in the interactive graph widget.",
+        message:
+            "The vector has a magnitude of %(magnitude)s and a direction of %(direction)s degrees.",
     },
     srVectorGrabHandle: {
         context:
             "Aria label for the interactive segment that allows the user to move the whole Vector in the interactive graph widget.",
         message:
-            "Vector from %(tailX)s comma %(tailY)s to %(tipX)s comma %(tipY)s.",
+            "Vector from %(tailX)s comma %(tailY)s to %(headX)s comma %(headY)s.",
     },
     srQuadraticGraph: {
         context:
@@ -1668,11 +1681,13 @@ export const mockStrings: PerseusStrings = {
     srRayEndpoint: ({x, y}) => `Endpoint at ${x} comma ${y}.`,
     srRayTerminalPoint: ({x, y}) => `Through point at ${x} comma ${y}.`,
     srVectorGraph: "A vector on a coordinate plane.",
-    srVectorPoints: ({tailX, tailY, tipX, tipY}) =>
-        `The tail is at ${tailX} comma ${tailY} and the tip is at ${tipX} comma ${tipY}.`,
-    srVectorTipPoint: ({x, y}) => `Tip point at ${x} comma ${y}.`,
-    srVectorGrabHandle: ({tailX, tailY, tipX, tipY}) =>
-        `Vector from ${tailX} comma ${tailY} to ${tipX} comma ${tipY}.`,
+    srVectorPoints: ({tailX, tailY, headX, headY}) =>
+        `The tail is at ${tailX} comma ${tailY} and the head is at ${headX} comma ${headY}.`,
+    srVectorHeadPoint: ({x, y}) => `Vector head at ${x} comma ${y}.`,
+    srVectorMagnitudeDirection: ({magnitude, direction}) =>
+        `The vector has a magnitude of ${magnitude} and a direction of ${direction} degrees.`,
+    srVectorGrabHandle: ({tailX, tailY, headX, headY}) =>
+        `Vector from ${tailX} comma ${tailY} to ${headX} comma ${headY}.`,
     srQuadraticGraph: "A parabola on a 4-quadrant coordinate plane.",
     srQuadraticFaceUp: "The parabola opens upward.",
     srQuadraticFaceDown: "The parabola opens downward.",

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.test.ts
@@ -757,14 +757,14 @@ describe("getAnnouncementText", () => {
             expect(result).toBe("Point 1 at -1 comma 2.");
         });
 
-        it("returns the tip label at the tip (index 1)", () => {
+        it("returns the head label at the head (index 1)", () => {
             const result = getAnnouncementText(
                 {type: "move-vector-point", pointIndex: 1, x: 5, y: 6},
                 mockStrings,
                 "en",
             );
 
-            expect(result).toBe("Tip point at 5 comma 6.");
+            expect(result).toBe("Vector head at 5 comma 6.");
         });
     });
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/screenreader-text.ts
@@ -30,8 +30,8 @@ export function getAnnouncementText(
             return strings.srVectorGrabHandle({
                 tailX: srFormatNumber(state.coords[0][0], locale),
                 tailY: srFormatNumber(state.coords[0][1], locale),
-                tipX: srFormatNumber(state.coords[1][0], locale),
-                tipY: srFormatNumber(state.coords[1][1], locale),
+                headX: srFormatNumber(state.coords[1][0], locale),
+                headY: srFormatNumber(state.coords[1][1], locale),
             });
         case "move-segment-point":
             return srSegmentPointLabel(state, strings, locale);
@@ -418,11 +418,11 @@ function srVectorPointLabel(
 ): string {
     const x = srFormatNumber(state.x, locale);
     const y = srFormatNumber(state.y, locale);
-    // Index 0 is the vector's tail (generic point label); index 1 is the tip,
+    // Index 0 is the vector's tail (generic point label); index 1 is the head,
     // which has a dedicated label.
     return state.pointIndex === 0
         ? strings.srPointAtCoordinates({num: 1, x, y})
-        : strings.srVectorTipPoint({x, y});
+        : strings.srVectorHeadPoint({x, y});
 }
 
 function srPolygonLabel(

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/vector.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/vector.test.tsx
@@ -58,7 +58,7 @@ describe("Vector graph screen reader", () => {
         // Assert
         expect(vectorGraph).toBeInTheDocument();
         expect(vectorGraph).toHaveAccessibleDescription(
-            "The tail is at -5 comma 0 and the tip is at 5 comma 0.",
+            "The tail is at -5 comma 0 and the head is at 5 comma 0. The vector has a magnitude of 10 and a direction of 0 degrees.",
         );
     });
 
@@ -78,19 +78,19 @@ describe("Vector graph screen reader", () => {
         );
     });
 
-    it("renders the tip point with an aria label", () => {
+    it("renders the head point with an aria label", () => {
         // Arrange
         render(<MafsGraph {...baseMafsGraphProps} state={baseVectorState} />);
 
         // Act
         const movableElements = screen.getAllByRole("button");
-        // Tab order: grab handle first, then tip point
-        const tipPoint = movableElements[1];
+        // Tab order: grab handle first, then head point
+        const headPoint = movableElements[1];
 
         // Assert
-        expect(tipPoint).toHaveAttribute(
+        expect(headPoint).toHaveAttribute(
             "aria-label",
-            "Tip point at 5 comma 0.",
+            "Vector head at 5 comma 0.",
         );
     });
 
@@ -125,16 +125,16 @@ describe("Vector graph screen reader", () => {
 
         // Act
         const movableElements = screen.getAllByRole("button");
-        const [grabHandle, tipPoint] = movableElements;
+        const [grabHandle, headPoint] = movableElements;
 
         // Assert
         expect(grabHandle).toHaveAttribute(
             "aria-label",
             "Vector from 1 comma 2 to 4 comma 6.",
         );
-        expect(tipPoint).toHaveAttribute(
+        expect(headPoint).toHaveAttribute(
             "aria-label",
-            "Tip point at 4 comma 6.",
+            "Vector head at 4 comma 6.",
         );
     });
 });
@@ -150,14 +150,17 @@ describe("describeVectorGraph", () => {
         // Assert
         expect(strings.srVectorGraph).toBe("A vector on a coordinate plane.");
         expect(strings.srVectorPoints).toBe(
-            "The tail is at -5 comma 0 and the tip is at 5 comma 0.",
+            "The tail is at -5 comma 0 and the head is at 5 comma 0.",
         );
-        expect(strings.srVectorTipPoint).toBe("Tip point at 5 comma 0.");
+        expect(strings.srVectorHeadPoint).toBe("Vector head at 5 comma 0.");
         expect(strings.srVectorGrabHandle).toBe(
             "Vector from -5 comma 0 to 5 comma 0.",
         );
+        expect(strings.srVectorDescription).toBe(
+            "The tail is at -5 comma 0 and the head is at 5 comma 0. The vector has a magnitude of 10 and a direction of 0 degrees.",
+        );
         expect(strings.srVectorInteractiveElement).toBe(
-            "Interactive elements: A vector on a coordinate plane. The tail is at -5 comma 0 and the tip is at 5 comma 0.",
+            "Interactive elements: A vector on a coordinate plane. The tail is at -5 comma 0 and the head is at 5 comma 0.",
         );
     });
 
@@ -177,11 +180,30 @@ describe("describeVectorGraph", () => {
         // Assert
         expect(strings.srVectorGraph).toBe("A vector on a coordinate plane.");
         expect(strings.srVectorPoints).toBe(
-            "The tail is at 1 comma 2 and the tip is at 4 comma 6.",
+            "The tail is at 1 comma 2 and the head is at 4 comma 6.",
         );
-        expect(strings.srVectorTipPoint).toBe("Tip point at 4 comma 6.");
+        expect(strings.srVectorHeadPoint).toBe("Vector head at 4 comma 6.");
         expect(strings.srVectorGrabHandle).toBe(
             "Vector from 1 comma 2 to 4 comma 6.",
+        );
+    });
+
+    it("describes the vector's magnitude and direction", () => {
+        // Arrange, Act — a 3-4-5 vector pointing up and to the right.
+        const strings = describeVectorGraph(
+            {
+                ...baseVectorState,
+                coords: [
+                    [1, 2],
+                    [4, 6],
+                ],
+            },
+            mockPerseusI18nContext,
+        );
+
+        // Assert
+        expect(strings.srVectorDescription).toBe(
+            "The tail is at 1 comma 2 and the head is at 4 comma 6. The vector has a magnitude of 5 and a direction of 53.13 degrees.",
         );
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/vector.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/vector.tsx
@@ -317,8 +317,6 @@ export function describeVectorGraph(
         direction: srFormatNumber(normalizedDirection, locale),
     });
 
-    // The full graph description appends the magnitude/direction sentence to
-    // the tail/head coordinates.
     const srVectorDescription = `${srVectorPoints} ${srVectorMagnitudeDirection}`;
 
     const srVectorInteractiveElement = strings.srInteractiveElements({

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/vector.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/vector.tsx
@@ -59,8 +59,8 @@ const VectorGraph = (props: Props) => {
     // Aria label strings
     const {
         srVectorGraph,
-        srVectorPoints,
-        srVectorTipPoint,
+        srVectorDescription,
+        srVectorHeadPoint,
         srVectorGrabHandle,
     } = describeVectorGraph(props.graphState, {strings, locale});
 
@@ -70,7 +70,7 @@ const VectorGraph = (props: Props) => {
     const tipArrowhead = useTipArrowhead({
         tail,
         tip,
-        ariaLabel: srVectorTipPoint,
+        ariaLabel: srVectorHeadPoint,
         ariaDescribedBy: pointsDescriptionId,
         onMove: (destination) => dispatch(actions.vector.moveTip(destination)),
     });
@@ -99,7 +99,9 @@ const VectorGraph = (props: Props) => {
             {tipArrowhead.visibleArrowhead}
 
             {/* Hidden SR description */}
-            <SRDescInSVG id={pointsDescriptionId}>{srVectorPoints}</SRDescInSVG>
+            <SRDescInSVG id={pointsDescriptionId}>
+                {srVectorDescription}
+            </SRDescInSVG>
         </g>
     );
 };
@@ -286,19 +288,38 @@ export function describeVectorGraph(
     const srVectorPoints = strings.srVectorPoints({
         tailX: srFormatNumber(tail[X], locale),
         tailY: srFormatNumber(tail[Y], locale),
-        tipX: srFormatNumber(tip[X], locale),
-        tipY: srFormatNumber(tip[Y], locale),
+        headX: srFormatNumber(tip[X], locale),
+        headY: srFormatNumber(tip[Y], locale),
     });
-    const srVectorTipPoint = strings.srVectorTipPoint({
+    const srVectorHeadPoint = strings.srVectorHeadPoint({
         x: srFormatNumber(tip[X], locale),
         y: srFormatNumber(tip[Y], locale),
     });
     const srVectorGrabHandle = strings.srVectorGrabHandle({
         tailX: srFormatNumber(tail[X], locale),
         tailY: srFormatNumber(tail[Y], locale),
-        tipX: srFormatNumber(tip[X], locale),
-        tipY: srFormatNumber(tip[Y], locale),
+        headX: srFormatNumber(tip[X], locale),
+        headY: srFormatNumber(tip[Y], locale),
     });
+
+    // Magnitude (length) and direction (angle measured counterclockwise from
+    // the positive x-axis, normalized to [0, 360) degrees) of the vector from
+    // tail to head. The tail and head can never overlap, so the magnitude is
+    // always positive and the angle is always well-defined.
+    const dx = tip[X] - tail[X];
+    const dy = tip[Y] - tail[Y];
+    const magnitude = Math.sqrt(dx * dx + dy * dy);
+    const directionDegrees = (Math.atan2(dy, dx) * 180) / Math.PI;
+    const normalizedDirection =
+        directionDegrees < 0 ? directionDegrees + 360 : directionDegrees;
+    const srVectorMagnitudeDirection = strings.srVectorMagnitudeDirection({
+        magnitude: srFormatNumber(magnitude, locale),
+        direction: srFormatNumber(normalizedDirection, locale),
+    });
+
+    // The full graph description appends the magnitude/direction sentence to
+    // the tail/head coordinates.
+    const srVectorDescription = `${srVectorPoints} ${srVectorMagnitudeDirection}`;
 
     const srVectorInteractiveElement = strings.srInteractiveElements({
         elements: [srVectorGraph, srVectorPoints].join(" "),
@@ -307,7 +328,8 @@ export function describeVectorGraph(
     return {
         srVectorGraph,
         srVectorPoints,
-        srVectorTipPoint,
+        srVectorDescription,
+        srVectorHeadPoint,
         srVectorGrabHandle,
         srVectorInteractiveElement,
     };


### PR DESCRIPTION
## Summary:
Updating the Vector graph descriptions so the screen reader copy matches the [Vector outline doc](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4817355148/Vector), and adding magnitude/direction context that is essential for all learners:
- Renames the user-facing "tip" terminology to "head" (the graph description, the arrowhead handle label, and the `srVectorTipPoint` → `srVectorHeadPoint` string key).
- Adds the vector's **magnitude** (length) and **direction** (angle in degrees, measured counterclockwise from the positive x-axis) to the graph description.

Follows the same pattern as the exponential (#3786) and logarithm (#3798) description polish.


Issue: LEMS-4124

## Test plan:

Run `pnpm storybook` and open **Widgets → Interactive Graph → Vector**. These are screen-reader strings, so verify with a screen reader or by inspecting the element `aria-label`s / `aria-describedby` text. Check:

1. **Graph description** — announces the tail and head coordinates and the vector's magnitude and direction, e.g. *"The tail is at 0 comma 0 and the head is at 6 comma 6. The vector has a magnitude of 8.485 and a direction of 45 degrees."* Drag the body/head to confirm it updates.
2. **Head handle** — reads *"Vector head at X comma Y."* (was "Tip point at …").
3. **Body grab handle** — reads *"Vector from … to …."* (unchanged).
4. **Interactive elements summary** — *"A vector on a coordinate plane. The tail is at …, and the head is at …."*
5. **Live announcements** — moving the head announces *"Vector head at X comma Y."* and dragging the whole vector announces *"Vector from … to …."* (kept minimal, matching the doc's notifications).
