### PR TITLE
[Interactive Graph] Fix locked figure points clipped at the graph boundary

### DIFF
--- a/.changeset/poor-stingrays-hang.md
+++ b/.changeset/poor-stingrays-hang.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Interactive Graph: Fix locked figure points clipped at the graph boundary

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph-initial-state-regression.stories.tsx
@@ -450,6 +450,49 @@ export const LockedPoints: Story = {
     },
 };
 
+// Verifies points on the graph boundary (corners and edge midpoints) render as
+// full circles rather than being clipped in half.
+export const LockedPointsAtGraphEdges: Story = {
+    args: {
+        range: [
+            [0, 10],
+            [0, 10],
+        ],
+        lockedFigures: [
+            // Corners
+            generateIGLockedPoint({coord: [0, 0]}),
+            generateIGLockedPoint({coord: [10, 0]}),
+            generateIGLockedPoint({coord: [0, 10]}),
+            generateIGLockedPoint({coord: [10, 10]}),
+            // Edge midpoints
+            generateIGLockedPoint({coord: [5, 10]}),
+            generateIGLockedPoint({coord: [5, 0]}),
+            generateIGLockedPoint({coord: [0, 5]}),
+            generateIGLockedPoint({coord: [10, 5]}),
+        ],
+    },
+};
+
+// Verifies a point at the origin of a first-quadrant graph (the reported bug):
+// it sits on both edges and previously rendered as a quarter-circle.
+export const LockedPointAtOrigin: Story = {
+    args: {
+        range: [
+            [0, 8],
+            [0, 80],
+        ],
+        step: [1, 10],
+        gridStep: [1, 10],
+        labels: ["time (s)", "distance (m)"],
+        labelLocation: "alongEdge",
+        lockedFigures: [
+            generateIGLockedPoint({coord: [0, 0], color: "red", filled: true}),
+            generateIGLockedPoint({coord: [2, 18], color: "red", filled: true}),
+            generateIGLockedPoint({coord: [4, 43], color: "red", filled: true}),
+        ],
+    },
+};
+
 // Verifies a locked line connecting two locked points.
 export const LockedLine: Story = {
     args: {

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph-initial-state-regression.stories.tsx
@@ -473,26 +473,6 @@ export const LockedPointsAtGraphEdges: Story = {
     },
 };
 
-// Verifies a point at the origin of a first-quadrant graph (the reported bug):
-// it sits on both edges and previously rendered as a quarter-circle.
-export const LockedPointAtOrigin: Story = {
-    args: {
-        range: [
-            [0, 8],
-            [0, 80],
-        ],
-        step: [1, 10],
-        gridStep: [1, 10],
-        labels: ["time (s)", "distance (m)"],
-        labelLocation: "alongEdge",
-        lockedFigures: [
-            generateIGLockedPoint({coord: [0, 0], color: "red", filled: true}),
-            generateIGLockedPoint({coord: [2, 18], color: "red", filled: true}),
-            generateIGLockedPoint({coord: [4, 43], color: "red", filled: true}),
-        ],
-    },
-};
-
 // Verifies a locked line connecting two locked points.
 export const LockedLine: Story = {
     args: {

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -1,7 +1,3 @@
-import {
-    generateIGLockedLine,
-    generateIGLockedPoint,
-} from "@khanacademy/perseus-core";
 import {screen, render, act} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import {vec} from "mafs";
@@ -117,58 +113,6 @@ describe("MafsGraph", () => {
         expect(line.getAttribute("y1")).toBe(-expectedY1 + "");
         expect(line.getAttribute("x2")).toBe(expectedX2 + "");
         expect(line.getAttribute("y2")).toBe(-expectedY2 + "");
-    });
-
-    it("renders locked points outside the clip group so boundary points are not cut off", () => {
-        // Arrange
-        const state: InteractiveGraphState = {
-            type: "none",
-            hasBeenInteractedWith: false,
-            range: [
-                [0, 10],
-                [0, 10],
-            ],
-            snapStep: [1, 1],
-        };
-
-        // Act
-        const {container} = render(
-            <MafsGraph
-                {...baseMafsProps}
-                state={state}
-                dispatch={jest.fn()}
-                lockedFigures={[
-                    // A clipped figure, so we know clip groups exist and the
-                    // negative assertion below is meaningful.
-                    generateIGLockedLine({
-                        points: [
-                            generateIGLockedPoint({coord: [1, 1]}),
-                            generateIGLockedPoint({coord: [9, 9]}),
-                        ],
-                    }),
-                    // A point on the graph boundary (the origin).
-                    generateIGLockedPoint({coord: [0, 0]}),
-                ]}
-            />,
-        );
-
-        // Assert
-        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-        const clipGroups = Array.from(container.querySelectorAll("svg")).filter(
-            (svg) => svg.getAttribute("x") !== null,
-        );
-        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-        const lockedPoint = container.querySelector(".locked-point");
-
-        expect(lockedPoint).toBeInTheDocument();
-        expect(clipGroups.length).toBeGreaterThan(0);
-        // The locked point must not live inside any clip group, otherwise a
-        // point on the boundary would be cut in half.
-        const pointIsClipped = clipGroups.some((svg) =>
-            // eslint-disable-next-line testing-library/no-node-access
-            svg.contains(lockedPoint),
-        );
-        expect(pointIsClipped).toBe(false);
     });
 
     it("should send analytics even when widget is rendered", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -1,3 +1,7 @@
+import {
+    generateIGLockedLine,
+    generateIGLockedPoint,
+} from "@khanacademy/perseus-core";
 import {screen, render, act} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import {vec} from "mafs";
@@ -113,6 +117,58 @@ describe("MafsGraph", () => {
         expect(line.getAttribute("y1")).toBe(-expectedY1 + "");
         expect(line.getAttribute("x2")).toBe(expectedX2 + "");
         expect(line.getAttribute("y2")).toBe(-expectedY2 + "");
+    });
+
+    it("renders locked points outside the clip group so boundary points are not cut off", () => {
+        // Arrange
+        const state: InteractiveGraphState = {
+            type: "none",
+            hasBeenInteractedWith: false,
+            range: [
+                [0, 10],
+                [0, 10],
+            ],
+            snapStep: [1, 1],
+        };
+
+        // Act
+        const {container} = render(
+            <MafsGraph
+                {...baseMafsProps}
+                state={state}
+                dispatch={jest.fn()}
+                lockedFigures={[
+                    // A clipped figure, so we know clip groups exist and the
+                    // negative assertion below is meaningful.
+                    generateIGLockedLine({
+                        points: [
+                            generateIGLockedPoint({coord: [1, 1]}),
+                            generateIGLockedPoint({coord: [9, 9]}),
+                        ],
+                    }),
+                    // A point on the graph boundary (the origin).
+                    generateIGLockedPoint({coord: [0, 0]}),
+                ]}
+            />,
+        );
+
+        // Assert
+        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+        const clipGroups = Array.from(container.querySelectorAll("svg")).filter(
+            (svg) => svg.getAttribute("x") !== null,
+        );
+        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+        const lockedPoint = container.querySelector(".locked-point");
+
+        expect(lockedPoint).toBeInTheDocument();
+        expect(clipGroups.length).toBeGreaterThan(0);
+        // The locked point must not live inside any clip group, otherwise a
+        // point on the boundary would be cut in half.
+        const pointIsClipped = clipGroups.some((svg) =>
+            // eslint-disable-next-line testing-library/no-node-access
+            svg.contains(lockedPoint),
+        );
+        expect(pointIsClipped).toBe(false);
     });
 
     it("should send analytics even when widget is rendered", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -216,6 +216,15 @@ export const MafsGraph = (props: MafsGraphProps) => {
         top: yMax === 0 ? halfStroke : 0,
     };
 
+    // Locked points render unclipped so boundary points aren't cut in half;
+    // everything else stays clipped to the graph bounds.
+    const lockedPointFigures = props.lockedFigures.filter(
+        (figure) => figure.type === "point",
+    );
+    const clippedLockedFigures = props.lockedFigures.filter(
+        (figure) => figure.type !== "point",
+    );
+
     return (
         <GraphConfigContext.Provider
             value={{
@@ -415,13 +424,19 @@ export const MafsGraph = (props: MafsGraphProps) => {
                                     </>
                                 )}
                                 {/* Locked figures clipped to graph bounds */}
-                                {props.lockedFigures.length > 0 && (
+                                {clippedLockedFigures.length > 0 && (
                                     <ClipToGraphBounds>
                                         <GraphLockedLayer
-                                            lockedFigures={props.lockedFigures}
+                                            lockedFigures={clippedLockedFigures}
                                             range={state.range}
                                         />
                                     </ClipToGraphBounds>
+                                )}
+                                {lockedPointFigures.length > 0 && (
+                                    <GraphLockedLayer
+                                        lockedFigures={lockedPointFigures}
+                                        range={state.range}
+                                    />
                                 )}
                             </Mafs>
                         </View>

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -216,8 +216,9 @@ export const MafsGraph = (props: MafsGraphProps) => {
         top: yMax === 0 ? halfStroke : 0,
     };
 
-    // Locked points render unclipped so boundary points aren't cut in half;
-    // everything else stays clipped to the graph bounds.
+    // Points are fixed-radius markers, so a point on the boundary would be
+    // sliced in half by the clip — render them unclipped. Other figures are
+    // geometry that should be clipped to the visible range.
     const lockedPointFigures = props.lockedFigures.filter(
         (figure) => figure.type === "point",
     );


### PR DESCRIPTION
## Summary:
This PR renders locked **points** in their own **unclipped** layer, while all other
locked figures stay clipped. This mirrors how interactive point handles are already
rendered outside `ClipToGraphBounds`, and removes the need for the axis-extension
workaround.

Issue: LEMS-4263

## Test plan: