### PR TITLE
Make categorizer visible and matcher hidden in editor dropdown

### DIFF
--- a/.changeset/wild-suits-arrive.md
+++ b/.changeset/wild-suits-arrive.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus": minor
 ---
 
-Hide matcher in the dropdown and show categorizer in the dropdown
+Hide matcher in the editor dropdown and show categorizer in the dropdown

--- a/.changeset/wild-suits-arrive.md
+++ b/.changeset/wild-suits-arrive.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Hide matcher in the dropdown and show categorizer in the dropdown

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -333,7 +333,6 @@ const WrappedCategorizer = withDependencies(Categorizer);
 export default {
     name: "categorizer",
     displayName: "Categorizer",
-    hidden: true,
     widget: WrappedCategorizer,
     getUserInputFromSerializedState,
     getCorrectUserInput,

--- a/packages/perseus/src/widgets/matcher/matcher.tsx
+++ b/packages/perseus/src/widgets/matcher/matcher.tsx
@@ -279,6 +279,7 @@ const WrappedMatcher = withDependencies(Matcher);
 export default {
     name: "matcher",
     displayName: "Matcher (two column)",
+    hidden: true,
     widget: WrappedMatcher,
     isLintable: true,
     getStartUserInput,


### PR DESCRIPTION
[Decision record
](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4821778538/Decision+Record+Categorizer+now+Recommended+but+inaccessible+and+Matcher+now+Avoid)
[LEMS-4337](https://khanacademy.atlassian.net/browse/LEMS-4337)


[LEMS-4337]: https://khanacademy.atlassian.net/browse/LEMS-4337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ