### PR TITLE
Migrate definition widget to WidgetPropsV2

### DIFF
--- a/.changeset/widget-props-v2-definition.md
+++ b/.changeset/widget-props-v2-definition.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Migrate the definition widget to group all `options` under a separate prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -479,7 +479,7 @@ review and commit the changes.
 - [x] Migrate `phet-simulation` to `WidgetPropsV2`.
 - [x] Migrate `iframe` to `WidgetPropsV2`.
 - [x] Migrate `sorter` to `WidgetPropsV2`.
-- [ ] Migrate `definition` to `WidgetPropsV2`.
+- [x] Migrate `definition` to `WidgetPropsV2`.
 - [ ] Migrate `explanation` to `WidgetPropsV2`.
 - [ ] Migrate `deprecated-standin` to `WidgetPropsV2`.
 - [ ] Migrate `free-response` to `WidgetPropsV2` (its `defaultProps` is

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -15,4 +15,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "phet-simulation",
     "iframe",
     "sorter",
+    "definition",
 ];

--- a/packages/perseus/src/widget-ai-utils/definition/definition-ai-utils.test.ts
+++ b/packages/perseus/src/widget-ai-utils/definition/definition-ai-utils.test.ts
@@ -26,8 +26,10 @@ const question: PerseusRenderer = generateTestPerseusRenderer({
 describe("Definition AI utils", () => {
     it("it returns JSON with the expected format and fields", () => {
         const widgetData: any = {
-            definition: "to confuse or fluster",
-            togglePrompt: "bumfuzzle",
+            options: {
+                definition: "to confuse or fluster",
+                togglePrompt: "bumfuzzle",
+            },
         };
 
         const resultJSON = getPromptJSON(widgetData);

--- a/packages/perseus/src/widget-ai-utils/definition/definition-ai-utils.ts
+++ b/packages/perseus/src/widget-ai-utils/definition/definition-ai-utils.ts
@@ -20,7 +20,7 @@ export const getPromptJSON = (
 ): DefinitionPromptJSON => {
     return {
         type: "definition",
-        definition: widgetData.definition,
-        togglePrompt: widgetData.togglePrompt,
+        definition: widgetData.options.definition,
+        togglePrompt: widgetData.options.togglePrompt,
     };
 };

--- a/packages/perseus/src/widgets/definition/definition.tsx
+++ b/packages/perseus/src/widgets/definition/definition.tsx
@@ -16,7 +16,7 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetProps,
+    WidgetPropsV2,
 } from "../../types";
 import type {DefinitionPromptJSON} from "../../widget-ai-utils/definition/definition-ai-utils";
 import type {
@@ -24,7 +24,7 @@ import type {
     PerseusRenderer,
 } from "@khanacademy/perseus-core";
 
-type DefinitionProps = WidgetProps<PerseusDefinitionWidgetOptions> & {
+type DefinitionProps = WidgetPropsV2<PerseusDefinitionWidgetOptions> & {
     widgets: PerseusRenderer["widgets"];
     dependencies: PerseusDependenciesV2;
 };
@@ -66,7 +66,7 @@ class Definition extends React.Component<DefinitionProps> implements Widget {
                             >
                                 <Renderer
                                     apiOptions={this.props.apiOptions}
-                                    content={this.props.definition}
+                                    content={this.props.options.definition}
                                     widgets={this.props.widgets}
                                     strings={this.context.strings}
                                 />
@@ -82,12 +82,12 @@ class Definition extends React.Component<DefinitionProps> implements Widget {
                                 setActiveDefinitionId(this.props.widgetId);
                             }}
                             aria-label={this.context.strings.definitionIdentifier(
-                                {word: this.props.togglePrompt},
+                                {word: this.props.options.togglePrompt},
                             )}
                         >
                             {() => (
                                 <span className={styles.definition}>
-                                    {this.props.togglePrompt}
+                                    {this.props.options.togglePrompt}
                                 </span>
                             )}
                         </Clickable>

--- a/packages/perseus/src/widgets/definition/definition.tsx
+++ b/packages/perseus/src/widgets/definition/definition.tsx
@@ -29,19 +29,9 @@ type DefinitionProps = WidgetProps<PerseusDefinitionWidgetOptions> & {
     dependencies: PerseusDependenciesV2;
 };
 
-type DefaultProps = {
-    togglePrompt: string;
-    definition: string;
-};
-
 class Definition extends React.Component<DefinitionProps> implements Widget {
     static contextType = PerseusI18nContext;
     declare context: React.ContextType<typeof PerseusI18nContext>;
-
-    static defaultProps: DefaultProps = {
-        togglePrompt: "define me",
-        definition: "definition goes here",
-    };
 
     // this just helps with TS weak typing when a Widget
     // doesn't implement any Widget methods


### PR DESCRIPTION
## Summary
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a Definition widget in http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.