### PR TITLE
Migrate phet-simulation widget to WidgetPropsV2

### DIFF
--- a/.changeset/widget-props-v2-phet-simulation.md
+++ b/.changeset/widget-props-v2-phet-simulation.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Migrate the phet-simulation widget to group all `options` under a separate prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -477,7 +477,7 @@ review and commit the changes.
 Migrate these **one at a time**, stopping after each step for the user to
 review and commit the changes.
 
-- [ ] Migrate `phet-simulation` to `WidgetPropsV2`.
+- [x] Migrate `phet-simulation` to `WidgetPropsV2`.
 - [ ] Migrate `iframe` to `WidgetPropsV2`.
 - [ ] Migrate `sorter` to `WidgetPropsV2`.
 - [ ] Migrate `definition` to `WidgetPropsV2`.

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -9,4 +9,8 @@
  * it — will be removed once every widget has been migrated.
  */
 // TODO(LEMS-4354): delete post-migration.
-export const MIGRATED_WIDGETS: ReadonlyArray<string> = ["dropdown", "radio"];
+export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
+    "dropdown",
+    "radio",
+    "phet-simulation",
+];

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.stories.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.stories.tsx
@@ -26,8 +26,10 @@ type Story = StoryObj<typeof PhetSimulation>;
 // Story showing the PhetSimulation component directly
 export const Default: Story = {
     args: {
-        url: "https://phet.colorado.edu/sims/html/projectile-data-lab/latest/projectile-data-lab_all.html",
-        description: "Projectile Data Lab",
+        options: {
+            url: "https://phet.colorado.edu/sims/html/projectile-data-lab/latest/projectile-data-lab_all.html",
+            description: "Projectile Data Lab",
+        },
         apiOptions: {
             ...ApiOptions.defaults,
             isMobileApp: false,

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -17,11 +17,11 @@ import {PerseusI18nContext} from "../../components/i18n-context";
 import {phoneMargin} from "../../styles/constants";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/phet-simulation/phet-simulation-ai-utils";
 
-import type {WidgetExports, WidgetProps, Widget} from "../../types";
+import type {WidgetExports, WidgetPropsV2, Widget} from "../../types";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
 import type {PerseusPhetSimulationWidgetOptions} from "@khanacademy/perseus-core";
 
-type Props = WidgetProps<PerseusPhetSimulationWidgetOptions>;
+type Props = WidgetPropsV2<PerseusPhetSimulationWidgetOptions>;
 
 type State = {
     banner: {
@@ -58,13 +58,13 @@ export class PhetSimulation
     };
 
     async componentDidMount() {
-        await this.updateSimState(this.props.url);
+        await this.updateSimState(this.props.options.url);
     }
 
-    async componentDidUpdate(prevProps) {
+    async componentDidUpdate(prevProps: Props) {
         // If the URL has changed, update our state
-        if (prevProps.url !== this.props.url) {
-            await this.updateSimState(this.props.url);
+        if (prevProps.options.url !== this.props.options.url) {
+            await this.updateSimState(this.props.options.url);
         }
     }
 
@@ -251,7 +251,7 @@ export class PhetSimulation
                 <View style={iframeContainerStyle}>
                     <iframe
                         ref={this.iframeRef}
-                        title={this.props.description}
+                        title={this.props.options.description}
                         sandbox={sandboxProperties}
                         className={css(styles.iframeResponsive)}
                         src={url?.toString()}


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a PHET widget in http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.