### PR TITLE
Remove immutableWidgets prop from Editor

### DIFF
--- a/.changeset/ninety-pumas-build.md
+++ b/.changeset/ninety-pumas-build.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Internal: The `immutableWidgets` prop of `Editor` has been removed. It was always set to false.

--- a/packages/perseus-editor/src/__docs__/editor.stories.tsx
+++ b/packages/perseus-editor/src/__docs__/editor.stories.tsx
@@ -30,7 +30,6 @@ export const Demo = (): React.ReactElement => {
             images={question1.images}
             disabled={false}
             widgetEnabled={true}
-            immutableWidgets={false}
             showWordCount={true}
             warnNoPrompt={true}
             warnNoWidgets={true}
@@ -68,7 +67,6 @@ export const DemoInteractiveGraph = (): React.ReactElement => {
                             images={images}
                             disabled={false}
                             widgetEnabled={true}
-                            immutableWidgets={false}
                             showWordCount={true}
                             warnNoPrompt={false}
                             warnNoWidgets={true}

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -123,7 +123,6 @@ type Props = Readonly<{
     images: any;
     disabled: boolean;
     widgetEnabled: boolean;
-    immutableWidgets: boolean;
     showWordCount: boolean;
     warnNoPrompt: boolean;
     warnNoWidgets: boolean;
@@ -136,7 +135,6 @@ type DefaultProps = {
     content: string;
     disabled: boolean;
     images: Record<any, any>;
-    immutableWidgets: boolean;
     placeholder: string;
     showWordCount: boolean;
     warnNoPrompt: boolean;
@@ -187,7 +185,6 @@ class Editor extends React.Component<Props, State> {
         images: {},
         disabled: false,
         widgetEnabled: true,
-        immutableWidgets: false,
         showWordCount: false,
         warnNoPrompt: false,
         warnNoWidgets: false,
@@ -948,22 +945,18 @@ class Editor extends React.Component<Props, State> {
                 </select>
             );
 
-            if (!this.props.immutableWidgets) {
-                // eslint-disable-next-line no-restricted-syntax
-                const widgetNodes = Object.values(widgets) as React.ReactNode;
-                widgetsAndTemplates = (
-                    <div className="perseus-editor-widgets">
-                        <div className="perseus-editor-widgets-selectors">
-                            <WidgetSelect onChange={this._addWidget} />
-                            {templatesDropDown}
-                            {wordCountDisplay}
-                        </div>
-                        {widgetNodes}
+            // eslint-disable-next-line no-restricted-syntax
+            const widgetNodes = Object.values(widgets) as React.ReactNode;
+            widgetsAndTemplates = (
+                <div className="perseus-editor-widgets">
+                    <div className="perseus-editor-widgets-selectors">
+                        <WidgetSelect onChange={this._addWidget} />
+                        {templatesDropDown}
+                        {wordCountDisplay}
                     </div>
-                );
-                // Prevent word count from being displayed elsewhere
-                wordCountDisplay = null;
-            }
+                    {widgetNodes}
+                </div>
+            );
         } else {
             underlayPieces = [this.props.content];
         }
@@ -1045,7 +1038,6 @@ class Editor extends React.Component<Props, State> {
                         Graded Groups should contain at least one widget
                     </div>
                 )}
-                {wordCountDisplay}
                 {widgetsAndTemplates}
             </div>
         );

--- a/packages/perseus-editor/src/widgets/explanation-editor.tsx
+++ b/packages/perseus-editor/src/widgets/explanation-editor.tsx
@@ -73,7 +73,6 @@ class ExplanationEditor extends React.Component<Props, State> {
                         content={this.props.explanation}
                         widgets={this.props.widgets}
                         widgetEnabled={true}
-                        immutableWidgets={false}
                         onChange={(props) => {
                             const newProps: Record<string, any> = {};
                             if (_.has(props, "content")) {

--- a/packages/perseus-editor/src/widgets/graded-group-editor.tsx
+++ b/packages/perseus-editor/src/widgets/graded-group-editor.tsx
@@ -94,7 +94,6 @@ class GradedGroupEditor extends React.Component<Props> {
                     apiOptions={this.props.apiOptions}
                     images={this.props.images}
                     widgetEnabled={true}
-                    immutableWidgets={false}
                     onChange={this.props.onChange}
                     warnNoPrompt={true}
                     warnNoWidgets={true}
@@ -123,7 +122,6 @@ class GradedGroupEditor extends React.Component<Props> {
                             apiOptions={this.props.apiOptions}
                             images={this.props.hint && this.props.hint.images}
                             widgetEnabled={true}
-                            immutableWidgets={false}
                             onChange={(props) => {
                                 // Copy all props over from the existing hint
                                 // and then add new props.

--- a/packages/perseus-editor/src/widgets/graded-group-set-editor.tsx
+++ b/packages/perseus-editor/src/widgets/graded-group-set-editor.tsx
@@ -62,7 +62,6 @@ class GradedGroupSetEditor extends React.Component<Props> {
                 {...group}
                 apiOptions={this.props.apiOptions}
                 widgetEnabled={true}
-                immutableWidgets={false}
                 onChange={(data) =>
                     // @ts-expect-error - TS2554 - Expected 3 arguments, but got 2.
                     this.change(

--- a/packages/perseus-editor/src/widgets/group-editor.tsx
+++ b/packages/perseus-editor/src/widgets/group-editor.tsx
@@ -52,7 +52,6 @@ class GroupEditor extends React.Component<Props> {
                     apiOptions={this.props.apiOptions}
                     images={this.props.images}
                     widgetEnabled={true}
-                    immutableWidgets={false}
                     onChange={this.props.onChange}
                 />
             </div>


### PR DESCRIPTION
## Summary:
`immutableWidgets` was always set to `false`.

Issue: none

## Test plan:

- `pnpm storybook`
- `open http://localhost:6006/?path=/docs/editors-editorpage--docs`
- You should be able to add and edit GradedGroup and GradedGroupSet
  widgets with sub-widgets.