### PR TITLE
Migrate video widget to WidgetPropsV2

### DIFF
--- a/.changeset/widget-props-v2-video.md
+++ b/.changeset/widget-props-v2-video.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Migrate the video widget to group all `options` under a separate prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -484,7 +484,7 @@ review and commit the changes.
 - [x] Migrate `deprecated-standin` to `WidgetPropsV2`.
 - [x] Migrate `free-response` to `WidgetPropsV2` (its `defaultProps` is
       `userInput`-only, so no option-field defaults to relocate).
-- [ ] Migrate `video` to `WidgetPropsV2`.
+- [x] Migrate `video` to `WidgetPropsV2`.
 - [ ] Migrate `image` to `WidgetPropsV2`.
 - [ ] Migrate `molecule` to `WidgetPropsV2`.
 - [ ] Migrate `measurer` to `WidgetPropsV2`.

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -19,4 +19,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "explanation",
     "deprecated-standin",
     "free-response",
+    "video",
 ];

--- a/packages/perseus/src/widgets/video/video.tsx
+++ b/packages/perseus/src/widgets/video/video.tsx
@@ -14,7 +14,7 @@ import {
     type PerseusDependenciesV2,
     type Widget,
     type WidgetExports,
-    type WidgetProps,
+    type WidgetPropsV2,
 } from "../../types";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/video/video-ai-utils";
 
@@ -33,7 +33,7 @@ const IS_URL = /^https?:\/\//;
 const IS_KA_SITE = /(khanacademy\.org|localhost)/;
 const IS_VIMEO = /(vimeo\.com)/;
 
-type Props = WidgetProps<PerseusVideoWidgetOptions> & {
+type Props = WidgetPropsV2<PerseusVideoWidgetOptions> & {
     dependencies: PerseusDependenciesV2;
 };
 
@@ -65,7 +65,7 @@ class Video extends React.Component<Props> implements Widget {
     render(): React.ReactNode {
         const {InitialRequestUrl} = getDependencies();
 
-        const location = this.props.location;
+        const location = this.props.options.location;
         if (!location) {
             return <div />;
         }

--- a/packages/perseus/src/widgets/video/video.tsx
+++ b/packages/perseus/src/widgets/video/video.tsx
@@ -65,7 +65,7 @@ class Video extends React.Component<Props> implements Widget {
     render(): React.ReactNode {
         const {InitialRequestUrl} = getDependencies();
 
-        const location = this.props.options.location;
+        const {location} = this.props.options;
         if (!location) {
             return <div />;
         }


### PR DESCRIPTION
## Summary
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a Video widget in http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.