### PR TITLE
Remove obsolete "Tab off to close" definition popover tests (AX-2216)

### DIFF
--- a/packages/perseus/src/widgets/definition/definition.test.ts
+++ b/packages/perseus/src/widgets/definition/definition.test.ts
@@ -162,46 +162,6 @@ describe("Definition widget", () => {
         });
     });
 
-    // TODO(eshmoel, AX-2216): unskip tests once @jandrade completes work to enable Tab off.
-    it.skip("should close the popover when we Tab off the close button", async () => {
-        // Arrange
-        renderQuestion(question);
-
-        // Act - Open the popover
-        const definitionAnchor = screen.getByText("the Pequots");
-        await userEvent.click(definitionAnchor);
-
-        // Verify popover is open
-        const tooltip = screen.getByRole("dialog");
-        expect(tooltip).toBeVisible();
-
-        // Tab off the close button
-        await userEvent.tab();
-
-        // Assert - Popover should be closed
-        expect(screen.queryByRole("dialog")).toBeNull();
-    });
-
-    // TODO(eshmoel, AX-2216): unskip tests once @jandrade completes work to enable Tab off.
-    it.skip("should close the popover when we Shift + Tab from the close button", async () => {
-        // Arrange
-        renderQuestion(question);
-
-        // Act - Open the popover
-        const definitionAnchor = screen.getByText("the Pequots");
-        await userEvent.click(definitionAnchor);
-
-        // Verify popover is open
-        const tooltip = screen.getByRole("dialog");
-        expect(tooltip).toBeVisible();
-
-        // Shift + Tab off the close button (tab backwards)
-        await userEvent.tab({shift: true});
-
-        // Assert - Popover should be closed
-        expect(screen.queryByRole("dialog")).toBeNull();
-    });
-
     it("should close the popover when we press Escape", async () => {
         // Arrange
         renderQuestion(question);


### PR DESCRIPTION
## Summary

Removes the two skipped definition-widget tests that were waiting on custom work to close the popover when focus tabs off the close button.

That behavior is now owned by the [Wonder Blocks `Popover`](https://github.com/Khan/wonder-blocks), which manages dismissal via **focus trapping** plus **Escape / outside-click** rather than closing on Tab. "Close on Tab off" is no longer a behavior Perseus implements or documents:

- `<Popover dismissEnabled>` closes only on Escape and outside-click; its `FocusManager` traps focus inside the popover and never closes on Tab.
- The widget's [`a11y.mdx`](packages/perseus/src/widgets/definition/__docs__/a11y.mdx) documents closing via **Escape** or **close-button + Enter** — there is no "Tab off closes it" requirement.
- When temporarily unskipped, forward-Tab "passed" only as a jsdom artifact while Shift+Tab failed — i.e. the tests asserted behavior that doesn't exist.

The remaining tests already cover the real keyboard requirements (Escape closes, other keys don't, Space opens, click/x dismiss), so these placeholders no longer add value.

Issue: [AX-2216](https://khanacademy.atlassian.net/browse/AX-2216)

## Test plan

- `pnpm jest packages/perseus/src/widgets/definition/definition.test.ts` → 10/10 pass
- `tsc -b` → 0 errors
- prettier → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AX-2216]: https://khanacademy.atlassian.net/browse/AX-2216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ