### PR TITLE
Fix math colors in dark mode

### DIFF
--- a/.changeset/seven-dots-stop.md
+++ b/.changeset/seven-dots-stop.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Math uses the appropriate colors for dark mode in more contexts (e.g. Radio widget choices).

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -104,7 +104,12 @@ const supportedThemes = {
             {
                 value: "thunderblocks",
                 icon: "lightning",
-                title: "Shape Your Learning (Thunder Blocks)",
+                title: "Shape Your Learning (thunderblocks)",
+            },
+            {
+                value: "syl-dark",
+                icon: "lightning",
+                title: "Shape Your Learning - Dark (syl-dark)",
             },
         ],
         // Change title based on selected value

--- a/packages/perseus/src/__docs__/dark-mode.stories.tsx
+++ b/packages/perseus/src/__docs__/dark-mode.stories.tsx
@@ -46,7 +46,7 @@ function RenderInDarkMode(renderer: PerseusRenderer): () => React.JSX.Element {
                 style={{
                     color: "var(--wb-semanticColor-core-foreground-neutral-strong)",
                     background:
-                        "var(--wb-semanticColor-core-background-base-subtle)",
+                        "var(--wb-semanticColor-core-background-instructive-subtle)",
                     display: "flex",
                     flexDirection: "column",
                     gap: "20px",

--- a/packages/perseus/src/__docs__/dark-mode.stories.tsx
+++ b/packages/perseus/src/__docs__/dark-mode.stories.tsx
@@ -2,14 +2,15 @@ import {
     generateRadioOptions,
     generateRadioWidget,
     generateTestPerseusRenderer,
-    PerseusRenderer
 } from "@khanacademy/perseus-core";
-import {SupportedThemes, THEME_DATA_ATTRIBUTE} from "@khanacademy/wonder-blocks-theming";
+import {THEME_DATA_ATTRIBUTE} from "@khanacademy/wonder-blocks-theming";
 import * as React from "react";
 import {useEffect} from "react";
 
 import QuestionRendererForStories from "../widgets/__testutils__/question-renderer-for-stories";
 
+import type {PerseusRenderer} from "@khanacademy/perseus-core";
+import type {SupportedThemes} from "@khanacademy/wonder-blocks-theming";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 type Story = StoryObj;
@@ -28,7 +29,7 @@ const meta: Meta = {
 };
 export default meta;
 
-function RenderInDarkMode(renderer: PerseusRenderer): (() => React.JSX.Element) {
+function RenderInDarkMode(renderer: PerseusRenderer): () => React.JSX.Element {
     return function Render() {
         // This is needed to apply a fictitious dark mode theme to the body element.
         useEffect(() => {
@@ -44,23 +45,22 @@ function RenderInDarkMode(renderer: PerseusRenderer): (() => React.JSX.Element) 
             <div
                 style={{
                     color: "var(--wb-semanticColor-core-foreground-neutral-strong)",
-                    background: "var(--wb-semanticColor-core-background-base-subtle)",
+                    background:
+                        "var(--wb-semanticColor-core-background-base-subtle)",
                     display: "flex",
                     flexDirection: "column",
                     gap: "20px",
                     padding: "50px",
                 }}
             >
-                <QuestionRendererForStories
-                    question={renderer}
-                />
+                <QuestionRendererForStories question={renderer} />
             </div>
         );
     };
 }
 
 const RenderImages = (content: string): (() => React.JSX.Element) => {
-    return RenderInDarkMode(generateTestPerseusRenderer({content: content}))
+    return RenderInDarkMode(generateTestPerseusRenderer({content: content}));
 };
 
 export const Icons: Story = {
@@ -125,10 +125,22 @@ export const MathJax: Story = {
 };
 
 export const RadioWithMathJax: Story = {
-    render: RenderInDarkMode(generateTestPerseusRenderer({
-        content: "[[☃ radio 1]]",
-        widgets: {
-            "radio 1": generateRadioWidget({options: generateRadioOptions({choices: [{id: "1", content: "$42 \\red{42} \\blue{42} \\green{42}$"}]})})
-        }
-    }))
-}
+    render: RenderInDarkMode(
+        generateTestPerseusRenderer({
+            content: "[[☃ radio 1]]",
+            widgets: {
+                "radio 1": generateRadioWidget({
+                    options: generateRadioOptions({
+                        choices: [
+                            {
+                                id: "1",
+                                content:
+                                    "$42 \\red{42} \\blue{42} \\green{42}$",
+                            },
+                        ],
+                    }),
+                }),
+            },
+        }),
+    ),
+};

--- a/packages/perseus/src/__docs__/dark-mode.stories.tsx
+++ b/packages/perseus/src/__docs__/dark-mode.stories.tsx
@@ -1,5 +1,10 @@
-import {generateTestPerseusRenderer} from "@khanacademy/perseus-core";
-import {THEME_DATA_ATTRIBUTE} from "@khanacademy/wonder-blocks-theming";
+import {
+    generateRadioOptions,
+    generateRadioWidget,
+    generateTestPerseusRenderer,
+    PerseusRenderer
+} from "@khanacademy/perseus-core";
+import {SupportedThemes, THEME_DATA_ATTRIBUTE} from "@khanacademy/wonder-blocks-theming";
 import * as React from "react";
 import {useEffect} from "react";
 
@@ -23,14 +28,14 @@ const meta: Meta = {
 };
 export default meta;
 
-const RenderImages = (content: string): (() => React.JSX.Element) => {
+function RenderInDarkMode(renderer: PerseusRenderer): (() => React.JSX.Element) {
     return function Render() {
-        // This is needed to apply a fictitious dark mode them to the body element.
+        // This is needed to apply a fictitious dark mode theme to the body element.
         useEffect(() => {
             setTimeout(() => {
                 document.body.setAttribute(
                     THEME_DATA_ATTRIBUTE,
-                    "some-theme-in-dark",
+                    "syl-dark" satisfies SupportedThemes,
                 );
             }, 10);
         }, []);
@@ -38,7 +43,8 @@ const RenderImages = (content: string): (() => React.JSX.Element) => {
         return (
             <div
                 style={{
-                    background: "black",
+                    color: "var(--wb-semanticColor-core-foreground-neutral-strong)",
+                    background: "var(--wb-semanticColor-core-background-base-subtle)",
                     display: "flex",
                     flexDirection: "column",
                     gap: "20px",
@@ -46,11 +52,15 @@ const RenderImages = (content: string): (() => React.JSX.Element) => {
                 }}
             >
                 <QuestionRendererForStories
-                    question={generateTestPerseusRenderer({content: content})}
+                    question={renderer}
                 />
             </div>
         );
     };
+}
+
+const RenderImages = (content: string): (() => React.JSX.Element) => {
+    return RenderInDarkMode(generateTestPerseusRenderer({content: content}))
 };
 
 export const Icons: Story = {
@@ -113,3 +123,12 @@ export const MathJax: Story = {
         }).join("\n\n"),
     ),
 };
+
+export const RadioWithMathJax: Story = {
+    render: RenderInDarkMode(generateTestPerseusRenderer({
+        content: "[[☃ radio 1]]",
+        widgets: {
+            "radio 1": generateRadioWidget({options: generateRadioOptions({choices: [{id: "1", content: "$42 \\red{42} \\blue{42} \\green{42}$"}]})})
+        }
+    }))
+}

--- a/packages/perseus/src/__docs__/dark-mode.stories.tsx
+++ b/packages/perseus/src/__docs__/dark-mode.stories.tsx
@@ -31,7 +31,9 @@ export default meta;
 
 function RenderInDarkMode(renderer: PerseusRenderer): () => React.JSX.Element {
     return function Render() {
-        // This is needed to apply a fictitious dark mode theme to the body element.
+        // Apply the dark mode theme to the body element. The element with
+        // THEME_DATA_ATTRIBUTE needs to be outside the .framework-perseus
+        // element for our styles to work.
         useEffect(() => {
             setTimeout(() => {
                 document.body.setAttribute(

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -381,7 +381,7 @@
         /* Since we invert all MathJax colors (above), we need to force the
            default foreground color to dark so it will be light when inverted.
            If we don't do this, then math will inherit the theme's foreground
-           color and invert it, resulting in very low contrast.
+           color and invert it, resulting in dark-on-dark text.
          */
         color: #21242c;
     }

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -382,7 +382,10 @@
            default foreground color to dark so it will be light when inverted.
            If we don't do this, then math will inherit the theme's foreground
            color and invert it, resulting in dark-on-dark text.
+
+           The precise color used here is unimportant; off-black colors get
+           washed out by the brightness filter, so they end up as #fff anyway.
          */
-        color: #21242c;
+        color: black;
     }
 }

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -368,8 +368,8 @@
 [data-wb-theme$="-dark"] .framework-perseus {
     img[src$=".png"],
     img[src$=".svg"],
-    .mathjax-wrapper
-    {
+    .graphie-label,
+    .mathjax-wrapper:not(.graphie-label *) {
         /* This filter is applied to all PNG/SVG images,
            and to the content of Graphie images (text labels, etc.),
            and to any MathJax.

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -368,13 +368,12 @@
 [data-wb-theme$="-dark"] .framework-perseus {
     img[src$=".png"],
     img[src$=".svg"],
-    .graphie-label,
-    .mathjax-wrapper:not(.graphie-label *) {
-        /* This filter is applied to all PNG/SVG images,
-           and to the content of Graphie images (text labels, etc.),
-           and to any MathJax.
-           It leaves JPEGs & GIFs untouched.
-        */
+    .graphie,
+    .mathjax-wrapper:not(.graphie *) {
+        /* This filter is applied to PNG/SVG images, Graphie (e.g. label
+           text), and MathJax. MathJax inside Graphie labels is excluded so it
+           doesn't get double-inverted. JPEGs & GIFs are untouched.
+         */
         filter: invert(1) hue-rotate(180deg) brightness(1.5);
     }
 

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -368,13 +368,22 @@
 [data-wb-theme$="-dark"] .framework-perseus {
     img[src$=".png"],
     img[src$=".svg"],
-    .graphie,
-    .perseus-block-math .mathjax-wrapper {
+    .mathjax-wrapper
+    {
         /* This filter is applied to all PNG/SVG images,
            and to the content of Graphie images (text labels, etc.),
            and to any MathJax.
            It leaves JPEGs & GIFs untouched.
         */
         filter: invert(1) hue-rotate(180deg) brightness(1.5);
+    }
+
+    .mathjax-wrapper {
+        /* Since we invert all MathJax colors (above), we need to force the
+           default foreground color to dark so it will be light when inverted.
+           If we don't do this, then math will inherit the theme's foreground
+           color and invert it, resulting in very low contrast.
+         */
+        color: #21242c;
     }
 }

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -990,7 +990,7 @@ export class Graphie {
                 .css({
                     position: "absolute",
                     padding: (pad != null ? pad : 7) + "px",
-                    color: "black",
+                    // color: "black",
                 })
                 .data("labelDirection", direction)
                 .appendTo(this.el);

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -990,7 +990,7 @@ export class Graphie {
                 .css({
                     position: "absolute",
                     padding: (pad != null ? pad : 7) + "px",
-                    // color: "black",
+                    color: "black",
                 })
                 .data("labelDirection", direction)
                 .appendTo(this.el);


### PR DESCRIPTION
## Summary:
Previously, MathJax colors weren't properly inverted in some contexts, e.g.
Radio widget choices. This PR fixes that.

Issue: LEMS-4412

## Test plan:

- `pnpm storybook`
- `open http://localhost:6006/?path=/docs/renderers-visual-regression-tests-dark-mode--docs`
- The SVG details and labels of Graphie images should render in a light color.
- MathJax in the Radio widget example should be legible.