### PR TITLE
Remove Plotter's default props

### DIFF
--- a/.changeset/modern-stars-change.md
+++ b/.changeset/modern-stars-change.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus-core": major
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus": major
+---
+
+Make all options of the Plotter widget required, and default them in the parser.

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1807,7 +1807,7 @@ export type PerseusPlotterWidgetOptions = {
      * Which ticks to display the labels for. For instance, setting this to "4"
      * will only show every 4th label (plus the last one)
      */
-    labelInterval?: number | null;
+    labelInterval: number;
     /**
      * Creates the specified number of divisions between the horizontal lines.
      * Fewer snaps between lines makes the graph easier for the student to
@@ -1819,11 +1819,11 @@ export type PerseusPlotterWidgetOptions = {
     /** The Y values that represent the correct answer expected */
     correct: number[];
     /** A picture to represent items in a graph. */
-    picUrl?: string | null;
+    picUrl: string | null;
     /** @deprecated */
-    picSize?: number | null;
+    picSize: number;
     /** @deprecated */
-    picBoxHeight?: number | null;
+    picBoxHeight: number;
     /** @deprecated */
     plotDimensions: number[];
 };

--- a/packages/perseus-core/src/parse-perseus-json/README.md
+++ b/packages/perseus-core/src/parse-perseus-json/README.md
@@ -91,8 +91,10 @@ typetests to keep the parsers in sync with data-schema.
 
 The tests in the `regression-tests` directory ensure that the parsing code can
 handle old data formats. **Understand that if you change existing regression
-tests, you risk breaking compatibility with old data.** The regression tests
-were generated from a snapshot of Khan Academy content taken in November 2024.
+test data in the `regression-tests/*-data` directories, you risk breaking
+compatibility with old data.** (Updating the snapshots is fine, though!) The
+regression tests were generated from an archive of Khan Academy content as of
+November 2024.
 
 The regression tests are data-driven: we have a bunch of real Perseus items and
 articles taken from production, and we run those through the parser and make

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/plotter-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/plotter-widget.ts
@@ -4,7 +4,6 @@ import {
     string,
     array,
     number,
-    optional,
     nullable,
     enumeration,
 } from "../general-purpose-parsers";
@@ -27,20 +26,32 @@ export const parsePlotterWidget = parseWidget(
         categories: array(string),
         type: plotterPlotTypes,
         maxY: number,
-        // The default value for scaleY comes from plotter.tsx.
+        // The default value for scaleY comes from widgets/plotter/index.ts.
         // See parse-perseus-json/README.md for why we want to duplicate the
         // defaults here.
         scaleY: defaulted(number, () => 1),
-        labelInterval: optional(nullable(number)),
-        // The default value for snapsPerLine comes from plotter.tsx.
+        // The default value for labelInterval comes from widgets/plotter/index.ts.
+        // See parse-perseus-json/README.md for why we want to duplicate the
+        // defaults here.
+        labelInterval: defaulted(number, () => 1),
+        // The default value for snapsPerLine comes from widgets/plotter/index.ts.
         // See parse-perseus-json/README.md for why we want to duplicate the
         // defaults here.
         snapsPerLine: defaulted(number, () => 2),
         starting: array(number),
-        correct: defaulted(array(number), () => []),
-        picUrl: optional(nullable(string)),
-        picSize: optional(nullable(number)),
-        picBoxHeight: optional(nullable(number)),
+        // The default value for correct comes from widgets/plotter/index.ts.
+        // See parse-perseus-json/README.md for why we want to duplicate the
+        // defaults here.
+        correct: defaulted(array(number), () => [1]),
+        picUrl: defaulted(nullable(string), () => null),
+        // The default value for picSize comes from widgets/plotter/index.ts.
+        // See parse-perseus-json/README.md for why we want to duplicate the
+        // defaults here.
+        picSize: defaulted(number, () => 30),
+        // The default value for picBoxHeight comes from widgets/plotter/index.ts.
+        // See parse-perseus-json/README.md for why we want to duplicate the
+        // defaults here.
+        picBoxHeight: defaulted(number, () => 36),
         // NOTE(benchristel): I copied the default plotDimensions from
         // plotter.tsx. See the parse-perseus-json/README.md for an explanation
         // of why we want to duplicate the defaults here.

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -744,7 +744,8 @@ describe("parseWidgetsMap", () => {
                 version: {major: 0, minor: 0},
                 options: {
                     labels: [],
-                    categories: [],
+                    labelInterval: 42,
+                    categories: [""],
                     type: "bar",
                     maxY: 0,
                     scaleY: 0,
@@ -752,6 +753,9 @@ describe("parseWidgetsMap", () => {
                     starting: [],
                     correct: [],
                     plotDimensions: [],
+                    picUrl: null,
+                    picSize: 1,
+                    picBoxHeight: 2,
                 },
             },
         };

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -19032,11 +19032,14 @@ $\\green5 - \\red3= \\purple{2}$",
             1,
             1,
           ],
+          "labelInterval": 1,
           "labels": [
             "Child",
             "Baskets",
           ],
           "maxY": 5,
+          "picBoxHeight": 36,
+          "picSize": 30,
           "picUrl": "http://i.imgur.com/B8mGnxB.png",
           "plotDimensions": [
             380,
@@ -19138,7 +19141,9 @@ exports[`parseAndMigratePerseusItem given plotter-missing-scaleY-and-snapsPerLin
             "Michaela",
             "James",
           ],
-          "correct": [],
+          "correct": [
+            1,
+          ],
           "labelInterval": 1,
           "labels": [
             "Child",
@@ -19204,6 +19209,9 @@ exports[`parseAndMigratePerseusItem given plotter-with-undefined-plotDimensions.
               "",
             ],
             "maxY": 10,
+            "picBoxHeight": 36,
+            "picSize": 30,
+            "picUrl": null,
             "plotDimensions": [
               380,
               300,

--- a/packages/perseus-core/src/utils/extract-perseus-ai-data.test.ts
+++ b/packages/perseus-core/src/utils/extract-perseus-ai-data.test.ts
@@ -38,6 +38,7 @@ import {
     generateNumericInputOptions,
     generateNumericInputWidget,
 } from "./generators/numeric-input-widget-generator";
+import {generatePlotterOptions} from "./generators/plotter-widget-generator";
 import {
     generateRadioChoice,
     generateRadioWidget,
@@ -1067,7 +1068,7 @@ describe("getAnswersFromWidgets", () => {
         const widget: PlotterWidget = {
             type: "plotter",
             graded: true,
-            options: {
+            options: generatePlotterOptions({
                 correct: [9, 6, 10, 5],
                 starting: [0, 0, 0, 0],
                 type: "bar",
@@ -1077,13 +1078,7 @@ describe("getAnswersFromWidgets", () => {
                 maxY: 10,
                 snapsPerLine: 1,
                 labelInterval: 1,
-
-                // deprecated
-                picUrl: null,
-                picSize: null,
-                picBoxHeight: null,
-                plotDimensions: [],
-            },
+            }),
         };
 
         const answer = getAnswersFromWidgets({"plotter 1": widget});

--- a/packages/perseus-core/src/utils/generators/plotter-widget-generator.test.ts
+++ b/packages/perseus-core/src/utils/generators/plotter-widget-generator.test.ts
@@ -42,6 +42,7 @@ describe("generatePlotterWidget", () => {
             options: {
                 type: "histogram",
                 labels: ["Score range", "Frequency"],
+                labelInterval: 1,
                 categories: ["0-10", "10-20", "20-30"],
                 starting: [2, 5, 8],
                 correct: [2, 5, 8],
@@ -49,6 +50,9 @@ describe("generatePlotterWidget", () => {
                 scaleY: 1,
                 snapsPerLine: 1,
                 plotDimensions: [380, 300],
+                picUrl: "the url",
+                picSize: 3,
+                picBoxHeight: 4,
             },
         });
 
@@ -60,6 +64,9 @@ describe("generatePlotterWidget", () => {
         expect(widget.options.type).toBe("histogram");
         expect(widget.options.categories).toEqual(["0-10", "10-20", "20-30"]);
         expect(widget.options.starting).toEqual([2, 5, 8]);
+        expect(widget.options.picUrl).toBe("the url");
+        expect(widget.options.picSize).toBe(3);
+        expect(widget.options.picBoxHeight).toBe(4);
     });
 
     it("accepts options built with the options generator", () => {

--- a/packages/perseus-core/src/utils/generators/plotter-widget-generator.test.ts
+++ b/packages/perseus-core/src/utils/generators/plotter-widget-generator.test.ts
@@ -67,6 +67,7 @@ describe("generatePlotterWidget", () => {
         expect(widget.options.picUrl).toBe("the url");
         expect(widget.options.picSize).toBe(3);
         expect(widget.options.picBoxHeight).toBe(4);
+        expect(widget.options.labelInterval).toBe(1);
     });
 
     it("accepts options built with the options generator", () => {

--- a/packages/perseus-editor/src/__testdata__/all-widgets.testdata.ts
+++ b/packages/perseus-editor/src/__testdata__/all-widgets.testdata.ts
@@ -24,6 +24,7 @@ import {
     generateNumericInputAnswer,
     generateNumericInputOptions,
     generateNumericInputWidget,
+    generatePlotterOptions,
     generateRadioChoice,
     generateRadioOptions,
     generateRadioWidget,
@@ -212,7 +213,7 @@ export const comprehensiveQuestion: PerseusRenderer = {
             version: {major: 0, minor: 0},
             static: false,
             type: "plotter",
-            options: {
+            options: generatePlotterOptions({
                 type: "pic",
                 labels: ["x", "y"],
                 categories: ["blue"],
@@ -222,7 +223,7 @@ export const comprehensiveQuestion: PerseusRenderer = {
                 correct: [2, 4, 3],
                 starting: [0, 0, 0, 2],
                 plotDimensions: [300, 300],
-            },
+            }),
         },
         "sorter 1": {
             graded: true,

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -674,6 +674,10 @@ class Editor extends React.Component<Props, State> {
         const initializeWidgetOptionsParams: InitializeWidgetOptionsParams = {
             selectedText,
         };
+        // TODO(benchristel): get rid of all these different ways of
+        //  initializing widget options. We should probably standardize on
+        //  getting the initial options from
+        //  CoreWidgetRegistry.getDefaultWidgetOptions().
         const startWidgetOptions = widgetEditor?.initializeWidgetOptions?.(
             initializeWidgetOptionsParams,
         );

--- a/packages/perseus/src/widgets/plotter/plotter.test.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.test.tsx
@@ -1,3 +1,4 @@
+import {generatePlotterOptions} from "@khanacademy/perseus-core";
 import {scorePerseusItem} from "@khanacademy/perseus-score";
 import {act, screen, waitFor} from "@testing-library/react";
 
@@ -53,7 +54,7 @@ describe("plotter widget", () => {
 
     describe("drag text", () => {
         function sharedPlotterOptions(): PerseusPlotterWidgetOptions {
-            return {
+            return generatePlotterOptions({
                 categories: ["0", "1", "2"],
                 plotDimensions: [300, 300],
                 correct: [0, 1, 2],
@@ -63,7 +64,7 @@ describe("plotter widget", () => {
                 snapsPerLine: 1,
                 starting: [0, 0, 0],
                 type: "bar",
-            };
+            });
         }
 
         it("should show drag text when not static", async () => {

--- a/packages/perseus/src/widgets/plotter/plotter.testdata.ts
+++ b/packages/perseus/src/widgets/plotter/plotter.testdata.ts
@@ -1,3 +1,5 @@
+import {generatePlotterOptions} from "@khanacademy/perseus-core";
+
 import type {PerseusRenderer} from "@khanacademy/perseus-core";
 
 export const question1: PerseusRenderer = {
@@ -42,7 +44,7 @@ export const simple: PerseusRenderer = {
     widgets: {
         "plotter 1": {
             type: "plotter",
-            options: {
+            options: generatePlotterOptions({
                 categories: ["0", "1", "2"],
                 plotDimensions: [300, 300],
                 correct: [0, 1, 2],
@@ -52,7 +54,7 @@ export const simple: PerseusRenderer = {
                 snapsPerLine: 1,
                 starting: [0, 0, 0],
                 type: "bar",
-            },
+            }),
         },
     },
 };
@@ -63,7 +65,7 @@ export const dotPlotter: PerseusRenderer = {
     widgets: {
         "plotter 1": {
             type: "plotter",
-            options: {
+            options: generatePlotterOptions({
                 correct: [1, 1, 1, 1],
                 starting: [1, 1, 1, 1],
                 type: "dotplot",
@@ -74,7 +76,7 @@ export const dotPlotter: PerseusRenderer = {
                 snapsPerLine: 2,
                 labelInterval: 1,
                 plotDimensions: [380, 300],
-            },
+            }),
         },
     },
 };

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -2,7 +2,6 @@
 /* eslint-disable react/no-unsafe */
 import {KhanMath} from "@khanacademy/kmath";
 import {
-    CoreWidgetRegistry,
     type PerseusPlotterUserInput,
     type PerseusPlotterWidgetOptions,
     type PlotterPublicWidgetOptions,
@@ -31,30 +30,12 @@ type Props = WidgetProps<
     PlotterPublicWidgetOptions,
     PerseusPlotterUserInput
 > & {
-    labelInterval: NonNullable<PerseusPlotterWidgetOptions["labelInterval"]>;
-    picSize: NonNullable<PerseusPlotterWidgetOptions["picSize"]>;
     dependencies: PerseusDependenciesV2;
-};
-
-type DefaultProps = {
-    type: Props["type"];
-    labels: Props["labels"];
-    categories: Props["categories"];
-    scaleY: Props["scaleY"];
-    maxY: Props["maxY"];
-    snapsPerLine: Props["snapsPerLine"];
-    picSize: Props["picSize"];
-    picBoxHeight: Props["picBoxHeight"];
-    picUrl: Props["picUrl"];
-    plotDimensions: Props["plotDimensions"];
-    labelInterval: Props["labelInterval"];
 };
 
 type State = {
     categoryHeights: Record<string, number>;
 };
-
-const plotterDefaults = CoreWidgetRegistry.getDefaultWidgetOptions("plotter");
 
 class Plotter extends React.Component<Props, State> implements Widget {
     static contextType = PerseusI18nContext;
@@ -67,8 +48,6 @@ class Plotter extends React.Component<Props, State> implements Widget {
     graphie: any;
     horizHairline: any;
     hairlineRange: any;
-
-    static defaultProps: DefaultProps = plotterDefaults;
 
     state: State = {
         // The measured rendered height of category strings. Used to calculate

--- a/packages/perseus/src/widgets/plotter/serialize-plotter.test.ts
+++ b/packages/perseus/src/widgets/plotter/serialize-plotter.test.ts
@@ -1,4 +1,5 @@
 import {
+    generatePlotterOptions,
     generateTestPerseusItem,
     generateTestPerseusRenderer,
 } from "@khanacademy/perseus-core";
@@ -39,7 +40,7 @@ describe("Plotter serialization", () => {
             widgets: {
                 "plotter 1": {
                     type: "plotter",
-                    options: {
+                    options: generatePlotterOptions({
                         categories: ["0", "1", "2"],
                         plotDimensions: [300, 300],
                         correct: [0, 1, 2],
@@ -49,7 +50,7 @@ describe("Plotter serialization", () => {
                         snapsPerLine: 1,
                         starting: [0, 0, 0],
                         type: "bar",
-                    },
+                    }),
                 },
             },
         });


### PR DESCRIPTION
## Summary:
We now apply defaults in the parser.

Issue: none

## Test plan:

- `pnpm storybook`
- `open http://localhost:6006/?path=/docs/editors-editorpage--docs`
- You should be able to create and edit a plotter widget.