### PR TITLE
Add tests for just-in-place translation (JIPT)

### DIFF
--- a/.changeset/five-geese-pick.md
+++ b/.changeset/five-geese-pick.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: improve type safety and tests of Crowdin just-in-place-translation (JIPT) code.

--- a/packages/perseus/src/__tests__/__snapshots__/renderer.new.test.tsx.snap
+++ b/packages/perseus/src/__tests__/__snapshots__/renderer.new.test.tsx.snap
@@ -1,5 +1,94 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`renderer in a JIPT context renders \`crwdn\` placeholders with data-perseus-component-index and data-perseus-paragraph-index attributes in an article: article with JIPT placeholders 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-component-index="42"
+      data-perseus-paragraph-index="0"
+    >
+      crwdns1:0crwdne1
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-component-index="42"
+      data-perseus-paragraph-index="1"
+    >
+      crwdns2:0crwdne2
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renderer in a JIPT context renders \`crwdn\` placeholders with data-perseus-component-index attributes in an exercise: exercise with JIPT placeholder 1`] = `
+<div>
+  <div
+    data-perseus-component-index="42"
+  >
+    crwdns123:0crwdne123
+  </div>
+</div>
+`;
+
+exports[`renderer in a JIPT context replaces the \`crwdn\` placeholder with the translated content of an article: JIPT-translated article 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-component-index="42"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="paragraph"
+      >
+        first paragraph
+      </div>
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-component-index="42"
+      data-perseus-paragraph-index="1"
+    >
+      <div
+        class="paragraph"
+      >
+        second paragraph
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renderer in a JIPT context replaces the \`crwdn\` placeholder with the translated content of an exercise: JIPT-translated exercise 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-component-index="42"
+      data-perseus-paragraph-index="0"
+    >
+      <div
+        class="paragraph"
+      >
+        <a
+          href="https://khanacademy.org"
+          target="_blank"
+        >
+          link
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`renderer rendering should render a table when isMobile: false 1`] = `
 <div>
   <div
@@ -325,6 +414,39 @@ exports[`renderer rendering should render the math 1`] = `
         </span>
       </div>
     </div>
+  </div>
+</div>
+`;
+
+exports[`renderer snapshots JIPT article: JIPT article 1`] = `
+<div>
+  <div
+    class="perseus-renderer perseus-renderer-responsive"
+  >
+    <div
+      class="paragraph"
+      data-perseus-component-index="42"
+      data-perseus-paragraph-index="0"
+    >
+      crwdns1:0crwdne1
+    </div>
+    <div
+      class="paragraph"
+      data-perseus-component-index="42"
+      data-perseus-paragraph-index="1"
+    >
+      crwdns2:0crwdne2
+    </div>
+  </div>
+</div>
+`;
+
+exports[`renderer snapshots JIPT exercise: JIPT exercise 1`] = `
+<div>
+  <div
+    data-perseus-component-index="42"
+  >
+    crwdns123:0crwdne123
   </div>
 </div>
 `;

--- a/packages/perseus/src/__tests__/__snapshots__/renderer.new.test.tsx.snap
+++ b/packages/perseus/src/__tests__/__snapshots__/renderer.new.test.tsx.snap
@@ -418,39 +418,6 @@ exports[`renderer rendering should render the math 1`] = `
 </div>
 `;
 
-exports[`renderer snapshots JIPT article: JIPT article 1`] = `
-<div>
-  <div
-    class="perseus-renderer perseus-renderer-responsive"
-  >
-    <div
-      class="paragraph"
-      data-perseus-component-index="42"
-      data-perseus-paragraph-index="0"
-    >
-      crwdns1:0crwdne1
-    </div>
-    <div
-      class="paragraph"
-      data-perseus-component-index="42"
-      data-perseus-paragraph-index="1"
-    >
-      crwdns2:0crwdne2
-    </div>
-  </div>
-</div>
-`;
-
-exports[`renderer snapshots JIPT exercise: JIPT exercise 1`] = `
-<div>
-  <div
-    data-perseus-component-index="42"
-  >
-    crwdns123:0crwdne123
-  </div>
-</div>
-`;
-
 exports[`renderer snapshots correct answer: correct answer 1`] = `
 <div>
   <div

--- a/packages/perseus/src/__tests__/renderer.new.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.new.test.tsx
@@ -154,8 +154,9 @@ describe("renderer", () => {
 
             // Act
             const {container} = renderQuestion({
-                ...question1,
                 content: "crwdns123:0crwdne123",
+                widgets: {},
+                images: {},
             });
 
             // Assert
@@ -176,8 +177,9 @@ describe("renderer", () => {
             // Act
             const {container} = renderQuestion(
                 {
-                    ...question1,
                     content: "crwdns1:0crwdne1\n\ncrwdns2:0crwdne2",
+                    widgets: {},
+                    images: {},
                 },
                 {isArticle: true},
             );
@@ -1535,8 +1537,9 @@ describe("renderer", () => {
             });
 
             renderQuestion({
-                ...question1,
                 content: "crwdns123:0crwdne123",
+                widgets: {},
+                images: {},
             });
 
             expect(addComponent).toHaveBeenCalledWith(expect.any(RendererNew));
@@ -1556,8 +1559,9 @@ describe("renderer", () => {
             // Act
             const {container} = renderQuestion(
                 {
-                    ...question1,
                     content: "crwdns123:0crwdne123",
+                    widgets: {},
+                    images: {},
                 },
                 {isArticle: false},
             );
@@ -1580,8 +1584,9 @@ describe("renderer", () => {
             // Act
             const {container} = renderQuestion(
                 {
-                    ...question1,
                     content: "crwdns1:0crwdne1\n\ncrwdns2:0crwdne2",
+                    widgets: {},
+                    images: {},
                 },
                 {isArticle: true},
             );
@@ -1603,8 +1608,9 @@ describe("renderer", () => {
             });
             const {container} = renderQuestion(
                 {
-                    ...question1,
                     content: "crwdns123:0crwdne123",
+                    widgets: {},
+                    images: {},
                 },
                 {isArticle: false},
             );
@@ -1635,8 +1641,9 @@ describe("renderer", () => {
             });
             const {container} = renderQuestion(
                 {
-                    ...question1,
                     content: "crwdns1:0crwdne1:0\n\ncrwdns2:0crwdne2:0",
+                    widgets: {},
+                    images: {},
                 },
                 {isArticle: true},
             );

--- a/packages/perseus/src/__tests__/renderer.new.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.new.test.tsx
@@ -22,6 +22,7 @@ import {
     isDifferentQuestion,
     type DifferentQuestionPartialProps,
 } from "../renderer";
+import RendererNew from "../renderer.new";
 import {testWidgetIdExtraction} from "../testing/extract-widget-ids-contract-tests";
 import {mockImageLoading} from "../testing/image-loader-utils";
 import {clone} from "../testing/object-utils";
@@ -138,6 +139,51 @@ describe("renderer", () => {
 
             // Assert
             expect(container).toMatchSnapshot("deprecated widget");
+        });
+
+        test("JIPT exercise", async () => {
+            // Arrange
+            jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
+                ...testDependencies,
+                JIPT: {useJIPT: true},
+                rendererTranslationComponents: {
+                    addComponent: () => 42,
+                    removeComponentAtIndex() {},
+                },
+            });
+
+            // Act
+            const {container} = renderQuestion({
+                ...question1,
+                content: "crwdns123:0crwdne123",
+            });
+
+            // Assert
+            expect(container).toMatchSnapshot("JIPT exercise");
+        });
+
+        test("JIPT article", async () => {
+            // Arrange
+            jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
+                ...testDependencies,
+                JIPT: {useJIPT: true},
+                rendererTranslationComponents: {
+                    addComponent: () => 42,
+                    removeComponentAtIndex() {},
+                },
+            });
+
+            // Act
+            const {container} = renderQuestion(
+                {
+                    ...question1,
+                    content: "crwdns1:0crwdne1\n\ncrwdns2:0crwdne2",
+                },
+                {isArticle: true},
+            );
+
+            // Assert
+            expect(container).toMatchSnapshot("JIPT article");
         });
     });
 
@@ -1469,6 +1515,143 @@ describe("renderer", () => {
             const widgetKeys = Object.keys(mockedRandomItem.widgets);
 
             expect(Object.keys(json.widgets)).toEqual(widgetKeys);
+        });
+    });
+
+    describe("in a JIPT context", () => {
+        // JIPT stands for just-in-place-translation.
+        // See: https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4860248066/JIPT+just-in-place+translation+in+Perseus
+
+        it("registers itself via rendererTranslationComponents", () => {
+            // Arrange
+            const addComponent = jest.fn().mockReturnValue(42);
+            jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
+                ...testDependencies,
+                JIPT: {useJIPT: true},
+                rendererTranslationComponents: {
+                    addComponent,
+                    removeComponentAtIndex() {},
+                },
+            });
+
+            renderQuestion({
+                ...question1,
+                content: "crwdns123:0crwdne123",
+            });
+
+            expect(addComponent).toHaveBeenCalledWith(expect.any(RendererNew));
+        });
+
+        it("renders `crwdn` placeholders with data-perseus-component-index attributes in an exercise", async () => {
+            // Arrange
+            jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
+                ...testDependencies,
+                JIPT: {useJIPT: true},
+                rendererTranslationComponents: {
+                    addComponent: () => 42,
+                    removeComponentAtIndex() {},
+                },
+            });
+
+            // Act
+            const {container} = renderQuestion(
+                {
+                    ...question1,
+                    content: "crwdns123:0crwdne123",
+                },
+                {isArticle: false},
+            );
+
+            // Assert
+            expect(container).toMatchSnapshot("exercise with JIPT placeholder");
+        });
+
+        it("renders `crwdn` placeholders with data-perseus-component-index and data-perseus-paragraph-index attributes in an article", async () => {
+            // Arrange
+            jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
+                ...testDependencies,
+                JIPT: {useJIPT: true},
+                rendererTranslationComponents: {
+                    addComponent: () => 42,
+                    removeComponentAtIndex() {},
+                },
+            });
+
+            // Act
+            const {container} = renderQuestion(
+                {
+                    ...question1,
+                    content: "crwdns1:0crwdne1\n\ncrwdns2:0crwdne2",
+                },
+                {isArticle: true},
+            );
+
+            // Assert
+            expect(container).toMatchSnapshot("article with JIPT placeholders");
+        });
+
+        it("replaces the `crwdn` placeholder with the translated content of an exercise", () => {
+            // Arrange
+            const addComponent = jest.fn().mockReturnValue(42);
+            jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
+                ...testDependencies,
+                JIPT: {useJIPT: true},
+                rendererTranslationComponents: {
+                    addComponent,
+                    removeComponentAtIndex() {},
+                },
+            });
+            const {container} = renderQuestion(
+                {
+                    ...question1,
+                    content: "crwdns123:0crwdne123",
+                },
+                {isArticle: false},
+            );
+
+            // Act
+            const renderer: RendererNew = addComponent.mock.calls[0][0];
+            act(() => {
+                renderer.replaceJiptContent(
+                    "[link](https://khanacademy.org)",
+                    undefined,
+                );
+            });
+
+            // Assert
+            expect(container).toMatchSnapshot("JIPT-translated exercise");
+        });
+
+        it("replaces the `crwdn` placeholder with the translated content of an article", () => {
+            // Arrange
+            const addComponent = jest.fn().mockReturnValue(42);
+            jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
+                ...testDependencies,
+                JIPT: {useJIPT: true},
+                rendererTranslationComponents: {
+                    addComponent,
+                    removeComponentAtIndex() {},
+                },
+            });
+            const {container} = renderQuestion(
+                {
+                    ...question1,
+                    content: "crwdns1:0crwdne1:0\n\ncrwdns2:0crwdne2:0",
+                },
+                {isArticle: true},
+            );
+
+            // Act
+            const renderer: RendererNew = addComponent.mock.calls[0][0];
+            act(() => {
+                renderer.replaceJiptContent("first paragraph", 0);
+            });
+            act(() => {
+                renderer.replaceJiptContent("second paragraph", 1);
+            });
+
+            // Assert
+            expect(container).toMatchSnapshot("JIPT-translated article");
         });
     });
 });

--- a/packages/perseus/src/__tests__/renderer.new.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.new.test.tsx
@@ -140,53 +140,6 @@ describe("renderer", () => {
             // Assert
             expect(container).toMatchSnapshot("deprecated widget");
         });
-
-        test("JIPT exercise", async () => {
-            // Arrange
-            jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
-                ...testDependencies,
-                JIPT: {useJIPT: true},
-                rendererTranslationComponents: {
-                    addComponent: () => 42,
-                    removeComponentAtIndex() {},
-                },
-            });
-
-            // Act
-            const {container} = renderQuestion({
-                content: "crwdns123:0crwdne123",
-                widgets: {},
-                images: {},
-            });
-
-            // Assert
-            expect(container).toMatchSnapshot("JIPT exercise");
-        });
-
-        test("JIPT article", async () => {
-            // Arrange
-            jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
-                ...testDependencies,
-                JIPT: {useJIPT: true},
-                rendererTranslationComponents: {
-                    addComponent: () => 42,
-                    removeComponentAtIndex() {},
-                },
-            });
-
-            // Act
-            const {container} = renderQuestion(
-                {
-                    content: "crwdns1:0crwdne1\n\ncrwdns2:0crwdne2",
-                    widgets: {},
-                    images: {},
-                },
-                {isArticle: true},
-            );
-
-            // Assert
-            expect(container).toMatchSnapshot("JIPT article");
-        });
     });
 
     describe("linting (TranslationLinter)", () => {
@@ -1524,37 +1477,34 @@ describe("renderer", () => {
         // JIPT stands for just-in-place-translation.
         // See: https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4860248066/JIPT+just-in-place+translation+in+Perseus
 
-        it("registers itself via rendererTranslationComponents", () => {
-            // Arrange
-            const addComponent = jest.fn().mockReturnValue(42);
+        let addComponentMock = jest.fn();
+        beforeEach(() => {
+            addComponentMock = jest.fn().mockReturnValue(0);
             jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
                 ...testDependencies,
                 JIPT: {useJIPT: true},
                 rendererTranslationComponents: {
-                    addComponent,
+                    addComponent: addComponentMock,
                     removeComponentAtIndex() {},
                 },
             });
+        });
 
+        it("registers itself via rendererTranslationComponents", () => {
             renderQuestion({
                 content: "crwdns123:0crwdne123",
                 widgets: {},
                 images: {},
             });
 
-            expect(addComponent).toHaveBeenCalledWith(expect.any(RendererNew));
+            expect(addComponentMock).toHaveBeenCalledWith(
+                expect.any(RendererNew),
+            );
         });
 
         it("renders `crwdn` placeholders with data-perseus-component-index attributes in an exercise", async () => {
             // Arrange
-            jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
-                ...testDependencies,
-                JIPT: {useJIPT: true},
-                rendererTranslationComponents: {
-                    addComponent: () => 42,
-                    removeComponentAtIndex() {},
-                },
-            });
+            addComponentMock.mockReturnValue(42);
 
             // Act
             const {container} = renderQuestion(
@@ -1572,14 +1522,7 @@ describe("renderer", () => {
 
         it("renders `crwdn` placeholders with data-perseus-component-index and data-perseus-paragraph-index attributes in an article", async () => {
             // Arrange
-            jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
-                ...testDependencies,
-                JIPT: {useJIPT: true},
-                rendererTranslationComponents: {
-                    addComponent: () => 42,
-                    removeComponentAtIndex() {},
-                },
-            });
+            addComponentMock.mockReturnValue(42);
 
             // Act
             const {container} = renderQuestion(
@@ -1597,15 +1540,7 @@ describe("renderer", () => {
 
         it("replaces the `crwdn` placeholder with the translated content of an exercise", () => {
             // Arrange
-            const addComponent = jest.fn().mockReturnValue(42);
-            jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
-                ...testDependencies,
-                JIPT: {useJIPT: true},
-                rendererTranslationComponents: {
-                    addComponent,
-                    removeComponentAtIndex() {},
-                },
-            });
+            addComponentMock.mockReturnValue(42);
             const {container} = renderQuestion(
                 {
                     content: "crwdns123:0crwdne123",
@@ -1616,7 +1551,7 @@ describe("renderer", () => {
             );
 
             // Act
-            const renderer: RendererNew = addComponent.mock.calls[0][0];
+            const renderer: RendererNew = addComponentMock.mock.calls[0][0];
             act(() => {
                 renderer.replaceJiptContent(
                     "[link](https://khanacademy.org)",
@@ -1630,15 +1565,7 @@ describe("renderer", () => {
 
         it("replaces the `crwdn` placeholder with the translated content of an article", () => {
             // Arrange
-            const addComponent = jest.fn().mockReturnValue(42);
-            jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
-                ...testDependencies,
-                JIPT: {useJIPT: true},
-                rendererTranslationComponents: {
-                    addComponent,
-                    removeComponentAtIndex() {},
-                },
-            });
+            addComponentMock.mockReturnValue(42);
             const {container} = renderQuestion(
                 {
                     content: "crwdns1:0crwdne1:0\n\ncrwdns2:0crwdne2:0",
@@ -1649,7 +1576,7 @@ describe("renderer", () => {
             );
 
             // Act
-            const renderer: RendererNew = addComponent.mock.calls[0][0];
+            const renderer: RendererNew = addComponentMock.mock.calls[0][0];
             act(() => {
                 renderer.replaceJiptContent("first paragraph", 0);
             });

--- a/packages/perseus/src/perseus-markdown.test.ts
+++ b/packages/perseus/src/perseus-markdown.test.ts
@@ -1,0 +1,34 @@
+import PerseusMarkdown from "./perseus-markdown";
+
+describe("PerseusMarkdown.parse()", () => {
+    it("parses Crowdin IDs when isJipt is true", () => {
+        const content =
+            "crwdns4137066:0crwdne4137066:0\n\ncrwdns4137067:0crwdne4137067:0";
+
+        const result = PerseusMarkdown.parse(content, {isJipt: true});
+
+        expect(result).toEqual([
+            {
+                type: "crowdinId",
+                id: "crwdns4137066:0crwdne4137066:0",
+            },
+            {
+                type: "crowdinId",
+                id: "crwdns4137067:0crwdne4137067:0",
+            },
+        ]);
+    });
+
+    it("ignores trailing newlines when isJipt is true", () => {
+        const content = "crwdns4137066:0crwdne4137066:0\n\n";
+
+        const result = PerseusMarkdown.parse(content, {isJipt: true});
+
+        expect(result).toEqual([
+            {
+                type: "crowdinId",
+                id: "crwdns4137066:0crwdne4137066:0",
+            },
+        ]);
+    });
+});

--- a/packages/perseus/src/renderer.new.tsx
+++ b/packages/perseus/src/renderer.new.tsx
@@ -768,10 +768,10 @@ class Renderer
         );
     };
 
-    replaceJiptContent: (content: string, paragraphIndex: number) => void = (
+    replaceJiptContent(
         content: string,
-        paragraphIndex: number,
-    ) => {
+        paragraphIndex: number | undefined,
+    ): void {
         if (paragraphIndex == null) {
             // we're not translating paragraph-wise; replace the whole content
             // (we could also theoretically check for apiOptions.isArticle
@@ -817,7 +817,7 @@ class Renderer
                 jiptContent: JiptParagraphs.joinFromArray(paragraphs),
             });
         }
-    };
+    }
 
     // wrap top-level elements in a QuestionParagraph, mostly
     // for appropriate spacing and other css

--- a/packages/perseus/src/renderer.new.tsx
+++ b/packages/perseus/src/renderer.new.tsx
@@ -167,7 +167,7 @@ type Props = Partial<React.ContextType<typeof DependenciesContext>> & {
 type State = {
     translationLintErrors: ReadonlyArray<string>;
     widgetInfo: Readonly<PerseusWidgetsMap>;
-    jiptContent: any;
+    jiptContent: string | null;
 };
 
 type FullLinterContext = LinterContextProps & {

--- a/packages/perseus/src/renderer.new.tsx
+++ b/packages/perseus/src/renderer.new.tsx
@@ -768,10 +768,7 @@ class Renderer
         );
     };
 
-    replaceJiptContent(
-        content: string,
-        paragraphIndex: number | undefined,
-    ): void {
+    replaceJiptContent(content: string, paragraphIndex?: number): void {
         if (paragraphIndex == null) {
             // we're not translating paragraph-wise; replace the whole content
             // (we could also theoretically check for apiOptions.isArticle

--- a/packages/perseus/src/renderer.old.tsx
+++ b/packages/perseus/src/renderer.old.tsx
@@ -760,10 +760,10 @@ class Renderer
         );
     };
 
-    replaceJiptContent: (content: string, paragraphIndex: number) => void = (
+    replaceJiptContent(
         content: string,
-        paragraphIndex: number,
-    ) => {
+        paragraphIndex: number | undefined,
+    ): void {
         if (paragraphIndex == null) {
             // we're not translating paragraph-wise; replace the whole content
             // (we could also theoretically check for apiOptions.isArticle
@@ -809,7 +809,7 @@ class Renderer
                 jiptContent: JiptParagraphs.joinFromArray(paragraphs),
             });
         }
-    };
+    }
 
     // wrap top-level elements in a QuestionParagraph, mostly
     // for appropriate spacing and other css

--- a/packages/perseus/src/renderer.old.tsx
+++ b/packages/perseus/src/renderer.old.tsx
@@ -167,7 +167,7 @@ export type Props = Partial<React.ContextType<typeof DependenciesContext>> & {
 type State = {
     translationLintErrors: ReadonlyArray<string>;
     widgetInfo: Readonly<PerseusWidgetsMap>;
-    jiptContent: any;
+    jiptContent: string | null;
 };
 
 type FullLinterContext = LinterContextProps & {

--- a/packages/perseus/src/renderer.old.tsx
+++ b/packages/perseus/src/renderer.old.tsx
@@ -760,10 +760,7 @@ class Renderer
         );
     };
 
-    replaceJiptContent(
-        content: string,
-        paragraphIndex: number | undefined,
-    ): void {
+    replaceJiptContent(content: string, paragraphIndex?: number): void {
         if (paragraphIndex == null) {
             // we're not translating paragraph-wise; replace the whole content
             // (we could also theoretically check for apiOptions.isArticle

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -261,7 +261,7 @@ export type JiptLabelStore = {
 };
 
 export interface JiptRenderer {
-    replaceJiptContent: (content: string, paragraphIndex: number) => void;
+    replaceJiptContent(content: string, paragraphIndex?: number): void;
 }
 
 type JiptTranslationComponents = {


### PR DESCRIPTION
## Summary:
Integrating Perseus with Crowdin's just-in-place translation system requires
some fairly convoluted interactions between Perseus and the frontend app. The
details are documented here:
https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4860248066/JIPT+just-in-place+translation+in+Perseus

This PR adds tests to ensure we don't break JIPT as we change the Renderer.

Issue: LEMS-4281

## Test plan:

Tests should pass on CI. Review the snapshots.