### PR TITLE
[Interactive Graph] Add screen-reader information for the interactive but not graded graph

### DIFF
--- a/.changeset/tidy-cobras-stare.md
+++ b/.changeset/tidy-cobras-stare.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Update Interactive Graph ungraded screen reader to read out the information about the graph is not graded

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -2117,7 +2117,7 @@ describe("Interactive Graph", function () {
             );
         });
 
-        it("renders a 'not graded' message when graded is false", () => {
+        it("shows the 'not graded' message to sighted users but hides it from the accessibility tree", () => {
             // Arrange, Act
             const question = generateInteractiveGraphQuestion({
                 graded: false,
@@ -2126,11 +2126,34 @@ describe("Interactive Graph", function () {
             renderQuestion(question, blankOptions);
 
             // Assert
-            expect(
-                screen.getByText(
+            const visibleNote = screen
+                .getAllByText(
                     "Use this graph to check your thinking, but it does not count as your answer.",
-                ),
-            ).toBeInTheDocument();
+                )
+                .find((node) => node.tagName === "P");
+            expect(visibleNote).toBeInTheDocument();
+            expect(visibleNote).toHaveAttribute("aria-hidden", "true");
+        });
+
+        it("announces the 'not graded' message as the graph's first description", () => {
+            // Arrange, Act
+            const question = generateInteractiveGraphQuestion({
+                graded: false,
+                graph: generateIGLinearGraph(),
+            });
+            renderQuestion(question, blankOptions);
+
+            // Assert
+            const figure = screen.getByRole("figure");
+            const [firstDescribedById] =
+                figure.getAttribute("aria-describedby")?.split(" ") ?? [];
+            const announcedNote = screen
+                .getAllByText(
+                    "Use this graph to check your thinking, but it does not count as your answer.",
+                )
+                .find((node) => node.getAttribute("id") === firstDescribedById);
+
+            expect(announcedNote).toBeInTheDocument();
         });
 
         it("does not render a 'not graded' message when graded is true", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -2117,7 +2117,7 @@ describe("Interactive Graph", function () {
             );
         });
 
-        it("shows the 'not graded' message to sighted users but hides it from the accessibility tree", () => {
+        it("renders a 'not graded' message when graded is false", () => {
             // Arrange, Act
             const question = generateInteractiveGraphQuestion({
                 graded: false,
@@ -2126,13 +2126,11 @@ describe("Interactive Graph", function () {
             renderQuestion(question, blankOptions);
 
             // Assert
-            const visibleNote = screen
-                .getAllByText(
+            expect(
+                screen.getByText(
                     "Use this graph to check your thinking, but it does not count as your answer.",
-                )
-                .find((node) => node.tagName === "P");
-            expect(visibleNote).toBeInTheDocument();
-            expect(visibleNote).toHaveAttribute("aria-hidden", "true");
+                ),
+            ).toBeInTheDocument();
         });
 
         it("announces the 'not graded' message as the graph's first description", () => {
@@ -2144,16 +2142,15 @@ describe("Interactive Graph", function () {
             renderQuestion(question, blankOptions);
 
             // Assert
+            const note = screen.getByText(
+                "Use this graph to check your thinking, but it does not count as your answer.",
+            );
             const figure = screen.getByRole("figure");
             const [firstDescribedById] =
                 figure.getAttribute("aria-describedby")?.split(" ") ?? [];
-            const announcedNote = screen
-                .getAllByText(
-                    "Use this graph to check your thinking, but it does not count as your answer.",
-                )
-                .find((node) => node.getAttribute("id") === firstDescribedById);
 
-            expect(announcedNote).toBeInTheDocument();
+            expect(note).toHaveAttribute("id");
+            expect(firstDescribedById).toBe(note.getAttribute("id"));
         });
 
         it("does not render a 'not graded' message when graded is true", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.tsx
@@ -274,7 +274,9 @@ class InteractiveGraph extends React.Component<Props, State> {
         return (
             <>
                 {showUngradedText && (
-                    <p>{this.context.strings.ungradedInteractiveGraph}</p>
+                    <p aria-hidden={true}>
+                        {this.context.strings.ungradedInteractiveGraph}
+                    </p>
                 )}
                 <StatefulMafsGraph
                     {...mafsProps}

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.tsx
@@ -270,11 +270,15 @@ class InteractiveGraph extends React.Component<Props, State> {
 
         const showUngradedText =
             this.props.graded === false && this.props.graph.type !== "none";
+        const ungradedDescriptionId = `interactive-graph-ungraded-description-${this.props.widgetId?.replace(
+            /\s+/g,
+            "-",
+        )}`;
 
         return (
             <>
                 {showUngradedText && (
-                    <p aria-hidden={true}>
+                    <p id={ungradedDescriptionId}>
                         {this.context.strings.ungradedInteractiveGraph}
                     </p>
                 )}
@@ -288,6 +292,9 @@ class InteractiveGraph extends React.Component<Props, State> {
                     readOnly={this.props.apiOptions?.readOnly}
                     widgetId={this.props.widgetId}
                     graded={this.props.graded}
+                    ungradedDescriptionId={
+                        showUngradedText ? ungradedDescriptionId : undefined
+                    }
                     apiOptions={this.props.apiOptions} // TODO(AITQ-385): clean up feature flag
                 />
             </>

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -99,6 +99,7 @@ export type MafsGraphProps = {
     readOnly: boolean;
     static: boolean | null | undefined;
     widgetId: string;
+    graded?: boolean | null;
     apiOptions?: APIOptionsWithDefaults; // TODO(AITQ-385): clean up feature flag
 };
 
@@ -112,6 +113,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
         fullGraphAriaLabel,
         fullGraphAriaDescription,
         widgetId,
+        graded,
     } = props;
     const {type} = state;
     const [width, height] = props.box;
@@ -123,6 +125,8 @@ export const MafsGraph = (props: MafsGraphProps) => {
     const interactiveElementsDescriptionId = `interactive-graph-interactive-elements-description-${uniqueId}`;
     const unlimitedGraphKeyboardPromptId = `unlimited-graph-keyboard-prompt-${uniqueId}`;
     const instructionsId = `instructions-${uniqueId}`;
+    const ungradedIndicatorId = `interactive-graph-ungraded-indicator-${uniqueId}`;
+    const showUngradedIndicator = graded === false && state.type !== "none";
     const graphRef = React.useRef<HTMLElement>(null);
     const {analytics} = useDependencies();
 
@@ -249,7 +253,8 @@ export const MafsGraph = (props: MafsGraphProps) => {
                     }}
                     aria-label={fullGraphAriaLabel}
                     aria-describedby={describedByIds(
-                        // Instructions read first on focus so screen reader
+                        showUngradedIndicator && ungradedIndicatorId,
+                        // Instructions read next on focus so screen reader
                         // users hear how to interact before the descriptions
                         state.type !== "none" &&
                             !disableInteraction &&
@@ -271,10 +276,19 @@ export const MafsGraph = (props: MafsGraphProps) => {
                     }}
                 >
                     {/*
-                      Instructions render first so screen reader users
+                      Instructions render next so screen reader users
                       encounter how to interact with the graph before the
                       graph and interactive-element descriptions
                     */}
+                    {showUngradedIndicator && (
+                        <View
+                            id={ungradedIndicatorId}
+                            tabIndex={-1}
+                            className="mafs-sr-only"
+                        >
+                            {strings.ungradedInteractiveGraph}
+                        </View>
+                    )}
                     {state.type !== "none" && (
                         <View
                             id={instructionsId}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -99,7 +99,7 @@ export type MafsGraphProps = {
     readOnly: boolean;
     static: boolean | null | undefined;
     widgetId: string;
-    graded?: boolean | null;
+    ungradedDescriptionId?: string;
     apiOptions?: APIOptionsWithDefaults; // TODO(AITQ-385): clean up feature flag
 };
 
@@ -113,7 +113,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
         fullGraphAriaLabel,
         fullGraphAriaDescription,
         widgetId,
-        graded,
+        ungradedDescriptionId,
     } = props;
     const {type} = state;
     const [width, height] = props.box;
@@ -125,8 +125,6 @@ export const MafsGraph = (props: MafsGraphProps) => {
     const interactiveElementsDescriptionId = `interactive-graph-interactive-elements-description-${uniqueId}`;
     const unlimitedGraphKeyboardPromptId = `unlimited-graph-keyboard-prompt-${uniqueId}`;
     const instructionsId = `instructions-${uniqueId}`;
-    const ungradedIndicatorId = `interactive-graph-ungraded-indicator-${uniqueId}`;
-    const showUngradedIndicator = graded === false && state.type !== "none";
     const graphRef = React.useRef<HTMLElement>(null);
     const {analytics} = useDependencies();
 
@@ -253,7 +251,7 @@ export const MafsGraph = (props: MafsGraphProps) => {
                     }}
                     aria-label={fullGraphAriaLabel}
                     aria-describedby={describedByIds(
-                        showUngradedIndicator && ungradedIndicatorId,
+                        ungradedDescriptionId,
                         // Instructions read next on focus so screen reader
                         // users hear how to interact before the descriptions
                         state.type !== "none" &&
@@ -276,19 +274,10 @@ export const MafsGraph = (props: MafsGraphProps) => {
                     }}
                 >
                     {/*
-                      Instructions render next so screen reader users
+                      Instructions render first so screen reader users
                       encounter how to interact with the graph before the
                       graph and interactive-element descriptions
                     */}
-                    {showUngradedIndicator && (
-                        <View
-                            id={ungradedIndicatorId}
-                            tabIndex={-1}
-                            className="mafs-sr-only"
-                        >
-                            {strings.ungradedInteractiveGraph}
-                        </View>
-                    )}
                     {state.type !== "none" && (
                         <View
                             id={instructionsId}

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.tsx
@@ -49,6 +49,7 @@ export type StatefulMafsGraphProps = {
     showAxisTicks: InteractiveGraphProps["showAxisTicks"];
     widgetId: string;
     graded?: boolean | null;
+    ungradedDescriptionId?: string;
     apiOptions?: APIOptionsWithDefaults; // TODO(AITQ-385): clean up feature flag
 };
 


### PR DESCRIPTION
## Summary:
Improve the screen reader for interactive graph which are not graded to include the text, "Use this graph to check your thinking, but it does not count as your answer."

Issue: LEMS-4288

## Test plan:
1. Navigate to the Ungraded story in Interactive Graph Widget
2. Confirm that the screen reader includes the text, "Use this graph to check your thinking, but it does not count as your answer."