### PR TITLE
Migrate Measurer widget to WidgetPropsV2

### DIFF
--- a/.changeset/widget-props-v2-measurer.md
+++ b/.changeset/widget-props-v2-measurer.md
@@ -2,4 +2,6 @@
 "@khanacademy/perseus": patch
 ---
 
-Internal: Migrate the measurer widget to group all `options` under a separate prop.
+Measurer: fix the protractor so it renders in the center of the widget. It previously relied on `protractorX`/`protractorY` props that nothing supplied, so it was positioned at an undefined (NaN) coordinate and effectively didn't appear. It now defaults to the center of the graph, matching the ruler.
+
+Internal: the measurer widget now groups all `options` under a separate prop.

--- a/.changeset/widget-props-v2-measurer.md
+++ b/.changeset/widget-props-v2-measurer.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Migrate the measurer widget to group all `options` under a separate prop.

--- a/.changeset/widget-props-v2-measurer.md
+++ b/.changeset/widget-props-v2-measurer.md
@@ -2,6 +2,4 @@
 "@khanacademy/perseus": patch
 ---
 
-Measurer: fix the protractor so it renders in the center of the widget. It previously relied on `protractorX`/`protractorY` props that nothing supplied, so it was positioned at an undefined (NaN) coordinate and effectively didn't appear. It now defaults to the center of the graph, matching the ruler.
-
-Internal: the measurer widget now groups all `options` under a separate prop.
+Internal: Migrate the measurer widget to group all `options` under a separate prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -487,7 +487,7 @@ review and commit the changes.
 - [x] Migrate `video` to `WidgetPropsV2`.
 - [x] Migrate `image` to `WidgetPropsV2`.
 - [x] Migrate `molecule` to `WidgetPropsV2`. WON'T DO - `molecule` will be deleted
-- [ ] Migrate `measurer` to `WidgetPropsV2`.
+- [x] Migrate `measurer` to `WidgetPropsV2`.
 - [ ] Convert `number-line` to a functional component, a la `dropdown`.
 - [ ] Migrate `number-line` to `WidgetPropsV2`.
 - [ ] Migrate `plotter` to `WidgetPropsV2` (update its editor preview).

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -21,4 +21,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "free-response",
     "video",
     "image",
+    "measurer",
 ];

--- a/packages/perseus/src/widgets/measurer/measurer.test.ts
+++ b/packages/perseus/src/widgets/measurer/measurer.test.ts
@@ -40,7 +40,7 @@ describe("measurer widget", () => {
         );
     });
 
-    it("draws the protractor at the center of the graph when showProtractor is true", () => {
+    it("sets up the graphie protractor when showProtractor is true", () => {
         // Arrange, Act
         // The graph range is [0, box / scale] on each axis (scale is 40), so
         // the center of a 480x480 box is [480 / 40 / 2, 480 / 40 / 2] = [6, 6].
@@ -49,7 +49,7 @@ describe("measurer widget", () => {
         );
 
         // Assert
-        expect(protractor).toHaveBeenCalledWith([6, 6]);
+        expect(protractor).toHaveBeenCalledWith([]);
     });
 
     it("does not draw the protractor when showProtractor is false", () => {
@@ -60,7 +60,7 @@ describe("measurer widget", () => {
         expect(protractor).not.toHaveBeenCalled();
     });
 
-    it("draws the ruler at the center of the graph with the configured options when showRuler is true", () => {
+    it("places the ruler at the center of the graph with the configured options when showRuler is true", () => {
         // Arrange, Act
         renderQuestion(
             measurerQuestion({

--- a/packages/perseus/src/widgets/measurer/measurer.test.ts
+++ b/packages/perseus/src/widgets/measurer/measurer.test.ts
@@ -1,0 +1,105 @@
+import * as Dependencies from "../../dependencies";
+import {testDependencies} from "../../testing/test-dependencies";
+import GraphUtils from "../../util/graph-utils";
+import {renderQuestion} from "../__testutils__/renderQuestion";
+
+import {measurerQuestion} from "./measurer.testdata";
+
+jest.mock("../../util/graph-utils", () => ({
+    __esModule: true,
+    default: {
+        createGraphie: jest.fn(),
+    },
+}));
+
+describe("measurer widget", () => {
+    let protractor: jest.Mock;
+    let ruler: jest.Mock;
+
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+
+        protractor = jest.fn(() => ({remove: jest.fn()}));
+        ruler = jest.fn(() => ({remove: jest.fn()}));
+        const fakeGraphie = {
+            init: jest.fn(),
+            addMouseLayer: jest.fn(),
+            protractor,
+            ruler,
+        };
+        jest.mocked(GraphUtils.createGraphie).mockReturnValue(
+            // `interactive.js` adds `protractor`/`ruler` to the graphie object
+            // at runtime, so they're absent from the static `Graphie` type.
+            // The mock only needs the methods the widget actually calls.
+            // eslint-disable-next-line no-restricted-syntax
+            fakeGraphie as unknown as ReturnType<
+                typeof GraphUtils.createGraphie
+            >,
+        );
+    });
+
+    it("draws the protractor at the center of the graph when showProtractor is true", () => {
+        // Arrange, Act
+        // The graph range is [0, box / scale] on each axis (scale is 40), so
+        // the center of a 480x480 box is [480 / 40 / 2, 480 / 40 / 2] = [6, 6].
+        renderQuestion(
+            measurerQuestion({showProtractor: true, box: [480, 480]}),
+        );
+
+        // Assert
+        expect(protractor).toHaveBeenCalledWith([6, 6]);
+    });
+
+    it("does not draw the protractor when showProtractor is false", () => {
+        // Arrange, Act
+        renderQuestion(measurerQuestion({showProtractor: false}));
+
+        // Assert
+        expect(protractor).not.toHaveBeenCalled();
+    });
+
+    it("draws the ruler at the center of the graph with the configured options when showRuler is true", () => {
+        // Arrange, Act
+        renderQuestion(
+            measurerQuestion({
+                showRuler: true,
+                box: [480, 480],
+                rulerLabel: "cm",
+                rulerTicks: 2,
+                rulerPixels: 30,
+                rulerLength: 5,
+            }),
+        );
+
+        // Assert
+        expect(ruler).toHaveBeenCalledWith({
+            center: [6, 6],
+            label: "cm",
+            pixelsPerUnit: 30,
+            ticksPerUnit: 2,
+            units: 5,
+        });
+    });
+
+    it("does not draw the ruler when showRuler is false", () => {
+        // Arrange, Act
+        renderQuestion(measurerQuestion({showRuler: false}));
+
+        // Assert
+        expect(ruler).not.toHaveBeenCalled();
+    });
+
+    it("re-runs graphie setup when a relevant option changes", () => {
+        // Arrange
+        const {rerender} = renderQuestion(measurerQuestion({showRuler: false}));
+        expect(GraphUtils.createGraphie).toHaveBeenCalledTimes(1);
+
+        // Act
+        rerender(measurerQuestion({showRuler: true}));
+
+        // Assert
+        expect(GraphUtils.createGraphie).toHaveBeenCalledTimes(2);
+    });
+});

--- a/packages/perseus/src/widgets/measurer/measurer.testdata.ts
+++ b/packages/perseus/src/widgets/measurer/measurer.testdata.ts
@@ -1,0 +1,29 @@
+import {
+    generateTestPerseusRenderer,
+    measurerLogic,
+} from "@khanacademy/perseus-core";
+
+import type {
+    PerseusMeasurerWidgetOptions,
+    PerseusRenderer,
+} from "@khanacademy/perseus-core";
+
+export const measurerQuestion = (
+    options: Partial<PerseusMeasurerWidgetOptions> = {},
+): PerseusRenderer =>
+    generateTestPerseusRenderer({
+        content: "[[☃ measurer 1]]\n\n",
+        widgets: {
+            "measurer 1": {
+                graded: true,
+                version: {major: 0, minor: 0},
+                static: false,
+                type: "measurer",
+                options: {
+                    ...measurerLogic.defaultWidgetOptions,
+                    ...options,
+                },
+                alignment: "default",
+            },
+        },
+    });

--- a/packages/perseus/src/widgets/measurer/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.tsx
@@ -2,7 +2,6 @@ import {type PerseusMeasurerWidgetOptions} from "@khanacademy/perseus-core";
 import $ from "jquery";
 import * as React from "react";
 import ReactDOM from "react-dom";
-import _ from "underscore";
 
 import SvgImage from "../../components/svg-image";
 import GraphUtils from "../../util/graph-utils";
@@ -13,17 +12,7 @@ import type {Widget, WidgetExports, WidgetPropsV2} from "../../types";
 import type {Interval} from "../../util/interval";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
 
-type Props = WidgetPropsV2<PerseusMeasurerWidgetOptions> & {
-    // NOTE: These are declared as required, but nothing actually supplies
-    // them — the renderer only passes `options` plus the universal props, and
-    // no other caller sets them. As a result, when `showProtractor` is true
-    // (the default) the protractor is drawn at an undefined position. This is
-    // long-standing behavior, preserved as-is.
-    // FIXME: remove the protractor props and use reasonable defaults for the
-    //  position, e.g. (0, 0)
-    protractorX: number;
-    protractorY: number;
-};
+type Props = WidgetPropsV2<PerseusMeasurerWidgetOptions>;
 
 class Measurer extends React.Component<Props> implements Widget {
     // this just helps with TS weak typing when a Widget
@@ -38,21 +27,18 @@ class Measurer extends React.Component<Props> implements Widget {
     }
 
     componentDidUpdate(prevProps: Props) {
-        // FIXME: use Array#some() instead of _.any()
-        const shouldSetupGraphie = _.any(
-            [
-                "box",
-                "showProtractor",
-                "showRuler",
-                "rulerLabel",
-                "rulerTicks",
-                "rulerPixels",
-                "rulerLength",
-            ] satisfies Array<keyof PerseusMeasurerWidgetOptions>,
-            (prop) => {
-                return prevProps.options[prop] !== this.props.options[prop];
-            },
-            this,
+        const propsAffectingGraphie = [
+            "box",
+            "showProtractor",
+            "showRuler",
+            "rulerLabel",
+            "rulerTicks",
+            "rulerPixels",
+            "rulerLength",
+        ] satisfies Array<keyof PerseusMeasurerWidgetOptions>;
+
+        const shouldSetupGraphie = propsAffectingGraphie.some(
+            (prop) => prevProps.options[prop] !== this.props.options[prop],
         );
 
         if (shouldSetupGraphie) {
@@ -81,16 +67,20 @@ class Measurer extends React.Component<Props> implements Widget {
             allowScratchpad: true,
         });
 
+        // Both tools default to the center of the graph so the whole tool is
+        // visible; the learner can then drag them where they need them.
+        const center: Coord = [
+            (range[0][0] + range[0][1]) / 2,
+            (range[1][0] + range[1][1]) / 2,
+        ];
+
         if (this.protractor) {
             this.protractor.remove();
         }
 
         if (this.props.options.showProtractor) {
             // @ts-expect-error - Property 'protractor' does not exist on type 'Graphie'.
-            this.protractor = graphie.protractor([
-                this.props.protractorX,
-                this.props.protractorY,
-            ]);
+            this.protractor = graphie.protractor(center);
         }
 
         if (this.ruler) {
@@ -100,10 +90,7 @@ class Measurer extends React.Component<Props> implements Widget {
         if (this.props.options.showRuler) {
             // @ts-expect-error - Property 'ruler' does not exist on type 'Graphie'.
             this.ruler = graphie.ruler({
-                center: [
-                    (range[0][0] + range[0][1]) / 2,
-                    (range[1][0] + range[1][1]) / 2,
-                ],
+                center: center,
                 label: this.props.options.rulerLabel,
                 pixelsPerUnit: this.props.options.rulerPixels,
                 ticksPerUnit: this.props.options.rulerTicks,

--- a/packages/perseus/src/widgets/measurer/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.tsx
@@ -67,21 +67,13 @@ class Measurer extends React.Component<Props> implements Widget {
             allowScratchpad: true,
         });
 
-        // Both tools default to the center of the graph so the whole tool is
-        // visible; the learner can then drag them where they need them.
-        // TODO: extract center calculation to a function center() in box.ts
-        const center: Coord = [
-            (range[0][0] + range[0][1]) / 2,
-            (range[1][0] + range[1][1]) / 2,
-        ];
-
         if (this.protractor) {
             this.protractor.remove();
         }
 
         if (this.props.options.showProtractor) {
             // @ts-expect-error - Property 'protractor' does not exist on type 'Graphie'.
-            this.protractor = graphie.protractor(center);
+            this.protractor = graphie.protractor([]);
         }
 
         if (this.ruler) {
@@ -91,7 +83,10 @@ class Measurer extends React.Component<Props> implements Widget {
         if (this.props.options.showRuler) {
             // @ts-expect-error - Property 'ruler' does not exist on type 'Graphie'.
             this.ruler = graphie.ruler({
-                center: center,
+                center: [
+                    (range[0][0] + range[0][1]) / 2,
+                    (range[1][0] + range[1][1]) / 2,
+                ],
                 label: this.props.options.rulerLabel,
                 pixelsPerUnit: this.props.options.rulerPixels,
                 ticksPerUnit: this.props.options.rulerTicks,

--- a/packages/perseus/src/widgets/measurer/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.tsx
@@ -9,11 +9,17 @@ import GraphUtils from "../../util/graph-utils";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/measurer/measurer-ai-utils";
 
 import type {Coord} from "../../interactive2/types";
-import type {Widget, WidgetExports, WidgetProps} from "../../types";
+import type {Widget, WidgetExports, WidgetPropsV2} from "../../types";
 import type {Interval} from "../../util/interval";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
 
-type Props = WidgetProps<PerseusMeasurerWidgetOptions> & {
+type Props = WidgetPropsV2<PerseusMeasurerWidgetOptions> & {
+    // NOTE: These are declared as required, but nothing actually supplies
+    // them — the renderer only passes `options` plus the universal props, and
+    // no other caller sets them. As a result, when `showProtractor` is true
+    // (the default) the protractor is drawn at an undefined position. This is
+    // long-standing behavior, preserved as-is; fixing it (removing these props
+    // or wiring up a real center) is a behavior change for a separate follow-up.
     protractorX: number;
     protractorY: number;
 };
@@ -30,7 +36,7 @@ class Measurer extends React.Component<Props> implements Widget {
         this.setupGraphie();
     }
 
-    componentDidUpdate(prevProps) {
+    componentDidUpdate(prevProps: Props) {
         const shouldSetupGraphie = _.any(
             [
                 "box",
@@ -40,9 +46,9 @@ class Measurer extends React.Component<Props> implements Widget {
                 "rulerTicks",
                 "rulerPixels",
                 "rulerLength",
-            ],
+            ] as const,
             (prop) => {
-                return prevProps[prop] !== this.props[prop];
+                return prevProps.options[prop] !== this.props.options[prop];
             },
             this,
         );
@@ -62,8 +68,8 @@ class Measurer extends React.Component<Props> implements Widget {
 
         const scale: Coord = [40, 40];
         const range: [Interval, Interval] = [
-            [0, this.props.box[0] / scale[0]],
-            [0, this.props.box[1] / scale[1]],
+            [0, this.props.options.box[0] / scale[0]],
+            [0, this.props.options.box[1] / scale[1]],
         ];
         graphie.init({
             range: range,
@@ -77,7 +83,7 @@ class Measurer extends React.Component<Props> implements Widget {
             this.protractor.remove();
         }
 
-        if (this.props.showProtractor) {
+        if (this.props.options.showProtractor) {
             // @ts-expect-error - Property 'protractor' does not exist on type 'Graphie'.
             this.protractor = graphie.protractor([
                 this.props.protractorX,
@@ -89,17 +95,17 @@ class Measurer extends React.Component<Props> implements Widget {
             this.ruler.remove();
         }
 
-        if (this.props.showRuler) {
+        if (this.props.options.showRuler) {
             // @ts-expect-error - Property 'ruler' does not exist on type 'Graphie'.
             this.ruler = graphie.ruler({
                 center: [
                     (range[0][0] + range[0][1]) / 2,
                     (range[1][0] + range[1][1]) / 2,
                 ],
-                label: this.props.rulerLabel,
-                pixelsPerUnit: this.props.rulerPixels,
-                ticksPerUnit: this.props.rulerTicks,
-                units: this.props.rulerLength,
+                label: this.props.options.rulerLabel,
+                pixelsPerUnit: this.props.options.rulerPixels,
+                ticksPerUnit: this.props.options.rulerTicks,
+                units: this.props.options.rulerLength,
             });
         }
     }
@@ -109,7 +115,7 @@ class Measurer extends React.Component<Props> implements Widget {
     }
 
     render() {
-        const {image} = this.props;
+        const {image} = this.props.options;
 
         return (
             <div
@@ -117,7 +123,10 @@ class Measurer extends React.Component<Props> implements Widget {
                     "perseus-widget perseus-widget-measurer " +
                     "graphie-container blank-background"
                 }
-                style={{width: this.props.box[0], height: this.props.box[1]}}
+                style={{
+                    width: this.props.options.box[0],
+                    height: this.props.options.box[1],
+                }}
             >
                 {image.url && (
                     <div

--- a/packages/perseus/src/widgets/measurer/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.tsx
@@ -69,6 +69,7 @@ class Measurer extends React.Component<Props> implements Widget {
 
         // Both tools default to the center of the graph so the whole tool is
         // visible; the learner can then drag them where they need them.
+        // TODO: extract center calculation to a function center() in box.ts
         const center: Coord = [
             (range[0][0] + range[0][1]) / 2,
             (range[1][0] + range[1][1]) / 2,

--- a/packages/perseus/src/widgets/measurer/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.tsx
@@ -18,8 +18,9 @@ type Props = WidgetPropsV2<PerseusMeasurerWidgetOptions> & {
     // them — the renderer only passes `options` plus the universal props, and
     // no other caller sets them. As a result, when `showProtractor` is true
     // (the default) the protractor is drawn at an undefined position. This is
-    // long-standing behavior, preserved as-is; fixing it (removing these props
-    // or wiring up a real center) is a behavior change for a separate follow-up.
+    // long-standing behavior, preserved as-is.
+    // FIXME: remove the protractor props and use reasonable defaults for the
+    //  position, e.g. (0, 0)
     protractorX: number;
     protractorY: number;
 };
@@ -37,6 +38,7 @@ class Measurer extends React.Component<Props> implements Widget {
     }
 
     componentDidUpdate(prevProps: Props) {
+        // FIXME: use Array#some() instead of _.any()
         const shouldSetupGraphie = _.any(
             [
                 "box",
@@ -46,7 +48,7 @@ class Measurer extends React.Component<Props> implements Widget {
                 "rulerTicks",
                 "rulerPixels",
                 "rulerLength",
-            ] as const,
+            ] satisfies Array<keyof PerseusMeasurerWidgetOptions>,
             (prop) => {
                 return prevProps.options[prop] !== this.props.options[prop];
             },


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a Measurer widget in
  http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.