### PR TITLE
[Interactive Graph] Fix locked figure screen-reader order to match author order

### DIFF
--- a/.changeset/huge-towns-brake.md
+++ b/.changeset/huge-towns-brake.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Interactive Graph] Fix locked figure screen-reader order to match author order

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -1,3 +1,4 @@
+import {getDefaultFigureForType} from "@khanacademy/perseus-core";
 import {screen, render, act} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import {vec} from "mafs";
@@ -18,7 +19,7 @@ import {calculateNestedSVGCoords, getBaseMafsGraphPropsForTests} from "./utils";
 import type {MafsGraphProps} from "./mafs-graph";
 import type {InteractiveGraphState} from "./types";
 import type {PerseusDependenciesV2} from "../../types";
-import type {GraphRange} from "@khanacademy/perseus-core";
+import type {GraphRange, LockedFigure} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
 
 const baseMafsProps = getBaseMafsGraphPropsForTests();
@@ -1056,6 +1057,52 @@ describe("MafsGraph", () => {
                 "description",
                 "element-details",
             ]);
+        });
+    });
+
+    describe("locked figure reading order", () => {
+        it("renders locked figures in author order regardless of type", () => {
+            // Arrange
+            // A point authored before vectors must still read first, even
+            // though points and other figures render in separate clip passes.
+            const lockedFigures: LockedFigure[] = [
+                {
+                    ...getDefaultFigureForType("point"),
+                    coord: [6, 3],
+                    ariaLabel: "Point A",
+                },
+                {
+                    ...getDefaultFigureForType("vector"),
+                    points: [
+                        [6, 3],
+                        [4, 2],
+                    ],
+                    ariaLabel: "Arrow 1",
+                },
+                {
+                    ...getDefaultFigureForType("vector"),
+                    points: [
+                        [4, 2],
+                        [2, 1],
+                    ],
+                    ariaLabel: "Arrow 2",
+                },
+            ];
+
+            // Act
+            render(
+                <MafsGraph
+                    {...baseMafsProps}
+                    lockedFigures={lockedFigures}
+                    dispatch={() => {}}
+                />,
+            );
+
+            // Assert
+            const labels = screen
+                .getAllByRole("img")
+                .map((figure) => figure.getAttribute("aria-label"));
+            expect(labels).toEqual(["Point A", "Arrow 1", "Arrow 2"]);
         });
     });
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -12,7 +12,11 @@ import {
 } from "../../testing/test-dependencies";
 
 import {MafsGraph} from "./mafs-graph";
-import {actions, REMOVE_POINT} from "./reducer/interactive-graph-action";
+import {
+    actions,
+    DELETE_INTENT,
+    REMOVE_POINT,
+} from "./reducer/interactive-graph-action";
 import {interactiveGraphReducer} from "./reducer/interactive-graph-reducer";
 import {calculateNestedSVGCoords, getBaseMafsGraphPropsForTests} from "./utils";
 
@@ -1063,8 +1067,6 @@ describe("MafsGraph", () => {
     describe("locked figure reading order", () => {
         it("renders locked figures in author order regardless of type", () => {
             // Arrange
-            // A point authored before vectors must still read first, even
-            // though points and other figures render in separate clip passes.
             const lockedFigures: LockedFigure[] = [
                 {
                     ...getDefaultFigureForType("point"),
@@ -1078,6 +1080,11 @@ describe("MafsGraph", () => {
                         [4, 2],
                     ],
                     ariaLabel: "Arrow 1",
+                },
+                {
+                    ...getDefaultFigureForType("point"),
+                    coord: [4, 2],
+                    ariaLabel: "Point B",
                 },
                 {
                     ...getDefaultFigureForType("vector"),
@@ -1102,7 +1109,12 @@ describe("MafsGraph", () => {
             const labels = screen
                 .getAllByRole("img")
                 .map((figure) => figure.getAttribute("aria-label"));
-            expect(labels).toEqual(["Point A", "Arrow 1", "Arrow 2"]);
+            expect(labels).toEqual([
+                "Point A",
+                "Arrow 1",
+                "Point B",
+                "Arrow 2",
+            ]);
         });
     });
 
@@ -1272,6 +1284,46 @@ describe("MafsGraph", () => {
 
             expect(mockDispatch.mock.calls).toContainEqual([
                 {type: REMOVE_POINT, index: 0},
+            ]);
+        });
+
+        it("point - removes the focused point when Delete is pressed on its handle", async () => {
+            // Arrange
+            const mockDispatch = jest.fn();
+            const state: InteractiveGraphState = {
+                type: "point",
+                numPoints: "unlimited",
+                focusedPointIndex: 0,
+                hasBeenInteractedWith: true,
+                showRemovePointButton: true,
+                interactionMode: "keyboard",
+                showKeyboardInteractionInvitation: false,
+                range: [
+                    [-10, 10],
+                    [-10, 10],
+                ],
+                snapStep: [2, 2],
+                coords: [[9, 9]],
+            };
+
+            render(
+                <MafsGraph
+                    {...baseMafsProps}
+                    markings="none"
+                    state={state}
+                    dispatch={mockDispatch}
+                />,
+            );
+
+            // Act: focus the real point handle, then press Delete.
+            const handle = screen.getByTestId(
+                "movable-point__focusable-handle",
+            );
+            handle.focus();
+            await userEvent.keyboard("{Delete}");
+
+            expect(mockDispatch.mock.calls).toContainEqual([
+                {type: DELETE_INTENT},
             ]);
         });
 

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.tsx
@@ -59,6 +59,13 @@ import {Protractor} from "./protractor";
 import {actions} from "./reducer/interactive-graph-action";
 import {GraphConfigContext} from "./reducer/use-graph-config";
 import {isUnlimitedGraphState, REMOVE_BUTTON_ID} from "./utils";
+import {
+    describedByIds,
+    getLockedFigureClipRuns,
+    handleBlurEvent,
+    handleFocusEvent,
+    handleKeyboardEvent,
+} from "./utils/mafs-graph-utils";
 
 import type {InteractiveGraphAction} from "./reducer/interactive-graph-action";
 import type {
@@ -220,15 +227,9 @@ export const MafsGraph = (props: MafsGraphProps) => {
         top: yMax === 0 ? halfStroke : 0,
     };
 
-    // Points are fixed-radius markers, so a point on the boundary would be
-    // sliced in half by the clip — render them unclipped. Other figures are
-    // geometry that should be clipped to the visible range.
-    const lockedPointFigures = props.lockedFigures.filter(
-        (figure) => figure.type === "point",
-    );
-    const clippedLockedFigures = props.lockedFigures.filter(
-        (figure) => figure.type !== "point",
-    );
+    // Group figures into ordered runs so points render unclipped and other
+    // figures clipped, while preserving author (and screen-reader) order.
+    const lockedFigureRuns = getLockedFigureClipRuns(props.lockedFigures);
 
     return (
         <GraphConfigContext.Provider
@@ -434,20 +435,26 @@ export const MafsGraph = (props: MafsGraphProps) => {
                                         <AxisArrows />
                                     </>
                                 )}
-                                {/* Locked figures clipped to graph bounds */}
-                                {clippedLockedFigures.length > 0 && (
-                                    <ClipToGraphBounds>
+                                {/* Locked figures in author order: clipped
+                                    runs are wrapped, point runs render
+                                    unclipped so boundary points aren't sliced. */}
+                                {lockedFigureRuns.map((run, index) =>
+                                    run.clipped ? (
+                                        <ClipToGraphBounds
+                                            key={`locked-figure-run-${index}`}
+                                        >
+                                            <GraphLockedLayer
+                                                lockedFigures={run.figures}
+                                                range={state.range}
+                                            />
+                                        </ClipToGraphBounds>
+                                    ) : (
                                         <GraphLockedLayer
-                                            lockedFigures={clippedLockedFigures}
+                                            key={`locked-figure-run-${index}`}
+                                            lockedFigures={run.figures}
                                             range={state.range}
                                         />
-                                    </ClipToGraphBounds>
-                                )}
-                                {lockedPointFigures.length > 0 && (
-                                    <GraphLockedLayer
-                                        lockedFigures={lockedPointFigures}
-                                        range={state.range}
-                                    />
+                                    ),
                                 )}
                             </Mafs>
                         </View>
@@ -758,70 +765,6 @@ const renderGraphControls = (props: {
     }
 };
 
-function handleFocusEvent(
-    event: React.FocusEvent,
-    state: InteractiveGraphState,
-    dispatch: (action: InteractiveGraphAction) => unknown,
-) {
-    if (isUnlimitedGraphState(state)) {
-        if (
-            event.target.classList.contains("mafs-graph") &&
-            state.interactionMode === "mouse"
-        ) {
-            dispatch(actions.global.changeKeyboardInvitationVisibility(true));
-        }
-    }
-}
-
-function handleBlurEvent(
-    _event: React.FocusEvent,
-    state: InteractiveGraphState,
-    dispatch: (action: InteractiveGraphAction) => unknown,
-) {
-    if (isUnlimitedGraphState(state)) {
-        dispatch(actions.global.changeKeyboardInvitationVisibility(false));
-    }
-}
-
-function handleKeyboardEvent(
-    event: React.KeyboardEvent,
-    state: InteractiveGraphState,
-    dispatch: (action: InteractiveGraphAction) => unknown,
-) {
-    if (isUnlimitedGraphState(state)) {
-        if (event.key === "Backspace" || event.key === "Delete") {
-            // NOTE(benchristel): Checking classList here is a hack to prevent
-            // points from being deleted if the user presses the backspace key
-            // while the whole graph is focused. Instead of doing this, we
-            // should move the keyboard event handler to the movable point
-            // handle element.
-            if (
-                document.activeElement?.classList.contains(
-                    "movable-point__focusable-handle",
-                )
-            ) {
-                // Only allow delete if type is point or a polygon that is open.
-                if (
-                    state.type === "point" ||
-                    (state.type === "polygon" && !state.closedPolygon)
-                ) {
-                    dispatch(actions.global.deleteIntent());
-                }
-            }
-
-            // After removing a point blur
-            // It would be nice if this could focus on the graph but doing so
-            // would trigger the message to prompt a learner to enter keyboard mode
-            // eslint-disable-next-line no-restricted-syntax
-            (document.activeElement as HTMLElement).blur();
-        } else if (event.shiftKey && event.key === "Enter") {
-            dispatch(actions.global.changeInteractionMode("keyboard"));
-        } else if (state.interactionMode === "keyboard" && event.key === "a") {
-            dispatch(actions.pointGraph.addPoint([0, 0]));
-        }
-    }
-}
-
 const renderGraphElements = (props: {
     state: InteractiveGraphState;
     dispatch: (action: InteractiveGraphAction) => unknown;
@@ -870,11 +813,3 @@ const renderGraphElements = (props: {
             throw new UnreachableCaseError(type);
     }
 };
-
-// Returns a space-separated string like "foo bar" given several optional
-// string IDs. If all args are falsy, returns undefined.
-function describedByIds(
-    ...args: Array<string | false | 0 | null | undefined>
-): string | undefined {
-    return args.filter(Boolean).join(" ") || undefined;
-}

--- a/packages/perseus/src/widgets/interactive-graphs/utils/mafs-graph-utils.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/utils/mafs-graph-utils.test.tsx
@@ -1,0 +1,456 @@
+import {getDefaultFigureForType} from "@khanacademy/perseus-core";
+
+import {actions} from "../reducer/interactive-graph-action";
+
+import {
+    describedByIds,
+    getLockedFigureClipRuns,
+    handleBlurEvent,
+    handleFocusEvent,
+    handleKeyboardEvent,
+} from "./mafs-graph-utils";
+
+import type {InteractiveGraphState} from "../types";
+import type {LockedFigure} from "@khanacademy/perseus-core";
+import type * as React from "react";
+
+// The handlers only read a couple of fields off the synthetic event, so we
+// build minimal stand-ins rather than full React synthetic events.
+function focusEventOn(target: Element) {
+    // eslint-disable-next-line no-restricted-syntax
+    return {target} as React.FocusEvent;
+}
+
+function keyboardEvent(props: {key: string; shiftKey?: boolean}) {
+    // eslint-disable-next-line no-restricted-syntax
+    return {shiftKey: false, ...props} as React.KeyboardEvent;
+}
+
+const unlimitedPointState: InteractiveGraphState = {
+    type: "point",
+    numPoints: "unlimited",
+    focusedPointIndex: 0,
+    hasBeenInteractedWith: true,
+    showRemovePointButton: false,
+    interactionMode: "mouse",
+    showKeyboardInteractionInvitation: false,
+    range: [
+        [-10, 10],
+        [-10, 10],
+    ],
+    snapStep: [1, 1],
+    coords: [[4, 5]],
+};
+
+// A non-unlimited graph: isUnlimitedGraphState is false, so the handlers
+// should be no-ops.
+const limitedPointState: InteractiveGraphState = {
+    ...unlimitedPointState,
+    numPoints: 1,
+};
+
+const unlimitedOpenPolygonState: InteractiveGraphState = {
+    type: "polygon",
+    numSides: "unlimited",
+    closedPolygon: false,
+    showAngles: false,
+    showSides: false,
+    snapTo: "grid",
+    focusedPointIndex: 0,
+    hasBeenInteractedWith: true,
+    showRemovePointButton: false,
+    interactionMode: "mouse",
+    showKeyboardInteractionInvitation: false,
+    range: [
+        [-10, 10],
+        [-10, 10],
+    ],
+    snapStep: [1, 1],
+    coords: [
+        [0, 0],
+        [2, 2],
+        [4, 0],
+    ],
+};
+
+const unlimitedClosedPolygonState: InteractiveGraphState = {
+    ...unlimitedOpenPolygonState,
+    closedPolygon: true,
+};
+
+// Focuses a movable-point handle so the delete branch of handleKeyboardEvent
+// runs, and returns a cleanup function.
+function focusMovablePointHandle(): () => void {
+    const handle = document.createElement("button");
+    handle.classList.add("movable-point__focusable-handle");
+    document.body.appendChild(handle);
+    handle.focus();
+    return () => handle.remove();
+}
+
+describe("getLockedFigureClipRuns", () => {
+    function point(ariaLabel: string): LockedFigure {
+        return {...getDefaultFigureForType("point"), ariaLabel};
+    }
+    function vector(ariaLabel: string): LockedFigure {
+        return {...getDefaultFigureForType("vector"), ariaLabel};
+    }
+    function label(text: string): LockedFigure {
+        return {...getDefaultFigureForType("label"), text};
+    }
+
+    it("returns no runs for an empty list", () => {
+        // Arrange, Act
+        const runs = getLockedFigureClipRuns([]);
+
+        // Assert
+        expect(runs).toEqual([]);
+    });
+
+    it("keeps points and non-points in author order as separate runs", () => {
+        // Arrange
+        const figures = [point("A"), vector("v1"), vector("v2"), point("B")];
+
+        // Act
+        const runs = getLockedFigureClipRuns(figures);
+
+        // Assert
+        // A point run, then a clipped run of vectors, then a point run —
+        // preserving the authored order across the clip boundary.
+        expect(runs.map((run) => run.clipped)).toEqual([false, true, false]);
+        expect(runs.map((run) => run.figures)).toEqual([
+            [figures[0]],
+            [figures[1], figures[2]],
+            [figures[3]],
+        ]);
+    });
+
+    it("groups adjacent figures of the same clip treatment into one run", () => {
+        // Arrange
+        const figures = [vector("v1"), vector("v2"), vector("v3")];
+
+        // Act
+        const runs = getLockedFigureClipRuns(figures);
+
+        // Assert
+        expect(runs).toHaveLength(1);
+        expect(runs[0]).toEqual({clipped: true, figures});
+    });
+
+    it("marks a run of only points as unclipped", () => {
+        // Arrange
+        const figures = [point("A"), point("B")];
+
+        // Act
+        const runs = getLockedFigureClipRuns(figures);
+
+        // Assert
+        expect(runs).toHaveLength(1);
+        expect(runs[0].clipped).toBe(false);
+    });
+
+    it("skips label figures so they don't split a run", () => {
+        // Arrange
+        // Labels render in the separate labels layer, so a label between two
+        // points must not break them into two runs (which would emit an empty
+        // clip wrapper).
+        const points = [point("A"), point("B")];
+        const figures = [points[0], label("hello"), points[1]];
+
+        // Act
+        const runs = getLockedFigureClipRuns(figures);
+
+        // Assert
+        expect(runs).toHaveLength(1);
+        expect(runs[0]).toEqual({clipped: false, figures: points});
+    });
+});
+
+describe("describedByIds", () => {
+    it("joins truthy ids with a space", () => {
+        // Arrange, Act
+        const result = describedByIds("a", "b", "c");
+
+        // Assert
+        expect(result).toBe("a b c");
+    });
+
+    it("skips falsy values", () => {
+        // Arrange, Act
+        const result = describedByIds("a", false, null, undefined, 0, "b");
+
+        // Assert
+        expect(result).toBe("a b");
+    });
+
+    it("returns undefined when there are no truthy ids", () => {
+        // Arrange, Act
+        const result = describedByIds(false, null, undefined, 0);
+
+        // Assert
+        expect(result).toBeUndefined();
+    });
+});
+
+describe("handleFocusEvent", () => {
+    it("invites keyboard interaction when the graph itself is focused via mouse", () => {
+        // Arrange
+        const dispatch = jest.fn();
+        const target = document.createElement("div");
+        target.classList.add("mafs-graph");
+
+        // Act
+        handleFocusEvent(focusEventOn(target), unlimitedPointState, dispatch);
+
+        // Assert
+        expect(dispatch).toHaveBeenCalledWith(
+            actions.global.changeKeyboardInvitationVisibility(true),
+        );
+    });
+
+    it("does nothing when the graph is not an unlimited graph", () => {
+        // Arrange
+        const dispatch = jest.fn();
+        const target = document.createElement("div");
+        target.classList.add("mafs-graph");
+
+        // Act
+        handleFocusEvent(focusEventOn(target), limitedPointState, dispatch);
+
+        // Assert
+        expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when a child element (not the graph) is focused", () => {
+        // Arrange
+        const dispatch = jest.fn();
+        const target = document.createElement("div");
+
+        // Act
+        handleFocusEvent(focusEventOn(target), unlimitedPointState, dispatch);
+
+        // Assert
+        expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it("does nothing when the interaction mode is not mouse", () => {
+        // Arrange
+        const dispatch = jest.fn();
+        const target = document.createElement("div");
+        target.classList.add("mafs-graph");
+
+        // Act
+        handleFocusEvent(
+            focusEventOn(target),
+            {...unlimitedPointState, interactionMode: "keyboard"},
+            dispatch,
+        );
+
+        // Assert
+        expect(dispatch).not.toHaveBeenCalled();
+    });
+});
+
+describe("handleBlurEvent", () => {
+    it("hides the keyboard invitation on an unlimited graph", () => {
+        // Arrange
+        const dispatch = jest.fn();
+
+        // Act
+        handleBlurEvent(
+            focusEventOn(document.createElement("div")),
+            unlimitedPointState,
+            dispatch,
+        );
+
+        // Assert
+        expect(dispatch).toHaveBeenCalledWith(
+            actions.global.changeKeyboardInvitationVisibility(false),
+        );
+    });
+
+    it("does nothing on a limited graph", () => {
+        // Arrange
+        const dispatch = jest.fn();
+
+        // Act
+        handleBlurEvent(
+            focusEventOn(document.createElement("div")),
+            limitedPointState,
+            dispatch,
+        );
+
+        // Assert
+        expect(dispatch).not.toHaveBeenCalled();
+    });
+});
+
+describe("handleKeyboardEvent", () => {
+    it("enters keyboard mode on Shift+Enter", () => {
+        // Arrange
+        const dispatch = jest.fn();
+
+        // Act
+        handleKeyboardEvent(
+            keyboardEvent({key: "Enter", shiftKey: true}),
+            unlimitedPointState,
+            dispatch,
+        );
+
+        // Assert
+        expect(dispatch).toHaveBeenCalledWith(
+            actions.global.changeInteractionMode("keyboard"),
+        );
+    });
+
+    it("adds a point when 'a' is pressed in keyboard mode", () => {
+        // Arrange
+        const dispatch = jest.fn();
+
+        // Act
+        handleKeyboardEvent(
+            keyboardEvent({key: "a"}),
+            {...unlimitedPointState, interactionMode: "keyboard"},
+            dispatch,
+        );
+
+        // Assert
+        expect(dispatch).toHaveBeenCalledWith(
+            actions.pointGraph.addPoint([0, 0]),
+        );
+    });
+
+    it("does not add a point when 'a' is pressed in mouse mode", () => {
+        // Arrange
+        const dispatch = jest.fn();
+
+        // Act
+        handleKeyboardEvent(
+            keyboardEvent({key: "a"}),
+            unlimitedPointState,
+            dispatch,
+        );
+
+        // Assert
+        expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    it.each(["Backspace", "Delete"])(
+        "deletes the focused point on %s when a point handle is focused",
+        (key) => {
+            // Arrange
+            const dispatch = jest.fn();
+            const cleanup = focusMovablePointHandle();
+
+            // Act
+            handleKeyboardEvent(
+                keyboardEvent({key}),
+                unlimitedPointState,
+                dispatch,
+            );
+
+            // Assert
+            expect(dispatch).toHaveBeenCalledWith(
+                actions.global.deleteIntent(),
+            );
+
+            // Cleanup
+            cleanup();
+        },
+    );
+
+    it("blurs the focused handle after a delete key, even when nothing is deleted", () => {
+        // Arrange
+        const dispatch = jest.fn();
+        const cleanup = focusMovablePointHandle();
+
+        // Act
+        handleKeyboardEvent(
+            keyboardEvent({key: "Backspace"}),
+            // Closed polygon: no delete dispatched, but the handle still blurs.
+            unlimitedClosedPolygonState,
+            dispatch,
+        );
+
+        // Assert
+        expect(dispatch).not.toHaveBeenCalledWith(
+            actions.global.deleteIntent(),
+        );
+        expect(document.activeElement).toBe(document.body);
+
+        // Cleanup
+        cleanup();
+    });
+
+    it("does not delete on Backspace when no point handle is focused", () => {
+        // Arrange
+        const dispatch = jest.fn();
+
+        // Act
+        handleKeyboardEvent(
+            keyboardEvent({key: "Backspace"}),
+            unlimitedPointState,
+            dispatch,
+        );
+
+        // Assert
+        expect(dispatch).not.toHaveBeenCalledWith(
+            actions.global.deleteIntent(),
+        );
+    });
+
+    it("deletes on Backspace for an open polygon when a point handle is focused", () => {
+        // Arrange
+        const dispatch = jest.fn();
+        const cleanup = focusMovablePointHandle();
+
+        // Act
+        handleKeyboardEvent(
+            keyboardEvent({key: "Backspace"}),
+            unlimitedOpenPolygonState,
+            dispatch,
+        );
+
+        // Assert
+        expect(dispatch).toHaveBeenCalledWith(actions.global.deleteIntent());
+
+        // Cleanup
+        cleanup();
+    });
+
+    it("does not delete on Backspace for a closed polygon", () => {
+        // Arrange
+        const dispatch = jest.fn();
+        const cleanup = focusMovablePointHandle();
+
+        // Act
+        handleKeyboardEvent(
+            keyboardEvent({key: "Backspace"}),
+            unlimitedClosedPolygonState,
+            dispatch,
+        );
+
+        // Assert
+        expect(dispatch).not.toHaveBeenCalledWith(
+            actions.global.deleteIntent(),
+        );
+
+        // Cleanup
+        cleanup();
+    });
+
+    it("does nothing on a limited graph", () => {
+        // Arrange
+        const dispatch = jest.fn();
+
+        // Act
+        handleKeyboardEvent(
+            keyboardEvent({key: "Enter", shiftKey: true}),
+            limitedPointState,
+            dispatch,
+        );
+
+        // Assert
+        expect(dispatch).not.toHaveBeenCalled();
+    });
+});

--- a/packages/perseus/src/widgets/interactive-graphs/utils/mafs-graph-utils.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/utils/mafs-graph-utils.tsx
@@ -1,0 +1,117 @@
+import {actions} from "../reducer/interactive-graph-action";
+import {isUnlimitedGraphState} from "../utils";
+
+import type {InteractiveGraphAction} from "../reducer/interactive-graph-action";
+import type {InteractiveGraphState} from "../types";
+import type {LockedFigure} from "@khanacademy/perseus-core";
+import type * as React from "react";
+
+/**
+ * A contiguous run of locked figures sharing the same clipping treatment.
+ * Points render unclipped (a boundary point would otherwise be sliced in half
+ * by the clip); every other figure is clipped to the graph's visible range.
+ */
+export interface LockedFigureClipRun {
+    clipped: boolean;
+    figures: LockedFigure[];
+}
+
+/**
+ * Group locked figures into contiguous runs by clipping treatment, preserving
+ * author order. Rendering all points in one pass would push them after every
+ * other figure, so the DOM (and screen-reader) order would no longer match the
+ * authored order; grouping into ordered runs keeps them interleaved as authored.
+ *
+ * Label figures are skipped: they render in GraphLockedLabelsLayer, not this
+ * layer, so including them would emit empty clip wrappers and split point runs.
+ */
+export function getLockedFigureClipRuns(
+    lockedFigures: ReadonlyArray<LockedFigure>,
+): ReadonlyArray<LockedFigureClipRun> {
+    const runs: LockedFigureClipRun[] = [];
+    for (const figure of lockedFigures) {
+        if (figure.type === "label") {
+            continue;
+        }
+        const clipped = figure.type !== "point";
+        const lastRun = runs[runs.length - 1];
+        if (lastRun?.clipped === clipped) {
+            lastRun.figures.push(figure);
+        } else {
+            runs.push({clipped, figures: [figure]});
+        }
+    }
+    return runs;
+}
+
+export function handleFocusEvent(
+    event: React.FocusEvent,
+    state: InteractiveGraphState,
+    dispatch: (action: InteractiveGraphAction) => unknown,
+) {
+    if (isUnlimitedGraphState(state)) {
+        if (
+            event.target.classList.contains("mafs-graph") &&
+            state.interactionMode === "mouse"
+        ) {
+            dispatch(actions.global.changeKeyboardInvitationVisibility(true));
+        }
+    }
+}
+
+export function handleBlurEvent(
+    _event: React.FocusEvent,
+    state: InteractiveGraphState,
+    dispatch: (action: InteractiveGraphAction) => unknown,
+) {
+    if (isUnlimitedGraphState(state)) {
+        dispatch(actions.global.changeKeyboardInvitationVisibility(false));
+    }
+}
+
+export function handleKeyboardEvent(
+    event: React.KeyboardEvent,
+    state: InteractiveGraphState,
+    dispatch: (action: InteractiveGraphAction) => unknown,
+) {
+    if (isUnlimitedGraphState(state)) {
+        if (event.key === "Backspace" || event.key === "Delete") {
+            // NOTE(benchristel): Checking classList here is a hack to prevent
+            // points from being deleted if the user presses the backspace key
+            // while the whole graph is focused. Instead of doing this, we
+            // should move the keyboard event handler to the movable point
+            // handle element.
+            if (
+                document.activeElement?.classList.contains(
+                    "movable-point__focusable-handle",
+                )
+            ) {
+                // Only allow delete if type is point or a polygon that is open.
+                if (
+                    state.type === "point" ||
+                    (state.type === "polygon" && !state.closedPolygon)
+                ) {
+                    dispatch(actions.global.deleteIntent());
+                }
+            }
+
+            // After removing a point blur
+            // It would be nice if this could focus on the graph but doing so
+            // would trigger the message to prompt a learner to enter keyboard mode
+            // eslint-disable-next-line no-restricted-syntax
+            (document.activeElement as HTMLElement).blur();
+        } else if (event.shiftKey && event.key === "Enter") {
+            dispatch(actions.global.changeInteractionMode("keyboard"));
+        } else if (state.interactionMode === "keyboard" && event.key === "a") {
+            dispatch(actions.pointGraph.addPoint([0, 0]));
+        }
+    }
+}
+
+// Returns a space-separated string like "foo bar" given several optional
+// string IDs. If all args are falsy, returns undefined.
+export function describedByIds(
+    ...args: Array<string | false | 0 | null | undefined>
+): string | undefined {
+    return args.filter(Boolean).join(" ") || undefined;
+}


### PR DESCRIPTION
## Summary:
Interactive graphs render author-defined "locked figures" (points, vectors, lines, etc.), each with its own aria-label. When a graph mixed figure types, the screen reader read them out of authored order — every locked point was announced after all other figures, regardless of placement.

Root cause: figures were rendered in two passes — non-points first (clipped to the graph bounds), then points (rendered unclipped so boundary points aren't sliced by the clip). Since SVG paint order is DOM order is screen-reader order, the trailing points pass reordered the accessibility tree. The unclipped-points behavior came from #3818; this fixes the ordering it introduced.

This change keeps points unclipped **and** preserves author order: figures are grouped into contiguous runs by clipping treatment, and each run is rendered in place — so points and non-points stay interleaved exactly as authored. This also includes a small refactoring moving util files for code organization and then add equivalent tests for them.

Issue: LEMS-4430

## Test plan: