### PR TITLE
Migrate interaction widget to WidgetPropsV2

### DIFF
--- a/.changeset/widget-props-v2-interaction.md
+++ b/.changeset/widget-props-v2-interaction.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Migrate the interaction widget to group all `options` under a separate prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -495,7 +495,7 @@ review and commit the changes.
 - [x] Migrate `cs-program` to `WidgetPropsV2`.
 - [x] Convert `python-program` to a functional component, a la `dropdown`.
 - [x] Migrate `python-program` to `WidgetPropsV2`.
-- [ ] Migrate `interaction` to `WidgetPropsV2`.
+- [x] Migrate `interaction` to `WidgetPropsV2`.
 - [ ] Migrate `numeric-input` and `input-number` (alias of `numeric-input`)
       to `WidgetPropsV2`.
 

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -25,4 +25,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "plotter",
     "cs-program",
     "python-program",
+    "interaction",
 ];

--- a/packages/perseus/src/widgets/interaction/interaction.tsx
+++ b/packages/perseus/src/widgets/interaction/interaction.tsx
@@ -10,7 +10,7 @@ import Util from "../../util";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/interaction/interaction-ai-utils";
 
 import type {Coord} from "../../interactive2/types";
-import type {Widget, WidgetExports, WidgetProps} from "../../types";
+import type {Widget, WidgetExports, WidgetPropsV2} from "../../types";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
 import type {
     PerseusInteractionElement,
@@ -95,7 +95,7 @@ const KAScompile = (
     return cached;
 };
 
-type Props = WidgetProps<PerseusInteractionWidgetOptions>;
+type Props = WidgetPropsV2<PerseusInteractionWidgetOptions>;
 
 type State = {
     variables: any;
@@ -108,8 +108,8 @@ class Interaction extends React.Component<Props, State> implements Widget {
     isWidget = true as const;
 
     state: State = {
-        variables: _getInitialVariables(this.props.elements),
-        functions: _getInitialFunctions(this.props.elements),
+        variables: _getInitialVariables(this.props.options.elements),
+        functions: _getInitialFunctions(this.props.options.elements),
     };
 
     UNSAFE_componentWillReceiveProps(nextProps: Props) {
@@ -123,10 +123,12 @@ class Interaction extends React.Component<Props, State> implements Widget {
         // fix would be to transform `variables` to the shape of `elements` and
         // call `this.props.onChange({elements})` to preserve user changes using
         // the Perseus state saving mechanism.
-        if (!_.isEqual(this.props.elements, nextProps.elements)) {
+        if (
+            !_.isEqual(this.props.options.elements, nextProps.options.elements)
+        ) {
             this.setState({
-                variables: _getInitialVariables(nextProps.elements),
-                functions: _getInitialFunctions(nextProps.elements),
+                variables: _getInitialVariables(nextProps.options.elements),
+                functions: _getInitialFunctions(nextProps.options.elements),
             });
         }
     }
@@ -134,10 +136,16 @@ class Interaction extends React.Component<Props, State> implements Widget {
     _setupGraphie: (arg1: any, arg2: any) => void = (graphie, options) => {
         graphie.graphInit(
             _.extend({}, options, {
-                grid: _.contains(["graph", "grid"], this.props.graph.markings),
-                axes: _.contains(["graph"], this.props.graph.markings),
-                ticks: _.contains(["graph"], this.props.graph.markings),
-                labels: _.contains(["graph"], this.props.graph.markings),
+                grid: _.contains(
+                    ["graph", "grid"],
+                    this.props.options.graph.markings,
+                ),
+                axes: _.contains(["graph"], this.props.options.graph.markings),
+                ticks: _.contains(["graph"], this.props.options.graph.markings),
+                labels: _.contains(
+                    ["graph"],
+                    this.props.options.graph.markings,
+                ),
                 labelFormat: function (s) {
                     return "\\small{" + s + "}";
                 },
@@ -229,16 +237,16 @@ class Interaction extends React.Component<Props, State> implements Widget {
     }
 
     render(): React.ReactNode {
-        const range = this.props.graph.range;
-        let labels = this.props.graph.labels;
-        if (this.props.graph.markings === "graph") {
+        const range = this.props.options.graph.range;
+        let labels = this.props.options.graph.labels;
+        if (this.props.options.graph.markings === "graph") {
             // Content creators may need to explicitly add the dollar signs so
             // the strings are picked up by our translation tools. However,
             // these math annotations are redundant because we already render
             // all graph labels in math mode. For example, a label value of
             // `$\text{Dollars}$` will be translatable, but we only want to
             // pass the string `\text{Dollars}` to the Graph widget.
-            labels = this.props.graph.labels.map((label) =>
+            labels = this.props.options.graph.labels.map((label) =>
                 label.startsWith("$") && label.endsWith("$")
                     ? label.slice(1, -1)
                     : label,
@@ -246,19 +254,19 @@ class Interaction extends React.Component<Props, State> implements Widget {
         }
         return (
             <Graphie
-                box={this.props.graph.box}
-                range={this.props.graph.range}
-                options={this.props.graph}
+                box={this.props.options.graph.box}
+                range={this.props.options.graph.range}
+                options={this.props.options.graph}
                 setup={this._setupGraphie}
             >
-                {this.props.graph.markings === "graph" && (
+                {this.props.options.graph.markings === "graph" && (
                     <Label
                         coord={[0, range[1][1]]}
                         text={labels[1]}
                         direction="above"
                     />
                 )}
-                {this.props.graph.markings === "graph" && (
+                {this.props.options.graph.markings === "graph" && (
                     <Label
                         coord={[range[0][1], 0]}
                         text={labels[0]}
@@ -266,7 +274,7 @@ class Interaction extends React.Component<Props, State> implements Widget {
                     />
                 )}
                 {_.map(
-                    this.props.elements,
+                    this.props.options.elements,
                     function (element, n) {
                         if (element.type === "point") {
                             return (


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit an Interaction widget in
  http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.