### PR TITLE
[Image] Fix for  divider showing up when a gif isn't animated

### DIFF
--- a/.changeset/sixty-chicken-behave.md
+++ b/.changeset/sixty-chicken-behave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Removed small divider when a gif doesn't have gif controls

--- a/packages/perseus/src/widgets/image/image.tsx
+++ b/packages/perseus/src/widgets/image/image.tsx
@@ -177,7 +177,7 @@ export const ImageComponent = (props: ImageWidgetProps) => {
             {svgImage}
 
             {/* Gif Controls, Description, and Caption */}
-            {(imageIsGif || caption || longDescription) && (
+            {(isAnimatedGif || caption || longDescription) && (
                 <ImageInfoArea
                     isGifPlaying={isGifPlaying}
                     setIsGifPlaying={setIsGifPlaying}


### PR DESCRIPTION
## Summary:
Removed small divider when a gif doesnt have gif controls

Issue: https://khanacademy.atlassian.net/browse/LEMS-4234

## Test plan:
- Verified in storybook by going to http://localhost:6006/?path=/story/widgets-image-visual-regression-tests-initial-state--non-animated-gif and making sure there is no bottom bar below the image

Before:
<img width="729" height="571" alt="Screenshot 2026-06-25 at 1 06 40 PM" src="https://github.com/user-attachments/assets/16780da4-b008-4998-b8dc-fec2fb41e57d" />

After:
<img width="802" height="645" alt="Screenshot 2026-06-25 at 1 06 17 PM" src="https://github.com/user-attachments/assets/7fd5ff9a-1d94-4d6c-a5d3-6caaef8741bd" />
