### PR TITLE
[Preview axe-core]: debounced axe-core scan in the presenter

### DIFF
--- a/.changeset/tough-moments-travel.md
+++ b/.changeset/tough-moments-travel.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+`usePreviewPresenter` gains a debounced axe-core scan, element-map management for resolving highlight targets, and a `highlightTargets` return value.

--- a/packages/perseus-editor/src/preview/message-types.ts
+++ b/packages/perseus-editor/src/preview/message-types.ts
@@ -196,14 +196,13 @@ export function createPreviewClearHighlightsMessage(): PreviewClearHighlightsMes
 
 /**
  * Union of all messages sent from parent to iframe
- *
- * TODO: add PreviewSetA11yEnabledMessage/PreviewHighlightIssuesMessage/
- * PreviewClearHighlightsMessage here once usePreviewPresenter handles them
- * (the exhaustive switch obligates a handler to land in the same change).
  */
 export type ParentToIframeMessage =
     | PreviewDataMessage
-    | PreviewIframeInitMessage;
+    | PreviewIframeInitMessage
+    | PreviewSetA11yEnabledMessage
+    | PreviewHighlightIssuesMessage
+    | PreviewClearHighlightsMessage;
 
 // ---- Iframe → Parent messages ----
 

--- a/packages/perseus-editor/src/preview/message-types.ts
+++ b/packages/perseus-editor/src/preview/message-types.ts
@@ -198,14 +198,13 @@ export function createPreviewClearHighlightsMessage(): PreviewClearHighlightsMes
 
 /**
  * Union of all messages sent from parent to iframe
- *
- * TODO: add PreviewSetA11yScanningEnabledMessage/PreviewHighlightIssuesMessage/
- * PreviewClearHighlightsMessage here once usePreviewPresenter handles them
- * (the exhaustive switch obligates a handler to land in the same change).
  */
 export type ParentToIframeMessage =
     | PreviewDataMessage
-    | PreviewIframeInitMessage;
+    | PreviewIframeInitMessage
+    | PreviewSetA11yScanningEnabledMessage
+    | PreviewHighlightIssuesMessage
+    | PreviewClearHighlightsMessage;
 
 // ---- Iframe → Parent messages ----
 

--- a/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
+++ b/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
@@ -5,19 +5,35 @@ import {usePreviewPresenter} from "./use-preview-presenter";
 
 import type {ParentToIframeMessage, PreviewContent} from "./message-types";
 
+const mockAxeRun = jest.fn().mockResolvedValue({
+    violations: [],
+    incomplete: [],
+});
+
+jest.mock("axe-core", () => ({
+    __esModule: true,
+    default: {
+        configure: jest.fn(),
+        run: mockAxeRun,
+    },
+}));
+
 describe("usePreviewPresenter", () => {
     let mockIframeElement: {
         dataset: {[key: string]: string | undefined};
     };
     let mockParentWindow: Window;
+    let mockPostMessage: jest.Mock;
     let originalFrameElement: Element | null;
     let originalParent: Window;
 
     beforeEach(() => {
-        // Mock parent window with postMessage
+        mockAxeRun.mockResolvedValue({violations: [], incomplete: []});
+
+        mockPostMessage = jest.fn();
         // eslint-disable-next-line no-restricted-syntax
         mockParentWindow = {
-            postMessage: jest.fn(),
+            postMessage: mockPostMessage,
         } as unknown as Window;
 
         // Mock iframe element with dataset
@@ -354,7 +370,7 @@ describe("usePreviewPresenter", () => {
     });
 
     describe("receiving iframe-init message", () => {
-        it("sets content from an iframe-init message", () => {
+        it("sets content and a11yEnabled together from one message", () => {
             const {result} = renderHook(() => usePreviewPresenter());
 
             const questionContent: PreviewContent = {
@@ -380,6 +396,7 @@ describe("usePreviewPresenter", () => {
                             source: PREVIEW_MESSAGE_SOURCE,
                             type: "iframe-init",
                             content: questionContent,
+                            a11yEnabled: true,
                         },
                         source: mockParentWindow,
                     }),
@@ -387,6 +404,7 @@ describe("usePreviewPresenter", () => {
             });
 
             expect(result.current.content).toEqual(questionContent);
+            expect(result.current.a11yEnabled).toBe(true);
         });
 
         it("handles null content (nothing sent yet)", () => {
@@ -399,6 +417,7 @@ describe("usePreviewPresenter", () => {
                             source: PREVIEW_MESSAGE_SOURCE,
                             type: "iframe-init",
                             content: null,
+                            a11yEnabled: false,
                         },
                         source: mockParentWindow,
                     }),
@@ -406,6 +425,328 @@ describe("usePreviewPresenter", () => {
             });
 
             expect(result.current.content).toBeNull();
+            expect(result.current.a11yEnabled).toBe(false);
+        });
+    });
+
+    describe("receiving set-a11y-enabled message", () => {
+        it("updates a11yEnabled when receiving set-a11y-enabled message", () => {
+            const {result} = renderHook(() => usePreviewPresenter());
+
+            expect(result.current.a11yEnabled).toBe(false);
+
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            source: PREVIEW_MESSAGE_SOURCE,
+                            type: "set-a11y-enabled",
+                            enabled: true,
+                        },
+                        source: mockParentWindow,
+                    }),
+                );
+            });
+
+            expect(result.current.a11yEnabled).toBe(true);
+        });
+    });
+
+    describe("axe-core scanning", () => {
+        const enableA11yScanning = () => {
+            window.dispatchEvent(
+                new MessageEvent("message", {
+                    data: {
+                        source: PREVIEW_MESSAGE_SOURCE,
+                        type: "set-a11y-enabled",
+                        enabled: true,
+                    },
+                    source: mockParentWindow,
+                }),
+            );
+        };
+
+        const sendContent = (content: PreviewContent) => {
+            window.dispatchEvent(
+                new MessageEvent("message", {
+                    data: {
+                        source: PREVIEW_MESSAGE_SOURCE,
+                        type: "content-data",
+                        content,
+                    },
+                    source: mockParentWindow,
+                }),
+            );
+        };
+
+        it("posts an a11y-report message 1500ms after content changes while scanning is enabled", async () => {
+            // Arrange
+            const contentContainerRef = {
+                current: document.createElement("div"),
+            };
+
+            renderHook(() => usePreviewPresenter({contentContainerRef}));
+
+            // Act
+            act(() => {
+                enableA11yScanning();
+                sendContent({
+                    type: "question",
+                    data: {
+                        question: {
+                            content: "What is 2+2?",
+                            widgets: {},
+                            images: {},
+                        },
+                        apiOptions: {readOnly: true},
+                        linterContext: {
+                            contentType: "exercise",
+                            highlightLint: false,
+                        },
+                    },
+                });
+            });
+
+            act(() => {
+                jest.advanceTimersByTime(1500);
+            });
+
+            // Assert
+            await waitFor(() => {
+                expect(mockAxeRun).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        include: contentContainerRef.current,
+                    }),
+                    expect.objectContaining({elementRef: true}),
+                );
+            });
+
+            expect(mockParentWindow.postMessage).toHaveBeenCalledWith(
+                expect.objectContaining({type: "a11y-report"}),
+                "/",
+            );
+        });
+    });
+
+    describe("receiving highlight-issues message", () => {
+        it("resolves previewIds to elements via the latest scan's element map", async () => {
+            // Arrange
+            const targetElement = document.createElement("button");
+            const contentContainerRef = {
+                current: document.createElement("div"),
+            };
+
+            mockAxeRun.mockResolvedValue({
+                violations: [
+                    {
+                        id: "button-name",
+                        helpUrl: "https://example.com",
+                        help: "Buttons must have discernible text",
+                        impact: "serious",
+                        nodes: [
+                            {
+                                element: targetElement,
+                                all: [],
+                                any: [],
+                                none: [],
+                            },
+                        ],
+                    },
+                ],
+                incomplete: [],
+            });
+
+            const {result} = renderHook(() =>
+                usePreviewPresenter({contentContainerRef}),
+            );
+
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            source: PREVIEW_MESSAGE_SOURCE,
+                            type: "set-a11y-enabled",
+                            enabled: true,
+                        },
+                        source: mockParentWindow,
+                    }),
+                );
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            source: PREVIEW_MESSAGE_SOURCE,
+                            type: "content-data",
+                            content: {
+                                type: "question",
+                                data: {
+                                    question: {
+                                        content: "What is 2+2?",
+                                        widgets: {},
+                                        images: {},
+                                    },
+                                    apiOptions: {readOnly: true},
+                                    linterContext: {
+                                        contentType: "exercise",
+                                        highlightLint: false,
+                                    },
+                                },
+                            },
+                        },
+                        source: mockParentWindow,
+                    }),
+                );
+            });
+
+            act(() => {
+                jest.advanceTimersByTime(1500);
+            });
+
+            await waitFor(() => {
+                expect(mockParentWindow.postMessage).toHaveBeenCalledWith(
+                    expect.objectContaining({type: "a11y-report"}),
+                    "/",
+                );
+            });
+
+            const reportCall = mockPostMessage.mock.calls.find(
+                (call) => call[0].type === "a11y-report",
+            );
+            const previewId = reportCall[0].violations[0].previewId;
+
+            // Act
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            source: PREVIEW_MESSAGE_SOURCE,
+                            type: "highlight-issues",
+                            previewIds: [previewId],
+                        },
+                        source: mockParentWindow,
+                    }),
+                );
+            });
+
+            // Assert
+            expect(result.current.highlightTargets).toEqual([targetElement]);
+        });
+    });
+
+    describe("receiving clear-highlights message", () => {
+        it("resets highlightTargets to empty", async () => {
+            // Arrange
+            const targetElement = document.createElement("button");
+            const contentContainerRef = {
+                current: document.createElement("div"),
+            };
+
+            mockAxeRun.mockResolvedValue({
+                violations: [
+                    {
+                        id: "button-name",
+                        helpUrl: "https://example.com",
+                        help: "Buttons must have discernible text",
+                        impact: "serious",
+                        nodes: [
+                            {
+                                element: targetElement,
+                                all: [],
+                                any: [],
+                                none: [],
+                            },
+                        ],
+                    },
+                ],
+                incomplete: [],
+            });
+
+            const {result} = renderHook(() =>
+                usePreviewPresenter({contentContainerRef}),
+            );
+
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            source: PREVIEW_MESSAGE_SOURCE,
+                            type: "set-a11y-enabled",
+                            enabled: true,
+                        },
+                        source: mockParentWindow,
+                    }),
+                );
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            source: PREVIEW_MESSAGE_SOURCE,
+                            type: "content-data",
+                            content: {
+                                type: "question",
+                                data: {
+                                    question: {
+                                        content: "What is 2+2?",
+                                        widgets: {},
+                                        images: {},
+                                    },
+                                    apiOptions: {readOnly: true},
+                                    linterContext: {
+                                        contentType: "exercise",
+                                        highlightLint: false,
+                                    },
+                                },
+                            },
+                        },
+                        source: mockParentWindow,
+                    }),
+                );
+            });
+
+            act(() => {
+                jest.advanceTimersByTime(1500);
+            });
+
+            await waitFor(() => {
+                expect(mockParentWindow.postMessage).toHaveBeenCalledWith(
+                    expect.objectContaining({type: "a11y-report"}),
+                    "/",
+                );
+            });
+
+            const reportCall = mockPostMessage.mock.calls.find(
+                (call) => call[0].type === "a11y-report",
+            );
+            const previewId = reportCall[0].violations[0].previewId;
+
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            source: PREVIEW_MESSAGE_SOURCE,
+                            type: "highlight-issues",
+                            previewIds: [previewId],
+                        },
+                        source: mockParentWindow,
+                    }),
+                );
+            });
+
+            expect(result.current.highlightTargets).toEqual([targetElement]);
+
+            // Act
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            source: PREVIEW_MESSAGE_SOURCE,
+                            type: "clear-highlights",
+                        },
+                        source: mockParentWindow,
+                    }),
+                );
+            });
+
+            // Assert
+            expect(result.current.highlightTargets).toEqual([]);
         });
     });
 

--- a/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
+++ b/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
@@ -5,19 +5,35 @@ import {usePreviewPresenter} from "./use-preview-presenter";
 
 import type {ParentToIframeMessage, PreviewContent} from "./message-types";
 
+const mockAxeRun = jest.fn().mockResolvedValue({
+    violations: [],
+    incomplete: [],
+});
+
+jest.mock("axe-core", () => ({
+    __esModule: true,
+    default: {
+        configure: jest.fn(),
+        run: mockAxeRun,
+    },
+}));
+
 describe("usePreviewPresenter", () => {
     let mockIframeElement: {
         dataset: {[key: string]: string | undefined};
     };
     let mockParentWindow: Window;
+    let mockPostMessage: jest.Mock;
     let originalFrameElement: Element | null;
     let originalParent: Window;
 
     beforeEach(() => {
-        // Mock parent window with postMessage
+        mockAxeRun.mockResolvedValue({violations: [], incomplete: []});
+
+        mockPostMessage = jest.fn();
         // eslint-disable-next-line no-restricted-syntax
         mockParentWindow = {
-            postMessage: jest.fn(),
+            postMessage: mockPostMessage,
         } as unknown as Window;
 
         // Mock iframe element with dataset
@@ -354,7 +370,7 @@ describe("usePreviewPresenter", () => {
     });
 
     describe("receiving iframe-init message", () => {
-        it("sets the question content", () => {
+        it("sets content and a11yScanningEnabled together from one message", () => {
             const {result} = renderHook(() => usePreviewPresenter());
 
             const questionContent: PreviewContent = {
@@ -380,6 +396,7 @@ describe("usePreviewPresenter", () => {
                             source: PREVIEW_MESSAGE_SOURCE,
                             type: "iframe-init",
                             content: questionContent,
+                            a11yScanningEnabled: true,
                         },
                         source: mockParentWindow,
                     }),
@@ -387,6 +404,7 @@ describe("usePreviewPresenter", () => {
             });
 
             expect(result.current.content).toEqual(questionContent);
+            expect(result.current.a11yScanningEnabled).toBe(true);
         });
 
         it("handles null content (nothing sent yet)", () => {
@@ -399,6 +417,7 @@ describe("usePreviewPresenter", () => {
                             source: PREVIEW_MESSAGE_SOURCE,
                             type: "iframe-init",
                             content: null,
+                            a11yScanningEnabled: false,
                         },
                         source: mockParentWindow,
                     }),
@@ -406,6 +425,328 @@ describe("usePreviewPresenter", () => {
             });
 
             expect(result.current.content).toBeNull();
+            expect(result.current.a11yScanningEnabled).toBe(false);
+        });
+    });
+
+    describe("receiving set-a11y-scanning-enabled message", () => {
+        it("enables scanning when told to", () => {
+            const {result} = renderHook(() => usePreviewPresenter());
+
+            expect(result.current.a11yScanningEnabled).toBe(false);
+
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            source: PREVIEW_MESSAGE_SOURCE,
+                            type: "set-a11y-scanning-enabled",
+                            enabled: true,
+                        },
+                        source: mockParentWindow,
+                    }),
+                );
+            });
+
+            expect(result.current.a11yScanningEnabled).toBe(true);
+        });
+    });
+
+    describe("axe-core scanning", () => {
+        const enableA11yScanning = () => {
+            window.dispatchEvent(
+                new MessageEvent("message", {
+                    data: {
+                        source: PREVIEW_MESSAGE_SOURCE,
+                        type: "set-a11y-scanning-enabled",
+                        enabled: true,
+                    },
+                    source: mockParentWindow,
+                }),
+            );
+        };
+
+        const sendContent = (content: PreviewContent) => {
+            window.dispatchEvent(
+                new MessageEvent("message", {
+                    data: {
+                        source: PREVIEW_MESSAGE_SOURCE,
+                        type: "content-data",
+                        content,
+                    },
+                    source: mockParentWindow,
+                }),
+            );
+        };
+
+        it("posts an a11y-report message 1500ms after content changes while scanning is enabled", async () => {
+            // Arrange
+            const contentContainerRef = {
+                current: document.createElement("div"),
+            };
+
+            renderHook(() => usePreviewPresenter({contentContainerRef}));
+
+            // Act
+            act(() => {
+                enableA11yScanning();
+                sendContent({
+                    type: "question",
+                    data: {
+                        question: {
+                            content: "What is 2+2?",
+                            widgets: {},
+                            images: {},
+                        },
+                        apiOptions: {readOnly: true},
+                        linterContext: {
+                            contentType: "exercise",
+                            highlightLint: false,
+                        },
+                    },
+                });
+            });
+
+            act(() => {
+                jest.advanceTimersByTime(1500);
+            });
+
+            // Assert
+            await waitFor(() => {
+                expect(mockAxeRun).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        include: contentContainerRef.current,
+                    }),
+                    expect.objectContaining({elementRef: true}),
+                );
+            });
+
+            expect(mockParentWindow.postMessage).toHaveBeenCalledWith(
+                expect.objectContaining({type: "a11y-report"}),
+                "/",
+            );
+        });
+    });
+
+    describe("receiving highlight-issues message", () => {
+        it("resolves previewIds to elements via the latest scan's element map", async () => {
+            // Arrange
+            const targetElement = document.createElement("button");
+            const contentContainerRef = {
+                current: document.createElement("div"),
+            };
+
+            mockAxeRun.mockResolvedValue({
+                violations: [
+                    {
+                        id: "button-name",
+                        helpUrl: "https://example.com",
+                        help: "Buttons must have discernible text",
+                        impact: "serious",
+                        nodes: [
+                            {
+                                element: targetElement,
+                                all: [],
+                                any: [],
+                                none: [],
+                            },
+                        ],
+                    },
+                ],
+                incomplete: [],
+            });
+
+            const {result} = renderHook(() =>
+                usePreviewPresenter({contentContainerRef}),
+            );
+
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            source: PREVIEW_MESSAGE_SOURCE,
+                            type: "set-a11y-scanning-enabled",
+                            enabled: true,
+                        },
+                        source: mockParentWindow,
+                    }),
+                );
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            source: PREVIEW_MESSAGE_SOURCE,
+                            type: "content-data",
+                            content: {
+                                type: "question",
+                                data: {
+                                    question: {
+                                        content: "What is 2+2?",
+                                        widgets: {},
+                                        images: {},
+                                    },
+                                    apiOptions: {readOnly: true},
+                                    linterContext: {
+                                        contentType: "exercise",
+                                        highlightLint: false,
+                                    },
+                                },
+                            },
+                        },
+                        source: mockParentWindow,
+                    }),
+                );
+            });
+
+            act(() => {
+                jest.advanceTimersByTime(1500);
+            });
+
+            await waitFor(() => {
+                expect(mockParentWindow.postMessage).toHaveBeenCalledWith(
+                    expect.objectContaining({type: "a11y-report"}),
+                    "/",
+                );
+            });
+
+            const reportCall = mockPostMessage.mock.calls.find(
+                (call) => call[0].type === "a11y-report",
+            );
+            const previewId = reportCall[0].violations[0].instanceId;
+
+            // Act
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            source: PREVIEW_MESSAGE_SOURCE,
+                            type: "highlight-issues",
+                            previewIds: [previewId],
+                        },
+                        source: mockParentWindow,
+                    }),
+                );
+            });
+
+            // Assert
+            expect(result.current.highlightTargets).toEqual([targetElement]);
+        });
+    });
+
+    describe("receiving clear-highlights message", () => {
+        it("resets highlightTargets to empty", async () => {
+            // Arrange
+            const targetElement = document.createElement("button");
+            const contentContainerRef = {
+                current: document.createElement("div"),
+            };
+
+            mockAxeRun.mockResolvedValue({
+                violations: [
+                    {
+                        id: "button-name",
+                        helpUrl: "https://example.com",
+                        help: "Buttons must have discernible text",
+                        impact: "serious",
+                        nodes: [
+                            {
+                                element: targetElement,
+                                all: [],
+                                any: [],
+                                none: [],
+                            },
+                        ],
+                    },
+                ],
+                incomplete: [],
+            });
+
+            const {result} = renderHook(() =>
+                usePreviewPresenter({contentContainerRef}),
+            );
+
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            source: PREVIEW_MESSAGE_SOURCE,
+                            type: "set-a11y-scanning-enabled",
+                            enabled: true,
+                        },
+                        source: mockParentWindow,
+                    }),
+                );
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            source: PREVIEW_MESSAGE_SOURCE,
+                            type: "content-data",
+                            content: {
+                                type: "question",
+                                data: {
+                                    question: {
+                                        content: "What is 2+2?",
+                                        widgets: {},
+                                        images: {},
+                                    },
+                                    apiOptions: {readOnly: true},
+                                    linterContext: {
+                                        contentType: "exercise",
+                                        highlightLint: false,
+                                    },
+                                },
+                            },
+                        },
+                        source: mockParentWindow,
+                    }),
+                );
+            });
+
+            act(() => {
+                jest.advanceTimersByTime(1500);
+            });
+
+            await waitFor(() => {
+                expect(mockParentWindow.postMessage).toHaveBeenCalledWith(
+                    expect.objectContaining({type: "a11y-report"}),
+                    "/",
+                );
+            });
+
+            const reportCall = mockPostMessage.mock.calls.find(
+                (call) => call[0].type === "a11y-report",
+            );
+            const previewId = reportCall[0].violations[0].instanceId;
+
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            source: PREVIEW_MESSAGE_SOURCE,
+                            type: "highlight-issues",
+                            previewIds: [previewId],
+                        },
+                        source: mockParentWindow,
+                    }),
+                );
+            });
+
+            expect(result.current.highlightTargets).toEqual([targetElement]);
+
+            // Act
+            act(() => {
+                window.dispatchEvent(
+                    new MessageEvent("message", {
+                        data: {
+                            source: PREVIEW_MESSAGE_SOURCE,
+                            type: "clear-highlights",
+                        },
+                        source: mockParentWindow,
+                    }),
+                );
+            });
+
+            // Assert
+            expect(result.current.highlightTargets).toEqual([]);
         });
     });
 

--- a/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
+++ b/packages/perseus-editor/src/preview/use-preview-presenter.test.ts
@@ -479,6 +479,65 @@ describe("usePreviewPresenter", () => {
             );
         };
 
+        const questionContent = (text: string): PreviewContent => ({
+            type: "question",
+            data: {
+                question: {content: text, widgets: {}, images: {}},
+                apiOptions: {readOnly: true},
+                linterContext: {
+                    contentType: "exercise",
+                    highlightLint: false,
+                },
+            },
+        });
+
+        it("rescans once the in-flight scan settles when content changed mid-scan", async () => {
+            // Arrange: hold the first scan open so the second request lands
+            // while it is still running.
+            const contentContainerRef = {
+                current: document.createElement("div"),
+            };
+            let finishFirstScan: (results: unknown) => void = () => {};
+            mockAxeRun.mockImplementationOnce(
+                () =>
+                    new Promise((resolve) => {
+                        finishFirstScan = resolve;
+                    }),
+            );
+
+            renderHook(() => usePreviewPresenter({contentContainerRef}));
+
+            act(() => {
+                enableA11yScanning();
+                sendContent(questionContent("What is 2+2?"));
+            });
+            act(() => {
+                jest.advanceTimersByTime(1500);
+            });
+            await waitFor(() => {
+                expect(mockAxeRun).toHaveBeenCalledTimes(1);
+            });
+
+            // Act: new content arrives and its debounce fires while the first
+            // scan is still in flight, then the first scan finishes.
+            act(() => {
+                sendContent(questionContent("What is 3+3?"));
+            });
+            act(() => {
+                jest.advanceTimersByTime(1500);
+            });
+            expect(mockAxeRun).toHaveBeenCalledTimes(1);
+
+            await act(async () => {
+                finishFirstScan({violations: [], incomplete: []});
+            });
+
+            // Assert
+            await waitFor(() => {
+                expect(mockAxeRun).toHaveBeenCalledTimes(2);
+            });
+        });
+
         it("posts an a11y-report message 1500ms after content changes while scanning is enabled", async () => {
             // Arrange
             const contentContainerRef = {

--- a/packages/perseus-editor/src/preview/use-preview-presenter.ts
+++ b/packages/perseus-editor/src/preview/use-preview-presenter.ts
@@ -1,7 +1,10 @@
+import {useActionScheduler} from "@khanacademy/wonder-blocks-timing";
 import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 import * as React from "react";
 
+import {mapAxeResults} from "./a11y/map-axe-results";
 import {
+    createPreviewA11yReportMessage,
     createPreviewIframeReadyMessage,
     PREVIEW_MESSAGE_SOURCE,
 } from "./message-types";
@@ -12,6 +15,14 @@ import type {
     ParentToIframeMessage,
     PreviewContent,
 } from "./message-types";
+
+type UsePreviewPresenterOptions = {
+    /**
+     * Ref to the element containing the rendered preview content. Used as
+     * the root for axe-core accessibility scans.
+     */
+    contentContainerRef?: React.RefObject<HTMLElement | null>;
+};
 
 type UsePreviewPresenterResult = {
     /**
@@ -30,6 +41,16 @@ type UsePreviewPresenterResult = {
      * Function to report the current height of the iframe content to the parent
      */
     reportHeight: (height: number) => void;
+    /**
+     * Whether axe-core accessibility scanning is enabled
+     */
+    a11yEnabled: boolean;
+    /**
+     * Elements to draw "Show Me" highlight overlays over, resolved from the
+     * latest scan's element map via the previewIds in a highlight-issues
+     * message.
+     */
+    highlightTargets: Element[];
 };
 
 /**
@@ -61,8 +82,16 @@ type UsePreviewPresenterResult = {
  * }
  * ```
  */
-export function usePreviewPresenter(): UsePreviewPresenterResult {
+export function usePreviewPresenter(
+    options: UsePreviewPresenterOptions = {},
+): UsePreviewPresenterResult {
+    const {contentContainerRef} = options;
     const [content, setContent] = React.useState<PreviewContent | null>(null);
+    const [a11yEnabled, setA11yEnabled] = React.useState(false);
+    const [highlightTargets, setHighlightTargets] = React.useState<Element[]>(
+        [],
+    );
+    const schedule = useActionScheduler();
 
     // eslint-disable-next-line no-restricted-syntax
     const iframe = window.frameElement as HTMLIFrameElement | null;
@@ -92,6 +121,24 @@ export function usePreviewPresenter(): UsePreviewPresenterResult {
 
                 case "iframe-init":
                     setContent(message.content);
+                    setA11yEnabled(message.a11yEnabled);
+                    break;
+
+                case "set-a11y-enabled":
+                    setA11yEnabled(message.enabled);
+                    break;
+
+                case "highlight-issues":
+                    setHighlightTargets(
+                        message.previewIds.flatMap(
+                            (previewId) =>
+                                elementMapRef.current.get(previewId) ?? [],
+                        ),
+                    );
+                    break;
+
+                case "clear-highlights":
+                    setHighlightTargets([]);
                     break;
 
                 default:
@@ -108,6 +155,75 @@ export function usePreviewPresenter(): UsePreviewPresenterResult {
             window.removeEventListener("message", handleMessage);
         };
     }, []);
+
+    // Tracks the latest a11yEnabled value for the async scan below, which
+    // needs to check it after awaiting rather than the value it closed over.
+    const a11yEnabledRef = React.useRef(a11yEnabled);
+    React.useEffect(() => {
+        a11yEnabledRef.current = a11yEnabled;
+    }, [a11yEnabled]);
+
+    // In-flight scan promise. Non-null means a scan is already running, so a
+    // debounce firing mid-scan is dropped rather than starting a second run.
+    const scanPromiseRef = React.useRef<Promise<void> | null>(null);
+
+    // The latest scan's previewId -> elements map, used to resolve
+    // highlight-issues messages to the elements they refer to.
+    const elementMapRef = React.useRef<Map<string, Element[]>>(new Map());
+
+    // Run an axe-core scan (debounced) whenever content changes and
+    // scanning is enabled.
+    React.useEffect(() => {
+        const container = contentContainerRef?.current;
+        if (!a11yEnabled || content == null || container == null) {
+            return;
+        }
+
+        const scheduledScan = schedule.timeout(() => {
+            if (scanPromiseRef.current != null) {
+                return;
+            }
+
+            scanPromiseRef.current = (async () => {
+                // Delay-loading axe-core so that we can easily bundle-split it
+                // out and avoid loading it if we aren't using it.
+                const axe = (await import("axe-core")).default;
+                axe.configure({reporter: "v2"});
+                const results = await axe.run(
+                    {
+                        include: container,
+                        exclude: [['[target="lint-help-window"]']],
+                    },
+                    // elementRef populates node.element on each result, which
+                    // mapAxeResults needs to resolve "Show Me" highlighting.
+                    {elementRef: true},
+                );
+
+                if (!a11yEnabledRef.current) {
+                    return;
+                }
+
+                const {issues: violations, elementMap: violationMap} =
+                    mapAxeResults(results.violations, "Alert");
+                const {issues: incompletes, elementMap: incompleteMap} =
+                    mapAxeResults(results.incomplete, "Warning");
+
+                elementMapRef.current = new Map([
+                    ...violationMap,
+                    ...incompleteMap,
+                ]);
+
+                window.parent.postMessage(
+                    createPreviewA11yReportMessage(violations, incompletes),
+                    "/",
+                );
+            })().finally(() => {
+                scanPromiseRef.current = null;
+            });
+        }, 1500);
+
+        return () => scheduledScan.clear();
+    }, [content, a11yEnabled, contentContainerRef, schedule]);
 
     // Memoized callback to report height
     const reportHeight = React.useCallback((height: number) => {
@@ -128,5 +244,7 @@ export function usePreviewPresenter(): UsePreviewPresenterResult {
         isMobile: iframe.dataset.mobile === "true",
         hasLintGutter: iframe.dataset.lintGutter === "true",
         reportHeight,
+        a11yEnabled,
+        highlightTargets,
     };
 }

--- a/packages/perseus-editor/src/preview/use-preview-presenter.ts
+++ b/packages/perseus-editor/src/preview/use-preview-presenter.ts
@@ -1,7 +1,10 @@
+import {useActionScheduler} from "@khanacademy/wonder-blocks-timing";
 import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 import * as React from "react";
 
+import {mapAxeResults} from "./a11y/map-axe-results";
 import {
+    createPreviewA11yReportMessage,
     createPreviewIframeReadyMessage,
     PREVIEW_MESSAGE_SOURCE,
 } from "./message-types";
@@ -12,6 +15,14 @@ import type {
     ParentToIframeMessage,
     PreviewContent,
 } from "./message-types";
+
+type UsePreviewPresenterOptions = {
+    /**
+     * Ref to the element containing the rendered preview content. Used as
+     * the root for axe-core accessibility scans.
+     */
+    contentContainerRef?: React.RefObject<HTMLElement | null>;
+};
 
 type UsePreviewPresenterResult = {
     /**
@@ -30,6 +41,16 @@ type UsePreviewPresenterResult = {
      * Function to report the current height of the iframe content to the parent
      */
     reportHeight: (height: number) => void;
+    /**
+     * Whether axe-core accessibility scanning is enabled
+     */
+    a11yScanningEnabled: boolean;
+    /**
+     * Elements to draw "Show Me" highlight overlays over, resolved from the
+     * latest scan's element map via the previewIds in a highlight-issues
+     * message.
+     */
+    highlightTargets: Element[];
 };
 
 /**
@@ -61,8 +82,16 @@ type UsePreviewPresenterResult = {
  * }
  * ```
  */
-export function usePreviewPresenter(): UsePreviewPresenterResult {
+export function usePreviewPresenter(
+    options: UsePreviewPresenterOptions = {},
+): UsePreviewPresenterResult {
+    const {contentContainerRef} = options;
     const [content, setContent] = React.useState<PreviewContent | null>(null);
+    const [a11yScanningEnabled, setA11yScanningEnabled] = React.useState(false);
+    const [highlightTargets, setHighlightTargets] = React.useState<Element[]>(
+        [],
+    );
+    const schedule = useActionScheduler();
 
     // eslint-disable-next-line no-restricted-syntax
     const iframe = window.frameElement as HTMLIFrameElement | null;
@@ -92,6 +121,24 @@ export function usePreviewPresenter(): UsePreviewPresenterResult {
 
                 case "iframe-init":
                     setContent(message.content);
+                    setA11yScanningEnabled(message.a11yScanningEnabled);
+                    break;
+
+                case "set-a11y-scanning-enabled":
+                    setA11yScanningEnabled(message.enabled);
+                    break;
+
+                case "highlight-issues":
+                    setHighlightTargets(
+                        message.previewIds.flatMap(
+                            (previewId) =>
+                                elementMapRef.current.get(previewId) ?? [],
+                        ),
+                    );
+                    break;
+
+                case "clear-highlights":
+                    setHighlightTargets([]);
                     break;
 
                 default:
@@ -108,6 +155,76 @@ export function usePreviewPresenter(): UsePreviewPresenterResult {
             window.removeEventListener("message", handleMessage);
         };
     }, []);
+
+    // Tracks the latest a11yScanningEnabled value for the async scan below,
+    // which needs to check it after awaiting rather than the value it closed
+    // over.
+    const a11yScanningEnabledRef = React.useRef(a11yScanningEnabled);
+    React.useEffect(() => {
+        a11yScanningEnabledRef.current = a11yScanningEnabled;
+    }, [a11yScanningEnabled]);
+
+    // In-flight scan promise. Non-null means a scan is already running, so a
+    // debounce firing mid-scan is dropped rather than starting a second run.
+    const scanPromiseRef = React.useRef<Promise<void> | null>(null);
+
+    // The latest scan's previewId -> elements map, used to resolve
+    // highlight-issues messages to the elements they refer to.
+    const elementMapRef = React.useRef<Map<string, Element[]>>(new Map());
+
+    // Run an axe-core scan (debounced) whenever content changes and
+    // scanning is enabled.
+    React.useEffect(() => {
+        const container = contentContainerRef?.current;
+        if (!a11yScanningEnabled || content == null || container == null) {
+            return;
+        }
+
+        const scheduledScan = schedule.timeout(() => {
+            if (scanPromiseRef.current != null) {
+                return;
+            }
+
+            scanPromiseRef.current = (async () => {
+                // Delay-loading axe-core so that we can easily bundle-split it
+                // out and avoid loading it if we aren't using it.
+                const axe = (await import("axe-core")).default;
+                axe.configure({reporter: "v2"});
+                const results = await axe.run(
+                    {
+                        include: container,
+                        exclude: [['[target="lint-help-window"]']],
+                    },
+                    // elementRef populates node.element on each result, which
+                    // mapAxeResults needs to resolve "Show Me" highlighting.
+                    {elementRef: true},
+                );
+
+                if (!a11yScanningEnabledRef.current) {
+                    return;
+                }
+
+                const {issues: violations, elementMap: violationMap} =
+                    mapAxeResults(results.violations, "Alert");
+                const {issues: incompletes, elementMap: incompleteMap} =
+                    mapAxeResults(results.incomplete, "Warning");
+
+                elementMapRef.current = new Map([
+                    ...violationMap,
+                    ...incompleteMap,
+                ]);
+
+                window.parent.postMessage(
+                    createPreviewA11yReportMessage(violations, incompletes),
+                    "/",
+                );
+            })().finally(() => {
+                scanPromiseRef.current = null;
+            });
+        }, 1500);
+
+        return () => scheduledScan.clear();
+    }, [content, a11yScanningEnabled, contentContainerRef, schedule]);
 
     // Memoized callback to report height
     const reportHeight = React.useCallback((height: number) => {
@@ -128,5 +245,7 @@ export function usePreviewPresenter(): UsePreviewPresenterResult {
         isMobile: iframe.dataset.mobile === "true",
         hasLintGutter: iframe.dataset.lintGutter === "true",
         reportHeight,
+        a11yScanningEnabled,
+        highlightTargets,
     };
 }

--- a/packages/perseus-editor/src/preview/use-preview-presenter.ts
+++ b/packages/perseus-editor/src/preview/use-preview-presenter.ts
@@ -164,13 +164,75 @@ export function usePreviewPresenter(
         a11yScanningEnabledRef.current = a11yScanningEnabled;
     }, [a11yScanningEnabled]);
 
-    // In-flight scan promise. Non-null means a scan is already running, so a
-    // debounce firing mid-scan is dropped rather than starting a second run.
+    // In-flight scan promise. Non-null means a scan is already running.
     const scanPromiseRef = React.useRef<Promise<void> | null>(null);
+
+    // Set when a scan is asked for while one is already running. axe-core has
+    // no way to cancel a run, so the newer request waits for the current run
+    // to settle instead of being dropped — otherwise an author who stops
+    // editing right then would be left looking at the previous content's
+    // issues forever.
+    const rescanRequestedRef = React.useRef(false);
 
     // The latest scan's previewId -> elements map, used to resolve
     // highlight-issues messages to the elements they refer to.
     const elementMapRef = React.useRef<Map<string, Element[]>>(new Map());
+
+    // Scans the container's current DOM, so a rescan picks up whatever
+    // content has rendered by the time it runs.
+    const startScan = React.useCallback(() => {
+        const container = contentContainerRef?.current;
+        if (!a11yScanningEnabledRef.current || container == null) {
+            return;
+        }
+
+        if (scanPromiseRef.current != null) {
+            rescanRequestedRef.current = true;
+            return;
+        }
+
+        scanPromiseRef.current = (async () => {
+            // Delay-loading axe-core so that we can easily bundle-split it
+            // out and avoid loading it if we aren't using it.
+            const axe = (await import("axe-core")).default;
+            axe.configure({reporter: "v2"});
+            const results = await axe.run(
+                {
+                    include: container,
+                    exclude: [['[target="lint-help-window"]']],
+                },
+                // elementRef populates node.element on each result, which
+                // mapAxeResults needs to resolve "Show Me" highlighting.
+                {elementRef: true},
+            );
+
+            if (!a11yScanningEnabledRef.current) {
+                return;
+            }
+
+            const {issues: violations, elementMap: violationMap} =
+                mapAxeResults(results.violations, "Alert");
+            const {issues: incompletes, elementMap: incompleteMap} =
+                mapAxeResults(results.incomplete, "Warning");
+
+            elementMapRef.current = new Map([
+                ...violationMap,
+                ...incompleteMap,
+            ]);
+
+            window.parent.postMessage(
+                createPreviewA11yReportMessage(violations, incompletes),
+                "/",
+            );
+        })().finally(() => {
+            scanPromiseRef.current = null;
+
+            if (rescanRequestedRef.current) {
+                rescanRequestedRef.current = false;
+                startScan();
+            }
+        });
+    }, [contentContainerRef]);
 
     // Run an axe-core scan (debounced) whenever content changes and
     // scanning is enabled.
@@ -180,51 +242,16 @@ export function usePreviewPresenter(
             return;
         }
 
-        const scheduledScan = schedule.timeout(() => {
-            if (scanPromiseRef.current != null) {
-                return;
-            }
-
-            scanPromiseRef.current = (async () => {
-                // Delay-loading axe-core so that we can easily bundle-split it
-                // out and avoid loading it if we aren't using it.
-                const axe = (await import("axe-core")).default;
-                axe.configure({reporter: "v2"});
-                const results = await axe.run(
-                    {
-                        include: container,
-                        exclude: [['[target="lint-help-window"]']],
-                    },
-                    // elementRef populates node.element on each result, which
-                    // mapAxeResults needs to resolve "Show Me" highlighting.
-                    {elementRef: true},
-                );
-
-                if (!a11yScanningEnabledRef.current) {
-                    return;
-                }
-
-                const {issues: violations, elementMap: violationMap} =
-                    mapAxeResults(results.violations, "Alert");
-                const {issues: incompletes, elementMap: incompleteMap} =
-                    mapAxeResults(results.incomplete, "Warning");
-
-                elementMapRef.current = new Map([
-                    ...violationMap,
-                    ...incompleteMap,
-                ]);
-
-                window.parent.postMessage(
-                    createPreviewA11yReportMessage(violations, incompletes),
-                    "/",
-                );
-            })().finally(() => {
-                scanPromiseRef.current = null;
-            });
-        }, 1500);
+        const scheduledScan = schedule.timeout(startScan, 1500);
 
         return () => scheduledScan.clear();
-    }, [content, a11yScanningEnabled, contentContainerRef, schedule]);
+    }, [
+        content,
+        a11yScanningEnabled,
+        contentContainerRef,
+        schedule,
+        startScan,
+    ]);
 
     // Memoized callback to report height
     const reportHeight = React.useCallback((height: number) => {


### PR DESCRIPTION
## About this stack: axe-core in the preview iframe

*This PR is one of a stacked series that moves axe-core accessibility scanning out of the parent editor and into the preview iframe. Previously a11y checks ran in the parent, reaching across the iframe boundary to scan the preview's DOM and to draw "Show Me" outline overlays in the parent document. The series relocates the scan into the iframe — where the DOM is directly accessible — reports results back over the typed preview `postMessage` protocol, and draws the highlight overlays inside the iframe. The outcome is a single code path with no cross-frame DOM access.*

**PRs in this stack:**

- #3905
- #3906
- #3907
- #3908
- 👉 #3909
- #3910
- #3911
- #3912

---

## Summary:

`usePreviewPresenter` gains the child-side scan: a debounced axe-core run rooted at the content container, element-map management that resolves the previewIds in a `highlight-issues` message to their elements, and a `highlightTargets` return value the host renders overlays over. axe-core is lazy-`import()`ed so it only loads once scanning is actually enabled.

Issue: LEMS-4402

## Test plan:

- `pnpm test`
- `pnpm typecheck`