### PR TITLE
Fix linter to find unused underscore imports

### DIFF
--- a/.changeset/famous-clowns-sing.md
+++ b/.changeset/famous-clowns-sing.md
@@ -1,0 +1,10 @@
+---
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus-score": patch
+"@khanacademy/perseus-core": patch
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+"@khanacademy/kas": patch
+---
+
+Tweak an eslint rule related to unused `_` variables and clean up related code

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -244,7 +244,7 @@ module.exports = {
                 args: "none",
                 caughtErrors: "none",
                 ignoreRestSiblings: true,
-                varsIgnorePattern: "^_[a-zA-Z]",
+                varsIgnorePattern: "^__+$",
             },
         ],
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -244,7 +244,7 @@ module.exports = {
                 args: "none",
                 caughtErrors: "none",
                 ignoreRestSiblings: true,
-                varsIgnorePattern: "^__+$",
+                varsIgnorePattern: "^_\\d+$",
             },
         ],
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -232,6 +232,22 @@ module.exports = {
         "object-curly-spacing": "off",
         semi: "off",
 
+        /**
+         * Overrides @khanacademy/eslint-config, which exempts any variable
+         * named `_` (varsIgnorePattern: "^_*$"). That exemption also covers
+         * import bindings, so a dead `import _ from "underscore"` was
+         * invisible to the linter
+         */
+        "@typescript-eslint/no-unused-vars": [
+            "error",
+            {
+                args: "none",
+                caughtErrors: "none",
+                ignoreRestSiblings: true,
+                varsIgnorePattern: "^_[a-zA-Z]",
+            },
+        ],
+
         "no-alert": "error",
 
         /**

--- a/packages/math-input/src/components/keypad/tab-icon-label.tsx
+++ b/packages/math-input/src/components/keypad/tab-icon-label.tsx
@@ -1,3 +1,4 @@
+import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 import * as React from "react";
 
 import type {KeypadPageType} from "../../types";
@@ -131,7 +132,7 @@ const TabIconLabel = function ({tintColor, type}: Props): React.ReactElement {
 
         default: {
             // Ensure we handle all icon types
-            throw new Error(`Invalid icon type: ${type}`);
+            throw new UnreachableCaseError(type);
         }
     }
 };

--- a/packages/math-input/src/components/keypad/tab-icon-label.tsx
+++ b/packages/math-input/src/components/keypad/tab-icon-label.tsx
@@ -131,7 +131,6 @@ const TabIconLabel = function ({tintColor, type}: Props): React.ReactElement {
 
         default: {
             // Ensure we handle all icon types
-            const _: never = type;
             throw new Error(`Invalid icon type: ${type}`);
         }
     }

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.ts
@@ -219,7 +219,7 @@ export function migrateV0ToV1(
     widget: ParsedValue<typeof parseRadioWidgetV0>,
 ): ParsedValue<typeof parseRadioWidgetV1> {
     const {options} = widget;
-    const {noneOfTheAbove: _, ...rest} = options;
+    const {noneOfTheAbove, ...rest} = options;
     return {
         ...widget,
         version: {major: 1, minor: 0},

--- a/packages/perseus-core/src/utils/generators/interactive-graph-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/interactive-graph-widget-generator.ts
@@ -281,12 +281,12 @@ export function generateInteractiveGraphQuestion(
     // This allows us to keep our test data more succinct.
     if (widgetOptions.correct && !widgetOptions.graph) {
         const {
-            coords: _,
-            coord: __,
-            center: ___,
-            radius: ____,
-            asymptote: _____,
-            match: ______,
+            coords,
+            coord,
+            center,
+            radius,
+            asymptote,
+            match,
             ...graphConfig
             // eslint-disable-next-line no-restricted-syntax
         } = widgetOptions.correct as Record<string, unknown>;

--- a/packages/perseus-core/src/widgets/grapher/grapher-util.ts
+++ b/packages/perseus-core/src/widgets/grapher/grapher-util.ts
@@ -8,6 +8,6 @@ export type GrapherPublicWidgetOptions = Pick<
 export function getGrapherPublicWidgetOptions(
     options: PerseusGrapherWidgetOptions,
 ): GrapherPublicWidgetOptions {
-    const {correct: _, ...publicOptions} = options;
+    const {correct, ...publicOptions} = options;
     return publicOptions;
 }

--- a/packages/perseus-core/src/widgets/interactive-graph/interactive-graph-util.ts
+++ b/packages/perseus-core/src/widgets/interactive-graph/interactive-graph-util.ts
@@ -23,6 +23,6 @@ export type InteractiveGraphPublicWidgetOptions = Pick<
 export function getInteractiveGraphPublicWidgetOptions(
     options: PerseusInteractiveGraphWidgetOptions,
 ): InteractiveGraphPublicWidgetOptions {
-    const {correct: _, ...publicOptions} = options;
+    const {correct, ...publicOptions} = options;
     return publicOptions;
 }

--- a/packages/perseus-core/src/widgets/label-image/label-image-util.ts
+++ b/packages/perseus-core/src/widgets/label-image/label-image-util.ts
@@ -37,7 +37,7 @@ export function getLabelImagePublicWidgetOptions(
 function getLabelImageMarkerPublicData(
     marker: PerseusLabelImageMarker,
 ): LabelImageMarkerPublicData {
-    const {answers: _, ...publicData} = marker;
+    const {answers, ...publicData} = marker;
     return publicData;
 }
 

--- a/packages/perseus-core/src/widgets/matrix/matrix-util.ts
+++ b/packages/perseus-core/src/widgets/matrix/matrix-util.ts
@@ -8,6 +8,6 @@ export type MatrixPublicWidgetOptions = Pick<
 export function getMatrixPublicWidgetOptions(
     options: PerseusMatrixWidgetOptions,
 ): MatrixPublicWidgetOptions {
-    const {answers: _, ...publicOptions} = options;
+    const {answers, ...publicOptions} = options;
     return publicOptions;
 }

--- a/packages/perseus-core/src/widgets/number-line/number-line-util.ts
+++ b/packages/perseus-core/src/widgets/number-line/number-line-util.ts
@@ -20,6 +20,6 @@ export type NumberLinePublicWidgetOptions = Pick<
 export function getNumberLinePublicWidgetOptions(
     options: PerseusNumberLineWidgetOptions,
 ): NumberLinePublicWidgetOptions {
-    const {correctX: _, correctRel: __, ...publicOptions} = options;
+    const {correctX, correctRel, ...publicOptions} = options;
     return publicOptions;
 }

--- a/packages/perseus-core/src/widgets/plotter/plotter-util.ts
+++ b/packages/perseus-core/src/widgets/plotter/plotter-util.ts
@@ -16,6 +16,6 @@ export type PlotterPublicWidgetOptions = Omit<
 export function getPlotterPublicWidgetOptions(
     options: PerseusPlotterWidgetOptions,
 ): PlotterPublicWidgetOptions {
-    const {correct: _, ...publicOptions} = options;
+    const {correct, ...publicOptions} = options;
     return publicOptions;
 }

--- a/packages/perseus-core/src/widgets/table/table-util.ts
+++ b/packages/perseus-core/src/widgets/table/table-util.ts
@@ -8,6 +8,6 @@ export type TablePublicWidgetOptions = Pick<
 export function getTablePublicWidgetOptions(
     options: PerseusTableWidgetOptions,
 ): TablePublicWidgetOptions {
-    const {answers: _, ...publicOptions} = options;
+    const {answers, ...publicOptions} = options;
     return publicOptions;
 }

--- a/packages/perseus-editor/src/preview/sanitize-api-options.ts
+++ b/packages/perseus-editor/src/preview/sanitize-api-options.ts
@@ -39,15 +39,15 @@ export function sanitizeApiOptions(
 ): SerializableApiOptions {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const {
-        onFocusChange: _,
-        answerableCallback: __,
-        getAnotherHint: ___,
-        interactionCallback: ____,
-        trackInteraction: _____,
-        baseElements: _______,
+        onFocusChange,
+        answerableCallback,
+        getAnotherHint,
+        interactionCallback,
+        trackInteraction,
+        baseElements,
         // Remove React nodes (placeholders)
-        imagePlaceholder: _________,
-        widgetPlaceholder: __________,
+        imagePlaceholder,
+        widgetPlaceholder,
         ...serializableOptions
     } = apiOptions;
 

--- a/packages/perseus-editor/src/widgets/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor.tsx
@@ -170,13 +170,13 @@ class ExpressionEditor extends React.Component<Props, State> {
         // which in most case is what we want, but is not what we want
         // in the editing experience because we should recalculate them
         // when answers change
-        const {extraKeys: _, ...restProps} = this.props;
+        const {extraKeys, ...restProps} = this.props;
 
-        const extraKeys = deriveExtraKeys({
+        const derivedExtraKeys = deriveExtraKeys({
             ...restProps,
             answerForms,
         });
-        this.props.onChange({answerForms, extraKeys});
+        this.props.onChange({answerForms, extraKeys: derivedExtraKeys});
     }
 
     // called when the selected buttonset changes

--- a/packages/perseus/src/components/number-input.tsx
+++ b/packages/perseus/src/components/number-input.tsx
@@ -226,10 +226,10 @@ class NumberInput extends React.Component<any, any> {
         }
 
         const {
-            onFormatChange: _,
-            checkValidity: __,
-            useArrowKeys: ___,
-            allowPiTruncation: ____,
+            onFormatChange,
+            checkValidity,
+            useArrowKeys,
+            allowPiTruncation,
             ...restProps
         } = this.props;
 

--- a/packages/perseus/src/interactive2/movable.test.ts
+++ b/packages/perseus/src/interactive2/movable.test.ts
@@ -84,7 +84,7 @@ describe("Movable", () => {
         const dummyGraphie: any = {};
         const modifySpy = jest.fn().mockName("modify");
 
-        const __ = new Movable(dummyGraphie, {modify: modifySpy});
+        const _0 = new Movable(dummyGraphie, {modify: modifySpy});
 
         const baseExpectedState = {
             add: [],

--- a/packages/perseus/src/interactive2/movable.test.ts
+++ b/packages/perseus/src/interactive2/movable.test.ts
@@ -84,7 +84,7 @@ describe("Movable", () => {
         const dummyGraphie: any = {};
         const modifySpy = jest.fn().mockName("modify");
 
-        const _ = new Movable(dummyGraphie, {modify: modifySpy});
+        const __ = new Movable(dummyGraphie, {modify: modifySpy});
 
         const baseExpectedState = {
             add: [],

--- a/packages/perseus/src/testing/item-flipbook/item-flipbook.tsx
+++ b/packages/perseus/src/testing/item-flipbook/item-flipbook.tsx
@@ -26,6 +26,6 @@ function useModel<T>(constructor: (observer: () => void) => T): T {
  * App-agnostic hook. Returns a function that requests a re-render of the UI.
  */
 function useRerender(): () => void {
-    const [_, dispatch] = useReducer((n) => n + 1, 0);
+    const [, dispatch] = useReducer((n) => n + 1, 0);
     return dispatch;
 }

--- a/packages/perseus/src/widgets/cs-program/cs-program.tsx
+++ b/packages/perseus/src/widgets/cs-program/cs-program.tsx
@@ -96,7 +96,7 @@ const CSProgram = forwardRef<Widget, Props>(function CSProgram(props, ref) {
          * [LEMS-3185] do not trust serializedState
          */
         getSerializedState: (): any => {
-            const {userInput: _, alignment: __, ...rest} = props;
+            const {userInput, alignment, ...rest} = props;
             return {
                 ...rest,
                 programType: rest.programType || null,

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -536,7 +536,7 @@ class Grapher extends React.Component<Props> implements Widget {
      * [LEMS-3185] do not trust serializedState
      */
     getSerializedState() {
-        const {userInput: _, correct: __, ...rest} = this.props;
+        const {userInput, correct, ...rest} = this.props;
         return {
             ...rest,
             plot: this.props.userInput,

--- a/packages/perseus/src/widgets/iframe/iframe.tsx
+++ b/packages/perseus/src/widgets/iframe/iframe.tsx
@@ -64,7 +64,7 @@ class Iframe extends React.Component<Props> implements Widget {
      * [LEMS-3185] do not trust serializedState
      */
     getSerializedState(): any {
-        const {userInput: _, alignment: __, ...rest} = this.props;
+        const {userInput, alignment, ...rest} = this.props;
         return rest;
     }
 

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/components/hairlines.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/components/hairlines.tsx
@@ -18,8 +18,8 @@ export default function Hairlines(props: Props) {
 
     const [[verticalStartX]] = useTransformVectorsToPixels([xMin, 0]);
     const [[verticalEndX]] = useTransformVectorsToPixels([xMax, 0]);
-    const [[_, horizontalStartY]] = useTransformVectorsToPixels([0, yMin]);
-    const [[__, horizontalEndY]] = useTransformVectorsToPixels([0, yMax]);
+    const [[, horizontalStartY]] = useTransformVectorsToPixels([0, yMin]);
+    const [[, horizontalEndY]] = useTransformVectorsToPixels([0, yMax]);
 
     return (
         <g

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.tsx
@@ -235,7 +235,7 @@ class InteractiveGraph extends React.Component<Props, State> {
      * [LEMS-3185] do not trust serializedState
      */
     getSerializedState() {
-        const {userInput: _, ...rest} = this.props;
+        const {userInput, ...rest} = this.props;
         return {
             ...rest,
             graph: this.props.userInput,

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
@@ -106,7 +106,7 @@ export const NumericInput = forwardRef<Widget, Props>(
              * [LEMS-3185] do not trust serializedState
              */
             getSerializedState() {
-                const {userInput, labelText, answers: _, ...rest} = props;
+                const {userInput, labelText, answers, ...rest} = props;
                 return {
                     ...rest,
                     answerForms: [],

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -1133,7 +1133,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
      * [LEMS-3185] do not trust serializedState
      */
     getSerializedState() {
-        const {userInput: _, ...rest} = this.props;
+        const {userInput, ...rest} = this.props;
         return {
             ...rest,
             values: this.props.userInput,

--- a/packages/perseus/src/widgets/radio/radio-widget.tsx
+++ b/packages/perseus/src/widgets/radio/radio-widget.tsx
@@ -135,12 +135,7 @@ const RadioWidget = forwardRef<RadioWidgetHandle, Props>(
                  * [LEMS-3185] do not trust serializedState
                  */
                 getSerializedState() {
-                    const {
-                        userInput: _,
-                        randomize: __,
-                        static: ___,
-                        ...rest
-                    } = props;
+                    const {userInput, randomize, static: __, ...rest} = props;
                     return {
                         ...rest,
                         numCorrect: props.numCorrect ?? 0,

--- a/packages/perseus/src/widgets/table/table.tsx
+++ b/packages/perseus/src/widgets/table/table.tsx
@@ -184,7 +184,7 @@ class Table extends React.Component<Props> implements Widget {
      * [LEMS-3185] do not trust serializedState
      */
     getSerializedState() {
-        const {userInput, editableHeaders: _, ...rest} = this.props;
+        const {userInput, editableHeaders, ...rest} = this.props;
         return {
             ...rest,
             answers: userInput,

--- a/utils/extract-css.js
+++ b/utils/extract-css.js
@@ -305,7 +305,7 @@ const getCssPropertyInfo = (property) => {
             } else {
                 const externalStyle = getImportedValues(property.argument.name);
                 if (externalStyle !== undefined) {
-                    const {importPath: _, ...styleProperties} = externalStyle;
+                    const {importPath, ...styleProperties} = externalStyle;
                     nestedRuleSet = Object.entries(styleProperties).map(
                         ([propertyName, value]) => {
                             const cssProperty = camelToKabob(propertyName);
@@ -377,7 +377,7 @@ const getImportedValues = (sourceName) => {
             )
             .forEach((node) => {
                 const filePath = getFilePath(node.source.value, fileDirectory);
-                const {_, parsedCode} = getCode(filePath);
+                const {parsedCode} = getCode(filePath);
                 const variablesFromCode = mapVariables(parsedCode);
                 if (variablesFromCode[sourceName] === undefined) {
                     importedModules[sourceName] = variablesFromCode;


### PR DESCRIPTION
## Summary:
This is a proposal to change our linting rules in a way that would have helped us catch the issue in the [previous PR](https://github.com/Khan/perseus/pull/3975). It does two things that are related:

### Change unused variable exception matching: `^_+$` to `^__+$`

Before
``` TS
// 👍 no error if unused
const _ = something;

// 👍 no error if unused
const __ = whatever;
```

After
``` TS
// 👎 error if unused
const _ = something;

// 👍 no error if unused
const __ = whatever;
```

This will help us catch needless `import _ from "underscore";`

### Add ignoreRestSiblings

Before
``` TS
// 👎 error if unused
const {something, ...rest} = whatever;

// 👍 no error if unused
const {something: __, ...rest} = whatever;
```

After
``` TS
// 👍 no error if unused
const {something, ...rest} = whatever;

// 👍 no error if unused
const {something: __, ...rest} = whatever;
```

To me this is the more semantically correct option: `something` _isn't_ unused, it's used to pull something out of `whatever` so that `rest` does not contain `something`. This keeps us from having to name variables `______` which is a real variable name I just removed. At the same time it still allows us to use `^__+$` if we want.