### PR TITLE
[Preview axe-core]: single iframe-init reply to iframe-ready

### DIFF
--- a/.changeset/all-ears-knock.md
+++ b/.changeset/all-ears-knock.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Preview bridge: the parent now replies to the iframe's `iframe-ready` handshake with a single `iframe-init` message carrying the full current preview state, resent on every ready (including reloads), so a freshly loaded preview iframe never misses state sent before it was listening.

--- a/packages/perseus-editor/src/preview/message-types.ts
+++ b/packages/perseus-editor/src/preview/message-types.ts
@@ -115,9 +115,33 @@ interface PreviewDataMessage extends PreviewMessageBase {
 }
 
 /**
+ * Reply from parent to the iframe's `iframe-ready` handshake, carrying the
+ * full current preview state in one message. Sent once per `iframe-ready`
+ * (including a genuine reload, which re-announces readiness) — this way a
+ * freshly (re)loaded iframe never has to rely on messages sent before it was
+ * listening.
+ */
+interface PreviewIframeInitMessage extends PreviewMessageBase {
+    type: "iframe-init";
+    content: PreviewContent | null;
+}
+
+export function createPreviewIframeInitMessage(
+    content: PreviewContent | null,
+): PreviewIframeInitMessage {
+    return {
+        source: PREVIEW_MESSAGE_SOURCE,
+        type: "iframe-init",
+        content,
+    };
+}
+
+/**
  * Union of all messages sent from parent to iframe
  */
-export type ParentToIframeMessage = PreviewDataMessage;
+export type ParentToIframeMessage =
+    | PreviewDataMessage
+    | PreviewIframeInitMessage;
 
 // ---- Iframe → Parent messages ----
 

--- a/packages/perseus-editor/src/preview/use-preview-controller.test.ts
+++ b/packages/perseus-editor/src/preview/use-preview-controller.test.ts
@@ -33,6 +33,24 @@ describe("usePreviewController", () => {
         iframeRef = {current: mockIframe as any};
     });
 
+    function markIframeReady() {
+        act(() => {
+            window.dispatchEvent(
+                new MessageEvent("message", {
+                    data: createPreviewIframeReadyMessage(),
+                    source: mockContentWindow,
+                }),
+            );
+        });
+    }
+
+    function messagesOfType(type: string) {
+        // eslint-disable-next-line no-restricted-syntax
+        return (mockContentWindow.postMessage as jest.Mock).mock.calls
+            .map(([msg]) => msg)
+            .filter((msg) => msg.type === type);
+    }
+
     describe("initialization", () => {
         it("initializes with null height", () => {
             const {result} = renderHook(() => usePreviewController(iframeRef));
@@ -101,17 +119,17 @@ describe("usePreviewController", () => {
             // iframe is now set
             localIframeRef.current = iframeRef.current;
 
-            act(() => {
-                window.dispatchEvent(
-                    new MessageEvent("message", {
-                        data: createPreviewIframeReadyMessage(),
-                        source: mockContentWindow,
-                    }),
-                );
-            });
+            markIframeReady();
 
-            // Should not post message yet
-            expect(mockContentWindow.postMessage).toHaveBeenCalledTimes(1);
+            // The pending content is flushed via iframe-init now that a
+            // contentWindow exists
+            expect(mockContentWindow.postMessage).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    type: "iframe-init",
+                    content: expect.objectContaining({type: "question"}),
+                }),
+                "/",
+            );
         });
 
         it("sends only latest data once iframe is ready", () => {
@@ -128,14 +146,7 @@ describe("usePreviewController", () => {
             expect(mockContentWindow.postMessage).not.toHaveBeenCalled();
 
             // Simulate iframe requesting data
-            act(() => {
-                window.dispatchEvent(
-                    new MessageEvent("message", {
-                        data: createPreviewIframeReadyMessage(),
-                        source: mockContentWindow,
-                    }),
-                );
-            });
+            markIframeReady();
 
             expect(mockContentWindow.postMessage).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -155,14 +166,7 @@ describe("usePreviewController", () => {
             const {result} = renderHook(() => usePreviewController(iframeRef));
 
             // Simulate iframe requesting data
-            act(() => {
-                window.dispatchEvent(
-                    new MessageEvent("message", {
-                        data: createPreviewIframeReadyMessage(),
-                        source: mockContentWindow,
-                    }),
-                );
-            });
+            markIframeReady();
 
             // Now send data
             const previewData = createQuestionPreview();
@@ -186,14 +190,7 @@ describe("usePreviewController", () => {
             const {result} = renderHook(() => usePreviewController(iframeRef));
 
             // Simulate iframe requesting data
-            act(() => {
-                window.dispatchEvent(
-                    new MessageEvent("message", {
-                        data: createPreviewIframeReadyMessage(),
-                        source: mockContentWindow,
-                    }),
-                );
-            });
+            markIframeReady();
 
             const previewData = createQuestionPreview({
                 apiOptions: {onFocusChange: jest.fn()},
@@ -202,9 +199,7 @@ describe("usePreviewController", () => {
                 result.current.sendData(previewData);
             });
 
-            // eslint-disable-next-line no-restricted-syntax
-            const sentMessage = (mockContentWindow.postMessage as jest.Mock)
-                .mock.calls[0][0];
+            const sentMessage = messagesOfType("content-data")[0];
 
             // Non-serializable functions should be removed
             expect(
@@ -252,7 +247,7 @@ describe("usePreviewController", () => {
     });
 
     describe("receiving iframe-ready message", () => {
-        it("responds to iframe-ready with pending data", async () => {
+        it("responds to iframe-ready with pending data via iframe-init", async () => {
             const {result} = renderHook(() => usePreviewController(iframeRef));
             const previewData = createQuestionPreview();
 
@@ -262,14 +257,7 @@ describe("usePreviewController", () => {
             });
 
             // Now iframe tells parent its ready
-            act(() => {
-                window.dispatchEvent(
-                    new MessageEvent("message", {
-                        data: createPreviewIframeReadyMessage(),
-                        source: mockContentWindow,
-                    }),
-                );
-            });
+            markIframeReady();
 
             await waitFor(() => {
                 expect(mockContentWindow.postMessage).toHaveBeenCalled();
@@ -278,7 +266,7 @@ describe("usePreviewController", () => {
             expect(mockContentWindow.postMessage).toHaveBeenCalledWith(
                 expect.objectContaining({
                     source: PREVIEW_MESSAGE_SOURCE,
-                    type: "content-data",
+                    type: "iframe-init",
                     content: expect.objectContaining({
                         type: "question",
                     }),
@@ -286,58 +274,63 @@ describe("usePreviewController", () => {
                 "/",
             );
         });
+    });
 
-        it("only sends data once if multiple iframe-ready events are received", async () => {
+    describe("replying to iframe-ready with an iframe-init message", () => {
+        it("sends null content when nothing has been set", () => {
+            renderHook(() => usePreviewController(iframeRef));
+
+            markIframeReady();
+
+            expect(mockContentWindow.postMessage).toHaveBeenCalledWith(
+                {
+                    source: PREVIEW_MESSAGE_SOURCE,
+                    type: "iframe-init",
+                    content: null,
+                },
+                "/",
+            );
+        });
+
+        it("sends the latest content set before the iframe was ready", () => {
+            const {result} = renderHook(() => usePreviewController(iframeRef));
+            const previewData1 = createQuestionPreview();
+            const previewData2 = createQuestionPreview({content: "Question 2"});
+
+            act(() => {
+                result.current.sendData(previewData1);
+                result.current.sendData(previewData2);
+            });
+            markIframeReady();
+
+            expect(messagesOfType("iframe-init")).toEqual([
+                expect.objectContaining({
+                    content: expect.objectContaining({
+                        data: expect.objectContaining({
+                            question: expect.objectContaining({
+                                content: "Question 2",
+                            }),
+                        }),
+                    }),
+                }),
+            ]);
+        });
+
+        it("resends the full current state again on a second iframe-ready event", () => {
             const {result} = renderHook(() => usePreviewController(iframeRef));
             const previewData = createQuestionPreview();
 
-            // Send data (will be pending)
             act(() => {
                 result.current.sendData(previewData);
             });
+            markIframeReady();
 
-            // Iframe says its ready
-            act(() => {
-                window.dispatchEvent(
-                    new MessageEvent("message", {
-                        data: createPreviewIframeReadyMessage(),
-                        source: mockContentWindow,
-                    }),
-                );
-            });
+            expect(messagesOfType("iframe-init")).toHaveLength(1);
 
-            await waitFor(() => {
-                expect(mockContentWindow.postMessage).toHaveBeenCalledTimes(1);
-            });
+            // Simulate a genuine reload: the iframe announces ready again.
+            markIframeReady();
 
-            // Second request should not send the same data again
-            act(() => {
-                window.dispatchEvent(
-                    new MessageEvent("message", {
-                        data: createPreviewIframeReadyMessage(),
-                        source: mockContentWindow,
-                    }),
-                );
-            });
-
-            // Should still be called only once
-            expect(mockContentWindow.postMessage).toHaveBeenCalledTimes(1);
-        });
-
-        it("doesn't reply to iframe-ready when there is no pending data", () => {
-            renderHook(() => usePreviewController(iframeRef));
-
-            // Iframe says its ready
-            act(() => {
-                window.dispatchEvent(
-                    new MessageEvent("message", {
-                        data: createPreviewIframeReadyMessage(),
-                        source: mockContentWindow,
-                    }),
-                );
-            });
-
-            expect(mockContentWindow.postMessage).not.toHaveBeenCalled();
+            expect(messagesOfType("iframe-init")).toHaveLength(2);
         });
     });
 
@@ -488,14 +481,7 @@ describe("usePreviewController", () => {
             const {result} = renderHook(() => usePreviewController(iframeRef));
 
             // 1. Iframe requests data
-            act(() => {
-                window.dispatchEvent(
-                    new MessageEvent("message", {
-                        data: createPreviewIframeReadyMessage(),
-                        source: mockContentWindow,
-                    }),
-                );
-            });
+            markIframeReady();
 
             // 2. Send preview data
             const previewData = createQuestionPreview();
@@ -528,14 +514,7 @@ describe("usePreviewController", () => {
             const {result} = renderHook(() => usePreviewController(iframeRef));
 
             // Setup: iframe requests data
-            act(() => {
-                window.dispatchEvent(
-                    new MessageEvent("message", {
-                        data: createPreviewIframeReadyMessage(),
-                        source: mockContentWindow,
-                    }),
-                );
-            });
+            markIframeReady();
 
             // Send first data
             const data1 = createQuestionPreview();
@@ -543,7 +522,7 @@ describe("usePreviewController", () => {
                 result.current.sendData(data1);
             });
 
-            expect(mockContentWindow.postMessage).toHaveBeenCalledTimes(1);
+            expect(messagesOfType("content-data")).toHaveLength(1);
 
             // Send second data
             const data2: PreviewContent = {
@@ -562,26 +541,17 @@ describe("usePreviewController", () => {
                 result.current.sendData(data2);
             });
 
-            expect(mockContentWindow.postMessage).toHaveBeenCalledTimes(2);
+            const contentDataMessages = messagesOfType("content-data");
+            expect(contentDataMessages).toHaveLength(2);
 
             // Verify second message contains hint data
-            // eslint-disable-next-line no-restricted-syntax
-            const secondCall = (mockContentWindow.postMessage as jest.Mock).mock
-                .calls[1][0];
-            expect(secondCall.content.type).toBe("hint");
+            expect(contentDataMessages[1].content.type).toBe("hint");
         });
 
         it("handles article-all with multiple sections", () => {
             const {result} = renderHook(() => usePreviewController(iframeRef));
 
-            act(() => {
-                window.dispatchEvent(
-                    new MessageEvent("message", {
-                        data: createPreviewIframeReadyMessage(),
-                        source: mockContentWindow,
-                    }),
-                );
-            });
+            markIframeReady();
 
             const articleData: PreviewContent = {
                 type: "article-all",
@@ -603,9 +573,7 @@ describe("usePreviewController", () => {
                 result.current.sendData(articleData);
             });
 
-            // eslint-disable-next-line no-restricted-syntax
-            const sentMessage = (mockContentWindow.postMessage as jest.Mock)
-                .mock.calls[0][0];
+            const sentMessage = messagesOfType("content-data")[0];
 
             // The shared apiOptions should be sanitized
             expect(sentMessage.content.data.article).toHaveLength(2);

--- a/packages/perseus-editor/src/preview/use-preview-controller.test.ts
+++ b/packages/perseus-editor/src/preview/use-preview-controller.test.ts
@@ -33,7 +33,7 @@ describe("usePreviewController", () => {
         iframeRef = {current: mockIframe as any};
     });
 
-    function markIframeReady() {
+    function sendIframeReadyMessage() {
         act(() => {
             window.dispatchEvent(
                 new MessageEvent("message", {
@@ -119,7 +119,7 @@ describe("usePreviewController", () => {
             // iframe is now set
             localIframeRef.current = iframeRef.current;
 
-            markIframeReady();
+            sendIframeReadyMessage();
 
             // The pending content is flushed via iframe-init now that a
             // contentWindow exists
@@ -146,7 +146,7 @@ describe("usePreviewController", () => {
             expect(mockContentWindow.postMessage).not.toHaveBeenCalled();
 
             // Simulate iframe requesting data
-            markIframeReady();
+            sendIframeReadyMessage();
 
             expect(mockContentWindow.postMessage).toHaveBeenCalledWith(
                 expect.objectContaining({
@@ -166,7 +166,7 @@ describe("usePreviewController", () => {
             const {result} = renderHook(() => usePreviewController(iframeRef));
 
             // Simulate iframe requesting data
-            markIframeReady();
+            sendIframeReadyMessage();
 
             // Now send data
             const previewData = createQuestionPreview();
@@ -190,7 +190,7 @@ describe("usePreviewController", () => {
             const {result} = renderHook(() => usePreviewController(iframeRef));
 
             // Simulate iframe requesting data
-            markIframeReady();
+            sendIframeReadyMessage();
 
             const previewData = createQuestionPreview({
                 apiOptions: {onFocusChange: jest.fn()},
@@ -257,7 +257,7 @@ describe("usePreviewController", () => {
             });
 
             // Now iframe tells parent its ready
-            markIframeReady();
+            sendIframeReadyMessage();
 
             await waitFor(() => {
                 expect(mockContentWindow.postMessage).toHaveBeenCalled();
@@ -280,7 +280,7 @@ describe("usePreviewController", () => {
         it("sends null content when nothing has been set", () => {
             renderHook(() => usePreviewController(iframeRef));
 
-            markIframeReady();
+            sendIframeReadyMessage();
 
             expect(mockContentWindow.postMessage).toHaveBeenCalledWith(
                 {
@@ -301,7 +301,7 @@ describe("usePreviewController", () => {
                 result.current.sendData(previewData1);
                 result.current.sendData(previewData2);
             });
-            markIframeReady();
+            sendIframeReadyMessage();
 
             expect(messagesOfType("iframe-init")).toEqual([
                 expect.objectContaining({
@@ -323,12 +323,12 @@ describe("usePreviewController", () => {
             act(() => {
                 result.current.sendData(previewData);
             });
-            markIframeReady();
+            sendIframeReadyMessage();
 
             expect(messagesOfType("iframe-init")).toHaveLength(1);
 
             // Simulate a genuine reload: the iframe announces ready again.
-            markIframeReady();
+            sendIframeReadyMessage();
 
             expect(messagesOfType("iframe-init")).toHaveLength(2);
         });
@@ -481,7 +481,7 @@ describe("usePreviewController", () => {
             const {result} = renderHook(() => usePreviewController(iframeRef));
 
             // 1. Iframe requests data
-            markIframeReady();
+            sendIframeReadyMessage();
 
             // 2. Send preview data
             const previewData = createQuestionPreview();
@@ -514,7 +514,7 @@ describe("usePreviewController", () => {
             const {result} = renderHook(() => usePreviewController(iframeRef));
 
             // Setup: iframe requests data
-            markIframeReady();
+            sendIframeReadyMessage();
 
             // Send first data
             const data1 = createQuestionPreview();
@@ -551,7 +551,7 @@ describe("usePreviewController", () => {
         it("handles article-all with multiple sections", () => {
             const {result} = renderHook(() => usePreviewController(iframeRef));
 
-            markIframeReady();
+            sendIframeReadyMessage();
 
             const articleData: PreviewContent = {
                 type: "article-all",

--- a/packages/perseus-editor/src/preview/use-preview-controller.ts
+++ b/packages/perseus-editor/src/preview/use-preview-controller.ts
@@ -1,7 +1,10 @@
 import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 import * as React from "react";
 
-import {PREVIEW_MESSAGE_SOURCE} from "./message-types";
+import {
+    createPreviewIframeInitMessage,
+    PREVIEW_MESSAGE_SOURCE,
+} from "./message-types";
 import {isIframeToParentMessage} from "./message-validators";
 import {sanitizePreviewData} from "./preview-data-sanitizer";
 
@@ -52,7 +55,13 @@ export function usePreviewController(
 ): UsePreviewControllerResult {
     const [height, setHeight] = React.useState<number | null>(null);
     const [isIframeReady, setIsIframeReady] = React.useState(false);
-    const pendingDataRef = React.useRef<PreviewContent | null>(null);
+
+    // The current desired preview content, resent in full as an
+    // `iframe-init` reply whenever the iframe announces `iframe-ready` —
+    // including on a later reload/remount, not just the first time. This way
+    // a freshly (re)loaded iframe never has to rely on messages sent before
+    // it was listening.
+    const currentContentRef = React.useRef<PreviewContent | null>(null);
 
     // Listen for messages from iframe
     React.useEffect(() => {
@@ -75,22 +84,14 @@ export function usePreviewController(
             // Handle the message
             switch (message.type) {
                 case "iframe-ready": {
-                    // Send the pending message (if any)
-                    if (pendingDataRef.current) {
-                        const sanitizedData = sanitizePreviewData(
-                            pendingDataRef.current,
-                        );
-
-                        const msg: ParentToIframeMessage = {
-                            source: PREVIEW_MESSAGE_SOURCE,
-                            type: "content-data",
-                            content: sanitizedData,
-                        };
-                        iframeRef.current.contentWindow.postMessage(msg, "/");
-
-                        // Clear the pending data
-                        pendingDataRef.current = null;
-                    }
+                    iframeRef.current.contentWindow.postMessage(
+                        createPreviewIframeInitMessage(
+                            currentContentRef.current
+                                ? sanitizePreviewData(currentContentRef.current)
+                                : null,
+                        ),
+                        "/",
+                    );
                     setIsIframeReady(true);
                     break;
                 }
@@ -114,9 +115,11 @@ export function usePreviewController(
     // Memoized function to send data to iframe
     const sendData = React.useCallback(
         (data: PreviewContent) => {
-            // If iframe hasn't sent request-data yet, store the data
+            currentContentRef.current = data;
+
+            // If iframe hasn't sent iframe-ready yet, the iframe-init reply
+            // above will carry this once it does.
             if (!isIframeReady) {
-                pendingDataRef.current = data;
                 return;
             }
 
@@ -125,13 +128,10 @@ export function usePreviewController(
                 return;
             }
 
-            // Iframe is ready, send immediately
-            const sanitizedData = sanitizePreviewData(data);
-
             const message: ParentToIframeMessage = {
                 source: PREVIEW_MESSAGE_SOURCE,
                 type: "content-data",
-                content: sanitizedData,
+                content: sanitizePreviewData(data),
             };
 
             contentWindow.postMessage(message, "/");

--- a/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
+++ b/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
@@ -353,6 +353,62 @@ describe("usePreviewPresenter", () => {
         });
     });
 
+    describe("receiving iframe-init message", () => {
+        it("sets content from an iframe-init message", () => {
+            const {result} = renderHook(() => usePreviewPresenter());
+
+            const questionContent: PreviewContent = {
+                type: "question",
+                data: {
+                    question: {
+                        content: "What is 2+2?",
+                        widgets: {},
+                        images: {},
+                    },
+                    apiOptions: {readOnly: true},
+                    linterContext: {
+                        contentType: "exercise",
+                        highlightLint: false,
+                    },
+                },
+            };
+
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            source: PREVIEW_MESSAGE_SOURCE,
+                            type: "iframe-init",
+                            content: questionContent,
+                        },
+                        source: mockParentWindow,
+                    }),
+                );
+            });
+
+            expect(result.current.content).toEqual(questionContent);
+        });
+
+        it("handles null content (nothing sent yet)", () => {
+            const {result} = renderHook(() => usePreviewPresenter());
+
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            source: PREVIEW_MESSAGE_SOURCE,
+                            type: "iframe-init",
+                            content: null,
+                        },
+                        source: mockParentWindow,
+                    }),
+                );
+            });
+
+            expect(result.current.content).toBeNull();
+        });
+    });
+
     describe("reportHeight", () => {
         it("sends height-update message", () => {
             const {result} = renderHook(() => usePreviewPresenter());

--- a/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
+++ b/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
@@ -354,7 +354,7 @@ describe("usePreviewPresenter", () => {
     });
 
     describe("receiving iframe-init message", () => {
-        it("sets content from an iframe-init message", () => {
+        it("sets the question content", () => {
             const {result} = renderHook(() => usePreviewPresenter());
 
             const questionContent: PreviewContent = {

--- a/packages/perseus-editor/src/preview/use-preview-presenter.ts
+++ b/packages/perseus-editor/src/preview/use-preview-presenter.ts
@@ -90,8 +90,12 @@ export function usePreviewPresenter(): UsePreviewPresenterResult {
                     setContent(message.content);
                     break;
 
+                case "iframe-init":
+                    setContent(message.content);
+                    break;
+
                 default:
-                    throw new UnreachableCaseError(message.type);
+                    throw new UnreachableCaseError(message);
             }
         };
 


### PR DESCRIPTION
## About this stack: axe-core in the preview iframe

*This PR is one of a stacked series that moves axe-core accessibility scanning out of the parent editor and into the preview iframe. Previously a11y checks ran in the parent, reaching across the iframe boundary to scan the preview's DOM and to draw "Show Me" outline overlays in the parent document. The series relocates the scan into the iframe — where the DOM is directly accessible — reports results back over the typed preview `postMessage` protocol, and draws the highlight overlays inside the iframe. The outcome is a single code path with no cross-frame DOM access.*

**PRs in this stack:**

- 👉 #3905
- #3906
- #3907
- #3908
- #3909
- #3910
- #3911
- #3912

---

## Summary:

The preview iframe and its parent editor negotiate startup with an `iframe-ready` handshake. Previously the parent tracked a "pending data" ref that only carried `content` and effectively only covered the first load, so a genuine reload or remount of the iframe — for example, switching the preview device type — could lose state that had already been sent. This change generalizes the handshake: the parent now replies to *every* `iframe-ready` with a single `iframe-init` message carrying the current preview content (`PreviewContent | null`). Because it's re-sent on every ready rather than only the first, a freshly (re)loaded iframe never has to rely on messages posted before it was listening.

This is the base of the stack; later branches extend `iframe-init` to also carry a11y scan state, but this branch is content-only and predates any axe-core code.

Issue: LEMS-4402

## Test plan:

- `pnpm test`
- `pnpm typecheck`
- In Storybook, open an editor preview and confirm content loads; switch the preview device type (which reloads the iframe) and confirm the content reappears without a manual re-send.