### PR TITLE
Remove unused defaultProps of Matcher

### DIFF
--- a/.changeset/two-facts-crash.md
+++ b/.changeset/two-facts-crash.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: the unused defaultProps of the Matcher widget have been removed.

--- a/packages/perseus/src/widgets/matcher/matcher.tsx
+++ b/packages/perseus/src/widgets/matcher/matcher.tsx
@@ -1,5 +1,4 @@
 import {shuffleMatcher} from "@khanacademy/perseus-core";
-import {linterContextDefault} from "@khanacademy/perseus-linter";
 import {CircularSpinner} from "@khanacademy/wonder-blocks-progress-spinner";
 import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
@@ -35,15 +34,6 @@ type Props = WidgetProps<
     dependencies: PerseusDependenciesV2;
 };
 
-type DefaultProps = {
-    labels: Props["labels"];
-    orderMatters: Props["orderMatters"];
-    padding: Props["padding"];
-    problemNum: Props["problemNum"];
-    linterContext: Props["linterContext"];
-    userInput: Props["userInput"];
-};
-
 type State = {
     leftHeight: number;
     rightHeight: number;
@@ -53,18 +43,6 @@ type State = {
 export class Matcher extends React.Component<Props, State> implements Widget {
     static contextType = PerseusI18nContext;
     declare context: React.ContextType<typeof PerseusI18nContext>;
-
-    static defaultProps: DefaultProps = {
-        labels: ["", ""],
-        orderMatters: false,
-        padding: true,
-        problemNum: 0,
-        linterContext: linterContextDefault,
-        userInput: {
-            left: [],
-            right: [],
-        },
-    };
 
     state: State = {
         leftHeight: 0,


### PR DESCRIPTION
## Summary:

- `problemNum` wasn't used.
- `linterContext` and `userInput` are always passed.
- the parser guarantees all `options` props are present.

Issue: none

## Test plan:

Test the Matcher and its editor in Storybook.