### PR TITLE
Migrate explanation widget to WidgetPropsV2

### DIFF
--- a/.changeset/widget-props-v2-explanation.md
+++ b/.changeset/widget-props-v2-explanation.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Migrate the explanation widget to group all `options` under a separate prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -480,7 +480,7 @@ review and commit the changes.
 - [x] Migrate `iframe` to `WidgetPropsV2`.
 - [x] Migrate `sorter` to `WidgetPropsV2`.
 - [x] Migrate `definition` to `WidgetPropsV2`.
-- [ ] Migrate `explanation` to `WidgetPropsV2`.
+- [x] Migrate `explanation` to `WidgetPropsV2`.
 - [ ] Migrate `deprecated-standin` to `WidgetPropsV2`.
 - [ ] Migrate `free-response` to `WidgetPropsV2` (its `defaultProps` is
       `userInput`-only, so no option-field defaults to relocate).

--- a/packages/perseus/src/__tests__/widget-container.test.tsx
+++ b/packages/perseus/src/__tests__/widget-container.test.tsx
@@ -69,10 +69,12 @@ describe("widget-container", () => {
                     type="explanation"
                     id="explanation 1"
                     widgetProps={{
-                        showPrompt: "Explanation",
-                        hidePrompt: "Hide explanation",
-                        explanation: "This is an explanation",
-                        widgets: {},
+                        options: {
+                            showPrompt: "Explanation",
+                            hidePrompt: "Hide explanation",
+                            explanation: "This is an explanation",
+                            widgets: {},
+                        },
 
                         findWidgets: () => [],
 

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -16,4 +16,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "iframe",
     "sorter",
     "definition",
+    "explanation",
 ];

--- a/packages/perseus/src/widget-ai-utils/explanation/explanation-ai-utils.test.ts
+++ b/packages/perseus/src/widget-ai-utils/explanation/explanation-ai-utils.test.ts
@@ -26,8 +26,10 @@ const question1: PerseusRenderer = generateTestPerseusRenderer({
 describe("Explanation getPromptJSON", () => {
     it("it returns JSON with the expected format and fields", () => {
         const widgetData: any = {
-            showPrompt: "Show explanation",
-            explanation: "This is the explanation",
+            options: {
+                showPrompt: "Show explanation",
+                explanation: "This is the explanation",
+            },
         };
 
         const resultJSON = getPromptJSON(widgetData);

--- a/packages/perseus/src/widget-ai-utils/explanation/explanation-ai-utils.ts
+++ b/packages/perseus/src/widget-ai-utils/explanation/explanation-ai-utils.ts
@@ -24,7 +24,7 @@ export const getPromptJSON = (
 ): ExplanationPromptJSON => {
     return {
         type: "explanation",
-        showPrompt: widgetData.showPrompt,
-        explanation: widgetData.explanation,
+        showPrompt: widgetData.options.showPrompt,
+        explanation: widgetData.options.explanation,
     };
 };

--- a/packages/perseus/src/widgets/explanation/explanation.tsx
+++ b/packages/perseus/src/widgets/explanation/explanation.tsx
@@ -81,10 +81,10 @@ class Explanation extends React.Component<Props, State> implements Widget {
     }
 
     render(): React.ReactNode {
-        const promptText = this.state.expanded
-            ? this.props.options.hidePrompt
-            : this.props.options.showPrompt;
+        const {hidePrompt, showPrompt, explanation, widgets} =
+            this.props.options;
 
+        const promptText = this.state.expanded ? hidePrompt : showPrompt;
         const caretIcon = this.state.expanded ? caretUp : caretDown;
 
         // TODO (LEMS-3815): Remove legacy styles
@@ -138,7 +138,7 @@ class Explanation extends React.Component<Props, State> implements Widget {
                                 style={stylesLegacy.contentWrapper}
                             >
                                 <UserInputManager
-                                    widgets={this.props.options.widgets}
+                                    widgets={widgets}
                                     problemNum={0}
                                 >
                                     {({
@@ -151,13 +151,8 @@ class Explanation extends React.Component<Props, State> implements Widget {
                                                 apiOptions={
                                                     this.props.apiOptions
                                                 }
-                                                content={
-                                                    this.props.options
-                                                        .explanation
-                                                }
-                                                widgets={
-                                                    this.props.options.widgets
-                                                }
+                                                content={explanation}
+                                                widgets={widgets}
                                                 linterContext={
                                                     this.props.linterContext
                                                 }

--- a/packages/perseus/src/widgets/explanation/explanation.tsx
+++ b/packages/perseus/src/widgets/explanation/explanation.tsx
@@ -18,20 +18,16 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetProps,
+    WidgetPropsV2,
 } from "../../types";
 import type {ExplanationPromptJSON} from "../../widget-ai-utils/explanation/explanation-ai-utils";
 import type {PerseusExplanationWidgetOptions} from "@khanacademy/perseus-core";
 
-type Props = WidgetProps<PerseusExplanationWidgetOptions> & {
+type Props = WidgetPropsV2<PerseusExplanationWidgetOptions> & {
     dependencies: PerseusDependenciesV2;
 };
 
 type DefaultProps = {
-    showPrompt: Props["showPrompt"];
-    hidePrompt: Props["hidePrompt"];
-    explanation: Props["explanation"];
-    widgets: Props["widgets"];
     linterContext: Props["linterContext"];
 };
 
@@ -51,10 +47,6 @@ class Explanation extends React.Component<Props, State> implements Widget {
     declare context: React.ContextType<typeof PerseusI18nContext>;
 
     static defaultProps: DefaultProps = {
-        showPrompt: "Explain",
-        hidePrompt: "Hide explanation",
-        explanation: "explanation goes here\n\nmore explanation",
-        widgets: {},
         linterContext: linterContextDefault,
     };
 
@@ -90,8 +82,8 @@ class Explanation extends React.Component<Props, State> implements Widget {
 
     render(): React.ReactNode {
         const promptText = this.state.expanded
-            ? this.props.hidePrompt
-            : this.props.showPrompt;
+            ? this.props.options.hidePrompt
+            : this.props.options.showPrompt;
 
         const caretIcon = this.state.expanded ? caretUp : caretDown;
 
@@ -146,7 +138,7 @@ class Explanation extends React.Component<Props, State> implements Widget {
                                 style={stylesLegacy.contentWrapper}
                             >
                                 <UserInputManager
-                                    widgets={this.props.widgets}
+                                    widgets={this.props.options.widgets}
                                     problemNum={0}
                                 >
                                     {({
@@ -159,8 +151,13 @@ class Explanation extends React.Component<Props, State> implements Widget {
                                                 apiOptions={
                                                     this.props.apiOptions
                                                 }
-                                                content={this.props.explanation}
-                                                widgets={this.props.widgets}
+                                                content={
+                                                    this.props.options
+                                                        .explanation
+                                                }
+                                                widgets={
+                                                    this.props.options.widgets
+                                                }
                                                 linterContext={
                                                     this.props.linterContext
                                                 }


### PR DESCRIPTION
## Summary
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit an Explanation widget in http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.