### PR TITLE
Add subscript button to MathInput keypad

### DIFF
--- a/.changeset/crisp-dots-behave.md
+++ b/.changeset/crisp-dots-behave.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-core": minor
+"@khanacademy/math-input": minor
+---
+
+Add support for subscript in the MathInput keypad

--- a/packages/math-input/src/components/input/__tests__/mathquill.test.ts
+++ b/packages/math-input/src/components/input/__tests__/mathquill.test.ts
@@ -166,6 +166,31 @@ describe("MathQuill", () => {
         });
     });
 
+    describe("Subscript", () => {
+        it("should prefix with empty parens after no content", () => {
+            mathField.pressKey("SUB");
+            expect(mathField.getContent()).toEqual("\\left(\\right)_{ }");
+
+            // Verify that the cursor is in the subscript, not within the parens,
+            // writing a unique character to verify cursor position.
+            expect(isInsideEmptyParens(mathField.getCursor())).toBeFalsy();
+            mathField.pressKey("PLUS");
+            expect(mathField.getContent()).toEqual("\\left(\\right)_{+}");
+        });
+
+        it("should prefix with empty parens after an operator", () => {
+            mathField.pressKey("PLUS");
+            mathField.pressKey("SUB");
+            expect(mathField.getContent()).toEqual("+\\left(\\right)_{ }");
+        });
+
+        it("should work after an expression", () => {
+            mathField.setContent("35x");
+            mathField.pressKey("SUB");
+            expect(mathField.getContent()).toEqual("35x_{ }");
+        });
+    });
+
     describe("Square Root", () => {
         it("should work with no content", () => {
             mathField.pressKey("SQRT");

--- a/packages/math-input/src/components/input/__tests__/mathquill.test.ts
+++ b/packages/math-input/src/components/input/__tests__/mathquill.test.ts
@@ -172,22 +172,24 @@ describe("MathQuill", () => {
             expect(mathField.getContent()).toEqual("\\left(\\right)_{ }");
 
             // Verify that the cursor is in the subscript, not within the parens,
-            // writing a unique character to verify cursor position.
+            // by writing a variable and checking it lands in the subscript.
             expect(isInsideEmptyParens(mathField.getCursor())).toBeFalsy();
-            mathField.pressKey("PLUS");
-            expect(mathField.getContent()).toEqual("\\left(\\right)_{+}");
+            mathField.pressKey("n");
+            expect(mathField.getContent()).toEqual("\\left(\\right)_{n}");
         });
 
         it("should prefix with empty parens after an operator", () => {
             mathField.pressKey("PLUS");
             mathField.pressKey("SUB");
-            expect(mathField.getContent()).toEqual("+\\left(\\right)_{ }");
+            mathField.pressKey("n");
+            expect(mathField.getContent()).toEqual("+\\left(\\right)_{n}");
         });
 
         it("should work after an expression", () => {
-            mathField.setContent("35x");
+            mathField.setContent("x");
             mathField.pressKey("SUB");
-            expect(mathField.getContent()).toEqual("35x_{ }");
+            mathField.pressKey("n");
+            expect(mathField.getContent()).toEqual("x_{n}");
         });
     });
 

--- a/packages/math-input/src/components/input/math-input.tsx
+++ b/packages/math-input/src/components/input/math-input.tsx
@@ -838,6 +838,7 @@ class MathInput extends React.Component<Props, State> {
             ">": "GT",
             "<": "LT",
             "^": "EXP",
+            _: "SUB",
         } as const;
 
         // Numbers

--- a/packages/math-input/src/components/key-handlers/handle-exponent.ts
+++ b/packages/math-input/src/components/key-handlers/handle-exponent.ts
@@ -1,29 +1,13 @@
-import {MathFieldActionType} from "../../types";
-import {mathQuillInstance} from "../input/mathquill-instance";
+import insertBaseParens from "./insert-base-parens";
 
 import type {MathFieldInterface} from "../input/mathquill-types";
 import type {KeypadKey} from "@khanacademy/perseus-core";
-
-const ArithmeticOperators = ["+", "-", "\\cdot", "\\times", "\\div"];
-const EqualityOperators = ["=", "\\neq", "<", "\\leq", ">", "\\geq"];
 
 export default function handleExponent(
     mathField: MathFieldInterface,
     key: KeypadKey,
 ) {
-    const cursor = mathField.cursor();
-    // If there's an invalid operator preceding the cursor (anything that
-    // knowingly cannot be raised to a power), add an empty set of
-    // parentheses and apply the exponent to that.
-    const invalidPrefixes = [...ArithmeticOperators, ...EqualityOperators];
-
-    const precedingNode = cursor[mathQuillInstance.L];
-    const shouldPrefixWithParens =
-        precedingNode === MathFieldActionType.MQ_END ||
-        invalidPrefixes.includes(precedingNode.ctrlSeq.trim());
-    if (shouldPrefixWithParens) {
-        mathField.write("\\left(\\right)");
-    }
+    const insertedParens = insertBaseParens(mathField);
 
     // Insert the appropriate exponent operator.
     switch (key) {
@@ -39,7 +23,7 @@ export default function handleExponent(
             // within the newly inserted parens, if they exist. This takes
             // exactly four left strokes, since the cursor by default would
             // end up to the right of the exponent.
-            if (shouldPrefixWithParens) {
+            if (insertedParens) {
                 mathField.keystroke("Left");
                 mathField.keystroke("Left");
                 mathField.keystroke("Left");

--- a/packages/math-input/src/components/key-handlers/handle-subscript.ts
+++ b/packages/math-input/src/components/key-handlers/handle-subscript.ts
@@ -1,0 +1,26 @@
+import {MathFieldActionType} from "../../types";
+import {mathQuillInstance} from "../input/mathquill-instance";
+
+import type {MathFieldInterface} from "../input/mathquill-types";
+
+const ArithmeticOperators = ["+", "-", "\\cdot", "\\times", "\\div"];
+const EqualityOperators = ["=", "\\neq", "<", "\\leq", ">", "\\geq"];
+
+export default function handleSubscript(mathField: MathFieldInterface) {
+    const cursor = mathField.cursor();
+    // If there's an invalid operator preceding the cursor (anything that
+    // knowingly cannot take a subscript), add an empty set of parentheses and
+    // apply the subscript to that. This mirrors the exponent behavior.
+    const invalidPrefixes = [...ArithmeticOperators, ...EqualityOperators];
+
+    const precedingNode = cursor[mathQuillInstance.L];
+    const shouldPrefixWithParens =
+        precedingNode === MathFieldActionType.MQ_END ||
+        invalidPrefixes.includes(precedingNode.ctrlSeq.trim());
+    if (shouldPrefixWithParens) {
+        mathField.write("\\left(\\right)");
+    }
+
+    // Insert the subscript operator, leaving the cursor inside it.
+    mathField.cmd("_");
+}

--- a/packages/math-input/src/components/key-handlers/handle-subscript.ts
+++ b/packages/math-input/src/components/key-handlers/handle-subscript.ts
@@ -1,25 +1,9 @@
-import {MathFieldActionType} from "../../types";
-import {mathQuillInstance} from "../input/mathquill-instance";
+import insertBaseParens from "./insert-base-parens";
 
 import type {MathFieldInterface} from "../input/mathquill-types";
 
-const ArithmeticOperators = ["+", "-", "\\cdot", "\\times", "\\div"];
-const EqualityOperators = ["=", "\\neq", "<", "\\leq", ">", "\\geq"];
-
 export default function handleSubscript(mathField: MathFieldInterface) {
-    const cursor = mathField.cursor();
-    // If there's an invalid operator preceding the cursor (anything that
-    // knowingly cannot take a subscript), add an empty set of parentheses and
-    // apply the subscript to that. This mirrors the exponent behavior.
-    const invalidPrefixes = [...ArithmeticOperators, ...EqualityOperators];
-
-    const precedingNode = cursor[mathQuillInstance.L];
-    const shouldPrefixWithParens =
-        precedingNode === MathFieldActionType.MQ_END ||
-        invalidPrefixes.includes(precedingNode.ctrlSeq.trim());
-    if (shouldPrefixWithParens) {
-        mathField.write("\\left(\\right)");
-    }
+    insertBaseParens(mathField);
 
     // Insert the subscript operator, leaving the cursor inside it.
     mathField.cmd("_");

--- a/packages/math-input/src/components/key-handlers/insert-base-parens.ts
+++ b/packages/math-input/src/components/key-handlers/insert-base-parens.ts
@@ -1,0 +1,34 @@
+import {MathFieldActionType} from "../../types";
+import {mathQuillInstance} from "../input/mathquill-instance";
+
+import type {MathFieldInterface} from "../input/mathquill-types";
+
+const ArithmeticOperators = ["+", "-", "\\cdot", "\\times", "\\div"];
+const EqualityOperators = ["=", "\\neq", "<", "\\leq", ">", "\\geq"];
+
+// Anything that knowingly cannot serve as the base of a superscript or
+// subscript (i.e. can't be raised to a power or given an index).
+const invalidPrefixes = [...ArithmeticOperators, ...EqualityOperators];
+
+/**
+ * Ensures there's a valid base immediately before the cursor for a superscript
+ * or subscript to attach to. If the preceding node is empty or an operator that
+ * can't take a script, an empty set of parentheses is inserted to act as the
+ * base.
+ *
+ * @returns whether empty parentheses were inserted, so callers can adjust the
+ * cursor position accordingly.
+ */
+export default function insertBaseParens(
+    mathField: MathFieldInterface,
+): boolean {
+    const cursor = mathField.cursor();
+    const precedingNode = cursor[mathQuillInstance.L];
+    const shouldPrefixWithParens =
+        precedingNode === MathFieldActionType.MQ_END ||
+        invalidPrefixes.includes(precedingNode.ctrlSeq.trim());
+    if (shouldPrefixWithParens) {
+        mathField.write("\\left(\\right)");
+    }
+    return shouldPrefixWithParens;
+}

--- a/packages/math-input/src/components/key-handlers/key-translator.ts
+++ b/packages/math-input/src/components/key-handlers/key-translator.ts
@@ -9,6 +9,7 @@ import {mathQuillInstance} from "../input/mathquill-instance";
 import handleArrow from "./handle-arrow";
 import handleExponent from "./handle-exponent";
 import handleJumpOut from "./handle-jump-out";
+import handleSubscript from "./handle-subscript";
 
 import type {
     MathFieldInterface,
@@ -82,6 +83,7 @@ export const getKeyTranslator = (
     EXP: handleExponent,
     EXP_2: handleExponent,
     EXP_3: handleExponent,
+    SUB: handleSubscript,
 
     JUMP_OUT_PARENTHESES: handleJumpOut,
     JUMP_OUT_EXPONENT: handleJumpOut,

--- a/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
@@ -180,15 +180,11 @@ describe("Keypad v2 with MathQuill", () => {
 
         // Act
 
-        // a
+        // use the keypad for `a_{1}`
         await userEvent.click(screen.getByRole("tab", {name: "Extras"}));
         await userEvent.click(screen.getByRole("button", {name: "a"}));
-
-        // subscript
         await userEvent.click(screen.getByRole("tab", {name: "Operators"}));
         await userEvent.click(screen.getByRole("button", {name: "Subscript"}));
-
-        // index (should land inside the subscript, not after it)
         await userEvent.click(screen.getByRole("tab", {name: "Numbers"}));
         await userEvent.click(screen.getByRole("button", {name: "1"}));
 

--- a/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/keypad-v2-mathquill.test.tsx
@@ -171,6 +171,31 @@ describe("Keypad v2 with MathQuill", () => {
         );
     });
 
+    it("can write an indexed variable using the subscript button", async () => {
+        // Arrange
+        const mockMathInputCallback = jest.fn();
+        render(
+            <V2KeypadWithMathquill onChangeMathInput={mockMathInputCallback} />,
+        );
+
+        // Act
+
+        // a
+        await userEvent.click(screen.getByRole("tab", {name: "Extras"}));
+        await userEvent.click(screen.getByRole("button", {name: "a"}));
+
+        // subscript
+        await userEvent.click(screen.getByRole("tab", {name: "Operators"}));
+        await userEvent.click(screen.getByRole("button", {name: "Subscript"}));
+
+        // index (should land inside the subscript, not after it)
+        await userEvent.click(screen.getByRole("tab", {name: "Numbers"}));
+        await userEvent.click(screen.getByRole("button", {name: "1"}));
+
+        // Assert
+        expect(mockMathInputCallback).toHaveBeenLastCalledWith("a_{1}");
+    });
+
     it("can write the Pythagorean theorem (complex)", async () => {
         // Arrange
         const mockMathInputCallback = jest.fn();

--- a/packages/math-input/src/components/keypad/button-assets.tsx
+++ b/packages/math-input/src/components/keypad/button-assets.tsx
@@ -505,8 +505,6 @@ export default function ButtonAsset({id}: Props): React.ReactNode {
                     />
                 </svg>
             );
-        // NOTE: This is a rough placeholder glyph — the base box from EXP with
-        // the small box moved to the lower-right to read as a subscript.
         case "SUB":
             return (
                 <svg

--- a/packages/math-input/src/components/keypad/button-assets.tsx
+++ b/packages/math-input/src/components/keypad/button-assets.tsx
@@ -505,6 +505,25 @@ export default function ButtonAsset({id}: Props): React.ReactNode {
                     />
                 </svg>
             );
+        // NOTE: This is a rough placeholder glyph — the base box from EXP with
+        // the small box moved to the lower-right to read as a subscript.
+        case "SUB":
+            return (
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="40"
+                    height="40"
+                    fill="none"
+                    viewBox="0 0 40 40"
+                >
+                    <path
+                        fill="#21242C"
+                        fillRule="evenodd"
+                        d="M14 13a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v14a1 1 0 0 1-1 1H15a1 1 0 0 1-1-1V13Zm2 1h8v12h-8V14Zm12 12a1 1 0 0 1 1-1h6a1 1 0 0 1 1 1v6a1 1 0 0 1-1 1h-6a1 1 0 0 1-1-1v-6Zm2 1h4v4h-4v-4Z"
+                        clipRule="evenodd"
+                    />
+                </svg>
+            );
         case "EXP_2":
             return (
                 <svg

--- a/packages/math-input/src/components/keypad/keypad-pages/keypad-pages.stories.tsx
+++ b/packages/math-input/src/components/keypad/keypad-pages/keypad-pages.stories.tsx
@@ -20,13 +20,13 @@ export default {
     },
 } satisfies Meta;
 
-export const NumericInput = (): React.ReactElement => (
+export const NumbersPageLayout = (): React.ReactElement => (
     <RenderKeyPadPanel selectedPage="Numbers" onClickKey={() => {}}>
         <NumbersPage onClickKey={action("onClickKey")} />
     </RenderKeyPadPanel>
 );
 
-export const PreAlgebraInput = (): React.ReactElement => (
+export const OperatorsPageLayout = (): React.ReactElement => (
     <RenderKeyPadPanel selectedPage="Operators" onClickKey={() => {}}>
         <OperatorsPage
             onClickKey={action("onClickKey")}
@@ -38,7 +38,55 @@ export const PreAlgebraInput = (): React.ReactElement => (
     </RenderKeyPadPanel>
 );
 
-export const TrigonometryInput = (): React.ReactElement => (
+export const OperatorsPageOnlyPreAlgebra = (): React.ReactElement => (
+    <RenderKeyPadPanel selectedPage="Operators" onClickKey={() => {}}>
+        <OperatorsPage
+            onClickKey={action("onClickKey")}
+            preAlgebra={true}
+            logarithms={false}
+            basicRelations={false}
+            advancedRelations={false}
+        />
+    </RenderKeyPadPanel>
+);
+
+export const OperatorsPageOnlyLogarithms = (): React.ReactElement => (
+    <RenderKeyPadPanel selectedPage="Operators" onClickKey={() => {}}>
+        <OperatorsPage
+            onClickKey={action("onClickKey")}
+            preAlgebra={false}
+            logarithms={true}
+            basicRelations={false}
+            advancedRelations={false}
+        />
+    </RenderKeyPadPanel>
+);
+
+export const OperatorsPageOnlyBasicRelations = (): React.ReactElement => (
+    <RenderKeyPadPanel selectedPage="Operators" onClickKey={() => {}}>
+        <OperatorsPage
+            onClickKey={action("onClickKey")}
+            preAlgebra={false}
+            logarithms={false}
+            basicRelations={true}
+            advancedRelations={false}
+        />
+    </RenderKeyPadPanel>
+);
+
+export const OperatorsPageOnlyAdvancedRelations = (): React.ReactElement => (
+    <RenderKeyPadPanel selectedPage="Operators" onClickKey={() => {}}>
+        <OperatorsPage
+            onClickKey={action("onClickKey")}
+            preAlgebra={false}
+            logarithms={false}
+            basicRelations={false}
+            advancedRelations={true}
+        />
+    </RenderKeyPadPanel>
+);
+
+export const GeometryInputPageLayout = (): React.ReactElement => (
     <RenderKeyPadPanel selectedPage="Extras" onClickKey={() => {}}>
         <GeometryInputPage onClickKey={action("onClickKey")} />
     </RenderKeyPadPanel>

--- a/packages/math-input/src/components/keypad/keypad-pages/operators-page.tsx
+++ b/packages/math-input/src/components/keypad/keypad-pages/operators-page.tsx
@@ -41,14 +41,21 @@ export default function OperatorsPage(props: Props) {
                         coord={[1, 0]}
                     />
                     <KeypadButton
-                        keyConfig={Keys.SQRT}
+                        keyConfig={Keys.SUB}
                         onClickKey={onClickKey}
                         coord={[2, 0]}
                     />
                     <KeypadButton
-                        keyConfig={Keys.RADICAL}
+                        keyConfig={Keys.SQRT}
                         onClickKey={onClickKey}
                         coord={[3, 0]}
+                    />
+                    {/* Row 1 is full (cols 4-5 are shared +/- keys), so RADICAL
+                        moves to the free cell at the end of the relations row. */}
+                    <KeypadButton
+                        keyConfig={Keys.RADICAL}
+                        onClickKey={onClickKey}
+                        coord={[3, 2]}
                     />
                 </>
             )}

--- a/packages/math-input/src/components/keypad/keypad-pages/operators-page.tsx
+++ b/packages/math-input/src/components/keypad/keypad-pages/operators-page.tsx
@@ -48,14 +48,12 @@ export default function OperatorsPage(props: Props) {
                     <KeypadButton
                         keyConfig={Keys.SQRT}
                         onClickKey={onClickKey}
-                        coord={[3, 0]}
+                        coord={[0, 2]}
                     />
-                    {/* Row 1 is full (cols 4-5 are shared +/- keys), so RADICAL
-                        moves to the free cell at the end of the relations row. */}
                     <KeypadButton
                         keyConfig={Keys.RADICAL}
                         onClickKey={onClickKey}
-                        coord={[3, 2]}
+                        coord={[1, 2]}
                     />
                 </>
             )}
@@ -87,17 +85,17 @@ export default function OperatorsPage(props: Props) {
                     <KeypadButton
                         keyConfig={Keys.EQUAL}
                         onClickKey={onClickKey}
-                        coord={[0, 2]}
+                        coord={[2, 2]}
                     />
                     <KeypadButton
                         keyConfig={Keys.LT}
                         onClickKey={onClickKey}
-                        coord={[1, 2]}
+                        coord={[0, 3]}
                     />
                     <KeypadButton
                         keyConfig={Keys.GT}
                         onClickKey={onClickKey}
-                        coord={[2, 2]}
+                        coord={[1, 3]}
                     />
                 </>
             )}
@@ -108,17 +106,17 @@ export default function OperatorsPage(props: Props) {
                     <KeypadButton
                         keyConfig={Keys.NEQ}
                         onClickKey={onClickKey}
-                        coord={[0, 3]}
+                        coord={[3, 2]}
                     />
                     <KeypadButton
                         keyConfig={Keys.LEQ}
                         onClickKey={onClickKey}
-                        coord={[1, 3]}
+                        coord={[2, 3]}
                     />
                     <KeypadButton
                         keyConfig={Keys.GEQ}
                         onClickKey={onClickKey}
-                        coord={[2, 3]}
+                        coord={[3, 3]}
                     />
                 </>
             )}

--- a/packages/math-input/src/components/keypad/keypad-pages/operators-page.tsx
+++ b/packages/math-input/src/components/keypad/keypad-pages/operators-page.tsx
@@ -43,17 +43,17 @@ export default function OperatorsPage(props: Props) {
                     <KeypadButton
                         keyConfig={Keys.SUB}
                         onClickKey={onClickKey}
-                        coord={[2, 0]}
+                        coord={[3, 1]}
                     />
                     <KeypadButton
                         keyConfig={Keys.SQRT}
                         onClickKey={onClickKey}
-                        coord={[0, 2]}
+                        coord={[2, 0]}
                     />
                     <KeypadButton
                         keyConfig={Keys.RADICAL}
                         onClickKey={onClickKey}
-                        coord={[1, 2]}
+                        coord={[3, 0]}
                     />
                 </>
             )}
@@ -85,17 +85,17 @@ export default function OperatorsPage(props: Props) {
                     <KeypadButton
                         keyConfig={Keys.EQUAL}
                         onClickKey={onClickKey}
-                        coord={[2, 2]}
+                        coord={[0, 2]}
                     />
                     <KeypadButton
                         keyConfig={Keys.LT}
                         onClickKey={onClickKey}
-                        coord={[0, 3]}
+                        coord={[1, 2]}
                     />
                     <KeypadButton
                         keyConfig={Keys.GT}
                         onClickKey={onClickKey}
-                        coord={[1, 3]}
+                        coord={[2, 2]}
                     />
                 </>
             )}
@@ -106,17 +106,17 @@ export default function OperatorsPage(props: Props) {
                     <KeypadButton
                         keyConfig={Keys.NEQ}
                         onClickKey={onClickKey}
-                        coord={[3, 2]}
+                        coord={[0, 3]}
                     />
                     <KeypadButton
                         keyConfig={Keys.LEQ}
                         onClickKey={onClickKey}
-                        coord={[2, 3]}
+                        coord={[1, 3]}
                     />
                     <KeypadButton
                         keyConfig={Keys.GEQ}
                         onClickKey={onClickKey}
-                        coord={[3, 3]}
+                        coord={[2, 3]}
                     />
                 </>
             )}

--- a/packages/math-input/src/components/keypad/shared-keys.tsx
+++ b/packages/math-input/src/components/keypad/shared-keys.tsx
@@ -31,10 +31,12 @@ export default function SharedKeys(props: Props) {
     const Keys = KeyConfigs(strings);
 
     // Fraction position depends on the page
-    const fractionCoord: readonly [number, number] =
-        selectedPage === "Numbers" || selectedPage === "Operators"
-            ? [3, 1]
-            : [3, 0];
+    let fractionCoord: readonly [number, number] = [3, 0];
+    if (selectedPage === "Numbers") {
+        fractionCoord = [3, 1];
+    } else if (selectedPage === "Operators") {
+        fractionCoord = [3, 2];
+    }
 
     return (
         <>

--- a/packages/math-input/src/data/key-configs.ts
+++ b/packages/math-input/src/data/key-configs.ts
@@ -193,6 +193,12 @@ const KeyConfigs = (
             ariaLabel: strings.cube,
         }),
     },
+    SUB: {
+        ...getDefaultOperatorFields({
+            key: "SUB",
+            ariaLabel: strings.subscript,
+        }),
+    },
     SQRT: {
         ...getDefaultOperatorFields({
             key: "SQRT",

--- a/packages/math-input/src/strings.ts
+++ b/packages/math-input/src/strings.ts
@@ -35,6 +35,7 @@ export type MathInputStrings = {
     fractionExpressionInNumerator: string;
     fractionExcludingExpression: string;
     customExponent: string;
+    subscript: string;
     square: string;
     cube: string;
     squareRoot: string;
@@ -154,6 +155,11 @@ export const strings: {
         context:
             "A label for a button that will allow the user to input a custom exponent.",
         message: "Custom exponent",
+    },
+    subscript: {
+        context:
+            "A label for a button that will allow the user to input a subscript.",
+        message: "Subscript",
     },
     square: {
         context:
@@ -302,6 +308,7 @@ export const mockStrings: MathInputStrings = {
         "Fraction, with current expression in numerator",
     fractionExcludingExpression: "Fraction, excluding the current expression",
     customExponent: "Custom exponent",
+    subscript: "Subscript",
     square: "Square",
     cube: "Cube",
     squareRoot: "Square root",

--- a/packages/perseus-core/src/keypad.ts
+++ b/packages/perseus-core/src/keypad.ts
@@ -20,6 +20,7 @@ export const KeypadKeys = [
     "EXP",
     "EXP_2",
     "EXP_3",
+    "SUB",
     "SQRT",
     "CUBE_ROOT",
     "RADICAL",

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/expression-keys.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/expression-keys.ts
@@ -22,6 +22,7 @@ export const keypadKeys = enumeration(
     "EXP",
     "EXP_2",
     "EXP_3",
+    "SUB",
     "SQRT",
     "CUBE_ROOT",
     "RADICAL",


### PR DESCRIPTION
## Summary:

Adds a new button for subscript to the prealgebra section of the operators tab on the MathInput keypad.

Layout:
<img width="384" height="233" alt="Screenshot 2026-07-09 at 1 50 43 PM" src="https://github.com/user-attachments/assets/61194fe6-0de2-49b8-a374-46e4ef3ac95a" />

Original demo (before rearranging the keys a bit):
https://github.com/user-attachments/assets/a44d0339-479b-4638-b89f-b904c2333a49

Issue: LEMS-4349

## Test plan:

- Go to an Expression widget that has `prealgebra` enabled
- Click the subscript button
- Note that it adds a subscript and moves the cursor into it