### PR TITLE
fix(math-input): avoid findDOMNode in MobileKeypad.getDOMNode

### DIFF
--- a/.changeset/tut-4350-mobile-keypad-getdomnode.md
+++ b/.changeset/tut-4350-mobile-keypad-getdomnode.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/math-input": patch
+---
+
+Fix "Unable to find node on an unmounted component" error from the mobile keypad: `MobileKeypad.getDOMNode` now returns a container ref instead of calling the deprecated `ReactDOM.findDOMNode`, and the keypad notifies consumers via `onElementMounted(null)` when it unmounts so they don't retain a stale reference.

--- a/.changeset/tut-4350-mobile-keypad-getdomnode.md
+++ b/.changeset/tut-4350-mobile-keypad-getdomnode.md
@@ -1,5 +1,10 @@
 ---
-"@khanacademy/math-input": patch
+"@khanacademy/math-input": major
 ---
 
 Fix "Unable to find node on an unmounted component" error from the mobile keypad: `MobileKeypad.getDOMNode` now returns a container ref instead of calling the deprecated `ReactDOM.findDOMNode`, and the keypad notifies consumers via `onElementMounted(null)` when it unmounts so they don't retain a stale reference.
+
+Breaking changes:
+
+- `KeypadAPI.getDOMNode` now returns `HTMLElement | null` (was `Element | Text | null`).
+- `MobileKeypad`'s `onElementMounted` is now typed `(api: KeypadAPI | null) => void` and is called with `null` on unmount, so callbacks must accept `null`.

--- a/packages/math-input/src/components/keypad/__tests__/mobile-keypad.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/mobile-keypad.test.tsx
@@ -111,4 +111,50 @@ describe("mobile keypad", () => {
             },
         });
     });
+
+    it("getDOMNode returns the keypad element while mounted", () => {
+        // Arrange
+        let api: any;
+
+        // Act
+        render(
+            <MobileKeypadInternals
+                onAnalyticsEvent={async () => undefined}
+                setKeypadActive={(keypadActive: boolean) => undefined}
+                keypadActive={true}
+                onElementMounted={(mounted) => {
+                    api = mounted;
+                }}
+            />,
+        );
+
+        // Assert
+        expect(api.getDOMNode()).toBeInstanceOf(HTMLElement);
+    });
+
+    it("clears the element reference and returns null from getDOMNode on unmount", () => {
+        // Arrange
+        let api: any;
+        const onElementMounted = jest.fn((mounted) => {
+            if (mounted) {
+                api = mounted;
+            }
+        });
+        const {unmount} = render(
+            <MobileKeypadInternals
+                onAnalyticsEvent={async () => undefined}
+                setKeypadActive={(keypadActive: boolean) => undefined}
+                keypadActive={true}
+                onElementMounted={onElementMounted}
+            />,
+        );
+
+        // Act
+        unmount();
+
+        // Assert: consumers are told the element is gone, and reading the DOM
+        // node no longer throws "Unable to find node on an unmounted component".
+        expect(onElementMounted).toHaveBeenLastCalledWith(null);
+        expect(api.getDOMNode()).toBeNull();
+    });
 });

--- a/packages/math-input/src/components/keypad/__tests__/mobile-keypad.test.tsx
+++ b/packages/math-input/src/components/keypad/__tests__/mobile-keypad.test.tsx
@@ -3,6 +3,8 @@ import * as React from "react";
 
 import MobileKeypadInternals from "../mobile-keypad-internals";
 
+import type {KeypadAPI} from "../../../types";
+
 describe("mobile keypad", () => {
     it("should render keypad when active", () => {
         // Arrange
@@ -114,7 +116,7 @@ describe("mobile keypad", () => {
 
     it("getDOMNode returns the keypad element while mounted", () => {
         // Arrange
-        let api: any;
+        const onElementMounted = jest.fn((api: KeypadAPI | null) => undefined);
 
         // Act
         render(
@@ -122,24 +124,18 @@ describe("mobile keypad", () => {
                 onAnalyticsEvent={async () => undefined}
                 setKeypadActive={(keypadActive: boolean) => undefined}
                 keypadActive={true}
-                onElementMounted={(mounted) => {
-                    api = mounted;
-                }}
+                onElementMounted={onElementMounted}
             />,
         );
 
         // Assert
-        expect(api.getDOMNode()).toBeInstanceOf(HTMLElement);
+        const api = onElementMounted.mock.calls[0][0];
+        expect(api?.getDOMNode()).toBeInstanceOf(HTMLElement);
     });
 
     it("clears the element reference and returns null from getDOMNode on unmount", () => {
         // Arrange
-        let api: any;
-        const onElementMounted = jest.fn((mounted) => {
-            if (mounted) {
-                api = mounted;
-            }
-        });
+        const onElementMounted = jest.fn((api: KeypadAPI | null) => undefined);
         const {unmount} = render(
             <MobileKeypadInternals
                 onAnalyticsEvent={async () => undefined}
@@ -152,9 +148,9 @@ describe("mobile keypad", () => {
         // Act
         unmount();
 
-        // Assert: consumers are told the element is gone, and reading the DOM
-        // node no longer throws "Unable to find node on an unmounted component".
+        // Assert
+        const api = onElementMounted.mock.calls[0][0];
         expect(onElementMounted).toHaveBeenLastCalledWith(null);
-        expect(api.getDOMNode()).toBeNull();
+        expect(api?.getDOMNode()).toBeNull();
     });
 });

--- a/packages/math-input/src/components/keypad/mobile-keypad-internals.tsx
+++ b/packages/math-input/src/components/keypad/mobile-keypad-internals.tsx
@@ -2,7 +2,6 @@ import {View} from "@khanacademy/wonder-blocks-core";
 import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
-import ReactDOM from "react-dom";
 
 import AphroditeCssTransitionGroup from "../aphrodite-css-transition-group";
 
@@ -97,6 +96,12 @@ class MobileKeypadInternals
             this._throttleResizeHandler,
         );
         this._containerResizeObserver?.disconnect?.();
+
+        // Notify consumers that the keypad element is gone so they don't hold
+        // on to a stale reference to this now-unmounted component (e.g.
+        // `KeypadContext.keypadElement`), which would otherwise let them call
+        // `getDOMNode` on an unmounted instance.
+        this.props.onElementMounted?.(null);
     }
 
     _resize = () => {
@@ -153,8 +158,14 @@ class MobileKeypadInternals
         this.setState({keyHandler});
     };
 
-    getDOMNode: () => ReturnType<typeof ReactDOM.findDOMNode> = () => {
-        return ReactDOM.findDOMNode(this);
+    getDOMNode: () => HTMLElement | null = () => {
+        // Return the container ref rather than `ReactDOM.findDOMNode(this)`.
+        // `findDOMNode` throws "Unable to find node on an unmounted component"
+        // when called after the keypad unmounts (which happens when consumers
+        // read the keypad's height on a deferred callback during teardown), and
+        // it is deprecated / removed in React 19. A ref resolves to `null`
+        // after unmount instead of throwing.
+        return this._containerRef.current;
     };
 
     _handleClickKey(key: KeypadKey) {

--- a/packages/math-input/src/components/keypad/mobile-keypad-internals.tsx
+++ b/packages/math-input/src/components/keypad/mobile-keypad-internals.tsx
@@ -19,7 +19,7 @@ import type {StyleType} from "@khanacademy/wonder-blocks-core";
 const AnimationDurationInMS = 200;
 
 type Props = {
-    onElementMounted?: (arg1: any) => void;
+    onElementMounted?: (api: KeypadAPI | null) => void;
     onDismiss?: () => void;
     style?: StyleType;
     onAnalyticsEvent: AnalyticsEventHandlerFn;
@@ -97,10 +97,8 @@ class MobileKeypadInternals
         );
         this._containerResizeObserver?.disconnect?.();
 
-        // Notify consumers that the keypad element is gone so they don't hold
-        // on to a stale reference to this now-unmounted component (e.g.
-        // `KeypadContext.keypadElement`), which would otherwise let them call
-        // `getDOMNode` on an unmounted instance.
+        // Clear consumers' reference (e.g. `KeypadContext.keypadElement`) so
+        // they don't keep calling into an unmounted keypad.
         this.props.onElementMounted?.(null);
     }
 
@@ -159,12 +157,6 @@ class MobileKeypadInternals
     };
 
     getDOMNode: () => HTMLElement | null = () => {
-        // Return the container ref rather than `ReactDOM.findDOMNode(this)`.
-        // `findDOMNode` throws "Unable to find node on an unmounted component"
-        // when called after the keypad unmounts (which happens when consumers
-        // read the keypad's height on a deferred callback during teardown), and
-        // it is deprecated / removed in React 19. A ref resolves to `null`
-        // after unmount instead of throwing.
         return this._containerRef.current;
     };
 

--- a/packages/math-input/src/types.ts
+++ b/packages/math-input/src/types.ts
@@ -6,7 +6,6 @@ import type {
     KeypadKey,
 } from "@khanacademy/perseus-core";
 import type * as React from "react";
-import type ReactDOM from "react-dom";
 
 export enum MathFieldActionType {
     WRITE = "write",
@@ -51,7 +50,7 @@ export interface KeypadAPI {
     configure: (configuration: KeypadConfiguration, cb: () => void) => void;
     setCursor: (cursor: Cursor) => void;
     setKeyHandler: (keyHandler: KeyHandler) => void;
-    getDOMNode: () => ReturnType<typeof ReactDOM.findDOMNode>;
+    getDOMNode: () => HTMLElement | null;
 }
 
 export type KeypadContextType = {


### PR DESCRIPTION
## Summary

The mobile keypad's `getDOMNode` called `ReactDOM.findDOMNode(this)`, which throws `"Unable to find node on an unmounted component"` when it's invoked after the keypad has unmounted. Consumers such as `useMobileMathKeypadHeight` (in the `Khan/frontend` monorepo) read the keypad's height on a deferred `0ms` timeout during teardown, so the keypad instance can already be unmounted by the time `getDOMNode()` runs — producing a high-volume Sentry error. `findDOMNode` is also deprecated and removed in React 19.

This PR:

- Returns the existing `_containerRef` from `getDOMNode` instead of calling `ReactDOM.findDOMNode(this)`. A ref resolves to `null` after unmount rather than throwing, so the error can no longer occur even if a caller holds a stale reference. The return type is narrowed from `Element | Text | null` to `HTMLElement | null`, which is what all current callers already expect (they cast to `HTMLElement` / read `offsetHeight` / `getBoundingClientRect`).
- Notifies consumers via `onElementMounted(null)` in `componentWillUnmount`, so shared references (e.g. `KeypadContext.keypadElement`) are cleared automatically on unmount instead of going stale.
- Removes the now-unused `ReactDOM` imports.

Issue: TUT-4371 (related to TUT-4350)

## Test plan

- `pnpm jest packages/math-input/src/components/keypad/__tests__/mobile-keypad.test.tsx` — added two tests: `getDOMNode` returns the element while mounted, and after unmount `onElementMounted` is called with `null` and `getDOMNode()` returns `null`.
- `pnpm typecheck` — clean.
- `pnpm exec eslint` on changed files — clean.

Made with [Cursor](https://cursor.com)