### PR TITLE
Update accessibility criteria for Grapher

### DIFF
--- a/.changeset/nice-pugs-invent.md
+++ b/.changeset/nice-pugs-invent.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": minor
+---
+
+The Grapher widget is now marked **accessible** if it has a single available function type that is not `quadratic`, and no background image.

--- a/packages/perseus-core/src/utils/generators/grapher-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/grapher-widget-generator.ts
@@ -10,3 +10,12 @@ export function generateGrapherWidgetOptions(
         ...options,
     };
 }
+
+export function generateGrapherGraph(
+    overrides: Partial<PerseusGrapherWidgetOptions["graph"]>,
+): PerseusGrapherWidgetOptions["graph"] {
+    return {
+        ...grapherWidgetLogic.defaultWidgetOptions.graph,
+        ...overrides,
+    };
+}

--- a/packages/perseus-core/src/widgets/grapher/index.test.ts
+++ b/packages/perseus-core/src/widgets/grapher/index.test.ts
@@ -13,6 +13,8 @@ describe("grapherWidgetLogic.accessible()", () => {
     const accessible = grapherWidgetLogic.accessible;
     invariant(accessible instanceof Function);
 
+    // A Grapher widget is accessible iff it has no background image and
+    // a single non-quadratic function type.
     const accessibleGraph = generateGrapherWidgetOptions({
         graph: generateGrapherGraph({backgroundImage: {url: null}}),
         availableTypes: ["linear"],

--- a/packages/perseus-core/src/widgets/grapher/index.test.ts
+++ b/packages/perseus-core/src/widgets/grapher/index.test.ts
@@ -1,0 +1,66 @@
+import invariant from "tiny-invariant";
+
+import {
+    generateGrapherGraph,
+    generateGrapherWidgetOptions,
+} from "../../utils/generators/grapher-widget-generator";
+
+import type {PerseusGrapherWidgetOptions} from "../../data-schema";
+
+import grapherWidgetLogic from "./index";
+
+describe("grapherWidgetLogic.accessible()", () => {
+    const accessible = grapherWidgetLogic.accessible;
+    invariant(accessible instanceof Function);
+
+    const accessibleGraph = generateGrapherWidgetOptions({
+        graph: generateGrapherGraph({backgroundImage: {url: null}}),
+        availableTypes: ["linear"],
+    });
+
+    it("returns true when the graph is accessible", () => {
+        expect(accessible(accessibleGraph)).toBe(true);
+    });
+
+    it("returns false when the graph has a background image URL", () => {
+        const graph = {
+            ...accessibleGraph,
+            graph: {
+                ...accessibleGraph.graph,
+                backgroundImage: {url: "something"},
+            },
+        };
+
+        expect(accessible(graph)).toBe(false);
+    });
+
+    it("returns true when the graph has an empty background image URL", () => {
+        const graph = {
+            ...accessibleGraph,
+            graph: {
+                ...accessibleGraph.graph,
+                backgroundImage: {url: ""},
+            },
+        };
+
+        expect(accessible(graph)).toBe(true);
+    });
+
+    it("returns false when the graph is quadratic", () => {
+        const graph: PerseusGrapherWidgetOptions = {
+            ...accessibleGraph,
+            availableTypes: ["quadratic"],
+        };
+
+        expect(accessible(graph)).toBe(false);
+    });
+
+    it("returns false when the graph has multiple available types (the choose-your-own-function case)", () => {
+        const graph: PerseusGrapherWidgetOptions = {
+            ...accessibleGraph,
+            availableTypes: ["linear", "tangent"],
+        };
+
+        expect(accessible(graph)).toBe(false);
+    });
+});

--- a/packages/perseus-core/src/widgets/grapher/index.ts
+++ b/packages/perseus-core/src/widgets/grapher/index.ts
@@ -40,7 +40,10 @@ const grapherWidgetLogic: WidgetLogic<
     name: "grapher",
     defaultWidgetOptions,
     getPublicWidgetOptions: getGrapherPublicWidgetOptions,
-    accessible: false,
+    accessible: (options) =>
+        !options.graph.backgroundImage.url &&
+        options.availableTypes.length === 1 &&
+        options.availableTypes[0] !== "quadratic",
 };
 
 export default grapherWidgetLogic;

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`ArticleEditor should match snapshot for editing disabled for all widget
                   class="svg_1q6jc65-o_O-medium_12bui46-o_O-inlineStyles_6947y3"
                   data-testid="issues-icon-warning-octagon-fill.svg"
                 />
-                17 issues
+                16 issues
               </div>
             </div>
             <div


### PR DESCRIPTION
## Summary:
The Grapher widget is now accessible if:

- it has no background image, AND
- it has a single available function type that is not `quadratic`

This is because we use the Interactive Graph UI components for Graphers that
aren't quadratic or choose-your-own-function. Graphers with background images
are not accessible because they don't have alt text.

Issue: https://khanacademy.atlassian.net/browse/LEMS-4289

## Test plan:

Deploy. Graphers in the content editor should not display an accessibility
lint warning if they meet the criteria above.