### PR TITLE
Update Zoomable to participate in AssetContext

### DIFF
--- a/.changeset/curly-cats-wish.md
+++ b/.changeset/curly-cats-wish.md
@@ -1,0 +1,8 @@
+---
+"@khanacademy/perseus": patch
+---
+
+FIX: `onRendered` now waits for zoomable content to settle. `Zoomable` — which
+wraps block math and tables on mobile, and takes several passes to measure and
+scale its content before fading it in — now reports its rendering status through
+the `AssetContext`, so items containing it are no longer declared rendered early.

--- a/.changeset/curly-cats-wish.md
+++ b/.changeset/curly-cats-wish.md
@@ -2,7 +2,5 @@
 "@khanacademy/perseus": patch
 ---
 
-FIX: `onRendered` now waits for zoomable content to settle. `Zoomable` — which
-wraps block math and tables on mobile, and takes several passes to measure and
-scale its content before fading it in — now reports its rendering status through
-the `AssetContext`, so items containing it are no longer declared rendered early.
+FIX: `ServerItemRenderer` now waits for zoomable content to settle before
+calling the `onRendered` callback.

--- a/packages/perseus/src/__testdata__/server-item-renderer.testdata.ts
+++ b/packages/perseus/src/__testdata__/server-item-renderer.testdata.ts
@@ -42,6 +42,15 @@ export const itemWithMath: PerseusItem = generateTestPerseusItem({
     question: generateTestPerseusRenderer({content: "$x + y$"}),
 });
 
+/**
+ * Content whose only asset is a table, which is zoomable on mobile.
+ */
+export const itemWithTable: PerseusItem = generateTestPerseusItem({
+    question: generateTestPerseusRenderer({
+        content: "| Column A | Column B |\n| --- | --- |\n| 1 | 2 |",
+    }),
+});
+
 export const itemWithMockWidget: PerseusItem = {
     question: {
         content: "Enter the number $$3$$ in the box: [[\u2603 mock-widget 1]]",

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -6,7 +6,7 @@ import {
 } from "@khanacademy/perseus-core";
 import {scorePerseusItem} from "@khanacademy/perseus-score";
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
-import {within, render, screen, act} from "@testing-library/react";
+import {within, render, screen, act, waitFor} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
@@ -321,7 +321,7 @@ describe("server item renderer", () => {
         expect(onRendered).toHaveBeenCalledWith(true);
     });
 
-    it("does not call the onRendered callback until zoomable math has settled", () => {
+    it("does not call the onRendered callback until zoomable math has settled", async () => {
         // Arrange
         // The default test TeX never fires onRender, so we need one that does
         // in order to get the Zoomable measuring.
@@ -355,18 +355,15 @@ describe("server item renderer", () => {
             </RenderStateRoot>,
         );
 
+        // Assert
         // On mobile, block math is wrapped in a Zoomable, which renders
         // asynchronously in order to measure and scale the math after MathJax
-        // has rendered it. We runAllTimers() (instead of
-        // runOnlyPendingTimers()) because there are more than one async tasks
-        // that need to settle here.
-        act(() => jest.runAllTimers());
-
-        // Assert
-        expect(onRendered).toHaveBeenCalledWith(true);
+        // has rendered it. waitFor moves the fake clock along between checks,
+        // so we don't have to know how many passes that takes.
+        await waitFor(() => expect(onRendered).toHaveBeenCalledWith(true));
     });
 
-    it("does not call the onRendered callback until a zoomable table has settled", () => {
+    it("does not call the onRendered callback until a zoomable table has settled", async () => {
         // On mobile, tables are wrapped in a Zoomable too, with the entrance
         // animation left enabled — so settling takes the measuring passes plus
         // the length of that animation.
@@ -394,17 +391,20 @@ describe("server item renderer", () => {
         expect(screen.getByRole("table")).toBeInTheDocument();
         expect(onRendered).not.toHaveBeenCalled();
 
-        // Measuring finishes and the content becomes visible, but the entrance
-        // animation is still running.
+        // Measuring finishes and the content starts fading in. Waiting on the
+        // DOM here, rather than flushing timers a set number of times, is what
+        // gives us a reliable point to measure the animation from.
+        await waitFor(() => expect(screen.getByRole("table")).toBeVisible());
+        expect(onRendered).not.toHaveBeenCalled();
+
+        // The entrance animation is running now, so we're still not settled.
         act(() =>
             jest.advanceTimersByTime(ENTRANCE_TRANSITION_DURATION_MS - 1),
         );
-        expect(screen.getByRole("table")).toBeVisible();
         expect(onRendered).not.toHaveBeenCalled();
 
         // Now wait for the animation to complete
         act(() => jest.advanceTimersByTime(2));
-        expect(screen.getByRole("table")).toBeVisible();
         expect(onRendered).toHaveBeenCalledWith(true);
     });
 

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -17,6 +17,7 @@ import {
     itemWithTwoMockWidgets,
     itemWithMockWidget,
     itemWithMath,
+    itemWithTable,
 } from "../__testdata__/server-item-renderer.testdata";
 import * as Dependencies from "../dependencies";
 import {ServerItemRenderer} from "../server-item-renderer";
@@ -362,6 +363,43 @@ describe("server item renderer", () => {
 
         act(() => jest.runOnlyPendingTimers());
         act(() => jest.runOnlyPendingTimers());
+        expect(onRendered).toHaveBeenCalledWith(true);
+    });
+
+    it("does not call the onRendered callback until a zoomable table has settled", () => {
+        // On mobile, tables are wrapped in a Zoomable too, with the entrance
+        // animation left enabled — so settling takes the measuring passes plus
+        // the length of that animation.
+
+        // Arrange
+        const onRendered = jest.fn();
+
+        // Act
+        render(
+            <RenderStateRoot>
+                <ServerItemRenderer
+                    item={itemWithTable}
+                    problemNum={0}
+                    reviewMode={false}
+                    apiOptions={{isMobile: true}}
+                    dependencies={testDependenciesV2}
+                    onRendered={onRendered}
+                />
+            </RenderStateRoot>,
+        );
+
+        // Assert
+        // Guard against the content silently not parsing as a table, which
+        // would skip the Zoomable entirely and make this test vacuous.
+        expect(screen.getByRole("table")).toBeInTheDocument();
+        expect(onRendered).not.toHaveBeenCalled();
+
+        // Measuring finishes and the content becomes visible, but the 300ms
+        // entrance animation is still running.
+        act(() => jest.advanceTimersByTime(299));
+        expect(onRendered).not.toHaveBeenCalled();
+
+        act(() => jest.runAllTimers());
         expect(onRendered).toHaveBeenCalledWith(true);
     });
 

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -19,6 +19,7 @@ import {
     itemWithMath,
     itemWithTable,
 } from "../__testdata__/server-item-renderer.testdata";
+import {ENTRANCE_TRANSITION_DURATION_MS} from "../components/zoomable";
 import * as Dependencies from "../dependencies";
 import {ServerItemRenderer} from "../server-item-renderer";
 import {
@@ -356,8 +357,10 @@ describe("server item renderer", () => {
 
         // On mobile, block math is wrapped in a Zoomable, which renders
         // asynchronously in order to measure and scale the math after MathJax
-        // has rendered it.
-        act(() => jest.runOnlyPendingTimers());
+        // has rendered it. We runAllTimers() (instead of
+        // runOnlyPendingTimers()) because there are more than one async tasks
+        // that need to settle here.
+        act(() => jest.runAllTimers());
 
         // Assert
         expect(onRendered).toHaveBeenCalledWith(true);
@@ -391,14 +394,16 @@ describe("server item renderer", () => {
         expect(screen.getByRole("table")).toBeInTheDocument();
         expect(onRendered).not.toHaveBeenCalled();
 
-        // Measuring finishes and the content becomes visible, but the 300ms
-        // entrance animation is still running.
-        act(() => jest.advanceTimersByTime(299));
+        // Measuring finishes and the content becomes visible, but the entrance
+        // animation is still running.
+        act(() =>
+            jest.advanceTimersByTime(ENTRANCE_TRANSITION_DURATION_MS - 1),
+        );
         expect(screen.getByRole("table")).toBeVisible();
         expect(onRendered).not.toHaveBeenCalled();
 
         // Now wait for the animation to complete
-        act(() => jest.runAllTimers());
+        act(() => jest.advanceTimersByTime(2));
         expect(screen.getByRole("table")).toBeVisible();
         expect(onRendered).toHaveBeenCalledWith(true);
     });

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -394,9 +394,12 @@ describe("server item renderer", () => {
         // Measuring finishes and the content becomes visible, but the 300ms
         // entrance animation is still running.
         act(() => jest.advanceTimersByTime(299));
+        expect(screen.getByRole("table")).toBeVisible();
         expect(onRendered).not.toHaveBeenCalled();
 
+        // Now wait for the animation to complete
         act(() => jest.runAllTimers());
+        expect(screen.getByRole("table")).toBeVisible();
         expect(onRendered).toHaveBeenCalledWith(true);
     });
 

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -319,6 +319,52 @@ describe("server item renderer", () => {
         expect(onRendered).toHaveBeenCalledWith(true);
     });
 
+    it("does not call the onRendered callback until zoomable math has settled", () => {
+        // On mobile, block math is wrapped in a Zoomable, which needs several
+        // asynchronous passes to measure and scale the math after MathJax has
+        // rendered it. Until those finish, we're not done rendering.
+
+        // Arrange
+        // The default test TeX never fires onRender, so we need one that does
+        // in order to get the Zoomable measuring.
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue({
+            ...testDependencies,
+            TeX: ({
+                children,
+                onRender,
+            }: {
+                children: React.ReactNode;
+                onRender?: () => void;
+            }) => {
+                React.useEffect(() => onRender?.(), [onRender]);
+                return <span className="mock-TeX">{children}</span>;
+            },
+        });
+
+        const onRendered = jest.fn();
+
+        // Act
+        render(
+            <RenderStateRoot>
+                <ServerItemRenderer
+                    item={itemWithMath}
+                    problemNum={0}
+                    reviewMode={false}
+                    apiOptions={{isMobile: true}}
+                    dependencies={testDependenciesV2}
+                    onRendered={onRendered}
+                />
+            </RenderStateRoot>,
+        );
+
+        // Assert
+        expect(onRendered).not.toHaveBeenCalled();
+
+        act(() => jest.runOnlyPendingTimers());
+        act(() => jest.runOnlyPendingTimers());
+        expect(onRendered).toHaveBeenCalledWith(true);
+    });
+
     it("should call the onRendered callback with no assets in content", () => {
         const content: PerseusItem = {
             question: {

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -321,10 +321,6 @@ describe("server item renderer", () => {
     });
 
     it("does not call the onRendered callback until zoomable math has settled", () => {
-        // On mobile, block math is wrapped in a Zoomable, which needs several
-        // asynchronous passes to measure and scale the math after MathJax has
-        // rendered it. Until those finish, we're not done rendering.
-
         // Arrange
         // The default test TeX never fires onRender, so we need one that does
         // in order to get the Zoomable measuring.
@@ -358,11 +354,12 @@ describe("server item renderer", () => {
             </RenderStateRoot>,
         );
 
-        // Assert
-        expect(onRendered).not.toHaveBeenCalled();
+        // On mobile, block math is wrapped in a Zoomable, which renders
+        // asynchronously in order to measure and scale the math after MathJax
+        // has rendered it.
+        act(() => jest.runOnlyPendingTimers());
 
-        act(() => jest.runOnlyPendingTimers());
-        act(() => jest.runOnlyPendingTimers());
+        // Assert
         expect(onRendered).toHaveBeenCalledWith(true);
     });
 

--- a/packages/perseus/src/asset-context.test.tsx
+++ b/packages/perseus/src/asset-context.test.tsx
@@ -1,13 +1,15 @@
-import * as React from "react";
+import {useOnMountEffect} from "@khanacademy/wonder-blocks-core";
 import {render} from "@testing-library/react";
+import * as React from "react";
+
 import AssetContext from "./asset-context";
 
 function AssetContextConsumer() {
     const {setAssetStatus} = React.useContext(AssetContext);
 
-    React.useEffect(() => {
+    useOnMountEffect(() => {
         setAssetStatus("demo", false);
-    }, []);
+    });
 
     return <div>Hello</div>;
 }

--- a/packages/perseus/src/asset-context.test.tsx
+++ b/packages/perseus/src/asset-context.test.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import {render} from "@testing-library/react";
+import AssetContext from "./asset-context";
+
+function AssetContextConsumer() {
+    const {setAssetStatus} = React.useContext(AssetContext);
+
+    React.useEffect(() => {
+        setAssetStatus("demo", false);
+    }, []);
+
+    return <div>Hello</div>;
+}
+
+describe("AssetContext", () => {
+    it("should provide safe defaults", () => {
+        expect(() => render(<AssetContextConsumer />)).not.toThrow();
+    });
+});

--- a/packages/perseus/src/components/__tests__/zoomable.test.tsx
+++ b/packages/perseus/src/components/__tests__/zoomable.test.tsx
@@ -663,24 +663,6 @@ describe("Zoomable", () => {
             ]);
         });
 
-        it("stays settled after a child mutation forces a re-measure", async () => {
-            // Arrange
-            const {setAssetStatus} = renderWithAssetContext(
-                <Zoomable>
-                    <span>Some zoomable text</span>
-                </Zoomable>,
-            );
-            act(() => jest.runAllTimers());
-
-            // Act
-            screen.getByText("Some zoomable text").innerHTML = "Some more text";
-            expect(await screen.findByText("Some more text")).toBeVisible();
-            act(() => jest.runAllTimers());
-
-            // Assert
-            expect(settledKeys(setAssetStatus)).toHaveLength(1);
-        });
-
         it("gives each instance its own asset key", () => {
             // Arrange, Act
             const {setAssetStatus} = renderWithAssetContext(

--- a/packages/perseus/src/components/__tests__/zoomable.test.tsx
+++ b/packages/perseus/src/components/__tests__/zoomable.test.tsx
@@ -4,7 +4,7 @@ import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
 import AssetContext from "../../asset-context";
-import Zoomable from "../zoomable";
+import Zoomable, {ENTRANCE_TRANSITION_DURATION_MS} from "../zoomable";
 
 import type {UserEvent} from "@testing-library/user-event";
 
@@ -25,16 +25,30 @@ const mockSize = (
     }
 };
 
+// Zoomable applies its transition styles only once its content has become
+// visible, so they tell us that measuring has finished. Waiting on the DOM
+// like this, instead of flushing timers a set number of times, means these
+// tests don't break when the number of render passes changes.
+async function waitForVisible(container: HTMLElement) {
+    await waitFor(() => {
+        // eslint-disable-next-line testing-library/no-node-access, no-restricted-syntax
+        const rootNode = container.firstElementChild as HTMLElement;
+        expect(rootNode.style.transitionDuration).toBe(
+            `${ENTRANCE_TRANSITION_DURATION_MS}ms`,
+        );
+    });
+}
+
 // The zoomable does some measuring after the initial render to determine what
 // its zoomed-out scaling should be. So on initial render, we want to wait for
-// this process so that we "see" the settled component state.
-const renderAndWaitToSettle = (component: React.ReactElement) => {
+// this process so that we "see" the measured component state.
+async function renderAndWaitForVisible(component: React.ReactElement) {
     const result = render(component);
 
-    act(() => jest.runAllTimers());
+    await waitForVisible(result.container);
 
     return result;
-};
+}
 
 describe("Zoomable", () => {
     let userEvent: UserEvent;
@@ -46,7 +60,7 @@ describe("Zoomable", () => {
 
     it("should render zoomed-out (scale != 1) initially", async () => {
         // Arrange and Act
-        const {container} = renderAndWaitToSettle(
+        const {container} = await renderAndWaitForVisible(
             <Zoomable readyToMeasure>
                 <span>Some zoomable text</span>
             </Zoomable>,
@@ -68,7 +82,7 @@ describe("Zoomable", () => {
 
     it("should toggle to zoomed-in (scale == 1) when clicked", async () => {
         // Arrange
-        const {container} = renderAndWaitToSettle(
+        const {container} = await renderAndWaitForVisible(
             <Zoomable>
                 <span>Some zoomable text</span>
             </Zoomable>,
@@ -95,7 +109,7 @@ describe("Zoomable", () => {
 
     it("should toggle back to zoomed-out state when clicked while zoomed in", async () => {
         // Arrange
-        const {container} = renderAndWaitToSettle(
+        const {container} = await renderAndWaitForVisible(
             <Zoomable>
                 <span>Some zoomable text</span>
             </Zoomable>,
@@ -127,7 +141,7 @@ describe("Zoomable", () => {
         const computeChildBounds = jest.fn(() => ({width: 1000, height: 1000}));
 
         // Act
-        renderAndWaitToSettle(
+        await renderAndWaitForVisible(
             <Zoomable computeChildBounds={computeChildBounds}>
                 <span>Some zoomable text</span>
             </Zoomable>,
@@ -139,7 +153,7 @@ describe("Zoomable", () => {
 
     it("should scale if computeChildBounds is larger than root node size", async () => {
         // Arrange
-        // We don't use the renderAndWaitToSettle() helper here because we need
+        // We don't use the renderAndWaitForVisible() helper here because we need
         // to mock _after_ initial render but _before_ the measuring stage
         // happens after that render!
         const {container} = render(
@@ -249,7 +263,7 @@ describe("Zoomable", () => {
     it("should not call onClick prop when zoomed out (ie. initial render)", async () => {
         // Arrange
         const onClickHandler = jest.fn();
-        renderAndWaitToSettle(
+        await renderAndWaitForVisible(
             <Zoomable>
                 <button onClick={onClickHandler}>Some zoomable text</button>
             </Zoomable>,
@@ -264,7 +278,7 @@ describe("Zoomable", () => {
 
     it("should call onClick prop when zoomed in", async () => {
         // Arrange
-        const {rerender} = renderAndWaitToSettle(
+        const {rerender} = await renderAndWaitForVisible(
             <Zoomable>
                 <span>Some zoomable text</span>
             </Zoomable>,
@@ -295,7 +309,7 @@ describe("Zoomable", () => {
             const props: Record<string, any> = {};
             props[propName] = jest.fn();
 
-            renderAndWaitToSettle(
+            await renderAndWaitForVisible(
                 <Zoomable>
                     <span {...props}>Some zoomable text</span>
                 </Zoomable>,
@@ -314,7 +328,7 @@ describe("Zoomable", () => {
             const props: Record<string, any> = {};
             props[propName] = jest.fn();
 
-            renderAndWaitToSettle(
+            await renderAndWaitForVisible(
                 <Zoomable>
                     <span {...props}>Some zoomable text</span>
                 </Zoomable>,
@@ -526,16 +540,16 @@ describe("Zoomable", () => {
 
         const renderWithAssetContext = (
             component: React.ReactElement,
-        ): {setAssetStatus: jest.Mock} => {
+        ): {setAssetStatus: jest.Mock; container: HTMLElement} => {
             const setAssetStatus = jest.fn();
-            render(
+            const {container} = render(
                 <AssetContext.Provider
                     value={{assetStatuses: {}, setAssetStatus}}
                 >
                     {component}
                 </AssetContext.Provider>,
             );
-            return {setAssetStatus};
+            return {setAssetStatus, container};
         };
 
         const settledKeys = (setAssetStatus: jest.Mock): Array<string> =>
@@ -559,60 +573,67 @@ describe("Zoomable", () => {
             );
         });
 
-        it("reports settled once the entrance animation has finished", () => {
+        it("reports settled once the entrance animation has finished", async () => {
             // Arrange
-            const {setAssetStatus} = renderWithAssetContext(
+            const {setAssetStatus, container} = renderWithAssetContext(
                 <Zoomable>
                     <span>Some zoomable text</span>
                 </Zoomable>,
             );
             const [assetKey] = setAssetStatus.mock.calls[0];
+            // Becoming visible is what starts the entrance animation, so it's
+            // the point we measure the animation's duration from.
+            await waitForVisible(container);
 
             // Act
-            act(() => jest.runAllTimers());
+            act(() =>
+                jest.advanceTimersByTime(ENTRANCE_TRANSITION_DURATION_MS),
+            );
 
             // Assert
             expect(setAssetStatus).toHaveBeenCalledWith(assetKey, true);
         });
 
-        it("does not report settled while the entrance animation is running", () => {
+        it("does not report settled while the entrance animation is running", async () => {
             // Arrange
-            const {setAssetStatus} = renderWithAssetContext(
+            const {setAssetStatus, container} = renderWithAssetContext(
                 <Zoomable>
                     <span>Some zoomable text</span>
                 </Zoomable>,
             );
+            await waitForVisible(container);
 
             // Act
-            // Enough time for measuring to complete and the content to become
-            // visible, but not for the 300ms entrance animation to finish.
-            act(() => jest.advanceTimersByTime(299));
+            // One tick short of the entrance animation finishing.
+            act(() =>
+                jest.advanceTimersByTime(ENTRANCE_TRANSITION_DURATION_MS - 1),
+            );
 
             // Assert
             expect(settledKeys(setAssetStatus)).toHaveLength(0);
         });
 
-        it("reports settled as soon as content is visible when the entrance animation is disabled", () => {
+        it("reports settled as soon as content is visible when the entrance animation is disabled", async () => {
             // Arrange
-            const {setAssetStatus} = renderWithAssetContext(
+            const {setAssetStatus, container} = renderWithAssetContext(
                 <Zoomable disableEntranceAnimation={true}>
                     <span>Some zoomable text</span>
                 </Zoomable>,
             );
             const [assetKey] = setAssetStatus.mock.calls[0];
+            await waitForVisible(container);
 
             // Act
-            // Zoomables initial render without an entrance animation takes a
-            // few clock ticks to settle. We want to wait long enough for these
-            // initial passes to complete and the content to become visible, but
-            // nowhere near the 300ms entrance animation.
-            act(() => jest.advanceTimersByTime(10));
+            // Deliberately nowhere near the entrance animation's duration:
+            // there's no animation to wait out, so settling happens on the
+            // next tick.
+            act(() => jest.advanceTimersByTime(0));
 
             // Assert
             expect(setAssetStatus).toHaveBeenCalledWith(assetKey, true);
         });
 
-        it("reports settled when the content fits and doesn't need scaling", () => {
+        it("reports settled when the content fits and doesn't need scaling", async () => {
             // Arrange
             const setAssetStatus = jest.fn();
             const {container} = render(
@@ -635,26 +656,35 @@ describe("Zoomable", () => {
             });
             const [assetKey] = setAssetStatus.mock.calls[0];
 
-            // Act
-            act(() => jest.runAllTimers());
-
-            // Assert
-            expect(setAssetStatus).toHaveBeenCalledWith(assetKey, true);
+            // Act, Assert
+            // This test only cares that the non-scaling branch settles at all,
+            // so we can wait on the report itself.
+            await waitFor(() =>
+                expect(setAssetStatus).toHaveBeenCalledWith(assetKey, true),
+            );
         });
 
-        it("stays settled after a window resize forces a re-measure", () => {
+        it("stays settled after a window resize forces a re-measure", async () => {
             // Arrange
-            const {setAssetStatus} = renderWithAssetContext(
+            const {setAssetStatus, container} = renderWithAssetContext(
                 <Zoomable>
                     <span>Some zoomable text</span>
                 </Zoomable>,
             );
             const [assetKey] = setAssetStatus.mock.calls[0];
-            act(() => jest.runAllTimers());
+            await waitForVisible(container);
+            act(() =>
+                jest.advanceTimersByTime(ENTRANCE_TRANSITION_DURATION_MS),
+            );
 
             // Act
+            // A resize hides the content and measures it again from scratch, so
+            // wait for it to become visible a second time.
             act(() => window.dispatchEvent(new Event("resize")));
-            act(() => jest.runAllTimers());
+            await waitForVisible(container);
+            act(() =>
+                jest.advanceTimersByTime(ENTRANCE_TRANSITION_DURATION_MS),
+            );
 
             // Assert - we went from not-loaded to loaded and stayed that way.
             expect(setAssetStatus.mock.calls).toEqual([

--- a/packages/perseus/src/components/__tests__/zoomable.test.tsx
+++ b/packages/perseus/src/components/__tests__/zoomable.test.tsx
@@ -241,14 +241,11 @@ describe("Zoomable", () => {
             window.dispatchEvent(resizeEvent);
         };
 
-        render(
+        await renderAndWaitForVisible(
             <Zoomable>
                 <span>Some zoomable text</span>
             </Zoomable>,
         );
-        // We need two cycles to get everything rendered and visible
-        act(() => jest.runOnlyPendingTimers());
-        act(() => jest.runOnlyPendingTimers());
 
         // Act
         act(() => resizeWindowTo(500, 500));
@@ -573,67 +570,66 @@ describe("Zoomable", () => {
             );
         });
 
-        it("reports settled once the entrance animation has finished", async () => {
+        it("reports settled once the entrance animation has finished", () => {
             // Arrange
-            const {setAssetStatus, container} = renderWithAssetContext(
+            const {setAssetStatus} = renderWithAssetContext(
                 <Zoomable>
                     <span>Some zoomable text</span>
                 </Zoomable>,
             );
             const [assetKey] = setAssetStatus.mock.calls[0];
-            // Becoming visible is what starts the entrance animation, so it's
-            // the point we measure the animation's duration from.
-            await waitForVisible(container);
 
             // Act
-            act(() =>
-                jest.advanceTimersByTime(ENTRANCE_TRANSITION_DURATION_MS),
-            );
+            // Two passes: the first lets React render with the content visible,
+            // which is what starts the entrance animation timer. The second
+            // runs that timer.
+            act(() => jest.runAllTimers());
+            act(() => jest.runAllTimers());
 
             // Assert
             expect(setAssetStatus).toHaveBeenCalledWith(assetKey, true);
         });
 
-        it("does not report settled while the entrance animation is running", async () => {
+        it("does not report settled while the entrance animation is running", () => {
             // Arrange
-            const {setAssetStatus, container} = renderWithAssetContext(
+            const {setAssetStatus} = renderWithAssetContext(
                 <Zoomable>
                     <span>Some zoomable text</span>
                 </Zoomable>,
             );
-            await waitForVisible(container);
 
             // Act
-            // One tick short of the entrance animation finishing.
-            act(() =>
-                jest.advanceTimersByTime(ENTRANCE_TRANSITION_DURATION_MS - 1),
-            );
+            // Enough time for measuring to complete and the content to become
+            // visible, but not for the 300ms entrance animation to finish.
+            act(() => jest.advanceTimersByTime(299));
 
             // Assert
             expect(settledKeys(setAssetStatus)).toHaveLength(0);
         });
 
-        it("reports settled as soon as content is visible when the entrance animation is disabled", async () => {
+        it("reports settled as soon as content is visible when the entrance animation is disabled", () => {
             // Arrange
-            const {setAssetStatus, container} = renderWithAssetContext(
+            const {setAssetStatus} = renderWithAssetContext(
                 <Zoomable disableEntranceAnimation={true}>
                     <span>Some zoomable text</span>
                 </Zoomable>,
             );
             const [assetKey] = setAssetStatus.mock.calls[0];
-            await waitForVisible(container);
 
             // Act
-            // Deliberately nowhere near the entrance animation's duration:
-            // there's no animation to wait out, so settling happens on the
-            // next tick.
-            act(() => jest.advanceTimersByTime(0));
+            // Zoomables initial render without an entrance animation takes a
+            // few clock ticks to settle. We want to wait long enough for these
+            // initial passes to complete and the content to become visible, but
+            // nowhere near the 300ms entrance animation. The second pass runs
+            // the settle timer that becoming visible schedules.
+            act(() => jest.advanceTimersByTime(10));
+            act(() => jest.advanceTimersByTime(10));
 
             // Assert
             expect(setAssetStatus).toHaveBeenCalledWith(assetKey, true);
         });
 
-        it("reports settled when the content fits and doesn't need scaling", async () => {
+        it("reports settled when the content fits and doesn't need scaling", () => {
             // Arrange
             const setAssetStatus = jest.fn();
             const {container} = render(
@@ -656,35 +652,29 @@ describe("Zoomable", () => {
             });
             const [assetKey] = setAssetStatus.mock.calls[0];
 
-            // Act, Assert
-            // This test only cares that the non-scaling branch settles at all,
-            // so we can wait on the report itself.
-            await waitFor(() =>
-                expect(setAssetStatus).toHaveBeenCalledWith(assetKey, true),
-            );
+            // Act
+            // Two passes: the first makes the content visible, the second runs
+            // the settle timer that scheduled.
+            act(() => jest.runAllTimers());
+            act(() => jest.runAllTimers());
+
+            // Assert
+            expect(setAssetStatus).toHaveBeenCalledWith(assetKey, true);
         });
 
-        it("stays settled after a window resize forces a re-measure", async () => {
+        it("stays settled after a window resize forces a re-measure", () => {
             // Arrange
-            const {setAssetStatus, container} = renderWithAssetContext(
+            const {setAssetStatus} = renderWithAssetContext(
                 <Zoomable>
                     <span>Some zoomable text</span>
                 </Zoomable>,
             );
             const [assetKey] = setAssetStatus.mock.calls[0];
-            await waitForVisible(container);
-            act(() =>
-                jest.advanceTimersByTime(ENTRANCE_TRANSITION_DURATION_MS),
-            );
+            act(() => jest.runAllTimers());
 
             // Act
-            // A resize hides the content and measures it again from scratch, so
-            // wait for it to become visible a second time.
             act(() => window.dispatchEvent(new Event("resize")));
-            await waitForVisible(container);
-            act(() =>
-                jest.advanceTimersByTime(ENTRANCE_TRANSITION_DURATION_MS),
-            );
+            act(() => jest.runAllTimers());
 
             // Assert - we went from not-loaded to loaded and stayed that way.
             expect(setAssetStatus.mock.calls).toEqual([

--- a/packages/perseus/src/components/__tests__/zoomable.test.tsx
+++ b/packages/perseus/src/components/__tests__/zoomable.test.tsx
@@ -602,10 +602,11 @@ describe("Zoomable", () => {
             const [assetKey] = setAssetStatus.mock.calls[0];
 
             // Act
-            // Enough time for measuring to complete and the content to become
-            // visible, but nowhere near the 300ms entrance animation.
-            act(() => jest.advanceTimersByTime(1));
-            act(() => jest.advanceTimersByTime(1));
+            // Zoomables initial render without an entrance animation takes a
+            // few clock ticks to settle. We want to wait long enough for these
+            // initial passes to complete and the content to become visible, but
+            // nowhere near the 300ms entrance animation.
+            act(() => jest.advanceTimersByTime(10));
 
             // Assert
             expect(setAssetStatus).toHaveBeenCalledWith(assetKey, true);

--- a/packages/perseus/src/components/__tests__/zoomable.test.tsx
+++ b/packages/perseus/src/components/__tests__/zoomable.test.tsx
@@ -698,17 +698,5 @@ describe("Zoomable", () => {
             const [[firstKey], [secondKey]] = setAssetStatus.mock.calls;
             expect(firstKey).not.toEqual(secondKey);
         });
-
-        it("renders without an AssetContext provider", () => {
-            // Arrange, Act
-            renderAndWaitToSettle(
-                <Zoomable>
-                    <span>Some zoomable text</span>
-                </Zoomable>,
-            );
-
-            // Assert
-            expect(screen.getByText("Some zoomable text")).toBeInTheDocument();
-        });
     });
 });

--- a/packages/perseus/src/components/__tests__/zoomable.test.tsx
+++ b/packages/perseus/src/components/__tests__/zoomable.test.tsx
@@ -56,7 +56,7 @@ describe("Zoomable", () => {
         expect(container).toMatchInlineSnapshot(`
             <div>
               <span
-                style="display: block; width: 100%; transform: scale(0, 0); transform-origin: 0 0; opacity: 1; height: 0px; transition-property: opacity transform; transition-duration: 0.3s; transition-timing-function: ease-out;"
+                style="display: block; width: 100%; transform: scale(0, 0); transform-origin: 0 0; opacity: 1; height: 0px; transition-property: opacity transform; transition-duration: 300ms; transition-timing-function: ease-out;"
               >
                 <span>
                   Some zoomable text
@@ -83,7 +83,7 @@ describe("Zoomable", () => {
         expect(container).toMatchInlineSnapshot(`
             <div>
               <span
-                style="display: block; width: 100%; transform: scale(1, 1); transform-origin: 0 0; opacity: 1; height: 1px; transition-property: opacity transform; transition-duration: 0.3s; transition-timing-function: ease-out;"
+                style="display: block; width: 100%; transform: scale(1, 1); transform-origin: 0 0; opacity: 1; height: 1px; transition-property: opacity transform; transition-duration: 300ms; transition-timing-function: ease-out;"
               >
                 <span>
                   Some zoomable text
@@ -112,7 +112,7 @@ describe("Zoomable", () => {
         expect(container).toMatchInlineSnapshot(`
             <div>
               <span
-                style="display: block; width: 100%; transform: scale(0, 0); transform-origin: 0 0; opacity: 1; height: 0px; transition-property: opacity transform; transition-duration: 0.3s; transition-timing-function: ease-out;"
+                style="display: block; width: 100%; transform: scale(0, 0); transform-origin: 0 0; opacity: 1; height: 0px; transition-property: opacity transform; transition-duration: 300ms; transition-timing-function: ease-out;"
               >
                 <span>
                   Some zoomable text
@@ -167,7 +167,7 @@ describe("Zoomable", () => {
         expect(container).toMatchInlineSnapshot(`
             <div>
               <span
-                style="display: block; width: 100%; transform: scale(0.4993757802746567, 0.4993757802746567); transform-origin: 0 0; opacity: 1; height: 101px; transition-property: opacity transform; transition-duration: 0.3s; transition-timing-function: ease-out;"
+                style="display: block; width: 100%; transform: scale(0.4993757802746567, 0.4993757802746567); transform-origin: 0 0; opacity: 1; height: 101px; transition-property: opacity transform; transition-duration: 300ms; transition-timing-function: ease-out;"
               >
                 <span>
                   Some zoomable text
@@ -203,7 +203,7 @@ describe("Zoomable", () => {
         expect(container).toMatchInlineSnapshot(`
             <div>
               <span
-                style="display: block; width: 100%; transform: scale(1, 1); transform-origin: 0 0; opacity: 1; transition-property: opacity transform; transition-duration: 0.3s; transition-timing-function: ease-out;"
+                style="display: block; width: 100%; transform: scale(1, 1); transform-origin: 0 0; opacity: 1; transition-property: opacity transform; transition-duration: 300ms; transition-timing-function: ease-out;"
               >
                 <span>
                   Some zoomable text
@@ -456,7 +456,7 @@ describe("Zoomable", () => {
             expect(componentContainer).toMatchInlineSnapshot(`
                 <div>
                   <span
-                    style="display: block; width: 100%; transform: scale(1, 1); transform-origin: 0 0; opacity: 1; transition-property: opacity transform; transition-duration: 0.3s; transition-timing-function: ease-out; height: 1001px;"
+                    style="display: block; width: 100%; transform: scale(1, 1); transform-origin: 0 0; opacity: 1; transition-property: opacity transform; transition-duration: 300ms; transition-timing-function: ease-out; height: 1001px;"
                   >
                     <span>
                       Some more zoomable text
@@ -479,7 +479,7 @@ describe("Zoomable", () => {
             expect(componentContainer).toMatchInlineSnapshot(`
                 <div>
                   <span
-                    style="display: block; width: 100%; transform: scale(1, 1); transform-origin: 0 0; opacity: 1; transition-property: opacity transform; transition-duration: 0.3s; transition-timing-function: ease-out; height: 1001px;"
+                    style="display: block; width: 100%; transform: scale(1, 1); transform-origin: 0 0; opacity: 1; transition-property: opacity transform; transition-duration: 300ms; transition-timing-function: ease-out; height: 1001px;"
                   >
                     <span>
                       Some more zoomable text
@@ -508,7 +508,7 @@ describe("Zoomable", () => {
             expect(componentContainer).toMatchInlineSnapshot(`
                 <div>
                   <span
-                    style="display: block; width: 100%; transform: scale(0.1998001998001998, 0.1998001998001998); transform-origin: 0 0; opacity: 1; transition-property: opacity transform; transition-duration: 0.3s; transition-timing-function: ease-out; height: 200px;"
+                    style="display: block; width: 100%; transform: scale(0.1998001998001998, 0.1998001998001998); transform-origin: 0 0; opacity: 1; transition-property: opacity transform; transition-duration: 300ms; transition-timing-function: ease-out; height: 200px;"
                   >
                     <span>
                       Some more zoomable text

--- a/packages/perseus/src/components/__tests__/zoomable.test.tsx
+++ b/packages/perseus/src/components/__tests__/zoomable.test.tsx
@@ -649,17 +649,18 @@ describe("Zoomable", () => {
                     <span>Some zoomable text</span>
                 </Zoomable>,
             );
+            const [assetKey] = setAssetStatus.mock.calls[0];
             act(() => jest.runAllTimers());
 
             // Act
             act(() => window.dispatchEvent(new Event("resize")));
             act(() => jest.runAllTimers());
 
-            // Assert
-            expect(settledKeys(setAssetStatus)).toHaveLength(1);
-            expect(
-                setAssetStatus.mock.calls.filter(([, loaded]) => !loaded),
-            ).toHaveLength(1);
+            // Assert - we went from not-loaded to loaded and stayed that way.
+            expect(setAssetStatus.mock.calls).toEqual([
+                [assetKey, false], // not loaded
+                [assetKey, true], // loaded
+            ]);
         });
 
         it("stays settled after a child mutation forces a re-measure", async () => {

--- a/packages/perseus/src/components/__tests__/zoomable.test.tsx
+++ b/packages/perseus/src/components/__tests__/zoomable.test.tsx
@@ -3,6 +3,7 @@ import {act, fireEvent, render, screen, waitFor} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
+import AssetContext from "../../asset-context";
 import Zoomable from "../zoomable";
 
 import type {UserEvent} from "@testing-library/user-event";
@@ -515,6 +516,197 @@ describe("Zoomable", () => {
                   </span>
                 </div>
             `);
+        });
+    });
+
+    describe("asset loading status", () => {
+        // Zoomable measures and scales its content over several asynchronous
+        // passes, so it reports to the AssetContext to keep the renderers from
+        // announcing they're done rendering too early.
+
+        const renderWithAssetContext = (
+            component: React.ReactElement,
+        ): {setAssetStatus: jest.Mock} => {
+            const setAssetStatus = jest.fn();
+            render(
+                <AssetContext.Provider
+                    value={{assetStatuses: {}, setAssetStatus}}
+                >
+                    {component}
+                </AssetContext.Provider>,
+            );
+            return {setAssetStatus};
+        };
+
+        const settledKeys = (setAssetStatus: jest.Mock): Array<string> =>
+            setAssetStatus.mock.calls
+                .filter(([, loaded]) => loaded)
+                .map(([assetKey]) => assetKey);
+
+        it("registers as unsettled before it has been measured", () => {
+            // Arrange, Act
+            const {setAssetStatus} = renderWithAssetContext(
+                <Zoomable>
+                    <span>Some zoomable text</span>
+                </Zoomable>,
+            );
+
+            // Assert
+            expect(setAssetStatus).toHaveBeenCalledTimes(1);
+            expect(setAssetStatus).toHaveBeenCalledWith(
+                expect.stringMatching(/^zoomable-\d+$/),
+                false,
+            );
+        });
+
+        it("reports settled once the entrance animation has finished", () => {
+            // Arrange
+            const {setAssetStatus} = renderWithAssetContext(
+                <Zoomable>
+                    <span>Some zoomable text</span>
+                </Zoomable>,
+            );
+            const [assetKey] = setAssetStatus.mock.calls[0];
+
+            // Act
+            act(() => jest.runAllTimers());
+
+            // Assert
+            expect(setAssetStatus).toHaveBeenCalledWith(assetKey, true);
+        });
+
+        it("does not report settled while the entrance animation is running", () => {
+            // Arrange
+            const {setAssetStatus} = renderWithAssetContext(
+                <Zoomable>
+                    <span>Some zoomable text</span>
+                </Zoomable>,
+            );
+
+            // Act
+            // Enough time for measuring to complete and the content to become
+            // visible, but not for the 300ms entrance animation to finish.
+            act(() => jest.advanceTimersByTime(299));
+
+            // Assert
+            expect(settledKeys(setAssetStatus)).toHaveLength(0);
+        });
+
+        it("reports settled as soon as content is visible when the entrance animation is disabled", () => {
+            // Arrange
+            const {setAssetStatus} = renderWithAssetContext(
+                <Zoomable disableEntranceAnimation={true}>
+                    <span>Some zoomable text</span>
+                </Zoomable>,
+            );
+            const [assetKey] = setAssetStatus.mock.calls[0];
+
+            // Act
+            // Enough time for measuring to complete and the content to become
+            // visible, but nowhere near the 300ms entrance animation.
+            act(() => jest.advanceTimersByTime(1));
+            act(() => jest.advanceTimersByTime(1));
+
+            // Assert
+            expect(setAssetStatus).toHaveBeenCalledWith(assetKey, true);
+        });
+
+        it("reports settled when the content fits and doesn't need scaling", () => {
+            // Arrange
+            const setAssetStatus = jest.fn();
+            const {container} = render(
+                <AssetContext.Provider
+                    value={{assetStatuses: {}, setAssetStatus}}
+                >
+                    <Zoomable>
+                        <span>Some zoomable text</span>
+                    </Zoomable>
+                </AssetContext.Provider>,
+            );
+            // eslint-disable-next-line testing-library/no-node-access, no-restricted-syntax
+            mockSize(container.firstElementChild as HTMLElement, {
+                width: 400,
+                height: 100,
+            });
+            mockSize(screen.getByText("Some zoomable text"), {
+                width: 100,
+                height: 100,
+            });
+            const [assetKey] = setAssetStatus.mock.calls[0];
+
+            // Act
+            act(() => jest.runAllTimers());
+
+            // Assert
+            expect(setAssetStatus).toHaveBeenCalledWith(assetKey, true);
+        });
+
+        it("stays settled after a window resize forces a re-measure", () => {
+            // Arrange
+            const {setAssetStatus} = renderWithAssetContext(
+                <Zoomable>
+                    <span>Some zoomable text</span>
+                </Zoomable>,
+            );
+            act(() => jest.runAllTimers());
+
+            // Act
+            act(() => window.dispatchEvent(new Event("resize")));
+            act(() => jest.runAllTimers());
+
+            // Assert
+            expect(settledKeys(setAssetStatus)).toHaveLength(1);
+            expect(
+                setAssetStatus.mock.calls.filter(([, loaded]) => !loaded),
+            ).toHaveLength(1);
+        });
+
+        it("stays settled after a child mutation forces a re-measure", async () => {
+            // Arrange
+            const {setAssetStatus} = renderWithAssetContext(
+                <Zoomable>
+                    <span>Some zoomable text</span>
+                </Zoomable>,
+            );
+            act(() => jest.runAllTimers());
+
+            // Act
+            screen.getByText("Some zoomable text").innerHTML = "Some more text";
+            expect(await screen.findByText("Some more text")).toBeVisible();
+            act(() => jest.runAllTimers());
+
+            // Assert
+            expect(settledKeys(setAssetStatus)).toHaveLength(1);
+        });
+
+        it("gives each instance its own asset key", () => {
+            // Arrange, Act
+            const {setAssetStatus} = renderWithAssetContext(
+                <>
+                    <Zoomable>
+                        <span>First zoomable text</span>
+                    </Zoomable>
+                    <Zoomable>
+                        <span>Second zoomable text</span>
+                    </Zoomable>
+                </>,
+            );
+
+            // Assert
+            const [[firstKey], [secondKey]] = setAssetStatus.mock.calls;
+            expect(firstKey).not.toEqual(secondKey);
+        });
+
+        it("renders without an AssetContext provider", () => {
+            // Arrange, Act
+            renderAndWaitToSettle(
+                <Zoomable>
+                    <span>Some zoomable text</span>
+                </Zoomable>,
+            );
+
+            // Assert
+            expect(screen.getByText("Some zoomable text")).toBeInTheDocument();
         });
     });
 });

--- a/packages/perseus/src/components/zoomable.tsx
+++ b/packages/perseus/src/components/zoomable.tsx
@@ -1,10 +1,17 @@
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
 
+import {withActionScheduler} from "@khanacademy/wonder-blocks-timing";
 import * as React from "react";
 import ReactDOM from "react-dom";
 
 import AssetContext from "../asset-context";
 import {getCSSZoomFactor} from "../util/css-zoom-utils";
+
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
+import type {
+    WithActionSchedulerProps,
+    WithoutActionScheduler,
+} from "@khanacademy/wonder-blocks-timing";
 
 /**
  * Duration of the transition that fades/slides content in once it's visible.
@@ -39,7 +46,7 @@ type Props = {
      * or not.  Defaults to true for synchronous components like tables.
      */
     readyToMeasure: boolean;
-};
+} & WithActionSchedulerProps;
 
 type DefaultProps = {
     animateHeight: Props["animateHeight"];
@@ -125,13 +132,6 @@ class Zoomable extends React.Component<Props, State> {
         if (this._observer) {
             this._observer.disconnect();
         }
-        if (this._settleTimeoutId != null) {
-            // TODO(jeff, CP-3128): Use Wonder Blocks Timing API
-            // eslint-disable-next-line no-restricted-syntax
-            clearTimeout(this._settleTimeoutId);
-            this._settleTimeoutId = null;
-        }
-
         this._isMounted = false;
     }
 
@@ -152,16 +152,13 @@ class Zoomable extends React.Component<Props, State> {
         if (this.props.disableEntranceAnimation) {
             this._hasSettled = true;
             this.context.setAssetStatus(this._assetKey, true);
-            return;
+        } else {
+            this.props.schedule.timeout(() => {
+                this._settleTimeoutId = null;
+                this._hasSettled = true;
+                this.context.setAssetStatus(this._assetKey, true);
+            }, ENTRANCE_TRANSITION_DURATION_MS);
         }
-
-        // TODO(jeff, CP-3128): Use Wonder Blocks Timing API
-        // eslint-disable-next-line no-restricted-syntax
-        this._settleTimeoutId = setTimeout(() => {
-            this._settleTimeoutId = null;
-            this._hasSettled = true;
-            this.context.setAssetStatus(this._assetKey, true);
-        }, ENTRANCE_TRANSITION_DURATION_MS);
     }
 
     reset: () => void = (): void => {
@@ -390,4 +387,12 @@ class Zoomable extends React.Component<Props, State> {
     }
 }
 
-export default Zoomable;
+type ExportProps = WithoutActionScheduler<PropsFor<typeof Zoomable>>;
+
+// withActionScheduler loses optionality of props that are provided as default
+// props, so we need to use the `as ...` syntax here to fix that. Fixing this
+// would involve a change to `withActionScheduler`.
+// eslint-disable-next-line no-restricted-syntax
+export default withActionScheduler(
+    Zoomable,
+) as React.ComponentType<ExportProps>;

--- a/packages/perseus/src/components/zoomable.tsx
+++ b/packages/perseus/src/components/zoomable.tsx
@@ -9,6 +9,7 @@ import {getCSSZoomFactor} from "../util/css-zoom-utils";
 
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 import type {
+    ITimeout,
     WithActionSchedulerProps,
     WithoutActionScheduler,
 } from "@khanacademy/wonder-blocks-timing";
@@ -75,7 +76,7 @@ class Zoomable extends React.Component<Props, State> {
     // completes, so it registers as an unsettled asset.
     _assetKey: string;
     _hasSettled: boolean = false;
-    _settleTimeoutId: ReturnType<typeof setTimeout> | null = null;
+    _settleTimeoutId: ITimeout | null = null;
 
     // @ts-expect-error - TS2564 - Property '_isMounted' has no initializer and is not definitely assigned in the constructor.
     _isMounted: boolean;
@@ -153,7 +154,7 @@ class Zoomable extends React.Component<Props, State> {
             this._hasSettled = true;
             this.context.setAssetStatus(this._assetKey, true);
         } else {
-            this.props.schedule.timeout(() => {
+            this._settleTimeoutId = this.props.schedule.timeout(() => {
                 this._settleTimeoutId = null;
                 this._hasSettled = true;
                 this.context.setAssetStatus(this._assetKey, true);

--- a/packages/perseus/src/components/zoomable.tsx
+++ b/packages/perseus/src/components/zoomable.tsx
@@ -347,9 +347,7 @@ class Zoomable extends React.Component<Props, State> {
         const transitionStyle = visible
             ? {
                   transitionProperty: property,
-                  transitionDuration: `${
-                      ENTRANCE_TRANSITION_DURATION_MS / 1000
-                  }s`,
+                  transitionDuration: `${ENTRANCE_TRANSITION_DURATION_MS}ms`,
                   transitionTimingFunction: "ease-out",
               }
             : {};

--- a/packages/perseus/src/components/zoomable.tsx
+++ b/packages/perseus/src/components/zoomable.tsx
@@ -123,6 +123,9 @@ class Zoomable extends React.Component<Props, State> {
 
     componentDidUpdate() {
         this.maybeInitializeMeasuring();
+        if (this.state.visible) {
+            this.markSettledWhenVisible();
+        }
     }
 
     componentWillUnmount() {
@@ -300,14 +303,12 @@ class Zoomable extends React.Component<Props, State> {
                     this.setState({
                         visible: true,
                     });
-                    this.markSettledWhenVisible();
                 }
             });
         } else {
             this.setState({
                 visible: true,
             });
-            this.markSettledWhenVisible();
         }
     }
 

--- a/packages/perseus/src/components/zoomable.tsx
+++ b/packages/perseus/src/components/zoomable.tsx
@@ -9,7 +9,6 @@ import {getCSSZoomFactor} from "../util/css-zoom-utils";
 
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 import type {
-    ITimeout,
     WithActionSchedulerProps,
     WithoutActionScheduler,
 } from "@khanacademy/wonder-blocks-timing";
@@ -18,7 +17,7 @@ import type {
  * Duration of the transition that fades/slides content in once it's visible.
  * Shared by the CSS transition and the timer that waits for it to finish.
  */
-const ENTRANCE_TRANSITION_DURATION_MS = 300;
+export const ENTRANCE_TRANSITION_DURATION_MS = 300;
 
 let assetKeyCounter = 0;
 
@@ -75,8 +74,7 @@ class Zoomable extends React.Component<Props, State> {
     // Zoomable's content isn't at its final size or visible until measuring
     // completes, so it registers as an unsettled asset.
     _assetKey: string;
-    _hasSettled: boolean = false;
-    _settleTimeoutId: ITimeout | null = null;
+    _didLaunchEntranceAnimation: boolean = false;
 
     // @ts-expect-error - TS2564 - Property '_isMounted' has no initializer and is not definitely assigned in the constructor.
     _isMounted: boolean;
@@ -129,10 +127,7 @@ class Zoomable extends React.Component<Props, State> {
 
     componentWillUnmount() {
         window.removeEventListener("resize", this.reset);
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        if (this._observer) {
-            this._observer.disconnect();
-        }
+        this._observer?.disconnect();
         this._isMounted = false;
     }
 
@@ -146,20 +141,19 @@ class Zoomable extends React.Component<Props, State> {
      * re-measurements (from a resize or a child mutation) don't unsettle us.
      */
     markSettledWhenVisible() {
-        if (this._hasSettled || this._settleTimeoutId != null) {
+        if (this._didLaunchEntranceAnimation) {
             return;
         }
 
-        if (this.props.disableEntranceAnimation) {
-            this._hasSettled = true;
+        const duration = this.props.disableEntranceAnimation
+            ? 0
+            : ENTRANCE_TRANSITION_DURATION_MS;
+
+        this.props.schedule.timeout(() => {
             this.context.setAssetStatus(this._assetKey, true);
-        } else {
-            this._settleTimeoutId = this.props.schedule.timeout(() => {
-                this._settleTimeoutId = null;
-                this._hasSettled = true;
-                this.context.setAssetStatus(this._assetKey, true);
-            }, ENTRANCE_TRANSITION_DURATION_MS);
-        }
+        }, duration);
+
+        this._didLaunchEntranceAnimation = true;
     }
 
     reset: () => void = (): void => {

--- a/packages/perseus/src/components/zoomable.tsx
+++ b/packages/perseus/src/components/zoomable.tsx
@@ -1,12 +1,18 @@
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
-/**
- * Zooms child to fit with tap-to-zoom behavior.
- */
 
 import * as React from "react";
 import ReactDOM from "react-dom";
 
+import AssetContext from "../asset-context";
 import {getCSSZoomFactor} from "../util/css-zoom-utils";
+
+/**
+ * Duration of the transition that fades/slides content in once it's visible.
+ * Shared by the CSS transition and the timer that waits for it to finish.
+ */
+const ENTRANCE_TRANSITION_DURATION_MS = 300;
+
+let assetKeyCounter = 0;
 
 type Bounds = {
     width: number;
@@ -51,7 +57,19 @@ type State = {
     zoomed: boolean;
 };
 
+/**
+ * Zooms child to fit with tap-to-zoom behavior.
+ */
 class Zoomable extends React.Component<Props, State> {
+    static contextType = AssetContext;
+    declare context: React.ContextType<typeof AssetContext>;
+
+    // Zoomable's content isn't at its final size or visible until measuring
+    // completes, so it registers as an unsettled asset.
+    _assetKey: string;
+    _hasSettled: boolean = false;
+    _settleTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
     // @ts-expect-error - TS2564 - Property '_isMounted' has no initializer and is not definitely assigned in the constructor.
     _isMounted: boolean;
     // @ts-expect-error - TS2564 - Property '_observer' has no initializer and is not definitely assigned in the constructor.
@@ -84,6 +102,14 @@ class Zoomable extends React.Component<Props, State> {
         zoomed: true,
     };
 
+    constructor(props: Props, context: React.ContextType<typeof AssetContext>) {
+        super(props, context);
+
+        assetKeyCounter += 1;
+        this._assetKey = `zoomable-${assetKeyCounter}`;
+        context.setAssetStatus(this._assetKey, false);
+    }
+
     componentDidMount() {
         this._isMounted = true;
         this.maybeInitializeMeasuring();
@@ -99,8 +125,43 @@ class Zoomable extends React.Component<Props, State> {
         if (this._observer) {
             this._observer.disconnect();
         }
+        if (this._settleTimeoutId != null) {
+            // TODO(jeff, CP-3128): Use Wonder Blocks Timing API
+            // eslint-disable-next-line no-restricted-syntax
+            clearTimeout(this._settleTimeoutId);
+            this._settleTimeoutId = null;
+        }
 
         this._isMounted = false;
+    }
+
+    /**
+     * Reports to the AssetContext that this Zoomable has settled: it's been
+     * measured, scaled, and finished animating in.
+     *
+     * Content becoming visible is the last measurement-driven change, but when
+     * the entrance animation is enabled the content is still moving after
+     * that, so we wait it out. We only ever report settling once; later
+     * re-measurements (from a resize or a child mutation) don't unsettle us.
+     */
+    markSettledWhenVisible() {
+        if (this._hasSettled || this._settleTimeoutId != null) {
+            return;
+        }
+
+        if (this.props.disableEntranceAnimation) {
+            this._hasSettled = true;
+            this.context.setAssetStatus(this._assetKey, true);
+            return;
+        }
+
+        // TODO(jeff, CP-3128): Use Wonder Blocks Timing API
+        // eslint-disable-next-line no-restricted-syntax
+        this._settleTimeoutId = setTimeout(() => {
+            this._settleTimeoutId = null;
+            this._hasSettled = true;
+            this.context.setAssetStatus(this._assetKey, true);
+        }, ENTRANCE_TRANSITION_DURATION_MS);
     }
 
     reset: () => void = (): void => {
@@ -247,12 +308,14 @@ class Zoomable extends React.Component<Props, State> {
                     this.setState({
                         visible: true,
                     });
+                    this.markSettledWhenVisible();
                 }
             });
         } else {
             this.setState({
                 visible: true,
             });
+            this.markSettledWhenVisible();
         }
     }
 
@@ -284,7 +347,9 @@ class Zoomable extends React.Component<Props, State> {
         const transitionStyle = visible
             ? {
                   transitionProperty: property,
-                  transitionDuration: "0.3s",
+                  transitionDuration: `${
+                      ENTRANCE_TRANSITION_DURATION_MS / 1000
+                  }s`,
                   transitionTimingFunction: "ease-out",
               }
             : {};

--- a/packages/perseus/src/components/zoomable.tsx
+++ b/packages/perseus/src/components/zoomable.tsx
@@ -1,10 +1,17 @@
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
 
+import {withActionScheduler} from "@khanacademy/wonder-blocks-timing";
 import * as React from "react";
 import ReactDOM from "react-dom";
 
 import AssetContext from "../asset-context";
 import {getCSSZoomFactor} from "../util/css-zoom-utils";
+
+import type {PropsFor} from "@khanacademy/wonder-blocks-core";
+import type {
+    WithActionSchedulerProps,
+    WithoutActionScheduler,
+} from "@khanacademy/wonder-blocks-timing";
 
 /**
  * Duration of the transition that fades/slides content in once it's visible.
@@ -39,7 +46,7 @@ type Props = {
      * or not.  Defaults to true for synchronous components like tables.
      */
     readyToMeasure: boolean;
-};
+} & WithActionSchedulerProps;
 
 type DefaultProps = {
     animateHeight: Props["animateHeight"];
@@ -125,13 +132,6 @@ class Zoomable extends React.Component<Props, State> {
         if (this._observer) {
             this._observer.disconnect();
         }
-        if (this._settleTimeoutId != null) {
-            // TODO(jeff, CP-3128): Use Wonder Blocks Timing API
-            // eslint-disable-next-line no-restricted-syntax
-            clearTimeout(this._settleTimeoutId);
-            this._settleTimeoutId = null;
-        }
-
         this._isMounted = false;
     }
 
@@ -152,16 +152,13 @@ class Zoomable extends React.Component<Props, State> {
         if (this.props.disableEntranceAnimation) {
             this._hasSettled = true;
             this.context.setAssetStatus(this._assetKey, true);
-            return;
+        } else {
+            this.props.schedule.timeout(() => {
+                this._settleTimeoutId = null;
+                this._hasSettled = true;
+                this.context.setAssetStatus(this._assetKey, true);
+            }, ENTRANCE_TRANSITION_DURATION_MS);
         }
-
-        // TODO(jeff, CP-3128): Use Wonder Blocks Timing API
-        // eslint-disable-next-line no-restricted-syntax
-        this._settleTimeoutId = setTimeout(() => {
-            this._settleTimeoutId = null;
-            this._hasSettled = true;
-            this.context.setAssetStatus(this._assetKey, true);
-        }, ENTRANCE_TRANSITION_DURATION_MS);
     }
 
     reset: () => void = (): void => {
@@ -392,4 +389,12 @@ class Zoomable extends React.Component<Props, State> {
     }
 }
 
-export default Zoomable;
+type ExportProps = WithoutActionScheduler<PropsFor<typeof Zoomable>>;
+
+// withActionScheduler loses optionality of props that are provided as default
+// props, so we need to use the `as ...` syntax here to fix that. Fixing this
+// would involve a change to `withActionScheduler`.
+// eslint-disable-next-line no-restricted-syntax
+export default withActionScheduler(
+    Zoomable,
+) as React.ComponentType<ExportProps>;

--- a/packages/perseus/src/components/zoomable.tsx
+++ b/packages/perseus/src/components/zoomable.tsx
@@ -1,12 +1,18 @@
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
-/**
- * Zooms child to fit with tap-to-zoom behavior.
- */
 
 import * as React from "react";
 import ReactDOM from "react-dom";
 
+import AssetContext from "../asset-context";
 import {getCSSZoomFactor} from "../util/css-zoom-utils";
+
+/**
+ * Duration of the transition that fades/slides content in once it's visible.
+ * Shared by the CSS transition and the timer that waits for it to finish.
+ */
+const ENTRANCE_TRANSITION_DURATION_MS = 300;
+
+let assetKeyCounter = 0;
 
 type Bounds = {
     width: number;
@@ -51,7 +57,19 @@ type State = {
     zoomed: boolean;
 };
 
+/**
+ * Zooms child to fit with tap-to-zoom behavior.
+ */
 class Zoomable extends React.Component<Props, State> {
+    static contextType = AssetContext;
+    declare context: React.ContextType<typeof AssetContext>;
+
+    // Zoomable's content isn't at its final size or visible until measuring
+    // completes, so it registers as an unsettled asset.
+    _assetKey: string;
+    _hasSettled: boolean = false;
+    _settleTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
     // @ts-expect-error - TS2564 - Property '_isMounted' has no initializer and is not definitely assigned in the constructor.
     _isMounted: boolean;
     // @ts-expect-error - TS2564 - Property '_observer' has no initializer and is not definitely assigned in the constructor.
@@ -84,6 +102,14 @@ class Zoomable extends React.Component<Props, State> {
         zoomed: true,
     };
 
+    constructor(props: Props, context: React.ContextType<typeof AssetContext>) {
+        super(props, context);
+
+        assetKeyCounter += 1;
+        this._assetKey = `zoomable-${assetKeyCounter}`;
+        context.setAssetStatus(this._assetKey, false);
+    }
+
     componentDidMount() {
         this._isMounted = true;
         this.maybeInitializeMeasuring();
@@ -99,8 +125,43 @@ class Zoomable extends React.Component<Props, State> {
         if (this._observer) {
             this._observer.disconnect();
         }
+        if (this._settleTimeoutId != null) {
+            // TODO(jeff, CP-3128): Use Wonder Blocks Timing API
+            // eslint-disable-next-line no-restricted-syntax
+            clearTimeout(this._settleTimeoutId);
+            this._settleTimeoutId = null;
+        }
 
         this._isMounted = false;
+    }
+
+    /**
+     * Reports to the AssetContext that this Zoomable has settled: it's been
+     * measured, scaled, and finished animating in.
+     *
+     * Content becoming visible is the last measurement-driven change, but when
+     * the entrance animation is enabled the content is still moving after
+     * that, so we wait it out. We only ever report settling once; later
+     * re-measurements (from a resize or a child mutation) don't unsettle us.
+     */
+    markSettledWhenVisible() {
+        if (this._hasSettled || this._settleTimeoutId != null) {
+            return;
+        }
+
+        if (this.props.disableEntranceAnimation) {
+            this._hasSettled = true;
+            this.context.setAssetStatus(this._assetKey, true);
+            return;
+        }
+
+        // TODO(jeff, CP-3128): Use Wonder Blocks Timing API
+        // eslint-disable-next-line no-restricted-syntax
+        this._settleTimeoutId = setTimeout(() => {
+            this._settleTimeoutId = null;
+            this._hasSettled = true;
+            this.context.setAssetStatus(this._assetKey, true);
+        }, ENTRANCE_TRANSITION_DURATION_MS);
     }
 
     reset: () => void = (): void => {
@@ -249,12 +310,14 @@ class Zoomable extends React.Component<Props, State> {
                     this.setState({
                         visible: true,
                     });
+                    this.markSettledWhenVisible();
                 }
             });
         } else {
             this.setState({
                 visible: true,
             });
+            this.markSettledWhenVisible();
         }
     }
 
@@ -286,7 +349,9 @@ class Zoomable extends React.Component<Props, State> {
         const transitionStyle = visible
             ? {
                   transitionProperty: property,
-                  transitionDuration: "0.3s",
+                  transitionDuration: `${
+                      ENTRANCE_TRANSITION_DURATION_MS / 1000
+                  }s`,
                   transitionTimingFunction: "ease-out",
               }
             : {};

--- a/packages/perseus/src/components/zoomable.tsx
+++ b/packages/perseus/src/components/zoomable.tsx
@@ -349,9 +349,7 @@ class Zoomable extends React.Component<Props, State> {
         const transitionStyle = visible
             ? {
                   transitionProperty: property,
-                  transitionDuration: `${
-                      ENTRANCE_TRANSITION_DURATION_MS / 1000
-                  }s`,
+                  transitionDuration: `${ENTRANCE_TRANSITION_DURATION_MS}ms`,
                   transitionTimingFunction: "ease-out",
               }
             : {};


### PR DESCRIPTION
## Summary:

`Zoomable` needs several asynchronous passes before its content is final — it measures its child, scales it to fit, and then fades it in — but it never reports any of that through `AssetContext`. On mobile it wraps both [block math](https://github.com/Khan/perseus/blob/4e4b66e07ee2e4aca7660bfb404d95a54090670b/packages/perseus/src/renderer.new.tsx#L1057) and [tables](https://github.com/Khan/perseus/blob/4e4b66e07ee2e4aca7660bfb404d95a54090670b/packages/perseus/src/renderer.new.tsx#L1212), so neither was being waited on before an item was declared rendered.

This means that any Perseus client using `ServerItemRenderer`'s `onRendered` prop to detect when rendering has settled won't wait for Zoomable's to complete. I haven't confirmed this yet, but I suspect this is partially the source for our Chromatic snapshots churning on PRs.

The fix is that `Zoomable` now registers itself when it is constructed and then reports through the `AssetContext` once measuring has finished. If the entrance animation is enabled it reports settled once that animation has run. The animation's duration is shared between the CSS transition and the timer that waits for it, so the two can't drift apart (and because I don't know of an event that fires at the end of a CSS transition).

_Note that an unmounted-before-settled `Zoomable` never reports, and there's no way to unregister an asset, so it would block completion indefinitely. This is the same for existing components that report to `AssetContext` like `Tex` and `SvgImage`. This PR keeps Zoomable consistent with them. If we want to fix this unmounted-before-settled, we should fix it separately across the board._ 

Issue: LEMS-4419

## Test plan:

- `pnpm test`
- `pnpm typecheck`
- New unit tests cover registration before measuring, settling on both the scaled and unscaled paths, waiting for the entrance animation when it's enabled, staying settled across resizes and child mutations, unique keys per instance, and rendering with no provider present
- Two new end-to-end `ServerItemRenderer` tests cover the mobile block-math and   mobile table paths
- On a mobile viewport, open an item with block math and one with a table and confirm the content still measures, scales and fades in as before