### PR TITLE
Migrate iframe widget to WidgetPropsV2

### DIFF
--- a/.changeset/widget-props-v2-iframe.md
+++ b/.changeset/widget-props-v2-iframe.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Migrate the iframe widget to group all `options` under a separate prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -478,7 +478,7 @@ Migrate these **one at a time**, stopping after each step for the user to
 review and commit the changes.
 
 - [x] Migrate `phet-simulation` to `WidgetPropsV2`.
-- [ ] Migrate `iframe` to `WidgetPropsV2`.
+- [x] Migrate `iframe` to `WidgetPropsV2`.
 - [ ] Migrate `sorter` to `WidgetPropsV2`.
 - [ ] Migrate `definition` to `WidgetPropsV2`.
 - [ ] Migrate `explanation` to `WidgetPropsV2`.

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -2221,7 +2221,10 @@ export type PerseusIFrameWidgetOptions = {
     height: number | string;
     /** Whether to allow the IFrame to become full-screen (like a video) */
     allowFullScreen: boolean;
-    /** Whether to allow the iframe content to redirect the page */
+    /**
+     * Whether to allow the iframe content to redirect the page
+     * @deprecated - not used in Perseus.
+     */
     allowTopNavigation?: boolean;
     /** Always false */
     static: boolean;

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -13,4 +13,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "dropdown",
     "radio",
     "phet-simulation",
+    "iframe",
 ];

--- a/packages/perseus/src/widgets/iframe/iframe.tsx
+++ b/packages/perseus/src/widgets/iframe/iframe.tsx
@@ -15,7 +15,7 @@ import {getDependencies} from "../../dependencies";
 import Util from "../../util";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/iframe/iframe-ai-utils";
 
-import type {WidgetExports, WidgetProps, Widget} from "../../types";
+import type {WidgetExports, WidgetPropsV2, Widget} from "../../types";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
 import type {
     PerseusIFrameUserInput,
@@ -24,11 +24,20 @@ import type {
 
 const {updateQueryString} = Util;
 
-type Props = WidgetProps<PerseusIFrameWidgetOptions, PerseusIFrameUserInput>;
+type Props = WidgetPropsV2<PerseusIFrameWidgetOptions, PerseusIFrameUserInput>;
 
 type DefaultProps = {
-    allowTopNavigation: Props["allowTopNavigation"];
     userInput: Props["userInput"];
+};
+
+// Option-field defaults, relocated out of `static defaultProps` during the
+// WidgetProps redesign. Option fields now live under `props.options`, but React
+// only applies `defaultProps` at the top level of props, so an option default
+// left there would never reach `props.options`. Authored JSON may omit
+// `allowTopNavigation` (the parser doesn't default it), so this default keeps
+// the (deprecated) serialized output stable.
+const OPTION_DEFAULTS = {
+    allowTopNavigation: false,
 };
 
 /* This renders the iframe and handles validation via window.postMessage */
@@ -37,7 +46,6 @@ class Iframe extends React.Component<Props> implements Widget {
     declare context: React.ContextType<typeof PerseusI18nContext>;
 
     static defaultProps: DefaultProps = {
-        allowTopNavigation: false,
         userInput: {
             status: "incomplete",
             // optional message
@@ -62,8 +70,11 @@ class Iframe extends React.Component<Props> implements Widget {
      * [LEMS-3185] do not trust serializedState
      */
     getSerializedState(): any {
-        const {userInput: _, alignment: __, ...rest} = this.props;
-        return rest;
+        const {userInput: _, alignment: __, options, ...rest} = this.props;
+        // `...rest` still carries the universal `static` prop, which spreads
+        // last so it wins over `options.static` — matching the pre-migration
+        // behavior where the universal prop shadowed the option field.
+        return {...OPTION_DEFAULTS, ...options, ...rest};
     }
 
     handleMessageEvent: (arg1: any) => void = (e) => {
@@ -90,8 +101,8 @@ class Iframe extends React.Component<Props> implements Widget {
 
     render(): React.ReactNode {
         const style = {
-            width: String(this.props.width),
-            height: String(this.props.height),
+            width: String(this.props.options.width),
+            height: String(this.props.options.height),
         } as const;
 
         const {InitialRequestUrl} = getDependencies();
@@ -103,7 +114,7 @@ class Iframe extends React.Component<Props> implements Widget {
             }
         });
 
-        let url = this.props.url;
+        let url = this.props.options.url;
 
         // If the URL doesnt start with http, it must be a program ID
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
@@ -112,8 +123,16 @@ class Iframe extends React.Component<Props> implements Widget {
                 "https://www.khanacademy.org/computer-programming/program/" +
                 url +
                 "/embedded?buttons=no&embed=yes&editor=no&author=no";
-            url = updateQueryString(url, "width", `${this.props.width}`);
-            url = updateQueryString(url, "height", `${this.props.height}`);
+            url = updateQueryString(
+                url,
+                "width",
+                `${this.props.options.width}`,
+            );
+            url = updateQueryString(
+                url,
+                "height",
+                `${this.props.options.height}`,
+            );
             // Origin is used by output.js in deciding to send messages
             url = updateQueryString(url, "origin", InitialRequestUrl.origin);
         }
@@ -125,9 +144,9 @@ class Iframe extends React.Component<Props> implements Widget {
         }
 
         // Turn array of [{name: "", value: ""}] into object
-        if (this.props.settings) {
+        if (this.props.options.settings) {
             const settings: Record<string, any> = {};
-            this.props.settings.forEach((setting) => {
+            this.props.options.settings.forEach((setting) => {
                 if (setting.name && setting.value) {
                     settings[setting.name] = setting.value;
                 }
@@ -149,7 +168,7 @@ class Iframe extends React.Component<Props> implements Widget {
                 sandbox={sandboxProperties}
                 style={style}
                 src={url}
-                allowFullScreen={this.props.allowFullScreen}
+                allowFullScreen={this.props.options.allowFullScreen}
             />
         );
     }

--- a/packages/perseus/src/widgets/iframe/iframe.tsx
+++ b/packages/perseus/src/widgets/iframe/iframe.tsx
@@ -88,9 +88,11 @@ class Iframe extends React.Component<Props> implements Widget {
     };
 
     render(): React.ReactNode {
+        const {width, height, allowFullScreen} = this.props.options;
+
         const style = {
-            width: String(this.props.options.width),
-            height: String(this.props.options.height),
+            width: String(width),
+            height: String(height),
         } as const;
 
         const {InitialRequestUrl} = getDependencies();
@@ -111,16 +113,8 @@ class Iframe extends React.Component<Props> implements Widget {
                 "https://www.khanacademy.org/computer-programming/program/" +
                 url +
                 "/embedded?buttons=no&embed=yes&editor=no&author=no";
-            url = updateQueryString(
-                url,
-                "width",
-                `${this.props.options.width}`,
-            );
-            url = updateQueryString(
-                url,
-                "height",
-                `${this.props.options.height}`,
-            );
+            url = updateQueryString(url, "width", `${width}`);
+            url = updateQueryString(url, "height", `${height}`);
             // Origin is used by output.js in deciding to send messages
             url = updateQueryString(url, "origin", InitialRequestUrl.origin);
         }
@@ -156,7 +150,7 @@ class Iframe extends React.Component<Props> implements Widget {
                 sandbox={sandboxProperties}
                 style={style}
                 src={url}
-                allowFullScreen={this.props.options.allowFullScreen}
+                allowFullScreen={allowFullScreen}
             />
         );
     }

--- a/packages/perseus/src/widgets/iframe/iframe.tsx
+++ b/packages/perseus/src/widgets/iframe/iframe.tsx
@@ -27,7 +27,6 @@ const {updateQueryString} = Util;
 type Props = WidgetProps<PerseusIFrameWidgetOptions, PerseusIFrameUserInput>;
 
 type DefaultProps = {
-    allowFullScreen: Props["allowFullScreen"];
     allowTopNavigation: Props["allowTopNavigation"];
     userInput: Props["userInput"];
 };
@@ -38,7 +37,6 @@ class Iframe extends React.Component<Props> implements Widget {
     declare context: React.ContextType<typeof PerseusI18nContext>;
 
     static defaultProps: DefaultProps = {
-        allowFullScreen: false,
         allowTopNavigation: false,
         userInput: {
             status: "incomplete",

--- a/packages/perseus/src/widgets/iframe/iframe.tsx
+++ b/packages/perseus/src/widgets/iframe/iframe.tsx
@@ -30,16 +30,6 @@ type DefaultProps = {
     userInput: Props["userInput"];
 };
 
-// Option-field defaults, relocated out of `static defaultProps` during the
-// WidgetProps redesign. Option fields now live under `props.options`, but React
-// only applies `defaultProps` at the top level of props, so an option default
-// left there would never reach `props.options`. Authored JSON may omit
-// `allowTopNavigation` (the parser doesn't default it), so this default keeps
-// the (deprecated) serialized output stable.
-const OPTION_DEFAULTS = {
-    allowTopNavigation: false,
-};
-
 /* This renders the iframe and handles validation via window.postMessage */
 class Iframe extends React.Component<Props> implements Widget {
     static contextType = PerseusI18nContext;
@@ -71,10 +61,8 @@ class Iframe extends React.Component<Props> implements Widget {
      */
     getSerializedState(): any {
         const {userInput: _, alignment: __, options, ...rest} = this.props;
-        // `...rest` still carries the universal `static` prop, which spreads
-        // last so it wins over `options.static` — matching the pre-migration
-        // behavior where the universal prop shadowed the option field.
-        return {...OPTION_DEFAULTS, ...options, ...rest};
+        const defaults = {allowTopNavigation: false};
+        return {...defaults, ...options, ...rest};
     }
 
     handleMessageEvent: (arg1: any) => void = (e) => {


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

I removed the default props because:

- `allowFullScreen` can't be undefined, so the default was never used.
- `allowTopNavigation` wasn't used by the component.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit an Iframe widget in http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.