### PR TITLE
[Interactive Graph] Increase vertex arrow border.

### DIFF
--- a/.changeset/kind-adults-mate.md
+++ b/.changeset/kind-adults-mate.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Interactive Graph] Increase Vector arrowhead border from 5px to 8px.

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -291,7 +291,7 @@
 
 .MafsView .movable-arrowhead-ring {
     stroke: var(--wb-semanticColor-core-border-knockout-default);
-    stroke-width: 5px;
+    stroke-width: 8px;
     vector-effect: non-scaling-stroke;
     transform-box: fill-box;
     transform-origin: 100% 50%;

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -291,7 +291,7 @@
 
 .MafsView .movable-arrowhead-ring {
     stroke: var(--wb-semanticColor-core-border-knockout-default);
-    stroke-width: 8px;
+    stroke-width: var(--wb-sizing-size_080);
     vector-effect: non-scaling-stroke;
     transform-box: fill-box;
     transform-origin: 100% 50%;


### PR DESCRIPTION
## Summary:
Increasing the border thickness on the Vector graph's arrowhead per design feedback.

### Before
<img width="755" height="770" alt="Screenshot 2026-07-16 at 11 12 20 AM" src="https://github.com/user-attachments/assets/b10744be-3719-4a5a-8107-599f77f3a597" />

### After
<img width="741" height="759" alt="Screenshot 2026-07-16 at 11 11 40 AM" src="https://github.com/user-attachments/assets/d3fa3510-d0fe-4be1-be6a-51e881cd93ab" />

Issue: LEMS-4361

## Test plan:
N/A