### PR TITLE
[Interactive Graph] Fix iOS 26.5 interactive graph scroll

### DIFF
--- a/.changeset/pink-oranges-throw.md
+++ b/.changeset/pink-oranges-throw.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix ios-26.5 interactive graph scroll

--- a/.changeset/pink-oranges-throw.md
+++ b/.changeset/pink-oranges-throw.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus": patch
 ---
 
-Fix ios-26.5 interactive graph scroll
+Interactive Graph: fix graphs blocking page scroll on touch devices (iOS 26.5+)

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -6091,14 +6091,6 @@ table: [[☃ table 1]]
                                     >
                                       <line
                                         aria-hidden="true"
-                                        style="stroke: transparent; stroke-width: 44;"
-                                        x1="0"
-                                        x2="14.4"
-                                        y1="0"
-                                        y2="-14.4"
-                                      />
-                                      <line
-                                        aria-hidden="true"
                                         class="movable-line-focus-outline"
                                         x1="0"
                                         x2="14.4"
@@ -10370,14 +10362,6 @@ table: [[☃ table 1]]
                                         style="cursor: grab;"
                                         tabindex="-1"
                                       >
-                                        <line
-                                          aria-hidden="true"
-                                          style="stroke: transparent; stroke-width: 44;"
-                                          x1="0"
-                                          x2="14.4"
-                                          y1="-14.4"
-                                          y2="-43.2"
-                                        />
                                         <line
                                           aria-hidden="true"
                                           class="movable-line-focus-outline"

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -6284,12 +6284,19 @@ table: [[☃ table 1]]
                               style="position: absolute; top: 0px; left: 0px; width: 288px; height: 288px; pointer-events: none;"
                             >
                               <div
-                                data-testid="movable-point__hitbox"
-                                style="position: absolute; left: 144px; top: 144px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                                aria-hidden="true"
+                                data-testid="movable-line__hitbox"
+                                style="position: absolute; pointer-events: auto; z-index: 1; cursor: grab; left: 151.2px; top: 136.8px; width: 20.36467529817258px; height: 44px; transform: translate(-50%, -50%) rotate(-45deg);"
                               />
                               <div
+                                aria-hidden="true"
                                 data-testid="movable-point__hitbox"
-                                style="position: absolute; left: 158.4px; top: 129.6px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                                style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 144px; top: 144px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
+                              />
+                              <div
+                                aria-hidden="true"
+                                data-testid="movable-point__hitbox"
+                                style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 158.4px; top: 129.6px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
                               />
                             </div>
                           </div>
@@ -10558,12 +10565,19 @@ table: [[☃ table 1]]
                                 style="position: absolute; top: 0px; left: 0px; width: 288px; height: 288px; pointer-events: none;"
                               >
                                 <div
-                                  data-testid="movable-point__hitbox"
-                                  style="position: absolute; left: 144px; top: 129.6px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                                  aria-hidden="true"
+                                  data-testid="movable-line__hitbox"
+                                  style="position: absolute; pointer-events: auto; z-index: 1; cursor: grab; left: 151.2px; top: 115.19999999999999px; width: 32.19937887599697px; height: 44px; transform: translate(-50%, -50%) rotate(-63.43494882292201deg);"
                                 />
                                 <div
+                                  aria-hidden="true"
                                   data-testid="movable-point__hitbox"
-                                  style="position: absolute; left: 158.4px; top: 100.8px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                                  style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 144px; top: 129.6px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
+                                />
+                                <div
+                                  aria-hidden="true"
+                                  data-testid="movable-point__hitbox"
+                                  style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 158.4px; top: 100.8px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
                                 />
                               </div>
                             </div>

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -6200,12 +6200,6 @@ table: [[☃ table 1]]
                                       style="--movable-point-color: var(--static-gray);"
                                     >
                                       <circle
-                                        class="movable-point-hitbox"
-                                        cx="0"
-                                        cy="0"
-                                        r="24"
-                                      />
-                                      <circle
                                         class="movable-point-halo"
                                         cx="0"
                                         cy="0"
@@ -6234,12 +6228,6 @@ table: [[☃ table 1]]
                                       data-testid="movable-point"
                                       style="--movable-point-color: var(--static-gray);"
                                     >
-                                      <circle
-                                        class="movable-point-hitbox"
-                                        cx="14.4"
-                                        cy="-14.4"
-                                        r="24"
-                                      />
                                       <circle
                                         class="movable-point-halo"
                                         cx="14.4"
@@ -6290,6 +6278,19 @@ table: [[☃ table 1]]
                                   </g>
                                 </svg>
                               </div>
+                            </div>
+                            <div
+                              class="interactive-graph-hitbox-layer"
+                              style="position: absolute; top: 0px; left: 0px; width: 288px; height: 288px; pointer-events: none;"
+                            >
+                              <div
+                                data-testid="movable-point__hitbox"
+                                style="position: absolute; left: 144px; top: 144px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                              />
+                              <div
+                                data-testid="movable-point__hitbox"
+                                style="position: absolute; left: 158.4px; top: 129.6px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                              />
                             </div>
                           </div>
                         </div>
@@ -10473,12 +10474,6 @@ table: [[☃ table 1]]
                                         style="--movable-point-color: var(--static-gray);"
                                       >
                                         <circle
-                                          class="movable-point-hitbox"
-                                          cx="0"
-                                          cy="-14.4"
-                                          r="24"
-                                        />
-                                        <circle
                                           class="movable-point-halo"
                                           cx="0"
                                           cy="-14.4"
@@ -10507,12 +10502,6 @@ table: [[☃ table 1]]
                                         data-testid="movable-point"
                                         style="--movable-point-color: var(--static-gray);"
                                       >
-                                        <circle
-                                          class="movable-point-hitbox"
-                                          cx="14.4"
-                                          cy="-43.2"
-                                          r="24"
-                                        />
                                         <circle
                                           class="movable-point-halo"
                                           cx="14.4"
@@ -10563,6 +10552,19 @@ table: [[☃ table 1]]
                                     </g>
                                   </svg>
                                 </div>
+                              </div>
+                              <div
+                                class="interactive-graph-hitbox-layer"
+                                style="position: absolute; top: 0px; left: 0px; width: 288px; height: 288px; pointer-events: none;"
+                              >
+                                <div
+                                  data-testid="movable-point__hitbox"
+                                  style="position: absolute; left: 144px; top: 129.6px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                                />
+                                <div
+                                  data-testid="movable-point__hitbox"
+                                  style="position: absolute; left: 158.4px; top: 100.8px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                                />
                               </div>
                             </div>
                           </div>

--- a/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
@@ -6400,12 +6400,19 @@ table: [[☃ table 1]]
                               style="position: absolute; top: 0px; left: 0px; width: 288px; height: 288px; pointer-events: none;"
                             >
                               <div
-                                data-testid="movable-point__hitbox"
-                                style="position: absolute; left: 144px; top: 144px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                                aria-hidden="true"
+                                data-testid="movable-line__hitbox"
+                                style="position: absolute; pointer-events: auto; z-index: 1; cursor: grab; left: 151.2px; top: 136.8px; width: 20.36467529817258px; height: 44px; transform: translate(-50%, -50%) rotate(-45deg);"
                               />
                               <div
+                                aria-hidden="true"
                                 data-testid="movable-point__hitbox"
-                                style="position: absolute; left: 158.4px; top: 129.6px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                                style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 144px; top: 144px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
+                              />
+                              <div
+                                aria-hidden="true"
+                                data-testid="movable-point__hitbox"
+                                style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 158.4px; top: 129.6px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
                               />
                             </div>
                           </div>
@@ -10625,12 +10632,19 @@ table: [[☃ table 1]]
                                 style="position: absolute; top: 0px; left: 0px; width: 288px; height: 288px; pointer-events: none;"
                               >
                                 <div
-                                  data-testid="movable-point__hitbox"
-                                  style="position: absolute; left: 144px; top: 129.6px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                                  aria-hidden="true"
+                                  data-testid="movable-line__hitbox"
+                                  style="position: absolute; pointer-events: auto; z-index: 1; cursor: grab; left: 151.2px; top: 115.19999999999999px; width: 32.19937887599697px; height: 44px; transform: translate(-50%, -50%) rotate(-63.43494882292201deg);"
                                 />
                                 <div
+                                  aria-hidden="true"
                                   data-testid="movable-point__hitbox"
-                                  style="position: absolute; left: 158.4px; top: 100.8px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                                  style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 144px; top: 129.6px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
+                                />
+                                <div
+                                  aria-hidden="true"
+                                  data-testid="movable-point__hitbox"
+                                  style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 158.4px; top: 100.8px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
                                 />
                               </div>
                             </div>

--- a/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
@@ -6316,12 +6316,6 @@ table: [[☃ table 1]]
                                       style="--movable-point-color: var(--static-gray);"
                                     >
                                       <circle
-                                        class="movable-point-hitbox"
-                                        cx="0"
-                                        cy="0"
-                                        r="24"
-                                      />
-                                      <circle
                                         class="movable-point-halo"
                                         cx="0"
                                         cy="0"
@@ -6350,12 +6344,6 @@ table: [[☃ table 1]]
                                       data-testid="movable-point"
                                       style="--movable-point-color: var(--static-gray);"
                                     >
-                                      <circle
-                                        class="movable-point-hitbox"
-                                        cx="14.4"
-                                        cy="-14.4"
-                                        r="24"
-                                      />
                                       <circle
                                         class="movable-point-halo"
                                         cx="14.4"
@@ -6406,6 +6394,19 @@ table: [[☃ table 1]]
                                   </g>
                                 </svg>
                               </div>
+                            </div>
+                            <div
+                              class="interactive-graph-hitbox-layer"
+                              style="position: absolute; top: 0px; left: 0px; width: 288px; height: 288px; pointer-events: none;"
+                            >
+                              <div
+                                data-testid="movable-point__hitbox"
+                                style="position: absolute; left: 144px; top: 144px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                              />
+                              <div
+                                data-testid="movable-point__hitbox"
+                                style="position: absolute; left: 158.4px; top: 129.6px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                              />
                             </div>
                           </div>
                         </div>
@@ -10540,12 +10541,6 @@ table: [[☃ table 1]]
                                         style="--movable-point-color: var(--static-gray);"
                                       >
                                         <circle
-                                          class="movable-point-hitbox"
-                                          cx="0"
-                                          cy="-14.4"
-                                          r="24"
-                                        />
-                                        <circle
                                           class="movable-point-halo"
                                           cx="0"
                                           cy="-14.4"
@@ -10574,12 +10569,6 @@ table: [[☃ table 1]]
                                         data-testid="movable-point"
                                         style="--movable-point-color: var(--static-gray);"
                                       >
-                                        <circle
-                                          class="movable-point-hitbox"
-                                          cx="14.4"
-                                          cy="-43.2"
-                                          r="24"
-                                        />
                                         <circle
                                           class="movable-point-halo"
                                           cx="14.4"
@@ -10630,6 +10619,19 @@ table: [[☃ table 1]]
                                     </g>
                                   </svg>
                                 </div>
+                              </div>
+                              <div
+                                class="interactive-graph-hitbox-layer"
+                                style="position: absolute; top: 0px; left: 0px; width: 288px; height: 288px; pointer-events: none;"
+                              >
+                                <div
+                                  data-testid="movable-point__hitbox"
+                                  style="position: absolute; left: 144px; top: 129.6px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                                />
+                                <div
+                                  data-testid="movable-point__hitbox"
+                                  style="position: absolute; left: 158.4px; top: 100.8px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                                />
                               </div>
                             </div>
                           </div>

--- a/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
@@ -6207,14 +6207,6 @@ table: [[☃ table 1]]
                                     >
                                       <line
                                         aria-hidden="true"
-                                        style="stroke: transparent; stroke-width: 44;"
-                                        x1="0"
-                                        x2="14.4"
-                                        y1="0"
-                                        y2="-14.4"
-                                      />
-                                      <line
-                                        aria-hidden="true"
                                         class="movable-line-focus-outline"
                                         x1="0"
                                         x2="14.4"
@@ -10437,14 +10429,6 @@ table: [[☃ table 1]]
                                         style="cursor: grab;"
                                         tabindex="-1"
                                       >
-                                        <line
-                                          aria-hidden="true"
-                                          style="stroke: transparent; stroke-width: 44;"
-                                          x1="0"
-                                          x2="14.4"
-                                          y1="-14.4"
-                                          y2="-43.2"
-                                        />
                                         <line
                                           aria-hidden="true"
                                           class="movable-line-focus-outline"

--- a/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
+++ b/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
@@ -1148,14 +1148,6 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                         >
                           <line
                             aria-hidden="true"
-                            style="stroke: transparent; stroke-width: 44;"
-                            x1="-100"
-                            x2="100"
-                            y1="-100"
-                            y2="-100"
-                          />
-                          <line
-                            aria-hidden="true"
                             class="movable-line-focus-outline"
                             x1="-100"
                             x2="100"

--- a/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
+++ b/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
@@ -1341,12 +1341,19 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                   style="position: absolute; top: 0px; left: 0px; width: 400px; height: 400px; pointer-events: none;"
                 >
                   <div
-                    data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 100px; top: 100px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    aria-hidden="true"
+                    data-testid="movable-line__hitbox"
+                    style="position: absolute; pointer-events: auto; z-index: 1; cursor: grab; left: 200px; top: 100px; width: 200px; height: 44px; transform: translate(-50%, -50%) rotate(0deg);"
                   />
                   <div
+                    aria-hidden="true"
                     data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 300px; top: 100px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 100px; top: 100px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
+                  />
+                  <div
+                    aria-hidden="true"
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 300px; top: 100px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
                   />
                 </div>
               </div>

--- a/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
+++ b/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
@@ -1257,12 +1257,6 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                           style="--movable-point-color: var(--mafs-blue);"
                         >
                           <circle
-                            class="movable-point-hitbox"
-                            cx="-100"
-                            cy="-100"
-                            r="24"
-                          />
-                          <circle
                             class="movable-point-halo"
                             cx="-100"
                             cy="-100"
@@ -1291,12 +1285,6 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                           data-testid="movable-point"
                           style="--movable-point-color: var(--mafs-blue);"
                         >
-                          <circle
-                            class="movable-point-hitbox"
-                            cx="100"
-                            cy="-100"
-                            r="24"
-                          />
                           <circle
                             class="movable-point-halo"
                             cx="100"
@@ -1347,6 +1335,19 @@ exports[`grapher widget should snapshot linear graph question: initial render 1`
                       </g>
                     </svg>
                   </div>
+                </div>
+                <div
+                  class="interactive-graph-hitbox-layer"
+                  style="position: absolute; top: 0px; left: 0px; width: 400px; height: 400px; pointer-events: none;"
+                >
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 100px; top: 100px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 300px; top: 100px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
                 </div>
               </div>
             </div>

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -1086,6 +1086,10 @@ exports[`Interactive Graph A none-type graph renders predictably: first render 1
                     />
                   </div>
                 </div>
+                <div
+                  class="interactive-graph-hitbox-layer"
+                  style="position: absolute; top: 0px; left: 0px; width: 400px; height: 400px; pointer-events: none;"
+                />
               </div>
             </div>
           </div>
@@ -1339,17 +1343,6 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
-                            <foreignobject
-                              height="48"
-                              width="48"
-                              x="176"
-                              y="-138.28571428571428"
-                            >
-                              <div
-                                class="movable-point-hitbox"
-                                style="width: 100%; height: 100%;"
-                              />
-                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -1414,17 +1407,6 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
-                            <foreignobject
-                              height="48"
-                              width="48"
-                              x="118.85714285714286"
-                              y="-252.57142857142858"
-                            >
-                              <div
-                                class="movable-point-hitbox"
-                                style="width: 100%; height: 100%;"
-                              />
-                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -1489,17 +1471,6 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
-                            <foreignobject
-                              height="48"
-                              width="48"
-                              x="61.71428571428572"
-                              y="-138.28571428571428"
-                            >
-                              <div
-                                class="movable-point-hitbox"
-                                style="width: 100%; height: 100%;"
-                              />
-                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -1537,6 +1508,23 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                       </g>
                     </svg>
                   </div>
+                </div>
+                <div
+                  class="interactive-graph-hitbox-layer"
+                  style="position: absolute; top: 0px; left: 0px; width: 400px; height: 400px; pointer-events: none;"
+                >
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 257.14285714285717px; top: 228.5714285714286px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 200px; top: 114.2857142857143px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 142.85714285714286px; top: 228.5714285714286px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
                 </div>
               </div>
             </div>
@@ -1777,17 +1765,6 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
-                            <foreignobject
-                              height="48"
-                              width="48"
-                              x="51"
-                              y="26"
-                            >
-                              <div
-                                class="movable-point-hitbox"
-                                style="width: 100%; height: 100%;"
-                              />
-                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -1852,17 +1829,6 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
-                            <foreignobject
-                              height="48"
-                              width="48"
-                              x="-24"
-                              y="-99"
-                            >
-                              <div
-                                class="movable-point-hitbox"
-                                style="width: 100%; height: 100%;"
-                              />
-                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -1927,17 +1893,6 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
-                            <foreignobject
-                              height="48"
-                              width="48"
-                              x="-99"
-                              y="26"
-                            >
-                              <div
-                                class="movable-point-hitbox"
-                                style="width: 100%; height: 100%;"
-                              />
-                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -1975,6 +1930,23 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                       </g>
                     </svg>
                   </div>
+                </div>
+                <div
+                  class="interactive-graph-hitbox-layer"
+                  style="position: absolute; top: 0px; left: 0px; width: 400px; height: 400px; pointer-events: none;"
+                >
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 275px; top: 250px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 200px; top: 125px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 125px; top: 250px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
                 </div>
               </div>
             </div>
@@ -2179,6 +2151,10 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                     </svg>
                   </div>
                 </div>
+                <div
+                  class="interactive-graph-hitbox-layer"
+                  style="position: absolute; top: 0px; left: 0px; width: 400px; height: 400px; pointer-events: none;"
+                />
               </div>
             </div>
             <div
@@ -2437,6 +2413,10 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                     </svg>
                   </div>
                 </div>
+                <div
+                  class="interactive-graph-hitbox-layer"
+                  style="position: absolute; top: 0px; left: 0px; width: 400px; height: 400px; pointer-events: none;"
+                />
               </div>
             </div>
             <div
@@ -2694,17 +2674,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
-                            <foreignobject
-                              height="48"
-                              width="48"
-                              x="290.2857142857143"
-                              y="-138.28571428571428"
-                            >
-                              <div
-                                class="movable-point-hitbox"
-                                style="width: 100%; height: 100%;"
-                              />
-                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -2769,17 +2738,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
-                            <foreignobject
-                              height="48"
-                              width="48"
-                              x="61.71428571428572"
-                              y="-309.7142857142857"
-                            >
-                              <div
-                                class="movable-point-hitbox"
-                                style="width: 100%; height: 100%;"
-                              />
-                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -2844,17 +2802,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
-                            <foreignobject
-                              height="48"
-                              width="48"
-                              x="61.71428571428572"
-                              y="-138.28571428571428"
-                            >
-                              <div
-                                class="movable-point-hitbox"
-                                style="width: 100%; height: 100%;"
-                              />
-                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -2892,6 +2839,23 @@ exports[`Interactive Graph question Should render user input predictably: with u
                       </g>
                     </svg>
                   </div>
+                </div>
+                <div
+                  class="interactive-graph-hitbox-layer"
+                  style="position: absolute; top: 0px; left: 0px; width: 400px; height: 400px; pointer-events: none;"
+                >
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 371.42857142857144px; top: 228.5714285714286px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 142.85714285714286px; top: 57.14285714285717px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 142.85714285714286px; top: 228.5714285714286px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
                 </div>
               </div>
             </div>
@@ -3132,17 +3096,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
-                            <foreignobject
-                              height="48"
-                              width="48"
-                              x="-174"
-                              y="151"
-                            >
-                              <div
-                                class="movable-point-hitbox"
-                                style="width: 100%; height: 100%;"
-                              />
-                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -3207,17 +3160,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
-                            <foreignobject
-                              height="48"
-                              width="48"
-                              x="1"
-                              y="76"
-                            >
-                              <div
-                                class="movable-point-hitbox"
-                                style="width: 100%; height: 100%;"
-                              />
-                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -3282,17 +3224,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
-                            <foreignobject
-                              height="48"
-                              width="48"
-                              x="-99"
-                              y="76"
-                            >
-                              <div
-                                class="movable-point-hitbox"
-                                style="width: 100%; height: 100%;"
-                              />
-                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -3330,6 +3261,23 @@ exports[`Interactive Graph question Should render user input predictably: with u
                       </g>
                     </svg>
                   </div>
+                </div>
+                <div
+                  class="interactive-graph-hitbox-layer"
+                  style="position: absolute; top: 0px; left: 0px; width: 400px; height: 400px; pointer-events: none;"
+                >
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 50px; top: 375px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 225px; top: 300px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 125px; top: 300px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
                 </div>
               </div>
             </div>
@@ -3560,17 +3508,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                           data-testid="movable-point__center"
                           style="fill: var(--mafs-blue);"
                         />
-                        <foreignobject
-                          height="48"
-                          width="48"
-                          x="-24"
-                          y="-24"
-                        >
-                          <div
-                            class="movable-point-hitbox"
-                            style="width: 100%; height: 100%;"
-                          />
-                        </foreignobject>
                       </g>
                       <g
                         aria-disabled="false"
@@ -3608,17 +3545,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                           data-testid="movable-point__center"
                           style="fill: var(--mafs-blue);"
                         />
-                        <foreignobject
-                          height="48"
-                          width="48"
-                          x="-149"
-                          y="-24"
-                        >
-                          <div
-                            class="movable-point-hitbox"
-                            style="width: 100%; height: 100%;"
-                          />
-                        </foreignobject>
                       </g>
                       <g
                         aria-disabled="false"
@@ -3656,20 +3582,26 @@ exports[`Interactive Graph question Should render user input predictably: with u
                           data-testid="movable-point__center"
                           style="fill: var(--mafs-blue);"
                         />
-                        <foreignobject
-                          height="48"
-                          width="48"
-                          x="-74"
-                          y="-24"
-                        >
-                          <div
-                            class="movable-point-hitbox"
-                            style="width: 100%; height: 100%;"
-                          />
-                        </foreignobject>
                       </g>
                     </svg>
                   </div>
+                </div>
+                <div
+                  class="interactive-graph-hitbox-layer"
+                  style="position: absolute; top: 0px; left: 0px; width: 400px; height: 400px; pointer-events: none;"
+                >
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 200px; top: 200px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 75px; top: 200px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 150px; top: 200px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
                 </div>
               </div>
             </div>
@@ -3956,17 +3888,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
-                            <foreignobject
-                              height="48"
-                              width="48"
-                              x="-107.33333333333334"
-                              y="-24"
-                            >
-                              <div
-                                class="movable-point-hitbox"
-                                style="width: 100%; height: 100%;"
-                              />
-                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -4031,17 +3952,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
-                            <foreignobject
-                              height="48"
-                              width="48"
-                              x="42.66666666666667"
-                              y="-274"
-                            >
-                              <div
-                                class="movable-point-hitbox"
-                                style="width: 100%; height: 100%;"
-                              />
-                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -4106,17 +4016,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
-                            <foreignobject
-                              height="48"
-                              width="48"
-                              x="42.66666666666667"
-                              y="-24"
-                            >
-                              <div
-                                class="movable-point-hitbox"
-                                style="width: 100%; height: 100%;"
-                              />
-                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -4181,17 +4080,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
-                            <foreignobject
-                              height="48"
-                              width="48"
-                              x="-7.333333333333332"
-                              y="-74"
-                            >
-                              <div
-                                class="movable-point-hitbox"
-                                style="width: 100%; height: 100%;"
-                              />
-                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -4229,6 +4117,27 @@ exports[`Interactive Graph question Should render user input predictably: with u
                       </g>
                     </svg>
                   </div>
+                </div>
+                <div
+                  class="interactive-graph-hitbox-layer"
+                  style="position: absolute; top: 0px; left: 0px; width: 400px; height: 400px; pointer-events: none;"
+                >
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 116.66666666666666px; top: 266.6666666666667px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 266.6666666666667px; top: 16.666666666666657px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 266.6666666666667px; top: 266.6666666666667px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
+                  <div
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; left: 216.66666666666666px; top: 216.66666666666669px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                  />
                 </div>
               </div>
             </div>

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -1514,16 +1514,24 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                   style="position: absolute; top: 0px; left: 0px; width: 400px; height: 400px; pointer-events: none;"
                 >
                   <div
-                    data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 257.14285714285717px; top: 228.5714285714286px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    aria-hidden="true"
+                    data-testid="movable-polygon__hitbox"
+                    style="position: absolute; pointer-events: auto; z-index: 1; cursor: grab; left: 142.85714285714286px; top: 114.2857142857143px; width: 114.2857142857143px; height: 114.2857142857143px; clip-path: polygon(114.2857142857143px 114.2857142857143px, 57.14285714285714px 0px, 0px 114.2857142857143px);"
                   />
                   <div
+                    aria-hidden="true"
                     data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 200px; top: 114.2857142857143px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 257.14285714285717px; top: 228.5714285714286px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
                   />
                   <div
+                    aria-hidden="true"
                     data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 142.85714285714286px; top: 228.5714285714286px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 200px; top: 114.2857142857143px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
+                  />
+                  <div
+                    aria-hidden="true"
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 142.85714285714286px; top: 228.5714285714286px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
                   />
                 </div>
               </div>
@@ -1936,16 +1944,24 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                   style="position: absolute; top: 0px; left: 0px; width: 400px; height: 400px; pointer-events: none;"
                 >
                   <div
-                    data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 275px; top: 250px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    aria-hidden="true"
+                    data-testid="movable-polygon__hitbox"
+                    style="position: absolute; pointer-events: auto; z-index: 1; cursor: grab; left: 125px; top: 125px; width: 150px; height: 125px; clip-path: polygon(150px 125px, 75px 0px, 0px 125px);"
                   />
                   <div
+                    aria-hidden="true"
                     data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 200px; top: 125px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 275px; top: 250px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
                   />
                   <div
+                    aria-hidden="true"
                     data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 125px; top: 250px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 200px; top: 125px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
+                  />
+                  <div
+                    aria-hidden="true"
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 125px; top: 250px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
                   />
                 </div>
               </div>
@@ -2845,16 +2861,24 @@ exports[`Interactive Graph question Should render user input predictably: with u
                   style="position: absolute; top: 0px; left: 0px; width: 400px; height: 400px; pointer-events: none;"
                 >
                   <div
-                    data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 371.42857142857144px; top: 228.5714285714286px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    aria-hidden="true"
+                    data-testid="movable-polygon__hitbox"
+                    style="position: absolute; pointer-events: auto; z-index: 1; cursor: grab; left: 142.85714285714286px; top: 57.14285714285717px; width: 228.57142857142858px; height: 171.42857142857144px; clip-path: polygon(228.57142857142858px 171.42857142857144px, 0px 0px, 0px 171.42857142857144px);"
                   />
                   <div
+                    aria-hidden="true"
                     data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 142.85714285714286px; top: 57.14285714285717px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 371.42857142857144px; top: 228.5714285714286px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
                   />
                   <div
+                    aria-hidden="true"
                     data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 142.85714285714286px; top: 228.5714285714286px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 142.85714285714286px; top: 57.14285714285717px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
+                  />
+                  <div
+                    aria-hidden="true"
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 142.85714285714286px; top: 228.5714285714286px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
                   />
                 </div>
               </div>
@@ -3267,16 +3291,24 @@ exports[`Interactive Graph question Should render user input predictably: with u
                   style="position: absolute; top: 0px; left: 0px; width: 400px; height: 400px; pointer-events: none;"
                 >
                   <div
-                    data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 50px; top: 375px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    aria-hidden="true"
+                    data-testid="movable-polygon__hitbox"
+                    style="position: absolute; pointer-events: auto; z-index: 1; cursor: grab; left: 50px; top: 300px; width: 175px; height: 75px; clip-path: polygon(0px 75px, 175px 0px, 75px 0px);"
                   />
                   <div
+                    aria-hidden="true"
                     data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 225px; top: 300px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 50px; top: 375px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
                   />
                   <div
+                    aria-hidden="true"
                     data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 125px; top: 300px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 225px; top: 300px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
+                  />
+                  <div
+                    aria-hidden="true"
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 125px; top: 300px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
                   />
                 </div>
               </div>
@@ -3591,16 +3623,19 @@ exports[`Interactive Graph question Should render user input predictably: with u
                   style="position: absolute; top: 0px; left: 0px; width: 400px; height: 400px; pointer-events: none;"
                 >
                   <div
+                    aria-hidden="true"
                     data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 200px; top: 200px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 200px; top: 200px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
                   />
                   <div
+                    aria-hidden="true"
                     data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 75px; top: 200px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 75px; top: 200px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
                   />
                   <div
+                    aria-hidden="true"
                     data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 150px; top: 200px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 150px; top: 200px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
                   />
                 </div>
               </div>
@@ -4123,20 +4158,29 @@ exports[`Interactive Graph question Should render user input predictably: with u
                   style="position: absolute; top: 0px; left: 0px; width: 400px; height: 400px; pointer-events: none;"
                 >
                   <div
-                    data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 116.66666666666666px; top: 266.6666666666667px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    aria-hidden="true"
+                    data-testid="movable-polygon__hitbox"
+                    style="position: absolute; pointer-events: auto; z-index: 1; cursor: grab; left: 116.66666666666666px; top: 16.666666666666657px; width: 150.00000000000003px; height: 250.00000000000003px; clip-path: polygon(0px 250.00000000000003px, 150.00000000000003px 0px, 150.00000000000003px 250.00000000000003px, 100px 200.00000000000003px);"
                   />
                   <div
+                    aria-hidden="true"
                     data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 266.6666666666667px; top: 16.666666666666657px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 116.66666666666666px; top: 266.6666666666667px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
                   />
                   <div
+                    aria-hidden="true"
                     data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 266.6666666666667px; top: 266.6666666666667px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 266.6666666666667px; top: 16.666666666666657px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
                   />
                   <div
+                    aria-hidden="true"
                     data-testid="movable-point__hitbox"
-                    style="position: absolute; left: 216.66666666666666px; top: 216.66666666666669px; width: 48px; height: 48px; transform: translate(-50%, -50%); pointer-events: auto; cursor: grab;"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 266.6666666666667px; top: 266.6666666666667px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
+                  />
+                  <div
+                    aria-hidden="true"
+                    data-testid="movable-point__hitbox"
+                    style="position: absolute; pointer-events: auto; z-index: 2; cursor: grab; left: 216.66666666666666px; top: 216.66666666666669px; width: 48px; height: 48px; transform: translate(-50%, -50%);"
                   />
                 </div>
               </div>

--- a/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/__snapshots__/interactive-graph.test.tsx.snap
@@ -1318,12 +1318,6 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                             style="--movable-point-color: var(--mafs-blue);"
                           >
                             <circle
-                              class="movable-point-hitbox"
-                              cx="200"
-                              cy="-114.28571428571429"
-                              r="24"
-                            />
-                            <circle
                               class="movable-point-halo"
                               cx="200"
                               cy="-114.28571428571429"
@@ -1345,6 +1339,17 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
+                            <foreignobject
+                              height="48"
+                              width="48"
+                              x="176"
+                              y="-138.28571428571428"
+                            >
+                              <div
+                                class="movable-point-hitbox"
+                                style="width: 100%; height: 100%;"
+                              />
+                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -1388,12 +1393,6 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                             style="--movable-point-color: var(--mafs-blue);"
                           >
                             <circle
-                              class="movable-point-hitbox"
-                              cx="142.85714285714286"
-                              cy="-228.57142857142858"
-                              r="24"
-                            />
-                            <circle
                               class="movable-point-halo"
                               cx="142.85714285714286"
                               cy="-228.57142857142858"
@@ -1415,6 +1414,17 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
+                            <foreignobject
+                              height="48"
+                              width="48"
+                              x="118.85714285714286"
+                              y="-252.57142857142858"
+                            >
+                              <div
+                                class="movable-point-hitbox"
+                                style="width: 100%; height: 100%;"
+                              />
+                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -1458,12 +1468,6 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                             style="--movable-point-color: var(--mafs-blue);"
                           >
                             <circle
-                              class="movable-point-hitbox"
-                              cx="85.71428571428572"
-                              cy="-114.28571428571429"
-                              r="24"
-                            />
-                            <circle
                               class="movable-point-halo"
                               cx="85.71428571428572"
                               cy="-114.28571428571429"
@@ -1485,6 +1489,17 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
+                            <foreignobject
+                              height="48"
+                              width="48"
+                              x="61.71428571428572"
+                              y="-138.28571428571428"
+                            >
+                              <div
+                                class="movable-point-hitbox"
+                                style="width: 100%; height: 100%;"
+                              />
+                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -1741,12 +1756,6 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                             style="--movable-point-color: var(--mafs-blue);"
                           >
                             <circle
-                              class="movable-point-hitbox"
-                              cx="75"
-                              cy="50"
-                              r="24"
-                            />
-                            <circle
                               class="movable-point-halo"
                               cx="75"
                               cy="50"
@@ -1768,6 +1777,17 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
+                            <foreignobject
+                              height="48"
+                              width="48"
+                              x="51"
+                              y="26"
+                            >
+                              <div
+                                class="movable-point-hitbox"
+                                style="width: 100%; height: 100%;"
+                              />
+                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -1811,12 +1831,6 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                             style="--movable-point-color: var(--mafs-blue);"
                           >
                             <circle
-                              class="movable-point-hitbox"
-                              cx="0"
-                              cy="-75"
-                              r="24"
-                            />
-                            <circle
                               class="movable-point-halo"
                               cx="0"
                               cy="-75"
@@ -1838,6 +1852,17 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
+                            <foreignobject
+                              height="48"
+                              width="48"
+                              x="-24"
+                              y="-99"
+                            >
+                              <div
+                                class="movable-point-hitbox"
+                                style="width: 100%; height: 100%;"
+                              />
+                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -1881,12 +1906,6 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                             style="--movable-point-color: var(--mafs-blue);"
                           >
                             <circle
-                              class="movable-point-hitbox"
-                              cx="-75"
-                              cy="50"
-                              r="24"
-                            />
-                            <circle
                               class="movable-point-halo"
                               cx="-75"
                               cy="50"
@@ -1908,6 +1927,17 @@ exports[`Interactive Graph question Should render blank predictably: first rende
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
+                            <foreignobject
+                              height="48"
+                              width="48"
+                              x="-99"
+                              y="26"
+                            >
+                              <div
+                                class="movable-point-hitbox"
+                                style="width: 100%; height: 100%;"
+                              />
+                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -2643,12 +2673,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                             style="--movable-point-color: var(--mafs-blue);"
                           >
                             <circle
-                              class="movable-point-hitbox"
-                              cx="314.2857142857143"
-                              cy="-114.28571428571429"
-                              r="24"
-                            />
-                            <circle
                               class="movable-point-halo"
                               cx="314.2857142857143"
                               cy="-114.28571428571429"
@@ -2670,6 +2694,17 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
+                            <foreignobject
+                              height="48"
+                              width="48"
+                              x="290.2857142857143"
+                              y="-138.28571428571428"
+                            >
+                              <div
+                                class="movable-point-hitbox"
+                                style="width: 100%; height: 100%;"
+                              />
+                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -2713,12 +2748,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                             style="--movable-point-color: var(--mafs-blue);"
                           >
                             <circle
-                              class="movable-point-hitbox"
-                              cx="85.71428571428572"
-                              cy="-285.7142857142857"
-                              r="24"
-                            />
-                            <circle
                               class="movable-point-halo"
                               cx="85.71428571428572"
                               cy="-285.7142857142857"
@@ -2740,6 +2769,17 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
+                            <foreignobject
+                              height="48"
+                              width="48"
+                              x="61.71428571428572"
+                              y="-309.7142857142857"
+                            >
+                              <div
+                                class="movable-point-hitbox"
+                                style="width: 100%; height: 100%;"
+                              />
+                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -2783,12 +2823,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                             style="--movable-point-color: var(--mafs-blue);"
                           >
                             <circle
-                              class="movable-point-hitbox"
-                              cx="85.71428571428572"
-                              cy="-114.28571428571429"
-                              r="24"
-                            />
-                            <circle
                               class="movable-point-halo"
                               cx="85.71428571428572"
                               cy="-114.28571428571429"
@@ -2810,6 +2844,17 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
+                            <foreignobject
+                              height="48"
+                              width="48"
+                              x="61.71428571428572"
+                              y="-138.28571428571428"
+                            >
+                              <div
+                                class="movable-point-hitbox"
+                                style="width: 100%; height: 100%;"
+                              />
+                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -3066,12 +3111,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                             style="--movable-point-color: var(--mafs-blue);"
                           >
                             <circle
-                              class="movable-point-hitbox"
-                              cx="-150"
-                              cy="175"
-                              r="24"
-                            />
-                            <circle
                               class="movable-point-halo"
                               cx="-150"
                               cy="175"
@@ -3093,6 +3132,17 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
+                            <foreignobject
+                              height="48"
+                              width="48"
+                              x="-174"
+                              y="151"
+                            >
+                              <div
+                                class="movable-point-hitbox"
+                                style="width: 100%; height: 100%;"
+                              />
+                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -3136,12 +3186,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                             style="--movable-point-color: var(--mafs-blue);"
                           >
                             <circle
-                              class="movable-point-hitbox"
-                              cx="25"
-                              cy="100"
-                              r="24"
-                            />
-                            <circle
                               class="movable-point-halo"
                               cx="25"
                               cy="100"
@@ -3163,6 +3207,17 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
+                            <foreignobject
+                              height="48"
+                              width="48"
+                              x="1"
+                              y="76"
+                            >
+                              <div
+                                class="movable-point-hitbox"
+                                style="width: 100%; height: 100%;"
+                              />
+                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -3206,12 +3261,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                             style="--movable-point-color: var(--mafs-blue);"
                           >
                             <circle
-                              class="movable-point-hitbox"
-                              cx="-75"
-                              cy="100"
-                              r="24"
-                            />
-                            <circle
                               class="movable-point-halo"
                               cx="-75"
                               cy="100"
@@ -3233,6 +3282,17 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
+                            <foreignobject
+                              height="48"
+                              width="48"
+                              x="-99"
+                              y="76"
+                            >
+                              <div
+                                class="movable-point-hitbox"
+                                style="width: 100%; height: 100%;"
+                              />
+                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -3479,12 +3539,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                         style="--movable-point-color: var(--mafs-blue);"
                       >
                         <circle
-                          class="movable-point-hitbox"
-                          cx="0"
-                          cy="0"
-                          r="24"
-                        />
-                        <circle
                           class="movable-point-halo"
                           cx="0"
                           cy="0"
@@ -3506,6 +3560,17 @@ exports[`Interactive Graph question Should render user input predictably: with u
                           data-testid="movable-point__center"
                           style="fill: var(--mafs-blue);"
                         />
+                        <foreignobject
+                          height="48"
+                          width="48"
+                          x="-24"
+                          y="-24"
+                        >
+                          <div
+                            class="movable-point-hitbox"
+                            style="width: 100%; height: 100%;"
+                          />
+                        </foreignobject>
                       </g>
                       <g
                         aria-disabled="false"
@@ -3522,12 +3587,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                         style="--movable-point-color: var(--mafs-blue);"
                       >
                         <circle
-                          class="movable-point-hitbox"
-                          cx="-125"
-                          cy="0"
-                          r="24"
-                        />
-                        <circle
                           class="movable-point-halo"
                           cx="-125"
                           cy="0"
@@ -3549,6 +3608,17 @@ exports[`Interactive Graph question Should render user input predictably: with u
                           data-testid="movable-point__center"
                           style="fill: var(--mafs-blue);"
                         />
+                        <foreignobject
+                          height="48"
+                          width="48"
+                          x="-149"
+                          y="-24"
+                        >
+                          <div
+                            class="movable-point-hitbox"
+                            style="width: 100%; height: 100%;"
+                          />
+                        </foreignobject>
                       </g>
                       <g
                         aria-disabled="false"
@@ -3565,12 +3635,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                         style="--movable-point-color: var(--mafs-blue);"
                       >
                         <circle
-                          class="movable-point-hitbox"
-                          cx="-50"
-                          cy="0"
-                          r="24"
-                        />
-                        <circle
                           class="movable-point-halo"
                           cx="-50"
                           cy="0"
@@ -3592,6 +3656,17 @@ exports[`Interactive Graph question Should render user input predictably: with u
                           data-testid="movable-point__center"
                           style="fill: var(--mafs-blue);"
                         />
+                        <foreignobject
+                          height="48"
+                          width="48"
+                          x="-74"
+                          y="-24"
+                        >
+                          <div
+                            class="movable-point-hitbox"
+                            style="width: 100%; height: 100%;"
+                          />
+                        </foreignobject>
                       </g>
                     </svg>
                   </div>
@@ -3860,12 +3935,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                             style="--movable-point-color: var(--mafs-blue);"
                           >
                             <circle
-                              class="movable-point-hitbox"
-                              cx="-83.33333333333334"
-                              cy="0"
-                              r="24"
-                            />
-                            <circle
                               class="movable-point-halo"
                               cx="-83.33333333333334"
                               cy="0"
@@ -3887,6 +3956,17 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
+                            <foreignobject
+                              height="48"
+                              width="48"
+                              x="-107.33333333333334"
+                              y="-24"
+                            >
+                              <div
+                                class="movable-point-hitbox"
+                                style="width: 100%; height: 100%;"
+                              />
+                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -3930,12 +4010,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                             style="--movable-point-color: var(--mafs-blue);"
                           >
                             <circle
-                              class="movable-point-hitbox"
-                              cx="66.66666666666667"
-                              cy="-250.00000000000003"
-                              r="24"
-                            />
-                            <circle
                               class="movable-point-halo"
                               cx="66.66666666666667"
                               cy="-250.00000000000003"
@@ -3957,6 +4031,17 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
+                            <foreignobject
+                              height="48"
+                              width="48"
+                              x="42.66666666666667"
+                              y="-274"
+                            >
+                              <div
+                                class="movable-point-hitbox"
+                                style="width: 100%; height: 100%;"
+                              />
+                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -4000,12 +4085,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                             style="--movable-point-color: var(--mafs-blue);"
                           >
                             <circle
-                              class="movable-point-hitbox"
-                              cx="66.66666666666667"
-                              cy="0"
-                              r="24"
-                            />
-                            <circle
                               class="movable-point-halo"
                               cx="66.66666666666667"
                               cy="0"
@@ -4027,6 +4106,17 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
+                            <foreignobject
+                              height="48"
+                              width="48"
+                              x="42.66666666666667"
+                              y="-24"
+                            >
+                              <div
+                                class="movable-point-hitbox"
+                                style="width: 100%; height: 100%;"
+                              />
+                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span
@@ -4070,12 +4160,6 @@ exports[`Interactive Graph question Should render user input predictably: with u
                             style="--movable-point-color: var(--mafs-blue);"
                           >
                             <circle
-                              class="movable-point-hitbox"
-                              cx="16.666666666666668"
-                              cy="-50"
-                              r="24"
-                            />
-                            <circle
                               class="movable-point-halo"
                               cx="16.666666666666668"
                               cy="-50"
@@ -4097,6 +4181,17 @@ exports[`Interactive Graph question Should render user input predictably: with u
                               data-testid="movable-point__center"
                               style="fill: var(--mafs-blue);"
                             />
+                            <foreignobject
+                              height="48"
+                              width="48"
+                              x="-7.333333333333332"
+                              y="-74"
+                            >
+                              <div
+                                class="movable-point-hitbox"
+                                style="width: 100%; height: 100%;"
+                              />
+                            </foreignobject>
                           </g>
                           <foreignobject>
                             <span

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -11,6 +11,7 @@ import useGraphConfig from "../reducer/use-graph-config";
 import {usePointAriaLabel} from "./components/build-point-aria-label";
 import {ClipToGraphBounds} from "./components/clip-to-graph-bounds";
 import Hairlines from "./components/hairlines";
+import {useHitbox} from "./components/hitbox";
 import {MovablePoint} from "./components/movable-point";
 import SRDescInSVG from "./components/sr-description-within-svg";
 import {describeCircleGraph} from "./strings/circle";
@@ -131,6 +132,7 @@ function MovableCircle(props: {
     const {snapStep, disableKeyboardInteraction, interactiveColor} =
         useGraphConfig();
     const [focused, setFocused] = React.useState(false);
+    const [hovered, setHovered] = React.useState(false);
 
     // Keeping focus and gesture targets on separate `<g>`s works around a
     // Safari-specific bug where dragging this group can result in the
@@ -138,6 +140,7 @@ function MovableCircle(props: {
     // Splitting them resolves it and better mirrors `useControlPoint`.
     const focusableHandleRef = useRef<SVGGElement>(null);
     const visibleGroupRef = useRef<SVGGElement>(null);
+    const circleHitboxRef = useRef<HTMLDivElement>(null);
 
     // Keyboard support (on focusableHandleRef)
     useDraggable({
@@ -147,12 +150,22 @@ function MovableCircle(props: {
         constrainKeyboardMovement: (p) => snap(snapStep, p),
     });
 
-    // Mouse/Touch support (on the visibleGroupRef)
+    // Mouse/Touch support runs through an HTML hitbox so Safari doesn't scroll
+    // the page during a drag (see hitbox.tsx).
     const {dragging} = useDraggable({
-        gestureTarget: visibleGroupRef,
+        gestureTarget: circleHitboxRef,
         point: center,
         onMove,
         constrainKeyboardMovement: (p) => snap(snapStep, p),
+    });
+
+    const circleHitbox = useHitbox({
+        shape: {kind: "ellipse", center, radius: [radius, radius]},
+        hitboxRef: circleHitboxRef,
+        layer: "body",
+        dragging,
+        onHoverChange: setHovered,
+        testId: "movable-circle__hitbox",
     });
 
     React.useLayoutEffect(() => {
@@ -166,6 +179,7 @@ function MovableCircle(props: {
 
     return (
         <>
+            {circleHitbox}
             <g
                 ref={focusableHandleRef}
                 className="movable-circle-focusable-handle"
@@ -180,7 +194,7 @@ function MovableCircle(props: {
             <g
                 aria-hidden={true}
                 ref={visibleGroupRef}
-                className={`movable-circle ${dragging ? "movable-circle--dragging" : ""}`}
+                className={`movable-circle${dragging ? " movable-circle--dragging" : ""}${hovered ? " movable-circle--hover" : ""}`}
             >
                 <ClipToGraphBounds>
                     <ellipse

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/circle.tsx
@@ -139,6 +139,8 @@ function MovableCircle(props: {
     // selection of page content once the cursor crosses the graph's edge.
     // Splitting them resolves it and better mirrors `useControlPoint`.
     const focusableHandleRef = useRef<SVGGElement>(null);
+    // Ref to the visible SVG circle group; not a gesture target — pointer/touch
+    // dragging is captured on the HTML hitbox below.
     const visibleGroupRef = useRef<SVGGElement>(null);
     const circleHitboxRef = useRef<HTMLDivElement>(null);
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/hitbox-layer-context.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/hitbox-layer-context.ts
@@ -1,32 +1,17 @@
 import * as React from "react";
 
 /**
- * DOM node of the HTML overlay that sits directly above the interactive graph's
- * SVG. Movable points portal an HTML hitbox `<div>` (with `touch-action: none`)
- * into this layer and use it as their drag gesture target.
+ * DOM node of the HTML overlay above the graph's SVG. Movable points portal an
+ * HTML hitbox `<div>` (`touch-action: none`) into it as their drag target.
  *
- * Why an HTML overlay instead of an SVG hitbox: Safari does NOT reliably honor
- * `touch-action` on SVG elements. With the graph container set to
- * `touch-action: pan-y` (so the page can scroll over the graph), an SVG hitbox
- * with `touch-action: none` is ignored and a vertical point-drag scrolls the
- * page instead of moving the point. `touch-action` on a *real* HTML element is
- * honored on every engine (it's why Mafs' own `.MafsView` HTML container worked
- * before), so the compositor blocks scrolling the instant a touch lands on the
- * point — no first-frame race and no JS `preventDefault` fallback.
+ * Why HTML, not an SVG hitbox: Safari ignores `touch-action` on SVG, so under
+ * the container's `touch-action: pan-y` a vertical point-drag scrolls the page.
+ * `touch-action` on real HTML is honored everywhere, so no scroll and no JS
+ * fallback. The layer is `pointer-events: none` (empty area falls through to
+ * scroll / add-point); each hitbox opts back in. Null until the layer mounts.
  *
- * The layer is `pointer-events: none` so touches on empty graph area fall
- * through to the SVG (page scroll / click-to-add-point); each hitbox `<div>`
- * re-enables pointer events for itself.
- *
- * Null before the layer mounts (SSR / first client render); points render no
- * hitbox until it's available.
- *
- * UPSTREAM (Mafs): this HTML-overlay hitbox technique — together with relaxing
- * `.MafsView { touch-action: none }` in `mafs/core.css` — is the fix to
- * contribute to Mafs' own `MovablePoint`/`useMovable` so every library consumer
- * gets scroll-over-graph with working drags. Perseus forked those components
- * (this file, `use-draggable.ts`, `use-control-point.tsx`, `MovablePointView`
- * are all Perseus-owned), so an upstream change won't flow back here
- * automatically — keep the two in sync if/when the Mafs PR lands.
+ * UPSTREAM (Mafs): this technique + relaxing `.MafsView { touch-action: none }`
+ * in `mafs/core.css` is the fix to contribute to Mafs' `MovablePoint`. Perseus
+ * forked these components, so keep them in sync if that PR lands.
  */
 export const HitboxLayerContext = React.createContext<HTMLElement | null>(null);

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/hitbox-layer-context.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/hitbox-layer-context.ts
@@ -1,0 +1,32 @@
+import * as React from "react";
+
+/**
+ * DOM node of the HTML overlay that sits directly above the interactive graph's
+ * SVG. Movable points portal an HTML hitbox `<div>` (with `touch-action: none`)
+ * into this layer and use it as their drag gesture target.
+ *
+ * Why an HTML overlay instead of an SVG hitbox: Safari does NOT reliably honor
+ * `touch-action` on SVG elements. With the graph container set to
+ * `touch-action: pan-y` (so the page can scroll over the graph), an SVG hitbox
+ * with `touch-action: none` is ignored and a vertical point-drag scrolls the
+ * page instead of moving the point. `touch-action` on a *real* HTML element is
+ * honored on every engine (it's why Mafs' own `.MafsView` HTML container worked
+ * before), so the compositor blocks scrolling the instant a touch lands on the
+ * point — no first-frame race and no JS `preventDefault` fallback.
+ *
+ * The layer is `pointer-events: none` so touches on empty graph area fall
+ * through to the SVG (page scroll / click-to-add-point); each hitbox `<div>`
+ * re-enables pointer events for itself.
+ *
+ * Null before the layer mounts (SSR / first client render); points render no
+ * hitbox until it's available.
+ *
+ * UPSTREAM (Mafs): this HTML-overlay hitbox technique — together with relaxing
+ * `.MafsView { touch-action: none }` in `mafs/core.css` — is the fix to
+ * contribute to Mafs' own `MovablePoint`/`useMovable` so every library consumer
+ * gets scroll-over-graph with working drags. Perseus forked those components
+ * (this file, `use-draggable.ts`, `use-control-point.tsx`, `MovablePointView`
+ * are all Perseus-owned), so an upstream change won't flow back here
+ * automatically — keep the two in sync if/when the Mafs PR lands.
+ */
+export const HitboxLayerContext = React.createContext<HTMLElement | null>(null);

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/hitbox.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/hitbox.tsx
@@ -27,7 +27,7 @@ export const HANDLE_HITBOX_SIZE_PX = 48;
  * pixel space with the same `pointToPixel` transform movable points use, so
  * hitboxes line up exactly with the SVG shapes they cover.
  */
-export type HitboxShape =
+type HitboxShape =
     // Square centered on a point (movable points, arrowheads).
     | {kind: "box"; center: vec.Vector2; sizePx: number}
     // Thick segment between two points (lines, vectors, asymptotes).

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/hitbox.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/hitbox.tsx
@@ -10,6 +10,13 @@ import {HitboxLayerContext} from "./hitbox-layer-context";
 import type {vec} from "mafs";
 
 /**
+ * Touch/click target size for small handles (movable points, arrowheads, the
+ * asymptote pill). Preserved from the legacy interactive graph (48×48px) and a
+ * comfortable target per WCAG 2.5.8.
+ */
+export const HANDLE_HITBOX_SIZE_PX = 48;
+
+/**
  * Drag hitbox for an interactive-graph element, rendered as a real HTML element
  * in the graph's overlay layer rather than as SVG. Safari doesn't reliably
  * honor `touch-action` on SVG, so under the container's `touch-action: pan-y`
@@ -62,6 +69,12 @@ export function useHitbox(params: HitboxParams): React.ReactNode {
 
     // Overlay not mounted yet (SSR / first render); no hitbox yet.
     if (!layerEl) {
+        return null;
+    }
+
+    // A polygon needs at least 3 vertices to have an interior to hit; fewer
+    // would produce a degenerate `clip-path` (and empty min/max math).
+    if (shape.kind === "polygon" && shape.vertices.length < 3) {
         return null;
     }
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/hitbox.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/hitbox.tsx
@@ -1,0 +1,167 @@
+import * as React from "react";
+import {useContext} from "react";
+import {createPortal} from "react-dom";
+
+import useGraphConfig from "../../reducer/use-graph-config";
+import {dimensionsToPixels, pointToPixel} from "../use-transform";
+
+import {HitboxLayerContext} from "./hitbox-layer-context";
+
+import type {vec} from "mafs";
+
+/**
+ * Drag hitbox for an interactive-graph element, rendered as a real HTML element
+ * in the graph's overlay layer rather than as SVG. Safari doesn't reliably
+ * honor `touch-action` on SVG, so under the container's `touch-action: pan-y`
+ * an SVG hitbox lets a drag scroll the page; a real HTML element's
+ * `touch-action: none` is honored everywhere. See {@link HitboxLayerContext}.
+ *
+ * All coordinates are **graph-space**; this hook converts them to the overlay's
+ * pixel space with the same `pointToPixel` transform movable points use, so
+ * hitboxes line up exactly with the SVG shapes they cover.
+ */
+export type HitboxShape =
+    // Square centered on a point (movable points, arrowheads).
+    | {kind: "box"; center: vec.Vector2; sizePx: number}
+    // Thick segment between two points (lines, vectors, asymptotes).
+    | {kind: "line"; start: vec.Vector2; end: vec.Vector2; thicknessPx: number}
+    // Ellipse centered on a point with graph-space radii (circles).
+    | {kind: "ellipse"; center: vec.Vector2; radius: vec.Vector2}
+    // Filled polygon through its vertices (polygon bodies).
+    | {kind: "polygon"; vertices: ReadonlyArray<vec.Vector2>};
+
+type HitboxParams = {
+    shape: HitboxShape;
+    /** Assigned to the hitbox element; use as the `useDraggable` gestureTarget. */
+    hitboxRef: React.RefObject<HTMLDivElement>;
+    /**
+     * Stacking within the overlay. Point/vertex handles ("handle") sit above
+     * shape bodies ("body") so a vertex on a segment/polygon stays grabbable.
+     */
+    layer?: "handle" | "body";
+    cursor?: string;
+    dragging?: boolean;
+    onClick?: () => void;
+    onHoverChange?: (hovered: boolean) => void;
+    testId?: string;
+};
+
+export function useHitbox(params: HitboxParams): React.ReactNode {
+    const {
+        shape,
+        hitboxRef,
+        layer = "handle",
+        cursor,
+        dragging = false,
+        onClick,
+        onHoverChange,
+        testId,
+    } = params;
+    const layerEl = useContext(HitboxLayerContext);
+    const graphConfig = useGraphConfig();
+
+    // Overlay not mounted yet (SSR / first render); no hitbox yet.
+    if (!layerEl) {
+        return null;
+    }
+
+    return createPortal(
+        // This <div> is a pointer-only hit surface: keyboard and assistive-tech
+        // interaction live on the sibling SVG element (a focusable
+        // `role="button"`), so it's `aria-hidden` and carries no role/tabindex
+        // (no duplicate control, no extra tab stop). The jsx-a11y rules are
+        // disabled for the same reason — pointer input only.
+        // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
+        <div
+            ref={hitboxRef}
+            aria-hidden={true}
+            data-testid={testId}
+            style={{
+                position: "absolute",
+                touchAction: "none",
+                pointerEvents: "auto",
+                // Handles above bodies so a vertex on a shape stays grabbable.
+                zIndex: layer === "body" ? 1 : 2,
+                cursor: dragging ? "grabbing" : cursor ?? "grab",
+                ...shapeStyle(shape, graphConfig),
+            }}
+            onClick={onClick}
+            onPointerEnter={() => onHoverChange?.(true)}
+            onPointerLeave={() => onHoverChange?.(false)}
+        />,
+        layerEl,
+    );
+}
+
+// Translates a graph-space shape into absolute-position CSS for the overlay.
+function shapeStyle(
+    shape: HitboxShape,
+    graphConfig: Parameters<typeof pointToPixel>[1],
+): React.CSSProperties {
+    switch (shape.kind) {
+        case "box": {
+            const [x, y] = pointToPixel(shape.center, graphConfig);
+            return {
+                left: x,
+                top: y,
+                width: shape.sizePx,
+                height: shape.sizePx,
+                transform: "translate(-50%, -50%)",
+            };
+        }
+        case "line": {
+            const [sx, sy] = pointToPixel(shape.start, graphConfig);
+            const [ex, ey] = pointToPixel(shape.end, graphConfig);
+            const dx = ex - sx;
+            const dy = ey - sy;
+            const length = Math.hypot(dx, dy);
+            const angleDeg = (Math.atan2(dy, dx) * 180) / Math.PI;
+            return {
+                // Center the rectangle on the line's midpoint, then rotate it to
+                // the line's angle — an exact match for the SVG hit-line.
+                left: (sx + ex) / 2,
+                top: (sy + ey) / 2,
+                width: length,
+                height: shape.thicknessPx,
+                transform: `translate(-50%, -50%) rotate(${angleDeg}deg)`,
+            };
+        }
+        case "ellipse": {
+            const [cx, cy] = pointToPixel(shape.center, graphConfig);
+            const [[rxPx, ryPx]] = dimensionsToPixels(
+                [shape.radius],
+                graphConfig,
+            );
+            return {
+                left: cx,
+                top: cy,
+                width: rxPx * 2,
+                height: ryPx * 2,
+                transform: "translate(-50%, -50%)",
+                borderRadius: "50%",
+            };
+        }
+        case "polygon": {
+            const pts = shape.vertices.map((v) => pointToPixel(v, graphConfig));
+            const xs = pts.map((p) => p[0]);
+            const ys = pts.map((p) => p[1]);
+            const minX = Math.min(...xs);
+            const minY = Math.min(...ys);
+            const maxX = Math.max(...xs);
+            const maxY = Math.max(...ys);
+            // `clip-path` clips both painting and pointer hit-testing, so only
+            // touches inside the polygon are captured; the rest of the bounding
+            // box falls through to the SVG/page (scroll / other handles).
+            const clip = pts
+                .map(([px, py]) => `${px - minX}px ${py - minY}px`)
+                .join(", ");
+            return {
+                left: minX,
+                top: minY,
+                width: maxX - minX,
+                height: maxY - minY,
+                clipPath: `polygon(${clip})`,
+            };
+        }
+    }
+}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-arrowhead-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-arrowhead-view.tsx
@@ -18,13 +18,14 @@ type Props = {
     angle: number; // degrees counterclockwise from the positive x-axis
     dragging: boolean;
     focused: boolean;
+    // Hover is driven by the HTML hitbox (see useControlArrowhead), not CSS
+    // `:hover`, because the hitbox sits on top of the SVG and intercepts the
+    // pointer.
+    hovered?: boolean;
     showFocusRing: boolean;
     cursor?: CSSCursor | undefined;
     onClick?: () => unknown;
 };
-
-// The hitbox size of 48px by 48px matches the movable point.
-const hitboxSizePx = 48;
 
 // Straight-line chevron arrowhead: two lines meeting at the tip.
 // Wings at (-5, ±5) give exactly 45° per side (90° total opening).
@@ -96,6 +97,7 @@ export const MovableArrowheadView = forwardRef(
             point,
             angle,
             dragging,
+            hovered,
             cursor,
             showFocusRing,
             onClick = () => {},
@@ -109,6 +111,7 @@ export const MovableArrowheadView = forwardRef(
             "movable-arrowhead",
             dragging && "movable-arrowhead--dragging",
             showFocusRing && "movable-arrowhead--focus",
+            hovered && "movable-arrowhead--hover",
         );
 
         const [[x, y]] = useTransformVectorsToPixels(point);
@@ -134,14 +137,6 @@ export const MovableArrowheadView = forwardRef(
                 data-testid="movable-arrowhead"
                 onClick={onClick}
             >
-                {/* Transparent circular hit target (48 × 48 px) */}
-                <circle
-                    className="movable-arrowhead-hitbox"
-                    r={hitboxSizePx / 2}
-                    cx={x}
-                    cy={y}
-                />
-
                 <g transform={`translate(${x} ${y}) rotate(${angle})`}>
                     {/* Halo — filled rounded triangle.  On focus,
                             a 2px stroke is added for the focus ring. */}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-asymptote.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-asymptote.tsx
@@ -5,7 +5,7 @@ import useGraphConfig from "../../reducer/use-graph-config";
 import {TARGET_SIZE} from "../../utils";
 import {useDraggable} from "../use-draggable";
 
-import {useHitbox} from "./hitbox";
+import {HANDLE_HITBOX_SIZE_PX, useHitbox} from "./hitbox";
 import {MovablePillHandle} from "./movable-pill-handle";
 import {SVGLine} from "./svg-line";
 
@@ -52,8 +52,7 @@ export function MovableAsymptote(props: Props) {
         ariaLabel,
         children,
     } = props;
-    const {interactiveColor, disableKeyboardInteraction, range} =
-        useGraphConfig();
+    const {interactiveColor, disableKeyboardInteraction} = useGraphConfig();
 
     const [focused, setFocused] = React.useState(false);
     const [hovered, setHovered] = React.useState(false);
@@ -76,23 +75,15 @@ export function MovableAsymptote(props: Props) {
         constrainKeyboardMovement: constrainKeyboardMovement ?? ((p) => p),
     });
 
-    // The asymptote spans the full graph in graph-space: a horizontal line at
-    // y = point.y, or a vertical line at x = point.x. Reconstruct those
-    // endpoints so the hitbox lines up with the visible line.
-    const [[xMin, xMax], [yMin, yMax]] = range;
-    const hitStart: vec.Vector2 =
-        orientation === "horizontal" ? [xMin, point[1]] : [point[0], yMin];
-    const hitEnd: vec.Vector2 =
-        orientation === "horizontal" ? [xMax, point[1]] : [point[0], yMax];
+    // The asymptote is dragged by its pill handle (centered at `point`), not the
+    // whole line. So the hitbox is a box on the handle — this matches the
+    // affordance and lets the page scroll where the finger is elsewhere along
+    // the line (a full-line hitbox would block scrolling across a full-width or
+    // full-height band).
     const asymptoteHitbox = useHitbox({
-        shape: {
-            kind: "line",
-            start: hitStart,
-            end: hitEnd,
-            thicknessPx: TARGET_SIZE,
-        },
+        shape: {kind: "box", center: point, sizePx: HANDLE_HITBOX_SIZE_PX},
         hitboxRef: asymptoteHitboxRef,
-        layer: "body",
+        layer: "handle",
         dragging,
         onHoverChange: setHovered,
         testId: "movable-asymptote__hitbox",
@@ -102,9 +93,12 @@ export function MovableAsymptote(props: Props) {
     // focus, so any previously focused element (e.g. a movable point) keeps
     // its focus styling. Focus the group on drag so focus follows the last
     // element the user interacted with — matches `useControlPoint`.
+    // `preventScroll` is essential here: this group contains the plotted curve
+    // (passed as children), so its bounding box is tall, and a default
+    // focus() would scroll that box into view — jumping the page mid-drag.
     React.useLayoutEffect(() => {
         if (dragging && !focused) {
-            groupRef.current?.focus();
+            groupRef.current?.focus({preventScroll: true});
         }
     }, [dragging, focused]);
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-asymptote.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-asymptote.tsx
@@ -5,6 +5,7 @@ import useGraphConfig from "../../reducer/use-graph-config";
 import {TARGET_SIZE} from "../../utils";
 import {useDraggable} from "../use-draggable";
 
+import {useHitbox} from "./hitbox";
 import {MovablePillHandle} from "./movable-pill-handle";
 import {SVGLine} from "./svg-line";
 
@@ -51,17 +52,50 @@ export function MovableAsymptote(props: Props) {
         ariaLabel,
         children,
     } = props;
-    const {interactiveColor, disableKeyboardInteraction} = useGraphConfig();
+    const {interactiveColor, disableKeyboardInteraction, range} =
+        useGraphConfig();
 
     const [focused, setFocused] = React.useState(false);
     const [hovered, setHovered] = React.useState(false);
 
     const groupRef = React.useRef<SVGGElement | null>(null);
-    const {dragging} = useDraggable({
+    const asymptoteHitboxRef = React.useRef<HTMLDivElement>(null);
+
+    // Keyboard drag stays on the focusable SVG group.
+    useDraggable({
         gestureTarget: groupRef,
         point,
         onMove,
         constrainKeyboardMovement: constrainKeyboardMovement ?? ((p) => p),
+    });
+    // Pointer/touch drag runs through the HTML hitbox (Safari-safe).
+    const {dragging} = useDraggable({
+        gestureTarget: asymptoteHitboxRef,
+        point,
+        onMove,
+        constrainKeyboardMovement: constrainKeyboardMovement ?? ((p) => p),
+    });
+
+    // The asymptote spans the full graph in graph-space: a horizontal line at
+    // y = point.y, or a vertical line at x = point.x. Reconstruct those
+    // endpoints so the hitbox lines up with the visible line.
+    const [[xMin, xMax], [yMin, yMax]] = range;
+    const hitStart: vec.Vector2 =
+        orientation === "horizontal" ? [xMin, point[1]] : [point[0], yMin];
+    const hitEnd: vec.Vector2 =
+        orientation === "horizontal" ? [xMax, point[1]] : [point[0], yMax];
+    const asymptoteHitbox = useHitbox({
+        shape: {
+            kind: "line",
+            start: hitStart,
+            end: hitEnd,
+            thicknessPx: TARGET_SIZE,
+        },
+        hitboxRef: asymptoteHitboxRef,
+        layer: "body",
+        dragging,
+        onHoverChange: setHovered,
+        testId: "movable-asymptote__hitbox",
     });
 
     // When a touch drag starts the asymptote group does not naturally receive
@@ -75,61 +109,68 @@ export function MovableAsymptote(props: Props) {
     }, [dragging, focused]);
 
     return (
-        <g
-            ref={groupRef}
-            tabIndex={disableKeyboardInteraction ? -1 : 0}
-            aria-disabled={disableKeyboardInteraction}
-            aria-label={ariaLabel}
-            className="movable-line"
-            style={{cursor: dragging ? "grabbing" : "grab"}}
-            role="button"
-            data-testid="movable-asymptote"
-            onFocus={() => setFocused(true)}
-            onBlur={() => setFocused(false)}
-            onMouseEnter={() => setHovered(true)}
-            onMouseLeave={() => setHovered(false)}
-        >
-            {/* Transparent hit target spanning the full line */}
-            <SVGLine
-                start={start}
-                end={end}
-                style={{stroke: "transparent", strokeWidth: TARGET_SIZE}}
-            />
-            {/* Solid white line underneath so dashes are visible on grid lines/axes */}
-            <SVGLine
-                start={start}
-                end={end}
-                style={{
-                    stroke: semanticColor.core.background.base.default,
-                    strokeWidth: "var(--movable-asymptote-stroke-weight)",
-                    strokeLinecap: "round",
-                }}
-                className={dragging ? "movable-dragging" : ""}
-            />
-            {/* Dashed line */}
-            <SVGLine
-                start={start}
-                end={end}
-                style={{
-                    stroke: interactiveColor,
-                    strokeWidth: "var(--movable-asymptote-stroke-weight)",
-                    strokeDasharray:
-                        "var(--movable-asymptote-dash-length) var(--movable-asymptote-dash-gap)",
-                    strokeLinecap: "round",
-                }}
-                className={dragging ? "movable-dragging" : ""}
-                testId="movable-asymptote__line"
-            />
-            {/* Content between lines and handle (e.g. curve) renders
+        <>
+            {asymptoteHitbox}
+            <g
+                ref={groupRef}
+                tabIndex={disableKeyboardInteraction ? -1 : 0}
+                aria-disabled={disableKeyboardInteraction}
+                aria-label={ariaLabel}
+                className={
+                    hovered
+                        ? "movable-line movable-line--hover"
+                        : "movable-line"
+                }
+                style={{cursor: dragging ? "grabbing" : "grab"}}
+                role="button"
+                data-testid="movable-asymptote"
+                onFocus={() => setFocused(true)}
+                onBlur={() => setFocused(false)}
+                onMouseEnter={() => setHovered(true)}
+                onMouseLeave={() => setHovered(false)}
+            >
+                {/* Transparent hit target spanning the full line */}
+                <SVGLine
+                    start={start}
+                    end={end}
+                    style={{stroke: "transparent", strokeWidth: TARGET_SIZE}}
+                />
+                {/* Solid white line underneath so dashes are visible on grid lines/axes */}
+                <SVGLine
+                    start={start}
+                    end={end}
+                    style={{
+                        stroke: semanticColor.core.background.base.default,
+                        strokeWidth: "var(--movable-asymptote-stroke-weight)",
+                        strokeLinecap: "round",
+                    }}
+                    className={dragging ? "movable-dragging" : ""}
+                />
+                {/* Dashed line */}
+                <SVGLine
+                    start={start}
+                    end={end}
+                    style={{
+                        stroke: interactiveColor,
+                        strokeWidth: "var(--movable-asymptote-stroke-weight)",
+                        strokeDasharray:
+                            "var(--movable-asymptote-dash-length) var(--movable-asymptote-dash-gap)",
+                        strokeLinecap: "round",
+                    }}
+                    className={dragging ? "movable-dragging" : ""}
+                    testId="movable-asymptote__line"
+                />
+                {/* Content between lines and handle (e.g. curve) renders
                 above the dashed line but below the drag handle */}
-            {children}
-            {/* Drag handle at the midpoint */}
-            <MovablePillHandle
-                center={mid}
-                rotation={orientation === "vertical" ? 90 : 0}
-                active={dragging || focused || hovered}
-                focused={focused}
-            />
-        </g>
+                {children}
+                {/* Drag handle at the midpoint */}
+                <MovablePillHandle
+                    center={mid}
+                    rotation={orientation === "vertical" ? 90 : 0}
+                    active={dragging || focused || hovered}
+                    focused={focused}
+                />
+            </g>
+        </>
     );
 }

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line/__snapshots__/movable-line.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line/__snapshots__/movable-line.test.tsx.snap
@@ -32,14 +32,6 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
       >
         <line
           aria-hidden="true"
-          style="stroke: transparent; stroke-width: 44;"
-          x1="0"
-          x2="0"
-          y1="0"
-          y2="0"
-        />
-        <line
-          aria-hidden="true"
           class="movable-line-focus-outline"
           x1="0"
           x2="0"
@@ -168,14 +160,6 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
       >
         <line
           aria-hidden="true"
-          style="stroke: transparent; stroke-width: 44;"
-          x1="0"
-          x2="0"
-          y1="0"
-          y2="0"
-        />
-        <line
-          aria-hidden="true"
           class="movable-line-focus-outline"
           x1="0"
           x2="0"
@@ -302,14 +286,6 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
         style="cursor: grab;"
         tabindex="0"
       >
-        <line
-          aria-hidden="true"
-          style="stroke: transparent; stroke-width: 44;"
-          x1="0"
-          x2="0"
-          y1="0"
-          y2="0"
-        />
         <line
           aria-hidden="true"
           class="movable-line-focus-outline"

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line/__snapshots__/movable-line.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line/__snapshots__/movable-line.test.tsx.snap
@@ -80,12 +80,6 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
         style="--movable-point-color: var(--mafs-blue);"
       >
         <circle
-          class="movable-point-hitbox"
-          cx="0"
-          cy="0"
-          r="24"
-        />
-        <circle
           class="movable-point-halo"
           cx="0"
           cy="0"
@@ -107,6 +101,17 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
           data-testid="movable-point__center"
           style="fill: var(--mafs-blue);"
         />
+        <foreignobject
+          height="48"
+          width="48"
+          x="-24"
+          y="-24"
+        >
+          <div
+            class="movable-point-hitbox"
+            style="width: 100%; height: 100%;"
+          />
+        </foreignobject>
       </g>
       <g
         aria-hidden="true"
@@ -115,12 +120,6 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
         style="--movable-point-color: var(--mafs-blue);"
       >
         <circle
-          class="movable-point-hitbox"
-          cx="0"
-          cy="0"
-          r="24"
-        />
-        <circle
           class="movable-point-halo"
           cx="0"
           cy="0"
@@ -142,6 +141,17 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
           data-testid="movable-point__center"
           style="fill: var(--mafs-blue);"
         />
+        <foreignobject
+          height="48"
+          width="48"
+          x="-24"
+          y="-24"
+        >
+          <div
+            class="movable-point-hitbox"
+            style="width: 100%; height: 100%;"
+          />
+        </foreignobject>
       </g>
     </svg>
   </div>
@@ -228,12 +238,6 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
         style="--movable-point-color: var(--mafs-blue);"
       >
         <circle
-          class="movable-point-hitbox"
-          cx="0"
-          cy="0"
-          r="24"
-        />
-        <circle
           class="movable-point-halo"
           cx="0"
           cy="0"
@@ -255,6 +259,17 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
           data-testid="movable-point__center"
           style="fill: var(--mafs-blue);"
         />
+        <foreignobject
+          height="48"
+          width="48"
+          x="-24"
+          y="-24"
+        >
+          <div
+            class="movable-point-hitbox"
+            style="width: 100%; height: 100%;"
+          />
+        </foreignobject>
       </g>
       <g
         aria-hidden="true"
@@ -263,12 +278,6 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
         style="--movable-point-color: var(--mafs-blue);"
       >
         <circle
-          class="movable-point-hitbox"
-          cx="0"
-          cy="0"
-          r="24"
-        />
-        <circle
           class="movable-point-halo"
           cx="0"
           cy="0"
@@ -290,6 +299,17 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
           data-testid="movable-point__center"
           style="fill: var(--mafs-blue);"
         />
+        <foreignobject
+          height="48"
+          width="48"
+          x="-24"
+          y="-24"
+        >
+          <div
+            class="movable-point-hitbox"
+            style="width: 100%; height: 100%;"
+          />
+        </foreignobject>
       </g>
     </svg>
   </div>
@@ -436,12 +456,6 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
         style="--movable-point-color: var(--mafs-blue);"
       >
         <circle
-          class="movable-point-hitbox"
-          cx="0"
-          cy="0"
-          r="24"
-        />
-        <circle
           class="movable-point-halo"
           cx="0"
           cy="0"
@@ -463,6 +477,17 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
           data-testid="movable-point__center"
           style="fill: var(--mafs-blue);"
         />
+        <foreignobject
+          height="48"
+          width="48"
+          x="-24"
+          y="-24"
+        >
+          <div
+            class="movable-point-hitbox"
+            style="width: 100%; height: 100%;"
+          />
+        </foreignobject>
       </g>
       <g
         aria-hidden="true"
@@ -471,12 +496,6 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
         style="--movable-point-color: var(--mafs-blue);"
       >
         <circle
-          class="movable-point-hitbox"
-          cx="0"
-          cy="0"
-          r="24"
-        />
-        <circle
           class="movable-point-halo"
           cx="0"
           cy="0"
@@ -498,6 +517,17 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
           data-testid="movable-point__center"
           style="fill: var(--mafs-blue);"
         />
+        <foreignobject
+          height="48"
+          width="48"
+          x="-24"
+          y="-24"
+        >
+          <div
+            class="movable-point-hitbox"
+            style="width: 100%; height: 100%;"
+          />
+        </foreignobject>
       </g>
     </svg>
   </div>

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line/__snapshots__/movable-line.test.tsx.snap
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line/__snapshots__/movable-line.test.tsx.snap
@@ -101,17 +101,6 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
           data-testid="movable-point__center"
           style="fill: var(--mafs-blue);"
         />
-        <foreignobject
-          height="48"
-          width="48"
-          x="-24"
-          y="-24"
-        >
-          <div
-            class="movable-point-hitbox"
-            style="width: 100%; height: 100%;"
-          />
-        </foreignobject>
       </g>
       <g
         aria-hidden="true"
@@ -141,17 +130,6 @@ exports[`Rendering Does NOT render extensions of line when option is disabled 1`
           data-testid="movable-point__center"
           style="fill: var(--mafs-blue);"
         />
-        <foreignobject
-          height="48"
-          width="48"
-          x="-24"
-          y="-24"
-        >
-          <div
-            class="movable-point-hitbox"
-            style="width: 100%; height: 100%;"
-          />
-        </foreignobject>
       </g>
     </svg>
   </div>
@@ -259,17 +237,6 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
           data-testid="movable-point__center"
           style="fill: var(--mafs-blue);"
         />
-        <foreignobject
-          height="48"
-          width="48"
-          x="-24"
-          y="-24"
-        >
-          <div
-            class="movable-point-hitbox"
-            style="width: 100%; height: 100%;"
-          />
-        </foreignobject>
       </g>
       <g
         aria-hidden="true"
@@ -299,17 +266,6 @@ exports[`Rendering Does NOT render extensions of line when option is not provide
           data-testid="movable-point__center"
           style="fill: var(--mafs-blue);"
         />
-        <foreignobject
-          height="48"
-          width="48"
-          x="-24"
-          y="-24"
-        >
-          <div
-            class="movable-point-hitbox"
-            style="width: 100%; height: 100%;"
-          />
-        </foreignobject>
       </g>
     </svg>
   </div>
@@ -477,17 +433,6 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
           data-testid="movable-point__center"
           style="fill: var(--mafs-blue);"
         />
-        <foreignobject
-          height="48"
-          width="48"
-          x="-24"
-          y="-24"
-        >
-          <div
-            class="movable-point-hitbox"
-            style="width: 100%; height: 100%;"
-          />
-        </foreignobject>
       </g>
       <g
         aria-hidden="true"
@@ -517,17 +462,6 @@ exports[`Rendering Does render extensions of line when option is enabled 1`] = `
           data-testid="movable-point__center"
           style="fill: var(--mafs-blue);"
         />
-        <foreignobject
-          height="48"
-          width="48"
-          x="-24"
-          y="-24"
-        >
-          <div
-            class="movable-point-hitbox"
-            style="width: 100%; height: 100%;"
-          />
-        </foreignobject>
       </g>
     </svg>
   </div>

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line/line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line/line.tsx
@@ -105,14 +105,8 @@ export const Line = (props: LineProps) => {
                 // the screen reader skip over its empty children.
                 role="button"
             >
-                {/**
-                 * This transparent line creates a nice big click/touch target.
-                 */}
-                <SVGLine
-                    start={startPtPx}
-                    end={endPtPx}
-                    style={{stroke: "transparent", strokeWidth: TARGET_SIZE}}
-                />
+                {/* Pointer/touch dragging is handled by the HTML hitbox
+                    (see lineHitbox); the SVG here is visual + keyboard focus. */}
                 <SVGLine
                     start={startPtPx}
                     end={endPtPx}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line/line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-line/line.tsx
@@ -1,4 +1,4 @@
-import {useRef} from "react";
+import {useRef, useState} from "react";
 import * as React from "react";
 
 import {snap} from "../../../math";
@@ -7,6 +7,7 @@ import {TARGET_SIZE} from "../../../utils";
 import {useDraggable} from "../../use-draggable";
 import {useTransformVectorsToPixels} from "../../use-transform";
 import {getIntersectionOfRayWithBox} from "../../utils";
+import {useHitbox} from "../hitbox";
 import {SVGLine} from "../svg-line";
 import {Vector} from "../vector";
 
@@ -55,22 +56,48 @@ export const Line = (props: LineProps) => {
     const endExtend = extend?.end ? computeExtensionTip(end, start) : undefined;
 
     const line = useRef<SVGGElement>(null);
-    const {dragging} = useDraggable({
+    const lineHitboxRef = useRef<HTMLDivElement>(null);
+    const [hovered, setHovered] = useState(false);
+
+    // Keyboard drag stays on the focusable SVG group.
+    useDraggable({
         gestureTarget: line,
         point: start,
         onMove,
         constrainKeyboardMovement: (p) => snap(snapStep, p),
     });
+    // Pointer/touch drag runs through an HTML hitbox so Safari doesn't scroll
+    // the page during a drag (see hitbox.tsx).
+    const {dragging} = useDraggable({
+        gestureTarget: lineHitboxRef,
+        point: start,
+        onMove,
+        constrainKeyboardMovement: (p) => snap(snapStep, p),
+    });
+
+    const lineHitbox = useHitbox({
+        shape: {kind: "line", start, end, thicknessPx: TARGET_SIZE},
+        hitboxRef: lineHitboxRef,
+        layer: "body",
+        dragging,
+        onHoverChange: setHovered,
+        testId: "movable-line__hitbox",
+    });
 
     return (
         <>
+            {lineHitbox}
             <g
                 ref={line}
                 tabIndex={disableKeyboardInteraction ? -1 : 0}
                 aria-label={ariaLabel}
                 aria-describedby={ariaDescribedBy}
                 aria-disabled={disableKeyboardInteraction}
-                className="movable-line"
+                className={
+                    hovered
+                        ? "movable-line movable-line--hover"
+                        : "movable-line"
+                }
                 data-testid="movable-line"
                 style={{cursor: dragging ? "grabbing" : "grab"}}
                 // Indicate that this element is interactive.

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -18,21 +18,19 @@ type Props = {
     point: vec.Vector2;
     dragging: boolean;
     focused: boolean;
+    // Hover is driven by the HTML hitbox (see useControlPoint), not CSS
+    // `:hover`, because the hitbox sits on top of the SVG in a separate DOM
+    // subtree and intercepts the pointer.
+    hovered?: boolean;
     showFocusRing: boolean;
     cursor?: CSSCursor | undefined;
     onClick?: () => unknown;
-    // Ref for the HTML hitbox that captures pointer/touch drags. See the
-    // `foreignObject` note below for why the hitbox is HTML rather than SVG.
-    hitboxDivRef?: React.Ref<HTMLDivElement>;
 };
-
-// The hitbox size of 48px by 48px is preserved from the legacy interactive
-// graph.
-const hitboxSizePx = 48;
 
 // MovablePointView is a purely presentational component (i.e. it is a pure
 // function with no state or effects) that renders the SVG for a movable point
-// on an interactive graph.
+// on an interactive graph. The drag hitbox is not here — it's an HTML element
+// in the graph's hitbox overlay layer (see useControlPoint / HitboxLayerContext).
 export const MovablePointView = forwardRef(function MovablePointViewWithRef(
     props: Props,
     hitboxRef: ForwardedRef<SVGGElement>,
@@ -48,10 +46,10 @@ export const MovablePointView = forwardRef(function MovablePointViewWithRef(
         point,
         dragging,
         focused,
+        hovered,
         cursor,
         showFocusRing,
         onClick = () => {},
-        hitboxDivRef,
     } = props;
 
     // WB Tooltip requires a WB color name for the background color.
@@ -68,6 +66,7 @@ export const MovablePointView = forwardRef(function MovablePointViewWithRef(
         "movable-point",
         dragging && "movable-point--dragging",
         showFocusRing && "movable-point--focus",
+        hovered && "movable-point--hover",
     );
 
     const [[x, y]] = useTransformVectorsToPixels(point);
@@ -106,37 +105,6 @@ export const MovablePointView = forwardRef(function MovablePointViewWithRef(
                 style={{fill: interactiveColor}}
                 data-testid="movable-point__center"
             />
-            {/*
-             * The drag hitbox is an HTML <div> inside a <foreignObject>, not an
-             * SVG element. WebKit (Safari) does not reliably honor
-             * `touch-action` on SVG, so an SVG hitbox with `touch-action: none`
-             * lets a vertical point-drag scroll the page (the container is
-             * `touch-action: pan-y` so page scroll can pass over the graph). An
-             * HTML element's `touch-action` *is* honored, so the compositor
-             * blocks scrolling the instant the touch lands on the point — no
-             * first-frame race, no JS `preventDefault` fallback needed. Rendered
-             * last so it sits on top and wins hit-testing; it's transparent so
-             * the visuals above show through.
-             *
-             * UPSTREAM (Mafs): this HTML-hitbox technique, plus relaxing
-             * `.MafsView { touch-action: none }` in mafs/core.css, is the fix to
-             * contribute to Mafs' own `MovablePoint`/`useMovable` so any library
-             * consumer gets scroll-over-graph with working drags. Perseus forked
-             * these components, so the upstream change won't flow back here
-             * automatically — keep the two in sync if/when the Mafs PR lands.
-             */}
-            <foreignObject
-                x={x - hitboxSizePx / 2}
-                y={y - hitboxSizePx / 2}
-                width={hitboxSizePx}
-                height={hitboxSizePx}
-            >
-                <div
-                    ref={hitboxDivRef}
-                    className="movable-point-hitbox"
-                    style={{width: "100%", height: "100%", touchAction: "none"}}
-                />
-            </foreignObject>
         </g>
     );
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/movable-point-view.tsx
@@ -21,6 +21,9 @@ type Props = {
     showFocusRing: boolean;
     cursor?: CSSCursor | undefined;
     onClick?: () => unknown;
+    // Ref for the HTML hitbox that captures pointer/touch drags. See the
+    // `foreignObject` note below for why the hitbox is HTML rather than SVG.
+    hitboxDivRef?: React.Ref<HTMLDivElement>;
 };
 
 // The hitbox size of 48px by 48px is preserved from the legacy interactive
@@ -48,6 +51,7 @@ export const MovablePointView = forwardRef(function MovablePointViewWithRef(
         cursor,
         showFocusRing,
         onClick = () => {},
+        hitboxDivRef,
     } = props;
 
     // WB Tooltip requires a WB color name for the background color.
@@ -92,12 +96,6 @@ export const MovablePointView = forwardRef(function MovablePointViewWithRef(
             data-testid="movable-point"
             onClick={onClick}
         >
-            <circle
-                className="movable-point-hitbox"
-                r={hitboxSizePx / 2}
-                cx={x}
-                cy={y}
-            />
             <circle className="movable-point-halo" cx={x} cy={y} />
             <circle className="movable-point-ring" cx={x} cy={y} />
             <circle className="movable-point-focus-outline" cx={x} cy={y} />
@@ -108,6 +106,37 @@ export const MovablePointView = forwardRef(function MovablePointViewWithRef(
                 style={{fill: interactiveColor}}
                 data-testid="movable-point__center"
             />
+            {/*
+             * The drag hitbox is an HTML <div> inside a <foreignObject>, not an
+             * SVG element. WebKit (Safari) does not reliably honor
+             * `touch-action` on SVG, so an SVG hitbox with `touch-action: none`
+             * lets a vertical point-drag scroll the page (the container is
+             * `touch-action: pan-y` so page scroll can pass over the graph). An
+             * HTML element's `touch-action` *is* honored, so the compositor
+             * blocks scrolling the instant the touch lands on the point — no
+             * first-frame race, no JS `preventDefault` fallback needed. Rendered
+             * last so it sits on top and wins hit-testing; it's transparent so
+             * the visuals above show through.
+             *
+             * UPSTREAM (Mafs): this HTML-hitbox technique, plus relaxing
+             * `.MafsView { touch-action: none }` in mafs/core.css, is the fix to
+             * contribute to Mafs' own `MovablePoint`/`useMovable` so any library
+             * consumer gets scroll-over-graph with working drags. Perseus forked
+             * these components, so the upstream change won't flow back here
+             * automatically — keep the two in sync if/when the Mafs PR lands.
+             */}
+            <foreignObject
+                x={x - hitboxSizePx / 2}
+                y={y - hitboxSizePx / 2}
+                width={hitboxSizePx}
+                height={hitboxSizePx}
+            >
+                <div
+                    ref={hitboxDivRef}
+                    className="movable-point-hitbox"
+                    style={{width: "100%", height: "100%", touchAction: "none"}}
+                />
+            </foreignObject>
         </g>
     );
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-arrowhead.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-arrowhead.tsx
@@ -7,6 +7,7 @@ import useGraphConfig from "../../reducer/use-graph-config";
 import {srFormatNumber} from "../strings/format-number";
 import {useDraggable} from "../use-draggable";
 
+import {useHitbox} from "./hitbox";
 import {MovableArrowheadView} from "./movable-arrowhead-view";
 
 import type {KeyboardMovementConstraint} from "../use-draggable";
@@ -49,6 +50,7 @@ export function useControlArrowhead(params: Params): Return {
     const {strings, locale} = usePerseusI18n();
 
     const [focused, setFocused] = useState(false);
+    const [hovered, setHovered] = useState(false);
     const focusableHandleRef = useRef<SVGGElement>(null);
 
     // Keyboard dragging is handled by the (invisible) focusable handle.
@@ -60,14 +62,26 @@ export function useControlArrowhead(params: Params): Return {
         constrainKeyboardMovement: constrain,
     });
 
-    // Mouse / touch dragging is handled by the visible arrowhead element.
+    // Mouse / touch dragging runs through an HTML hitbox so Safari doesn't
+    // scroll the page during a drag (see hitbox.tsx).
     const visibleRef = useRef<SVGGElement>(null);
+    const arrowheadHitboxRef = useRef<HTMLDivElement>(null);
     const {dragging} = useDraggable({
-        gestureTarget: visibleRef,
+        gestureTarget: arrowheadHitboxRef,
         point,
         onMove,
         onDragEnd,
         constrainKeyboardMovement: constrain,
+    });
+
+    const hitbox = useHitbox({
+        // 48px box matches the arrowhead's legacy hit target and the point.
+        shape: {kind: "box", center: point, sizePx: 48},
+        hitboxRef: arrowheadHitboxRef,
+        dragging,
+        onClick: () => focusableHandleRef.current?.focus(),
+        onHoverChange: setHovered,
+        testId: "movable-arrowhead__hitbox",
     });
 
     const pointAriaLabel =
@@ -102,17 +116,21 @@ export function useControlArrowhead(params: Params): Return {
     );
 
     const visibleArrowhead = (
-        <MovableArrowheadView
-            point={point}
-            angle={angle}
-            dragging={dragging}
-            focused={focused}
-            ref={visibleRef}
-            showFocusRing={focused}
-            onClick={() => {
-                focusableHandleRef.current?.focus();
-            }}
-        />
+        <>
+            <MovableArrowheadView
+                point={point}
+                angle={angle}
+                dragging={dragging}
+                focused={focused}
+                hovered={hovered}
+                ref={visibleRef}
+                showFocusRing={focused}
+                onClick={() => {
+                    focusableHandleRef.current?.focus();
+                }}
+            />
+            {hitbox}
+        </>
     );
 
     return {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-arrowhead.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-arrowhead.tsx
@@ -117,6 +117,7 @@ export function useControlArrowhead(params: Params): Return {
 
     const visibleArrowhead = (
         <>
+            {hitbox}
             <MovableArrowheadView
                 point={point}
                 angle={angle}
@@ -129,7 +130,6 @@ export function useControlArrowhead(params: Params): Return {
                     focusableHandleRef.current?.focus();
                 }}
             />
-            {hitbox}
         </>
     );
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-arrowhead.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-arrowhead.tsx
@@ -7,7 +7,7 @@ import useGraphConfig from "../../reducer/use-graph-config";
 import {srFormatNumber} from "../strings/format-number";
 import {useDraggable} from "../use-draggable";
 
-import {useHitbox} from "./hitbox";
+import {HANDLE_HITBOX_SIZE_PX, useHitbox} from "./hitbox";
 import {MovableArrowheadView} from "./movable-arrowhead-view";
 
 import type {KeyboardMovementConstraint} from "../use-draggable";
@@ -63,7 +63,8 @@ export function useControlArrowhead(params: Params): Return {
     });
 
     // Mouse / touch dragging runs through an HTML hitbox so Safari doesn't
-    // scroll the page during a drag (see hitbox.tsx).
+    // scroll the page during a drag (see hitbox.tsx). `visibleRef` is the SVG
+    // view ref (forwarded), not a gesture target.
     const visibleRef = useRef<SVGGElement>(null);
     const arrowheadHitboxRef = useRef<HTMLDivElement>(null);
     const {dragging} = useDraggable({
@@ -75,8 +76,7 @@ export function useControlArrowhead(params: Params): Return {
     });
 
     const hitbox = useHitbox({
-        // 48px box matches the arrowhead's legacy hit target and the point.
-        shape: {kind: "box", center: point, sizePx: 48},
+        shape: {kind: "box", center: point, sizePx: HANDLE_HITBOX_SIZE_PX},
         hitboxRef: arrowheadHitboxRef,
         dragging,
         onClick: () => focusableHandleRef.current?.focus(),

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -75,9 +75,6 @@ export function useControlPoint(params: Params): Return {
         onMove,
         onDragEnd,
         constrainKeyboardMovement: constrain,
-        // A point is a small handle: a touch that lands on it is always a grab,
-        // so claim it immediately rather than let iOS scroll the page first.
-        claimOnPointerDown: true,
     });
 
     const visiblePointRef = useRef<SVGGElement>(null);
@@ -88,7 +85,6 @@ export function useControlPoint(params: Params): Return {
         onDragStart,
         onDragEnd,
         constrainKeyboardMovement: constrain,
-        claimOnPointerDown: true,
     });
 
     // if custom aria label is not provided, will use default of sequence number and point coordinates

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -1,12 +1,15 @@
 import * as React from "react";
-import {useState, useRef, useLayoutEffect} from "react";
+import {useState, useRef, useLayoutEffect, useContext} from "react";
+import {createPortal} from "react-dom";
 
 import {usePerseusI18n} from "../../../../components/i18n-context";
 import {snap, X, Y} from "../../math";
 import useGraphConfig from "../../reducer/use-graph-config";
 import {srFormatNumber} from "../strings/format-number";
+import {pointToPixel} from "../use-transform";
 import {useDraggable} from "../use-draggable";
 
+import {HitboxLayerContext} from "./hitbox-layer-context";
 import {MovablePointView} from "./movable-point-view";
 
 import type {CSSCursor} from "./css-cursor";
@@ -47,7 +50,8 @@ type Return = {
 };
 
 export function useControlPoint(params: Params): Return {
-    const {snapStep, disableKeyboardInteraction} = useGraphConfig();
+    const graphConfig = useGraphConfig();
+    const {snapStep, disableKeyboardInteraction} = graphConfig;
     const {
         point,
         ariaDescribedBy,
@@ -67,6 +71,7 @@ export function useControlPoint(params: Params): Return {
     const {strings, locale} = usePerseusI18n();
 
     const [focused, setFocused] = useState(false);
+    const [hovered, setHovered] = useState(false);
     const focusableHandleRef = useRef<SVGGElement>(null);
 
     useDraggable({
@@ -78,9 +83,10 @@ export function useControlPoint(params: Params): Return {
     });
 
     const visiblePointRef = useRef<SVGGElement>(null);
-    // The touch/pointer drag is captured on an HTML hitbox (rendered inside the
-    // point's <foreignObject>) rather than the SVG group, because Safari doesn't
-    // reliably honor `touch-action` on SVG. See MovablePointView for details.
+    // The touch/pointer drag is captured on an HTML hitbox <div> that is
+    // portaled into the graph's HTML overlay layer, not the SVG group, because
+    // Safari doesn't reliably honor `touch-action` on SVG. See
+    // HitboxLayerContext for the full rationale.
     const hitboxDivRef = useRef<HTMLDivElement>(null);
     const {dragging} = useDraggable({
         gestureTarget: hitboxDivRef,
@@ -90,6 +96,17 @@ export function useControlPoint(params: Params): Return {
         onDragEnd,
         constrainKeyboardMovement: constrain,
     });
+
+    // The overlay layer that the hitbox is portaled into, and this point's
+    // position in that layer's (pixel) coordinate space. Null before the layer
+    // mounts, in which case the hitbox isn't rendered yet.
+    const hitboxLayer = useContext(HitboxLayerContext);
+    const [hitboxX, hitboxY] = pointToPixel(point, graphConfig);
+
+    const focusPoint = () => {
+        onClick();
+        focusableHandleRef.current?.focus();
+    };
 
     // if custom aria label is not provided, will use default of sequence number and point coordinates
     const pointAriaLabel =
@@ -135,20 +152,50 @@ export function useControlPoint(params: Params): Return {
             }}
         />
     );
+    // HTML drag hitbox, portaled into the overlay layer above the SVG and
+    // centered on the point. `touch-action: none` (honored on HTML, unlike SVG)
+    // stops a touch-drag from scrolling the page; `pointer-events: auto` opts
+    // back in over the otherwise pass-through layer. This is the gesture target
+    // and also carries the point's click/hover, since it sits on top of the
+    // SVG and receives the pointer input.
+    const hitbox =
+        hitboxLayer &&
+        createPortal(
+            <div
+                ref={hitboxDivRef}
+                data-testid="movable-point__hitbox"
+                style={{
+                    position: "absolute",
+                    left: hitboxX,
+                    top: hitboxY,
+                    width: HITBOX_SIZE_PX,
+                    height: HITBOX_SIZE_PX,
+                    transform: "translate(-50%, -50%)",
+                    touchAction: "none",
+                    pointerEvents: "auto",
+                    cursor: dragging ? "grabbing" : cursor ?? "grab",
+                }}
+                onClick={focusPoint}
+                onPointerEnter={() => setHovered(true)}
+                onPointerLeave={() => setHovered(false)}
+            />,
+            hitboxLayer,
+        );
+
     const visiblePoint = (
-        <MovablePointView
-            cursor={cursor}
-            onClick={() => {
-                onClick();
-                focusableHandleRef.current?.focus();
-            }}
-            point={point}
-            dragging={dragging}
-            focused={focused}
-            ref={visiblePointRef}
-            hitboxDivRef={hitboxDivRef}
-            showFocusRing={focused}
-        />
+        <>
+            <MovablePointView
+                cursor={cursor}
+                onClick={focusPoint}
+                point={point}
+                dragging={dragging}
+                focused={focused}
+                hovered={hovered}
+                ref={visiblePointRef}
+                showFocusRing={focused}
+            />
+            {hitbox}
+        </>
     );
 
     return {
@@ -158,6 +205,9 @@ export function useControlPoint(params: Params): Return {
         visiblePointRef,
     };
 }
+
+// Hitbox size preserved from the legacy interactive graph (48x48px).
+const HITBOX_SIZE_PX = 48;
 
 function setForwardedRef<T>(ref: React.ForwardedRef<T>, value: T): void {
     if (typeof ref === "function") {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -6,8 +6,8 @@ import {usePerseusI18n} from "../../../../components/i18n-context";
 import {snap, X, Y} from "../../math";
 import useGraphConfig from "../../reducer/use-graph-config";
 import {srFormatNumber} from "../strings/format-number";
-import {pointToPixel} from "../use-transform";
 import {useDraggable} from "../use-draggable";
+import {pointToPixel} from "../use-transform";
 
 import {HitboxLayerContext} from "./hitbox-layer-context";
 import {MovablePointView} from "./movable-point-view";
@@ -158,9 +158,16 @@ export function useControlPoint(params: Params): Return {
     // back in over the otherwise pass-through layer. This is the gesture target
     // and also carries the point's click/hover, since it sits on top of the
     // SVG and receives the pointer input.
+    //
+    // This <div> is a pointer-only hit surface, so the jsx-a11y rules below are
+    // intentionally disabled: all keyboard and assistive-tech interaction lives
+    // on the sibling `focusableHandle` (a focusable `<g role="button">` with
+    // arrow-key movement). Giving this div a role + keyboard handlers would
+    // create a duplicate control and a second tab stop for the same point.
     const hitbox =
         hitboxLayer &&
         createPortal(
+            // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
             <div
                 ref={hitboxDivRef}
                 data-testid="movable-point__hitbox"

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -1,15 +1,13 @@
 import * as React from "react";
-import {useState, useRef, useLayoutEffect, useContext} from "react";
-import {createPortal} from "react-dom";
+import {useState, useRef, useLayoutEffect} from "react";
 
 import {usePerseusI18n} from "../../../../components/i18n-context";
 import {snap, X, Y} from "../../math";
 import useGraphConfig from "../../reducer/use-graph-config";
 import {srFormatNumber} from "../strings/format-number";
 import {useDraggable} from "../use-draggable";
-import {pointToPixel} from "../use-transform";
 
-import {HitboxLayerContext} from "./hitbox-layer-context";
+import {useHitbox} from "./hitbox";
 import {MovablePointView} from "./movable-point-view";
 
 import type {CSSCursor} from "./css-cursor";
@@ -50,8 +48,7 @@ type Return = {
 };
 
 export function useControlPoint(params: Params): Return {
-    const graphConfig = useGraphConfig();
-    const {snapStep, disableKeyboardInteraction} = graphConfig;
+    const {snapStep, disableKeyboardInteraction} = useGraphConfig();
     const {
         point,
         ariaDescribedBy,
@@ -83,10 +80,9 @@ export function useControlPoint(params: Params): Return {
     });
 
     const visiblePointRef = useRef<SVGGElement>(null);
-    // The touch/pointer drag is captured on an HTML hitbox <div> that is
-    // portaled into the graph's HTML overlay layer, not the SVG group, because
-    // Safari doesn't reliably honor `touch-action` on SVG. See
-    // HitboxLayerContext for the full rationale.
+    // The touch/pointer drag is captured on an HTML hitbox that is portaled
+    // into the graph's overlay layer, not the SVG group, because Safari doesn't
+    // reliably honor `touch-action` on SVG. See hitbox.tsx / HitboxLayerContext.
     const hitboxDivRef = useRef<HTMLDivElement>(null);
     const {dragging} = useDraggable({
         gestureTarget: hitboxDivRef,
@@ -97,16 +93,20 @@ export function useControlPoint(params: Params): Return {
         constrainKeyboardMovement: constrain,
     });
 
-    // The overlay layer that the hitbox is portaled into, and this point's
-    // position in that layer's (pixel) coordinate space. Null before the layer
-    // mounts, in which case the hitbox isn't rendered yet.
-    const hitboxLayer = useContext(HitboxLayerContext);
-    const [hitboxX, hitboxY] = pointToPixel(point, graphConfig);
-
     const focusPoint = () => {
         onClick();
         focusableHandleRef.current?.focus();
     };
+
+    const hitbox = useHitbox({
+        shape: {kind: "box", center: point, sizePx: HITBOX_SIZE_PX},
+        hitboxRef: hitboxDivRef,
+        cursor,
+        dragging,
+        onClick: focusPoint,
+        onHoverChange: setHovered,
+        testId: "movable-point__hitbox",
+    });
 
     // if custom aria label is not provided, will use default of sequence number and point coordinates
     const pointAriaLabel =
@@ -152,42 +152,6 @@ export function useControlPoint(params: Params): Return {
             }}
         />
     );
-    // HTML drag hitbox, portaled into the overlay layer above the SVG and
-    // centered on the point. `touch-action: none` (honored on HTML, unlike SVG)
-    // stops a touch-drag from scrolling the page; `pointer-events: auto` opts
-    // back in over the otherwise pass-through layer. This is the gesture target
-    // and also carries the point's click/hover, since it sits on top of the
-    // SVG and receives the pointer input.
-    //
-    // This <div> is a pointer-only hit surface, so the jsx-a11y rules below are
-    // intentionally disabled: all keyboard and assistive-tech interaction lives
-    // on the sibling `focusableHandle` (a focusable `<g role="button">` with
-    // arrow-key movement). Giving this div a role + keyboard handlers would
-    // create a duplicate control and a second tab stop for the same point.
-    const hitbox =
-        hitboxLayer &&
-        createPortal(
-            // eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events
-            <div
-                ref={hitboxDivRef}
-                data-testid="movable-point__hitbox"
-                style={{
-                    position: "absolute",
-                    left: hitboxX,
-                    top: hitboxY,
-                    width: HITBOX_SIZE_PX,
-                    height: HITBOX_SIZE_PX,
-                    transform: "translate(-50%, -50%)",
-                    touchAction: "none",
-                    pointerEvents: "auto",
-                    cursor: dragging ? "grabbing" : cursor ?? "grab",
-                }}
-                onClick={focusPoint}
-                onPointerEnter={() => setHovered(true)}
-                onPointerLeave={() => setHovered(false)}
-            />,
-            hitboxLayer,
-        );
 
     const visiblePoint = (
         <>

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -75,6 +75,9 @@ export function useControlPoint(params: Params): Return {
         onMove,
         onDragEnd,
         constrainKeyboardMovement: constrain,
+        // A point is a small handle: a touch that lands on it is always a grab,
+        // so claim it immediately rather than let iOS scroll the page first.
+        claimOnPointerDown: true,
     });
 
     const visiblePointRef = useRef<SVGGElement>(null);
@@ -85,6 +88,7 @@ export function useControlPoint(params: Params): Return {
         onDragStart,
         onDragEnd,
         constrainKeyboardMovement: constrain,
+        claimOnPointerDown: true,
     });
 
     // if custom aria label is not provided, will use default of sequence number and point coordinates

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -7,7 +7,7 @@ import useGraphConfig from "../../reducer/use-graph-config";
 import {srFormatNumber} from "../strings/format-number";
 import {useDraggable} from "../use-draggable";
 
-import {useHitbox} from "./hitbox";
+import {HANDLE_HITBOX_SIZE_PX, useHitbox} from "./hitbox";
 import {MovablePointView} from "./movable-point-view";
 
 import type {CSSCursor} from "./css-cursor";
@@ -79,6 +79,8 @@ export function useControlPoint(params: Params): Return {
         constrainKeyboardMovement: constrain,
     });
 
+    // Ref to the visible SVG point (for the forwarded ref); not a gesture
+    // target — pointer/touch dragging is captured on the HTML hitbox below.
     const visiblePointRef = useRef<SVGGElement>(null);
     // The touch/pointer drag is captured on an HTML hitbox that is portaled
     // into the graph's overlay layer, not the SVG group, because Safari doesn't
@@ -99,7 +101,7 @@ export function useControlPoint(params: Params): Return {
     };
 
     const hitbox = useHitbox({
-        shape: {kind: "box", center: point, sizePx: HITBOX_SIZE_PX},
+        shape: {kind: "box", center: point, sizePx: HANDLE_HITBOX_SIZE_PX},
         hitboxRef: hitboxDivRef,
         cursor,
         dragging,
@@ -128,7 +130,8 @@ export function useControlPoint(params: Params): Return {
             // If the point is being dragged, focus the focusable handle so that
             // users can continue to interact with the point using the keyboard or buttons.
             // This particular focus call ensures that the focus ring and hairlines are visible.
-            focusableHandleRef.current?.focus();
+            // `preventScroll` so focusing mid-drag never scrolls the page.
+            focusableHandleRef.current?.focus({preventScroll: true});
         }
     }, [dragging, focused]);
 
@@ -176,9 +179,6 @@ export function useControlPoint(params: Params): Return {
         visiblePointRef,
     };
 }
-
-// Hitbox size preserved from the legacy interactive graph (48x48px).
-const HITBOX_SIZE_PX = 48;
 
 function setForwardedRef<T>(ref: React.ForwardedRef<T>, value: T): void {
     if (typeof ref === "function") {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -78,8 +78,12 @@ export function useControlPoint(params: Params): Return {
     });
 
     const visiblePointRef = useRef<SVGGElement>(null);
+    // The touch/pointer drag is captured on an HTML hitbox (rendered inside the
+    // point's <foreignObject>) rather than the SVG group, because Safari doesn't
+    // reliably honor `touch-action` on SVG. See MovablePointView for details.
+    const hitboxDivRef = useRef<HTMLDivElement>(null);
     const {dragging} = useDraggable({
-        gestureTarget: visiblePointRef,
+        gestureTarget: hitboxDivRef,
         point,
         onMove,
         onDragStart,
@@ -142,6 +146,7 @@ export function useControlPoint(params: Params): Return {
             dragging={dragging}
             focused={focused}
             ref={visiblePointRef}
+            hitboxDivRef={hitboxDivRef}
             showFocusRing={focused}
         />
     );

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/use-control-point.tsx
@@ -158,6 +158,7 @@ export function useControlPoint(params: Params): Return {
 
     const visiblePoint = (
         <>
+            {hitbox}
             <MovablePointView
                 cursor={cursor}
                 onClick={focusPoint}
@@ -168,7 +169,6 @@ export function useControlPoint(params: Params): Return {
                 ref={visiblePointRef}
                 showFocusRing={focused}
             />
-            {hitbox}
         </>
     );
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -188,7 +188,8 @@ const PolygonGraph = (props: Props) => {
 
     return (
         <>
-            {coords.length >= 3 && polygonHitbox}
+            {/* useHitbox renders nothing until the polygon has ≥3 vertices. */}
+            {polygonHitbox}
             {numSides === "unlimited" ? (
                 <UnlimitedPolygonGraph {...statefulProps} />
             ) : (

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -22,6 +22,7 @@ import {bound, TARGET_SIZE} from "../utils";
 
 import {PolygonAngle} from "./components/angle-indicators";
 import {usePointAriaLabel} from "./components/build-point-aria-label";
+import {useHitbox} from "./components/hitbox";
 import {MovablePoint} from "./components/movable-point";
 import SRDescInSVG from "./components/sr-description-within-svg";
 import {TextLabel} from "./components/text-label";
@@ -92,6 +93,9 @@ const PolygonGraph = (props: Props) => {
 
     // Ref to implement the dragging behavior on a Limited/Closed Polygon.
     const polygonRef = React.useRef<SVGPolygonElement>(null);
+    // HTML hitbox that captures the whole-shape pointer/touch drag (Safari
+    // doesn't honor `touch-action` on the SVG polygon; see hitbox.tsx).
+    const polygonHitboxRef = React.useRef<HTMLDivElement>(null);
     // Ref to manage dynamic focus for the points in Unlimited Polygon
     const pointsRef = React.useRef<Array<SVGElement | null>>([]);
     // Ref to manage the last move time for a Limited Polygon.
@@ -108,12 +112,21 @@ const PolygonGraph = (props: Props) => {
     const constrain: KeyboardMovementConstraint =
         getKeyboardMovementConstraintForPolygon(snapStep, snapTo);
 
-    const {dragging} = useDraggable({
+    const moveAll = (newStart: vec.Vector2) => {
+        dispatch(actions.polygon.moveAll(newStart));
+    };
+    // Keyboard drag stays on the focusable SVG polygon.
+    useDraggable({
         gestureTarget: polygonRef,
         point: dragReferencePoint,
-        onMove: (newStart) => {
-            dispatch(actions.polygon.moveAll(newStart));
-        },
+        onMove: moveAll,
+        constrainKeyboardMovement: constrain,
+    });
+    // Pointer/touch drag runs through the HTML hitbox.
+    const {dragging} = useDraggable({
+        gestureTarget: polygonHitboxRef,
+        point: dragReferencePoint,
+        onMove: moveAll,
         constrainKeyboardMovement: constrain,
     });
 
@@ -122,6 +135,18 @@ const PolygonGraph = (props: Props) => {
     // This is more so required for the re-rendering that occurs when state
     // updates; specifically with regard to line weighting and polygon focus.
     const [focusVisible, setFocusVisible] = React.useState(false);
+
+    // Whole-shape drag hitbox: an HTML polygon (via clip-path) matching the
+    // current vertices. Only meaningful once the polygon has an interior
+    // (≥ 3 vertices); while it's still being drawn, points are the interaction.
+    const polygonHitbox = useHitbox({
+        shape: {kind: "polygon", vertices: coords},
+        hitboxRef: polygonHitboxRef,
+        layer: "body",
+        dragging,
+        onHoverChange: setHovered,
+        testId: "movable-polygon__hitbox",
+    });
 
     // This useEffect is to handle the focus snapping for Unlimited Polygon.
     React.useEffect(() => {
@@ -161,10 +186,15 @@ const PolygonGraph = (props: Props) => {
         setFocusVisible,
     };
 
-    return numSides === "unlimited" ? (
-        <UnlimitedPolygonGraph {...statefulProps} />
-    ) : (
-        <LimitedPolygonGraph {...statefulProps} />
+    return (
+        <>
+            {coords.length >= 3 && polygonHitbox}
+            {numSides === "unlimited" ? (
+                <UnlimitedPolygonGraph {...statefulProps} />
+            ) : (
+                <LimitedPolygonGraph {...statefulProps} />
+            )}
+        </>
     );
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.test.tsx
@@ -17,7 +17,6 @@ function TestDraggable(props: {
     constrainKeyboardMovement?: KeyboardMovementConstraint;
     onDragStart?: () => unknown;
     onMove?: (point: vec.Vector2) => unknown;
-    claimOnPointerDown?: boolean;
 }) {
     const {onMove = () => {}, constrainKeyboardMovement = (p) => p} = props;
     const gestureTarget = useRef<HTMLButtonElement>(null);
@@ -27,7 +26,6 @@ function TestDraggable(props: {
         onMove,
         constrainKeyboardMovement,
         gestureTarget,
-        claimOnPointerDown: props.claimOnPointerDown,
     });
     return (
         <button ref={gestureTarget} tabIndex={0}>
@@ -368,23 +366,6 @@ describe("useDraggable", () => {
         expect(moveMouseTo(element, 0, 0)).toBe(true);
         // ...but a move that actually drags the shape should.
         expect(moveMouseTo(element, 20, 20)).toBe(false);
-    });
-
-    it("does not claim a mouse press on pointer-down even with claimOnPointerDown", () => {
-        // claimOnPointerDown claims a *touch* the instant it lands, to beat
-        // iOS's first-frame scroll. Mouse input never scrolls the page, so it
-        // must stay movement-gated: claiming a mouse press on pointer-down
-        // would suppress native focus/selection for no benefit.
-        // Arrange
-        render(
-            <Mafs width={200} height={200}>
-                <TestDraggable point={[0, 0]} claimOnPointerDown={true} />
-            </Mafs>,
-        );
-
-        // Act, Assert: the mouse press is not prevented (fireEvent returns false
-        // only when a handler called preventDefault).
-        expect(mouseDownAt(screen.getByRole("button"), 0, 0)).toBe(true);
     });
 });
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.test.tsx
@@ -17,6 +17,7 @@ function TestDraggable(props: {
     constrainKeyboardMovement?: KeyboardMovementConstraint;
     onDragStart?: () => unknown;
     onMove?: (point: vec.Vector2) => unknown;
+    claimOnPointerDown?: boolean;
 }) {
     const {onMove = () => {}, constrainKeyboardMovement = (p) => p} = props;
     const gestureTarget = useRef<HTMLButtonElement>(null);
@@ -26,6 +27,7 @@ function TestDraggable(props: {
         onMove,
         constrainKeyboardMovement,
         gestureTarget,
+        claimOnPointerDown: props.claimOnPointerDown,
     });
     return (
         <button ref={gestureTarget} tabIndex={0}>
@@ -330,7 +332,6 @@ describe("useDraggable", () => {
         // it (stopPropagation), or the page can't scroll over the graph. This
         // regressed on iOS 26.5+, where WebKit began honoring default/gesture
         // suppression during the pointer-down phase.
-        // See .claude/LEMS-4353-ios-26.5-interactive-graph-scroll-investigation.md
         const parentMouseDownSpy = jest.fn();
         // Arrange, Act
         render(
@@ -346,6 +347,45 @@ describe("useDraggable", () => {
         // Assert: the press reached the ancestor (propagation was not stopped)
         expect(parentMouseDownSpy).toHaveBeenCalled();
     });
+
+    it("prevents default scrolling once a drag actually moves", () => {
+        // Dragging a shape must not also scroll the page. Safari doesn't
+        // reliably honor `touch-action: none` on the SVG draggable bodies, so
+        // once a real drag starts we suppress the browser's default scroll in
+        // JS. This must NOT happen before there's movement (see the test
+        // above), or a plain swipe over the graph could no longer scroll.
+        // Arrange
+        render(
+            <Mafs width={200} height={200}>
+                <TestDraggable point={[0, 0]} />
+            </Mafs>,
+        );
+        const element = screen.getByRole("button");
+        mouseDownAt(element, 0, 0);
+
+        // Act, Assert: a press with no movement should not prevent default
+        // (fireEvent returns false only when a handler called preventDefault)...
+        expect(moveMouseTo(element, 0, 0)).toBe(true);
+        // ...but a move that actually drags the shape should.
+        expect(moveMouseTo(element, 20, 20)).toBe(false);
+    });
+
+    it("does not claim a mouse press on pointer-down even with claimOnPointerDown", () => {
+        // claimOnPointerDown claims a *touch* the instant it lands, to beat
+        // iOS's first-frame scroll. Mouse input never scrolls the page, so it
+        // must stay movement-gated: claiming a mouse press on pointer-down
+        // would suppress native focus/selection for no benefit.
+        // Arrange
+        render(
+            <Mafs width={200} height={200}>
+                <TestDraggable point={[0, 0]} claimOnPointerDown={true} />
+            </Mafs>,
+        );
+
+        // Act, Assert: the mouse press is not prevented (fireEvent returns false
+        // only when a handler called preventDefault).
+        expect(mouseDownAt(screen.getByRole("button"), 0, 0)).toBe(true);
+    });
 });
 
 function mouseDownAt(element: Element, clientX: number, clientY: number) {
@@ -353,7 +393,7 @@ function mouseDownAt(element: Element, clientX: number, clientY: number) {
     // terms of userEvent. The tests for @use-gesture/react use fireEvent, so
     // I went with that approach.
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.mouseDown(element, {
+    return fireEvent.mouseDown(element, {
         pointerId: 1,
         buttons: 1,
         clientX,
@@ -366,7 +406,7 @@ function moveMouseTo(element: Element, clientX: number, clientY: number) {
     // terms of userEvent. The tests for @use-gesture/react use fireEvent, so
     // I went with that approach.
     // eslint-disable-next-line testing-library/prefer-user-event
-    fireEvent.mouseMove(element, {
+    return fireEvent.mouseMove(element, {
         pointerId: 1,
         buttons: 1,
         clientX,

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.test.tsx
@@ -323,6 +323,29 @@ describe("useDraggable", () => {
         // Assert: the element moved one step to the right and then one step up
         expect(onMoveSpy.mock.calls).toEqual([[[1, 0]], [[0, 1]]]);
     });
+
+    it("lets a press with no movement propagate so a swipe can still scroll the page", () => {
+        // A touch that lands on a draggable but doesn't move yet is
+        // indistinguishable from the start of a page scroll. We must not claim
+        // it (stopPropagation), or the page can't scroll over the graph. This
+        // regressed on iOS 26.5+, where WebKit began honoring default/gesture
+        // suppression during the pointer-down phase.
+        // See .claude/LEMS-4353-ios-26.5-interactive-graph-scroll-investigation.md
+        const parentMouseDownSpy = jest.fn();
+        // Arrange, Act
+        render(
+            // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+            <div onMouseDown={parentMouseDownSpy}>
+                <Mafs width={200} height={200}>
+                    <TestDraggable point={[0, 0]} />
+                </Mafs>
+            </div>,
+        );
+        mouseDownAt(screen.getByRole("button"), 0, 0);
+
+        // Assert: the press reached the ancestor (propagation was not stopped)
+        expect(parentMouseDownSpy).toHaveBeenCalled();
+    });
 });
 
 function mouseDownAt(element: Element, clientX: number, clientY: number) {

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.ts
@@ -83,11 +83,13 @@ export function useDraggable(args: Params): DragState {
     useDrag(
         (state) => {
             const {type, event} = state;
-            event?.stopPropagation();
 
             const isKeyboard = type.includes("key");
             if (isKeyboard) {
                 invariant(event instanceof KeyboardEvent);
+                // Keyboard interactions should never bubble or trigger the
+                // browser's default scroll-on-arrow-key behavior.
+                event?.stopPropagation();
                 event?.preventDefault();
 
                 // When a key is held down, we see multiple "keydown" events,
@@ -174,8 +176,18 @@ export function useDraggable(args: Params): DragState {
                     dragStarted.current = false;
                 }
                 if (vec.mag(pixelMovement) === 0) {
+                    // No movement yet, so we can't tell a drag from the start
+                    // of a page scroll. Leave the event alone (don't stop
+                    // propagation or claim it) so a plain touch-and-swipe over
+                    // the graph still scrolls the page. This matters on iOS
+                    // 26.5+, where WebKit now honors default-prevention during
+                    // the pointer-down phase and would otherwise block scroll.
+                    // See .claude/LEMS-4353-ios-26.5-interactive-graph-scroll-investigation.md
                     return;
                 }
+                // A real drag is underway: claim the gesture so it doesn't
+                // bubble to parents (e.g. the page scroller).
+                event?.stopPropagation();
                 // Don't start a drag if no movement; a click with zero
                 // movement should not set isCurrentlyDragging and block
                 // subsequent click-to-add-point events.

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.ts
@@ -34,17 +34,6 @@ export type Params = {
     onDragEnd?: () => unknown;
     point: vec.Vector2;
     constrainKeyboardMovement: KeyboardMovementConstraint;
-    /**
-     * For small, unambiguous handles (points, arrowheads), claim a touch
-     * gesture the moment it lands on the handle instead of waiting for
-     * movement. A touch that starts exactly on a small handle is always a
-     * grab, never an intended page scroll, so claiming immediately stops iOS
-     * from starting a scroll on the first frame (its compositor can beat our
-     * main-thread preventDefault on a fast flick). Leave this off (default) for
-     * large bodies like lines and polygons, where a swipe that begins on the
-     * shape may be an intended page scroll and should still scroll through.
-     */
-    claimOnPointerDown?: boolean;
 };
 
 export type KeyboardMovementConstraint =
@@ -75,7 +64,6 @@ export function useDraggable(args: Params): DragState {
         onDragEnd,
         point,
         constrainKeyboardMovement,
-        claimOnPointerDown = false,
     } = args;
     const [dragging, setDragging] = React.useState(false);
     const {xSpan, ySpan} = useSpanContext();
@@ -188,32 +176,16 @@ export function useDraggable(args: Params): DragState {
                     dragStarted.current = false;
                 }
                 if (vec.mag(pixelMovement) === 0) {
-                    // No movement yet. For small handles (points/arrowheads) a
-                    // touch that lands here is unambiguously a grab, so claim
-                    // it now to stop iOS starting a scroll on the first frame.
-                    // We restrict this to touch so mouse focus/selection is
-                    // unchanged, and we still don't *start* the drag until
-                    // there's real movement below.
-                    if (claimOnPointerDown && isTouchEvent(event)) {
-                        event?.stopPropagation();
-                        event?.preventDefault();
-                        return;
-                    }
-                    // Otherwise we can't yet tell a drag from the start of a
-                    // page scroll, so leave the event alone (don't claim it) so
-                    // a plain touch-and-swipe over the graph still scrolls the
-                    // page. This matters on iOS 26.5+, where WebKit now honors
-                    // default-prevention during the pointer-down phase and
-                    // would otherwise block scroll.
+                    // No movement yet: can't tell a drag from the start of a
+                    // page scroll, so leave the event alone and let a swipe
+                    // scroll the page (iOS 26.5+ honors pointer-down
+                    // suppression and would otherwise block scroll).
                     return;
                 }
-                // A real drag is underway: claim the gesture and suppress the
-                // browser's default touch-scroll so dragging doesn't also
-                // scroll the page. We do this in JS rather than via
-                // `touch-action: none` because Safari doesn't reliably honor
-                // `touch-action` on SVG (which every draggable body is).
-                // Only on move (not pointer-down), so a plain swipe still
-                // scrolls.
+                // Real drag underway: suppress touch-scroll so dragging doesn't
+                // also scroll the page. Done in JS because Safari doesn't
+                // reliably honor `touch-action` on SVG; only on move, so a
+                // plain swipe still scrolls.
                 event?.stopPropagation();
                 event?.preventDefault();
                 // Don't start a drag if no movement; a click with zero
@@ -260,21 +232,6 @@ const directionForKey: Record<
     ArrowUp: "up",
     ArrowDown: "down",
 };
-
-// True for touch input. Mouse/pen drags never scroll the page, so the
-// early-claim behavior in useDraggable is scoped to touch to avoid changing
-// their focus/selection semantics. Real iOS Safari delivers PointerEvents
-// (pointerType "touch"); some environments deliver TouchEvents instead, so we
-// accept either. Mouse events report neither and are treated as non-touch.
-function isTouchEvent(event: unknown): boolean {
-    if (event == null || typeof event !== "object") {
-        return false;
-    }
-    if ("pointerType" in event) {
-        return event.pointerType === "touch";
-    }
-    return typeof TouchEvent !== "undefined" && event instanceof TouchEvent;
-}
 
 function getInverseTransform(transform: vec.Matrix) {
     const invert = vec.matrixInvert(transform);

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/use-draggable.ts
@@ -34,6 +34,17 @@ export type Params = {
     onDragEnd?: () => unknown;
     point: vec.Vector2;
     constrainKeyboardMovement: KeyboardMovementConstraint;
+    /**
+     * For small, unambiguous handles (points, arrowheads), claim a touch
+     * gesture the moment it lands on the handle instead of waiting for
+     * movement. A touch that starts exactly on a small handle is always a
+     * grab, never an intended page scroll, so claiming immediately stops iOS
+     * from starting a scroll on the first frame (its compositor can beat our
+     * main-thread preventDefault on a fast flick). Leave this off (default) for
+     * large bodies like lines and polygons, where a swipe that begins on the
+     * shape may be an intended page scroll and should still scroll through.
+     */
+    claimOnPointerDown?: boolean;
 };
 
 export type KeyboardMovementConstraint =
@@ -64,6 +75,7 @@ export function useDraggable(args: Params): DragState {
         onDragEnd,
         point,
         constrainKeyboardMovement,
+        claimOnPointerDown = false,
     } = args;
     const [dragging, setDragging] = React.useState(false);
     const {xSpan, ySpan} = useSpanContext();
@@ -176,18 +188,34 @@ export function useDraggable(args: Params): DragState {
                     dragStarted.current = false;
                 }
                 if (vec.mag(pixelMovement) === 0) {
-                    // No movement yet, so we can't tell a drag from the start
-                    // of a page scroll. Leave the event alone (don't stop
-                    // propagation or claim it) so a plain touch-and-swipe over
-                    // the graph still scrolls the page. This matters on iOS
-                    // 26.5+, where WebKit now honors default-prevention during
-                    // the pointer-down phase and would otherwise block scroll.
-                    // See .claude/LEMS-4353-ios-26.5-interactive-graph-scroll-investigation.md
+                    // No movement yet. For small handles (points/arrowheads) a
+                    // touch that lands here is unambiguously a grab, so claim
+                    // it now to stop iOS starting a scroll on the first frame.
+                    // We restrict this to touch so mouse focus/selection is
+                    // unchanged, and we still don't *start* the drag until
+                    // there's real movement below.
+                    if (claimOnPointerDown && isTouchEvent(event)) {
+                        event?.stopPropagation();
+                        event?.preventDefault();
+                        return;
+                    }
+                    // Otherwise we can't yet tell a drag from the start of a
+                    // page scroll, so leave the event alone (don't claim it) so
+                    // a plain touch-and-swipe over the graph still scrolls the
+                    // page. This matters on iOS 26.5+, where WebKit now honors
+                    // default-prevention during the pointer-down phase and
+                    // would otherwise block scroll.
                     return;
                 }
-                // A real drag is underway: claim the gesture so it doesn't
-                // bubble to parents (e.g. the page scroller).
+                // A real drag is underway: claim the gesture and suppress the
+                // browser's default touch-scroll so dragging doesn't also
+                // scroll the page. We do this in JS rather than via
+                // `touch-action: none` because Safari doesn't reliably honor
+                // `touch-action` on SVG (which every draggable body is).
+                // Only on move (not pointer-down), so a plain swipe still
+                // scrolls.
                 event?.stopPropagation();
+                event?.preventDefault();
                 // Don't start a drag if no movement; a click with zero
                 // movement should not set isCurrentlyDragging and block
                 // subsequent click-to-add-point events.
@@ -232,6 +260,21 @@ const directionForKey: Record<
     ArrowUp: "up",
     ArrowDown: "down",
 };
+
+// True for touch input. Mouse/pen drags never scroll the page, so the
+// early-claim behavior in useDraggable is scoped to touch to avoid changing
+// their focus/selection semantics. Real iOS Safari delivers PointerEvents
+// (pointerType "touch"); some environments deliver TouchEvents instead, so we
+// accept either. Mouse events report neither and are treated as non-touch.
+function isTouchEvent(event: unknown): boolean {
+    if (event == null || typeof event !== "object") {
+        return false;
+    }
+    if ("pointerType" in event) {
+        return event.pointerType === "touch";
+    }
+    return typeof TouchEvent !== "undefined" && event instanceof TouchEvent;
+}
 
 function getInverseTransform(transform: vec.Matrix) {
     const invert = vec.matrixInvert(transform);

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/vector.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/vector.test.tsx
@@ -97,9 +97,10 @@ describe("Vector graph screen reader", () => {
         // Arrange
         render(<MafsGraph {...baseMafsGraphProps} state={baseVectorState} />);
 
-        // Act — hover the vector body to make the pill visible
-        const vectorBody = screen.getByTestId("movable-vector");
-        await userEvent.hover(vectorBody);
+        // Act — hover the vector's hitbox to make the pill visible. The hitbox
+        // is the HTML pointer surface layered over the SVG body (see hitbox.tsx).
+        const vectorHitbox = screen.getByTestId("movable-vector__hitbox");
+        await userEvent.hover(vectorHitbox);
         const dragHandle = screen.getByTestId("movable-pill-handle");
 
         // Assert

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/vector.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/vector.tsx
@@ -200,17 +200,11 @@ const VectorBody = (props: VectorBodyProps) => {
                 data-testid="movable-vector"
                 style={{cursor: dragging ? "grabbing" : "grab"}}
                 role="button"
-                onMouseEnter={() => setHovered(true)}
-                onMouseLeave={() => setHovered(false)}
                 onFocus={() => setFocused(true)}
                 onBlur={() => setFocused(false)}
             >
-                {/* Transparent hit target for dragging the whole vector */}
-                <SVGLine
-                    start={tailPx}
-                    end={lineEndPx}
-                    style={{stroke: "transparent", strokeWidth: TARGET_SIZE}}
-                />
+                {/* Pointer/touch dragging (and hover) is handled by the HTML
+                    hitbox (see vectorHitbox); the SVG is visual + keyboard. */}
                 {/* Visible line from tail to tip, pulled back slightly */}
                 <SVGLine
                     start={tailPx}

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/vector.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/vector.tsx
@@ -11,6 +11,7 @@ import useGraphConfig from "../reducer/use-graph-config";
 import {TARGET_SIZE} from "../utils";
 
 import Hairlines from "./components/hairlines";
+import {useHitbox} from "./components/hitbox";
 import {MovablePillHandle} from "./components/movable-pill-handle";
 import SRDescInSVG from "./components/sr-description-within-svg";
 import {SVGLine} from "./components/svg-line";
@@ -129,8 +130,18 @@ const VectorBody = (props: VectorBodyProps) => {
     const [tailPx, tipPx] = useTransformVectorsToPixels(tail, tip);
 
     const bodyRef = useRef<SVGGElement>(null);
-    const {dragging} = useDraggable({
+    const vectorHitboxRef = useRef<HTMLDivElement>(null);
+
+    // Keyboard drag stays on the focusable SVG group.
+    useDraggable({
         gestureTarget: bodyRef,
+        point: tail,
+        onMove,
+        constrainKeyboardMovement: (p) => snap(snapStep, p),
+    });
+    // Pointer/touch drag runs through the HTML hitbox (Safari-safe).
+    const {dragging} = useDraggable({
+        gestureTarget: vectorHitboxRef,
         point: tail,
         onMove,
         onDragEnd: () => {
@@ -139,6 +150,15 @@ const VectorBody = (props: VectorBodyProps) => {
             bodyRef.current?.blur();
         },
         constrainKeyboardMovement: (p) => snap(snapStep, p),
+    });
+
+    const vectorHitbox = useHitbox({
+        shape: {kind: "line", start: tail, end: tip, thicknessPx: TARGET_SIZE},
+        hitboxRef: vectorHitboxRef,
+        layer: "body",
+        dragging,
+        onHoverChange: setHovered,
+        testId: "movable-vector__hitbox",
     });
 
     // Calculate angle for drag handle rotation
@@ -164,45 +184,55 @@ const VectorBody = (props: VectorBodyProps) => {
     const active = hovered || dragging || focused;
 
     return (
-        <g
-            ref={bodyRef}
-            tabIndex={disableKeyboardInteraction ? -1 : 0}
-            aria-label={ariaLabel}
-            aria-describedby={ariaDescribedBy}
-            aria-disabled={disableKeyboardInteraction}
-            className="movable-line"
-            data-testid="movable-vector"
-            style={{cursor: dragging ? "grabbing" : "grab"}}
-            role="button"
-            onMouseEnter={() => setHovered(true)}
-            onMouseLeave={() => setHovered(false)}
-            onFocus={() => setFocused(true)}
-            onBlur={() => setFocused(false)}
-        >
-            {/* Transparent hit target for dragging the whole vector */}
-            <SVGLine
-                start={tailPx}
-                end={lineEndPx}
-                style={{stroke: "transparent", strokeWidth: TARGET_SIZE}}
-            />
-            {/* Visible line from tail to tip, pulled back slightly */}
-            <SVGLine
-                start={tailPx}
-                end={lineEndPx}
-                className={`movable-vector-line ${active ? "movable-dragging" : ""}`}
-                style={{stroke: interactiveColor, strokeWidth: sizing.size_020}}
-                testId="movable-vector__line"
-            />
-            {/* Drag handle pill — only visible on hover / focus / drag */}
-            {active && (
-                <MovablePillHandle
-                    center={handlePx}
-                    rotation={angleDeg}
-                    active={active}
-                    focused={focused}
+        <>
+            {vectorHitbox}
+            <g
+                ref={bodyRef}
+                tabIndex={disableKeyboardInteraction ? -1 : 0}
+                aria-label={ariaLabel}
+                aria-describedby={ariaDescribedBy}
+                aria-disabled={disableKeyboardInteraction}
+                className={
+                    hovered
+                        ? "movable-line movable-line--hover"
+                        : "movable-line"
+                }
+                data-testid="movable-vector"
+                style={{cursor: dragging ? "grabbing" : "grab"}}
+                role="button"
+                onMouseEnter={() => setHovered(true)}
+                onMouseLeave={() => setHovered(false)}
+                onFocus={() => setFocused(true)}
+                onBlur={() => setFocused(false)}
+            >
+                {/* Transparent hit target for dragging the whole vector */}
+                <SVGLine
+                    start={tailPx}
+                    end={lineEndPx}
+                    style={{stroke: "transparent", strokeWidth: TARGET_SIZE}}
                 />
-            )}
-        </g>
+                {/* Visible line from tail to tip, pulled back slightly */}
+                <SVGLine
+                    start={tailPx}
+                    end={lineEndPx}
+                    className={`movable-vector-line ${active ? "movable-dragging" : ""}`}
+                    style={{
+                        stroke: interactiveColor,
+                        strokeWidth: sizing.size_020,
+                    }}
+                    testId="movable-vector__line"
+                />
+                {/* Drag handle pill — only visible on hover / focus / drag */}
+                {active && (
+                    <MovablePillHandle
+                        center={handlePx}
+                        rotation={angleDeg}
+                        active={active}
+                        focused={focused}
+                    />
+                )}
+            </g>
+        </>
     );
 };
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -35,6 +35,7 @@ import {
 } from "./backgrounds/utils";
 import GraphLockedLabelsLayer from "./graph-locked-labels-layer";
 import GraphLockedLayer from "./graph-locked-layer";
+import {HitboxLayerContext} from "./graphs/components/hitbox-layer-context";
 import {renderAbsoluteValueGraph} from "./graphs/absolute-value";
 import {renderAngleGraph} from "./graphs/angle";
 import {renderCircleGraph} from "./graphs/circle";
@@ -127,6 +128,11 @@ export const MafsGraph = (props: MafsGraphProps) => {
     const unlimitedGraphKeyboardPromptId = `unlimited-graph-keyboard-prompt-${uniqueId}`;
     const instructionsId = `instructions-${uniqueId}`;
     const graphRef = React.useRef<HTMLElement>(null);
+    // HTML overlay that holds movable points' drag hitboxes. Populated via ref
+    // callback after mount; movable points portal their hitbox into it. See
+    // HitboxLayerContext for why the hitboxes are HTML rather than SVG.
+    const [hitboxLayerEl, setHitboxLayerEl] =
+        React.useState<HTMLDivElement | null>(null);
     const {analytics} = useDependencies();
 
     const i18n = usePerseusI18n();
@@ -458,29 +464,49 @@ export const MafsGraph = (props: MafsGraphProps) => {
                             !props.static && (
                                 <MovablePointLabelsLayer state={state} />
                             )}
-                        <View style={{position: "absolute"}}>
-                            <Mafs
-                                preserveAspectRatio={false}
-                                viewBox={{
-                                    x: state.range[X],
-                                    y: state.range[Y],
-                                    padding: 0,
+                        <HitboxLayerContext.Provider value={hitboxLayerEl}>
+                            <View style={{position: "absolute"}}>
+                                <Mafs
+                                    preserveAspectRatio={false}
+                                    viewBox={{
+                                        x: state.range[X],
+                                        y: state.range[Y],
+                                        padding: 0,
+                                    }}
+                                    pan={false}
+                                    zoom={false}
+                                    width={width}
+                                    height={height}
+                                >
+                                    {/* Protractor clipped to graph bounds */}
+                                    {props.showProtractor && (
+                                        <ClipToGraphBounds>
+                                            <Protractor />
+                                        </ClipToGraphBounds>
+                                    )}
+                                    {/* Interactive layer.*/}
+                                    {graph}
+                                </Mafs>
+                            </View>
+                            {/* HTML overlay above the SVG holding movable-point
+                                drag hitboxes. `pointer-events: none` so empty
+                                graph area falls through to the SVG (page scroll
+                                / click-to-add-point); hitboxes opt back in.
+                                Positioned at the graph origin, matching the
+                                pixel coordinates from `pointToPixel`. */}
+                            <div
+                                ref={setHitboxLayerEl}
+                                className="interactive-graph-hitbox-layer"
+                                style={{
+                                    position: "absolute",
+                                    top: 0,
+                                    left: 0,
+                                    width,
+                                    height,
+                                    pointerEvents: "none",
                                 }}
-                                pan={false}
-                                zoom={false}
-                                width={width}
-                                height={height}
-                            >
-                                {/* Protractor clipped to graph bounds */}
-                                {props.showProtractor && (
-                                    <ClipToGraphBounds>
-                                        <Protractor />
-                                    </ClipToGraphBounds>
-                                )}
-                                {/* Interactive layer.*/}
-                                {graph}
-                            </Mafs>
-                        </View>
+                            />
+                        </HitboxLayerContext.Provider>
                     </View>
                     {interactionPrompt && (
                         <View

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -35,11 +35,11 @@ import {
 } from "./backgrounds/utils";
 import GraphLockedLabelsLayer from "./graph-locked-labels-layer";
 import GraphLockedLayer from "./graph-locked-layer";
-import {HitboxLayerContext} from "./graphs/components/hitbox-layer-context";
 import {renderAbsoluteValueGraph} from "./graphs/absolute-value";
 import {renderAngleGraph} from "./graphs/angle";
 import {renderCircleGraph} from "./graphs/circle";
 import {ClipToGraphBounds} from "./graphs/components/clip-to-graph-bounds";
+import {HitboxLayerContext} from "./graphs/components/hitbox-layer-context";
 import MovablePointLabelsLayer from "./graphs/components/movable-point-labels-layer";
 import {SvgDefs} from "./graphs/components/text-label";
 import {renderExponentialGraph} from "./graphs/exponential";

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -155,20 +155,22 @@
     fill: var(--wb-semanticColor-core-border-knockout-default);
 }
 
-.MafsView .movable-point:hover .movable-point-center {
+.MafsView
+    .movable-point:is(:hover, .movable-point--hover)
+    .movable-point-center {
     r: calc(
         var(--movable-point-hover-expansion) +
             var(--movable-point-center-radius)
     );
 }
 
-.MafsView .movable-point:hover .movable-point-ring {
+.MafsView .movable-point:is(:hover, .movable-point--hover) .movable-point-ring {
     r: calc(
         var(--movable-point-hover-expansion) + var(--movable-point-ring-radius)
     );
 }
 
-.MafsView .movable-point:hover .movable-point-halo {
+.MafsView .movable-point:is(:hover, .movable-point--hover) .movable-point-halo {
     r: calc(
         var(--movable-point-hover-expansion) + var(--movable-point-halo-radius)
     );
@@ -185,7 +187,9 @@
     stroke: var(--mafs-blue);
 }
 
-.MafsView .movable-point:hover .movable-point-focus-outline {
+.MafsView
+    .movable-point:is(:hover, .movable-point--hover)
+    .movable-point-focus-outline {
     r: calc(
         var(--movable-point-hover-expansion) + var(--movable-point-halo-radius) +
             var(--movable-point-focus-ring-offset)

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -72,6 +72,7 @@
 }
 
 .MafsView .movable-line:hover,
+.MafsView .movable-line--hover,
 .MafsView .movable-line:focus-visible,
 .movable-dragging {
     --movable-line-stroke-weight: var(--movable-line-stroke-weight-active);
@@ -219,7 +220,7 @@
     fill: transparent;
 }
 
-.MafsView .movable-circle:hover .circle {
+.MafsView .movable-circle:is(:hover, .movable-circle--hover) .circle {
     fill: var(--mafs-blue);
     fill-opacity: 0.16;
 }
@@ -323,15 +324,21 @@
 }
 
 /* Hover: arms grow longer (stroke stays 2px), ring/halo/focus expand */
-.MafsView .movable-arrowhead:hover .movable-arrowhead-center {
+.MafsView
+    .movable-arrowhead:is(:hover, .movable-arrowhead--hover)
+    .movable-arrowhead-center {
     transform: scale(1.2);
 }
 
-.MafsView .movable-arrowhead:hover .movable-arrowhead-ring {
+.MafsView
+    .movable-arrowhead:is(:hover, .movable-arrowhead--hover)
+    .movable-arrowhead-ring {
     transform: scale(1.2);
 }
 
-.MafsView .movable-arrowhead:hover .movable-arrowhead-halo {
+.MafsView
+    .movable-arrowhead:is(:hover, .movable-arrowhead--hover)
+    .movable-arrowhead-halo {
     transform: scale(1.15);
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -122,10 +122,6 @@
     opacity: 0;
 }
 
-.MafsView .movable-point-hitbox {
-    fill: transparent;
-}
-
 .MafsView
     :is(
         .movable-point-center,
@@ -271,10 +267,6 @@
 
 .MafsView .movable-arrowhead.movable-arrowhead--dragging {
     cursor: grabbing;
-}
-
-.MafsView .movable-arrowhead-hitbox {
-    fill: transparent;
 }
 
 .MafsView

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -44,6 +44,23 @@
     --movable-asymptote-dash-length-active: 8;
     --movable-asymptote-dash-gap-active: 12;
     overflow: visible !important;
+
+    /* Override Mafs' `touch-action: none` so the page can scroll vertically
+       over the graph (iOS 26.5+ started honoring `none` and trapped scrolling).
+       Dragging a shape is kept from scrolling the page by preventDefault in
+       use-draggable.ts, since Safari doesn't reliably honor `touch-action` on
+       the SVG draggable bodies; the per-element `touch-action: none` below is a
+       fast-path hint for browsers that do (e.g. Chrome). */
+    touch-action: pan-y;
+}
+
+/* Re-block touch scrolling on draggable bodies so vertical drags move the
+   shape instead of scrolling the page (honored by Chrome; Safari relies on the
+   preventDefault backstop in use-draggable.ts). */
+.MafsView .movable-line,
+.MafsView .movable-circle,
+.MafsView .movable-polygon {
+    touch-action: none;
 }
 
 .MafsView > svg {

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -45,21 +45,23 @@
     --movable-asymptote-dash-gap-active: 12;
     overflow: visible !important;
 
-    /* Override Mafs' `touch-action: none` so the page can scroll vertically
-       over the graph (iOS 26.5+ started honoring `none` and trapped scrolling).
-       Dragging a shape is kept from scrolling the page by preventDefault in
-       use-draggable.ts, since Safari doesn't reliably honor `touch-action` on
-       the SVG draggable bodies; the per-element `touch-action: none` below is a
-       fast-path hint for browsers that do (e.g. Chrome). */
+    /* Override Mafs' `touch-action: none` so the page can scroll over the graph
+       (iOS 26.5+ honors `none` and trapped scrolling). Dragging is kept from
+       scrolling by preventDefault in use-draggable.ts (Safari ignores
+       `touch-action` on SVG); the per-element `none` below is a fast path for
+       browsers that honor it. */
     touch-action: pan-y;
+
+    /* Prevent Android Chrome pull-to-refresh when page scroll passes through. */
+    overscroll-behavior-y: contain;
 }
 
-/* Re-block touch scrolling on draggable bodies so vertical drags move the
-   shape instead of scrolling the page (honored by Chrome; Safari relies on the
-   preventDefault backstop in use-draggable.ts). */
+/* Re-block scrolling on draggable gesture targets so vertical drags move the
+   shape. `.movable-point__focusable-handle` is an invisible a11y drag target. */
 .MafsView .movable-line,
 .MafsView .movable-circle,
-.MafsView .movable-polygon {
+.MafsView .movable-polygon,
+.MafsView .movable-point__focusable-handle {
     touch-action: none;
 }
 

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.test.tsx
@@ -69,16 +69,9 @@ describe("StatefulMafsGraph", () => {
     });
 
     it("renders", () => {
-        const {container} = render(
-            <StatefulMafsGraph {...getBaseStatefulMafsGraphProps()} />,
-        );
+        render(<StatefulMafsGraph {...getBaseStatefulMafsGraphProps()} />);
 
-        // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
-        const movablePoints = container.querySelectorAll(
-            "circle.movable-point-hitbox",
-        );
-
-        expect(movablePoints).not.toBe(0);
+        expect(screen.getAllByTestId("movable-point").length).toBeGreaterThan(0);
     });
 
     it("calls onChange when using graph", async () => {

--- a/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/stateful-mafs-graph.test.tsx
@@ -71,7 +71,9 @@ describe("StatefulMafsGraph", () => {
     it("renders", () => {
         render(<StatefulMafsGraph {...getBaseStatefulMafsGraphProps()} />);
 
-        expect(screen.getAllByTestId("movable-point").length).toBeGreaterThan(0);
+        expect(screen.getAllByTestId("movable-point").length).toBeGreaterThan(
+            0,
+        );
     });
 
     it("calls onChange when using graph", async () => {


### PR DESCRIPTION
## Summary:
Fix iOS 26.5 interactive graph scroll

Issue: LEMS-4353

## Summary

On **iOS 26.5+** (reported on 26.5.2), an article containing an interactive graph could not be scrolled: swiping over the graph — and the area immediately around it — failed to scroll the page, so readers got stuck and couldn't reach content further down. The same content scrolls fine on every iOS older than 26.5.

This is a WebKit **behavior change** shipped in Safari/WebKit 26.5, not a recent Perseus code change. Our interactive-graph drag handling was written against the *old* WebKit semantics and relies on behavior that 26.5 changed.

The Mafs library's own stylesheet (`import "mafs/core.css"` in `mafs-graph.tsx`) sets `touch-action: none` on the whole `.MafsView` container `<div>`, and Perseus's `mafs-styles.css` overrides that container's `overflow` and colors but never resets `touch-action`. Since `touch-action` on an ancestor also constrains its descendants, that single `none` blocks touch-scrolling across the **entire graph area** (and its overflow) — which is why the whole region felt stuck, not just the interactive points.

This is version-gated by a **Safari/WebKit 26.5** change (shipped in iOS 26.5, May 11, 2026):

> "Fixed an issue where calling `preventDefault()` on `pointerdown` events did not prevent page scrolling when only passive touch event listeners are installed."

**Earlier iOS did not enforce this container-level suppression against the page's scroller in this configuration; from 26.5 on it does, so the container's `touch-action: none` now traps the scroll.**

## Test plan:
Use the latest ZND link.
1. Confirm that in mobile with iOS 26.5++ version [simple pendulums exercise](https://www.khanacademy.org/science/ap-physics-c-mechanics/x077f5683c1428fac:oscillations/x077f5683c1428fac:simple-pendulums/e/simple-pendulums) can now scroll properly and user can interact with the interactive graph
2. Smoke test other graph types and confirm that it behaves as expected
3. Confirm that the [protractor](https://www.khanacademy.org/internal-courses/test-everything/test-everything-1/te-measurer/a/measurer-article) in mobile still works as expected
4. Confirm that in mobile with older iOS < 26.5 version [simple pendulums exercise](https://www.khanacademy.org/science/ap-physics-c-mechanics/x077f5683c1428fac:oscillations/x077f5683c1428fac:simple-pendulums/e/simple-pendulums) can still scroll properly and user can interact with the interactive graph