### PR TITLE
Migrate python-program to WidgetPropsV2

### DIFF
--- a/.changeset/puny-meteors-sneeze.md
+++ b/.changeset/puny-meteors-sneeze.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: the Python Program widget is now a functional component.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -493,8 +493,8 @@ review and commit the changes.
 - [x] Migrate `plotter` to `WidgetPropsV2` (update its editor preview).
 - [x] Convert `cs-program` to a functional component, a la `dropdown`.
 - [x] Migrate `cs-program` to `WidgetPropsV2`.
-- [ ] Convert `python-program` to a functional component, a la `dropdown`.
-- [ ] Migrate `python-program` to `WidgetPropsV2`.
+- [x] Convert `python-program` to a functional component, a la `dropdown`.
+- [x] Migrate `python-program` to `WidgetPropsV2`.
 - [ ] Migrate `interaction` to `WidgetPropsV2`.
 - [ ] Migrate `numeric-input` and `input-number` (alias of `numeric-input`)
       to `WidgetPropsV2`.

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -24,4 +24,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "measurer",
     "plotter",
     "cs-program",
+    "python-program",
 ];

--- a/packages/perseus/src/widgets/python-program/python-program.tsx
+++ b/packages/perseus/src/widgets/python-program/python-program.tsx
@@ -3,52 +3,55 @@
  */
 import {View} from "@khanacademy/wonder-blocks-core";
 import {StyleSheet} from "aphrodite";
-import * as React from "react";
+import React, {forwardRef, useImperativeHandle} from "react";
 
-import {PerseusI18nContext} from "../../components/i18n-context";
+import {usePerseusI18n} from "../../components/i18n-context";
 import {withDependencies} from "../../components/with-dependencies";
-import {
-    type PerseusDependenciesV2,
-    type Widget,
-    type WidgetExports,
-} from "../../types";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/python-program/python-ai-utils";
 
+import type {
+    PerseusDependenciesV2,
+    Widget,
+    WidgetExports,
+    WidgetPropsV2,
+} from "../../types";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
+import type {PerseusPythonProgramWidgetOptions} from "@khanacademy/perseus-core";
 
-function getUrlFromProgramID(programID: any) {
+function getUrlFromProgramID(programID: string) {
     return `/python-program/${programID}/embedded`;
 }
 
-type Props = {
-    programID: string;
-    height: number;
+type Props = WidgetPropsV2<PerseusPythonProgramWidgetOptions> & {
     dependencies: PerseusDependenciesV2;
 };
+
+// The Widget-interface methods this component exposes via its ref.
+type WidgetHandle = Pick<Widget, "getPromptJSON">;
 
 /**
  * This renders the program in an iframe.
  */
-// TODO(benchristel): Rewrite PythonProgram as a functional component,
-//  following dropdown.tsx's example.
-class PythonProgram extends React.Component<Props> implements Widget {
-    static contextType = PerseusI18nContext;
-    declare context: React.ContextType<typeof PerseusI18nContext>;
+const PythonProgram = forwardRef<WidgetHandle, Props>(
+    function PythonProgram(props, ref) {
+        const {strings, locale} = usePerseusI18n();
+        const {programID, height} = props.options;
+        const {dependencies} = props;
 
-    getPromptJSON(): UnsupportedWidgetPromptJSON {
-        return _getPromptJSON();
-    }
+        useImperativeHandle(ref, () => ({
+            getPromptJSON: (): UnsupportedWidgetPromptJSON => {
+                return _getPromptJSON();
+            },
+        }));
 
-    render(): React.ReactNode {
-        let url = getUrlFromProgramID(this.props.programID);
-        url = this.props.dependencies.generateUrl({
-            url,
+        const url = dependencies.generateUrl({
+            url: getUrlFromProgramID(programID),
             context: "python_program:program_url",
-            kaLocale: this.context?.locale,
+            kaLocale: locale,
         });
 
         const iframeStyle = {
-            height: this.props.height,
+            height,
             width: "100%",
         } as const;
 
@@ -66,7 +69,7 @@ class PythonProgram extends React.Component<Props> implements Widget {
         return (
             <View style={styles.container}>
                 <iframe
-                    title={this.context.strings.pythonProgram}
+                    title={strings.pythonProgram}
                     sandbox={sandboxOptions}
                     src={url}
                     style={iframeStyle}
@@ -74,8 +77,8 @@ class PythonProgram extends React.Component<Props> implements Widget {
                 />
             </View>
         );
-    }
-}
+    },
+);
 
 const styles = StyleSheet.create({
     container: {


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a Python Program widget in
  http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.