### PR TITLE
Remove needless underscore imports

### DIFF
--- a/.changeset/clever-cars-jog.md
+++ b/.changeset/clever-cars-jog.md
@@ -1,0 +1,9 @@
+---
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus-score": patch
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus": patch
+"@khanacademy/kas": patch
+---
+
+Remove unused underscore imports

--- a/packages/kas/src/__tests__/compilation.test.ts
+++ b/packages/kas/src/__tests__/compilation.test.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import * as KAS from "../index";
 
 type Variables = {

--- a/packages/kas/src/__tests__/evaluating.test.ts
+++ b/packages/kas/src/__tests__/evaluating.test.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import * as KAS from "../index";
 
 type Variables = {

--- a/packages/kas/src/__tests__/transforming.test.ts
+++ b/packages/kas/src/__tests__/transforming.test.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import * as KAS from "../index";
 
 expect.extend({

--- a/packages/kas/src/__tests__/units.test.ts
+++ b/packages/kas/src/__tests__/units.test.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import * as KAS from "../index";
 
 expect.extend({

--- a/packages/perseus-core/src/utils/split-perseus-renderer.ts
+++ b/packages/perseus-core/src/utils/split-perseus-renderer.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import {applyDefaultsToWidgets} from "../widgets/apply-defaults";
 import {getPublicWidgetOptionsFunction} from "../widgets/core-widget-registry";
 

--- a/packages/perseus-core/src/utils/test-utils.ts
+++ b/packages/perseus-core/src/utils/test-utils.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import deepClone from "./deep-clone";
 
 import type {PerseusItem, PerseusRenderer} from "../data-schema";

--- a/packages/perseus-editor/src/diffs/answer-area-diff.tsx
+++ b/packages/perseus-editor/src/diffs/answer-area-diff.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import _ from "underscore";
 
 import DiffEntry from "./shared/diff-entry";
 import performDiff from "./shared/widget-diff-performer";

--- a/packages/perseus-editor/src/diffs/image-widget-diff.tsx
+++ b/packages/perseus-editor/src/diffs/image-widget-diff.tsx
@@ -1,7 +1,6 @@
 import {components} from "@khanacademy/perseus";
 import classNames from "classnames";
 import * as React from "react";
-import _ from "underscore";
 
 import type {ImageWidget} from "@khanacademy/perseus-core";
 

--- a/packages/perseus-editor/src/diffs/widget-diff.tsx
+++ b/packages/perseus-editor/src/diffs/widget-diff.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import _ from "underscore";
 
 import ImageWidgetDiff from "./image-widget-diff";
 import DiffEntry from "./shared/diff-entry";

--- a/packages/perseus-score/src/widgets/plotter/score-plotter.ts
+++ b/packages/perseus-score/src/widgets/plotter/score-plotter.ts
@@ -1,5 +1,4 @@
 import {approximateDeepEqual} from "@khanacademy/perseus-core";
-import _ from "underscore";
 
 import type {
     PerseusPlotterUserInput,

--- a/packages/perseus-score/src/widgets/plotter/validate-plotter.ts
+++ b/packages/perseus-score/src/widgets/plotter/validate-plotter.ts
@@ -1,5 +1,4 @@
 import {approximateDeepEqual} from "@khanacademy/perseus-core";
-import _ from "underscore";
 
 import type {
     PerseusPlotterUserInput,

--- a/packages/perseus-score/src/widgets/sorter/score-sorter.ts
+++ b/packages/perseus-score/src/widgets/sorter/score-sorter.ts
@@ -1,5 +1,4 @@
 import {approximateDeepEqual} from "@khanacademy/perseus-core";
-import _ from "underscore";
 
 import type {
     PerseusSorterRubric,

--- a/packages/perseus/src/mixins/editor-jsonify.ts
+++ b/packages/perseus/src/mixins/editor-jsonify.ts
@@ -1,5 +1,3 @@
-import _ from "underscore";
-
 import {excludeDenylistKeys} from "./widget-prop-denylist";
 
 /**

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.tsx
@@ -1,6 +1,5 @@
 import {Errors, PerseusError} from "@khanacademy/perseus-core";
 import * as React from "react";
-import _ from "underscore";
 
 import {PerseusI18nContext} from "../../components/i18n-context";
 import Util from "../../util";

--- a/packages/perseus/src/widgets/label-image/answer-choices.tsx
+++ b/packages/perseus/src/widgets/label-image/answer-choices.tsx
@@ -7,7 +7,6 @@ import {
     OptionItem,
 } from "@khanacademy/wonder-blocks-dropdown";
 import * as React from "react";
-import _ from "underscore";
 
 import {usePerseusI18n} from "../../components/i18n-context";
 import Renderer from "../../renderer";

--- a/packages/perseus/src/widgets/numeric-input/input-with-examples.tsx
+++ b/packages/perseus/src/widgets/numeric-input/input-with-examples.tsx
@@ -2,7 +2,6 @@ import * as PerseusLinter from "@khanacademy/perseus-linter";
 import Tooltip, {TooltipContent} from "@khanacademy/wonder-blocks-tooltip";
 import * as React from "react";
 import {forwardRef, useId, useImperativeHandle} from "react";
-import _ from "underscore";
 
 import {PerseusI18nContext} from "../../components/i18n-context";
 import TextInput from "../../components/text-input";

--- a/packages/perseus/src/widgets/video/video.tsx
+++ b/packages/perseus/src/widgets/video/video.tsx
@@ -4,7 +4,6 @@
 
 import {View} from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
-import _ from "underscore";
 
 import FixedToResponsive from "../../components/fixed-to-responsive";
 import {PerseusI18nContext} from "../../components/i18n-context";


### PR DESCRIPTION
## Summary:
These aren't used. We have a linter rule that finds unused variables, but it excludes `_`. :(

Claude recommends bringing in [eslint-plugin-unused-imports](https://github.com/sweepline/eslint-plugin-unused-imports), but that's a new dep that we're currently not using.

Another idea to catch these automatically is in [this PR (link)](https://github.com/Khan/perseus/pull/3977/changes#diff-e2954b558f2aa82baff0e30964490d12942e0e251c1aa56c3294de6ec67b7cf5).