### PR TITLE
[Radio] Pass apiOptions to the renderer used for choice content rendering

### DIFF
--- a/.changeset/purple-ears-compare.md
+++ b/.changeset/purple-ears-compare.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Radio] Pass apiOptions to the renderer used for choice content rendering

--- a/packages/perseus/src/widgets/radio/radio-widget.tsx
+++ b/packages/perseus/src/widgets/radio/radio-widget.tsx
@@ -198,6 +198,7 @@ const RadioWidget = forwardRef<RadioWidgetHandle, Props>(
                 >
                     <Renderer
                         key="choiceContentRenderer"
+                        apiOptions={apiOptions}
                         content={content}
                         findExternalWidgets={findWidgets}
                         alwaysUpdate={true}


### PR DESCRIPTION
## Summary:
The apiOptions that were passed to the Radio widget were not passed along to the renderer that is used to render the content of the choices. So, things like feature flag settings weren't being passed along to the choices. This PR resolves that.

## Test plan:
All tests pass.