### PR TITLE
[Interactive Graph] Fix thin border around the interactive graph

### DIFF
--- a/.changeset/smooth-wolves-reply.md
+++ b/.changeset/smooth-wolves-reply.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus": patch
+---
+
+Fix thin border around the interactive graph

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -5141,6 +5141,14 @@ table: [[☃ table 1]]
                                       />
                                     </g>
                                   </svg>
+                                  <rect
+                                    class="mafs-graph-border"
+                                    data-testid="graph-border"
+                                    height="288"
+                                    width="288"
+                                    x="-144"
+                                    y="-144"
+                                  />
                                   <svg
                                     height="288"
                                     preserveAspectRatio="xMidYMin"
@@ -9394,6 +9402,14 @@ table: [[☃ table 1]]
                                         />
                                       </g>
                                     </svg>
+                                    <rect
+                                      class="mafs-graph-border"
+                                      data-testid="graph-border"
+                                      height="288"
+                                      width="288"
+                                      x="-144"
+                                      y="-144"
+                                    />
                                     <svg
                                       height="288"
                                       preserveAspectRatio="xMidYMin"

--- a/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
@@ -5245,6 +5245,14 @@ table: [[☃ table 1]]
                                       />
                                     </g>
                                   </svg>
+                                  <rect
+                                    class="mafs-graph-border"
+                                    data-testid="graph-border"
+                                    height="288"
+                                    width="288"
+                                    x="-144"
+                                    y="-144"
+                                  />
                                   <svg
                                     height="288"
                                     preserveAspectRatio="xMidYMin"
@@ -9449,6 +9457,14 @@ table: [[☃ table 1]]
                                         />
                                       </g>
                                     </svg>
+                                    <rect
+                                      class="mafs-graph-border"
+                                      data-testid="graph-border"
+                                      height="288"
+                                      width="288"
+                                      x="-144"
+                                      y="-144"
+                                    />
                                     <svg
                                       height="288"
                                       preserveAspectRatio="xMidYMin"

--- a/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
+++ b/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
@@ -198,6 +198,14 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                           />
                         </g>
                       </svg>
+                      <rect
+                        class="mafs-graph-border"
+                        data-testid="graph-border"
+                        height="400"
+                        width="400"
+                        x="-200"
+                        y="-200"
+                      />
                       <svg
                         height="400"
                         preserveAspectRatio="xMidYMin"

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -159,6 +159,14 @@ exports[`Interactive Graph A none-type graph renders predictably: first render 1
                           />
                         </g>
                       </svg>
+                      <rect
+                        class="mafs-graph-border"
+                        data-testid="graph-border"
+                        height="400"
+                        width="400"
+                        x="-200"
+                        y="-200"
+                      />
                       <svg
                         height="400"
                         preserveAspectRatio="xMidYMin"

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/graph-border.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/graph-border.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+
+import useGraphConfig from "../reducer/use-graph-config";
+import {calculateNestedSVGCoords} from "../utils";
+
+/**
+ * Draws a 1px border at the exact graph bounds.
+ *
+ * Previously the frame was just the outermost grid line, which is clipped to
+ * the bounds and so lost the outer half of its stroke (~0.5px). An explicit
+ * rect gives a full 1px on all four sides regardless of range or `gridStep`.
+ * Kept outside `<ClipToGraphBounds>` so its stroke isn't halved.
+ */
+export const GraphBorder = () => {
+    const {range, graphDimensionsInPixels, markings} = useGraphConfig();
+    const [width, height] = graphDimensionsInPixels;
+
+    // Only frame where grid lines were shown; "axes" and "none" get no frame.
+    if (markings !== "graph" && markings !== "grid") {
+        return null;
+    }
+
+    const {viewboxX, viewboxY} = calculateNestedSVGCoords(range, width, height);
+
+    return (
+        <rect
+            className="mafs-graph-border"
+            x={viewboxX}
+            y={viewboxY}
+            width={width}
+            height={height}
+        />
+    );
+};

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/graph-border.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/graph-border.tsx
@@ -1,21 +1,24 @@
 import * as React from "react";
 
-import useGraphConfig from "../reducer/use-graph-config";
 import {calculateNestedSVGCoords} from "../utils";
 
-/**
- * Draws a 1px border at the exact graph bounds.
- *
- * Previously the frame was just the outermost grid line, which is clipped to
- * the bounds and so lost the outer half of its stroke (~0.5px). An explicit
- * rect gives a full 1px on all four sides regardless of range or `gridStep`.
- * Kept outside `<ClipToGraphBounds>` so its stroke isn't halved.
- */
-export const GraphBorder = () => {
-    const {range, graphDimensionsInPixels, markings} = useGraphConfig();
-    const [width, height] = graphDimensionsInPixels;
+import type {GraphRange, MarkingsType} from "@khanacademy/perseus-core";
 
-    // Only frame where grid lines were shown; "axes" and "none" get no frame.
+interface Props {
+    range: GraphRange;
+    width: number;
+    height: number;
+    markings: MarkingsType;
+}
+
+/**
+ * Draws a 1px border at the exact graph bounds to match the design.
+ *
+ * A dedicated rect is needed because the old frame (the outermost grid line)
+ * is clipped to the bounds, losing the outer half of its stroke (~0.5px). Kept
+ * on top of the grid so the full stroke renders crisply.
+ */
+export const GraphBorder = ({range, width, height, markings}: Props) => {
     if (markings !== "graph" && markings !== "grid") {
         return null;
     }
@@ -25,6 +28,7 @@ export const GraphBorder = () => {
     return (
         <rect
             className="mafs-graph-border"
+            data-testid="graph-border"
             x={viewboxX}
             y={viewboxY}
             width={width}

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -115,6 +115,39 @@ describe("MafsGraph", () => {
         expect(line.getAttribute("y2")).toBe(-expectedY2 + "");
     });
 
+    describe("graph border", () => {
+        it("renders a 1px border spanning the full graph bounds", () => {
+            // Arrange, Act
+            render(<MafsGraph {...baseMafsProps} markings="graph" />);
+
+            // Assert
+            const border = screen.getByTestId("graph-border");
+            const {viewboxX, viewboxY} = calculateNestedSVGCoords(
+                baseMafsProps.state.range,
+                400,
+                400,
+            );
+            expect(border).toBeInTheDocument();
+            expect(border).toHaveAttribute("x", String(viewboxX));
+            expect(border).toHaveAttribute("y", String(viewboxY));
+            expect(border).toHaveAttribute("width", "400");
+            expect(border).toHaveAttribute("height", "400");
+        });
+
+        it.each(["axes", "none"] as const)(
+            "does not render a border when markings are %s",
+            (markings) => {
+                // Arrange, Act
+                render(<MafsGraph {...baseMafsProps} markings={markings} />);
+
+                // Assert
+                expect(
+                    screen.queryByTestId("graph-border"),
+                ).not.toBeInTheDocument();
+            },
+        );
+    });
+
     it("should send analytics even when widget is rendered", () => {
         const mockDispatch = jest.fn();
         const state: InteractiveGraphState = {

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -24,6 +24,7 @@ import {useDependencies} from "../../dependencies";
 import AxisArrows from "./backgrounds/axis-arrows";
 import AxisLabels from "./backgrounds/axis-labels";
 import {AxisTicks} from "./backgrounds/axis-ticks";
+import {GraphBorder} from "./backgrounds/graph-border";
 import {Axes, Grid} from "./backgrounds/grid";
 import {LegacyGrid} from "./backgrounds/legacy-grid";
 import {
@@ -396,6 +397,12 @@ export const MafsGraph = (props: MafsGraphProps) => {
                                         height={height}
                                     />
                                 </ClipToGraphBounds>
+                                <GraphBorder
+                                    range={state.range}
+                                    width={width}
+                                    height={height}
+                                    markings={props.markings}
+                                />
                                 {/* Axis lines, ticks, and arrows. Only
                                     rendered when the markings include axes. */}
                                 {showsAxisLabels && (

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -355,6 +355,14 @@
     stroke: var(--wb-semanticColor-core-border-neutral-subtle);
 }
 
+/* 1px graph frame; non-scaling-stroke keeps it crisp under viewBox scaling. */
+.MafsView .mafs-graph-border {
+    fill: none;
+    stroke: var(--wb-semanticColor-core-border-neutral-default);
+    stroke-width: var(--wb-border-width-thin);
+    vector-effect: non-scaling-stroke;
+}
+
 .MafsView .angle-arc-interactive {
     stroke: var(--mafs-blue);
     stroke-width: 0.1px;


### PR DESCRIPTION
## Summary:
This fixes the interactive graph border to visually look thicker. The issue before is that it was already 1px similar with the design, but it gets cutoff with ClipToGraphBounds causing it to look 0.5px instead of 1px. The solution is to add a dedicated border distinct concept from the gridlines.

Issue: LEMS-4128

## Test plan: