### PR TITLE
Migrate deprecated-standin widget to WidgetPropsV2

### DIFF
--- a/.changeset/widget-props-v2-deprecated-standin.md
+++ b/.changeset/widget-props-v2-deprecated-standin.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Migrate the deprecated-standin widget to group all `options` under a separate prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -481,7 +481,7 @@ review and commit the changes.
 - [x] Migrate `sorter` to `WidgetPropsV2`.
 - [x] Migrate `definition` to `WidgetPropsV2`.
 - [x] Migrate `explanation` to `WidgetPropsV2`.
-- [ ] Migrate `deprecated-standin` to `WidgetPropsV2`.
+- [x] Migrate `deprecated-standin` to `WidgetPropsV2`.
 - [ ] Migrate `free-response` to `WidgetPropsV2` (its `defaultProps` is
       `userInput`-only, so no option-field defaults to relocate).
 - [ ] Migrate `video` to `WidgetPropsV2`.

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -17,4 +17,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "sorter",
     "definition",
     "explanation",
+    "deprecated-standin",
 ];


### PR DESCRIPTION
## Summary
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a Deprecated Standin widget in http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.