### PR TITLE
[Interactive Graph] Fix tangent graph showing asymptotes for degenerate vertical/horizontal control-point line

### DIFF
--- a/.changeset/pink-eggs-bet.md
+++ b/.changeset/pink-eggs-bet.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix tangent graph showing asymptotes for degenerate vertical/horizontal control-point line

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/strings/tangent.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/strings/tangent.ts
@@ -127,6 +127,15 @@ function buildTangentDescription(
         ? strings.srTangentIncreasing({period: periodFormatted})
         : strings.srTangentDecreasing({period: periodFormatted});
 
+    // A tangent only has asymptotes when it's a genuine curve. It degenerates
+    // — with no asymptotes to announce — when the two control points form a
+    // vertical line (dx === 0) or a horizontal line (dy === 0, so the curve is
+    // the flat midline). This mirrors the visible asymptote lines, which are
+    // likewise omitted in these cases.
+    if (dx === 0 || dy === 0) {
+        return `${points} ${direction}`;
+    }
+
     // The nearest vertical asymptotes sit half a period on either side of the
     // inflection point.
     const halfPeriod = period / 2;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/strings/tangent.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/strings/tangent.ts
@@ -1,3 +1,5 @@
+import invariant from "tiny-invariant";
+
 import {X, Y} from "../../math";
 import {getCustomPointLabel} from "../components/build-point-aria-label";
 
@@ -107,6 +109,14 @@ function buildTangentDescription(
     const dx = control[X] - inflection[X];
     const dy = control[Y] - inflection[Y];
 
+    // A degenerate vertical (dx === 0) or horizontal (dy === 0) line has no
+    // asymptotes to announce. The reducer prevents these, so assert rather
+    // than defensively handle them.
+    invariant(
+        dx !== 0 && dy !== 0,
+        "Tangent requires two control points that differ in both x and y.",
+    );
+
     const points = strings.srTangentDescriptionPoints({
         inflectionX: srFormatNumber(inflection[X], locale),
         inflectionY: srFormatNumber(inflection[Y], locale),
@@ -126,15 +136,6 @@ function buildTangentDescription(
     const direction = increasing
         ? strings.srTangentIncreasing({period: periodFormatted})
         : strings.srTangentDecreasing({period: periodFormatted});
-
-    // A tangent only has asymptotes when it's a genuine curve. It degenerates
-    // — with no asymptotes to announce — when the two control points form a
-    // vertical line (dx === 0) or a horizontal line (dy === 0, so the curve is
-    // the flat midline). This mirrors the visible asymptote lines, which are
-    // likewise omitted in these cases.
-    if (dx === 0 || dy === 0) {
-        return `${points} ${direction}`;
-    }
 
     // The nearest vertical asymptotes sit half a period on either side of the
     // inflection point.

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/tangent.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/tangent.test.tsx
@@ -76,6 +76,32 @@ describe("Tangent graph screen reader", () => {
         );
     });
 
+    it("omits the asymptote description when the points form a horizontal line", () => {
+        // Arrange, Act — same y on both points gives amplitude 0, so the curve
+        // is the flat midline and has no asymptotes to announce.
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseTangentState,
+                    coords: [
+                        [0, 0],
+                        [2, 0],
+                    ],
+                }}
+            />,
+        );
+        const graph = screen.getByLabelText(
+            "A tangent curve on a coordinate plane.",
+        );
+
+        // Assert — the description stops after the direction sentence; no
+        // "The nearest vertical asymptotes are at…" clause is appended.
+        expect(graph).toHaveAccessibleDescription(
+            "The curve passes through an inflection point at 0 comma 0 and a control point at 2 comma 0. The curve decreases through the inflection point, repeating every 8 units.",
+        );
+    });
+
     it("should have aria labels for tangent graph points", () => {
         // Arrange
         render(<MafsGraph {...baseMafsGraphProps} state={baseTangentState} />);
@@ -239,6 +265,28 @@ describe("Tangent graph asymptotes", () => {
             screen.getAllByTestId("tangent-asymptote__line").length,
         ).toBeGreaterThan(2);
     });
+
+    it("renders no asymptote lines when the points form a horizontal line", () => {
+        // Arrange, Act — same y on both points gives amplitude 0, so the curve
+        // is the flat midline and has no asymptotes.
+        render(
+            <MafsGraph
+                {...baseMafsGraphProps}
+                state={{
+                    ...baseTangentState,
+                    coords: [
+                        [0, 0],
+                        [2, 0],
+                    ],
+                }}
+            />,
+        );
+
+        // Assert
+        expect(screen.queryAllByTestId("tangent-asymptote__line")).toHaveLength(
+            0,
+        );
+    });
 });
 
 describe("TangentGraph", () => {
@@ -280,7 +328,11 @@ describe("TangentGraph", () => {
 });
 
 describe("getTangentKeyboardConstraint", () => {
-    it("should snap to the grid and avoid putting points on a vertical line", () => {
+    it("snaps to the grid and steps over both the vertical and horizontal lines through the other point", () => {
+        // Moving point 0 ([0, 0]) while point 1 sits at [1, 1]: an up move
+        // would land on y=1 (same horizontal line) and a right move on x=1
+        // (same vertical line), so each takes an extra snapStep to skip the
+        // degenerate position.
         const coords: TangentGraphState["coords"] = [
             [0, 0],
             [1, 1],
@@ -289,10 +341,10 @@ describe("getTangentKeyboardConstraint", () => {
         const constraint = getTangentKeyboardConstraint(coords, snapStep, 0);
 
         expect(constraint).toEqual({
-            up: [0, 1],
+            up: [0, 2], // Skips the horizontal line at y=1
             down: [0, -1],
             left: [-1, 0],
-            right: [2, 0], // Avoids putting the point on a vertical line
+            right: [2, 0], // Skips the vertical line at x=1
         });
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/tangent.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/tangent.test.tsx
@@ -76,32 +76,6 @@ describe("Tangent graph screen reader", () => {
         );
     });
 
-    it("omits the asymptote description when the points form a horizontal line", () => {
-        // Arrange, Act — same y on both points gives amplitude 0, so the curve
-        // is the flat midline and has no asymptotes to announce.
-        render(
-            <MafsGraph
-                {...baseMafsGraphProps}
-                state={{
-                    ...baseTangentState,
-                    coords: [
-                        [0, 0],
-                        [2, 0],
-                    ],
-                }}
-            />,
-        );
-        const graph = screen.getByLabelText(
-            "A tangent curve on a coordinate plane.",
-        );
-
-        // Assert — the description stops after the direction sentence; no
-        // "The nearest vertical asymptotes are at…" clause is appended.
-        expect(graph).toHaveAccessibleDescription(
-            "The curve passes through an inflection point at 0 comma 0 and a control point at 2 comma 0. The curve decreases through the inflection point, repeating every 8 units.",
-        );
-    });
-
     it("should have aria labels for tangent graph points", () => {
         // Arrange
         render(<MafsGraph {...baseMafsGraphProps} state={baseTangentState} />);
@@ -266,25 +240,25 @@ describe("Tangent graph asymptotes", () => {
         ).toBeGreaterThan(2);
     });
 
-    it("renders no asymptote lines when the points form a horizontal line", () => {
-        // Arrange, Act — same y on both points gives amplitude 0, so the curve
-        // is the flat midline and has no asymptotes.
-        render(
-            <MafsGraph
-                {...baseMafsGraphProps}
-                state={{
-                    ...baseTangentState,
-                    coords: [
-                        [0, 0],
-                        [2, 0],
-                    ],
-                }}
-            />,
-        );
+    it.each`
+        description          | coords
+        ${"vertical line"}   | ${[[0, 0], [0, 2]]}
+        ${"horizontal line"} | ${[[0, 0], [2, 0]]}
+    `("throws when the points form a degenerate $description", ({coords}) => {
+        // A degenerate line has no well-defined tangent, so rendering asserts
+        // against it. Silence React's expected error logging for the throw.
+        jest.spyOn(console, "error").mockImplementation(() => {});
 
-        // Assert
-        expect(screen.queryAllByTestId("tangent-asymptote__line")).toHaveLength(
-            0,
+        // Arrange, Act, Assert
+        expect(() =>
+            render(
+                <MafsGraph
+                    {...baseMafsGraphProps}
+                    state={{...baseTangentState, coords}}
+                />,
+            ),
+        ).toThrow(
+            "Tangent requires two control points that differ in both x and y.",
         );
     });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/tangent.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/tangent.tsx
@@ -74,7 +74,17 @@ function TangentGraph(props: TangentGraphProps) {
     // splitting that works around the Mafs discontinuity below.
     const xRange: [number, number] = [range[0][0], range[0][1]];
     const yRange: [number, number] = [range[1][0], range[1][1]];
-    const asymptotes = getAsymptotePositions(coeffRef.current, xRange);
+
+    // A tangent only has asymptotes when it's a genuine curve. It degenerates
+    // — and mathematically has no asymptotes — when the two control points
+    // coincide or form a vertical line (coeffs undefined) or a horizontal line
+    // (amplitude 0, so a·tan(…) collapses to the constant midline). In those
+    // cases we render no asymptotes, mirroring how the vertical-line case is
+    // already rejected at the reducer.
+    const hasAsymptotes = coeffs !== undefined && coeffs.amplitude !== 0;
+    const asymptotes = hasAsymptotes
+        ? getAsymptotePositions(coeffRef.current, xRange)
+        : [];
 
     // WORKAROUND for Mafs discontinuity rendering — see getPlotSegments().
     const segments = getPlotSegments(asymptotes, xRange);
@@ -153,17 +163,22 @@ export const getTangentKeyboardConstraint = (
     const coordToBeMoved = coords[pointIndex];
     const otherPoint = coords[1 - pointIndex];
 
-    // Create a helper function that checks if the new point is on the same
-    // vertical line as the other point. If it is, we need to move the point
-    // an additional snapStep.
+    // Create a helper function that checks if the new point lands on the same
+    // vertical or horizontal line as the other point. If it does, we move the
+    // point an additional snapStep so the two points never share an x (which
+    // makes the frequency undefined) or a y (which zeroes the amplitude) —
+    // neither of which is a valid tangent. This mirrors the reducer guard so
+    // arrow keys step over the degenerate position instead of stalling on it.
     const movePointWithConstraint = (
         moveFunc: (coord: vec.Vector2) => vec.Vector2,
     ): vec.Vector2 => {
         // Move the point
         let movedCoord = moveFunc(coordToBeMoved);
-        // If the moved point overlaps with the other point in the line,
-        // move the point again.
-        if (movedCoord[X] === otherPoint[X]) {
+        // If the moved point lines up with the other point, move it again.
+        if (
+            movedCoord[X] === otherPoint[X] ||
+            movedCoord[Y] === otherPoint[Y]
+        ) {
             movedCoord = moveFunc(movedCoord);
         }
         return movedCoord;

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/tangent.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/tangent.tsx
@@ -1,5 +1,6 @@
 import {Plot, vec} from "mafs";
 import * as React from "react";
+import invariant from "tiny-invariant";
 
 import {
     usePerseusI18n,
@@ -51,23 +52,19 @@ function TangentGraph(props: TangentGraphProps) {
     // coords[1] is a quarter-period away (where amplitude is reached)
     const {coords, snapStep} = graphState;
 
-    // The coefficients are used to calculate the tangent equation, plot
-    // the graph, and to indicate to content creators the currently selected
-    // "correct answer" in the Content Editor. While we should technically
-    // never have invalid coordinates, we want to ensure that we have a
-    // fallback so that the graph can still be plotted without crashing.
-    const coeffRef = React.useRef<NamedTangentCoefficient>({
-        amplitude: 1,
-        angularFrequency: 1,
-        phase: 1,
-        verticalOffset: 0,
-    });
+    // The coefficients are used to calculate the tangent equation, plot the
+    // graph, and to indicate to content creators the currently selected
+    // "correct answer" in the Content Editor. A genuine tangent requires two
+    // control points that differ in both x and y. The reducer enforces this,
+    // so invalid coefficients — undefined for a vertical line, amplitude 0 for
+    // a horizontal one — should never reach render. Assert it here to narrow
+    // the type and surface the bug if a degenerate state ever slips through
+    // (e.g. hand-authored coordinates).
     const coeffs = getTangentCoefficients(coords);
-
-    // If the coefficients are valid, update the reference
-    if (coeffs !== undefined) {
-        coeffRef.current = coeffs;
-    }
+    invariant(
+        coeffs !== undefined && coeffs.amplitude !== 0,
+        "Tangent requires two control points that differ in both x and y.",
+    );
 
     // Asymptote positions derive from the two control points, so they move
     // live with the points. Used for both the dashed lines and the segment
@@ -75,16 +72,7 @@ function TangentGraph(props: TangentGraphProps) {
     const xRange: [number, number] = [range[0][0], range[0][1]];
     const yRange: [number, number] = [range[1][0], range[1][1]];
 
-    // A tangent only has asymptotes when it's a genuine curve. It degenerates
-    // — and mathematically has no asymptotes — when the two control points
-    // coincide or form a vertical line (coeffs undefined) or a horizontal line
-    // (amplitude 0, so a·tan(…) collapses to the constant midline). In those
-    // cases we render no asymptotes, mirroring how the vertical-line case is
-    // already rejected at the reducer.
-    const hasAsymptotes = coeffs !== undefined && coeffs.amplitude !== 0;
-    const asymptotes = hasAsymptotes
-        ? getAsymptotePositions(coeffRef.current, xRange)
-        : [];
+    const asymptotes = getAsymptotePositions(coeffs, xRange);
 
     // WORKAROUND for Mafs discontinuity rendering — see getPlotSegments().
     const segments = getPlotSegments(asymptotes, xRange);
@@ -112,7 +100,7 @@ function TangentGraph(props: TangentGraphProps) {
                 {segments.map(([segStart, segEnd], i) => (
                     <Plot.OfX
                         key={`tangent-segment-${i}`}
-                        y={(x) => computeTangent(x, coeffRef.current)}
+                        y={(x) => computeTangent(x, coeffs)}
                         domain={[segStart, segEnd]}
                         color={interactiveColor}
                         svgPathProps={{
@@ -302,7 +290,7 @@ function getAsymptotePositions(
 // To remove this workaround:
 // 1. Delete getPlotSegments() and getAsymptotePositions()
 // 2. Replace the segments.map(...) in TangentGraph with a single:
-//    <Plot.OfX y={(x) => computeTangent(x, coeffRef.current)}
+//    <Plot.OfX y={(x) => computeTangent(x, coeffs)}
 //        color={interactiveColor} svgPathProps={{"aria-hidden": true}} />
 function getPlotSegments(
     asymptotes: ReadonlyArray<number>,

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.test.ts
@@ -397,6 +397,29 @@ describe("movePointInFigure", () => {
         ]);
     });
 
+    it("does not allow moving the endpoints of a tangent to the same y location", () => {
+        const state = generateTangentGraphState({
+            coords: [
+                [1, 1],
+                [2, 2],
+            ],
+        });
+
+        // Move point 0 to y=2, which would put both points on the same
+        // horizontal line (zero amplitude / flat curve).
+        const updated = interactiveGraphReducer(
+            state,
+            actions.tangent.movePoint(0, [1, 2]),
+        );
+
+        invariant(updated.type === "tangent");
+        // Assert: the move was canceled
+        expect(updated.coords).toEqual([
+            [1, 1],
+            [2, 2],
+        ]);
+    });
+
     it("rejects a tangent move with a destination that clamps onto the other point's x", () => {
         // coords: point 0 at x=8, point 1 at x=10 (at the edge).
         // Moving point 0 to [15, 5] clamps to [10, 5] (range max 10),

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -850,11 +850,17 @@ function doMovePoint(
             );
 
             // Reject the move if it would place both points on the same
-            // vertical line — same-x control points produce division by
-            // zero in getTangentCoefficients (angularFrequency = π/(4*0)).
+            // vertical or horizontal line. Neither is a valid tangent:
+            // same-x control points produce division by zero in
+            // getTangentCoefficients (angularFrequency = π/(4*0)), and
+            // same-y control points produce a zero amplitude, collapsing
+            // the curve to a flat line with no asymptotes.
             const newCoords: vec.Vector2[] = [...state.coords];
             newCoords[action.index] = boundDestination;
-            if (newCoords[0][X] === newCoords[1][X]) {
+            if (
+                newCoords[0][X] === newCoords[1][X] ||
+                newCoords[0][Y] === newCoords[1][Y]
+            ) {
                 return state;
             }
 


### PR DESCRIPTION
## Summary:
A tangent graph is defined by two control points: the horizontal gap sets the period, the vertical gap sets the amplitude. Neither degenerate configuration has real asymptotes — a **vertical line** (same x) has an undefined frequency, and a **horizontal line** (same y) has zero amplitude, collapsing to a flat line. The vertical case was already prevented at the reducer, but the horizontal case still drew vertical dashed asymptotes (surfaced in a playtest with two points on the x-axis).

This change makes both cases consistent: neither a vertical nor a horizontal line of control points can be formed, and any degenerate config reached otherwise (e.g. hand-authored coords) shows no asymptotes.


Issue: LEMS-4416

## Test plan:
- dragging the tangent point cannot form a vertical or horizontal line, and a flat tangent shows no dashed asymptotes.