### PR TITLE
[Interactive Graph] Enable 'Show point labels' toggle for at least one custom label

### DIFF
--- a/.changeset/eight-oranges-kiss.md
+++ b/.changeset/eight-oranges-kiss.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus-linter": patch
+---
+
+Update the behavior of the Interactive Graph showPointLabels toggle enabling it when at least one custom label is provided

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/show-point-labels-toggle.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/show-point-labels-toggle.test.tsx
@@ -54,7 +54,7 @@ describe("ShowPointLabelsToggle", () => {
         );
     });
 
-    it("disables the toggle when some pointLabels entries are empty and some are not", () => {
+    it("enables the toggle when at least one pointLabels entry is non-empty", () => {
         // Arrange, Act
         render(
             <ShowPointLabelsToggle
@@ -65,7 +65,7 @@ describe("ShowPointLabelsToggle", () => {
         );
 
         // Assert
-        expect(screen.getByLabelText("Show point labels")).toHaveAttribute(
+        expect(screen.getByLabelText("Show point labels")).not.toHaveAttribute(
             "aria-disabled",
             "true",
         );

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/show-point-labels-toggle.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/show-point-labels-toggle.tsx
@@ -15,29 +15,28 @@ interface Props {
 }
 
 // Editor-level toggle for the graph's `showPointLabels` field. The toggle
-// is disabled until every point has a non-empty label; the InfoTip
-// explains why.
+// is disabled until at least one point has a non-empty label; the InfoTip
+// explains why. When on, points with a custom label display it and
+// unlabeled points show nothing.
 export default function ShowPointLabelsToggle({
     showPointLabels,
     pointLabels,
     onChange,
 }: Props) {
-    const labelsPopulated =
-        pointLabels !== undefined &&
-        pointLabels.length > 0 &&
-        pointLabels.every((label) => label !== "");
+    const hasAtLeastOneLabel =
+        pointLabels !== undefined && pointLabels.some((label) => label !== "");
 
     return (
         <View className={styles.switchRow}>
             <LabeledSwitch
                 label="Show point labels"
-                checked={labelsPopulated && showPointLabels}
-                disabled={!labelsPopulated}
+                checked={hasAtLeastOneLabel && showPointLabels}
+                disabled={!hasAtLeastOneLabel}
                 onChange={onChange}
             />
             <InfoTip>
-                When on, each movable point displays a visible label next to it.
-                Add a name to every point below to enable this option.
+                When on, each labeled point displays a visible label next to it.
+                Add a name to at least one point below to enable this option.
             </InfoTip>
         </View>
     );

--- a/packages/perseus-linter/src/rules/interactive-graph-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/interactive-graph-widget-error.test.ts
@@ -154,14 +154,14 @@ describe("interactive-graph-widget-error", () => {
             },
             {
                 message:
-                    "showPointLabels is true but pointLabels is missing. Provide a label for every point.",
+                    "showPointLabels is true but pointLabels has no labels. Provide a label for at least one point.",
                 severity: Rule.Severity.ERROR,
             },
         );
     });
 
-    it("warns when showPointLabels is true but pointLabels has an empty entry", () => {
-        expectWarning(
+    it("passes when showPointLabels is true and only some pointLabels entries are provided", () => {
+        expectPass(
             interactiveGraphWidgetErrorRule,
             "[[☃ interactive-graph 1]]",
             {
@@ -176,9 +176,28 @@ describe("interactive-graph-widget-error", () => {
                     }),
                 },
             },
+        );
+    });
+
+    it("warns when showPointLabels is true but every pointLabels entry is empty", () => {
+        expectWarning(
+            interactiveGraphWidgetErrorRule,
+            "[[☃ interactive-graph 1]]",
+            {
+                widgets: {
+                    "interactive-graph 1": generateInteractiveGraphWidget({
+                        options: generateInteractiveGraphOptions({
+                            correct: generateIGPolygonGraph({
+                                showPointLabels: true,
+                                pointLabels: ["", "", ""],
+                            }),
+                        }),
+                    }),
+                },
+            },
             {
                 message:
-                    "showPointLabels is true but pointLabels has empty entries. Provide a label for every point.",
+                    "showPointLabels is true but pointLabels has no labels. Provide a label for at least one point.",
                 severity: Rule.Severity.ERROR,
             },
         );
@@ -201,7 +220,7 @@ describe("interactive-graph-widget-error", () => {
             },
             {
                 message:
-                    "showPointLabels is true but pointLabels is missing. Provide a label for every point.",
+                    "showPointLabels is true but pointLabels has no labels. Provide a label for at least one point.",
                 severity: Rule.Severity.ERROR,
             },
         );

--- a/packages/perseus-linter/src/rules/interactive-graph-widget-error.ts
+++ b/packages/perseus-linter/src/rules/interactive-graph-widget-error.ts
@@ -109,15 +109,9 @@ function checkShowPointLabelsHasLabels(
         return;
     }
     const labels = g.pointLabels;
-    if (labels == null || labels.length === 0) {
+    if (labels === undefined || labels.every((l) => l == null || l === "")) {
         issues.push(
-            "showPointLabels is true but pointLabels is missing. Provide a label for every point.",
-        );
-        return;
-    }
-    if (labels.some((l) => l == null || l === "")) {
-        issues.push(
-            "showPointLabels is true but pointLabels has empty entries. Provide a label for every point.",
+            "showPointLabels is true but pointLabels has no labels. Provide a label for at least one point.",
         );
     }
 }


### PR DESCRIPTION
## Summary:
The editor's **Show point labels** toggle was only enabled once **every** movable point had a non-empty custom label. Per content-editor feedback, an author should be able to label just one point and still turn labels on for that point. This PR updates the condition to enable the toggle for at least one custom label.

Issue: LEMS-4332

## Test plan: