### PR TITLE
Migrate cs-program widget to WidgetPropsV2

### DIFF
--- a/.changeset/widget-props-v2-cs-program.md
+++ b/.changeset/widget-props-v2-cs-program.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Migrate the cs-program widget to group all `options` under a separate prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -491,8 +491,8 @@ review and commit the changes.
 - [x] Convert `number-line` to a functional component, a la `dropdown`.
 - [x] Migrate `number-line` to `WidgetPropsV2`.
 - [x] Migrate `plotter` to `WidgetPropsV2` (update its editor preview).
-- [ ] Convert `cs-program` to a functional component, a la `dropdown`.
-- [ ] Migrate `cs-program` to `WidgetPropsV2`.
+- [x] Convert `cs-program` to a functional component, a la `dropdown`.
+- [x] Migrate `cs-program` to `WidgetPropsV2`.
 - [ ] Convert `python-program` to a functional component, a la `dropdown`.
 - [ ] Migrate `python-program` to `WidgetPropsV2`.
 - [ ] Migrate `interaction` to `WidgetPropsV2`.

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -23,4 +23,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "image",
     "measurer",
     "plotter",
+    "cs-program",
 ];

--- a/packages/perseus/src/widgets/cs-program/cs-program.tsx
+++ b/packages/perseus/src/widgets/cs-program/cs-program.tsx
@@ -13,7 +13,7 @@ import {isFileProtocol} from "../../util/mobile-native-utils";
 import {toAbsoluteUrl} from "../../util/url-utils";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/cs-program/cs-program-ai-utils";
 
-import type {Widget, WidgetExports, WidgetProps} from "../../types";
+import type {Widget, WidgetExports, WidgetPropsV2} from "../../types";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
 import type {
     PerseusCSProgramWidgetOptions,
@@ -22,7 +22,7 @@ import type {
 
 const {updateQueryString} = Util;
 
-type Props = WidgetProps<
+type Props = WidgetPropsV2<
     PerseusCSProgramWidgetOptions,
     PerseusCSProgramUserInput
 >;
@@ -59,7 +59,7 @@ const CSProgram = forwardRef<WidgetHandle, Props>(
             settings,
             showEditor = false,
             showButtons = false,
-        } = props;
+        } = props.options;
 
         // We receive data from the iframe that contains
         // {testsPassed: true/false} and use that to set the status. It could
@@ -100,10 +100,11 @@ const CSProgram = forwardRef<WidgetHandle, Props>(
              * [LEMS-3185] do not trust serializedState
              */
             getSerializedState: (): any => {
-                const {userInput: _, alignment: __, ...rest} = props;
+                const {userInput: _, alignment: __, options, ...rest} = props;
                 return {
+                    ...options,
                     ...rest,
-                    programType: rest.programType || null,
+                    programType: options.programType || null,
                 };
             },
         }));


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a CS Program widget in
  http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.