### PR TITLE
⚠️ Use WB semanticColor CSS variables in paragraph styles

### DIFF
--- a/.changeset/strict-symbols-float.md
+++ b/.changeset/strict-symbols-float.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Update primitive HEX colors to use semanticColor tokens (to support multiple WB themes including dark mode)

--- a/packages/perseus/src/styles/paragraph-styles.css
+++ b/packages/perseus/src/styles/paragraph-styles.css
@@ -1,7 +1,7 @@
 .framework-perseus.perseus-article:not(.perseus-mobile)
     .perseus-renderer
     > .paragraph {
-    color: #21242c;
+    color: var(--wb-semanticColor-core-foreground-neutral-strong);
     font-size: 20px;
     line-height: 30px;
     margin: 0 auto;
@@ -11,7 +11,7 @@
     .perseus-renderer
     > .paragraph
     .paragraph {
-    color: #21242c;
+    color: var(--wb-semanticColor-core-foreground-neutral-strong);
     font-size: 20px;
     line-height: 30px;
     margin-bottom: 32px;
@@ -36,7 +36,7 @@
     .perseus-renderer
     > .paragraph
     ul:not([data-widget="radio"]) {
-    color: #21242c;
+    color: var(--wb-semanticColor-core-foreground-neutral-strong);
     font-size: 20px;
     line-height: 30px;
 }
@@ -55,7 +55,7 @@
     .perseus-renderer
     .paragraph
     ul {
-    color: rgba(33, 36, 44, 0.64);
+    color: var(--wb-semanticColor-core-foreground-neutral-subtle);
     font-size: 14px;
     line-height: 19px;
     text-align: left;
@@ -182,7 +182,7 @@
         font-family: inherit;
         font-size: 18px;
         line-height: 1.4;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile
         .perseus-renderer
@@ -191,7 +191,7 @@
         font-family: inherit;
         font-size: 18px;
         line-height: 1.4;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile
         .perseus-renderer
@@ -200,19 +200,19 @@
         font-family: inherit;
         font-size: 18px;
         line-height: 1.4;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile .perseus-renderer > .paragraph ol {
         font-family: inherit;
         font-size: 18px;
         line-height: 1.4;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile
         .perseus-image-caption
         .paragraph
         .paragraph {
-        color: #888d93;
+        color: var(--wb-semanticColor-core-foreground-neutral-subtle);
         font-size: 14px;
         line-height: 1.3;
         text-align: left;
@@ -226,7 +226,7 @@
         font-family: inherit;
         font-size: 20px;
         line-height: 1.5;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile
         .perseus-renderer
@@ -235,7 +235,7 @@
         font-family: inherit;
         font-size: 20px;
         line-height: 1.5;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile
         .perseus-renderer
@@ -244,19 +244,19 @@
         font-family: inherit;
         font-size: 20px;
         line-height: 1.5;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile .perseus-renderer > .paragraph ol {
         font-family: inherit;
         font-size: 20px;
         line-height: 1.5;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile
         .perseus-image-caption
         .paragraph
         .paragraph {
-        color: #888d93;
+        color: var(--wb-semanticColor-core-foreground-neutral-subtle);
         font-size: 17px;
         line-height: 1.4;
         text-align: left;
@@ -270,7 +270,7 @@
         font-family: inherit;
         font-size: 22px;
         line-height: 1.4;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile
         .perseus-renderer
@@ -279,7 +279,7 @@
         font-family: inherit;
         font-size: 22px;
         line-height: 1.4;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile
         .perseus-renderer
@@ -288,19 +288,19 @@
         font-family: inherit;
         font-size: 22px;
         line-height: 1.4;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile .perseus-renderer > .paragraph ol {
         font-family: inherit;
         font-size: 22px;
         line-height: 1.4;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile
         .perseus-image-caption
         .paragraph
         .paragraph {
-        color: #888d93;
+        color: var(--wb-semanticColor-core-foreground-neutral-subtle);
         font-size: 20px;
         line-height: 1.4;
         text-align: left;


### PR DESCRIPTION
## Summary:
Replace hardcoded color HEX/rgba values in article paragraph and image
caption styles with Wonder Blocks semanticColor CSS variables. This lets
these text colors resolve correctly under WB themes (including dark mode)
instead of being pinned to fixed light-mode values.

Body text (#21242c) maps exactly to neutral-strong and mobile paragraph
text (#626569) maps near-exactly to neutral-default. The image caption
colors (#888d93 and rgba(33,36,44,0.64)) map to neutral-subtle for
semantic intent, which shifts their appearance slightly.

Issue: FEI-7862

## Test plan:

Visual verification recommended (colors were not verified before commit):
- In Storybook (http://localhost:8228/), view the ArticleRenderer stories
  in both desktop and mobile layouts, and in light + dark themes.
- Confirm paragraph body text and image caption text render with the
  expected contrast. Pay particular attention to the image captions, whose
  color shifts slightly (#888d93 → neutral-subtle #717378, and the
  desktop rgba caption → neutral-subtle).

## Review plan:

Please review these risky changes

1. ⚠️ [`paragraph-styles.css`](https://github.com/Khan/perseus/pull/3919#discussion_r3598111052)

### Common patterns:

**1 File (19 declarations):** Replace hardcoded color HEX/rgba values with
WB semanticColor CSS variables based on semantic role (body vs. caption).

```css
/* before */
color: #21242c;
color: rgba(33, 36, 44, 0.64);
color: #626569;
color: #888d93;

/* after */
color: var(--wb-semanticColor-core-foreground-neutral-strong);
color: var(--wb-semanticColor-core-foreground-neutral-subtle);
color: var(--wb-semanticColor-core-foreground-neutral-default);
color: var(--wb-semanticColor-core-foreground-neutral-subtle);
```
