### PR TITLE
feat: Serialize calcVariant into PerseusAnswerArea

### DIFF
--- a/.changeset/ready-bears-stick.md
+++ b/.changeset/ready-bears-stick.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Enables adding calc variant field into editor json

--- a/packages/perseus-editor/src/item-extras-editor.tsx
+++ b/packages/perseus-editor/src/item-extras-editor.tsx
@@ -68,6 +68,7 @@ class ItemExtrasEditor extends React.Component<Props> {
         for (const key of ItemExtras) {
             data[key] = !!this.props[key];
         }
+        data.calculatorVariant = this.props.calculatorVariant;
         return data;
     }
 


### PR DESCRIPTION
## Summary:
- Enables calcVariant field to be added into PerseusAnswerArea json

Note:
Does not need any FE changes 


Issue: LEMS-XXXX

## Test plan:
[ZND](https://prod-znd-260706-13324-2852fc8.khanacademy.org/math/ap-statistics/bivariate-data-ap/least-squares-regression/e/calculating-equation-least-squares)
- Validated that calc variant field is added to JSON in exercise editor 

Before

https://github.com/user-attachments/assets/884a8b31-333f-4f7b-ba48-653e9d785b47


After

https://github.com/user-attachments/assets/6b61ba9d-6605-4ecf-9d7e-24d94c046162
