### PR TITLE
Fix `picUrl` in PlotterEditor

### DIFF
--- a/.changeset/polite-balloons-melt.md
+++ b/.changeset/polite-balloons-melt.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Update PlotterEditor's picUrl prop to match the Perseus data schema

--- a/packages/perseus-editor/src/widgets/__tests__/plotter-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/plotter-editor.test.tsx
@@ -5,11 +5,6 @@ import * as React from "react";
 import {testDependencies} from "../../testing/test-dependencies";
 import PlotterEditor from "../plotter-editor";
 
-const baseProps = {
-    onChange: () => undefined,
-    apiOptions: ApiOptions.defaults,
-};
-
 describe("PlotterEditor", () => {
     beforeEach(() => {
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
@@ -20,7 +15,9 @@ describe("PlotterEditor", () => {
     it("renders without crashing when picUrl is undefined", () => {
         render(
             <PlotterEditor
-                {...baseProps}
+                onChange={() => undefined}
+                apiOptions={ApiOptions.defaults}
+                static={false}
                 type="pic"
                 picUrl={undefined}
             />,
@@ -39,12 +36,15 @@ describe("PlotterEditor", () => {
             height: 200,
         };
         jest.spyOn(global, "Image").mockImplementation(
+            // eslint-disable-next-line no-restricted-syntax
             () => mockImage as HTMLImageElement,
         );
 
         const {rerender} = render(
             <PlotterEditor
-                {...baseProps}
+                onChange={() => undefined}
+                apiOptions={ApiOptions.defaults}
+                static={false}
                 type="pic"
                 picUrl="https://example.com/image.png"
             />,
@@ -62,13 +62,18 @@ describe("PlotterEditor", () => {
 
         // Act — clear the URL
         rerender(
-            <PlotterEditor {...baseProps} type="pic" picUrl={undefined} />,
+            <PlotterEditor
+                onChange={() => undefined}
+                apiOptions={ApiOptions.defaults}
+                static={false}
+                type="pic"
+                picUrl={undefined}
+            />,
         );
 
         // Assert — stale warning should be gone
         expect(
             screen.queryByText(/You are using a picture which is not square/),
         ).not.toBeInTheDocument();
-
     });
 });

--- a/packages/perseus-editor/src/widgets/__tests__/plotter-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/plotter-editor.test.tsx
@@ -1,0 +1,74 @@
+import {ApiOptions, Dependencies} from "@khanacademy/perseus";
+import {act, render, screen} from "@testing-library/react";
+import * as React from "react";
+
+import {testDependencies} from "../../testing/test-dependencies";
+import PlotterEditor from "../plotter-editor";
+
+const baseProps = {
+    onChange: () => undefined,
+    apiOptions: ApiOptions.defaults,
+};
+
+describe("PlotterEditor", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("renders without crashing when picUrl is undefined", () => {
+        render(
+            <PlotterEditor
+                {...baseProps}
+                type="pic"
+                picUrl={undefined}
+            />,
+        );
+
+        expect(screen.getByText(/Picture:/)).toBeInTheDocument();
+    });
+
+    it("clears a stale image when picUrl changes to undefined", () => {
+        // Arrange — mock Image so we can trigger onload synchronously
+        const mockImage: Partial<HTMLImageElement> & {
+            onload: (() => void) | null;
+        } = {
+            onload: null,
+            width: 100,
+            height: 200,
+        };
+        jest.spyOn(global, "Image").mockImplementation(
+            () => mockImage as HTMLImageElement,
+        );
+
+        const {rerender} = render(
+            <PlotterEditor
+                {...baseProps}
+                type="pic"
+                picUrl="https://example.com/image.png"
+            />,
+        );
+
+        // Act — fire onload to simulate the image loading
+        act(() => {
+            mockImage.onload?.();
+        });
+
+        // The non-square image warning should now be visible
+        expect(
+            screen.getByText(/You are using a picture which is not square/),
+        ).toBeInTheDocument();
+
+        // Act — clear the URL
+        rerender(
+            <PlotterEditor {...baseProps} type="pic" picUrl={undefined} />,
+        );
+
+        // Assert — stale warning should be gone
+        expect(
+            screen.queryByText(/You are using a picture which is not square/),
+        ).not.toBeInTheDocument();
+
+    });
+});

--- a/packages/perseus-editor/src/widgets/plotter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/plotter-editor.tsx
@@ -106,7 +106,9 @@ class PlotterEditor extends React.Component<Props, State> {
     }
 
     fetchPic: (url: string | null | undefined) => void = (url) => {
-        if (!url) {
+        if (url == null) {
+            // Make sure we don't display a previously-loaded picUrl if we no
+            // longer have one.
             if (this.state.pic !== null) {
                 this.setState({pic: null, loadedUrl: null});
             }

--- a/packages/perseus-editor/src/widgets/plotter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/plotter-editor.tsx
@@ -51,7 +51,7 @@ type Props = {
     snapsPerLine: number;
     picSize: number;
     picBoxHeight: number;
-    picUrl: string;
+    picUrl?: string | null;
     plotDimensions: ReadonlyArray<number>;
     labelInterval: number;
     starting: ReadonlyArray<number>;
@@ -105,7 +105,13 @@ class PlotterEditor extends React.Component<Props, State> {
         }
     }
 
-    fetchPic: (arg1: string) => any = (url) => {
+    fetchPic: (url: string | null | undefined) => void = (url) => {
+        if (!url) {
+            if (this.state.pic !== null) {
+                this.setState({pic: null, loadedUrl: null});
+            }
+            return;
+        }
         if (this.state.loadedUrl !== url) {
             const pic = new Image();
             pic.src = url;
@@ -394,7 +400,7 @@ class PlotterEditor extends React.Component<Props, State> {
                             Picture:{" "}
                             <BlurInput
                                 className="pic-url"
-                                value={this.props.picUrl}
+                                value={this.props.picUrl ?? ""}
                                 onChange={this.changePicUrl}
                             />
                             <InfoTip>


### PR DESCRIPTION
`PlotterEditor` has a `type: "pic"` mode where the user can supply a URL for a custom plotter image. The `picUrl` option is declared as `string | null | undefined` in the Perseus data schema, but the editor's local props type had it typed as a required `string`, hiding the mismatch from TypeScript.

At runtime, when no URL has been set (as in the comprehensive test data), `picUrl` arrives as `undefined`. This caused two problems: `fetchPic` was called with `undefined`, which would coerce to the string `"undefined"` as an image `src`; and the controlled `<BlurInput>` received `undefined` as its `value`, triggering a React warning about uncontrolled/null inputs.

This PR fixes all three layers: aligns the props type with the schema, adds an early-return guard inside `fetchPic` so callers never need to check before calling it, and falls back to an empty string for the controlled input.

Issue: LEMS-4335

## Test plan:

- Run `pnpm test`
- Open the `Editors / EditorPage - With Editing Disabled` Storybook story and confirm the React warning about `value prop on input should not be null` no longer appears in the console