### PR TITLE
[Preview axe-core]: axe-core props for PreviewWithIframe

### DIFF
--- a/.changeset/goofy-buttons-say.md
+++ b/.changeset/goofy-buttons-say.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+`PreviewWithIframe` gains `a11yEnabled`, `highlightPreviewIds`, and `onA11yReport` props, and a new `A11yContext` wires axe-core scan/highlight state through the editor.

--- a/.changeset/goofy-buttons-say.md
+++ b/.changeset/goofy-buttons-say.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus-editor": minor
 ---
 
-`PreviewWithIframe` gains `a11yEnabled`, `highlightPreviewIds`, and `onA11yReport` props, and a new `A11yContext` wires axe-core scan/highlight state through the editor.
+`PreviewWithIframe` gains `a11yScanningEnabled`, `highlightPreviewIds`, and `onA11yReport` props, which drive axe-core scanning and "Show Me" highlighting inside the preview iframe.

--- a/packages/perseus-editor/src/components/highlight-context.tsx
+++ b/packages/perseus-editor/src/components/highlight-context.tsx
@@ -1,9 +1,0 @@
-import * as React from "react";
-
-export type HighlightContextValue = {
-    /** Activate highlight for an issue (null clears it). */
-    setIssueHighlight: (issueId: string, previewId: string | null) => void;
-};
-
-export const HighlightContext =
-    React.createContext<HighlightContextValue | null>(null);

--- a/packages/perseus-editor/src/components/highlight-context.tsx
+++ b/packages/perseus-editor/src/components/highlight-context.tsx
@@ -1,0 +1,9 @@
+import * as React from "react";
+
+export type HighlightContextValue = {
+    /** Activate highlight for an issue (null clears it). */
+    setIssueHighlight: (issueId: string, previewId: string | null) => void;
+};
+
+export const HighlightContext =
+    React.createContext<HighlightContextValue | null>(null);

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -8,12 +8,23 @@ import {clone} from "./testing/object-utils";
 import type {PreviewContent} from "./preview/message-types";
 
 const mockSendData = jest.fn();
+const mockSetA11yEnabled = jest.fn();
+const mockHighlightIssues = jest.fn();
+const mockClearHighlights = jest.fn();
 let mockHeight: number | null = null;
+let mockA11yReport: {
+    violations: Array<{id: string}>;
+    incompletes: Array<{id: string}>;
+} | null = null;
 
 jest.mock("./preview/use-preview-controller", () => ({
     usePreviewController: () => ({
         sendData: mockSendData,
         height: mockHeight,
+        setA11yEnabled: mockSetA11yEnabled,
+        highlightIssues: mockHighlightIssues,
+        clearHighlights: mockClearHighlights,
+        a11yReport: mockA11yReport,
     }),
 }));
 
@@ -34,7 +45,11 @@ function buildArticleContent(): PreviewContent {
 describe("PreviewWithIframe", () => {
     beforeEach(() => {
         mockHeight = null;
+        mockA11yReport = null;
         mockSendData.mockClear();
+        mockSetA11yEnabled.mockClear();
+        mockHighlightIssues.mockClear();
+        mockClearHighlights.mockClear();
     });
 
     it("does not call sendData when content is null", () => {
@@ -190,5 +205,85 @@ describe("PreviewWithIframe", () => {
 
         const container = screen.getByTitle(/perseus-preview/);
         expect(container.style.height).toBe("500px");
+    });
+
+    describe("a11yEnabled prop", () => {
+        it("calls setA11yEnabled with the prop's value", () => {
+            // Arrange, Act
+            render(
+                <PreviewWithIframe
+                    url="/preview"
+                    isMobile={false}
+                    seamless={false}
+                    content={buildArticleContent()}
+                    a11yEnabled={true}
+                />,
+            );
+
+            // Assert
+            expect(mockSetA11yEnabled).toHaveBeenCalledWith(true);
+        });
+    });
+
+    describe("highlightPreviewIds prop", () => {
+        it("calls highlightIssues with the given previewIds", () => {
+            // Arrange, Act
+            render(
+                <PreviewWithIframe
+                    url="/preview"
+                    isMobile={false}
+                    seamless={false}
+                    content={buildArticleContent()}
+                    highlightPreviewIds={["violation-1"]}
+                />,
+            );
+
+            // Assert
+            expect(mockHighlightIssues).toHaveBeenCalledWith(["violation-1"]);
+            expect(mockClearHighlights).not.toHaveBeenCalled();
+        });
+
+        it("calls clearHighlights when previewIds is empty", () => {
+            // Arrange, Act
+            render(
+                <PreviewWithIframe
+                    url="/preview"
+                    isMobile={false}
+                    seamless={false}
+                    content={buildArticleContent()}
+                    highlightPreviewIds={[]}
+                />,
+            );
+
+            // Assert
+            expect(mockClearHighlights).toHaveBeenCalled();
+            expect(mockHighlightIssues).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("onA11yReport prop", () => {
+        it("calls onA11yReport with the latest report from usePreviewController", () => {
+            // Arrange
+            const report = {
+                violations: [{id: "button-name"}],
+                incompletes: [],
+            };
+            mockA11yReport = report;
+            const onA11yReport = jest.fn();
+
+            // Act
+            render(
+                <PreviewWithIframe
+                    url="/preview"
+                    isMobile={false}
+                    seamless={false}
+                    content={buildArticleContent()}
+                    onA11yReport={onA11yReport}
+                />,
+            );
+
+            // Assert
+            expect(onA11yReport).toHaveBeenCalledWith(report);
+        });
     });
 });

--- a/packages/perseus-editor/src/preview-with-iframe.test.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.test.tsx
@@ -8,7 +8,7 @@ import {clone} from "./testing/object-utils";
 import type {PreviewContent} from "./preview/message-types";
 
 const mockSendData = jest.fn();
-const mockSetA11yEnabled = jest.fn();
+const mockSetA11yScanningEnabled = jest.fn();
 const mockHighlightIssues = jest.fn();
 const mockClearHighlights = jest.fn();
 let mockHeight: number | null = null;
@@ -21,7 +21,7 @@ jest.mock("./preview/use-preview-controller", () => ({
     usePreviewController: () => ({
         sendData: mockSendData,
         height: mockHeight,
-        setA11yEnabled: mockSetA11yEnabled,
+        setA11yScanningEnabled: mockSetA11yScanningEnabled,
         highlightIssues: mockHighlightIssues,
         clearHighlights: mockClearHighlights,
         a11yReport: mockA11yReport,
@@ -47,7 +47,7 @@ describe("PreviewWithIframe", () => {
         mockHeight = null;
         mockA11yReport = null;
         mockSendData.mockClear();
-        mockSetA11yEnabled.mockClear();
+        mockSetA11yScanningEnabled.mockClear();
         mockHighlightIssues.mockClear();
         mockClearHighlights.mockClear();
     });
@@ -207,8 +207,8 @@ describe("PreviewWithIframe", () => {
         expect(container.style.height).toBe("500px");
     });
 
-    describe("a11yEnabled prop", () => {
-        it("calls setA11yEnabled with the prop's value", () => {
+    describe("a11yScanningEnabled prop", () => {
+        it("calls setA11yScanningEnabled with the prop's value", () => {
             // Arrange, Act
             render(
                 <PreviewWithIframe
@@ -216,12 +216,12 @@ describe("PreviewWithIframe", () => {
                     isMobile={false}
                     seamless={false}
                     content={buildArticleContent()}
-                    a11yEnabled={true}
+                    a11yScanningEnabled={true}
                 />,
             );
 
             // Assert
-            expect(mockSetA11yEnabled).toHaveBeenCalledWith(true);
+            expect(mockSetA11yScanningEnabled).toHaveBeenCalledWith(true);
         });
     });
 

--- a/packages/perseus-editor/src/preview-with-iframe.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.tsx
@@ -2,8 +2,8 @@ import * as React from "react";
 
 import {usePreviewController} from "./preview/use-preview-controller";
 
-import type {A11yReport} from "./preview/use-preview-controller";
 import type {PreviewContent} from "./preview/message-types";
+import type {A11yReport} from "./preview/use-preview-controller";
 
 type Props = {
     /**
@@ -96,9 +96,12 @@ function PreviewWithIframe(props: Props) {
         }
     }, [highlightIssues, clearHighlights, props.highlightPreviewIds]);
 
+    // Destructured so the effect depends on the specific prop rather than the
+    // whole `props` object (which changes on every render).
+    const {onA11yReport} = props;
     React.useEffect(() => {
-        props.onA11yReport?.(a11yReport);
-    }, [a11yReport, props.onA11yReport]);
+        onA11yReport?.(a11yReport);
+    }, [a11yReport, onA11yReport]);
 
     // Update container height based on iframe content height if we're in
     // seamless mode.

--- a/packages/perseus-editor/src/preview-with-iframe.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import {usePreviewController} from "./preview/use-preview-controller";
 
+import type {A11yReport} from "./preview/use-preview-controller";
 import type {PreviewContent} from "./preview/message-types";
 
 type Props = {
@@ -24,6 +25,21 @@ type Props = {
      * been provided yet and the iframe should render an empty placeholder.
      */
     content: PreviewContent | null;
+
+    /**
+     * Whether the iframe should run axe-core accessibility scans.
+     */
+    a11yEnabled?: boolean;
+    /**
+     * previewIds of the issues to draw "Show Me" highlight overlays over in
+     * the iframe. Empty clears any highlights.
+     */
+    highlightPreviewIds?: string[];
+    /**
+     * Called whenever the iframe reports a new accessibility scan result (or
+     * `null` if scanning is disabled).
+     */
+    onA11yReport?: (report: A11yReport | null) => void;
 };
 
 /**
@@ -45,7 +61,14 @@ type Props = {
 function PreviewWithIframe(props: Props) {
     const iframeRef = React.useRef<HTMLIFrameElement>(null);
 
-    const {sendData, height} = usePreviewController(iframeRef);
+    const {
+        sendData,
+        height,
+        setA11yEnabled,
+        highlightIssues,
+        clearHighlights,
+        a11yReport,
+    } = usePreviewController(iframeRef);
 
     // NOTE: The `props.content` is an object and will trigger a re-render of
     // this component any time its identity changes (regardless of whether it
@@ -57,6 +80,25 @@ function PreviewWithIframe(props: Props) {
             sendData(props.content);
         }
     }, [sendData, props.content]);
+
+    React.useEffect(() => {
+        setA11yEnabled(props.a11yEnabled ?? false);
+    }, [setA11yEnabled, props.a11yEnabled]);
+
+    React.useEffect(() => {
+        if (
+            props.highlightPreviewIds != null &&
+            props.highlightPreviewIds.length > 0
+        ) {
+            highlightIssues(props.highlightPreviewIds);
+        } else {
+            clearHighlights();
+        }
+    }, [highlightIssues, clearHighlights, props.highlightPreviewIds]);
+
+    React.useEffect(() => {
+        props.onA11yReport?.(a11yReport);
+    }, [a11yReport, props.onA11yReport]);
 
     // Update container height based on iframe content height if we're in
     // seamless mode.

--- a/packages/perseus-editor/src/preview-with-iframe.tsx
+++ b/packages/perseus-editor/src/preview-with-iframe.tsx
@@ -29,7 +29,7 @@ type Props = {
     /**
      * Whether the iframe should run axe-core accessibility scans.
      */
-    a11yEnabled?: boolean;
+    a11yScanningEnabled?: boolean;
     /**
      * previewIds of the issues to draw "Show Me" highlight overlays over in
      * the iframe. Empty clears any highlights.
@@ -64,7 +64,7 @@ function PreviewWithIframe(props: Props) {
     const {
         sendData,
         height,
-        setA11yEnabled,
+        setA11yScanningEnabled,
         highlightIssues,
         clearHighlights,
         a11yReport,
@@ -82,8 +82,8 @@ function PreviewWithIframe(props: Props) {
     }, [sendData, props.content]);
 
     React.useEffect(() => {
-        setA11yEnabled(props.a11yEnabled ?? false);
-    }, [setA11yEnabled, props.a11yEnabled]);
+        setA11yScanningEnabled(props.a11yScanningEnabled ?? false);
+    }, [setA11yScanningEnabled, props.a11yScanningEnabled]);
 
     React.useEffect(() => {
         if (

--- a/packages/perseus-editor/src/testing/preview/exercise-preview-page.test.tsx
+++ b/packages/perseus-editor/src/testing/preview/exercise-preview-page.test.tsx
@@ -1,0 +1,77 @@
+import {render, screen} from "@testing-library/react";
+import * as React from "react";
+
+import ExercisePreviewPage from "./exercise-preview-page";
+
+import type {PreviewContent} from "../../preview/message-types";
+
+const mockReportHeight = jest.fn();
+let mockContent: PreviewContent | null = null;
+let mockHighlightTargets: Element[] = [];
+
+jest.mock("../../preview/use-preview-presenter", () => ({
+    usePreviewPresenter: () => ({
+        content: mockContent,
+        isMobile: false,
+        hasLintGutter: false,
+        reportHeight: mockReportHeight,
+        a11yEnabled: false,
+        highlightTargets: mockHighlightTargets,
+    }),
+}));
+
+jest.mock("./preview-renderer", () => ({
+    PreviewRenderer: () => <div>Preview content</div>,
+}));
+
+function buildQuestionContent(): PreviewContent {
+    return {
+        type: "question",
+        data: {
+            question: {content: "What is 2+2?", widgets: {}, images: {}},
+            apiOptions: {},
+            linterContext: {contentType: "exercise", highlightLint: false},
+        },
+    };
+}
+
+describe("ExercisePreviewPage", () => {
+    beforeEach(() => {
+        mockContent = null;
+        mockHighlightTargets = [];
+
+        // eslint-disable-next-line no-restricted-syntax
+        window.ResizeObserver = jest.fn().mockImplementation(() => ({
+            observe: jest.fn(),
+            unobserve: jest.fn(),
+            disconnect: jest.fn(),
+        })) as unknown as typeof ResizeObserver;
+    });
+
+    it("renders one overlay per highlight target", () => {
+        // Arrange
+        mockContent = buildQuestionContent();
+        mockHighlightTargets = [
+            document.createElement("button"),
+            document.createElement("input"),
+        ];
+
+        // Act
+        render(<ExercisePreviewPage />);
+
+        // Assert
+        expect(screen.getAllByTestId("a11y-overlay")).toHaveLength(2);
+    });
+
+    it("renders no overlays when there are no highlight targets", () => {
+        // Arrange
+        mockContent = buildQuestionContent();
+        mockHighlightTargets = [];
+
+        // Act
+        render(<ExercisePreviewPage />);
+
+        // Assert
+        expect(screen.queryByTestId("a11y-overlay")).not.toBeInTheDocument();
+    });
+});

--- a/packages/perseus-editor/src/testing/preview/exercise-preview-page.test.tsx
+++ b/packages/perseus-editor/src/testing/preview/exercise-preview-page.test.tsx
@@ -15,7 +15,7 @@ jest.mock("../../preview/use-preview-presenter", () => ({
         isMobile: false,
         hasLintGutter: false,
         reportHeight: mockReportHeight,
-        a11yEnabled: false,
+        a11yScanningEnabled: false,
         highlightTargets: mockHighlightTargets,
     }),
 }));

--- a/packages/perseus-editor/src/testing/preview/exercise-preview-page.tsx
+++ b/packages/perseus-editor/src/testing/preview/exercise-preview-page.tsx
@@ -3,6 +3,7 @@ import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
+import {A11yOverlays} from "../../preview/a11y/overlays";
 import {usePreviewPresenter} from "../../preview/use-preview-presenter";
 
 import {PreviewRenderer} from "./preview-renderer";
@@ -12,9 +13,18 @@ import {PreviewRenderer} from "./preview-renderer";
  * only be used to support editor previews in Storybook!
  */
 const ExercisePreviewPage = () => {
-    const {content, isMobile, hasLintGutter, reportHeight} =
-        usePreviewPresenter();
-    const containerRef = React.useRef<HTMLDivElement>(null);
+    const containerRef = React.useRef<HTMLElement | null>(null);
+    const [containerElement, setContainerElement] =
+        React.useState<HTMLElement | null>(null);
+    // Also updates state so <A11yOverlays> re-renders with a non-null
+    // container as soon as it mounts, rather than seeing containerRef.current
+    // as null on the render pass before the ref attaches.
+    const setContainerRefs = React.useCallback((node: HTMLElement | null) => {
+        containerRef.current = node;
+        setContainerElement(node);
+    }, []);
+    const {content, isMobile, hasLintGutter, reportHeight, highlightTargets} =
+        usePreviewPresenter({contentContainerRef: containerRef});
     const lastHeightRef = React.useRef<number | null>(null);
 
     // Set the overflow on the body within the iframe (scroll for
@@ -72,13 +82,17 @@ const ExercisePreviewPage = () => {
     }
 
     return (
-        <div ref={containerRef}>
+        <View ref={setContainerRefs} style={styles.container}>
             <PreviewRenderer
                 content={content}
                 isMobile={isMobile}
                 hasLintGutter={hasLintGutter}
             />
-        </div>
+            <A11yOverlays
+                container={containerElement}
+                targets={highlightTargets}
+            />
+        </View>
     );
 };
 
@@ -86,6 +100,11 @@ const styles = StyleSheet.create({
     loading: {
         padding: spacing.medium_16,
         textAlign: "center",
+    },
+    container: {
+        // A11yOverlays positions its overlay divs `absolute`, measured
+        // against this element's box — it must be a positioned ancestor.
+        position: "relative",
     },
 });
 


### PR DESCRIPTION
## About this stack: axe-core in the preview iframe

*This PR is one of a stacked series that moves axe-core accessibility scanning out of the parent editor and into the preview iframe. Previously a11y checks ran in the parent, reaching across the iframe boundary to scan the preview's DOM and to draw "Show Me" outline overlays in the parent document. The series relocates the scan into the iframe — where the DOM is directly accessible — reports results back over the typed preview `postMessage` protocol, and draws the highlight overlays inside the iframe. The outcome is a single code path with no cross-frame DOM access.*

**PRs in this stack:**

- #3905
- #3906
- #3907
- #3908
- #3909
- 👉 #3910
- #3911
- #3912

---

## Summary:

`PreviewWithIframe` becomes fully declarative for a11y: it gains `a11yEnabled`, `highlightPreviewIds`, and `onA11yReport` props (all optional, so existing callers are unaffected) and internally wires them through `usePreviewController`. Adds `A11yContext` to route scan/highlight state through the editor subtree, and updates the Storybook preview page to render `A11yOverlays` inside the (position-relative) content container. This is the first branch where scanning works end-to-end in Storybook.

Issue: LEMS-4402

## Test plan:

- `pnpm test`
- `pnpm typecheck`
- In Storybook, open an editor preview, enable the axe-core scan, and confirm issues appear and "Show Me" outlines draw inside the iframe.