### PR TITLE
Remove unused default props from the Interaction widget

### DIFF
--- a/.changeset/eleven-houses-study.md
+++ b/.changeset/eleven-houses-study.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: the Interaction widget's default props have been removed. Parsed Interaction widgets always contain all required options.

--- a/packages/perseus/src/widgets/interaction/interaction.tsx
+++ b/packages/perseus/src/widgets/interaction/interaction.tsx
@@ -97,32 +97,12 @@ const KAScompile = (
 
 type Props = WidgetProps<PerseusInteractionWidgetOptions>;
 
-type DefaultProps = {
-    graph: Props["graph"];
-    elements: Props["elements"];
-};
-
 type State = {
     variables: any;
     functions: any;
 };
 
 class Interaction extends React.Component<Props, State> implements Widget {
-    static defaultProps: DefaultProps = {
-        graph: {
-            box: [400, 400],
-            labels: ["x", "y"],
-            range: [
-                [-10, 10],
-                [-10, 10],
-            ],
-            tickStep: [1, 1],
-            gridStep: [1, 1],
-            markings: "graph",
-        },
-        elements: [],
-    };
-
     // this just helps with TS weak typing when a Widget
     // doesn't implement any Widget methods
     isWidget = true as const;


### PR DESCRIPTION
## Summary:

The defaults were never used. The parser ensures all options are set.

Issue: none

## Test plan:

You should be able to create, edit, and preview an interaction widget in
http://localhost:6006/?path=/docs/editors-editorpage--docs