### PR TITLE
Remove defaultProps from the PythonProgram widget

### DIFF
--- a/.changeset/few-games-feel.md
+++ b/.changeset/few-games-feel.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus": patch
 ---
 
-Internal: The PythonProgram widget no longer assigns defaults for props, since all options are required by the schema types.
+Internal: The PythonProgram widget no longer assigns defaults for props, since its options are never undefined in the data.

--- a/.changeset/few-games-feel.md
+++ b/.changeset/few-games-feel.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: The PythonProgram widget no longer assigns defaults for props, since all options are required by the schema types.

--- a/packages/perseus/src/widgets/python-program/python-program.tsx
+++ b/packages/perseus/src/widgets/python-program/python-program.tsx
@@ -26,20 +26,14 @@ type Props = {
     dependencies: PerseusDependenciesV2;
 };
 
-type DefaultProps = {
-    height: Props["height"];
-};
-
 /**
  * This renders the program in an iframe.
  */
+// TODO(benchristel): Rewrite PythonProgram as a functional component,
+//  following dropdown.tsx's example.
 class PythonProgram extends React.Component<Props> implements Widget {
     static contextType = PerseusI18nContext;
     declare context: React.ContextType<typeof PerseusI18nContext>;
-
-    static defaultProps: DefaultProps = {
-        height: 400,
-    };
 
     getPromptJSON(): UnsupportedWidgetPromptJSON {
         return _getPromptJSON();


### PR DESCRIPTION
## Summary:
None of the options can be undefined.

Issue: none

## Test plan:

- `pnpm storybook`
- `open http://localhost:6006/?path=/docs/editors-editorpage--docs`
- You should be able to create and edit a Python widget.