### PR TITLE
Preserve whole widget options object in Image subcomponents

### DIFF
--- a/.changeset/neat-laws-battle.md
+++ b/.changeset/neat-laws-battle.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal improvements to the Image widget.

--- a/packages/perseus/src/widgets/image/components/common-image-props.ts
+++ b/packages/perseus/src/widgets/image/components/common-image-props.ts
@@ -1,6 +1,6 @@
+import type {APIOptions} from "../../../types";
 import type {PerseusImageWidgetOptions} from "@khanacademy/perseus-core";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
-import type {APIOptions} from "@khanacademy/perseus";
 
 export interface CommonImageProps {
     options: PerseusImageWidgetOptions;

--- a/packages/perseus/src/widgets/image/components/common-image-props.ts
+++ b/packages/perseus/src/widgets/image/components/common-image-props.ts
@@ -8,5 +8,5 @@ export interface CommonImageProps {
     apiOptions: APIOptions;
     widgetId: string;
     isGifPlaying: boolean;
-    setIsGifPlaying: (isPaused: boolean) => void;
+    setIsGifPlaying: (isPlaying: boolean) => void;
 }

--- a/packages/perseus/src/widgets/image/components/common-image-props.ts
+++ b/packages/perseus/src/widgets/image/components/common-image-props.ts
@@ -1,0 +1,12 @@
+import type {PerseusImageWidgetOptions} from "@khanacademy/perseus-core";
+import type {LinterContextProps} from "@khanacademy/perseus-linter";
+import type {APIOptions} from "@khanacademy/perseus";
+
+export interface CommonImageProps {
+    options: PerseusImageWidgetOptions;
+    linterContext: LinterContextProps;
+    apiOptions: APIOptions;
+    widgetId: string;
+    isGifPlaying: boolean;
+    setIsGifPlaying: (isPaused: boolean) => void;
+}

--- a/packages/perseus/src/widgets/image/components/explore-image-modal-content.tsx
+++ b/packages/perseus/src/widgets/image/components/explore-image-modal-content.tsx
@@ -11,31 +11,34 @@ import {decodeGifFrames, isGif, isSvg} from "../utils";
 
 import {GifControlsButton} from "./gif-controls-button";
 
-import type {CommonImageProps, GifProps} from "./image-info-area";
+import type {GifProps, ImageInfoProps} from "./image-info-area";
 import type {ParsedFrame} from "gifuct-js";
 
 const MODAL_HEIGHT = 568;
 
-type Props = CommonImageProps &
+type Props = ImageInfoProps &
     GifProps & {
         captionId: string;
         longDescId: string;
     };
 
 export default function ExploreImageModalContent({
-    backgroundImage,
-    scale: contentScale,
-    caption,
-    alt,
-    longDescription,
+    options,
     linterContext,
     apiOptions,
-    box,
-    labels,
-    range,
     captionId,
     longDescId,
 }: Props) {
+    const {
+        backgroundImage,
+        scale: contentScale,
+        caption,
+        alt,
+        longDescription,
+        box,
+        labels,
+        range,
+    } = options;
     const [isGifPlaying, setIsGifPlaying] = React.useState(false);
     // Decoded GIF frames; null until decoding completes.
     const [gifFrames, setGifFrames] = React.useState<ParsedFrame[] | null>(

--- a/packages/perseus/src/widgets/image/components/explore-image-modal-content.tsx
+++ b/packages/perseus/src/widgets/image/components/explore-image-modal-content.tsx
@@ -11,8 +11,8 @@ import {decodeGifFrames, isGif, isSvg} from "../utils";
 
 import {GifControlsButton} from "./gif-controls-button";
 
+import type {CommonImageProps} from "./common-image-props";
 import type {ParsedFrame} from "gifuct-js";
-import {CommonImageProps} from "./common-image-props";
 
 const MODAL_HEIGHT = 568;
 

--- a/packages/perseus/src/widgets/image/components/explore-image-modal-content.tsx
+++ b/packages/perseus/src/widgets/image/components/explore-image-modal-content.tsx
@@ -11,16 +11,15 @@ import {decodeGifFrames, isGif, isSvg} from "../utils";
 
 import {GifControlsButton} from "./gif-controls-button";
 
-import type {GifProps, ImageInfoProps} from "./image-info-area";
 import type {ParsedFrame} from "gifuct-js";
+import {CommonImageProps} from "./common-image-props";
 
 const MODAL_HEIGHT = 568;
 
-type Props = ImageInfoProps &
-    GifProps & {
-        captionId: string;
-        longDescId: string;
-    };
+interface Props extends CommonImageProps {
+    captionId: string;
+    longDescId: string;
+}
 
 export default function ExploreImageModalContent({
     options,

--- a/packages/perseus/src/widgets/image/components/explore-image-modal.test.tsx
+++ b/packages/perseus/src/widgets/image/components/explore-image-modal.test.tsx
@@ -1,3 +1,4 @@
+import {generateImageOptions} from "@khanacademy/perseus-core";
 import {act, render, waitFor, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
@@ -19,7 +20,7 @@ import {
 
 import {ExploreImageModal} from "./explore-image-modal";
 
-import type {Interval, Size} from "@khanacademy/perseus-core";
+import type {PerseusImageWidgetOptions} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
 
 jest.mock("../utils", () => ({
@@ -44,24 +45,14 @@ function renderModal(props: React.ComponentProps<typeof ExploreImageModal>) {
 }
 
 const defaultProps = {
-    backgroundImage: {},
-    scale: 1,
-    title: "",
-    caption: "",
-    // Images should have alt text, and need alt text to be detectable
-    // by the testing library.
-    alt: "widget alt text",
-    // Explore image modal is only showing up because there is
-    // a long description.
-    longDescription: "widget long description",
-    // Zoom size would not be 0 for a legitimate image
-    zoomSize: [100, 100] satisfies Size,
-    box: [400, 400] satisfies Size,
-    labels: [],
-    range: [
-        [0, 10],
-        [0, 10],
-    ] satisfies [Interval, Interval],
+    options: generateImageOptions({
+        // Images should have alt text, and need alt text to be detectable
+        // by the testing library.
+        alt: "widget alt text",
+        // Explore image modal is only showing up because there is
+        // a long description.
+        longDescription: "widget long description",
+    }),
     linterContext: {
         contentType: "",
         highlightLint: false,
@@ -72,6 +63,15 @@ const defaultProps = {
     setIsGifPlaying: () => {},
     widgetId: "image 1",
 };
+
+// Render the modal with the default props, overriding specific widget options
+// (e.g. the background image) merged onto the defaults.
+function renderModalWithOptions(options: Partial<PerseusImageWidgetOptions>) {
+    return renderModal({
+        ...defaultProps,
+        options: {...defaultProps.options, ...options},
+    });
+}
 
 describe("ExploreImageModal", () => {
     let userEvent: UserEvent;
@@ -128,18 +128,14 @@ describe("ExploreImageModal", () => {
     });
 
     it("should have null content if there is no background image URL", () => {
-        // Arrange
-        const props = {
-            ...defaultProps,
+        // Arrange, Act
+        renderModalWithOptions({
             backgroundImage: {
                 url: undefined,
                 width: 100,
                 height: 100,
             },
-        };
-
-        // Act
-        renderModal(props);
+        });
         act(() => {
             jest.runAllTimers();
         });
@@ -154,18 +150,14 @@ describe("ExploreImageModal", () => {
     });
 
     it("should still render the modal content if the width is not provided", () => {
-        // Arrange
-        const props = {
-            ...defaultProps,
+        // Arrange, Act
+        renderModalWithOptions({
             backgroundImage: {
                 url: earthMoonImage.url,
                 width: undefined,
                 height: 100,
             },
-        };
-
-        // Act
-        renderModal(props);
+        });
         act(() => {
             jest.runAllTimers();
         });
@@ -180,18 +172,14 @@ describe("ExploreImageModal", () => {
     });
 
     it("should still render the modal content if the height is not provided", () => {
-        // Arrange
-        const props = {
-            ...defaultProps,
+        // Arrange, Act
+        renderModalWithOptions({
             backgroundImage: {
                 url: earthMoonImage.url,
                 width: 100,
                 height: undefined,
             },
-        };
-
-        // Act
-        renderModal(props);
+        });
         act(() => {
             jest.runAllTimers();
         });
@@ -221,7 +209,7 @@ describe("ExploreImageModal", () => {
         // Arrange
 
         // Act
-        renderModal({...defaultProps, title: "widget title"});
+        renderModalWithOptions({title: "widget title"});
 
         // Assert
         const title = screen.getByRole("heading", {level: 1});
@@ -233,8 +221,7 @@ describe("ExploreImageModal", () => {
         // Arrange
 
         // Act
-        renderModal({
-            ...defaultProps,
+        renderModalWithOptions({
             backgroundImage: earthMoonImage,
             caption: "widget caption",
         });
@@ -247,8 +234,7 @@ describe("ExploreImageModal", () => {
         // Arrange
 
         // Act
-        renderModal({
-            ...defaultProps,
+        renderModalWithOptions({
             backgroundImage: earthMoonImage,
             longDescription: "widget long description",
         });
@@ -261,8 +247,7 @@ describe("ExploreImageModal", () => {
 
     it("sets the describedby to short and long description IDs if there is a caption", () => {
         // Arrange, Act
-        renderModal({
-            ...defaultProps,
+        renderModalWithOptions({
             backgroundImage: earthMoonImage,
             caption: "widget caption",
         });
@@ -277,8 +262,7 @@ describe("ExploreImageModal", () => {
 
     it("sets the describedby to long description ID if there is no caption", () => {
         // Arrange, Act
-        renderModal({
-            ...defaultProps,
+        renderModalWithOptions({
             backgroundImage: earthMoonImage,
             longDescription: "widget long description",
         });
@@ -303,8 +287,7 @@ describe("ExploreImageModal", () => {
 
         it("should render gif controls if the image is a multi frame gif", async () => {
             // Arrange, Act — beforeEach decodes the gif into two frames
-            renderModal({
-                ...defaultProps,
+            renderModalWithOptions({
                 backgroundImage: animatedGifLandscape,
             });
 
@@ -320,8 +303,7 @@ describe("ExploreImageModal", () => {
             // eslint-disable-next-line no-restricted-syntax
             (decodeGifFrames as jest.Mock).mockResolvedValue([fakeFrame]);
             //Act
-            renderModal({
-                ...defaultProps,
+            renderModalWithOptions({
                 backgroundImage: nonAnimatedGif,
             });
 
@@ -342,10 +324,8 @@ describe("ExploreImageModal", () => {
 
         it("should not render gif controls if the image is not a gif", () => {
             // Arrange, Act
-            renderModal({
-                ...defaultProps,
+            renderModalWithOptions({
                 backgroundImage: earthMoonImage,
-                apiOptions: ApiOptions.defaults,
             });
 
             // Assert
@@ -361,8 +341,7 @@ describe("ExploreImageModal", () => {
 
         it("should show the pause icon when the gif is playing when it is a multi frame gif", async () => {
             // Arrange
-            renderModal({
-                ...defaultProps,
+            renderModalWithOptions({
                 backgroundImage: animatedGifLandscape,
             });
 
@@ -380,11 +359,9 @@ describe("ExploreImageModal", () => {
         });
 
         it("should show the play icon when the gif is paused", async () => {
-            // Arrange
-            renderModal({
-                ...defaultProps,
+            // Arrange — the modal always opens in a paused state
+            renderModalWithOptions({
                 backgroundImage: animatedGifLandscape,
-                isGifPlaying: false,
             });
 
             // Act
@@ -398,8 +375,7 @@ describe("ExploreImageModal", () => {
 
         it("should toggle the gif playing state when the play button is clicked when it is a multi frame gif", async () => {
             // Arrange
-            renderModal({
-                ...defaultProps,
+            renderModalWithOptions({
                 backgroundImage: animatedGifLandscape,
             });
 
@@ -417,8 +393,7 @@ describe("ExploreImageModal", () => {
 
         it("should toggle the gif playing state when the pause button is clicked when it is a multi frame gif", async () => {
             // Arrange
-            renderModal({
-                ...defaultProps,
+            renderModalWithOptions({
                 backgroundImage: animatedGifLandscape,
             });
 

--- a/packages/perseus/src/widgets/image/components/explore-image-modal.test.tsx
+++ b/packages/perseus/src/widgets/image/components/explore-image-modal.test.tsx
@@ -20,7 +20,6 @@ import {
 
 import {ExploreImageModal} from "./explore-image-modal";
 
-import type {PerseusImageWidgetOptions} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
 
 jest.mock("../utils", () => ({
@@ -46,12 +45,11 @@ function renderModal(props: React.ComponentProps<typeof ExploreImageModal>) {
 
 const defaultProps = {
     options: generateImageOptions({
-        // Images should have alt text, and need alt text to be detectable
-        // by the testing library.
-        alt: "widget alt text",
-        // Explore image modal is only showing up because there is
-        // a long description.
-        longDescription: "widget long description",
+        backgroundImage: earthMoonImage,
+        // Images need alt text to be detectable by the testing library.
+        alt: "default alt text - do not assert",
+        // The ExploreImageModal is only shown when there is a long description.
+        longDescription: "default long description - do not assert",
     }),
     linterContext: {
         contentType: "",
@@ -63,15 +61,6 @@ const defaultProps = {
     setIsGifPlaying: () => {},
     widgetId: "image 1",
 };
-
-// Render the modal with the default props, overriding specific widget options
-// (e.g. the background image) merged onto the defaults.
-function renderModalWithOptions(options: Partial<PerseusImageWidgetOptions>) {
-    return renderModal({
-        ...defaultProps,
-        options: {...defaultProps.options, ...options},
-    });
-}
 
 describe("ExploreImageModal", () => {
     let userEvent: UserEvent;
@@ -128,14 +117,21 @@ describe("ExploreImageModal", () => {
     });
 
     it("should have null content if there is no background image URL", () => {
-        // Arrange, Act
-        renderModalWithOptions({
-            backgroundImage: {
-                url: undefined,
-                width: 100,
-                height: 100,
+        // Arrange
+        const props = {
+            ...defaultProps,
+            options: {
+                ...defaultProps.options,
+                backgroundImage: {
+                    url: undefined,
+                    width: 100,
+                    height: 100,
+                },
             },
-        });
+        };
+
+        // Act
+        renderModal(props);
         act(() => {
             jest.runAllTimers();
         });
@@ -150,14 +146,21 @@ describe("ExploreImageModal", () => {
     });
 
     it("should still render the modal content if the width is not provided", () => {
-        // Arrange, Act
-        renderModalWithOptions({
-            backgroundImage: {
-                url: earthMoonImage.url,
-                width: undefined,
-                height: 100,
+        // Arrange
+        const props = {
+            ...defaultProps,
+            options: {
+                ...defaultProps.options,
+                backgroundImage: {
+                    url: earthMoonImage.url,
+                    width: undefined,
+                    height: 100,
+                },
             },
-        });
+        };
+
+        // Act
+        renderModal(props);
         act(() => {
             jest.runAllTimers();
         });
@@ -172,14 +175,21 @@ describe("ExploreImageModal", () => {
     });
 
     it("should still render the modal content if the height is not provided", () => {
-        // Arrange, Act
-        renderModalWithOptions({
-            backgroundImage: {
-                url: earthMoonImage.url,
-                width: 100,
-                height: undefined,
+        // Arrange
+        const props = {
+            ...defaultProps,
+            options: {
+                ...defaultProps.options,
+                backgroundImage: {
+                    url: earthMoonImage.url,
+                    width: 100,
+                    height: undefined,
+                },
             },
-        });
+        };
+
+        // Act
+        renderModal(props);
         act(() => {
             jest.runAllTimers();
         });
@@ -209,7 +219,10 @@ describe("ExploreImageModal", () => {
         // Arrange
 
         // Act
-        renderModalWithOptions({title: "widget title"});
+        renderModal({
+            ...defaultProps,
+            options: {...defaultProps.options, title: "widget title"},
+        });
 
         // Assert
         const title = screen.getByRole("heading", {level: 1});
@@ -221,9 +234,12 @@ describe("ExploreImageModal", () => {
         // Arrange
 
         // Act
-        renderModalWithOptions({
-            backgroundImage: earthMoonImage,
-            caption: "widget caption",
+        renderModal({
+            ...defaultProps,
+            options: {
+                ...defaultProps.options,
+                caption: "widget caption",
+            },
         });
 
         // Assert
@@ -234,22 +250,28 @@ describe("ExploreImageModal", () => {
         // Arrange
 
         // Act
-        renderModalWithOptions({
-            backgroundImage: earthMoonImage,
-            longDescription: "widget long description",
+        renderModal({
+            ...defaultProps,
+            options: {
+                ...defaultProps.options,
+                longDescription: "a lengthy description",
+            },
         });
 
         // Assert
         const descriptionLabel = screen.getByText("Description");
         expect(descriptionLabel).toBeInTheDocument();
-        expect(screen.getByText("widget long description")).toBeInTheDocument();
+        expect(screen.getByText("a lengthy description")).toBeInTheDocument();
     });
 
     it("sets the describedby to short and long description IDs if there is a caption", () => {
         // Arrange, Act
-        renderModalWithOptions({
-            backgroundImage: earthMoonImage,
-            caption: "widget caption",
+        renderModal({
+            ...defaultProps,
+            options: {
+                ...defaultProps.options,
+                caption: "widget caption",
+            },
         });
 
         // Assert
@@ -262,9 +284,12 @@ describe("ExploreImageModal", () => {
 
     it("sets the describedby to long description ID if there is no caption", () => {
         // Arrange, Act
-        renderModalWithOptions({
-            backgroundImage: earthMoonImage,
-            longDescription: "widget long description",
+        renderModal({
+            ...defaultProps,
+            options: {
+                ...defaultProps.options,
+                caption: "",
+            },
         });
 
         // Assert
@@ -287,8 +312,12 @@ describe("ExploreImageModal", () => {
 
         it("should render gif controls if the image is a multi frame gif", async () => {
             // Arrange, Act — beforeEach decodes the gif into two frames
-            renderModalWithOptions({
-                backgroundImage: animatedGifLandscape,
+            renderModal({
+                ...defaultProps,
+                options: {
+                    ...defaultProps.options,
+                    backgroundImage: animatedGifLandscape,
+                },
             });
 
             // Assert — wait for the async GIF decode to report frame count
@@ -303,8 +332,12 @@ describe("ExploreImageModal", () => {
             // eslint-disable-next-line no-restricted-syntax
             (decodeGifFrames as jest.Mock).mockResolvedValue([fakeFrame]);
             //Act
-            renderModalWithOptions({
-                backgroundImage: nonAnimatedGif,
+            renderModal({
+                ...defaultProps,
+                options: {
+                    ...defaultProps.options,
+                    backgroundImage: nonAnimatedGif,
+                },
             });
 
             // Assert
@@ -324,8 +357,12 @@ describe("ExploreImageModal", () => {
 
         it("should not render gif controls if the image is not a gif", () => {
             // Arrange, Act
-            renderModalWithOptions({
-                backgroundImage: earthMoonImage,
+            renderModal({
+                ...defaultProps,
+                options: {
+                    ...defaultProps.options,
+                    backgroundImage: earthMoonImage,
+                },
             });
 
             // Assert
@@ -341,8 +378,12 @@ describe("ExploreImageModal", () => {
 
         it("should show the pause icon when the gif is playing when it is a multi frame gif", async () => {
             // Arrange
-            renderModalWithOptions({
-                backgroundImage: animatedGifLandscape,
+            renderModal({
+                ...defaultProps,
+                options: {
+                    ...defaultProps.options,
+                    backgroundImage: animatedGifLandscape,
+                },
             });
 
             // Act — the modal starts paused, so click Play first
@@ -359,9 +400,14 @@ describe("ExploreImageModal", () => {
         });
 
         it("should show the play icon when the gif is paused", async () => {
-            // Arrange — the modal always opens in a paused state
-            renderModalWithOptions({
-                backgroundImage: animatedGifLandscape,
+            // Arrange
+            renderModal({
+                ...defaultProps,
+                options: {
+                    ...defaultProps.options,
+                    backgroundImage: animatedGifLandscape,
+                },
+                isGifPlaying: false,
             });
 
             // Act
@@ -375,8 +421,12 @@ describe("ExploreImageModal", () => {
 
         it("should toggle the gif playing state when the play button is clicked when it is a multi frame gif", async () => {
             // Arrange
-            renderModalWithOptions({
-                backgroundImage: animatedGifLandscape,
+            renderModal({
+                ...defaultProps,
+                options: {
+                    ...defaultProps.options,
+                    backgroundImage: animatedGifLandscape,
+                },
             });
 
             // Act — modal starts paused, click Play
@@ -393,8 +443,12 @@ describe("ExploreImageModal", () => {
 
         it("should toggle the gif playing state when the pause button is clicked when it is a multi frame gif", async () => {
             // Arrange
-            renderModalWithOptions({
-                backgroundImage: animatedGifLandscape,
+            renderModal({
+                ...defaultProps,
+                options: {
+                    ...defaultProps.options,
+                    backgroundImage: animatedGifLandscape,
+                },
             });
 
             // Act — click Play then Pause

--- a/packages/perseus/src/widgets/image/components/explore-image-modal.tsx
+++ b/packages/perseus/src/widgets/image/components/explore-image-modal.tsx
@@ -9,9 +9,9 @@ import styles from "../image-widget.module.css";
 
 import ExploreImageModalContent from "./explore-image-modal-content";
 
-import type {CommonImageProps, GifProps} from "./image-info-area";
+import type {GifProps, ImageInfoProps} from "./image-info-area";
 
-type Props = CommonImageProps & GifProps;
+type Props = ImageInfoProps & GifProps;
 
 export const ExploreImageModal = (props: Props) => {
     const context = React.useContext(PerseusI18nContext);
@@ -37,7 +37,8 @@ export const ExploreImageModal = (props: Props) => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    const titleText = props.title || context.strings.imageAlternativeTitle;
+    const titleText =
+        props.options.title || context.strings.imageAlternativeTitle;
     const title = (
         <h1
             className={`perseus-image-modal-title ${styles.modalTitleContainer}`}
@@ -69,7 +70,9 @@ export const ExploreImageModal = (props: Props) => {
                     />
                 }
                 aria-describedby={
-                    props.caption ? `${captionId} ${longDescId}` : longDescId
+                    props.options.caption
+                        ? `${captionId} ${longDescId}`
+                        : longDescId
                 }
                 styles={{
                     root: wbStyles.root,

--- a/packages/perseus/src/widgets/image/components/explore-image-modal.tsx
+++ b/packages/perseus/src/widgets/image/components/explore-image-modal.tsx
@@ -8,7 +8,8 @@ import Renderer from "../../../renderer";
 import styles from "../image-widget.module.css";
 
 import ExploreImageModalContent from "./explore-image-modal-content";
-import {CommonImageProps} from "./common-image-props";
+
+import type {CommonImageProps} from "./common-image-props";
 
 export const ExploreImageModal = (props: CommonImageProps) => {
     const context = React.useContext(PerseusI18nContext);

--- a/packages/perseus/src/widgets/image/components/explore-image-modal.tsx
+++ b/packages/perseus/src/widgets/image/components/explore-image-modal.tsx
@@ -8,12 +8,9 @@ import Renderer from "../../../renderer";
 import styles from "../image-widget.module.css";
 
 import ExploreImageModalContent from "./explore-image-modal-content";
+import {CommonImageProps} from "./common-image-props";
 
-import type {GifProps, ImageInfoProps} from "./image-info-area";
-
-type Props = ImageInfoProps & GifProps;
-
-export const ExploreImageModal = (props: Props) => {
+export const ExploreImageModal = (props: CommonImageProps) => {
     const context = React.useContext(PerseusI18nContext);
     const uniqueId = React.useId();
     const captionId = `${uniqueId}-caption`;

--- a/packages/perseus/src/widgets/image/components/image-info-area.tsx
+++ b/packages/perseus/src/widgets/image/components/image-info-area.tsx
@@ -1,9 +1,3 @@
-import {
-    type Interval,
-    type PerseusImageBackground,
-    type PerseusImageLabel,
-    type Size,
-} from "@khanacademy/perseus-core";
 import {ModalLauncher} from "@khanacademy/wonder-blocks-modal";
 import * as React from "react";
 
@@ -17,6 +11,7 @@ import {ExploreImageModal} from "./explore-image-modal";
 import {GifControlsIcon} from "./gif-controls-icon";
 
 import type {APIOptions} from "../../../types";
+import type {PerseusImageWidgetOptions} from "@khanacademy/perseus-core";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
 export interface GifProps {
@@ -24,22 +19,18 @@ export interface GifProps {
     setIsGifPlaying: (isPaused: boolean) => void;
 }
 
-export interface CommonImageProps {
-    backgroundImage: PerseusImageBackground;
-    scale: number;
-    title: string;
-    caption: string;
-    alt: string;
-    longDescription: string;
-    box: Size;
-    labels: Array<PerseusImageLabel>;
-    range: [Interval, Interval];
+/**
+ * The image widget's options together with the rendering context needed to
+ * display the image's info area and explore-image modal.
+ */
+export interface ImageInfoProps {
+    options: PerseusImageWidgetOptions;
     linterContext: LinterContextProps;
     apiOptions: APIOptions;
     widgetId: string;
 }
 
-type Props = GifProps & CommonImageProps & {isAnimatedGif: boolean};
+type Props = GifProps & ImageInfoProps & {isAnimatedGif: boolean};
 
 /**
  * The ImageInfoArea component includes the GIF controls, description modal
@@ -48,9 +39,7 @@ type Props = GifProps & CommonImageProps & {isAnimatedGif: boolean};
  */
 export const ImageInfoArea = (props: Props) => {
     const {
-        backgroundImage,
-        caption,
-        longDescription,
+        options,
         apiOptions,
         linterContext,
         isGifPlaying,
@@ -58,6 +47,7 @@ export const ImageInfoArea = (props: Props) => {
         isAnimatedGif,
         widgetId,
     } = props;
+    const {backgroundImage, caption, longDescription} = options;
 
     const context = React.useContext(PerseusI18nContext);
     const {analytics} = useDependencies();

--- a/packages/perseus/src/widgets/image/components/image-info-area.tsx
+++ b/packages/perseus/src/widgets/image/components/image-info-area.tsx
@@ -13,24 +13,16 @@ import {GifControlsIcon} from "./gif-controls-icon";
 import type {APIOptions} from "../../../types";
 import type {PerseusImageWidgetOptions} from "@khanacademy/perseus-core";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
+import {CommonImageProps} from "./common-image-props";
 
 export interface GifProps {
     isGifPlaying: boolean;
     setIsGifPlaying: (isPaused: boolean) => void;
 }
 
-/**
- * The image widget's options together with the rendering context needed to
- * display the image's info area and explore-image modal.
- */
-export interface ImageInfoProps {
-    options: PerseusImageWidgetOptions;
-    linterContext: LinterContextProps;
-    apiOptions: APIOptions;
-    widgetId: string;
+interface Props extends CommonImageProps {
+    isAnimatedGif: boolean;
 }
-
-type Props = GifProps & ImageInfoProps & {isAnimatedGif: boolean};
 
 /**
  * The ImageInfoArea component includes the GIF controls, description modal

--- a/packages/perseus/src/widgets/image/components/image-info-area.tsx
+++ b/packages/perseus/src/widgets/image/components/image-info-area.tsx
@@ -10,15 +10,7 @@ import ExploreImageButton from "./explore-image-button";
 import {ExploreImageModal} from "./explore-image-modal";
 import {GifControlsIcon} from "./gif-controls-icon";
 
-import type {APIOptions} from "../../../types";
-import type {PerseusImageWidgetOptions} from "@khanacademy/perseus-core";
-import type {LinterContextProps} from "@khanacademy/perseus-linter";
-import {CommonImageProps} from "./common-image-props";
-
-export interface GifProps {
-    isGifPlaying: boolean;
-    setIsGifPlaying: (isPaused: boolean) => void;
-}
+import type {CommonImageProps} from "./common-image-props";
 
 interface Props extends CommonImageProps {
     isAnimatedGif: boolean;

--- a/packages/perseus/src/widgets/image/image.tsx
+++ b/packages/perseus/src/widgets/image/image.tsx
@@ -198,7 +198,7 @@ const ImageWidget = forwardRef<WidgetHandle, ImageWidgetProps>(
                         isGifPlaying={isGifPlaying}
                         setIsGifPlaying={setIsGifPlaying}
                         isAnimatedGif={isAnimatedGif}
-                        {...props.options}
+                        options={props.options}
                         apiOptions={apiOptions}
                         linterContext={linterContext}
                         widgetId={widgetId}


### PR DESCRIPTION
Rather than spread the options into props (which causes types to be duplicated)
we can just pass them around.

Issue: LEMS-4354

## Test plan:

CI checks should pass.