### PR TITLE
[Bugfix] ServerItemRenderer reports onRendered correctly for async-rendered content

### DIFF
--- a/.changeset/tidy-cats-go.md
+++ b/.changeset/tidy-cats-go.md
@@ -1,0 +1,11 @@
+---
+"@khanacademy/perseus": patch
+---
+
+FIX: `ServerItemRenderer` no longer calls `onRendered` before
+asynchronously-rendered content has finished rendering. Assets register
+themselves while it is still rendering, so it now tracks their statuses
+synchronously instead of in React state, where they weren't visible until after
+it had already reported completion. Previously any item containing an async
+asset — math or images — reported complete during mount, and because that report
+is only made once, no corrected call followed.

--- a/packages/perseus/src/__testdata__/server-item-renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/server-item-renderer.testdata.ts
@@ -35,6 +35,13 @@ export const itemWithNumericInput: PerseusItem = generateTestPerseusItem({
     ],
 });
 
+/**
+ * Content whose only asset is a block of math, which renders asynchronously.
+ */
+export const itemWithMath: PerseusItem = generateTestPerseusItem({
+    question: generateTestPerseusRenderer({content: "$x + y$"}),
+});
+
 export const itemWithMockWidget: PerseusItem = {
     question: {
         content: "Enter the number $$3$$ in the box: [[\u2603 mock-widget 1]]",

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -278,6 +278,44 @@ describe("server item renderer", () => {
         expect(onRendered).not.toHaveBeenCalled();
     });
 
+    it("calls onRendered only once when an asset settles during mount", () => {
+        // Arrange
+        // A layout effect runs before the parent ServerItemRenderer's
+        // componentDidMount, which reproduces an asset settling synchronously
+        // during the mount lifecycle.
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
+            ...testDependencies,
+            TeX: ({
+                children,
+                onRender,
+            }: {
+                children: React.ReactNode;
+                onRender?: () => void;
+            }) => {
+                React.useLayoutEffect(() => onRender?.(), [onRender]);
+                return <span className="mock-TeX">{children}</span>;
+            },
+        });
+        const onRendered = jest.fn();
+
+        // Act
+        render(
+            <RenderStateRoot>
+                <ServerItemRenderer
+                    item={itemWithMath}
+                    problemNum={0}
+                    reviewMode={false}
+                    dependencies={testDependenciesV2}
+                    onRendered={onRendered}
+                />
+            </RenderStateRoot>,
+        );
+
+        // Assert
+        expect(onRendered).toHaveBeenCalledTimes(1);
+        expect(onRendered).toHaveBeenCalledWith(true);
+    });
+
     it("should call the onRendered callback with no assets in content", () => {
         const content: PerseusItem = {
             question: {

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -16,6 +16,7 @@ import {
     itemWithRadioAndExpressionWidgets,
     itemWithTwoMockWidgets,
     itemWithMockWidget,
+    itemWithMath,
 } from "../__testdata__/server-item-renderer.testdata";
 import * as Dependencies from "../dependencies";
 import {ServerItemRenderer} from "../server-item-renderer";
@@ -245,6 +246,36 @@ describe("server item renderer", () => {
 
         // Assert
         expect(onRendered).toHaveBeenCalledWith(true);
+    });
+
+    it("does not call the onRendered callback while math is still rendering", () => {
+        // Arrange
+        // This TeX never reports rendering, standing in for math that MathJax
+        // hasn't finished with yet.
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
+            ...testDependencies,
+            TeX: ({children}: {children: React.ReactNode}) => (
+                <span className="mock-TeX">{children}</span>
+            ),
+        });
+
+        const onRendered = jest.fn();
+
+        // Act
+        render(
+            <RenderStateRoot>
+                <ServerItemRenderer
+                    item={itemWithMath}
+                    problemNum={0}
+                    reviewMode={false}
+                    dependencies={testDependenciesV2}
+                    onRendered={onRendered}
+                />
+            </RenderStateRoot>,
+        );
+
+        // Assert
+        expect(onRendered).not.toHaveBeenCalled();
     });
 
     it("should call the onRendered callback with no assets in content", () => {

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -280,9 +280,12 @@ describe("server item renderer", () => {
 
     it("calls onRendered only once when an asset settles during mount", () => {
         // Arrange
-        // A layout effect runs before the parent ServerItemRenderer's
-        // componentDidMount, which reproduces an asset settling synchronously
-        // during the mount lifecycle.
+        // `useLayoutEffect` fires in the same commit phase as a class
+        // component's `componentDidMount`, and React commits children before
+        // parents — so this TeX settles its asset before ServerItemRenderer
+        // has mounted, which is the case we're covering. (`useEffect` runs
+        // after paint, so it would land after `componentDidMount` instead.)
+        // https://legacy.reactjs.org/docs/hooks-reference.html#uselayouteffect
         jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
             ...testDependencies,
             TeX: ({

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -126,10 +126,6 @@ export class ServerItemRenderer
         this.maybeCallOnRendered();
     }
 
-    componentDidUpdate() {
-        this.maybeCallOnRendered();
-    }
-
     componentWillUnmount() {
         if (this.blurTimeoutID != null) {
             // TODO(jeff, CP-3128): Use Wonder Blocks Timing API.
@@ -139,6 +135,13 @@ export class ServerItemRenderer
         }
     }
 
+    /**
+     * Reports that we've finished rendering, if every asset has settled.
+     *
+     * Called once we've mounted (to cover content with no assets at all) and
+     * again on every status change, so it doesn't depend on a render pass
+     * happening at the right moment. Only ever reports once.
+     */
     maybeCallOnRendered() {
         if (!this._fullyRendered) {
             const assetsLoaded = Object.values(this._assetStatuses).every(

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -92,7 +92,8 @@ export class ServerItemRenderer
      * This is deliberately not React state: assets register themselves in
      * their constructors, while we're still rendering, and a state update
      * from there isn't visible to us until a later render pass — by which point we'd
-     * already have decided we were done rendering.
+     * already have called `onRendered()` under the assumption
+     * there were no assets to wait for.
      */
     _assetStatuses: {[assetKey: string]: boolean};
     blurTimeoutID: number | null | undefined;

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -61,16 +61,6 @@ type DefaultProps = Required<
     Pick<Props, "apiOptions" | "onRendered" | "linterContext">
 >;
 
-type State = {
-    /**
-     * Keeps track of whether each asset (SvgImage or TeX) rendered by
-     * the questionRenderer has finished loading or rendering.
-     */
-    assetStatuses: {
-        [assetKey: string]: boolean;
-    };
-};
-
 /**
  * @deprecated and likely a very broken API
  * [LEMS-3185] do not trust serializedState
@@ -81,7 +71,7 @@ type SerializedState = {
 };
 
 export class ServerItemRenderer
-    extends React.Component<Props, State>
+    extends React.Component<Props>
     implements
         RendererInterface,
         KeypadContextRendererInterface,
@@ -95,6 +85,16 @@ export class ServerItemRenderer
     hintsRenderer: any;
     _currentFocus: FocusPath;
     _fullyRendered: boolean;
+    /**
+     * Tracks whether each asset rendered below us (images, math, anything else
+     * that takes extra passes to settle) has finished rendering.
+     *
+     * This is deliberately not React state: assets register themselves in
+     * their constructors, while we're still rendering, and a state update
+     * from there isn't visible to us until a later pass — by which point we'd
+     * already have decided we were done rendering.
+     */
+    _assetStatuses: {[assetKey: string]: boolean};
     blurTimeoutID: number | null | undefined;
     userInput: UserInputMap;
 
@@ -108,9 +108,7 @@ export class ServerItemRenderer
     constructor(props: Props) {
         super(props);
 
-        this.state = {
-            assetStatuses: {},
-        };
+        this._assetStatuses = {};
         this._fullyRendered = false;
         this.userInput = {};
     }
@@ -122,9 +120,9 @@ export class ServerItemRenderer
         // In cases where we are rendering content that doesn't have any assets
         // (things that are async loaded/rendered, such as images or TeX), we
         // want to ensure that we fire the onRendered callback at least once.
-        // By the time the component mounts, assets will already be registered,
-        // but may not be loaded. So we will know if all assets are loaded at
-        // this point in the component lifecycle.
+        // Assets register themselves in their constructors, so by the time we
+        // mount they're all in _assetStatuses (unloaded) and we can tell
+        // whether there's anything to wait for.
         this.maybeCallOnRendered();
     }
 
@@ -143,7 +141,7 @@ export class ServerItemRenderer
 
     maybeCallOnRendered() {
         if (!this._fullyRendered) {
-            const assetsLoaded = Object.values(this.state.assetStatuses).every(
+            const assetsLoaded = Object.values(this._assetStatuses).every(
                 Boolean,
             );
 
@@ -317,12 +315,8 @@ export class ServerItemRenderer
         assetKey,
         status,
     ) => {
-        // setState doesn't properly merge objects so we have to do it ourselves
-        const assetStatuses = {
-            ...this.state.assetStatuses,
-            [assetKey]: status,
-        } as const;
-        this.setState({assetStatuses});
+        this._assetStatuses[assetKey] = status;
+        this.maybeCallOnRendered();
     };
 
     render(): React.ReactNode {
@@ -333,7 +327,7 @@ export class ServerItemRenderer
         } as const;
 
         const contextValue = {
-            assetStatuses: this.state.assetStatuses,
+            assetStatuses: this._assetStatuses,
             setAssetStatus: this.setAssetStatus,
         } as const;
 

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -91,7 +91,7 @@ export class ServerItemRenderer
      *
      * This is deliberately not React state: assets register themselves in
      * their constructors, while we're still rendering, and a state update
-     * from there isn't visible to us until a later pass — by which point we'd
+     * from there isn't visible to us until a later render pass — by which point we'd
      * already have decided we were done rendering.
      */
     _assetStatuses: {[assetKey: string]: boolean};

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -115,7 +115,6 @@ export class ServerItemRenderer
 
     componentDidMount() {
         this._currentFocus = null;
-        this._fullyRendered = false;
 
         // In cases where we are rendering content that doesn't have any assets
         // (things that are async loaded/rendered, such as images or TeX), we


### PR DESCRIPTION
_Sorry, this is a bit long, but I think it's useful to fully describe this as it's tricky!_

`ServerItemRenderer` uses the `onRendered` prop and `LoadingContext.Consumer` to tell clients an item has finished. It had a bug where it was firing the callback during mount, before asynchronously-rendered content had actually rendered. Before this PR, an item containing only math or only an image, both reported complete immediately on mount — and since `onRendered` is called at most once, no corrected call followed.

This isn't longstanding: the mechanism worked when it was introduced ([D51188](https://phabricator.khanacademy.org/D51188) (internal)), and regressed in two steps. #2579 (LEMS-3200) added the completion check to `componentDidMount` on the premise that "by the time the component mounts, assets will already be registered" — which isn't true, and is what made the callback fire immediately. Before that, Khan/webapp#2156 removed the instance field that `setAssetStatus` merged into, in favour of merging from `this.state`, so registrations arriving in the same batch could clobber each other.

The `AssetContext` mechanism meant to prevent this was inert on this path. Assets register themselves as early as possible (typically in their constructors), during the render pass, so the resulting state update isn't visible to `ServerItemRenderer` until a later pass — by which point `componentDidMount` has already seen an empty set of assets, concluded there was nothing to wait for, and latched. Asset statuses now live in an instance field that's readable synchronously, and completion is checked directly whenever a status changes rather than depending on a render pass landing at the right moment.

The child components' half of the contract was always fine — `Tex` and `SvgImage` register and report correctly. So did the other provider of this context, the Cypress test helper, which keeps statuses in a plain object and polls them, so it never had the timing problem. Content with no async assets was also unaffected, since reporting immediately is the right answer there. What was broken was `ServerItemRenderer`'s reading of the statuses it had been given.

Two things to take note of:
  1) Asset statuses are no longer in React state, so the item no longer re-renders each time an asset loads. Nothing re-renders based on asset statuses internally and we (correctly) call `onRendered` based on reported statuses now.
  2) The `componentDidUpdate` hook is gone: it existed only to trigger the completion check, which is now redundant.

Also fixed here: the completion latch was being reset in `componentDidMount`, which allowed a second `onRendered` call when an asset settled during mount (for example from a layout effect, which runs before the parent's `componentDidMount`).

This doesn't cover or fix assets that register on a later render pass — those can still register after the item has reported complete. Also, `Zoomable` is not participating at all; that was the component that spurred this research and fix and is the next PR in the stack.

Issue: LEMS-4419 

## Test plan:

- `pnpm test`
- `pnpm typecheck`
- Two new `ServerItemRenderer` tests cover it: one asserts nothing is reported while math is still rendering, the other that completion is reported exactly once when an asset settles during mount
- To see the old behaviour, run either new test against `main` — both fail because completion is reported during mount