### PR TITLE
Make fields required in ImageWidget schema, and default them in the parsers

### DIFF
--- a/.changeset/thick-squids-poke.md
+++ b/.changeset/thick-squids-poke.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-core": major
+"@khanacademy/perseus": major
+---
+
+Make all options of the image widget required. Perseus consumers should, as always, use the parsers to upgrade data to the latest schema.

--- a/packages/perseus-core/src/accessibility.test.ts
+++ b/packages/perseus-core/src/accessibility.test.ts
@@ -129,7 +129,7 @@ describe("isItemAccessible", () => {
                     content: "Here's an image: [[☃ image 1]]",
                     widgets: {
                         "image 1": generateImageWidget({
-                            options: {
+                            options: generateImageOptions({
                                 backgroundImage: {
                                     url: "https://example.com/image.png",
                                     width: 400,
@@ -137,7 +137,7 @@ describe("isItemAccessible", () => {
                                 },
                                 // No alt text makes this image inaccessible
                                 alt: "",
-                            },
+                            }),
                         }),
                     },
                 }),

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -890,11 +890,13 @@ export type PerseusImageWidgetOptions = {
      * but still appear in old content.
      */
     labels: Array<PerseusImageLabel>;
-    /** @deprecated - range for labels was removed from the image widget editor
+    /**
+     * @deprecated - range for labels was removed from the image widget editor
      * in 2017, but still appears in old content.
      */
     range: [Interval, Interval];
-    /** @deprecated - box for labels was removed from the image widget editor
+    /**
+     * @deprecated - box for labels was removed from the image widget editor
      * in 2017, but still appears in old content.
      */
     box: Size;

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -889,15 +889,15 @@ export type PerseusImageWidgetOptions = {
      * @deprecated - labels were removed from the image widget editor in 2017,
      * but still appear in old content.
      */
-    labels?: Array<PerseusImageLabel>;
+    labels: Array<PerseusImageLabel>;
     /** @deprecated - range for labels was removed from the image widget editor
      * in 2017, but still appears in old content.
      */
-    range?: [Interval, Interval];
+    range: [Interval, Interval];
     /** @deprecated - box for labels was removed from the image widget editor
      * in 2017, but still appears in old content.
      */
-    box?: Size;
+    box: Size;
 };
 
 export type PerseusImageLabel = {

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -869,29 +869,34 @@ export type PerseusGroupWidgetOptions = PerseusRenderer;
 /** Options for the image widget. Shows an image with a caption and alt text. */
 export type PerseusImageWidgetOptions = {
     /** Translatable Markdown; Text to be shown for the title of the image */
-    title?: string;
+    title: string;
     /** Translatable Markdown; Text to be shown in the caption section of an image */
-    caption?: string;
+    caption: string;
     /** Translatable Text; The alt text to be shown in the img.alt attribute */
-    alt?: string;
+    alt: string;
     /** Translatable Markdown; Text to be shown as the long description of an image */
-    longDescription?: string;
+    longDescription: string;
     /**
      * When true, standalone image will be rendered with alt="" and without any alt
      * text, caption, title, or long description.
      */
-    decorative?: boolean;
+    decorative: boolean;
     /** The image details for the image to be displayed */
     backgroundImage: PerseusImageBackground;
     /** The size scale of the image */
-    scale?: number;
-    /** Always false. Not used for this widget */
-    static?: boolean;
-    /** @deprecated - labels were removed from the image widget in 2017 */
+    scale: number;
+    /**
+     * @deprecated - labels were removed from the image widget editor in 2017,
+     * but still appear in old content.
+     */
     labels?: Array<PerseusImageLabel>;
-    /** @deprecated - range for labels was removed from the image widget in 2017 */
+    /** @deprecated - range for labels was removed from the image widget editor
+     * in 2017, but still appears in old content.
+     */
     range?: [Interval, Interval];
-    /** @deprecated - box for labels was removed from the image widget in 2017 */
+    /** @deprecated - box for labels was removed from the image widget editor
+     * in 2017, but still appears in old content.
+     */
     box?: Size;
 };
 

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/image-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/image-widget.ts
@@ -2,9 +2,9 @@ import {
     array,
     boolean,
     constant,
+    defaulted,
     number,
     object,
-    optional,
     pair,
     string,
 } from "../general-purpose-parsers";
@@ -17,15 +17,14 @@ const pairOfNumbers = pair(number, number);
 export const parseImageWidget = parseWidget(
     constant("image"),
     object({
-        title: optional(string),
-        caption: optional(string),
-        alt: optional(string),
-        longDescription: optional(string),
-        decorative: optional(boolean),
+        title: defaulted(string, () => ""),
+        caption: defaulted(string, () => ""),
+        alt: defaulted(string, () => ""),
+        longDescription: defaulted(string, () => ""),
+        decorative: defaulted(boolean, () => false),
         backgroundImage: parsePerseusImageBackground,
-        scale: optional(number),
-        static: optional(boolean),
-        labels: optional(
+        scale: defaulted(number, () => 1),
+        labels: defaulted(
             array(
                 object({
                     content: string,
@@ -33,8 +32,15 @@ export const parseImageWidget = parseWidget(
                     coordinates: array(number),
                 }),
             ),
+            () => [],
         ),
-        range: optional(pair(pairOfNumbers, pairOfNumbers)),
-        box: optional(pairOfNumbers),
+        range: defaulted(
+            pair(pairOfNumbers, pairOfNumbers),
+            (): [[number, number], [number, number]] => [
+                [0, 10],
+                [0, 10],
+            ],
+        ),
+        box: defaulted(pairOfNumbers, (): [number, number] => [400, 400]),
     }),
 );

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -383,7 +383,10 @@ describe("parseWidgetsMap", () => {
                     decorative: true,
                     labels: [],
                     longDescription: "the long description",
-                    range: [[0, 1], [2, 3]],
+                    range: [
+                        [0, 1],
+                        [2, 3],
+                    ],
                     scale: 7,
                     title: "the title",
                 },

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -376,7 +376,16 @@ describe("parseWidgetsMap", () => {
                 type: "image",
                 version: {major: 0, minor: 0},
                 options: {
+                    alt: "the alt text",
                     backgroundImage: {},
+                    box: [1, 2],
+                    caption: "the caption",
+                    decorative: true,
+                    labels: [],
+                    longDescription: "the long description",
+                    range: [[0, 1], [2, 3]],
+                    scale: 7,
+                    title: "the title",
                 },
             },
         };

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -69,7 +69,9 @@ Whether or not we have specific numbers, conceptually we can measure the opportu
             281,
           ],
           "caption": "This production possibilities frontier shows a tradeoff between devoting social resources to healthcare and devoting them to education. At A all resources go to healthcare and at B, most go to healthcare. At D most resources go to education, and at F, all go to education.",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -80,7 +82,7 @@ Whether or not we have specific numbers, conceptually we can measure the opportu
               10,
             ],
           ],
-          "static": false,
+          "scale": 1,
           "title": "A Healthcare vs. Education Production Possibilities Frontier ",
         },
         "static": false,
@@ -146,7 +148,9 @@ The particular mix of goods and services being produced—that is, the specific 
             313,
           ],
           "caption": "Productive efficiency means it is impossible to produce more of one good without decreasing the quantity that is produced of another good. Thus, all choices along a given PPF like B, C, and D display productive efficiency, but R does not. Allocative efficiency means that the particular mix of goods being produced—that is, the specific choice along the production possibilities frontier—represents the allocation that society most desires.",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -157,7 +161,7 @@ The particular mix of goods and services being produced—that is, the specific 
               10,
             ],
           ],
-          "static": false,
+          "scale": 1,
           "title": "Productive and Allocative Efficiency ",
         },
         "static": false,
@@ -208,7 +212,9 @@ The slope of the PPF gives the opportunity cost of producing an additional unit 
             401,
           ],
           "caption": "The U.S. PPF is flatter than the Brazil PPF implying that the opportunity cost of wheat in term of sugar cane is lower in the U.S. than in Brazil. Conversely, the opportunity cost of sugar cane is lower in Brazil. The U.S. has comparative advantage in wheat and Brazil has comparative advantage in sugar cane.",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -219,7 +225,7 @@ The slope of the PPF gives the opportunity cost of producing an additional unit 
               10,
             ],
           ],
-          "static": false,
+          "scale": 1,
           "title": "Production Possibility Frontier for the U.S. and Brazil ",
         },
         "static": false,
@@ -332,7 +338,9 @@ Both the budget constraint and the PPF show the constraint that each operates un
             313,
           ],
           "caption": "Productive efficiency means it is impossible to produce more of one good without decreasing the quantity that is produced of another good. Thus, all choices along a given PPF like B, C, and D display productive efficiency, but R does not. Allocative efficiency means that the particular mix of goods being produced—that is, the specific choice along the production possibilities frontier—represents the allocation that society most desires.",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -343,7 +351,7 @@ Both the budget constraint and the PPF show the constraint that each operates un
               10,
             ],
           ],
-          "static": false,
+          "scale": 1,
           "title": "Productive and Allocative Efficiency ",
         },
         "static": false,
@@ -2483,7 +2491,9 @@ more explanation",
             233,
           ],
           "caption": "*Incandescent light bulbs with tungsten filaments*",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -2494,7 +2504,7 @@ more explanation",
               10,
             ],
           ],
-          "static": false,
+          "scale": 1,
           "title": "",
         },
         "static": false,
@@ -2653,7 +2663,9 @@ more explanation",
             233,
           ],
           "caption": "*Incandescent light bulbs with tungsten filaments*",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -2665,7 +2677,6 @@ more explanation",
             ],
           ],
           "scale": 1,
-          "static": false,
           "title": "",
         },
         "static": false,
@@ -3937,6 +3948,7 @@ exports[`parseAndMigratePerseusItem given iframe-missing-allowFullScreen.ts retu
         "image 1": {
           "graded": true,
           "options": {
+            "alt": "",
             "backgroundImage": {
               "height": 215,
               "url": "https://s3.amazonaws.com/ka-cs-algorithms/hanoi_exercise_step2_1.png",
@@ -3946,7 +3958,10 @@ exports[`parseAndMigratePerseusItem given iframe-missing-allowFullScreen.ts retu
               304,
               215,
             ],
+            "caption": "",
+            "decorative": false,
             "labels": [],
+            "longDescription": "",
             "range": [
               [
                 0,
@@ -3957,6 +3972,8 @@ exports[`parseAndMigratePerseusItem given iframe-missing-allowFullScreen.ts retu
                 10,
               ],
             ],
+            "scale": 1,
+            "title": "",
           },
           "type": "image",
           "version": {
@@ -4226,6 +4243,122 @@ exports[`parseAndMigratePerseusItem given iframe-missing-static.ts returns the s
 }
 `;
 
+exports[`parseAndMigratePerseusItem given image-missing-defaulted-fields.ts returns the same result as before 1`] = `
+{
+  "answerArea": {
+    "calculator": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTimeToPayOff": false,
+    "financialCalculatorTotalAmount": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+  },
+  "hints": [],
+  "question": {
+    "content": "[[☃ image 1]]",
+    "images": {},
+    "metadata": null,
+    "widgets": {
+      "image 1": {
+        "alignment": "block",
+        "graded": true,
+        "key": null,
+        "options": {
+          "alt": "",
+          "backgroundImage": {
+            "url": null,
+          },
+          "box": [
+            400,
+            400,
+          ],
+          "caption": "",
+          "decorative": false,
+          "labels": [],
+          "longDescription": "",
+          "range": [
+            [
+              0,
+              10,
+            ],
+            [
+              0,
+              10,
+            ],
+          ],
+          "scale": 1,
+          "title": "",
+        },
+        "static": false,
+        "type": "image",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`parseAndMigratePerseusItem given image-missing-defaulted-fields.ts returns the same result as before with answer information removed 1`] = `
+{
+  "answerArea": {
+    "calculator": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTimeToPayOff": false,
+    "financialCalculatorTotalAmount": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+  },
+  "hints": [],
+  "question": {
+    "content": "[[☃ image 1]]",
+    "images": {},
+    "metadata": null,
+    "widgets": {
+      "image 1": {
+        "alignment": "block",
+        "graded": true,
+        "key": null,
+        "options": {
+          "alt": "",
+          "backgroundImage": {
+            "url": null,
+          },
+          "box": [
+            400,
+            400,
+          ],
+          "caption": "",
+          "decorative": false,
+          "labels": [],
+          "longDescription": "",
+          "range": [
+            [
+              0,
+              10,
+            ],
+            [
+              0,
+              10,
+            ],
+          ],
+          "scale": 1,
+          "title": "",
+        },
+        "static": false,
+        "type": "image",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`parseAndMigratePerseusItem given image-with-null-dimensions.ts returns the same result as before 1`] = `
 {
   "answerArea": {
@@ -4270,7 +4403,9 @@ exports[`parseAndMigratePerseusItem given image-with-null-dimensions.ts returns 
               325,
             ],
             "caption": "",
+            "decorative": false,
             "labels": [],
+            "longDescription": "",
             "range": [
               [
                 0,
@@ -4281,7 +4416,7 @@ exports[`parseAndMigratePerseusItem given image-with-null-dimensions.ts returns 
                 10,
               ],
             ],
-            "static": false,
+            "scale": 1,
             "title": "",
           },
           "static": false,
@@ -4319,7 +4454,9 @@ exports[`parseAndMigratePerseusItem given image-with-null-dimensions.ts returns 
               325,
             ],
             "caption": "",
+            "decorative": false,
             "labels": [],
+            "longDescription": "",
             "range": [
               [
                 0,
@@ -4330,7 +4467,7 @@ exports[`parseAndMigratePerseusItem given image-with-null-dimensions.ts returns 
                 10,
               ],
             ],
-            "static": false,
+            "scale": 1,
             "title": "",
           },
           "static": false,
@@ -4368,7 +4505,9 @@ exports[`parseAndMigratePerseusItem given image-with-null-dimensions.ts returns 
               325,
             ],
             "caption": "",
+            "decorative": false,
             "labels": [],
+            "longDescription": "",
             "range": [
               [
                 0,
@@ -4379,7 +4518,7 @@ exports[`parseAndMigratePerseusItem given image-with-null-dimensions.ts returns 
                 10,
               ],
             ],
-            "static": false,
+            "scale": 1,
             "title": "",
           },
           "static": false,
@@ -4424,7 +4563,9 @@ exports[`parseAndMigratePerseusItem given image-with-null-dimensions.ts returns 
             325,
           ],
           "caption": "",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -4435,7 +4576,7 @@ exports[`parseAndMigratePerseusItem given image-with-null-dimensions.ts returns 
               10,
             ],
           ],
-          "static": false,
+          "scale": 1,
           "title": "",
         },
         "static": false,
@@ -4563,7 +4704,9 @@ exports[`parseAndMigratePerseusItem given image-with-null-dimensions.ts returns 
             325,
           ],
           "caption": "",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -4575,7 +4718,6 @@ exports[`parseAndMigratePerseusItem given image-with-null-dimensions.ts returns 
             ],
           ],
           "scale": 1,
-          "static": false,
           "title": "",
         },
         "static": false,
@@ -9851,7 +9993,9 @@ As we can see the direction of the vertical component is downwards $(\\downarrow
               151,
             ],
             "caption": "",
+            "decorative": false,
             "labels": [],
+            "longDescription": "",
             "range": [
               [
                 0,
@@ -9862,7 +10006,7 @@ As we can see the direction of the vertical component is downwards $(\\downarrow
                 10,
               ],
             ],
-            "static": false,
+            "scale": 1,
             "title": "",
           },
           "static": false,
@@ -9919,7 +10063,9 @@ $\\begin{align}
                     156,
                   ],
                   "caption": "",
+                  "decorative": false,
                   "labels": [],
+                  "longDescription": "",
                   "range": [
                     [
                       0,
@@ -9930,7 +10076,7 @@ $\\begin{align}
                       10,
                     ],
                   ],
-                  "static": false,
+                  "scale": 1,
                   "title": "",
                 },
                 "static": false,
@@ -11686,7 +11832,9 @@ ___
             600,
           ],
           "caption": "",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -11697,7 +11845,7 @@ ___
               10,
             ],
           ],
-          "static": false,
+          "scale": 1,
           "title": "",
         },
         "static": false,
@@ -11845,7 +11993,9 @@ ___
             600,
           ],
           "caption": "",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -11857,7 +12007,6 @@ ___
             ],
           ],
           "scale": 1,
-          "static": false,
           "title": "",
         },
         "static": false,
@@ -15468,6 +15617,7 @@ exports[`parseAndMigratePerseusItem given numeric-input-missing-labelText.ts ret
         "image 1": {
           "graded": true,
           "options": {
+            "alt": "",
             "backgroundImage": {
               "height": 0,
               "url": null,
@@ -15478,7 +15628,9 @@ exports[`parseAndMigratePerseusItem given numeric-input-missing-labelText.ts ret
               400,
             ],
             "caption": "",
+            "decorative": false,
             "labels": [],
+            "longDescription": "",
             "range": [
               [
                 0,
@@ -15489,6 +15641,7 @@ exports[`parseAndMigratePerseusItem given numeric-input-missing-labelText.ts ret
                 10,
               ],
             ],
+            "scale": 1,
             "title": "",
           },
           "type": "image",
@@ -15943,7 +16096,9 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-null-answerForms.ts
               275,
             ],
             "caption": "",
+            "decorative": false,
             "labels": [],
+            "longDescription": "",
             "range": [
               [
                 0,
@@ -15954,7 +16109,7 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-null-answerForms.ts
                 10,
               ],
             ],
-            "static": false,
+            "scale": 1,
             "title": "",
           },
           "static": false,
@@ -15992,7 +16147,9 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-null-answerForms.ts
               275,
             ],
             "caption": "",
+            "decorative": false,
             "labels": [],
+            "longDescription": "",
             "range": [
               [
                 0,
@@ -16003,7 +16160,7 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-null-answerForms.ts
                 10,
               ],
             ],
-            "static": false,
+            "scale": 1,
             "title": "",
           },
           "static": false,
@@ -16041,7 +16198,9 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-null-answerForms.ts
               275,
             ],
             "caption": "",
+            "decorative": false,
             "labels": [],
+            "longDescription": "",
             "range": [
               [
                 0,
@@ -16052,7 +16211,7 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-null-answerForms.ts
                 10,
               ],
             ],
-            "static": false,
+            "scale": 1,
             "title": "",
           },
           "static": false,
@@ -16118,7 +16277,9 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-null-answerForms.ts
             275,
           ],
           "caption": "",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -16129,7 +16290,7 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-null-answerForms.ts
               10,
             ],
           ],
-          "static": false,
+          "scale": 1,
           "title": "",
         },
         "static": false,
@@ -16345,7 +16506,9 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-null-answerForms.ts
             275,
           ],
           "caption": "",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -16357,7 +16520,6 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-null-answerForms.ts
             ],
           ],
           "scale": 1,
-          "static": false,
           "title": "",
         },
         "static": false,
@@ -16541,7 +16703,9 @@ We are given the measure of an angle and the length of the $\\purpleC{\\text{hyp
               252,
             ],
             "caption": "",
+            "decorative": false,
             "labels": [],
+            "longDescription": "",
             "range": [
               [
                 0,
@@ -16552,7 +16716,7 @@ We are given the measure of an angle and the length of the $\\purpleC{\\text{hyp
                 10,
               ],
             ],
-            "static": false,
+            "scale": 1,
             "title": "",
           },
           "static": false,
@@ -16615,7 +16779,9 @@ Stella landed $1.68$ kilometers from the skydiving center.",
             270,
           ],
           "caption": "",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -16626,7 +16792,7 @@ Stella landed $1.68$ kilometers from the skydiving center.",
               10,
             ],
           ],
-          "static": false,
+          "scale": 1,
           "title": "",
         },
         "static": false,
@@ -16758,7 +16924,9 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-simplify-accepted.t
             270,
           ],
           "caption": "",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -16770,7 +16938,6 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-simplify-accepted.t
             ],
           ],
           "scale": 1,
-          "static": false,
           "title": "",
         },
         "static": false,
@@ -18432,7 +18599,9 @@ A free body diagram of the **box** is shown below.
             263,
           ],
           "caption": "",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -18443,7 +18612,7 @@ A free body diagram of the **box** is shown below.
               10,
             ],
           ],
-          "static": false,
+          "scale": 1,
           "title": "",
         },
         "static": false,
@@ -18468,7 +18637,9 @@ A free body diagram of the **box** is shown below.
             306,
           ],
           "caption": "",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -18479,7 +18650,7 @@ A free body diagram of the **box** is shown below.
               10,
             ],
           ],
-          "static": false,
+          "scale": 1,
           "title": "",
         },
         "static": false,
@@ -18632,7 +18803,9 @@ A free body diagram of the **box** is shown below.
             263,
           ],
           "caption": "",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -18644,7 +18817,6 @@ A free body diagram of the **box** is shown below.
             ],
           ],
           "scale": 1,
-          "static": false,
           "title": "",
         },
         "static": false,
@@ -18669,7 +18841,9 @@ A free body diagram of the **box** is shown below.
             306,
           ],
           "caption": "",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -18681,7 +18855,6 @@ A free body diagram of the **box** is shown below.
             ],
           ],
           "scale": 1,
-          "static": false,
           "title": "",
         },
         "static": false,
@@ -20718,7 +20891,9 @@ exports[`parseAndMigratePerseusItem given radio-with-extra-fields-from-go-schema
             3448,
           ],
           "caption": "",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -20729,7 +20904,7 @@ exports[`parseAndMigratePerseusItem given radio-with-extra-fields-from-go-schema
               10,
             ],
           ],
-          "static": false,
+          "scale": 1,
           "title": "",
         },
         "static": false,
@@ -20932,7 +21107,9 @@ exports[`parseAndMigratePerseusItem given radio-with-extra-fields-from-go-schema
             3448,
           ],
           "caption": "",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -20944,7 +21121,6 @@ exports[`parseAndMigratePerseusItem given radio-with-extra-fields-from-go-schema
             ],
           ],
           "scale": 1,
-          "static": false,
           "title": "",
         },
         "static": false,
@@ -21305,7 +21481,9 @@ ___
             782,
           ],
           "caption": "",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -21316,7 +21494,7 @@ ___
               10,
             ],
           ],
-          "static": false,
+          "scale": 1,
           "title": "",
         },
         "static": false,
@@ -21476,7 +21654,9 @@ ___
             782,
           ],
           "caption": "",
+          "decorative": false,
           "labels": [],
+          "longDescription": "",
           "range": [
             [
               0,
@@ -21488,7 +21668,6 @@ ___
             ],
           ],
           "scale": 1,
-          "static": false,
           "title": "",
         },
         "static": false,

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -4257,7 +4257,6 @@ exports[`parseAndMigratePerseusItem given image-missing-defaulted-fields.ts retu
   "question": {
     "content": "[[☃ image 1]]",
     "images": {},
-    "metadata": null,
     "widgets": {
       "image 1": {
         "alignment": "block",
@@ -4315,7 +4314,6 @@ exports[`parseAndMigratePerseusItem given image-missing-defaulted-fields.ts retu
   "question": {
     "content": "[[☃ image 1]]",
     "images": {},
-    "metadata": null,
     "widgets": {
       "image 1": {
         "alignment": "block",

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/image-missing-defaulted-fields.ts
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/image-missing-defaulted-fields.ts
@@ -1,0 +1,28 @@
+// WARNING: Do not change or delete this file! If you do, Perseus might become
+// unable to parse the current data format, which will break clients.
+// If you need to add more regression tests, add a new file to this directory.
+export default {
+    question: {
+        content: "[[☃ image 1]]",
+        widgets: {
+            "image 1": {
+                type: "image",
+                static: false,
+                graded: true,
+                alignment: "block",
+                id: null,
+                key: null,
+                version: {
+                    major: 0,
+                    minor: 0,
+                },
+                options: {
+                    backgroundImage: {url: null},
+                },
+            },
+        },
+        replace: null,
+        metadata: null,
+        images: {},
+    },
+};

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/image-missing-defaulted-fields.ts
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/image-missing-defaulted-fields.ts
@@ -21,8 +21,6 @@ export default {
                 },
             },
         },
-        replace: null,
-        metadata: null,
         images: {},
     },
 };

--- a/packages/perseus-core/src/utils/extract-perseus-ai-data.test.ts
+++ b/packages/perseus-core/src/utils/extract-perseus-ai-data.test.ts
@@ -1,5 +1,7 @@
 import {describe, it, expect} from "@jest/globals";
 
+import {generateImageOptions} from "@khanacademy/perseus-core";
+
 import {
     getAnswersFromWidgets,
     getPerseusAIData,
@@ -346,14 +348,14 @@ describe("injectWidgets", () => {
         const widgets: PerseusWidgetsMap = {
             "image 1": {
                 type: "image",
-                options: {
+                options: generateImageOptions({
                     alt: "image alt text",
                     backgroundImage: {
                         url: "",
                         width: 100,
                         height: 100,
                     },
-                },
+                }),
             },
         } as const;
         const content = injectWidgets(

--- a/packages/perseus-core/src/utils/extract-perseus-ai-data.test.ts
+++ b/packages/perseus-core/src/utils/extract-perseus-ai-data.test.ts
@@ -1,7 +1,5 @@
 import {describe, it, expect} from "@jest/globals";
 
-import {generateImageOptions} from "@khanacademy/perseus-core";
-
 import {
     getAnswersFromWidgets,
     getPerseusAIData,
@@ -24,6 +22,7 @@ import {
     generateGradedGroupOptions,
     generateGradedGroupWidget,
 } from "./generators/graded-group-widget-generator";
+import {generateImageOptions} from "./generators/image-widget-generator";
 import {
     generateInputNumberAnswer,
     generateInputNumberOptions,

--- a/packages/perseus-core/src/utils/generators/image-widget-generator.test.ts
+++ b/packages/perseus-core/src/utils/generators/image-widget-generator.test.ts
@@ -50,9 +50,15 @@ describe("generateImageWidget", () => {
         expect(widget.options).toEqual({
             alt: "",
             backgroundImage: {},
+            box: [400, 400],
             caption: "",
             decorative: false,
+            labels: [],
             longDescription: "",
+            range: [
+                [0, 10],
+                [0, 10],
+            ],
             scale: 1,
             title: "",
         });

--- a/packages/perseus-core/src/utils/generators/image-widget-generator.test.ts
+++ b/packages/perseus-core/src/utils/generators/image-widget-generator.test.ts
@@ -9,9 +9,9 @@ describe("generateImageOptions", () => {
     test("builds a default image options", () => {
         const options: PerseusImageWidgetOptions = generateImageOptions();
 
-        expect(options.title).toBe(undefined);
-        expect(options.caption).toBe(undefined);
-        expect(options.alt).toBe(undefined);
+        expect(options.title).toBe("");
+        expect(options.caption).toBe("");
+        expect(options.alt).toBe("");
         expect(options.backgroundImage).toEqual({});
     });
 
@@ -39,7 +39,7 @@ describe("generateImageOptions", () => {
 });
 
 describe("generateImageWidget", () => {
-    test("builds a default image widget", () => {
+    it("builds a default image widget", () => {
         const widget: ImageWidget = generateImageWidget();
 
         expect(widget.type).toBe("image");
@@ -47,26 +47,20 @@ describe("generateImageWidget", () => {
         expect(widget.static).toBe(false);
         expect(widget.version).toEqual({major: 0, minor: 0});
         expect(widget.alignment).toBe("default");
-        expect(widget.options).toEqual({backgroundImage: {}});
+        expect(widget.options).toEqual({
+            alt: "",
+            backgroundImage: {},
+            caption: "",
+            decorative: false,
+            longDescription: "",
+            scale: 1,
+            title: "",
+        });
     });
 
-    test("builds an image widget with all props", () => {
+    it("lets you override the defaults", () => {
         const widget: ImageWidget = generateImageWidget({
             graded: false,
-            version: {major: 1, minor: 0},
-            static: true,
-            alignment: "block",
-            options: {backgroundImage: {url: "image.png"}},
-        });
-
-        expect(widget.static).toBe(true);
-        expect(widget.graded).toBe(false);
-        expect(widget.alignment).toBe("block");
-        expect(widget.options).toEqual({backgroundImage: {url: "image.png"}});
-    });
-
-    test("adds options when option builder is used", () => {
-        const widget: ImageWidget = generateImageWidget({
             static: true,
             alignment: "block",
             options: generateImageOptions({
@@ -81,6 +75,7 @@ describe("generateImageWidget", () => {
             }),
         });
 
+        expect(widget.graded).toBe(false);
         expect(widget.static).toBe(true);
         expect(widget.alignment).toBe("block");
         expect(widget.options.title).toBe("the title");

--- a/packages/perseus-core/src/utils/generators/image-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/image-widget-generator.ts
@@ -3,7 +3,7 @@ import type {ImageWidget, PerseusImageWidgetOptions} from "../../data-schema";
 export function generateImageOptions(
     options?: Partial<PerseusImageWidgetOptions>,
 ): PerseusImageWidgetOptions {
-    return {
+    const defaultImageOptions: PerseusImageWidgetOptions = {
         title: "",
         caption: "",
         alt: "",
@@ -17,6 +17,10 @@ export function generateImageOptions(
             [0, 10],
             [0, 10],
         ],
+    };
+
+    return {
+        ...defaultImageOptions,
         ...options,
     };
 }

--- a/packages/perseus-core/src/utils/generators/image-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/image-widget-generator.ts
@@ -11,6 +11,12 @@ export function generateImageOptions(
         decorative: false,
         backgroundImage: {},
         scale: 1,
+        box: [400, 400],
+        labels: [],
+        range: [
+            [0, 10],
+            [0, 10],
+        ],
         ...options,
     };
 }

--- a/packages/perseus-core/src/utils/generators/image-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/image-widget-generator.ts
@@ -1,14 +1,16 @@
-import type {PerseusImageWidgetOptions, ImageWidget} from "../../data-schema";
+import type {ImageWidget, PerseusImageWidgetOptions} from "../../data-schema";
 
 export function generateImageOptions(
     options?: Partial<PerseusImageWidgetOptions>,
 ): PerseusImageWidgetOptions {
-    const defaultImageOptions: PerseusImageWidgetOptions = {
-        backgroundImage: {},
-    };
-
     return {
-        ...defaultImageOptions,
+        title: "",
+        caption: "",
+        alt: "",
+        longDescription: "",
+        decorative: false,
+        backgroundImage: {},
+        scale: 1,
         ...options,
     };
 }

--- a/packages/perseus-core/src/widgets/image/image.test.ts
+++ b/packages/perseus-core/src/widgets/image/image.test.ts
@@ -1,3 +1,5 @@
+import {generateImageOptions} from "@khanacademy/perseus-core";
+
 import type {PerseusImageWidgetOptions} from "../../data-schema";
 
 import imageWidgetLogic from "./index";
@@ -10,88 +12,58 @@ describe("image widget accessible logic", () => {
         throw new Error("accessible function not defined");
     };
 
-    it("should be accessible if background has 'alt' text", () => {
-        const options: PerseusImageWidgetOptions = {
-            title: "",
-            range: [
-                [0, 10],
-                [0, 10],
-            ],
-            box: [400, 400],
+    it("should be accessible if background has 'alt' text and not decorative", () => {
+        const options: PerseusImageWidgetOptions = generateImageOptions({
             backgroundImage: {
                 url: "https://example.com/image.png",
                 width: 400,
                 height: 400,
             },
-            labels: [],
             alt: "A meaningful description",
-            caption: "",
-        };
+            decorative: false,
+        });
 
         expect(runAccessible(options)).toBe(true);
     });
 
     it("should be inaccessible if background has no 'alt' text and not decorative", () => {
-        const options: PerseusImageWidgetOptions = {
-            title: "",
-            range: [
-                [0, 10],
-                [0, 10],
-            ],
-            box: [400, 400],
+        const options: PerseusImageWidgetOptions = generateImageOptions({
             backgroundImage: {
                 url: "https://example.com/image.png",
                 width: 400,
                 height: 400,
             },
-            labels: [],
             alt: "",
-            caption: "",
             decorative: false,
-        };
+        });
 
         expect(runAccessible(options)).toBe(false);
     });
 
     it("should be accessible if background has no 'alt' text but is decorative", () => {
-        const options: PerseusImageWidgetOptions = {
-            title: "",
-            range: [
-                [0, 10],
-                [0, 10],
-            ],
-            box: [400, 400],
+        const options: PerseusImageWidgetOptions = generateImageOptions({
             backgroundImage: {
                 url: "https://example.com/image.png",
                 width: 400,
                 height: 400,
             },
-            labels: [],
             alt: "",
-            caption: "",
             decorative: true,
-        };
+        });
 
         expect(runAccessible(options)).toBe(true);
     });
 
     it("should be inaccessible if no background image even with alt text", () => {
-        const options: PerseusImageWidgetOptions = {
-            title: "",
-            range: [
-                [0, 10],
-                [0, 10],
-            ],
-            box: [400, 400],
+        const options: PerseusImageWidgetOptions = generateImageOptions({
             backgroundImage: {
                 url: null,
                 width: 0,
                 height: 0,
             },
-            labels: [],
             alt: "A meaningful description",
-            caption: "",
-        };
+            decorative: true,
+        });
 
         expect(runAccessible(options)).toBe(false);
     });

--- a/packages/perseus-core/src/widgets/image/image.test.ts
+++ b/packages/perseus-core/src/widgets/image/image.test.ts
@@ -1,4 +1,4 @@
-import {generateImageOptions} from "@khanacademy/perseus-core";
+import {generateImageOptions} from "../../utils/generators/image-widget-generator";
 
 import type {PerseusImageWidgetOptions} from "../../data-schema";
 

--- a/packages/perseus-core/src/widgets/image/index.ts
+++ b/packages/perseus-core/src/widgets/image/index.ts
@@ -49,7 +49,7 @@ const imageWidgetLogic: WidgetLogic<PerseusImageWidgetOptions> = {
         // - has background image and decorative is true
         const hasBackgroundImage = bgImage.url != null;
         const hasAltText = !!widgetOptions.alt;
-        const isDecorative = widgetOptions.decorative === true;
+        const isDecorative = widgetOptions.decorative;
 
         return hasBackgroundImage && (hasAltText || isDecorative);
     },

--- a/packages/perseus-editor/src/__testdata__/all-widgets.testdata.ts
+++ b/packages/perseus-editor/src/__testdata__/all-widgets.testdata.ts
@@ -17,6 +17,7 @@ import {
     generateGroupWidget,
     generateIGLinearGraph,
     generateIGLockedPoint,
+    generateImageOptions,
     generateImageWidget,
     generateInteractiveGraphOptions,
     generateInteractiveGraphWidget,
@@ -176,7 +177,7 @@ export const comprehensiveQuestion: PerseusRenderer = {
             }),
         }),
         "image 1": generateImageWidget({
-            options: {
+            options: generateImageOptions({
                 backgroundImage: {
                     url: "https://ka-perseus-images.s3.amazonaws.com/sample-diagram.png",
                     width: 300,
@@ -189,7 +190,7 @@ export const comprehensiveQuestion: PerseusRenderer = {
                         alignment: "center",
                     },
                 ],
-            },
+            }),
         }),
         "table 1": {
             graded: true,

--- a/packages/perseus-editor/src/__testdata__/article-renderer.testdata.ts
+++ b/packages/perseus-editor/src/__testdata__/article-renderer.testdata.ts
@@ -1,3 +1,5 @@
+import {generateImageOptions} from "@khanacademy/perseus-core";
+
 import type {PerseusRenderer} from "@khanacademy/perseus-core";
 
 export const articleWithImages: PerseusRenderer = {
@@ -10,8 +12,7 @@ export const articleWithImages: PerseusRenderer = {
             alignment: "block",
             static: false,
             graded: true,
-            options: {
-                static: false,
+            options: generateImageOptions({
                 title: "",
                 range: [
                     [0, 10],
@@ -27,7 +28,7 @@ export const articleWithImages: PerseusRenderer = {
                 alt: "From space, the sun appears over Earth's horizon, illuminating the atmosphere as a blue layer above Earth. Above the atmosphere, space appears black.",
                 caption:
                     "*Sunrise photo from the International Space Station. Earth's atmosphere scatters electromagnetic radiation from the sun, producing a bright sky during the day.*",
-            },
+            }),
             version: {
                 major: 0,
                 minor: 0,
@@ -38,8 +39,7 @@ export const articleWithImages: PerseusRenderer = {
             alignment: "block",
             static: false,
             graded: true,
-            options: {
-                static: false,
+            options: generateImageOptions({
                 title: "",
                 range: [
                     [0, 10],
@@ -54,7 +54,7 @@ export const articleWithImages: PerseusRenderer = {
                 labels: [],
                 alt: "An animation shows a blue electric field arrow oscillating up and down. Connected to the base of the electric field arrow is a magnetic field arrow, which oscillates from side to side. The two fields oscillate in unison: when one extends the other extends too, creating a repeating wave pattern.",
                 caption: "",
-            },
+            }),
             version: {
                 major: 0,
                 minor: 0,
@@ -65,8 +65,7 @@ export const articleWithImages: PerseusRenderer = {
             alignment: "block",
             static: false,
             graded: true,
-            options: {
-                static: false,
+            options: generateImageOptions({
                 title: "",
                 range: [
                     [0, 10],
@@ -81,7 +80,7 @@ export const articleWithImages: PerseusRenderer = {
                 labels: [],
                 alt: "A squiggly curve drawn from left to right. The right end of the curve has an arrow point. The curve begins with a small amount of wiggle on the left, which grows in amplitude in the middle and then decreases again on the right. The result is a small wave packet.",
                 caption: "",
-            },
+            }),
             version: {
                 major: 0,
                 minor: 0,

--- a/packages/perseus-editor/src/__tests__/editor.test.tsx
+++ b/packages/perseus-editor/src/__tests__/editor.test.tsx
@@ -4,6 +4,7 @@ import {
     DependenciesContext,
     Util,
 } from "@khanacademy/perseus";
+import {generateImageOptions} from "@khanacademy/perseus-core";
 import {act, fireEvent, render, screen, waitFor} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
@@ -31,13 +32,13 @@ const Harnessed = (props: Partial<PropsFor<typeof Editor>>) => {
                 widgets={{
                     "image 1": {
                         type: "image",
-                        options: {
+                        options: generateImageOptions({
                             backgroundImage: {
                                 url: "http://placekitten.com/200/300",
                                 width: 200,
                                 height: 300,
                             },
-                        },
+                        }),
                     },
                 }}
                 {...props}
@@ -160,11 +161,11 @@ describe("Editor", () => {
                     "image 1": {
                         type: "image",
                         key: undefined,
-                        options: {
+                        options: generateImageOptions({
                             backgroundImage: {
                                 url: "http://placekitten.com/200/300",
                             },
-                        },
+                        }),
                     },
                 }}
             />,
@@ -225,13 +226,13 @@ describe("Editor", () => {
             widgets: {
                 "image 1": {
                     type: "image",
-                    options: {
+                    options: generateImageOptions({
                         backgroundImage: {
                             url: "http://placekitten.com/200/300",
                             width: 200,
                             height: 300,
                         },
-                    },
+                    }),
                 },
             },
         };
@@ -268,13 +269,13 @@ describe("Editor", () => {
         expect(renderer.widgets).toEqual({
             "image 1": {
                 type: "image",
-                options: {
+                options: expect.objectContaining({
                     backgroundImage: {
                         url: "http://placekitten.com/200/300",
                         width: 200,
                         height: 300,
                     },
-                },
+                }),
             },
         });
     });

--- a/packages/perseus-editor/src/diffs/__tests__/__snapshots__/renderer-diff.test.tsx.snap
+++ b/packages/perseus-editor/src/diffs/__tests__/__snapshots__/renderer-diff.test.tsx.snap
@@ -161,6 +161,108 @@ exports[`RendererDiff renders an image widget in the diff view 1`] = `
               style="clear: both;"
             >
               <div
+                class="removed diff-row before"
+              >
+                <div
+                  style="padding-left: 20px;"
+                >
+                  title: 
+                  <span
+                    class="inner-value dark removed"
+                  >
+                    "Original Image"
+                  </span>
+                </div>
+              </div>
+              <div
+                class="added diff-row after"
+              >
+                <div
+                  style="padding-left: 20px;"
+                >
+                  title: 
+                  <span
+                    class="inner-value dark added"
+                  >
+                    "Updated Image"
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div
+              style="clear: both;"
+            >
+              <div
+                class="removed diff-row before"
+              >
+                <div
+                  style="padding-left: 20px;"
+                >
+                  caption: 
+                  <span
+                    class="inner-value dark removed"
+                  >
+                    "This is the original image"
+                  </span>
+                </div>
+              </div>
+              <div
+                class="added diff-row after"
+              >
+                <div
+                  style="padding-left: 20px;"
+                >
+                  caption: 
+                  <span
+                    class="inner-value dark added"
+                  >
+                    "This is the updated image"
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div
+              style="clear: both;"
+            >
+              <div
+                class="removed diff-row before"
+              >
+                <div
+                  style="padding-left: 20px;"
+                >
+                  alt: 
+                  <span
+                    class="inner-value dark removed"
+                  >
+                    "Original image description"
+                  </span>
+                </div>
+              </div>
+              <div
+                class="added diff-row after"
+              >
+                <div
+                  style="padding-left: 20px;"
+                >
+                  alt: 
+                  <span
+                    class="inner-value dark added"
+                  >
+                    "Updated image description"
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div>
+            <div
+              style="clear: both;"
+            >
+              <div
                 class="diff-row before"
               >
                 <div
@@ -288,105 +390,47 @@ exports[`RendererDiff renders an image widget in the diff view 1`] = `
               </div>
             </div>
           </div>
-          <div>
+          <div
+            style="clear: both;"
+          >
             <div
-              style="clear: both;"
+              class="diff-row collapsed before"
             >
               <div
-                class="removed diff-row before"
+                style="padding-left: 20px;"
               >
-                <div
-                  style="padding-left: 20px;"
+                <button
+                  aria-disabled="false"
+                  class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+                  data-kind="secondary"
+                  type="button"
                 >
-                  title: 
                   <span
-                    class="inner-value dark removed"
+                    class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
                   >
-                    "Original Image"
+                    show unmodified
                   </span>
-                </div>
-              </div>
-              <div
-                class="added diff-row after"
-              >
-                <div
-                  style="padding-left: 20px;"
-                >
-                  title: 
-                  <span
-                    class="inner-value dark added"
-                  >
-                    "Updated Image"
-                  </span>
-                </div>
+                </button>
               </div>
             </div>
-          </div>
-          <div>
             <div
-              style="clear: both;"
+              class="diff-row collapsed after"
             >
               <div
-                class="removed diff-row before"
+                style="padding-left: 20px;"
               >
-                <div
-                  style="padding-left: 20px;"
+                <button
+                  aria-disabled="false"
+                  class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1qlmkty-o_O-small_tjsyec"
+                  data-kind="secondary"
+                  type="button"
                 >
-                  caption: 
                   <span
-                    class="inner-value dark removed"
+                    class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf-o_O-text_1kowsup-o_O-smallText_v9nlfb"
                   >
-                    "This is the original image"
+                    show unmodified
                   </span>
-                </div>
-              </div>
-              <div
-                class="added diff-row after"
-              >
-                <div
-                  style="padding-left: 20px;"
-                >
-                  caption: 
-                  <span
-                    class="inner-value dark added"
-                  >
-                    "This is the updated image"
-                  </span>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div>
-            <div
-              style="clear: both;"
-            >
-              <div
-                class="removed diff-row before"
-              >
-                <div
-                  style="padding-left: 20px;"
-                >
-                  alt: 
-                  <span
-                    class="inner-value dark removed"
-                  >
-                    "Original image description"
-                  </span>
-                </div>
-              </div>
-              <div
-                class="added diff-row after"
-              >
-                <div
-                  style="padding-left: 20px;"
-                >
-                  alt: 
-                  <span
-                    class="inner-value dark added"
-                  >
-                    "Updated image description"
-                  </span>
-                </div>
+                </button>
               </div>
             </div>
           </div>

--- a/packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/__tests__/image-editor.test.tsx
@@ -79,6 +79,8 @@ describe("image editor", () => {
                     apiOptions={apiOptions}
                     onChange={() => {}}
                     backgroundImage={backgroundImage}
+                    longDescription={""}
+                    decorative={false}
                 />,
             );
 
@@ -112,6 +114,7 @@ describe("image editor", () => {
                 longDescription="Earth and moon long description"
                 caption="Earth and moon caption"
                 title="Earth and moon title"
+                decorative={false}
                 onChange={() => {}}
             />,
         );
@@ -167,6 +170,8 @@ describe("image editor", () => {
                 apiOptions={apiOptions}
                 backgroundImage={earthMoonImage}
                 onChange={() => {}}
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -220,6 +225,8 @@ describe("image editor", () => {
                 apiOptions={apiOptions}
                 backgroundImage={{}}
                 onChange={onChangeMock}
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -241,6 +248,8 @@ describe("image editor", () => {
                 // frescoImage is very large (1698 x 955)
                 backgroundImage={frescoImage}
                 onChange={() => {}}
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -260,6 +269,8 @@ describe("image editor", () => {
                 // earthMoonImage is small (400 x 225)
                 backgroundImage={earthMoonImage}
                 onChange={() => {}}
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -282,6 +293,8 @@ describe("image editor", () => {
                     backgroundImage={earthMoonImage}
                     alt="Earth and moon alt"
                     onChange={() => {}}
+                    longDescription={""}
+                    decorative={false}
                 />
             </DependenciesContext.Provider>,
         );
@@ -304,6 +317,8 @@ describe("image editor", () => {
                     apiOptions={apiOptions}
                     backgroundImage={earthMoonImage}
                     onChange={() => {}}
+                    longDescription={""}
+                    decorative={false}
                 />
             </DependenciesContext.Provider>,
         );
@@ -325,6 +340,8 @@ describe("image editor", () => {
                 apiOptions={apiOptions}
                 backgroundImage={{}}
                 onChange={onChangeMock}
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -352,6 +369,8 @@ describe("image editor", () => {
             <ImageEditorWithDependencies
                 apiOptions={apiOptions}
                 onChange={onChangeMock}
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -380,6 +399,8 @@ describe("image editor", () => {
                 apiOptions={apiOptions}
                 onChange={onChangeMock}
                 backgroundImage={{url: "abc"}}
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -413,6 +434,8 @@ describe("image editor", () => {
                     height: earthMoonImage.height / 2,
                 }}
                 onChange={onChangeMock}
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -436,6 +459,8 @@ describe("image editor", () => {
                 apiOptions={apiOptions}
                 backgroundImage={earthMoonImage}
                 onChange={onChangeMock}
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -457,6 +482,8 @@ describe("image editor", () => {
                 apiOptions={apiOptions}
                 backgroundImage={earthMoonImage}
                 onChange={onChangeMock}
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -480,6 +507,8 @@ describe("image editor", () => {
                 backgroundImage={earthMoonImage}
                 alt="Earth and moon"
                 onChange={onChangeMock}
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -501,6 +530,8 @@ describe("image editor", () => {
                 apiOptions={apiOptions}
                 backgroundImage={earthMoonImage}
                 onChange={onChangeMock}
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -526,6 +557,7 @@ describe("image editor", () => {
                 backgroundImage={earthMoonImage}
                 longDescription="Earth and moon long description"
                 onChange={onChangeMock}
+                decorative={false}
             />,
         );
 
@@ -549,6 +581,8 @@ describe("image editor", () => {
                 apiOptions={apiOptions}
                 backgroundImage={earthMoonImage}
                 onChange={onChangeMock}
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -572,6 +606,8 @@ describe("image editor", () => {
                 backgroundImage={earthMoonImage}
                 caption="Earth and moon"
                 onChange={onChangeMock}
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -592,6 +628,8 @@ describe("image editor", () => {
                 apiOptions={apiOptions}
                 backgroundImage={earthMoonImage}
                 onChange={onChangeMock}
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -615,6 +653,8 @@ describe("image editor", () => {
                 backgroundImage={earthMoonImage}
                 title="Earth and moon"
                 onChange={onChangeMock}
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -636,6 +676,8 @@ describe("image editor", () => {
                 apiOptions={apiOptions}
                 onChange={onChangeMock}
                 backgroundImage={earthMoonImage}
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -659,6 +701,8 @@ describe("image editor", () => {
                 apiOptions={apiOptions}
                 onChange={onChangeMock}
                 backgroundImage={earthMoonImage}
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -680,6 +724,8 @@ describe("image editor", () => {
                 onChange={onChangeMock}
                 backgroundImage={earthMoonImage}
                 alt="aaa" // Start with short alt text that will trigger error on blur
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -707,6 +753,8 @@ describe("image editor", () => {
                 onChange={() => {}}
                 backgroundImage={earthMoonImage}
                 alt="123456789"
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -722,6 +770,8 @@ describe("image editor", () => {
                 apiOptions={apiOptions}
                 backgroundImage={earthMoonImage}
                 onChange={() => {}}
+                longDescription={""}
+                decorative={false}
             />,
         );
 
@@ -738,6 +788,7 @@ describe("image editor", () => {
                     backgroundImage={earthMoonImage}
                     decorative={true}
                     onChange={() => {}}
+                    longDescription={""}
                 />,
             );
 
@@ -757,6 +808,8 @@ describe("image editor", () => {
                     apiOptions={apiOptions}
                     backgroundImage={earthMoonImage}
                     onChange={onChangeMock}
+                    longDescription={""}
+                    decorative={false}
                 />,
             );
 
@@ -781,6 +834,8 @@ describe("image editor", () => {
                     backgroundImage={earthMoonImage}
                     scale={1}
                     onChange={onChangeMock}
+                    longDescription={""}
+                    decorative={false}
                 />,
             );
 
@@ -813,6 +868,8 @@ describe("image editor", () => {
                     backgroundImage={earthMoonImage}
                     scale={2}
                     onChange={onChangeMock}
+                    longDescription={""}
+                    decorative={false}
                 />,
             );
 
@@ -839,6 +896,8 @@ describe("image editor", () => {
                     backgroundImage={earthMoonImage}
                     scale={1}
                     onChange={onChangeMock}
+                    longDescription={""}
+                    decorative={false}
                 />,
             );
 
@@ -863,6 +922,8 @@ describe("image editor", () => {
                     backgroundImage={earthMoonImage}
                     scale={1}
                     onChange={onChangeMock}
+                    longDescription={""}
+                    decorative={false}
                 />,
             );
 
@@ -889,6 +950,8 @@ describe("image editor", () => {
                     backgroundImage={earthMoonImage}
                     scale={1}
                     onChange={onChangeMock}
+                    longDescription={""}
+                    decorative={false}
                 />,
             );
 
@@ -917,6 +980,8 @@ describe("image editor", () => {
                         backgroundImage={earthMoonImage}
                         scale={1}
                         onChange={onChangeMock}
+                        longDescription={""}
+                        decorative={false}
                     />,
                 );
 
@@ -944,6 +1009,8 @@ describe("image editor", () => {
                         url: earthMoonImage.url,
                     }}
                     onChange={onChangeMock}
+                    longDescription={""}
+                    decorative={false}
                 />,
             );
 
@@ -967,6 +1034,8 @@ describe("image editor", () => {
                     apiOptions={apiOptions}
                     backgroundImage={{url: earthMoonImage.url}}
                     onChange={() => {}}
+                    longDescription={""}
+                    decorative={false}
                 />,
             );
 
@@ -989,6 +1058,8 @@ describe("image editor", () => {
                         height: 0,
                     }}
                     onChange={() => {}}
+                    longDescription={""}
+                    decorative={false}
                 />,
             );
 
@@ -1012,6 +1083,8 @@ describe("image editor", () => {
                         height: earthMoonImage.height,
                     }}
                     onChange={onChangeMock}
+                    longDescription={""}
+                    decorative={false}
                 />,
             );
 
@@ -1035,6 +1108,8 @@ describe("image editor", () => {
                     apiOptions={apiOptions}
                     backgroundImage={earthMoonImage}
                     onChange={() => {}}
+                    longDescription={""}
+                    decorative={false}
                 />,
             );
 

--- a/packages/perseus/src/__testdata__/article-renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/article-renderer.testdata.ts
@@ -2,6 +2,7 @@ import {
     generateExpressionAnswerForm,
     generateExpressionOptions,
     generateExpressionWidget,
+    generateImageOptions,
     generateTestPerseusRenderer,
     type PerseusRenderer,
 } from "@khanacademy/perseus-core";
@@ -16,8 +17,7 @@ export const singleSectionArticle: PerseusRenderer = {
             alignment: "block",
             static: false,
             graded: true,
-            options: {
-                static: false,
+            options: generateImageOptions({
                 title: "",
                 range: [
                     [0, 10],
@@ -33,7 +33,7 @@ export const singleSectionArticle: PerseusRenderer = {
                 alt: 'A scene from Pixar\'s film "Toy Story 3" where the characters are swimming in a sea of trash and look very afraid.',
                 caption:
                     'A scene from Pixar\'s film "Toy Story 3" where the characters are swimming in a sea of trash and look very afraid."',
-            },
+            }),
             version: {major: 0, minor: 0},
         },
     },

--- a/packages/perseus/src/__testdata__/graphie.testdata.ts
+++ b/packages/perseus/src/__testdata__/graphie.testdata.ts
@@ -1,4 +1,5 @@
 import {
+    generateImageOptions,
     getDefaultAnswerArea,
     type PerseusItem,
 } from "@khanacademy/perseus-core";
@@ -13,7 +14,7 @@ export const itemWithPieChart: PerseusItem = {
             "image 1": {
                 alignment: "block",
                 graded: true,
-                options: {
+                options: generateImageOptions({
                     alt: "This chart presents a pie graph divided into 2 sectors: 28 percent are unsuccessful and 72 percent are successful.",
                     backgroundImage: {
                         height: 210,
@@ -27,9 +28,8 @@ export const itemWithPieChart: PerseusItem = {
                         [0, 10],
                         [0, 10],
                     ],
-                    static: false,
                     title: "Percentage of Successful Cometary Missions (1978-2014)",
-                },
+                }),
                 static: false,
                 type: "image",
                 version: {

--- a/packages/perseus/src/__testdata__/renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/renderer.testdata.ts
@@ -3,6 +3,7 @@ import {
     generateDefinitionWidget,
     generateDropdownOptions,
     generateDropdownWidget,
+    generateImageOptions,
     generateTestPerseusRenderer,
 } from "@khanacademy/perseus-core";
 
@@ -34,14 +35,14 @@ export const dropdownWidget: DropdownWidget = generateDropdownWidget({
 export const imageWidget: ImageWidget = {
     alignment: "block",
     graded: true,
-    options: {
+    options: generateImageOptions({
         alt: "A number line labeled 200 to 300 with tick marks at every 5 units. The tick marks at 200, 210, 220, 230, 240, 250, 260, 270, 280, 290, and 300 are labeled. A red circle labeled A is between 220 tick mark and 230 tick mark.",
         backgroundImage: {
             height: 80,
             url: "web+graphie://ka-perseus-graphie.s3.amazonaws.com/3351ccf19e60c28a1d08664f5c16defa76ed0348",
             width: 380,
         },
-    },
+    }),
     static: false,
     type: "image",
     version: {major: 0, minor: 0},

--- a/packages/perseus/src/__testdata__/server-item-renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/server-item-renderer.testdata.ts
@@ -10,6 +10,7 @@ import {
     generateNumericInputAnswer,
     generateNumericInputOptions,
     generateRadioWidget,
+    generateImageOptions,
 } from "@khanacademy/perseus-core";
 
 import type {MockWidget} from "../widgets/mock-widgets/mock-widget-types";
@@ -278,8 +279,7 @@ And what follows are _hints_...
                 alignment: "block",
                 static: false,
                 graded: true,
-                options: {
-                    static: false,
+                options: generateImageOptions({
                     title: "",
                     backgroundImage: {
                         url: "https://ka-perseus-graphie.s3.amazonaws.com/532e339d4d95f9cf6423e66bdc70dd06f1143a97.png",
@@ -289,7 +289,7 @@ And what follows are _hints_...
                     alt: "A right triangle word problem. How far does the parachute fall?",
                     caption:
                         "A right triangle word problem. How far does the parachute fall?",
-                },
+                }),
                 version: {
                     major: 0,
                     minor: 0,
@@ -300,7 +300,7 @@ And what follows are _hints_...
                 alignment: "block",
                 static: false,
                 graded: true,
-                options: {
+                options: generateImageOptions({
                     backgroundImage: {
                         url: "https://ka-perseus-images.s3.amazonaws.com/12d7324ae8a09074f029d778bc4939aa85a6ee63.jpg",
                         width: 2317,
@@ -309,7 +309,7 @@ And what follows are _hints_...
                     alt: "The patron, Enrico Scrovegni presenting the Arena Chapel to the Three Marys (detail), Giotto, Last Judgment, Arena (Scrovegni) Chapel, 1305-06, fresco, Padua (photo: Steven Zucker: CC BY-NC-SA 2.0)",
                     caption:
                         "The patron, Enrico Scrovegni presenting the Arena Chapel to the Three Marys (detail), Giotto, *Last Judgment*, Arena (Scrovegni) Chapel, 1305-06, fresco, Padua (photo: Steven Zucker: CC BY-NC-SA 2.0)",
-                },
+                }),
                 version: {
                     major: 0,
                     minor: 0,
@@ -320,8 +320,7 @@ And what follows are _hints_...
                 alignment: "block",
                 static: false,
                 graded: true,
-                options: {
-                    static: false,
+                options: generateImageOptions({
                     title: "",
                     range: [
                         [0, 10],
@@ -337,7 +336,7 @@ And what follows are _hints_...
                     alt: "A chemical diagram with O atom in the center connected on one side to an R atom by a single bond and on the other side to an H atom by a single bond.",
                     caption:
                         "A chemical diagram with O atom in the center connected on one side to an R atom by a single bond and on the other side to an H atom by a single bond.",
-                },
+                }),
                 version: {major: 0, minor: 0},
             },
             "image 4": {
@@ -345,8 +344,7 @@ And what follows are _hints_...
                 alignment: "block",
                 static: false,
                 graded: true,
-                options: {
-                    static: false,
+                options: generateImageOptions({
                     title: "",
                     backgroundImage: {
                         url: "https://ka-perseus-images.s3.amazonaws.com/c983f96a29a07e5c3369a85f2c9b6ae9d2d07d2b.jpg",
@@ -356,7 +354,7 @@ And what follows are _hints_...
                     alt: "Milo dreaming he is riding on a bird's back to the moon.",
                     caption:
                         "Milo dreaming he is riding on a bird's back to the moon.",
-                },
+                }),
                 version: {
                     major: 0,
                     minor: 0,
@@ -375,7 +373,7 @@ And what follows are _hints_...
                     alignment: "block",
                     static: false,
                     graded: true,
-                    options: {
+                    options: generateImageOptions({
                         backgroundImage: {
                             url: "https://ka-perseus-images.s3.amazonaws.com/12d7324ae8a09074f029d778bc4939aa85a6ee63.jpg",
                             width: 2317,
@@ -384,7 +382,7 @@ And what follows are _hints_...
                         alt: "The patron, Enrico Scrovegni presenting the Arena Chapel to the Three Marys (detail), Giotto, Last Judgment, Arena (Scrovegni) Chapel, 1305-06, fresco, Padua (photo: Steven Zucker: CC BY-NC-SA 2.0)",
                         caption:
                             "The patron, Enrico Scrovegni presenting the Arena Chapel to the Three Marys (detail), Giotto, *Last Judgment*, Arena (Scrovegni) Chapel, 1305-06, fresco, Padua (photo: Steven Zucker: CC BY-NC-SA 2.0)",
-                    },
+                    }),
                     version: {
                         major: 0,
                         minor: 0,
@@ -402,7 +400,7 @@ And what follows are _hints_...
                     alignment: "block",
                     static: false,
                     graded: true,
-                    options: {
+                    options: generateImageOptions({
                         backgroundImage: {
                             url: "https://ka-perseus-images.s3.amazonaws.com/12d7324ae8a09074f029d778bc4939aa85a6ee63.jpg",
                             width: 2317,
@@ -411,7 +409,7 @@ And what follows are _hints_...
                         alt: "The patron, Enrico Scrovegni presenting the Arena Chapel to the Three Marys (detail), Giotto, Last Judgment, Arena (Scrovegni) Chapel, 1305-06, fresco, Padua (photo: Steven Zucker: CC BY-NC-SA 2.0)",
                         caption:
                             "The patron, Enrico Scrovegni presenting the Arena Chapel to the Three Marys (detail), Giotto, *Last Judgment*, Arena (Scrovegni) Chapel, 1305-06, fresco, Padua (photo: Steven Zucker: CC BY-NC-SA 2.0)",
-                    },
+                    }),
                     version: {
                         major: 0,
                         minor: 0,

--- a/packages/perseus/src/__tests__/renderer.new.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.new.test.tsx
@@ -1,6 +1,7 @@
 // TODO(LEMS-4304): feature flag cleanup - rename this file to renderer.test.tsx.
 import {describe, beforeAll, beforeEach, afterEach, it} from "@jest/globals";
 import {
+    generateImageOptions,
     generateTestPerseusItem,
     splitPerseusItem,
 } from "@khanacademy/perseus-core";
@@ -816,14 +817,14 @@ describe("renderer", () => {
                         "image 1": {
                             alignment: "block",
                             graded: true,
-                            options: {
+                            options: generateImageOptions({
                                 alt: "A number line labeled 200 to 300 with tick marks at every 5 units. The tick marks at 200, 210, 220, 230, 240, 250, 260, 270, 280, 290, and 300 are labeled. A red circle labeled A is between 220 tick mark and 230 tick mark.",
                                 backgroundImage: {
                                     height: 80,
                                     url: "web+graphie://ka-perseus-graphie.s3.amazonaws.com/3351ccf19e60c28a1d08664f5c16defa76ed0348",
                                     width: 380,
                                 },
-                            },
+                            }),
                             static: false,
                             type: "image",
                             version: {major: 0, minor: 0},
@@ -1181,13 +1182,13 @@ describe("renderer", () => {
                     "image 1": {
                         type: "image",
                         graded: false,
-                        options: {
+                        options: generateImageOptions({
                             backgroundImage: {
                                 url: "https://example.com/cat.png",
                                 width: 100,
                                 height: 100,
                             },
-                        },
+                        }),
                     },
                 },
             });
@@ -1224,13 +1225,13 @@ describe("renderer", () => {
                     "image 1": {
                         type: "image",
                         graded: false,
-                        options: {
+                        options: generateImageOptions({
                             backgroundImage: {
                                 url: "https://example.com/cat.png",
                                 width: 100,
                                 height: 100,
                             },
-                        },
+                        }),
                     },
                 },
             });

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -1,6 +1,7 @@
 // TODO(LEMS-4304): feature flag cleanup - remove this file.
 import {describe, beforeAll, beforeEach, afterEach, it} from "@jest/globals";
 import {
+    generateImageOptions,
     generateTestPerseusItem,
     splitPerseusItem,
 } from "@khanacademy/perseus-core";
@@ -815,14 +816,14 @@ describe("renderer", () => {
                         "image 1": {
                             alignment: "block",
                             graded: true,
-                            options: {
+                            options: generateImageOptions({
                                 alt: "A number line labeled 200 to 300 with tick marks at every 5 units. The tick marks at 200, 210, 220, 230, 240, 250, 260, 270, 280, 290, and 300 are labeled. A red circle labeled A is between 220 tick mark and 230 tick mark.",
                                 backgroundImage: {
                                     height: 80,
                                     url: "web+graphie://ka-perseus-graphie.s3.amazonaws.com/3351ccf19e60c28a1d08664f5c16defa76ed0348",
                                     width: 380,
                                 },
-                            },
+                            }),
                             static: false,
                             type: "image",
                             version: {major: 0, minor: 0},
@@ -1180,13 +1181,13 @@ describe("renderer", () => {
                     "image 1": {
                         type: "image",
                         graded: false,
-                        options: {
+                        options: generateImageOptions({
                             backgroundImage: {
                                 url: "https://example.com/cat.png",
                                 width: 100,
                                 height: 100,
                             },
-                        },
+                        }),
                     },
                 },
             });
@@ -1223,13 +1224,13 @@ describe("renderer", () => {
                     "image 1": {
                         type: "image",
                         graded: false,
-                        options: {
+                        options: generateImageOptions({
                             backgroundImage: {
                                 url: "https://example.com/cat.png",
                                 width: 100,
                                 height: 100,
                             },
-                        },
+                        }),
                     },
                 },
             });

--- a/packages/perseus/src/util/extract-perseus-data.test.ts
+++ b/packages/perseus/src/util/extract-perseus-data.test.ts
@@ -1,3 +1,5 @@
+import {generateImageOptions} from "@khanacademy/perseus-core";
+
 import {getImagesWithoutAltData} from "./extract-perseus-data";
 
 import type {
@@ -11,30 +13,30 @@ describe("getImagesWithoutAltData", () => {
         const widgets: PerseusWidgetsMap = {
             "image 1": {
                 type: "image",
-                options: {
+                options: generateImageOptions({
                     alt: "",
                     backgroundImage: {
                         url: "https://example.com/image1.jpg",
                     },
-                },
+                }),
             },
             "image 2": {
                 type: "image",
-                options: {
+                options: generateImageOptions({
                     alt: "Has alt data!",
                     backgroundImage: {
                         url: "https://example.com/image2.jpg",
                     },
-                },
+                }),
             },
             "image 3": {
                 type: "image",
-                options: {
+                options: generateImageOptions({
                     alt: "",
                     backgroundImage: {
                         url: "",
                     },
-                },
+                }),
             },
         };
         const perseusRenderer: PerseusRenderer = {

--- a/packages/perseus/src/widget-ai-utils/image/image-ai-utils.test.ts
+++ b/packages/perseus/src/widget-ai-utils/image/image-ai-utils.test.ts
@@ -1,3 +1,5 @@
+import {generateImageOptions} from "@khanacademy/perseus-core";
+
 import {renderQuestion} from "../../widgets/__testutils__/renderQuestion";
 
 import {getPromptJSON} from "./image-ai-utils";
@@ -16,7 +18,7 @@ const question = {
         "image 1": {
             alignment: "block",
             graded: true,
-            options: {
+            options: generateImageOptions({
                 alt: "An array of isosceles triangles. A triangle has height A. Two smaller triangle, one with height B and one with height C, have approximately the same combined height as A.",
                 title: "Image Title",
                 caption: "Image Caption",
@@ -31,8 +33,7 @@ const question = {
                     [0, 10],
                     [0, 10],
                 ],
-                static: false,
-            },
+            }),
             static: false,
             type: "image",
             version: {major: 0, minor: 0},

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.testdata.ts
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.testdata.ts
@@ -1,6 +1,7 @@
 import {
     generateGradedGroupOptions,
     generateGradedGroupSetWidget,
+    generateImageOptions,
     generateImageWidget,
     generateNumericInputAnswer,
     generateNumericInputOptions,
@@ -39,34 +40,34 @@ export const article1: PerseusRenderer = {
                                 "There are many ways to solve this problem. Let's see two student solutions.\n\n###Student A's solution:\n\nI thought in terms of tenths.\n\n$\\phantom{=}0.5 + 0.4$\n\n$=5$ tenths $+ ~4$ tenths\n\n$=9$ tenths\n\n$=0.9$\n\n###Student B's solution:\n\nI used tenths grids.\n\n[[☃ image 1]]\n\n[[☃ image 2]]\n\n[[☃ image 3]]\n\n$\\blueD{0.5} + \\greenD{0.4} = 0.9$\n\n###The answer:\n\n$0.5 + 0.4 = 0.9$",
                             widgets: {
                                 "image 3": generateImageWidget({
-                                    options: {
+                                    options: generateImageOptions({
                                         backgroundImage: {
                                             url: "web+graphie://ka-perseus-graphie.s3.amazonaws.com/cda00c119dac3e52c8ed150ef4a9a37355f5c713",
                                             width: 234,
                                             height: 132,
                                         },
                                         alt: "A square divided into 10 rows to show tenths. 5 of the rows are shaded in blue and 4 of the rows are shaded in green.",
-                                    },
+                                    }),
                                 }),
                                 "image 2": generateImageWidget({
-                                    options: {
+                                    options: generateImageOptions({
                                         backgroundImage: {
                                             url: "web+graphie://ka-perseus-graphie.s3.amazonaws.com/217d580bc0baddb903bbcb648fc8d3ea3d0f4408",
                                             width: 180,
                                             height: 132,
                                         },
                                         alt: "A square divided into 10 rows to show tenths. 4 of the rows are shaded to represent 4 tenths.",
-                                    },
+                                    }),
                                 }),
                                 "image 1": generateImageWidget({
-                                    options: {
+                                    options: generateImageOptions({
                                         backgroundImage: {
                                             url: "web+graphie://ka-perseus-graphie.s3.amazonaws.com/2a56a60275b7227ed9c5b89e489587c8cb13eb7b",
                                             width: 180,
                                             height: 132,
                                         },
                                         alt: "A square divided into 10 rows to show tenths. 5 of the rows are shaded to represent 5 tenths.",
-                                    },
+                                    }),
                                 }),
                             },
                         }),
@@ -91,34 +92,34 @@ export const article1: PerseusRenderer = {
                                 "There are many ways to solve this problem. Let's see two student solutions.\n\n###Student A's solution:\n\nI thought in terms of tenths.\n\n$\\phantom{=}0.6 + 0.4$\n\n$=6$ tenths $+ ~4$ tenths\n\n$=10$ tenths\n\n$=1$\n\n###Student B's solution:\n\nI used tenths grids.\n\n[[☃ image 1]]\n\n[[☃ image 2]]\n\n[[☃ image 3]]\n\n$\\blueD{0.6} + \\greenD{0.4} = 1$\n\n###The answer:\n\n$0.6 + 0.4 = 1$",
                             widgets: {
                                 "image 3": generateImageWidget({
-                                    options: {
+                                    options: generateImageOptions({
                                         backgroundImage: {
                                             url: "web+graphie://ka-perseus-graphie.s3.amazonaws.com/54fbc06d92097119f1be5d1679391596209296a7",
                                             width: 234,
                                             height: 132,
                                         },
                                         alt: "A square divided into 10 rows to show tenths. 6 of the rows are shaded in blue and 4 of the rows are shaded in green.",
-                                    },
+                                    }),
                                 }),
                                 "image 2": generateImageWidget({
-                                    options: {
+                                    options: generateImageOptions({
                                         backgroundImage: {
                                             url: "web+graphie://ka-perseus-graphie.s3.amazonaws.com/217d580bc0baddb903bbcb648fc8d3ea3d0f4408",
                                             width: 180,
                                             height: 132,
                                         },
                                         alt: "A square divided into 10 rows to show tenths. 4 of the rows are shaded to represent 4 tenths.",
-                                    },
+                                    }),
                                 }),
                                 "image 1": generateImageWidget({
-                                    options: {
+                                    options: generateImageOptions({
                                         backgroundImage: {
                                             url: "web+graphie://ka-perseus-graphie.s3.amazonaws.com/8e353e65446a4322f53d640aba33dccd69b0874c",
                                             width: 180,
                                             height: 132,
                                         },
                                         alt: "A square divided into 10 rows to show tenths. 6 of the rows are shaded to represent 6 tenths.",
-                                    },
+                                    }),
                                 }),
                             },
                         }),
@@ -145,34 +146,34 @@ export const article1: PerseusRenderer = {
                                 "There are many ways to solve this problem. Let's see two student solutions.\n\n###Student A's solution:\n\nI thought in terms of tenths.\n\n$\\phantom{=}0.8 + 0.4$\n\n$=8$ tenths $+ ~4$ tenths\n\n$=12$ tenths\n\n$=1.2$\n\n###Student B's solution:\n\nI used tenths grids.\n\n[[☃ image 1]]\n\n[[☃ image 2]]\n\n[[☃ image 3]]\n$\\blueD{0.8} + \\greenD{0.4} = 1.2$\n\n###The answer:\n\n$ 0.8+0.4=1.2 $",
                             widgets: {
                                 "image 3": generateImageWidget({
-                                    options: {
+                                    options: generateImageOptions({
                                         backgroundImage: {
                                             url: "web+graphie://ka-perseus-graphie.s3.amazonaws.com/4b595ea53e5edc2b5991f2171f384a7eae2eeb24",
                                             width: 354,
                                             height: 132,
                                         },
                                         alt: "Two equal sized squares. Each square is divided into 10 rows to show tenths. In the first square, 8 of the rows are shaded in blue and 2 of the rows are shaded in green. In the second square, 2 of the rows are shaded in green.",
-                                    },
+                                    }),
                                 }),
                                 "image 2": generateImageWidget({
-                                    options: {
+                                    options: generateImageOptions({
                                         backgroundImage: {
                                             url: "web+graphie://ka-perseus-graphie.s3.amazonaws.com/217d580bc0baddb903bbcb648fc8d3ea3d0f4408",
                                             width: 180,
                                             height: 132,
                                         },
                                         alt: "A square divided into 10 rows to show tenths. 4 of the rows are shaded to represent 4 tenths.",
-                                    },
+                                    }),
                                 }),
                                 "image 1": generateImageWidget({
-                                    options: {
+                                    options: generateImageOptions({
                                         backgroundImage: {
                                             url: "web+graphie://ka-perseus-graphie.s3.amazonaws.com/58d09bc7bdfadbd860c55734bf146578f047edbc",
                                             width: 180,
                                             height: 132,
                                         },
                                         alt: "A square divided into 10 rows to show tenths. 8 of the rows are shaded to represent 8 tenths.",
-                                    },
+                                    }),
                                 }),
                             },
                         }),

--- a/packages/perseus/src/widgets/group/group.test.tsx
+++ b/packages/perseus/src/widgets/group/group.test.tsx
@@ -224,12 +224,14 @@ describe("group widget", () => {
                     },
                     box: [380, 80],
                     caption: "",
+                    decorative: false,
                     labels: [],
+                    longDescription: "",
                     range: [
                         [0, 10],
                         [0, 10],
                     ],
-                    static: false,
+                    scale: 1,
                     title: "",
                 },
                 "numeric-input 1": {

--- a/packages/perseus/src/widgets/group/group.testdata.ts
+++ b/packages/perseus/src/widgets/group/group.testdata.ts
@@ -75,12 +75,12 @@ export const question1: PerseusRenderer = generateTestPerseusRenderer({
                             },
                             box: [380, 80],
                             caption: "",
+                            longDescription: "",
                             labels: [],
                             range: [
                                 [0, 10],
                                 [0, 10],
                             ],
-                            static: false,
                             title: "",
                         }),
                     }),

--- a/packages/perseus/src/widgets/image/image.class.tsx
+++ b/packages/perseus/src/widgets/image/image.class.tsx
@@ -1,6 +1,4 @@
-import {linterContextDefault} from "@khanacademy/perseus-linter";
 import * as React from "react";
-import _ from "underscore";
 
 import {PerseusI18nContext} from "../../components/i18n-context";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/image/image-ai-utils";
@@ -9,66 +7,13 @@ import {ImageComponent} from "./image";
 
 import type {WidgetExports, WidgetProps, Widget} from "../../types";
 import type {ImagePromptJSON} from "../../widget-ai-utils/image/image-ai-utils";
-import type {Range, PerseusImageWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusImageWidgetOptions} from "@khanacademy/perseus-core";
 
-const defaultBoxSize = 400;
-const defaultRange: Range = [0, 10];
-const defaultBackgroundImage = {
-    url: null,
-    width: 0,
-    height: 0,
-} as const;
-
-type ExternalProps = WidgetProps<PerseusImageWidgetOptions>;
-
-export interface ImageWidgetProps extends ExternalProps {
-    alignment: NonNullable<ExternalProps["alignment"]>;
-    title: NonNullable<ExternalProps["title"]>;
-    range: NonNullable<ExternalProps["range"]>;
-    box: NonNullable<ExternalProps["box"]>;
-    backgroundImage: NonNullable<ExternalProps["backgroundImage"]>;
-    scale: NonNullable<ExternalProps["scale"]>;
-    labels: NonNullable<ExternalProps["labels"]>;
-    alt: NonNullable<ExternalProps["alt"]>;
-    longDescription: NonNullable<ExternalProps["longDescription"]>;
-    decorative: NonNullable<ExternalProps["decorative"]>;
-    caption: NonNullable<ExternalProps["caption"]>;
-    linterContext: NonNullable<ExternalProps["linterContext"]>;
-}
-
-interface DefaultProps extends Partial<ImageWidgetProps> {
-    alignment: ImageWidgetProps["alignment"];
-    title: ImageWidgetProps["title"];
-    range: ImageWidgetProps["range"];
-    box: ImageWidgetProps["box"];
-    backgroundImage: ImageWidgetProps["backgroundImage"];
-    scale: ImageWidgetProps["scale"];
-    labels: ImageWidgetProps["labels"];
-    alt: ImageWidgetProps["alt"];
-    longDescription: ImageWidgetProps["longDescription"];
-    decorative: ImageWidgetProps["decorative"];
-    caption: ImageWidgetProps["caption"];
-    linterContext: ImageWidgetProps["linterContext"];
-}
+export type ImageWidgetProps = WidgetProps<PerseusImageWidgetOptions>;
 
 class ImageWidget extends React.Component<ImageWidgetProps> implements Widget {
     static contextType = PerseusI18nContext;
     declare context: React.ContextType<typeof PerseusI18nContext>;
-
-    static defaultProps: DefaultProps = {
-        alignment: "block",
-        title: "",
-        range: [defaultRange, defaultRange],
-        box: [defaultBoxSize, defaultBoxSize],
-        backgroundImage: defaultBackgroundImage,
-        scale: 1,
-        labels: [],
-        alt: "",
-        longDescription: "",
-        decorative: false,
-        caption: "",
-        linterContext: linterContextDefault,
-    };
 
     // this just helps with TS weak typing when a Widget
     // doesn't implement any Widget methods

--- a/packages/perseus/src/widgets/label-image/__tests__/label-image.testdata.ts
+++ b/packages/perseus/src/widgets/label-image/__tests__/label-image.testdata.ts
@@ -1,3 +1,5 @@
+import {generateImageOptions} from "@khanacademy/perseus-core";
+
 import type {PerseusRenderer} from "@khanacademy/perseus-core";
 
 export const textQuestion: PerseusRenderer = {
@@ -333,8 +335,7 @@ export const mixedContentQuestion: PerseusRenderer = {
             alignment: "block",
             static: false,
             graded: true,
-            options: {
-                static: false,
+            options: generateImageOptions({
                 title: "",
                 range: [
                     [0, 10],
@@ -349,7 +350,7 @@ export const mixedContentQuestion: PerseusRenderer = {
                 labels: [],
                 alt: "An inflated beach ball floats on the surface of water. Only a small portion of the ball is underwater.",
                 caption: "",
-            },
+            }),
             version: {
                 major: 0,
                 minor: 0,


### PR DESCRIPTION
## Summary:
This is in service of moving all Image Widget options to a separate `options`
prop in the ImageWidget component, to improve type safety and readability.

Default props are problematic if we're grouping all the `options` into an
object.  The most idiomatic way to default them is via destructuring:

```ts
const {
  foo = "default",
  bar = 42,
} = options;
```

The default values are applied if the property is undefined, but not if it's
null.  This mirrors the behavior of React's `defaultProps`.

The complication with ImageWidget is that it renders several other
sub-components that each need the options. We'd either have to create separate
prop types for each of those components, where each of the `options` is
required, or repeat the destructure-with-defaults pattern in each component.
Both approaches make the code more verbose.

To dodge the dilemma, this PR moves the defaults to the parser.

This will change the published data (adding defaults for fields that were
previously omitted) but no change to the Go schema is needed.

Issue: LEMS-4354

## Test plan:

CI checks should pass.