### PR TITLE
Don't set default apiOptions - they're provided always

### DIFF
--- a/.changeset/whole-dragons-relate.md
+++ b/.changeset/whole-dragons-relate.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Remove apiOptions from defaultProps in ExpressionEditor, NumericInputEditor, and FreeResponseEditor. Its provided by the widget editor wrapper always.

--- a/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
@@ -4,22 +4,30 @@ import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
 import {testDependencies} from "../../testing/test-dependencies";
+import ExpressionEditor from "../expression-editor";
 
-import type ExpressionEditor from "../expression-editor";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 import type {UserEvent} from "@testing-library/user-event";
 
-const Harnessed = (
-    props: Omit<PropsFor<typeof ExpressionEditor>, "apiOptions">,
-) => {
-    return (
-        <Harnessed
-            apiOptions={ApiOptions.defaults}
-            onChange={() => undefined}
-            {...props}
-        />
-    );
-};
+const HarnessedEditor = React.forwardRef<
+    ExpressionEditor,
+    Partial<PropsFor<typeof ExpressionEditor>>
+>(
+    (
+        {onChange = () => undefined, apiOptions = ApiOptions.defaults, ...rest},
+        ref,
+    ) => {
+        return (
+            <ExpressionEditor
+                apiOptions={apiOptions}
+                onChange={onChange}
+                ref={ref}
+                {...rest}
+            />
+        );
+    },
+);
+HarnessedEditor.displayName = "Harnessed ExpressionEditor";
 
 describe("expression-editor", () => {
     let userEvent: UserEvent;
@@ -34,7 +42,7 @@ describe("expression-editor", () => {
     });
 
     it("should render", async () => {
-        render(<Harnessed />);
+        render(<HarnessedEditor />);
         act(() => jest.runOnlyPendingTimers());
 
         expect(await screen.findByText(/Add new answer/)).toBeInTheDocument();
@@ -65,7 +73,7 @@ describe("expression-editor", () => {
             },
         ];
 
-        render(<Harnessed answerForms={answerForms} />);
+        render(<HarnessedEditor answerForms={answerForms} />);
         act(() => jest.runOnlyPendingTimers());
 
         expect(await screen.findByText(/π/)).toBeInTheDocument();
@@ -74,7 +82,7 @@ describe("expression-editor", () => {
     it("should toggle multiplication checkbox", async () => {
         const onChangeMock = jest.fn();
 
-        render(<Harnessed onChange={onChangeMock} />);
+        render(<HarnessedEditor onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
@@ -91,7 +99,7 @@ describe("expression-editor", () => {
     it("should be possible to change function variables", async () => {
         const onChangeMock = jest.fn();
 
-        render(<Harnessed onChange={onChangeMock} functions={[]} />);
+        render(<HarnessedEditor onChange={onChangeMock} functions={[]} />);
         act(() => jest.runOnlyPendingTimers());
 
         const input = screen.getByRole("textbox", {
@@ -114,7 +122,7 @@ describe("expression-editor", () => {
     it("should toggle division checkbox", async () => {
         const onChangeMock = jest.fn();
 
-        render(<Harnessed onChange={onChangeMock} />);
+        render(<HarnessedEditor onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
@@ -131,7 +139,7 @@ describe("expression-editor", () => {
     it("should toggle trig checkbox", async () => {
         const onChangeMock = jest.fn();
 
-        render(<Harnessed onChange={onChangeMock} />);
+        render(<HarnessedEditor onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
@@ -148,7 +156,7 @@ describe("expression-editor", () => {
     it("should toggle prealgebra checkbox", async () => {
         const onChangeMock = jest.fn();
 
-        render(<Harnessed onChange={onChangeMock} />);
+        render(<HarnessedEditor onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
@@ -164,7 +172,7 @@ describe("expression-editor", () => {
 
     it("should toggle logarithms checkbox", async () => {
         const onChangeMock = jest.fn();
-        render(<Harnessed onChange={onChangeMock} />);
+        render(<HarnessedEditor onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
@@ -180,7 +188,7 @@ describe("expression-editor", () => {
 
     it("should toggle basic relations checkbox", async () => {
         const onChangeMock = jest.fn();
-        render(<Harnessed onChange={onChangeMock} />);
+        render(<HarnessedEditor onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
@@ -197,7 +205,7 @@ describe("expression-editor", () => {
     it("should toggle advanced relations checkbox", async () => {
         const onChangeMock = jest.fn();
 
-        render(<Harnessed onChange={onChangeMock} />);
+        render(<HarnessedEditor onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
@@ -214,7 +222,7 @@ describe("expression-editor", () => {
     it("should toggle scientific checkbox", async () => {
         const onChangeMock = jest.fn();
 
-        render(<Harnessed onChange={onChangeMock} />);
+        render(<HarnessedEditor onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
@@ -232,7 +240,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
         crypto.randomUUID = jest.fn(() => "0-0-0-0-0");
 
-        render(<Harnessed onChange={onChangeMock} />);
+        render(<HarnessedEditor onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
@@ -259,7 +267,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(
-            <Harnessed
+            <HarnessedEditor
                 onChange={onChangeMock}
                 answerForms={[
                     {
@@ -305,7 +313,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(
-            <Harnessed
+            <HarnessedEditor
                 onChange={onChangeMock}
                 answerForms={[
                     {
@@ -344,7 +352,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(
-            <Harnessed
+            <HarnessedEditor
                 onChange={onChangeMock}
                 answerForms={[
                     {
@@ -383,7 +391,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(
-            <Harnessed
+            <HarnessedEditor
                 onChange={onChangeMock}
                 answerForms={[
                     {
@@ -418,7 +426,7 @@ describe("expression-editor", () => {
     it("serializes", () => {
         const editorRef = React.createRef<ExpressionEditor>();
 
-        render(<Harnessed ref={editorRef} />);
+        render(<HarnessedEditor ref={editorRef} />);
 
         const options = editorRef.current?.serialize();
 
@@ -435,7 +443,7 @@ describe("expression-editor", () => {
         const editorRef = React.createRef<ExpressionEditor>();
 
         render(
-            <Harnessed
+            <HarnessedEditor
                 ref={editorRef}
                 onChange={() => {}}
                 answerForms={[
@@ -460,7 +468,7 @@ describe("expression-editor", () => {
         let options: any;
 
         render(
-            <Harnessed
+            <HarnessedEditor
                 onChange={(o) => {
                     options = o;
                 }}

--- a/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/expression-editor.test.tsx
@@ -1,13 +1,25 @@
-import {Dependencies} from "@khanacademy/perseus";
+import {ApiOptions, Dependencies} from "@khanacademy/perseus";
 import {act, render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
 import {testDependencies} from "../../testing/test-dependencies";
-import ExpressionEditor from "../expression-editor";
 
+import type ExpressionEditor from "../expression-editor";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 import type {UserEvent} from "@testing-library/user-event";
+
+const Harnessed = (
+    props: Omit<PropsFor<typeof ExpressionEditor>, "apiOptions">,
+) => {
+    return (
+        <Harnessed
+            apiOptions={ApiOptions.defaults}
+            onChange={() => undefined}
+            {...props}
+        />
+    );
+};
 
 describe("expression-editor", () => {
     let userEvent: UserEvent;
@@ -19,11 +31,10 @@ describe("expression-editor", () => {
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
             testDependencies,
         );
-        jest.useFakeTimers();
     });
 
     it("should render", async () => {
-        render(<ExpressionEditor onChange={() => undefined} />);
+        render(<Harnessed />);
         act(() => jest.runOnlyPendingTimers());
 
         expect(await screen.findByText(/Add new answer/)).toBeInTheDocument();
@@ -54,12 +65,7 @@ describe("expression-editor", () => {
             },
         ];
 
-        render(
-            <ExpressionEditor
-                onChange={() => undefined}
-                answerForms={answerForms}
-            />,
-        );
+        render(<Harnessed answerForms={answerForms} />);
         act(() => jest.runOnlyPendingTimers());
 
         expect(await screen.findByText(/π/)).toBeInTheDocument();
@@ -68,7 +74,7 @@ describe("expression-editor", () => {
     it("should toggle multiplication checkbox", async () => {
         const onChangeMock = jest.fn();
 
-        render(<ExpressionEditor onChange={onChangeMock} />);
+        render(<Harnessed onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
@@ -85,7 +91,7 @@ describe("expression-editor", () => {
     it("should be possible to change function variables", async () => {
         const onChangeMock = jest.fn();
 
-        render(<ExpressionEditor onChange={onChangeMock} functions={[]} />);
+        render(<Harnessed onChange={onChangeMock} functions={[]} />);
         act(() => jest.runOnlyPendingTimers());
 
         const input = screen.getByRole("textbox", {
@@ -108,7 +114,7 @@ describe("expression-editor", () => {
     it("should toggle division checkbox", async () => {
         const onChangeMock = jest.fn();
 
-        render(<ExpressionEditor onChange={onChangeMock} />);
+        render(<Harnessed onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
@@ -125,7 +131,7 @@ describe("expression-editor", () => {
     it("should toggle trig checkbox", async () => {
         const onChangeMock = jest.fn();
 
-        render(<ExpressionEditor onChange={onChangeMock} />);
+        render(<Harnessed onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
@@ -142,7 +148,7 @@ describe("expression-editor", () => {
     it("should toggle prealgebra checkbox", async () => {
         const onChangeMock = jest.fn();
 
-        render(<ExpressionEditor onChange={onChangeMock} />);
+        render(<Harnessed onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
@@ -158,7 +164,7 @@ describe("expression-editor", () => {
 
     it("should toggle logarithms checkbox", async () => {
         const onChangeMock = jest.fn();
-        render(<ExpressionEditor onChange={onChangeMock} />);
+        render(<Harnessed onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
@@ -174,7 +180,7 @@ describe("expression-editor", () => {
 
     it("should toggle basic relations checkbox", async () => {
         const onChangeMock = jest.fn();
-        render(<ExpressionEditor onChange={onChangeMock} />);
+        render(<Harnessed onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
@@ -191,7 +197,7 @@ describe("expression-editor", () => {
     it("should toggle advanced relations checkbox", async () => {
         const onChangeMock = jest.fn();
 
-        render(<ExpressionEditor onChange={onChangeMock} />);
+        render(<Harnessed onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
@@ -208,7 +214,7 @@ describe("expression-editor", () => {
     it("should toggle scientific checkbox", async () => {
         const onChangeMock = jest.fn();
 
-        render(<ExpressionEditor onChange={onChangeMock} />);
+        render(<Harnessed onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
@@ -226,7 +232,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
         crypto.randomUUID = jest.fn(() => "0-0-0-0-0");
 
-        render(<ExpressionEditor onChange={onChangeMock} />);
+        render(<Harnessed onChange={onChangeMock} />);
         act(() => jest.runOnlyPendingTimers());
 
         await userEvent.click(
@@ -253,7 +259,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(
-            <ExpressionEditor
+            <Harnessed
                 onChange={onChangeMock}
                 answerForms={[
                     {
@@ -299,7 +305,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(
-            <ExpressionEditor
+            <Harnessed
                 onChange={onChangeMock}
                 answerForms={[
                     {
@@ -338,7 +344,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(
-            <ExpressionEditor
+            <Harnessed
                 onChange={onChangeMock}
                 answerForms={[
                     {
@@ -377,7 +383,7 @@ describe("expression-editor", () => {
         const onChangeMock = jest.fn();
 
         render(
-            <ExpressionEditor
+            <Harnessed
                 onChange={onChangeMock}
                 answerForms={[
                     {
@@ -412,7 +418,7 @@ describe("expression-editor", () => {
     it("serializes", () => {
         const editorRef = React.createRef<ExpressionEditor>();
 
-        render(<ExpressionEditor ref={editorRef} onChange={() => {}} />);
+        render(<Harnessed ref={editorRef} />);
 
         const options = editorRef.current?.serialize();
 
@@ -429,7 +435,7 @@ describe("expression-editor", () => {
         const editorRef = React.createRef<ExpressionEditor>();
 
         render(
-            <ExpressionEditor
+            <Harnessed
                 ref={editorRef}
                 onChange={() => {}}
                 answerForms={[
@@ -454,7 +460,7 @@ describe("expression-editor", () => {
         let options: any;
 
         render(
-            <ExpressionEditor
+            <Harnessed
                 onChange={(o) => {
                     options = o;
                 }}

--- a/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
@@ -1,4 +1,4 @@
-import {Dependencies} from "@khanacademy/perseus";
+import {ApiOptions, Dependencies} from "@khanacademy/perseus";
 import {render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
@@ -6,7 +6,23 @@ import * as React from "react";
 import {testDependencies} from "../../testing/test-dependencies";
 import FreeResponseEditor from "../free-response-editor";
 
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 import type {UserEvent} from "@testing-library/user-event";
+
+const Harnassed = React.forwardRef<
+    FreeResponseEditor,
+    Omit<PropsFor<typeof FreeResponseEditor>, "apiOptions">
+>((props, ref) => {
+    return (
+        <FreeResponseEditor
+            apiOptions={ApiOptions.defaults}
+            onChange={() => undefined}
+            ref={ref}
+            {...props}
+        />
+    );
+});
+Harnassed.displayName = "Harnassed FreeResponseEditor";
 
 describe("free-response editor", () => {
     let userEvent: UserEvent;
@@ -22,9 +38,7 @@ describe("free-response editor", () => {
 
     it("renders the question", async () => {
         // Act
-        render(
-            <FreeResponseEditor question="test-question" onChange={() => {}} />,
-        );
+        render(<Harnassed question="test-question" />);
 
         // Assert
         expect(screen.getByText("Question")).toBeInTheDocument();
@@ -37,7 +51,7 @@ describe("free-response editor", () => {
 
         // Act
         render(
-            <FreeResponseEditor
+            <Harnassed
                 allowUnlimitedCharacters={false}
                 onChange={onChangeMock}
             />,
@@ -58,9 +72,7 @@ describe("free-response editor", () => {
         const onChangeMock = jest.fn();
 
         // Act
-        render(
-            <FreeResponseEditor characterLimit={0} onChange={onChangeMock} />,
-        );
+        render(<Harnassed characterLimit={0} onChange={onChangeMock} />);
 
         await userEvent.type(screen.getByLabelText(/Character limit/), "1");
 
@@ -73,9 +85,7 @@ describe("free-response editor", () => {
         const onChangeMock = jest.fn();
 
         // Act
-        render(
-            <FreeResponseEditor characterLimit={5} onChange={onChangeMock} />,
-        );
+        render(<Harnassed />);
 
         await userEvent.type(screen.getByLabelText(/Character limit/), "e");
 
@@ -88,7 +98,7 @@ describe("free-response editor", () => {
         const onChangeMock = jest.fn();
 
         // Act
-        render(<FreeResponseEditor onChange={onChangeMock} />);
+        render(<Harnassed onChange={onChangeMock} />);
         await userEvent.type(screen.getByLabelText("Question"), "2");
 
         // Assert
@@ -101,7 +111,7 @@ describe("free-response editor", () => {
 
         // Act
         render(
-            <FreeResponseEditor
+            <Harnassed
                 placeholder="test-placeholder"
                 onChange={onChangeMock}
             />,
@@ -121,7 +131,7 @@ describe("free-response editor", () => {
 
         // Act
         render(
-            <FreeResponseEditor
+            <Harnassed
                 onChange={onChangeMock}
                 scoringCriteria={[{text: ""}]}
             />,
@@ -139,9 +149,7 @@ describe("free-response editor", () => {
         const ref = React.createRef<FreeResponseEditor>();
 
         // Act
-        render(
-            <FreeResponseEditor ref={ref} question="" onChange={() => {}} />,
-        );
+        render(<Harnassed ref={ref} question="" />);
 
         // Assert
         expect(ref.current?.getSaveWarnings()).toEqual([
@@ -154,13 +162,7 @@ describe("free-response editor", () => {
         const ref = React.createRef<FreeResponseEditor>();
 
         // Act
-        render(
-            <FreeResponseEditor
-                ref={ref}
-                question="[[☃ radio 1]]"
-                onChange={() => {}}
-            />,
-        );
+        render(<Harnassed ref={ref} question="[[☃ radio 1]]" />);
 
         // Assert
         expect(ref.current?.getSaveWarnings()).toEqual([
@@ -173,14 +175,7 @@ describe("free-response editor", () => {
         const ref = React.createRef<FreeResponseEditor>();
 
         // Act
-        render(
-            <FreeResponseEditor
-                ref={ref}
-                placeholder=""
-                question="test-question"
-                onChange={() => {}}
-            />,
-        );
+        render(<Harnassed ref={ref} placeholder="" question="test-question" />);
 
         // Assert
         expect(ref.current?.getSaveWarnings()).toEqual([]);
@@ -191,13 +186,7 @@ describe("free-response editor", () => {
         const ref = React.createRef<FreeResponseEditor>();
 
         // Act
-        render(
-            <FreeResponseEditor
-                ref={ref}
-                question="test-question"
-                onChange={() => {}}
-            />,
-        );
+        render(<Harnassed ref={ref} question="test-question" />);
 
         // Assert
         expect(ref.current?.serialize()).toMatchObject({
@@ -211,14 +200,13 @@ describe("free-response editor", () => {
 
         // Act
         render(
-            <FreeResponseEditor
+            <Harnassed
                 ref={ref}
                 question="test-question"
                 scoringCriteria={[
                     {text: "test-criterion-1"},
                     {text: "test-criterion-2"},
                 ]}
-                onChange={() => {}}
             />,
         );
 
@@ -236,7 +224,7 @@ describe("free-response editor", () => {
         const ref = React.createRef<FreeResponseEditor>();
 
         // Act
-        render(<FreeResponseEditor ref={ref} onChange={() => {}} />);
+        render(<Harnassed ref={ref} />);
 
         // Assert
         expect(ref.current?.serialize()).toMatchObject({
@@ -249,7 +237,7 @@ describe("free-response editor", () => {
         const ref = React.createRef<FreeResponseEditor>();
 
         // Act
-        render(<FreeResponseEditor ref={ref} onChange={() => {}} />);
+        render(<Harnassed ref={ref} />);
 
         // Assert
         expect(ref.current?.serialize()).toMatchObject({
@@ -263,7 +251,7 @@ describe("free-response editor", () => {
 
         // Act
         render(
-            <FreeResponseEditor
+            <Harnassed
                 scoringCriteria={[{text: "criterion-1"}]}
                 onChange={onChangeMock}
             />,
@@ -284,7 +272,7 @@ describe("free-response editor", () => {
 
         // Act
         render(
-            <FreeResponseEditor
+            <Harnassed
                 scoringCriteria={[{text: "criterion-1"}]}
                 onChange={onChangeMock}
             />,
@@ -304,7 +292,7 @@ describe("free-response editor", () => {
 
         // Act
         render(
-            <FreeResponseEditor
+            <Harnassed
                 scoringCriteria={[{text: "criterion-1"}, {text: "criterion-2"}]}
                 onChange={onChangeMock}
             />,

--- a/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/free-response-editor.test.tsx
@@ -9,20 +9,25 @@ import FreeResponseEditor from "../free-response-editor";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 import type {UserEvent} from "@testing-library/user-event";
 
-const Harnassed = React.forwardRef<
+const HarnessedEditor = React.forwardRef<
     FreeResponseEditor,
-    Omit<PropsFor<typeof FreeResponseEditor>, "apiOptions">
->((props, ref) => {
-    return (
-        <FreeResponseEditor
-            apiOptions={ApiOptions.defaults}
-            onChange={() => undefined}
-            ref={ref}
-            {...props}
-        />
-    );
-});
-Harnassed.displayName = "Harnassed FreeResponseEditor";
+    Partial<PropsFor<typeof FreeResponseEditor>>
+>(
+    (
+        {onChange = () => undefined, apiOptions = ApiOptions.defaults, ...rest},
+        ref,
+    ) => {
+        return (
+            <FreeResponseEditor
+                apiOptions={apiOptions}
+                onChange={onChange}
+                ref={ref}
+                {...rest}
+            />
+        );
+    },
+);
+HarnessedEditor.displayName = "Harnessed FreeResponseEditor";
 
 describe("free-response editor", () => {
     let userEvent: UserEvent;
@@ -38,7 +43,7 @@ describe("free-response editor", () => {
 
     it("renders the question", async () => {
         // Act
-        render(<Harnassed question="test-question" />);
+        render(<HarnessedEditor question="test-question" />);
 
         // Assert
         expect(screen.getByText("Question")).toBeInTheDocument();
@@ -51,7 +56,7 @@ describe("free-response editor", () => {
 
         // Act
         render(
-            <Harnassed
+            <HarnessedEditor
                 allowUnlimitedCharacters={false}
                 onChange={onChangeMock}
             />,
@@ -72,7 +77,7 @@ describe("free-response editor", () => {
         const onChangeMock = jest.fn();
 
         // Act
-        render(<Harnassed characterLimit={0} onChange={onChangeMock} />);
+        render(<HarnessedEditor characterLimit={0} onChange={onChangeMock} />);
 
         await userEvent.type(screen.getByLabelText(/Character limit/), "1");
 
@@ -85,7 +90,7 @@ describe("free-response editor", () => {
         const onChangeMock = jest.fn();
 
         // Act
-        render(<Harnassed />);
+        render(<HarnessedEditor />);
 
         await userEvent.type(screen.getByLabelText(/Character limit/), "e");
 
@@ -98,7 +103,7 @@ describe("free-response editor", () => {
         const onChangeMock = jest.fn();
 
         // Act
-        render(<Harnassed onChange={onChangeMock} />);
+        render(<HarnessedEditor onChange={onChangeMock} />);
         await userEvent.type(screen.getByLabelText("Question"), "2");
 
         // Assert
@@ -111,7 +116,7 @@ describe("free-response editor", () => {
 
         // Act
         render(
-            <Harnassed
+            <HarnessedEditor
                 placeholder="test-placeholder"
                 onChange={onChangeMock}
             />,
@@ -131,7 +136,7 @@ describe("free-response editor", () => {
 
         // Act
         render(
-            <Harnassed
+            <HarnessedEditor
                 onChange={onChangeMock}
                 scoringCriteria={[{text: ""}]}
             />,
@@ -149,7 +154,7 @@ describe("free-response editor", () => {
         const ref = React.createRef<FreeResponseEditor>();
 
         // Act
-        render(<Harnassed ref={ref} question="" />);
+        render(<HarnessedEditor ref={ref} question="" />);
 
         // Assert
         expect(ref.current?.getSaveWarnings()).toEqual([
@@ -162,7 +167,7 @@ describe("free-response editor", () => {
         const ref = React.createRef<FreeResponseEditor>();
 
         // Act
-        render(<Harnassed ref={ref} question="[[☃ radio 1]]" />);
+        render(<HarnessedEditor ref={ref} question="[[☃ radio 1]]" />);
 
         // Assert
         expect(ref.current?.getSaveWarnings()).toEqual([
@@ -175,7 +180,13 @@ describe("free-response editor", () => {
         const ref = React.createRef<FreeResponseEditor>();
 
         // Act
-        render(<Harnassed ref={ref} placeholder="" question="test-question" />);
+        render(
+            <HarnessedEditor
+                ref={ref}
+                placeholder=""
+                question="test-question"
+            />,
+        );
 
         // Assert
         expect(ref.current?.getSaveWarnings()).toEqual([]);
@@ -186,7 +197,7 @@ describe("free-response editor", () => {
         const ref = React.createRef<FreeResponseEditor>();
 
         // Act
-        render(<Harnassed ref={ref} question="test-question" />);
+        render(<HarnessedEditor ref={ref} question="test-question" />);
 
         // Assert
         expect(ref.current?.serialize()).toMatchObject({
@@ -200,7 +211,7 @@ describe("free-response editor", () => {
 
         // Act
         render(
-            <Harnassed
+            <HarnessedEditor
                 ref={ref}
                 question="test-question"
                 scoringCriteria={[
@@ -224,7 +235,7 @@ describe("free-response editor", () => {
         const ref = React.createRef<FreeResponseEditor>();
 
         // Act
-        render(<Harnassed ref={ref} />);
+        render(<HarnessedEditor ref={ref} />);
 
         // Assert
         expect(ref.current?.serialize()).toMatchObject({
@@ -237,7 +248,7 @@ describe("free-response editor", () => {
         const ref = React.createRef<FreeResponseEditor>();
 
         // Act
-        render(<Harnassed ref={ref} />);
+        render(<HarnessedEditor ref={ref} />);
 
         // Assert
         expect(ref.current?.serialize()).toMatchObject({
@@ -251,7 +262,7 @@ describe("free-response editor", () => {
 
         // Act
         render(
-            <Harnassed
+            <HarnessedEditor
                 scoringCriteria={[{text: "criterion-1"}]}
                 onChange={onChangeMock}
             />,
@@ -272,7 +283,7 @@ describe("free-response editor", () => {
 
         // Act
         render(
-            <Harnassed
+            <HarnessedEditor
                 scoringCriteria={[{text: "criterion-1"}]}
                 onChange={onChangeMock}
             />,
@@ -292,7 +303,7 @@ describe("free-response editor", () => {
 
         // Act
         render(
-            <Harnassed
+            <HarnessedEditor
                 scoringCriteria={[{text: "criterion-1"}, {text: "criterion-2"}]}
                 onChange={onChangeMock}
             />,

--- a/packages/perseus-editor/src/widgets/__tests__/numeric-input-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/numeric-input-editor.test.tsx
@@ -10,17 +10,25 @@ import NumericInputEditor from "../numeric-input-editor";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 import type {UserEvent} from "@testing-library/user-event";
 
-const Harnessed = (
-    props: Omit<PropsFor<typeof NumericInputEditor>, "apiOptions">,
-) => {
-    return (
-        <NumericInputEditor
-            apiOptions={ApiOptions.defaults}
-            onChange={() => undefined}
-            {...props}
-        />
-    );
-};
+const HarnessedEditor = React.forwardRef<
+    NumericInputEditor,
+    Partial<PropsFor<typeof NumericInputEditor>>
+>(
+    (
+        {onChange = () => undefined, apiOptions = ApiOptions.defaults, ...rest},
+        ref,
+    ) => {
+        return (
+            <NumericInputEditor
+                apiOptions={apiOptions}
+                onChange={onChange}
+                ref={ref}
+                {...rest}
+            />
+        );
+    },
+);
+HarnessedEditor.displayName = "Harnessed NumericInputEditor";
 
 describe("numeric-input-editor", () => {
     let userEvent: UserEvent;
@@ -35,7 +43,7 @@ describe("numeric-input-editor", () => {
     });
 
     it("should render", async () => {
-        render(<Harnessed />);
+        render(<HarnessedEditor />);
 
         await waitFor(async () =>
             expect(
@@ -47,7 +55,7 @@ describe("numeric-input-editor", () => {
     it("should be possible to select normal width", async () => {
         const onChangeMock = jest.fn();
 
-        render(<Harnessed onChange={onChangeMock} />);
+        render(<HarnessedEditor onChange={onChangeMock} />);
 
         await userEvent.click(
             within(screen.getByRole("radiogroup", {name: /^Width/})).getByRole(
@@ -65,7 +73,7 @@ describe("numeric-input-editor", () => {
     it("should be possible to select small width", async () => {
         const onChangeMock = jest.fn();
 
-        render(<Harnessed onChange={onChangeMock} />);
+        render(<HarnessedEditor onChange={onChangeMock} />);
 
         await userEvent.click(
             within(screen.getByRole("radiogroup", {name: /^Width/})).getByRole(
@@ -83,7 +91,7 @@ describe("numeric-input-editor", () => {
     it("should be possible to change text alignment", async () => {
         const onChangeMock = jest.fn();
 
-        render(<Harnessed onChange={onChangeMock} />);
+        render(<HarnessedEditor onChange={onChangeMock} />);
 
         // Act
         const opener = await screen.findByRole("combobox", {
@@ -103,7 +111,7 @@ describe("numeric-input-editor", () => {
     it("should be possible to select coefficient", async () => {
         const onChangeMock = jest.fn();
 
-        render(<Harnessed onChange={onChangeMock} />);
+        render(<HarnessedEditor onChange={onChangeMock} />);
 
         await userEvent.click(
             within(
@@ -117,7 +125,7 @@ describe("numeric-input-editor", () => {
     it("should be possible to select strictly match only these formats", async () => {
         const onChangeMock = jest.fn();
 
-        render(<Harnessed onChange={onChangeMock} />);
+        render(<HarnessedEditor onChange={onChangeMock} />);
 
         await userEvent.click(
             within(
@@ -143,7 +151,7 @@ describe("numeric-input-editor", () => {
     it("should be possible to update label text", async () => {
         const onChangeMock = jest.fn();
 
-        render(<Harnessed onChange={onChangeMock} />);
+        render(<HarnessedEditor onChange={onChangeMock} />);
 
         const input = screen.getByRole("textbox", {
             name: "aria label",
@@ -168,7 +176,7 @@ describe("numeric-input-editor", () => {
                 });
             }
 
-            return <Harnessed onChange={mergeProps} {...props} />;
+            return <HarnessedEditor onChange={mergeProps} {...props} />;
         }
 
         render(<StatefulNumericInputEditor />);
@@ -185,7 +193,7 @@ describe("numeric-input-editor", () => {
     it("should be possible to set unsimplified answers to ungraded", async () => {
         const onChangeMock = jest.fn();
 
-        render(<Harnessed onChange={onChangeMock} />);
+        render(<HarnessedEditor onChange={onChangeMock} />);
 
         await userEvent.click(
             within(
@@ -207,7 +215,7 @@ describe("numeric-input-editor", () => {
     it("should be possible to set unsimplified answers to accepted", async () => {
         const onChangeMock = jest.fn();
 
-        render(<Harnessed onChange={onChangeMock} />);
+        render(<HarnessedEditor onChange={onChangeMock} />);
 
         await userEvent.click(
             within(
@@ -229,7 +237,7 @@ describe("numeric-input-editor", () => {
     it("should be possible to set unsimplified answers to wrong", async () => {
         const onChangeMock = jest.fn();
 
-        render(<Harnessed onChange={onChangeMock} />);
+        render(<HarnessedEditor onChange={onChangeMock} />);
 
         await userEvent.click(
             within(
@@ -261,7 +269,7 @@ describe("numeric-input-editor", () => {
         it(`should be possible to set suggested answer format to: ${name}`, async () => {
             const onChangeMock = jest.fn();
 
-            render(<Harnessed onChange={onChangeMock} />);
+            render(<HarnessedEditor onChange={onChangeMock} />);
 
             await userEvent.click(screen.getByRole("checkbox", {name: name}));
 

--- a/packages/perseus-editor/src/widgets/__tests__/numeric-input-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/numeric-input-editor.test.tsx
@@ -1,4 +1,4 @@
-import {Dependencies} from "@khanacademy/perseus";
+import {ApiOptions, Dependencies} from "@khanacademy/perseus";
 import {render, screen, waitFor, within} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
@@ -7,7 +7,20 @@ import {useState} from "react";
 import {testDependencies} from "../../testing/test-dependencies";
 import NumericInputEditor from "../numeric-input-editor";
 
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 import type {UserEvent} from "@testing-library/user-event";
+
+const Harnessed = (
+    props: Omit<PropsFor<typeof NumericInputEditor>, "apiOptions">,
+) => {
+    return (
+        <NumericInputEditor
+            apiOptions={ApiOptions.defaults}
+            onChange={() => undefined}
+            {...props}
+        />
+    );
+};
 
 describe("numeric-input-editor", () => {
     let userEvent: UserEvent;
@@ -22,7 +35,7 @@ describe("numeric-input-editor", () => {
     });
 
     it("should render", async () => {
-        render(<NumericInputEditor onChange={() => undefined} />);
+        render(<Harnessed />);
 
         await waitFor(async () =>
             expect(
@@ -34,7 +47,7 @@ describe("numeric-input-editor", () => {
     it("should be possible to select normal width", async () => {
         const onChangeMock = jest.fn();
 
-        render(<NumericInputEditor onChange={onChangeMock} />);
+        render(<Harnessed onChange={onChangeMock} />);
 
         await userEvent.click(
             within(screen.getByRole("radiogroup", {name: /^Width/})).getByRole(
@@ -52,7 +65,7 @@ describe("numeric-input-editor", () => {
     it("should be possible to select small width", async () => {
         const onChangeMock = jest.fn();
 
-        render(<NumericInputEditor onChange={onChangeMock} />);
+        render(<Harnessed onChange={onChangeMock} />);
 
         await userEvent.click(
             within(screen.getByRole("radiogroup", {name: /^Width/})).getByRole(
@@ -70,7 +83,7 @@ describe("numeric-input-editor", () => {
     it("should be possible to change text alignment", async () => {
         const onChangeMock = jest.fn();
 
-        render(<NumericInputEditor onChange={onChangeMock} />);
+        render(<Harnessed onChange={onChangeMock} />);
 
         // Act
         const opener = await screen.findByRole("combobox", {
@@ -90,7 +103,7 @@ describe("numeric-input-editor", () => {
     it("should be possible to select coefficient", async () => {
         const onChangeMock = jest.fn();
 
-        render(<NumericInputEditor onChange={onChangeMock} />);
+        render(<Harnessed onChange={onChangeMock} />);
 
         await userEvent.click(
             within(
@@ -104,7 +117,7 @@ describe("numeric-input-editor", () => {
     it("should be possible to select strictly match only these formats", async () => {
         const onChangeMock = jest.fn();
 
-        render(<NumericInputEditor onChange={onChangeMock} />);
+        render(<Harnessed onChange={onChangeMock} />);
 
         await userEvent.click(
             within(
@@ -130,7 +143,7 @@ describe("numeric-input-editor", () => {
     it("should be possible to update label text", async () => {
         const onChangeMock = jest.fn();
 
-        render(<NumericInputEditor onChange={onChangeMock} />);
+        render(<Harnessed onChange={onChangeMock} />);
 
         const input = screen.getByRole("textbox", {
             name: "aria label",
@@ -155,7 +168,7 @@ describe("numeric-input-editor", () => {
                 });
             }
 
-            return <NumericInputEditor onChange={mergeProps} {...props} />;
+            return <Harnessed onChange={mergeProps} {...props} />;
         }
 
         render(<StatefulNumericInputEditor />);
@@ -172,7 +185,7 @@ describe("numeric-input-editor", () => {
     it("should be possible to set unsimplified answers to ungraded", async () => {
         const onChangeMock = jest.fn();
 
-        render(<NumericInputEditor onChange={onChangeMock} />);
+        render(<Harnessed onChange={onChangeMock} />);
 
         await userEvent.click(
             within(
@@ -194,7 +207,7 @@ describe("numeric-input-editor", () => {
     it("should be possible to set unsimplified answers to accepted", async () => {
         const onChangeMock = jest.fn();
 
-        render(<NumericInputEditor onChange={onChangeMock} />);
+        render(<Harnessed onChange={onChangeMock} />);
 
         await userEvent.click(
             within(
@@ -216,7 +229,7 @@ describe("numeric-input-editor", () => {
     it("should be possible to set unsimplified answers to wrong", async () => {
         const onChangeMock = jest.fn();
 
-        render(<NumericInputEditor onChange={onChangeMock} />);
+        render(<Harnessed onChange={onChangeMock} />);
 
         await userEvent.click(
             within(
@@ -248,7 +261,7 @@ describe("numeric-input-editor", () => {
         it(`should be possible to set suggested answer format to: ${name}`, async () => {
             const onChangeMock = jest.fn();
 
-            render(<NumericInputEditor onChange={onChangeMock} />);
+            render(<Harnessed onChange={onChangeMock} />);
 
             await userEvent.click(screen.getByRole("checkbox", {name: name}));
 

--- a/packages/perseus-editor/src/widgets/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor.tsx
@@ -1,5 +1,5 @@
 import * as KAS from "@khanacademy/kas";
-import {ApiOptions, components, Expression} from "@khanacademy/perseus";
+import {components, Expression} from "@khanacademy/perseus";
 import {
     PerseusExpressionAnswerFormConsidered,
     deriveExtraKeys,
@@ -64,7 +64,6 @@ class ExpressionEditor extends React.Component<Props, State> {
 
     static defaultProps = {
         ...expressionLogic.defaultWidgetOptions,
-        apiOptions: ApiOptions.defaults,
     };
 
     constructor(props: Props) {

--- a/packages/perseus-editor/src/widgets/free-response-editor.tsx
+++ b/packages/perseus-editor/src/widgets/free-response-editor.tsx
@@ -1,4 +1,4 @@
-import {ApiOptions, Util} from "@khanacademy/perseus";
+import {Util} from "@khanacademy/perseus";
 import {freeResponseLogic} from "@khanacademy/perseus-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
@@ -29,7 +29,6 @@ type Props = PerseusFreeResponseWidgetOptions & {
 class FreeResponseEditor extends React.Component<Props> {
     static defaultProps = {
         ...freeResponseLogic.defaultWidgetOptions,
-        apiOptions: ApiOptions.defaults,
     };
 
     static widgetName = "free-response" as const;

--- a/packages/perseus-editor/src/widgets/numeric-input-editor.tsx
+++ b/packages/perseus-editor/src/widgets/numeric-input-editor.tsx
@@ -1,6 +1,5 @@
 import {KhanMath} from "@khanacademy/kmath";
 import {
-    ApiOptions,
     components,
     Changeable,
     EditorJsonify,
@@ -84,7 +83,6 @@ class NumericInputEditor extends React.Component<Props, State> {
 
     static defaultProps = {
         ...numericInputLogic.defaultWidgetOptions,
-        apiOptions: ApiOptions.defaults,
     };
 
     constructor(props: Props) {


### PR DESCRIPTION
## Summary:

Adding a widget to the editor was crashing the preview with a `DataCloneError` because `postMessage` can't serialize functions. The crash traced back to three widget editors — `ExpressionEditor`, `NumericInputEditor`, and `FreeResponseEditor` — each including `apiOptions: ApiOptions.defaults` in their static `defaultProps`. 

`ApiOptions.defaults` contains fields that cannot be passed through the [structured-clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm) used by `postMessage` for sending data to the preview iframe.

The bug surfaced because `Editor._addWidgetToContent` uses `widgetEditor.defaultProps` as the initial options for a newly added widget. That put the unserializable values directly into the widget data, which then flowed through `postMessage` to the preview iframe.

The fix is to remove `apiOptions` from those three editors' `defaultProps`. Widget editors should never provide a default `apiOptions` — the `WidgetEditor` wrapper always supplies it as a prop, so having it in `defaultProps` was both redundant and harmful.

Widget editor tests have been also updated to handle `apiOptions` being required and not defaulted now.

Issue: LEMS-3741

## Test plan:

- Open the `EditorPage` demo in Storybook, add an `expression` widget to the content, and confirm the preview no longer crashes with a `DataCloneError`
- Run `pnpm test`