### PR TITLE
Group all of the Radio widget's `options` under a separate prop

### DIFF
--- a/.changeset/strict-lions-move.md
+++ b/.changeset/strict-lions-move.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Migrate the radio widget to group all `options` under a separate prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -468,7 +468,7 @@ review and commit the changes.
 
 - [x] Migrate `dropdown` to `WidgetPropsV2` (pilot; functional widget with
       inline destructuring defaults).
-- [ ] Migrate `radio` to `WidgetPropsV2` (second pilot; update the hand-built
+- [x] Migrate `radio` to `WidgetPropsV2` (second pilot; update the hand-built
       `getBaseProps` factory in `radio-widget.test.tsx`; subtype lookup already
       handled by scaffolding).
 

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -9,4 +9,4 @@
  * it — will be removed once every widget has been migrated.
  */
 // TODO(LEMS-4354): delete post-migration.
-export const MIGRATED_WIDGETS: ReadonlyArray<string> = ["dropdown"];
+export const MIGRATED_WIDGETS: ReadonlyArray<string> = ["dropdown", "radio"];

--- a/packages/perseus/src/widget-ai-utils/radio/radio-ai-utils.test.ts
+++ b/packages/perseus/src/widget-ai-utils/radio/radio-ai-utils.test.ts
@@ -79,35 +79,36 @@ describe("Radio AI utils", () => {
     it("should get prompt json which matches the state of the UI", () => {
         // Arrange
         const widgetData: any = {
-            numCorrect: 1,
-            countChoices: false,
-            deselectEnabled: false,
-            hasNoneOfTheAbove: false,
-            multipleSelect: false,
-            choices: [
-                {
-                    id: "3-3-3-3-3",
-                    content: "Content 4",
-                    originalIndex: 3,
-                },
-                {
-                    id: "1-1-1-1-1",
-                    content: "Content 2",
-                    originalIndex: 1,
-                },
-                {
-                    id: "0-0-0-0-0",
-                    content: "Content 1",
-                    originalIndex: 0,
-                },
+            options: {
+                numCorrect: 1,
+                countChoices: false,
+                deselectEnabled: false,
+                hasNoneOfTheAbove: false,
+                multipleSelect: false,
+                choices: [
+                    {
+                        id: "3-3-3-3-3",
+                        content: "Content 4",
+                        originalIndex: 3,
+                    },
+                    {
+                        id: "1-1-1-1-1",
+                        content: "Content 2",
+                        originalIndex: 1,
+                    },
+                    {
+                        id: "0-0-0-0-0",
+                        content: "Content 1",
+                        originalIndex: 0,
+                    },
 
-                {
-                    id: "2-2-2-2-2",
-                    content: "Content 3",
-                    originalIndex: 2,
-                },
-            ],
-            selectedChoiceIds: ["3-3-3-3-3"],
+                    {
+                        id: "2-2-2-2-2",
+                        content: "Content 3",
+                        originalIndex: 2,
+                    },
+                ],
+            },
         };
 
         const userInput: PerseusRadioUserInput = {
@@ -178,30 +179,32 @@ describe("Radio AI utils", () => {
     it("should handle undefined/null user input", () => {
         // Arange
         const widgetData: any = {
-            numCorrect: 1,
-            countChoices: false,
-            deselectEnabled: false,
-            hasNoneOfTheAbove: false,
-            multipleSelect: false,
-            choices: [
-                {
-                    content: "Content 4",
-                    originalIndex: 3,
-                },
-                {
-                    content: "Content 2",
-                    originalIndex: 1,
-                },
-                {
-                    content: "Content 1",
-                    originalIndex: 0,
-                },
+            options: {
+                numCorrect: 1,
+                countChoices: false,
+                deselectEnabled: false,
+                hasNoneOfTheAbove: false,
+                multipleSelect: false,
+                choices: [
+                    {
+                        content: "Content 4",
+                        originalIndex: 3,
+                    },
+                    {
+                        content: "Content 2",
+                        originalIndex: 1,
+                    },
+                    {
+                        content: "Content 1",
+                        originalIndex: 0,
+                    },
 
-                {
-                    content: "Content 3",
-                    originalIndex: 2,
-                },
-            ],
+                    {
+                        content: "Content 3",
+                        originalIndex: 2,
+                    },
+                ],
+            },
         };
 
         // Act

--- a/packages/perseus/src/widget-ai-utils/radio/radio-ai-utils.ts
+++ b/packages/perseus/src/widget-ai-utils/radio/radio-ai-utils.ts
@@ -68,7 +68,7 @@ export const getPromptJSON = (
     userInput: RecursiveReadonly<PerseusRadioUserInput>,
 ): RadioPromptJSON => {
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-    const choices = widgetData.choices || [];
+    const choices = widgetData.options.choices || [];
 
     const options = choices.map((choice) => {
         const option: BasicOption = {

--- a/packages/perseus/src/widgets/radio/__tests__/radio-widget.test.tsx
+++ b/packages/perseus/src/widgets/radio/__tests__/radio-widget.test.tsx
@@ -117,27 +117,40 @@ describe("Radio widget", () => {
         });
     });
 
-    it("reports only the clicked choice's ID in single-select mode", async () => {
+    // This tests a production bug where widget state can become misaligned during
+    // content updates or partial state restoration, causing the choiceStates array
+    // to have a different length than the choices array
+    it("handles mismatched choiceStates and choices array lengths without crashing", async () => {
         // Arrange
         const handleUserInput = jest.fn();
-        const props = getBaseProps({handleUserInput});
+        const props = getBaseProps({
+            handleUserInput,
+            // FIXME: extract getBaseOptions(), mirroring the pattern of getBaseProps(),
+            //  so we can do: `options: getBaseOptions({choiceState: baseChoiceStates.slice(0, 1)})`.
+            //  Also use getBaseOptions in getBaseProps().
+            options: {
+                ...getBaseProps().options,
+                choiceStates: baseChoiceStates.slice(0, 1),
+            }, // Only 1 state for 2 choices
+        });
         render(<Radio {...props} />);
+
+        // Act & Assert - First click (choice with existing state)
         const buttons = screen.getAllByRole("button");
+        await expect(userEvent.click(buttons[0])).resolves.not.toThrow();
 
-        // Act - click the first choice
-        await userEvent.click(buttons[0]);
-
-        // Assert - only the first choice is reported
         expect(handleUserInput).toHaveBeenCalledWith({
             selectedChoiceIds: ["choice-1"],
         });
 
+        // Reset for next assertion
         handleUserInput.mockClear();
 
-        // Act - click the second choice
-        await userEvent.click(buttons[1]);
+        // Act & Assert - Second click (choice without state)
+        // This should work without throwing even though there's no choiceState for index 1
+        await expect(userEvent.click(buttons[1])).resolves.not.toThrow();
 
-        // Assert - only the second choice is reported
+        // In single-select mode, clicking button 2 deselects button 1 and selects button 2
         expect(handleUserInput).toHaveBeenCalledWith({
             selectedChoiceIds: ["choice-2"],
         });

--- a/packages/perseus/src/widgets/radio/__tests__/radio-widget.test.tsx
+++ b/packages/perseus/src/widgets/radio/__tests__/radio-widget.test.tsx
@@ -13,7 +13,7 @@ import {testDependencies} from "../../../testing/test-dependencies";
 import {containerSizeClass} from "../../../util/sizing-utils";
 import Radio from "../radio-widget";
 
-import type {WidgetProps} from "../../../types";
+import type {WidgetPropsV2} from "../../../types";
 import type {RadioChoiceWithMetadata, RadioProps} from "../radio-widget";
 import type {
     PerseusRadioRubric,
@@ -53,17 +53,19 @@ const baseLinterContext: LinterContextProps = {
 
 const getBaseProps = (
     overrides?: Partial<
-        WidgetProps<RadioProps, PerseusRadioUserInput, PerseusRadioRubric>
+        WidgetPropsV2<RadioProps, PerseusRadioUserInput, PerseusRadioRubric>
     >,
-): WidgetProps<RadioProps, PerseusRadioUserInput, PerseusRadioRubric> => ({
-    numCorrect: baseOptions.numCorrect ?? 0,
-    hasNoneOfTheAbove: baseOptions.hasNoneOfTheAbove,
-    multipleSelect: baseOptions.multipleSelect,
-    countChoices: baseOptions.countChoices,
-    deselectEnabled: baseOptions.deselectEnabled,
-    choices: baseChoices,
-    choiceStates: baseChoiceStates,
-    randomize: false,
+): WidgetPropsV2<RadioProps, PerseusRadioUserInput, PerseusRadioRubric> => ({
+    options: {
+        numCorrect: baseOptions.numCorrect ?? 0,
+        hasNoneOfTheAbove: baseOptions.hasNoneOfTheAbove,
+        multipleSelect: baseOptions.multipleSelect,
+        countChoices: baseOptions.countChoices,
+        deselectEnabled: baseOptions.deselectEnabled,
+        choices: baseChoices,
+        choiceStates: baseChoiceStates,
+        randomize: false,
+    },
     trackInteraction: jest.fn(),
     widgetId: "radio-1",
     widgetIndex: 0,
@@ -115,34 +117,27 @@ describe("Radio widget", () => {
         });
     });
 
-    // This tests a production bug where widget state can become misaligned during
-    // content updates or partial state restoration, causing the choiceStates array
-    // to have a different length than the choices array
-    it("handles mismatched choiceStates and choices array lengths without crashing", async () => {
+    it("reports only the clicked choice's ID in single-select mode", async () => {
         // Arrange
         const handleUserInput = jest.fn();
-        const props = getBaseProps({
-            handleUserInput,
-            choiceStates: baseChoiceStates.slice(0, 1), // Only 1 state for 2 choices
-        });
+        const props = getBaseProps({handleUserInput});
         render(<Radio {...props} />);
-
-        // Act & Assert - First click (choice with existing state)
         const buttons = screen.getAllByRole("button");
-        await expect(userEvent.click(buttons[0])).resolves.not.toThrow();
 
+        // Act - click the first choice
+        await userEvent.click(buttons[0]);
+
+        // Assert - only the first choice is reported
         expect(handleUserInput).toHaveBeenCalledWith({
             selectedChoiceIds: ["choice-1"],
         });
 
-        // Reset for next assertion
         handleUserInput.mockClear();
 
-        // Act & Assert - Second click (choice without state)
-        // This should work without throwing even though there's no choiceState for index 1
-        await expect(userEvent.click(buttons[1])).resolves.not.toThrow();
+        // Act - click the second choice
+        await userEvent.click(buttons[1]);
 
-        // In single-select mode, clicking button 2 deselects button 1 and selects button 2
+        // Assert - only the second choice is reported
         expect(handleUserInput).toHaveBeenCalledWith({
             selectedChoiceIds: ["choice-2"],
         });

--- a/packages/perseus/src/widgets/radio/__tests__/radio-widget.test.tsx
+++ b/packages/perseus/src/widgets/radio/__tests__/radio-widget.test.tsx
@@ -51,21 +51,24 @@ const baseLinterContext: LinterContextProps = {
     stack: [],
 };
 
+const getBaseOptions = (overrides?: Partial<RadioProps>): RadioProps => ({
+    numCorrect: baseOptions.numCorrect ?? 0,
+    hasNoneOfTheAbove: baseOptions.hasNoneOfTheAbove,
+    multipleSelect: baseOptions.multipleSelect,
+    countChoices: baseOptions.countChoices,
+    deselectEnabled: baseOptions.deselectEnabled,
+    choices: baseChoices,
+    choiceStates: baseChoiceStates,
+    randomize: false,
+    ...overrides,
+});
+
 const getBaseProps = (
     overrides?: Partial<
         WidgetPropsV2<RadioProps, PerseusRadioUserInput, PerseusRadioRubric>
     >,
 ): WidgetPropsV2<RadioProps, PerseusRadioUserInput, PerseusRadioRubric> => ({
-    options: {
-        numCorrect: baseOptions.numCorrect ?? 0,
-        hasNoneOfTheAbove: baseOptions.hasNoneOfTheAbove,
-        multipleSelect: baseOptions.multipleSelect,
-        countChoices: baseOptions.countChoices,
-        deselectEnabled: baseOptions.deselectEnabled,
-        choices: baseChoices,
-        choiceStates: baseChoiceStates,
-        randomize: false,
-    },
+    options: getBaseOptions(),
     trackInteraction: jest.fn(),
     widgetId: "radio-1",
     widgetIndex: 0,
@@ -125,13 +128,10 @@ describe("Radio widget", () => {
         const handleUserInput = jest.fn();
         const props = getBaseProps({
             handleUserInput,
-            // FIXME: extract getBaseOptions(), mirroring the pattern of getBaseProps(),
-            //  so we can do: `options: getBaseOptions({choiceState: baseChoiceStates.slice(0, 1)})`.
-            //  Also use getBaseOptions in getBaseProps().
-            options: {
-                ...getBaseProps().options,
+            // Only 1 state for 2 choices
+            options: getBaseOptions({
                 choiceStates: baseChoiceStates.slice(0, 1),
-            }, // Only 1 state for 2 choices
+            }),
         });
         render(<Radio {...props} />);
 

--- a/packages/perseus/src/widgets/radio/radio-widget.tsx
+++ b/packages/perseus/src/widgets/radio/radio-widget.tsx
@@ -79,7 +79,8 @@ type Props = WidgetPropsV2<
  */
 const RadioWidget = forwardRef<RadioWidgetHandle, Props>(
     function RadioWidget(props, ref) {
-        const {multipleSelect = false, countChoices = false} = props.options;
+        const {options} = props;
+        const {multipleSelect = false, countChoices = false} = options;
         const {
             showSolutions = "none",
             apiOptions,
@@ -97,18 +98,13 @@ const RadioWidget = forwardRef<RadioWidgetHandle, Props>(
         const choices = useMemo(() => {
             return [
                 ...choiceTransform(
-                    props.options.choices,
-                    props.options.randomize,
+                    options.choices,
+                    options.randomize,
                     strings,
                     randomSeed,
                 ),
             ];
-        }, [
-            props.options.choices,
-            props.options.randomize,
-            strings,
-            randomSeed,
-        ]);
+        }, [options.choices, options.randomize, strings, randomSeed]);
 
         useOnMountEffect(() => {
             analytics.onAnalyticsEvent({
@@ -365,7 +361,7 @@ const RadioWidget = forwardRef<RadioWidgetHandle, Props>(
         };
 
         const choicesProps = prepareChoicesProps();
-        const numCorrect = props.options.numCorrect;
+        const numCorrect = options.numCorrect;
 
         // This is strange, but currently we're showing the same view for both
         // reviewMode, and showSolutions === "all". We may wish to

--- a/packages/perseus/src/widgets/radio/radio-widget.tsx
+++ b/packages/perseus/src/widgets/radio/radio-widget.tsx
@@ -146,11 +146,16 @@ const RadioWidget = forwardRef<RadioWidgetHandle, Props>(
                  * [LEMS-3185] do not trust serializedState
                  */
                 getSerializedState() {
-                    const {userInput: _, static: __, options, ...rest} = props;
-                    const {randomize: ___, ...restOptions} = options;
+                    const {
+                        userInput: _,
+                        static: __,
+                        options,
+                        ...otherProps
+                    } = props;
+                    const {randomize: ___, ...otherOptions} = options;
                     return {
-                        ...restOptions,
-                        ...rest,
+                        ...otherOptions,
+                        ...otherProps,
                         numCorrect: options.numCorrect ?? 0,
                         choices,
                         hasNoneOfTheAbove: options.hasNoneOfTheAbove ?? false,

--- a/packages/perseus/src/widgets/radio/radio-widget.tsx
+++ b/packages/perseus/src/widgets/radio/radio-widget.tsx
@@ -13,7 +13,7 @@ import RadioComponent from "./radio-component";
 import {choiceTransform} from "./util";
 import {getChoiceStates} from "./utils/general-utils";
 
-import type {WidgetProps, ChoiceState, Widget} from "../../types";
+import type {WidgetPropsV2, ChoiceState, Widget} from "../../types";
 import type {RadioPromptJSON} from "../../widget-ai-utils/radio/radio-ai-utils";
 import type {
     PerseusRadioChoice,
@@ -59,7 +59,11 @@ export interface RadioChoiceWithMetadata extends PerseusRadioChoice {
     correct?: boolean;
 }
 
-type Props = WidgetProps<RadioProps, PerseusRadioUserInput, PerseusRadioRubric>;
+type Props = WidgetPropsV2<
+    RadioProps,
+    PerseusRadioUserInput,
+    PerseusRadioRubric
+>;
 
 /**
  * RadioWidget implements the Widget interface for multiple choice questions.
@@ -75,9 +79,8 @@ type Props = WidgetProps<RadioProps, PerseusRadioUserInput, PerseusRadioRubric>;
  */
 const RadioWidget = forwardRef<RadioWidgetHandle, Props>(
     function RadioWidget(props, ref) {
+        const {multipleSelect = false, countChoices = false} = props.options;
         const {
-            multipleSelect = false,
-            countChoices = false,
             showSolutions = "none",
             apiOptions,
             handleUserInput,
@@ -94,13 +97,18 @@ const RadioWidget = forwardRef<RadioWidgetHandle, Props>(
         const choices = useMemo(() => {
             return [
                 ...choiceTransform(
-                    props.choices,
-                    props.randomize,
+                    props.options.choices,
+                    props.options.randomize,
                     strings,
                     randomSeed,
                 ),
             ];
-        }, [props.choices, props.randomize, strings, randomSeed]);
+        }, [
+            props.options.choices,
+            props.options.randomize,
+            strings,
+            randomSeed,
+        ]);
 
         useOnMountEffect(() => {
             analytics.onAnalyticsEvent({
@@ -128,24 +136,24 @@ const RadioWidget = forwardRef<RadioWidgetHandle, Props>(
                  * @returns A structured JSON object representing the widget's prompt
                  */
                 getPromptJSON: (): RadioPromptJSON => {
-                    return _getPromptJSON({...props, choices}, props.userInput);
+                    return _getPromptJSON(
+                        {...props, options: {...props.options, choices}},
+                        props.userInput,
+                    );
                 },
                 /**
                  * @deprecated and likely very broken API
                  * [LEMS-3185] do not trust serializedState
                  */
                 getSerializedState() {
-                    const {
-                        userInput: _,
-                        randomize: __,
-                        static: ___,
-                        ...rest
-                    } = props;
+                    const {userInput: _, static: __, options, ...rest} = props;
+                    const {randomize: ___, ...restOptions} = options;
                     return {
+                        ...restOptions,
                         ...rest,
-                        numCorrect: props.numCorrect ?? 0,
+                        numCorrect: options.numCorrect ?? 0,
                         choices,
-                        hasNoneOfTheAbove: props.hasNoneOfTheAbove ?? false,
+                        hasNoneOfTheAbove: options.hasNoneOfTheAbove ?? false,
                         choiceStates: choices.map((choice) => {
                             // TODO(LEMS-3861): Investigate if this code path is used and fix root cause
                             const selected =
@@ -260,7 +268,7 @@ const RadioWidget = forwardRef<RadioWidgetHandle, Props>(
         const announceChoiceChange = (newCheckedCount: number) => {
             let screenReaderMessage = "";
 
-            if (!props.multipleSelect) {
+            if (!multipleSelect) {
                 // Single-select choice only announces when it is de-selected
                 screenReaderMessage =
                     newCheckedCount === 0 ? strings.notSelected : "";
@@ -273,7 +281,7 @@ const RadioWidget = forwardRef<RadioWidgetHandle, Props>(
             announceMessage({message: screenReaderMessage});
             // Temporary setup to enable proper reading of multiple-select announcements
             // Waiting on WB Announcer fix (WB-2240 - https://khanacademy.atlassian.net/browse/WB-2240)
-            if (props.multipleSelect) {
+            if (multipleSelect) {
                 setTimeout(() => {
                     announceMessage({message: ""});
                 }, 300);
@@ -352,7 +360,7 @@ const RadioWidget = forwardRef<RadioWidgetHandle, Props>(
         };
 
         const choicesProps = prepareChoicesProps();
-        const numCorrect = props.numCorrect;
+        const numCorrect = props.options.numCorrect;
 
         // This is strange, but currently we're showing the same view for both
         // reviewMode, and showSolutions === "all". We may wish to


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a Radio widget in http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.