### PR TITLE
Migrate sorter widget to WidgetPropsV2

### DIFF
--- a/.changeset/widget-props-v2-sorter.md
+++ b/.changeset/widget-props-v2-sorter.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Migrate the sorter widget to group all `options` under a separate prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -373,10 +373,9 @@ for the recommended per-widget branching shape.
          values. Use the two-statement pattern in the "Examples to follow" section
          above (the dropdown example).
        - Class widgets: apply the option defaults inside the component when it reads
-         options — destructure with defaults, or merge once at the top of `render`:
-         `const options = {...OPTION_DEFAULTS, ...this.props.options};`, where
-         `OPTION_DEFAULTS` is the option-only slice moved out of the old
-         `static defaultProps`.
+         options — destructure with defaults so both missing properties and
+         explicitly-undefined properties get the default.
+
        (`getWidgetProps` could instead merge the option defaults into the `options`
        object it builds, but that pushes per-widget knowledge into the shared
        renderer — prefer the component-local approach.)

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -478,7 +478,7 @@ review and commit the changes.
 
 - [x] Migrate `phet-simulation` to `WidgetPropsV2`.
 - [x] Migrate `iframe` to `WidgetPropsV2`.
-- [ ] Migrate `sorter` to `WidgetPropsV2`.
+- [x] Migrate `sorter` to `WidgetPropsV2`.
 - [ ] Migrate `definition` to `WidgetPropsV2`.
 - [ ] Migrate `explanation` to `WidgetPropsV2`.
 - [ ] Migrate `deprecated-standin` to `WidgetPropsV2`.

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -14,4 +14,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "radio",
     "phet-simulation",
     "iframe",
+    "sorter",
 ];

--- a/packages/perseus/src/widgets/sorter/sorter.tsx
+++ b/packages/perseus/src/widgets/sorter/sorter.tsx
@@ -25,9 +25,6 @@ type Props = WidgetProps<PerseusSorterWidgetOptions, PerseusSorterUserInput> & {
 };
 
 type DefaultProps = {
-    correct: Props["correct"];
-    layout: Props["layout"];
-    padding: Props["padding"];
     problemNum: Props["problemNum"];
     linterContext: Props["linterContext"];
 };
@@ -36,9 +33,6 @@ class Sorter extends React.Component<Props> implements Widget {
     _isMounted: boolean = false;
 
     static defaultProps: DefaultProps = {
-        correct: [],
-        layout: "horizontal",
-        padding: true,
         problemNum: 0,
         linterContext: linterContextDefault,
     };

--- a/packages/perseus/src/widgets/sorter/sorter.tsx
+++ b/packages/perseus/src/widgets/sorter/sorter.tsx
@@ -11,7 +11,7 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetProps,
+    WidgetPropsV2,
 } from "../../types";
 import type {SorterPromptJSON} from "../../widget-ai-utils/sorter/sorter-ai-utils";
 import type {
@@ -20,7 +20,10 @@ import type {
     SorterPublicWidgetOptions,
 } from "@khanacademy/perseus-core";
 
-type Props = WidgetProps<PerseusSorterWidgetOptions, PerseusSorterUserInput> & {
+type Props = WidgetPropsV2<
+    PerseusSorterWidgetOptions,
+    PerseusSorterUserInput
+> & {
     dependencies: PerseusDependenciesV2;
 };
 
@@ -96,9 +99,10 @@ class Sorter extends React.Component<Props> implements Widget {
      * [LEMS-3185] do not trust serializedState
      */
     getSerializedState(): any {
-        const {userInput, ...rest} = this.props;
+        const {userInput, options, ...rest} = this.props;
         return {
             ...rest,
+            ...options,
             changed: userInput.changed,
             options: userInput.options,
         };
@@ -112,9 +116,9 @@ class Sorter extends React.Component<Props> implements Widget {
             <div className="perseus-widget-sorter perseus-clearfix">
                 <Sortable
                     options={userInput.options}
-                    layout={this.props.layout}
+                    layout={this.props.options.layout}
                     margin={marginPx}
-                    padding={this.props.padding}
+                    padding={this.props.options.padding}
                     onChange={this.handleChange}
                     linterContext={this.props.linterContext}
                     // eslint-disable-next-line react/no-string-refs


### PR DESCRIPTION
## Summary
This continues the work started in https://github.com/Khan/perseus/pull/3869.

I removed some default props — they were unused because the corresponding
options are always set.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a Sorter widget in http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.