### PR TITLE
Bugfix: axes thickness when on the edge

### DIFF
--- a/.changeset/old-jokes-breathe.md
+++ b/.changeset/old-jokes-breathe.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix axes from getting cut off when they're on the edge of an InteractiveGraph

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
@@ -47,6 +47,7 @@ import {
     floatingPointIssueQuestion,
     ungradedQuestion,
     noTicks,
+    onEdge,
 } from "../interactive-graph.testdata";
 
 import type {Meta, StoryObj} from "@storybook/react-vite";
@@ -576,6 +577,14 @@ export const NoTicks: Story = {
     args: {
         item: generateTestPerseusItem({
             question: noTicks,
+        }),
+    },
+};
+
+export const OnEdge: Story = {
+    args: {
+        item: generateTestPerseusItem({
+            question: onEdge,
         }),
     },
 };

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph.stories.tsx
@@ -47,7 +47,8 @@ import {
     floatingPointIssueQuestion,
     ungradedQuestion,
     noTicks,
-    onEdge,
+    onEdgeLeftBottom,
+    onEdgeRightTop,
 } from "../interactive-graph.testdata";
 
 import type {Meta, StoryObj} from "@storybook/react-vite";
@@ -581,10 +582,18 @@ export const NoTicks: Story = {
     },
 };
 
-export const OnEdge: Story = {
+export const OnEdgeLeftBottom: Story = {
     args: {
         item: generateTestPerseusItem({
-            question: onEdge,
+            question: onEdgeLeftBottom,
+        }),
+    },
+};
+
+export const OnEdgeRightTop: Story = {
+    args: {
+        item: generateTestPerseusItem({
+            question: onEdgeRightTop,
         }),
     },
 };

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -153,6 +153,60 @@ exports[`Interactive Graph A none-type graph renders predictably: first render 1
                           <g
                             stroke="var(--mafs-origin-color)"
                             stroke-width="var(--mafs-axis-stroke-width)"
+                          />
+                          <g
+                            class="mafs-shadow"
+                          />
+                        </g>
+                      </svg>
+                      <svg
+                        height="400"
+                        preserveAspectRatio="xMidYMin"
+                        viewBox="-200 -200 400 400"
+                        width="400"
+                        x="-200"
+                        y="-200"
+                      >
+                        <g
+                          fill="none"
+                        >
+                          <pattern
+                            height="20"
+                            id="cartesian-1"
+                            patternUnits="userSpaceOnUse"
+                            width="20"
+                            x="0"
+                            y="0"
+                          >
+                            <pattern
+                              height="20"
+                              id="cartesian-1-subdivision"
+                              patternUnits="userSpaceOnUse"
+                              width="20"
+                            >
+                              <g
+                                stroke="var(--grid-line-subdivision-color)"
+                              />
+                            </pattern>
+                            <rect
+                              fill="url(#cartesian-1-subdivision)"
+                              height="20"
+                              width="20"
+                            />
+                            <g
+                              stroke="var(--mafs-line-color)"
+                            />
+                          </pattern>
+                          <rect
+                            fill="url(#cartesian-1)"
+                            height="640"
+                            width="640"
+                            x="-320"
+                            y="-320"
+                          />
+                          <g
+                            stroke="var(--mafs-origin-color)"
+                            stroke-width="var(--mafs-axis-stroke-width)"
                           >
                             <line
                               x1="-320"

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/grid.tsx
@@ -7,14 +7,6 @@ import type {SizeClass} from "../../../util/sizing-utils";
 import type {GraphRange, MarkingsType} from "@khanacademy/perseus-core";
 import type {vec} from "mafs";
 
-/**
- * The width, in pixels, of the rendered axis lines. Must be kept in sync with
- * the `--mafs-axis-stroke-width` CSS variable in mafs-styles.css. It's
- * duplicated here so callers can account for the stroke width when clipping
- * the axes (see how `<Axes>` is clipped in mafs-graph.tsx).
- */
-export const AXIS_STROKE_WIDTH = 2;
-
 interface GridProps {
     gridStep: vec.Vector2;
     range: GraphRange;
@@ -23,12 +15,6 @@ interface GridProps {
     width: number;
     height: number;
 }
-
-/**
- * Whether the axis lines should be drawn for the given markings.
- */
-export const axesAreShown = (markings: MarkingsType): boolean =>
-    markings === "graph" || markings === "axes";
 
 /**
  * gridLineOptions determine the grid-line options for Mafs, with the axis
@@ -61,7 +47,7 @@ const gridLineOptions = (
  */
 const axisLineOptions = (props: Omit<GridProps, "containerSizeClass">) => {
     return {
-        axis: axesAreShown(props.markings),
+        axis: props.markings === "graph" || props.markings === "axes",
         lines: false as const,
         labels: false as const,
     };

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/grid.tsx
@@ -35,7 +35,7 @@ const gridLineOptions = (
     const lines: number | false =
         props.markings === "axes" ? false : props.gridStep[axisIndex];
     return {
-        axis: false as const,
+        axis: false,
         lines: lines,
         labels: false as const,
     };

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/grid.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/grid.tsx
@@ -7,6 +7,14 @@ import type {SizeClass} from "../../../util/sizing-utils";
 import type {GraphRange, MarkingsType} from "@khanacademy/perseus-core";
 import type {vec} from "mafs";
 
+/**
+ * The width, in pixels, of the rendered axis lines. Must be kept in sync with
+ * the `--mafs-axis-stroke-width` CSS variable in mafs-styles.css. It's
+ * duplicated here so callers can account for the stroke width when clipping
+ * the axes (see how `<Axes>` is clipped in mafs-graph.tsx).
+ */
+export const AXIS_STROKE_WIDTH = 2;
+
 interface GridProps {
     gridStep: vec.Vector2;
     range: GraphRange;
@@ -17,7 +25,15 @@ interface GridProps {
 }
 
 /**
- * axisOptions determine axis options for Mafs
+ * Whether the axis lines should be drawn for the given markings.
+ */
+export const axesAreShown = (markings: MarkingsType): boolean =>
+    markings === "graph" || markings === "axes";
+
+/**
+ * gridLineOptions determine the grid-line options for Mafs, with the axis
+ * lines disabled. The axis lines are rendered separately by `<Axes>` so that
+ * they can be clipped differently from the grid lines (see `<Axes>` below).
  *
  * axisIndex is for grabbing data in an array that contains
  * data for multiple axes. For example range: [[-10, 10], [-10, 10]]
@@ -26,24 +42,58 @@ interface GridProps {
  * @param {GridProps} props
  * @param {number} axisIndex which axis we're getting options for
  */
-const axisOptions = (
+const gridLineOptions = (
     props: Omit<GridProps, "containerSizeClass">,
     axisIndex: number,
 ) => {
     const lines: number | false =
         props.markings === "axes" ? false : props.gridStep[axisIndex];
     return {
-        axis: props.markings === "graph" || props.markings === "axes",
+        axis: false as const,
         lines: lines,
         labels: false as const,
     };
 };
 
+/**
+ * axisLineOptions determine the axis-line options for Mafs, with the grid
+ * lines disabled.
+ */
+const axisLineOptions = (props: Omit<GridProps, "containerSizeClass">) => {
+    return {
+        axis: axesAreShown(props.markings),
+        lines: false as const,
+        labels: false as const,
+    };
+};
+
+/**
+ * Renders the Cartesian grid lines (not the axis lines). This is intended to
+ * be clipped to the graph's exact bounds so grid lines never spill past the
+ * edge. The axis lines are rendered separately by `<Axes>`.
+ */
 export const Grid = (props: GridProps) => {
     return props.markings === "none" ? null : (
         <Coordinates.Cartesian
-            xAxis={axisOptions(props, X)}
-            yAxis={axisOptions(props, Y)}
+            xAxis={gridLineOptions(props, X)}
+            yAxis={gridLineOptions(props, Y)}
+        />
+    );
+};
+
+/**
+ * Renders the Cartesian axis lines (not the grid lines). When an axis sits on
+ * the graph's edge, the outer half of its stroke would be clipped away by the
+ * graph bounds, making the axis look half its intended width. To avoid that,
+ * this is clipped to the graph bounds expanded outward (by half the stroke
+ * width) only on the sides where an axis sits on the edge — see how this is
+ * clipped in mafs-graph.tsx.
+ */
+export const Axes = (props: GridProps) => {
+    return props.markings === "none" ? null : (
+        <Coordinates.Cartesian
+            xAxis={axisLineOptions(props)}
+            yAxis={axisLineOptions(props)}
         />
     );
 };

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/clip-to-graph-bounds.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/clip-to-graph-bounds.tsx
@@ -14,7 +14,23 @@ import {calculateNestedSVGCoords} from "../../utils";
 // React context from Mafs and the --mafs-view-transform CSS variable
 // both survive the nested SVG, so Mafs primitives continue to render
 // correctly inside it.
-export function ClipToGraphBounds({children}: {children: React.ReactNode}) {
+//
+// `expand` grows the clip region outward (in pixels) on the given sides,
+// while preserving the identity mapping between the nested SVG's coordinates
+// and the parent's. Use it for content that sits exactly on the graph
+// boundary and would otherwise have the outer half of its stroke clipped away
+// (e.g. an axis line sitting on the edge). Only the side the stroke spills
+// over is expanded, so the perpendicular ends of the content stay clipped to
+// the graph bounds.
+type Insets = {top?: number; right?: number; bottom?: number; left?: number};
+
+export function ClipToGraphBounds({
+    children,
+    expand,
+}: {
+    children: React.ReactNode;
+    expand?: Insets;
+}) {
     const {range, graphDimensionsInPixels} = useGraphConfig();
     const [pixelWidth, pixelHeight] = graphDimensionsInPixels;
     const {viewboxX, viewboxY} = calculateNestedSVGCoords(
@@ -22,14 +38,19 @@ export function ClipToGraphBounds({children}: {children: React.ReactNode}) {
         pixelWidth,
         pixelHeight,
     );
+    const {top = 0, right = 0, bottom = 0, left = 0} = expand ?? {};
+    const x = viewboxX - left;
+    const y = viewboxY - top;
+    const clipWidth = pixelWidth + left + right;
+    const clipHeight = pixelHeight + top + bottom;
     return (
         <svg
-            width={pixelWidth}
-            height={pixelHeight}
-            viewBox={`${viewboxX} ${viewboxY} ${pixelWidth} ${pixelHeight}`}
+            width={clipWidth}
+            height={clipHeight}
+            viewBox={`${x} ${y} ${clipWidth} ${clipHeight}`}
             preserveAspectRatio="xMidYMin"
-            x={viewboxX}
-            y={viewboxY}
+            x={x}
+            y={y}
         >
             {children}
         </svg>

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/clip-to-graph-bounds.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/clip-to-graph-bounds.tsx
@@ -3,6 +3,8 @@ import * as React from "react";
 import useGraphConfig from "../../reducer/use-graph-config";
 import {calculateNestedSVGCoords} from "../../utils";
 
+type Insets = {top?: number; right?: number; bottom?: number; left?: number};
+
 // Clips its children to the graph's visible bounds via a nested <svg>
 // sized to the graph range (default SVG overflow:hidden does the
 // clipping). Wrap any rendering that could extend past the graph if
@@ -22,8 +24,6 @@ import {calculateNestedSVGCoords} from "../../utils";
 // (e.g. an axis line sitting on the edge). Only the side the stroke spills
 // over is expanded, so the perpendicular ends of the content stay clipped to
 // the graph bounds.
-type Insets = {top?: number; right?: number; bottom?: number; left?: number};
-
 export function ClipToGraphBounds({
     children,
     expand,

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -1645,3 +1645,26 @@ export const circleWithCustomLabelsQuestion: PerseusRenderer =
             showPointLabels: true,
         }),
     });
+
+// A graph where the axis lines are on the edge of the chart
+// see: https://khanacademy.atlassian.net/browse/LEMS-4273
+export const onEdge: PerseusRenderer = generateInteractiveGraphQuestion({
+    range: [
+        [0, 10],
+        [0, 10],
+    ],
+    showAxisArrows: {
+        xMin: false,
+        xMax: true,
+        yMin: false,
+        yMax: true,
+    },
+    labels: ["My cool X label", "My cool Y label"],
+    labelLocation: "alongEdge",
+    correct: generateIGLinearGraph({
+        coords: [
+            [0, 0],
+            [5, 5],
+        ],
+    }),
+});

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.testdata.ts
@@ -1648,23 +1648,49 @@ export const circleWithCustomLabelsQuestion: PerseusRenderer =
 
 // A graph where the axis lines are on the edge of the chart
 // see: https://khanacademy.atlassian.net/browse/LEMS-4273
-export const onEdge: PerseusRenderer = generateInteractiveGraphQuestion({
-    range: [
-        [0, 10],
-        [0, 10],
-    ],
-    showAxisArrows: {
-        xMin: false,
-        xMax: true,
-        yMin: false,
-        yMax: true,
-    },
-    labels: ["My cool X label", "My cool Y label"],
-    labelLocation: "alongEdge",
-    correct: generateIGLinearGraph({
-        coords: [
-            [0, 0],
-            [5, 5],
+export const onEdgeLeftBottom: PerseusRenderer =
+    generateInteractiveGraphQuestion({
+        range: [
+            [0, 10],
+            [0, 10],
         ],
-    }),
-});
+        showAxisArrows: {
+            xMin: false,
+            xMax: true,
+            yMin: false,
+            yMax: true,
+        },
+        labels: ["My cool X label", "My cool Y label"],
+        labelLocation: "alongEdge",
+        correct: generateIGLinearGraph({
+            coords: [
+                [0, 0],
+                [5, 5],
+            ],
+        }),
+    });
+
+// A graph where the axis lines are on the edge of the chart
+// see: https://khanacademy.atlassian.net/browse/LEMS-4273
+export const onEdgeRightTop: PerseusRenderer = generateInteractiveGraphQuestion(
+    {
+        range: [
+            [-10, 0],
+            [-10, 0],
+        ],
+        showAxisArrows: {
+            xMin: true,
+            xMax: false,
+            yMin: true,
+            yMax: false,
+        },
+        labels: ["My cool X label", "My cool Y label"],
+        labelLocation: "alongEdge",
+        correct: generateIGLinearGraph({
+            coords: [
+                [0, 0],
+                [5, 5],
+            ],
+        }),
+    },
+);

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -24,7 +24,7 @@ import {useDependencies} from "../../dependencies";
 import AxisArrows from "./backgrounds/axis-arrows";
 import AxisLabels from "./backgrounds/axis-labels";
 import {AxisTicks} from "./backgrounds/axis-ticks";
-import {Grid} from "./backgrounds/grid";
+import {Axes, axesAreShown, AXIS_STROKE_WIDTH, Grid} from "./backgrounds/grid";
 import {LegacyGrid} from "./backgrounds/legacy-grid";
 import {
     fontSize,
@@ -199,6 +199,23 @@ export const MafsGraph = (props: MafsGraphProps) => {
         showsAxisLabels,
     );
 
+    // When an axis sits exactly on the graph's edge, the outer half of its
+    // stroke would be clipped away by the graph bounds, making it look half
+    // its intended width. Expand the axis clip region outward by half the
+    // stroke width — but only on the side(s) where an axis lands on the edge,
+    // so the perpendicular ends (tips) of the axes stay flush with the graph
+    // bounds rather than poking out.
+    const [[xMin, xMax], [yMin, yMax]] = state.range;
+    const halfStroke = AXIS_STROKE_WIDTH / 2;
+    const axisClipExpand = axesAreShown(props.markings)
+        ? {
+              left: xMin === 0 ? halfStroke : 0,
+              right: xMax === 0 ? halfStroke : 0,
+              bottom: yMin === 0 ? halfStroke : 0,
+              top: yMax === 0 ? halfStroke : 0,
+          }
+        : undefined;
+
     return (
         <GraphConfigContext.Provider
             value={{
@@ -355,9 +372,26 @@ export const MafsGraph = (props: MafsGraphProps) => {
                             >
                                 {/* Svg definitions to render only once */}
                                 <SvgDefs />
-                                {/* Cartesian grid clipped to graph bounds */}
+                                {/* Cartesian grid lines clipped to graph bounds */}
                                 <ClipToGraphBounds>
                                     <Grid
+                                        gridStep={props.gridStep}
+                                        range={state.range}
+                                        containerSizeClass={
+                                            props.containerSizeClass
+                                        }
+                                        markings={props.markings}
+                                        width={width}
+                                        height={height}
+                                    />
+                                </ClipToGraphBounds>
+                                {/* Axis lines, clipped to graph bounds but
+                                    expanded by half the stroke width on any
+                                    edge an axis sits on, so an edge-aligned
+                                    axis keeps its full width without its tips
+                                    poking past the graph */}
+                                <ClipToGraphBounds expand={axisClipExpand}>
+                                    <Axes
                                         gridStep={props.gridStep}
                                         range={state.range}
                                         containerSizeClass={

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -24,7 +24,7 @@ import {useDependencies} from "../../dependencies";
 import AxisArrows from "./backgrounds/axis-arrows";
 import AxisLabels from "./backgrounds/axis-labels";
 import {AxisTicks} from "./backgrounds/axis-ticks";
-import {Axes, axesAreShown, AXIS_STROKE_WIDTH, Grid} from "./backgrounds/grid";
+import {Axes, Grid} from "./backgrounds/grid";
 import {LegacyGrid} from "./backgrounds/legacy-grid";
 import {
     fontSize,
@@ -206,7 +206,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
     // so the perpendicular ends (tips) of the axes stay flush with the graph
     // bounds rather than poking out.
     const [[xMin, xMax], [yMin, yMax]] = state.range;
-    const halfStroke = AXIS_STROKE_WIDTH / 2;
+    const halfStroke = 1;
     const axisClipExpand = {
         left: xMin === 0 ? halfStroke : 0,
         right: xMax === 0 ? halfStroke : 0,
@@ -385,7 +385,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                                 </ClipToGraphBounds>
                                 {/* Axis lines, ticks, and arrows. Only
                                     rendered when the markings include axes. */}
-                                {axesAreShown(props.markings) && (
+                                {showsAxisLabels && (
                                     <>
                                         {/* Axis lines are clipped to the graph
                                             bounds, expanded by half the stroke

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -207,14 +207,12 @@ export const MafsGraph = (props: MafsGraphProps) => {
     // bounds rather than poking out.
     const [[xMin, xMax], [yMin, yMax]] = state.range;
     const halfStroke = AXIS_STROKE_WIDTH / 2;
-    const axisClipExpand = axesAreShown(props.markings)
-        ? {
-              left: xMin === 0 ? halfStroke : 0,
-              right: xMax === 0 ? halfStroke : 0,
-              bottom: yMin === 0 ? halfStroke : 0,
-              top: yMax === 0 ? halfStroke : 0,
-          }
-        : undefined;
+    const axisClipExpand = {
+        left: xMin === 0 ? halfStroke : 0,
+        right: xMax === 0 ? halfStroke : 0,
+        bottom: yMin === 0 ? halfStroke : 0,
+        top: yMax === 0 ? halfStroke : 0,
+    };
 
     return (
         <GraphConfigContext.Provider
@@ -385,34 +383,34 @@ export const MafsGraph = (props: MafsGraphProps) => {
                                         height={height}
                                     />
                                 </ClipToGraphBounds>
-                                {/* Axis lines, clipped to graph bounds but
-                                    expanded by half the stroke width on any
-                                    edge an axis sits on, so an edge-aligned
-                                    axis keeps its full width without its tips
-                                    poking past the graph */}
-                                <ClipToGraphBounds expand={axisClipExpand}>
-                                    <Axes
-                                        gridStep={props.gridStep}
-                                        range={state.range}
-                                        containerSizeClass={
-                                            props.containerSizeClass
-                                        }
-                                        markings={props.markings}
-                                        width={width}
-                                        height={height}
-                                    />
-                                </ClipToGraphBounds>
-                                {/* Axis Ticks, Labels, and Arrows */}
-                                {
-                                    // Only render the axis ticks and arrows if the markings are set to a full "graph"
-                                    (props.markings === "graph" ||
-                                        props.markings === "axes") && (
-                                        <>
-                                            <AxisTicks />
-                                            <AxisArrows />
-                                        </>
-                                    )
-                                }
+                                {/* Axis lines, ticks, and arrows. Only
+                                    rendered when the markings include axes. */}
+                                {axesAreShown(props.markings) && (
+                                    <>
+                                        {/* Axis lines are clipped to the graph
+                                            bounds, expanded by half the stroke
+                                            width on any edge an axis sits on,
+                                            so an edge-aligned axis keeps its
+                                            full width without its tips poking
+                                            past the graph */}
+                                        <ClipToGraphBounds
+                                            expand={axisClipExpand}
+                                        >
+                                            <Axes
+                                                gridStep={props.gridStep}
+                                                range={state.range}
+                                                containerSizeClass={
+                                                    props.containerSizeClass
+                                                }
+                                                markings={props.markings}
+                                                width={width}
+                                                height={height}
+                                            />
+                                        </ClipToGraphBounds>
+                                        <AxisTicks />
+                                        <AxisArrows />
+                                    </>
+                                )}
                                 {/* Locked figures clipped to graph bounds */}
                                 {props.lockedFigures.length > 0 && (
                                     <ClipToGraphBounds>

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -9,7 +9,8 @@
     /* Grid lines */
     --mafs-line-color: var(--wb-semanticColor-core-border-neutral-subtle);
 
-    /* Axis lines */
+    /* Axis lines. Keep in sync with AXIS_STROKE_WIDTH in backgrounds/grid.tsx,
+    which uses it to clip the axes without halving an edge-aligned axis. */
     --mafs-axis-stroke-width: 2px;
 
     --mafs-blue: var(--wb-semanticColor-core-foreground-instructive-default);

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -9,8 +9,7 @@
     /* Grid lines */
     --mafs-line-color: var(--wb-semanticColor-core-border-neutral-subtle);
 
-    /* Axis lines. Keep in sync with AXIS_STROKE_WIDTH in backgrounds/grid.tsx,
-    which uses it to clip the axes without halving an edge-aligned axis. */
+    /* Axis lines */
     --mafs-axis-stroke-width: 2px;
 
     --mafs-blue: var(--wb-semanticColor-core-foreground-instructive-default);


### PR DESCRIPTION
## Summary:

This was a little tricky:

- We want to extend the clipping region only when an axis is on the edge
- We only want to extend the clipping on the broadside of an axis (not the tip), otherwise the axis will stick through the arrow
- We only want to extend the axis, nothing else

Issue: LEMS-4273 (this is only one part of LEMS-4273)

## Test plan:

### Before
<img width="464" height="472" alt="Screenshot 2026-06-23 at 2 14 27 PM" src="https://github.com/user-attachments/assets/ebbd7512-9be5-434c-a8ed-9763fe1fa57a" />
<img width="478" height="458" alt="Screenshot 2026-06-23 at 2 14 33 PM" src="https://github.com/user-attachments/assets/6a5885c5-b90c-48dd-839f-babf32ef0565" />

### After
<img width="473" height="469" alt="Screenshot 2026-06-23 at 2 14 51 PM" src="https://github.com/user-attachments/assets/099049b4-14e4-4256-91e6-d6d97f1c74fe" />
<img width="475" height="460" alt="Screenshot 2026-06-23 at 2 14 57 PM" src="https://github.com/user-attachments/assets/910ab87d-b67f-4d55-a9b2-2ae9dd7bd13e" />

