### PR TITLE
Migrate free-response widget to WidgetPropsV2

### DIFF
--- a/.changeset/widget-props-v2-free-response.md
+++ b/.changeset/widget-props-v2-free-response.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Migrate the free-response widget to group all `options` under a separate prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -482,7 +482,7 @@ review and commit the changes.
 - [x] Migrate `definition` to `WidgetPropsV2`.
 - [x] Migrate `explanation` to `WidgetPropsV2`.
 - [x] Migrate `deprecated-standin` to `WidgetPropsV2`.
-- [ ] Migrate `free-response` to `WidgetPropsV2` (its `defaultProps` is
+- [x] Migrate `free-response` to `WidgetPropsV2` (its `defaultProps` is
       `userInput`-only, so no option-field defaults to relocate).
 - [ ] Migrate `video` to `WidgetPropsV2`.
 - [ ] Migrate `image` to `WidgetPropsV2`.

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -18,4 +18,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "definition",
     "explanation",
     "deprecated-standin",
+    "free-response",
 ];

--- a/packages/perseus/src/widgets/free-response/free-response.stories.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.stories.tsx
@@ -22,48 +22,63 @@ type Story = StoryObj<typeof FreeResponse>;
 
 export const Primary: Story = {
     args: {
-        allowUnlimitedCharacters: false,
-        characterLimit: 500,
-        placeholder: "Enter your answer here",
-        question: "What is the theme of the essay?",
+        options: {
+            allowUnlimitedCharacters: false,
+            characterLimit: 500,
+            placeholder: "Enter your answer here",
+            question: "What is the theme of the essay?",
+            scoringCriteria: [],
+        },
     },
 };
 
 export const CharacterLimit: Story = {
     args: {
-        allowUnlimitedCharacters: false,
-        characterLimit: 500,
-        placeholder: "Enter your answer here",
-        question: "What is the theme of the essay?",
+        options: {
+            allowUnlimitedCharacters: false,
+            characterLimit: 500,
+            placeholder: "Enter your answer here",
+            question: "What is the theme of the essay?",
+            scoringCriteria: [],
+        },
     },
 };
 
 export const BoldedQuestion: Story = {
     args: {
-        allowUnlimitedCharacters: false,
-        characterLimit: 500,
-        placeholder: "Enter your answer here",
-        question: "**What is the theme of the essay?**",
+        options: {
+            allowUnlimitedCharacters: false,
+            characterLimit: 500,
+            placeholder: "Enter your answer here",
+            question: "**What is the theme of the essay?**",
+            scoringCriteria: [],
+        },
     },
 };
 
 export const UnlimitedCharacters: Story = {
     args: {
-        allowUnlimitedCharacters: true,
-        characterLimit: 500,
-        placeholder: "Enter your answer here",
-        question:
-            "What is the theme of the essay?\n\n**Put your answer in your own words.**",
+        options: {
+            allowUnlimitedCharacters: true,
+            characterLimit: 500,
+            placeholder: "Enter your answer here",
+            question:
+                "What is the theme of the essay?\n\n**Put your answer in your own words.**",
+            scoringCriteria: [],
+        },
     },
 };
 
 export const QuestionWithTex: Story = {
     name: "Question with TeX content",
     args: {
-        allowUnlimitedCharacters: true,
-        characterLimit: 500,
-        placeholder: "Enter your answer here",
-        question:
-            "What changes are required to solve the following equation? $\\dfrac{6-3}{1-0}=\\dfrac{3}{1}=3$",
+        options: {
+            allowUnlimitedCharacters: true,
+            characterLimit: 500,
+            placeholder: "Enter your answer here",
+            question:
+                "What changes are required to solve the following equation? $\\dfrac{6-3}{1-0}=\\dfrac{3}{1}=3$",
+            scoringCriteria: [],
+        },
     },
 };

--- a/packages/perseus/src/widgets/free-response/free-response.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.tsx
@@ -69,12 +69,18 @@ export class FreeResponse extends React.Component<Props> implements Widget {
     }
 
     render(): React.ReactNode {
+        const {
+            allowUnlimitedCharacters,
+            characterLimit,
+            question,
+            placeholder,
+        } = this.props.options;
         const isOverLimit = this.isOverLimit();
-        const characterCountText = this.props.options.allowUnlimitedCharacters
+        const characterCountText = allowUnlimitedCharacters
             ? undefined
             : this.context.strings.characterCount({
                   used: this.characterCount(),
-                  num: this.props.options.characterLimit,
+                  num: characterLimit,
               });
         if (characterCountText) {
             this.announceCharacterCount(characterCountText, isOverLimit);
@@ -86,7 +92,7 @@ export class FreeResponse extends React.Component<Props> implements Widget {
                     label={
                         <View className="free-response-question">
                             <Renderer
-                                content={this.props.options.question}
+                                content={question}
                                 strings={this.context.strings}
                             />
                         </View>
@@ -95,7 +101,7 @@ export class FreeResponse extends React.Component<Props> implements Widget {
                         <TextArea
                             error={isOverLimit}
                             onChange={this._handleUserInput}
-                            placeholder={this.props.options.placeholder}
+                            placeholder={placeholder}
                             style={styles.textarea}
                             value={this.props.userInput.currentValue}
                         />

--- a/packages/perseus/src/widgets/free-response/free-response.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.tsx
@@ -18,13 +18,13 @@ import * as React from "react";
 import {PerseusI18nContext} from "../../components/i18n-context";
 import Renderer from "../../renderer";
 
-import type {Widget, WidgetExports, WidgetProps} from "../../types";
+import type {Widget, WidgetExports, WidgetPropsV2} from "../../types";
 import type {
     PerseusFreeResponseUserInput,
     PerseusFreeResponseWidgetOptions,
 } from "@khanacademy/perseus-core";
 
-type Props = WidgetProps<
+type Props = WidgetPropsV2<
     PerseusFreeResponseWidgetOptions,
     PerseusFreeResponseUserInput
 >;
@@ -63,18 +63,18 @@ export class FreeResponse extends React.Component<Props> implements Widget {
 
     isOverLimit() {
         return (
-            !this.props.allowUnlimitedCharacters &&
-            this.characterCount() > this.props.characterLimit
+            !this.props.options.allowUnlimitedCharacters &&
+            this.characterCount() > this.props.options.characterLimit
         );
     }
 
     render(): React.ReactNode {
         const isOverLimit = this.isOverLimit();
-        const characterCountText = this.props.allowUnlimitedCharacters
+        const characterCountText = this.props.options.allowUnlimitedCharacters
             ? undefined
             : this.context.strings.characterCount({
                   used: this.characterCount(),
-                  num: this.props.characterLimit,
+                  num: this.props.options.characterLimit,
               });
         if (characterCountText) {
             this.announceCharacterCount(characterCountText, isOverLimit);
@@ -86,7 +86,7 @@ export class FreeResponse extends React.Component<Props> implements Widget {
                     label={
                         <View className="free-response-question">
                             <Renderer
-                                content={this.props.question}
+                                content={this.props.options.question}
                                 strings={this.context.strings}
                             />
                         </View>
@@ -95,7 +95,7 @@ export class FreeResponse extends React.Component<Props> implements Widget {
                         <TextArea
                             error={isOverLimit}
                             onChange={this._handleUserInput}
-                            placeholder={this.props.placeholder}
+                            placeholder={this.props.options.placeholder}
                             style={styles.textarea}
                             value={this.props.userInput.currentValue}
                         />


### PR DESCRIPTION
## Summary
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a Free Response widget in http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.