### PR TITLE
Fix FreeResponseEditor passing invalid props to native DOM elements

### DIFF
--- a/.changeset/petite-pigs-care.md
+++ b/.changeset/petite-pigs-care.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Fix Free Response editor to use WB components with LabelledField

--- a/.changeset/petite-pigs-care.md
+++ b/.changeset/petite-pigs-care.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus-editor": patch
 ---
 
-Fix Free Response editor to use WB components with LabelledField
+Fix Free Response editor to use WB components with LabeledField

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -2,7 +2,7 @@ import {ApiOptions, Util} from "@khanacademy/perseus";
 import {freeResponseLogic} from "@khanacademy/perseus-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {Checkbox} from "@khanacademy/wonder-blocks-form";
+import {Checkbox, TextArea, TextField} from "@khanacademy/wonder-blocks-form";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
 import {spacing, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
@@ -16,7 +16,6 @@ import type {
     PerseusFreeResponseWidgetOptions,
     PerseusFreeResponseWidgetScoringCriterion,
 } from "@khanacademy/perseus-core";
-import type {ChangeEventHandler} from "react";
 
 type Props = PerseusFreeResponseWidgetOptions & {
     apiOptions: APIOptions;
@@ -58,8 +57,8 @@ class FreeResponseEditor extends React.Component<Props> {
         return warnings;
     };
 
-    handleUpdateCharacterLimit: ChangeEventHandler<HTMLInputElement> = (e) => {
-        const val = parseInt(e.target.value);
+    handleUpdateCharacterLimit = (newValue: string) => {
+        const val = parseInt(newValue);
         if (isNaN(val)) {
             return;
         }
@@ -124,10 +123,10 @@ class FreeResponseEditor extends React.Component<Props> {
                 <LabeledField
                     label="Question"
                     field={
-                        <textarea
+                        <TextArea
                             value={this.props.question}
-                            onChange={(e) =>
-                                this.props.onChange({question: e.target.value})
+                            onChange={(newValue) =>
+                                this.props.onChange({question: newValue})
                             }
                         />
                     }
@@ -136,11 +135,11 @@ class FreeResponseEditor extends React.Component<Props> {
                 <LabeledField
                     label="Placeholder"
                     field={
-                        <textarea
+                        <TextArea
                             value={this.props.placeholder}
-                            onChange={(e) =>
+                            onChange={(newValue) =>
                                 this.props.onChange({
-                                    placeholder: e.target.value,
+                                    placeholder: newValue,
                                 })
                             }
                         />
@@ -165,10 +164,10 @@ class FreeResponseEditor extends React.Component<Props> {
                     <LabeledField
                         label="Character limit"
                         field={
-                            <input
+                            <TextField
                                 type="number"
                                 min={1}
-                                value={this.props.characterLimit}
+                                value={String(this.props.characterLimit)}
                                 onChange={this.handleUpdateCharacterLimit}
                             />
                         }


### PR DESCRIPTION
## Summary:

`FreeResponseEditor` was passing unrecognized props to native DOM elements. `LabeledField` injects `error` and `testId` into its `field` child, which React rejects with console errors when the child is a native `<textarea>` or `<input>`. Replacing those with Wonder Blocks `TextArea` and `TextField` fixes this — they're designed to accept `LabeledField`'s injected props correctly.

The `handleUpdateCharacterLimit` handler was also updated from a `ChangeEventHandler<HTMLInputElement>` (which receives a synthetic event) to `(newValue: string)` to match `TextField`'s `onChange` signature.

Fixes these two issues: 

<img width="731" height="157" alt="image" src="https://github.com/user-attachments/assets/9ca80a18-b2c7-448d-a445-933b7547d3b7" />

<img width="732" height="144" alt="image" src="https://github.com/user-attachments/assets/e1016d59-fb44-49c4-bb37-45feb5368bd5" />


Issue: none

## Test plan:

- `pnpm test`
- Open Storybook and load the `editors/EditorPage` story with editing disabled — confirm no React DOM prop warnings in the console for the free-response widget fields