### PR TITLE
Migrate image widget to WidgetPropsV2

### DIFF
--- a/.changeset/widget-props-v2-image.md
+++ b/.changeset/widget-props-v2-image.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Migrate the image widget to group all `options` under a separate prop.

--- a/.fixie/config.json
+++ b/.fixie/config.json
@@ -2,6 +2,7 @@
     "verify": "pnpm --silent tsc && pnpm --silent tesc && pnpm --silent linc",
     "fix": "pnpm --silent fixc",
     "todoPatterns": [
+        "(^| )TODO-NEXT(:|\\([a-z])",
         "(^| )TODO(:|\\([a-z])"
     ]
 }

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -485,7 +485,7 @@ review and commit the changes.
 - [x] Migrate `free-response` to `WidgetPropsV2` (its `defaultProps` is
       `userInput`-only, so no option-field defaults to relocate).
 - [x] Migrate `video` to `WidgetPropsV2`.
-- [ ] Migrate `image` to `WidgetPropsV2`.
+- [x] Migrate `image` to `WidgetPropsV2`.
 - [ ] Migrate `molecule` to `WidgetPropsV2`.
 - [ ] Migrate `measurer` to `WidgetPropsV2`.
 - [ ] Migrate `number-line` to `WidgetPropsV2`.

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -20,4 +20,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "deprecated-standin",
     "free-response",
     "video",
+    "image",
 ];

--- a/packages/perseus/src/widget-ai-utils/image/image-ai-utils.test.ts
+++ b/packages/perseus/src/widget-ai-utils/image/image-ai-utils.test.ts
@@ -55,11 +55,13 @@ describe("Image AI utils", () => {
 
     it("it returns JSON with the expected format and fields", () => {
         const widgetData: any = {
-            alt: "An image of a textbook",
-            title: "Textbook",
-            caption: "A textbook",
-            backgroundImage: {
-                url: "https://www.khanacademy.org/some-image.png",
+            options: {
+                alt: "An image of a textbook",
+                title: "Textbook",
+                caption: "A textbook",
+                backgroundImage: {
+                    url: "https://www.khanacademy.org/some-image.png",
+                },
             },
         };
 

--- a/packages/perseus/src/widget-ai-utils/image/image-ai-utils.ts
+++ b/packages/perseus/src/widget-ai-utils/image/image-ai-utils.ts
@@ -37,10 +37,10 @@ export const getPromptJSON = (
     return {
         type: "image",
         options: {
-            altText: widgetData.alt,
-            title: widgetData.title,
-            caption: widgetData.caption,
-            imageUrl: widgetData.backgroundImage.url,
+            altText: widgetData.options.alt,
+            title: widgetData.options.title,
+            caption: widgetData.options.caption,
+            imageUrl: widgetData.options.backgroundImage.url,
         },
     };
 };

--- a/packages/perseus/src/widgets/image/image.tsx
+++ b/packages/perseus/src/widgets/image/image.tsx
@@ -12,12 +12,12 @@ import {ImageInfoArea} from "./components/image-info-area";
 import styles from "./image-widget.module.css";
 import {isGif, decodeGifFrames} from "./utils";
 
-import type {WidgetExports, WidgetProps, Widget} from "../../types";
+import type {WidgetExports, Widget, WidgetPropsV2} from "../../types";
 import type {ImagePromptJSON} from "../../widget-ai-utils/image/image-ai-utils";
 import type {PerseusImageWidgetOptions} from "@khanacademy/perseus-core";
 import type {ParsedFrame} from "gifuct-js";
 
-type ImageWidgetProps = WidgetProps<PerseusImageWidgetOptions>;
+type ImageWidgetProps = WidgetPropsV2<PerseusImageWidgetOptions>;
 
 // Widget interface methods exposed via ref
 type WidgetHandle = Pick<Widget, "getPromptJSON">;
@@ -35,7 +35,7 @@ const ImageWidget = forwardRef<WidgetHandle, ImageWidgetProps>(
             labels,
             range,
             title,
-        } = props;
+        } = props.options;
         const context = React.useContext(PerseusI18nContext);
         const {analytics} = useDependencies();
 
@@ -92,7 +92,7 @@ const ImageWidget = forwardRef<WidgetHandle, ImageWidgetProps>(
         const isAnimatedGif =
             imageIsGif && gifFrames != null && gifFrames.length > 1;
 
-        let scale = props.scale;
+        let scale = props.options.scale;
         // Set the scale to 1 if the scale is invalid.
         if (scale <= 0 || scale === Infinity || scale === -Infinity) {
             scale = 1;
@@ -198,7 +198,7 @@ const ImageWidget = forwardRef<WidgetHandle, ImageWidgetProps>(
                         isGifPlaying={isGifPlaying}
                         setIsGifPlaying={setIsGifPlaying}
                         isAnimatedGif={isAnimatedGif}
-                        {...props}
+                        {...props.options}
                         apiOptions={apiOptions}
                         linterContext={linterContext}
                         widgetId={widgetId}


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit an Image widget in http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.