### PR TITLE
Migrate plotter widget to WidgetPropsV2

### DIFF
--- a/.changeset/widget-props-v2-plotter.md
+++ b/.changeset/widget-props-v2-plotter.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Internal: Migrate the plotter widget to group all `options` under a separate prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -490,7 +490,7 @@ review and commit the changes.
 - [x] Migrate `measurer` to `WidgetPropsV2`.
 - [x] Convert `number-line` to a functional component, a la `dropdown`.
 - [x] Migrate `number-line` to `WidgetPropsV2`.
-- [ ] Migrate `plotter` to `WidgetPropsV2` (update its editor preview).
+- [x] Migrate `plotter` to `WidgetPropsV2` (update its editor preview).
 - [ ] Convert `cs-program` to a functional component, a la `dropdown`.
 - [ ] Migrate `cs-program` to `WidgetPropsV2`.
 - [ ] Convert `python-program` to a functional component, a la `dropdown`.

--- a/packages/perseus-editor/src/widgets/plotter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/plotter-editor.tsx
@@ -145,12 +145,6 @@ class PlotterEditor extends React.Component<Props, State> {
         });
     };
 
-    handlePlotterChange: (arg1: any) => void = (newProps) => {
-        const props: Record<string, any> = {};
-        props[this.state.editing] = newProps.values;
-        this.props.onChange(props);
-    };
-
     changeType: (arg1: any) => void = (type) => {
         let categories;
         if (type === "histogram") {
@@ -297,13 +291,26 @@ class PlotterEditor extends React.Component<Props, State> {
             this.props.type,
         );
         const canChangeSnaps = !_.contains(["pic", "dotplot"], this.props.type);
-        const plotterProps: any = {
-            ...this.props,
+        const plotterProps = {
+            options: {
+                type: this.props.type,
+                labels: this.props.labels,
+                categories: this.props.categories,
+                scaleY: this.props.scaleY,
+                maxY: this.props.maxY,
+                snapsPerLine: this.props.snapsPerLine,
+                picUrl: this.props.picUrl,
+                picSize: this.props.picSize,
+                picBoxHeight: this.props.picBoxHeight,
+                plotDimensions: this.props.plotDimensions,
+                labelInterval: this.props.labelInterval,
+                starting: this.props[this.state.editing],
+            },
+            apiOptions: this.props.apiOptions,
+            static: this.props.static,
             trackInteraction: () => {},
-            starting: this.props[this.state.editing],
-            onChange: this.handlePlotterChange,
             userInput: this.props.correct,
-            handleUserInput: (userInput) => {
+            handleUserInput: (userInput: number[]) => {
                 this.props.onChange({correct: userInput});
             },
         };

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -22,4 +22,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "video",
     "image",
     "measurer",
+    "plotter",
 ];

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -22,11 +22,11 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetProps,
+    WidgetPropsV2,
 } from "../../types";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
 
-type Props = WidgetProps<
+type Props = WidgetPropsV2<
     PlotterPublicWidgetOptions,
     PerseusPlotterUserInput
 > & {
@@ -72,7 +72,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
     }
 
     UNSAFE_componentWillReceiveProps(nextProps: Props) {
-        const props = [
+        const optionProps: Array<keyof PlotterPublicWidgetOptions> = [
             "type",
             "labels",
             "categories",
@@ -81,21 +81,27 @@ class Plotter extends React.Component<Props, State> implements Widget {
             "snapsPerLine",
             "picUrl",
             "labelInterval",
-            "static",
         ];
 
-        this.shouldSetupGraphie = _.any(
-            props,
-            (prop) => !_.isEqual(this.props[prop], nextProps[prop]),
-            this,
-        );
+        this.shouldSetupGraphie =
+            this.props.static !== nextProps.static ||
+            optionProps.some(
+                (prop) =>
+                    !_.isEqual(
+                        this.props.options[prop],
+                        nextProps.options[prop],
+                    ),
+            );
 
         if (
-            !_.isEqual(this.props.starting, nextProps.starting) &&
-            !_.isEqual(this.props.userInput, nextProps.starting)
+            !_.isEqual(
+                this.props.options.starting,
+                nextProps.options.starting,
+            ) &&
+            !_.isEqual(this.props.userInput, nextProps.options.starting)
         ) {
             this.shouldSetupGraphie = true;
-            this.props.handleUserInput(nextProps.starting);
+            this.props.handleUserInput(nextProps.options.starting);
         }
     }
 
@@ -139,11 +145,11 @@ class Plotter extends React.Component<Props, State> implements Widget {
         self.graphie.pics = [];
         self.graphie.dotTicks = [];
 
-        const isBar = self.props.type === "bar";
-        const isLine = self.props.type === "line";
-        const isPic = self.props.type === "pic";
-        const isHistogram = self.props.type === "histogram";
-        const isDotplot = self.props.type === "dotplot";
+        const isBar = self.props.options.type === "bar";
+        const isLine = self.props.options.type === "line";
+        const isPic = self.props.options.type === "pic";
+        const isHistogram = self.props.options.type === "histogram";
+        const isDotplot = self.props.options.type === "dotplot";
 
         const isTiledPlot = isPic || isDotplot;
 
@@ -158,11 +164,11 @@ class Plotter extends React.Component<Props, State> implements Widget {
             points: [],
             dividers: [],
         };
-        c.scaleY = self.props.scaleY;
-        c.dimX = self.props.categories.length;
+        c.scaleY = self.props.options.scaleY;
+        c.dimX = self.props.options.categories.length;
         const plotDimensions = isMobile
             ? [288, 336]
-            : self.props.plotDimensions;
+            : self.props.options.plotDimensions;
         if (isLine) {
             // Subtracting 0.2 makes line have equal padding on each side
             c.dimX += isMobile ? -0.2 : 1;
@@ -174,8 +180,9 @@ class Plotter extends React.Component<Props, State> implements Widget {
             c.barWidth = 1 - 2 * c.barPad;
             c.dimX += (isMobile ? -2 : 2) * c.barPad;
         } else if (isTiledPlot) {
-            c.picBoxHeight = self.props.picBoxHeight;
-            c.picBoxWidthPx = plotDimensions[0] / self.props.categories.length;
+            c.picBoxHeight = self.props.options.picBoxHeight;
+            c.picBoxWidthPx =
+                plotDimensions[0] / self.props.options.categories.length;
             const picPadAllWidth = plotDimensions[0] - c.dimX * c.picBoxWidthPx;
             c.picPad = picPadAllWidth / (2 * c.dimX + 2);
             const picFullWidth = c.picBoxWidthPx + 2 * c.picPad;
@@ -191,12 +198,12 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 this.DOT_PLOT_POINT_SIZE() * 2 + this.DOT_PLOT_POINT_PADDING();
         }
 
-        c.dimY = Math.ceil(self.props.maxY / c.scaleY) * c.scaleY;
+        c.dimY = Math.ceil(self.props.options.maxY / c.scaleY) * c.scaleY;
 
         let padX = 25;
 
         if ((isBar || isLine) && isMobile) {
-            padX = self.props.labels[1].length !== 0 ? 17 : 11;
+            padX = self.props.options.labels[1].length !== 0 ? 17 : 11;
         }
 
         // Since dotplot doesn't have an axis along the left it looks weird
@@ -205,7 +212,11 @@ class Plotter extends React.Component<Props, State> implements Widget {
             padX /= 2;
         }
 
-        if (isMobile && isTiledPlot && self.props.labels[1].length === 0) {
+        if (
+            isMobile &&
+            isTiledPlot &&
+            self.props.options.labels[1].length === 0
+        ) {
             padX = 0;
         }
 
@@ -344,7 +355,10 @@ class Plotter extends React.Component<Props, State> implements Widget {
                         graphie.line([0, 0], [c.dimX, 0]);
 
                         // Draw the left axis for non-dotplots
-                        if (self.props.labels[1].length !== 0 || !isMobile) {
+                        if (
+                            self.props.options.labels[1].length !== 0 ||
+                            !isMobile
+                        ) {
                             graphie.style(
                                 {
                                     stroke: isMobile
@@ -386,7 +400,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
         const xAxisLabel = graphie
             .label(
                 [c.dimX / 2, isMobile ? -padBottom : -35 / c.scale[1]],
-                self.props.labels[0],
+                self.props.options.labels[0],
                 isMobile ? "above" : "below",
                 false,
             )
@@ -398,7 +412,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
         const yAxisLabel = graphie
             .label(
                 [(isMobile ? -35 : -60) / c.scale[0], c.dimY / 2],
-                self.props.labels[1],
+                self.props.options.labels[1],
                 "center",
                 false,
             )
@@ -512,9 +526,9 @@ class Plotter extends React.Component<Props, State> implements Widget {
         // The deferred measurements returned from `labelCategory`.
         const categoryHeightPromises = [];
 
-        if (self.props.type === "histogram") {
+        if (self.props.options.type === "histogram") {
             // Histograms with n labels/categories have n - 1 buckets
-            _.times(self.props.categories.length - 1, function (i) {
+            _.times(self.props.options.categories.length - 1, function (i) {
                 self.setupBar({
                     index: i,
                     startHeight: self.props.userInput[i],
@@ -524,7 +538,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
             });
 
             // Label categories
-            _.each(self.props.categories, function (category, i) {
+            _.each(self.props.options.categories, function (category, i) {
                 const x = 0.5 + i * c.barWidth;
 
                 // @ts-expect-error - TS2345 - Argument of type 'Promise<any>' is not assignable to parameter of type 'never'.
@@ -542,40 +556,40 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 );
             });
         } else {
-            _.each(self.props.categories, function (category, i) {
+            _.each(self.props.options.categories, function (category, i) {
                 const startHeight = self.props.userInput[i];
 
                 let x;
 
-                if (self.props.type === "bar") {
+                if (self.props.options.type === "bar") {
                     x = self.setupBar({
                         index: i,
                         startHeight: startHeight,
                         config: config,
                         isHistogram: false,
                     });
-                } else if (self.props.type === "line") {
+                } else if (self.props.options.type === "line") {
                     x = self.setupLine(i, startHeight, config);
-                } else if (self.props.type === "pic") {
+                } else if (self.props.options.type === "pic") {
                     x = self.setupPic(i, config);
-                } else if (self.props.type === "dotplot") {
+                } else if (self.props.options.type === "dotplot") {
                     x = self.setupDotplot(i, config);
                 }
 
                 let tickStart = 0;
                 let tickEnd = -6 / c.scale[1];
 
-                if (self.props.type === "dotplot" && !isMobile) {
+                if (self.props.options.type === "dotplot" && !isMobile) {
                     tickStart = -tickEnd;
                 }
 
-                if (self.props.type === "dotplot") {
+                if (self.props.options.type === "dotplot") {
                     // Dotplot lets you specify to only show labels every 'n'
                     // ticks. It also looks nicer if it makes the labelled
                     // ticks a bit bigger.
                     if (
-                        i % self.props.labelInterval === 0 ||
-                        i === self.props.categories.length - 1
+                        i % self.props.options.labelInterval === 0 ||
+                        i === self.props.options.categories.length - 1
                     ) {
                         categoryHeightPromises.push(
                             // @ts-expect-error - TS2345 - Argument of type 'Promise<any>' is not assignable to parameter of type 'never'.
@@ -746,7 +760,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
         }
 
         if (isMobile) {
-            const snap = config.scaleY / self.props.snapsPerLine;
+            const snap = config.scaleY / self.props.options.snapsPerLine;
             config.graph.lines[i] = Interactive2.addMaybeMobileMovablePoint(
                 this,
                 {
@@ -796,7 +810,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
             config.graph.lines[i] = graphie.addMovableLineSegment({
                 coordA: [x - barHalfWidth, startHeight],
                 coordZ: [x + barHalfWidth, startHeight],
-                snapY: config.scaleY / self.props.snapsPerLine,
+                snapY: config.scaleY / self.props.options.snapsPerLine,
                 constraints: {
                     constrainX: true,
                 },
@@ -848,7 +862,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
         const x = i + (isMobile ? 0.4 : 1);
 
         if (isMobile) {
-            const snap = config.scaleY / self.props.snapsPerLine;
+            const snap = config.scaleY / self.props.options.snapsPerLine;
             c.graph.points[i] = Interactive2.addMaybeMobileMovablePoint(this, {
                 coord: [x, startHeight],
                 constraints: [
@@ -900,7 +914,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
                     fill: KhanColors.INTERACTIVE,
                     stroke: KhanColors.INTERACTIVE,
                 },
-                snapY: c.scaleY / self.props.snapsPerLine,
+                snapY: c.scaleY / self.props.options.snapsPerLine,
             });
             c.graph.points[i].onMove = function (x, y) {
                 y = Math.min(Math.max(y, 0), c.dimY);
@@ -951,9 +965,9 @@ class Plotter extends React.Component<Props, State> implements Widget {
         const graphie = this.graphie;
         return this.setupTiledPlot(i, 0, config, (x, y) => {
             const scaledCenter = graphie.scalePoint([x, y]);
-            const size = this.props.picSize;
+            const size = this.props.options.picSize;
             return graphie.raphael.image(
-                this.props.picUrl,
+                this.props.options.picUrl,
                 scaledCenter[0] - size / 2,
                 scaledCenter[1] - size / 2,
                 size,
@@ -1094,10 +1108,10 @@ class Plotter extends React.Component<Props, State> implements Widget {
 
         _.each(pics, function (ps, i) {
             _.each(ps, function (pic, j) {
-                const y = (j + 1) * self.props.scaleY;
+                const y = (j + 1) * self.props.options.scaleY;
                 const show = y <= values[i];
 
-                if (self.props.type === "dotplot") {
+                if (self.props.options.type === "dotplot") {
                     const wasShown = y <= prevValues[i];
                     const wasJustShown = show && !wasShown;
                     if (wasJustShown) {
@@ -1133,8 +1147,9 @@ class Plotter extends React.Component<Props, State> implements Widget {
      * [LEMS-3185] do not trust serializedState
      */
     getSerializedState() {
-        const {userInput: _, ...rest} = this.props;
+        const {userInput: _, options, ...rest} = this.props;
         return {
+            ...options,
             ...rest,
             values: this.props.userInput,
         };
@@ -1143,7 +1158,9 @@ class Plotter extends React.Component<Props, State> implements Widget {
     render(): React.ReactNode {
         const paddingForBottomLabel = 75;
         const style = {
-            marginBottom: this.props.labels[0] ? paddingForBottomLabel : 0,
+            marginBottom: this.props.options.labels[0]
+                ? paddingForBottomLabel
+                : 0,
         } as const;
 
         return (

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -72,7 +72,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
     }
 
     UNSAFE_componentWillReceiveProps(nextProps: Props) {
-        const optionProps: Array<keyof PlotterPublicWidgetOptions> = [
+        const optionsKeys: Array<keyof PlotterPublicWidgetOptions> = [
             "type",
             "labels",
             "categories",
@@ -83,25 +83,21 @@ class Plotter extends React.Component<Props, State> implements Widget {
             "labelInterval",
         ];
 
+        const options = this.props.options;
+        const nextOptions = nextProps.options;
+
         this.shouldSetupGraphie =
             this.props.static !== nextProps.static ||
-            optionProps.some(
-                (prop) =>
-                    !_.isEqual(
-                        this.props.options[prop],
-                        nextProps.options[prop],
-                    ),
+            optionsKeys.some(
+                (key) => !_.isEqual(options[key], nextOptions[key]),
             );
 
         if (
-            !_.isEqual(
-                this.props.options.starting,
-                nextProps.options.starting,
-            ) &&
-            !_.isEqual(this.props.userInput, nextProps.options.starting)
+            !_.isEqual(options.starting, nextOptions.starting) &&
+            !_.isEqual(this.props.userInput, nextOptions.starting)
         ) {
             this.shouldSetupGraphie = true;
-            this.props.handleUserInput(nextProps.options.starting);
+            this.props.handleUserInput(nextOptions.starting);
         }
     }
 


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a Plotter widget in
  http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.