### PR TITLE
[Preview axe-core]: add axe-core protocol messages, tighten validators

### DIFF
--- a/.changeset/tasty-coins-write.md
+++ b/.changeset/tasty-coins-write.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Preview bridge protocol: add message types and constructors for enabling axe-core scanning (`set-a11y-enabled`), highlighting issues (`highlight-issues`), clearing highlights (`clear-highlights`), and reporting results (`a11y-report`), with tightened message validators.

--- a/packages/perseus-editor/src/preview/message-types.test.ts
+++ b/packages/perseus-editor/src/preview/message-types.test.ts
@@ -1,0 +1,98 @@
+import {
+    PREVIEW_MESSAGE_SOURCE,
+    createPreviewA11yReportMessage,
+    createPreviewClearHighlightsMessage,
+    createPreviewHighlightIssuesMessage,
+    createPreviewSetA11yEnabledMessage,
+} from "./message-types";
+
+import type {Issue} from "../components/issues-panel";
+
+const issue = (id: string): Issue => ({
+    id,
+    description: `description ${id}`,
+    helpUrl: "https://example.com/help",
+    help: "Learn more",
+    impact: "medium",
+    message: `message ${id}`,
+});
+
+describe("message constructors", () => {
+    describe("createPreviewSetA11yEnabledMessage", () => {
+        it("builds a set-a11y-enabled command carrying the enabled flag", () => {
+            // Arrange, Act
+            const message = createPreviewSetA11yEnabledMessage(true);
+
+            // Assert
+            expect(message).toEqual({
+                source: PREVIEW_MESSAGE_SOURCE,
+                type: "set-a11y-enabled",
+                enabled: true,
+            });
+        });
+
+        it("carries enabled: false when disabling", () => {
+            // Arrange, Act
+            const message = createPreviewSetA11yEnabledMessage(false);
+
+            // Assert
+            expect(message).toEqual({
+                source: PREVIEW_MESSAGE_SOURCE,
+                type: "set-a11y-enabled",
+                enabled: false,
+            });
+        });
+    });
+
+    describe("createPreviewHighlightIssuesMessage", () => {
+        it("builds a highlight-issues command carrying the previewIds", () => {
+            // Arrange, Act
+            const message = createPreviewHighlightIssuesMessage([
+                "violation-1",
+                "incomplete-2",
+            ]);
+
+            // Assert
+            expect(message).toEqual({
+                source: PREVIEW_MESSAGE_SOURCE,
+                type: "highlight-issues",
+                previewIds: ["violation-1", "incomplete-2"],
+            });
+        });
+    });
+
+    describe("createPreviewClearHighlightsMessage", () => {
+        it("builds a clear-highlights command", () => {
+            // Arrange, Act
+            const message = createPreviewClearHighlightsMessage();
+
+            // Assert
+            expect(message).toEqual({
+                source: PREVIEW_MESSAGE_SOURCE,
+                type: "clear-highlights",
+            });
+        });
+    });
+
+    describe("createPreviewA11yReportMessage", () => {
+        it("builds an a11y-report carrying violations and incompletes", () => {
+            // Arrange
+            const violations = [issue("v1")];
+            const incompletes = [issue("i1")];
+
+            // Act
+            const message = createPreviewA11yReportMessage(
+                violations,
+                incompletes,
+            );
+
+            // Assert
+            expect(message).toEqual({
+                source: PREVIEW_MESSAGE_SOURCE,
+                type: "a11y-report",
+                violations,
+                incompletes,
+            });
+        });
+    });
+});

--- a/packages/perseus-editor/src/preview/message-types.test.ts
+++ b/packages/perseus-editor/src/preview/message-types.test.ts
@@ -75,15 +75,15 @@ describe("message constructors", () => {
     });
 
     describe("createPreviewA11yReportMessage", () => {
-        it("builds an a11y-report carrying violations and incompletes", () => {
+        it("builds an a11y-report carrying violations and unsures", () => {
             // Arrange
             const violations = [issue("v1")];
-            const incompletes = [issue("i1")];
+            const unsures = [issue("i1")];
 
             // Act
             const message = createPreviewA11yReportMessage(
                 violations,
-                incompletes,
+                unsures,
             );
 
             // Assert
@@ -91,7 +91,7 @@ describe("message constructors", () => {
                 source: PREVIEW_MESSAGE_SOURCE,
                 type: "a11y-report",
                 violations,
-                incompletes,
+                unsures,
             });
         });
     });

--- a/packages/perseus-editor/src/preview/message-types.test.ts
+++ b/packages/perseus-editor/src/preview/message-types.test.ts
@@ -81,10 +81,7 @@ describe("message constructors", () => {
             const unsures = [issue("i1")];
 
             // Act
-            const message = createPreviewA11yReportMessage(
-                violations,
-                unsures,
-            );
+            const message = createPreviewA11yReportMessage(violations, unsures);
 
             // Assert
             expect(message).toEqual({

--- a/packages/perseus-editor/src/preview/message-types.ts
+++ b/packages/perseus-editor/src/preview/message-types.ts
@@ -4,6 +4,7 @@
  */
 
 import type {SerializableApiOptions} from "./sanitize-api-options";
+import type {Issue} from "../components/issues-panel";
 import type {
     Hint,
     PerseusItem,
@@ -137,7 +138,65 @@ export function createPreviewIframeInitMessage(
 }
 
 /**
+ * Command from parent telling the iframe to enable or disable axe-core
+ * accessibility scanning. When enabled, the iframe runs scans and reports back;
+ * when disabled, it neither imports nor runs axe-core.
+ */
+interface PreviewSetA11yEnabledMessage extends PreviewMessageBase {
+    type: "set-a11y-enabled";
+    enabled: boolean;
+}
+
+export function createPreviewSetA11yEnabledMessage(
+    enabled: boolean,
+): PreviewSetA11yEnabledMessage {
+    return {
+        source: PREVIEW_MESSAGE_SOURCE,
+        type: "set-a11y-enabled",
+        enabled,
+    };
+}
+
+/**
+ * Command from parent telling the iframe to highlight the elements for the
+ * given previewIds (the "Show Me" overlays drawn inside the iframe).
+ */
+interface PreviewHighlightIssuesMessage extends PreviewMessageBase {
+    type: "highlight-issues";
+    previewIds: string[];
+}
+
+export function createPreviewHighlightIssuesMessage(
+    previewIds: string[],
+): PreviewHighlightIssuesMessage {
+    return {
+        source: PREVIEW_MESSAGE_SOURCE,
+        type: "highlight-issues",
+        previewIds,
+    };
+}
+
+/**
+ * Command from parent telling the iframe to remove any "Show Me" highlight
+ * overlays it is currently drawing.
+ */
+interface PreviewClearHighlightsMessage extends PreviewMessageBase {
+    type: "clear-highlights";
+}
+
+export function createPreviewClearHighlightsMessage(): PreviewClearHighlightsMessage {
+    return {
+        source: PREVIEW_MESSAGE_SOURCE,
+        type: "clear-highlights",
+    };
+}
+
+/**
  * Union of all messages sent from parent to iframe
+ *
+ * TODO: add PreviewSetA11yEnabledMessage/PreviewHighlightIssuesMessage/
+ * PreviewClearHighlightsMessage here once usePreviewPresenter handles them
+ * (the exhaustive switch obligates a handler to land in the same change).
  */
 export type ParentToIframeMessage =
     | PreviewDataMessage
@@ -161,7 +220,20 @@ interface PreviewHeightUpdateMessage extends PreviewMessageBase {
 }
 
 /**
+ * Message from iframe reporting axe-core accessibility scan results back to the
+ * parent. `violations` are confirmed issues; `incompletes` need manual review.
+ */
+interface PreviewA11yReportMessage extends PreviewMessageBase {
+    type: "a11y-report";
+    violations: Issue[];
+    incompletes: Issue[];
+}
+
+/**
  * Union of all messages sent from iframe to parent
+ *
+ * TODO: add PreviewA11yReportMessage here once usePreviewController handles it
+ * (the exhaustive switch obligates a handler to land in the same change).
  */
 export type IframeToParentMessage =
     | PreviewIframeReadyMessage
@@ -171,5 +243,17 @@ export function createPreviewIframeReadyMessage(): PreviewIframeReadyMessage {
     return {
         source: PREVIEW_MESSAGE_SOURCE,
         type: "iframe-ready",
+    };
+}
+
+export function createPreviewA11yReportMessage(
+    violations: Issue[],
+    incompletes: Issue[],
+): PreviewA11yReportMessage {
+    return {
+        source: PREVIEW_MESSAGE_SOURCE,
+        type: "a11y-report",
+        violations,
+        incompletes,
     };
 }

--- a/packages/perseus-editor/src/preview/message-types.ts
+++ b/packages/perseus-editor/src/preview/message-types.ts
@@ -221,12 +221,17 @@ interface PreviewHeightUpdateMessage extends PreviewMessageBase {
 
 /**
  * Message from iframe reporting axe-core accessibility scan results back to the
- * parent. `violations` are confirmed issues; `incompletes` need manual review.
+ * parent.
  */
 interface PreviewA11yReportMessage extends PreviewMessageBase {
     type: "a11y-report";
+    /** Violations are issues that are confirmed by the a11y scanner. **/
     violations: Issue[];
-    incompletes: Issue[];
+    /**
+     * Unsures are issues that the scanner cannot definitively say is a
+     * violation or not. Requires manual review. *
+     */
+    unsures: Issue[];
 }
 
 /**
@@ -248,12 +253,12 @@ export function createPreviewIframeReadyMessage(): PreviewIframeReadyMessage {
 
 export function createPreviewA11yReportMessage(
     violations: Issue[],
-    incompletes: Issue[],
+    unsures: Issue[],
 ): PreviewA11yReportMessage {
     return {
         source: PREVIEW_MESSAGE_SOURCE,
         type: "a11y-report",
         violations,
-        incompletes,
+        unsures,
     };
 }

--- a/packages/perseus-editor/src/preview/message-validators.test.ts
+++ b/packages/perseus-editor/src/preview/message-validators.test.ts
@@ -83,14 +83,21 @@ describe("message-validators", () => {
             expect(isIframeToParentMessage([])).toBe(false);
         });
 
-        it("returns true for message with correct source but missing required fields", () => {
+        it("returns false for object missing a type", () => {
             const message = {
                 source: PREVIEW_MESSAGE_SOURCE,
             };
 
-            // Type guard only checks source, not message-specific fields
-            // This should still return true because the type guard is minimal
-            expect(isIframeToParentMessage(message)).toBe(true);
+            expect(isIframeToParentMessage(message)).toBe(false);
+        });
+
+        it("returns false for object with a non-string type", () => {
+            const message = {
+                source: PREVIEW_MESSAGE_SOURCE,
+                type: 42,
+            };
+
+            expect(isIframeToParentMessage(message)).toBe(false);
         });
     });
 
@@ -178,13 +185,21 @@ describe("message-validators", () => {
             expect(isParentToIframeMessage([1, 2, 3])).toBe(false);
         });
 
-        it("returns true for message with correct source (minimal validation)", () => {
+        it("returns false for object missing a type", () => {
             const message = {
                 source: PREVIEW_MESSAGE_SOURCE,
             };
 
-            // Type guard only checks source, not message-specific fields
-            expect(isParentToIframeMessage(message)).toBe(true);
+            expect(isParentToIframeMessage(message)).toBe(false);
+        });
+
+        it("returns false for object with a non-string type", () => {
+            const message = {
+                source: PREVIEW_MESSAGE_SOURCE,
+                type: {nested: "object"},
+            };
+
+            expect(isParentToIframeMessage(message)).toBe(false);
         });
 
         it("handles message with additional unexpected properties", () => {
@@ -205,7 +220,8 @@ describe("message-validators", () => {
                 type: "some-type",
             };
 
-            // Both type guards only check source, so this passes both
+            // Both type guards check only source + a string type, so this
+            // structurally valid message passes both.
             expect(isIframeToParentMessage(message)).toBe(true);
             expect(isParentToIframeMessage(message)).toBe(true);
         });

--- a/packages/perseus-editor/src/preview/message-validators.ts
+++ b/packages/perseus-editor/src/preview/message-validators.ts
@@ -22,7 +22,9 @@ export function isIframeToParentMessage(
         message !== null &&
         "source" in message &&
         typeof message.source === "string" &&
-        message.source === PREVIEW_MESSAGE_SOURCE
+        message.source === PREVIEW_MESSAGE_SOURCE &&
+        "type" in message &&
+        typeof message.type === "string"
     );
 }
 
@@ -43,6 +45,8 @@ export function isParentToIframeMessage(
         message !== null &&
         "source" in message &&
         typeof message.source === "string" &&
-        message.source === PREVIEW_MESSAGE_SOURCE
+        message.source === PREVIEW_MESSAGE_SOURCE &&
+        "type" in message &&
+        typeof message.type === "string"
     );
 }

--- a/packages/perseus-editor/src/preview/message-validators.ts
+++ b/packages/perseus-editor/src/preview/message-validators.ts
@@ -21,7 +21,6 @@ export function isIframeToParentMessage(
         typeof message === "object" &&
         message !== null &&
         "source" in message &&
-        typeof message.source === "string" &&
         message.source === PREVIEW_MESSAGE_SOURCE &&
         "type" in message &&
         typeof message.type === "string"
@@ -44,7 +43,6 @@ export function isParentToIframeMessage(
         typeof message === "object" &&
         message !== null &&
         "source" in message &&
-        typeof message.source === "string" &&
         message.source === PREVIEW_MESSAGE_SOURCE &&
         "type" in message &&
         typeof message.type === "string"

--- a/packages/perseus-editor/src/util/a11y-checker.ts
+++ b/packages/perseus-editor/src/util/a11y-checker.ts
@@ -177,16 +177,16 @@ const runAxeCore = (
                 "Alert",
                 isInStorybook ? null : previewWindow,
             );
-            const incompletes = mapResultsToIssues(
+            const unsures = mapResultsToIssues(
                 results.incomplete,
                 "Warning",
                 isInStorybook ? null : previewWindow,
             );
-            const issues = violations.concat(incompletes);
+            const issues = violations.concat(unsures);
             log(`  Issues: `, issues);
             if (
                 violations.length === 0 &&
-                incompletes.length === 0 &&
+                unsures.length === 0 &&
                 results.passes.length === 0
             ) {
                 setTimeout(runAxeCore, 1500, updateIssuesFn, logToConsole); // No valid results indicates that content may not be fully loaded yet


### PR DESCRIPTION
## About this stack: axe-core in the preview iframe

*This PR is one of a stacked series that moves axe-core accessibility scanning out of the parent editor and into the preview iframe. Previously a11y checks ran in the parent, reaching across the iframe boundary to scan the preview's DOM and to draw "Show Me" outline overlays in the parent document. The series relocates the scan into the iframe — where the DOM is directly accessible — reports results back over the typed preview `postMessage` protocol, and draws the highlight overlays inside the iframe. The outcome is a single code path with no cross-frame DOM access.*

**PRs in this stack:**

- #3905
- 👉 #3906
- #3907
- #3908
- #3909
- #3910
- #3911
- #3912

---

## Summary:

Adds the typed preview-bridge messages the axe-core-in-iframe work will use, plus tightens the message validators. Four new message types and their constructors land here: `set-a11y-enabled` (parent → iframe, toggles scanning), `highlight-issues` and `clear-highlights` (parent → iframe, drive the "Show Me" overlays), and `a11y-report` (iframe → parent, scan results). This is pure protocol groundwork — no code sends or handles these yet; the controller and presenter branches stacked on top wire them up.

Issue: LEMS-4402

## Test plan:

- `pnpm test`
- `pnpm typecheck`