### PR TITLE
Remove default props from FreeResponse widget

### DIFF
--- a/.changeset/quiet-sheep-wish.md
+++ b/.changeset/quiet-sheep-wish.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: `defaultProps` have been removed from the `FreeResponse` widget. The `userInput` prop did not need a default; it is always passed.

--- a/packages/perseus/src/widgets/free-response/free-response.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.tsx
@@ -29,8 +29,6 @@ type Props = WidgetProps<
     PerseusFreeResponseUserInput
 >;
 
-type DefaultProps = Pick<Props, "userInput">;
-
 // TODO(agoforth): Create a custom validator for the widget that will cause
 //   renderer.emptyWidgets() to work when there is no user input.
 
@@ -41,12 +39,6 @@ export class FreeResponse extends React.Component<Props> implements Widget {
     // this just helps with TS weak typing when a Widget
     // doesn't implement any Widget methods
     isWidget = true as const;
-
-    static defaultProps: DefaultProps = {
-        userInput: {
-            currentValue: "",
-        },
-    };
 
     announceCharacterCount = (message: string, isOverLimit: boolean) => {
         const level = isOverLimit ? "assertive" : "polite";


### PR DESCRIPTION
## Summary:
The only defaulted prop was `userInput`, which is always set by the UserInputManager.

Issue: none

## Test plan:

- `pnpm storybook`
- `open http://localhost:6006/?path=/docs/editors-editorpage--docs`
- You should be able to add, edit, and preview a Free Response widget.