### PR TITLE
Remove unused defaultProps and options from the Matrix widget

### DIFF
--- a/.changeset/ten-singers-repair.md
+++ b/.changeset/ten-singers-repair.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-core": major
+"@khanacademy/perseus": patch
+---
+
+The unused `cursorPosition` and `static` options of the Matrix widget have been removed, and the `prefix` and `suffix` options are now required. As always, clients should use the parsers to migrate data to the latest schema, and avoid constructing Perseus widget data manually.

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1559,29 +1559,19 @@ export type PerseusMatrixWidgetAnswers = number[][];
 /** Options for the matrix widget. A grid of numeric cells to fill in. */
 export type PerseusMatrixWidgetOptions = {
     /** Translatable Text; Shown before the matrix */
-    prefix?: string | undefined;
+    prefix: string;
     /** Translatable Text; Shown after the matrix */
-    suffix?: string | undefined;
+    suffix: string;
     /**
      * A data matrix representing the "correct" answers to be entered into the
      * matrix
      */
     answers: PerseusMatrixWidgetAnswers;
     /**
-     * The coordinate location of the cursor position at start.
-     * default: [0, 0]
-     */
-    cursorPosition?: number[] | undefined;
-    /**
      * The coordinate size of the matrix. Only supports 2-dimensional matrix.
      * default: [3, 3]
      */
     matrixBoardSize: number[];
-    /**
-     * Whether this is meant to statically display the answers (true) or be
-     * used as an input field, graded against the answers
-     */
-    static?: boolean | undefined;
 };
 
 /** Options for the measurer widget. A virtual ruler and/or protractor. */

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matrix-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/matrix-widget.ts
@@ -1,10 +1,8 @@
 import {
     array,
-    boolean,
     constant,
     number,
     object,
-    optional,
     pipeParsers,
     string,
     union,
@@ -22,11 +20,9 @@ const numeric = pipeParsers(defaulted(numberOrStringOrNaN, () => NaN)).then(
 export const parseMatrixWidget = parseWidget(
     defaulted(constant("matrix"), () => "matrix" as const),
     object({
-        prefix: optional(string),
-        suffix: optional(string),
+        prefix: defaulted(string, () => ""),
+        suffix: defaulted(string, () => ""),
         answers: defaulted(array(array(numeric)), () => []),
-        cursorPosition: optional(array(number)),
         matrixBoardSize: array(number),
-        static: optional(boolean),
     }),
 );

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -508,9 +508,7 @@ describe("parseWidgetsMap", () => {
                     prefix: "",
                     suffix: "",
                     answers: [],
-                    cursorPosition: [],
                     matrixBoardSize: [],
-                    static: false,
                 },
             },
         };

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -2868,16 +2868,11 @@ $ \\text{H}=\\left[\\begin{array}{rr}4 & -1 \\\\ 4 & 0\\end{array}\\right]$ ",
               0,
             ],
           ],
-          "cursorPosition": [
-            0,
-            0,
-          ],
           "matrixBoardSize": [
             3,
             3,
           ],
           "prefix": "$\\textbf {H = }$",
-          "static": false,
           "suffix": "",
         },
         "static": false,
@@ -2936,16 +2931,11 @@ exports[`parseAndMigratePerseusItem given graded-group-with-false-hint.ts return
         "graded": true,
         "options": {
           "answers": [],
-          "cursorPosition": [
-            0,
-            0,
-          ],
           "matrixBoardSize": [
             3,
             3,
           ],
           "prefix": "$\\textbf {H = }$",
-          "static": false,
           "suffix": "",
         },
         "static": false,
@@ -12882,6 +12872,8 @@ exports[`parseAndMigratePerseusItem given matrix-missing-version.ts returns the 
             3,
             3,
           ],
+          "prefix": "",
+          "suffix": "",
         },
         "type": "matrix",
       },
@@ -12957,10 +12949,6 @@ exports[`parseAndMigratePerseusItem given matrix-missing-version.ts returns the 
         "graded": true,
         "options": {
           "answers": [],
-          "cursorPosition": [
-            0,
-            0,
-          ],
           "matrixBoardSize": [
             3,
             3,
@@ -13018,16 +13006,11 @@ exports[`parseAndMigratePerseusItem given matrix-with-nulls-in-answer.ts returns
               NaN,
             ],
           ],
-          "cursorPosition": [
-            0,
-            0,
-          ],
           "matrixBoardSize": [
             3,
             3,
           ],
           "prefix": "",
-          "static": false,
           "suffix": "",
         },
         "static": false,
@@ -13064,16 +13047,11 @@ exports[`parseAndMigratePerseusItem given matrix-with-nulls-in-answer.ts returns
         "graded": true,
         "options": {
           "answers": [],
-          "cursorPosition": [
-            0,
-            0,
-          ],
           "matrixBoardSize": [
             3,
             3,
           ],
           "prefix": "",
-          "static": false,
           "suffix": "",
         },
         "static": false,
@@ -13327,16 +13305,11 @@ $\\left[\\begin{array}{c}
               -5,
             ],
           ],
-          "cursorPosition": [
-            0,
-            0,
-          ],
           "matrixBoardSize": [
             4,
             1,
           ],
           "prefix": "",
-          "static": false,
           "suffix": "",
         },
         "static": false,
@@ -13413,16 +13386,11 @@ $\\left[\\begin{array}{c}
         "graded": true,
         "options": {
           "answers": [],
-          "cursorPosition": [
-            0,
-            0,
-          ],
           "matrixBoardSize": [
             4,
             1,
           ],
           "prefix": "",
-          "static": false,
           "suffix": "",
         },
         "static": false,

--- a/packages/perseus-core/src/utils/extract-perseus-ai-data.test.ts
+++ b/packages/perseus-core/src/utils/extract-perseus-ai-data.test.ts
@@ -1274,10 +1274,8 @@ describe("getAnswersFromWidgets", () => {
                     [1, -4, 7, 5],
                     [3, 4, 6, 1],
                 ],
-                cursorPosition: [0, 0],
                 matrixBoardSize: [3, 4],
                 prefix: "",
-                static: false,
                 suffix: "",
             },
         };

--- a/packages/perseus-core/src/utils/generators/matrix-widget-generator.test.ts
+++ b/packages/perseus-core/src/utils/generators/matrix-widget-generator.test.ts
@@ -82,7 +82,6 @@ describe("generateMatrixWidget", () => {
             answers: [[5, -2, 1]],
             prefix: "Row 1:",
             suffix: "",
-            cursorPosition: [0, 0],
         });
     });
 

--- a/packages/perseus-core/src/utils/generators/matrix-widget-generator.test.ts
+++ b/packages/perseus-core/src/utils/generators/matrix-widget-generator.test.ts
@@ -15,7 +15,6 @@ describe("generateMatrixOptions", () => {
         expect(options.answers).toEqual([[]]);
         expect(options.prefix).toBe("");
         expect(options.suffix).toBe("");
-        expect(options.cursorPosition).toEqual([0, 0]);
     });
 
     it("builds matrix options with all props", () => {
@@ -28,8 +27,6 @@ describe("generateMatrixOptions", () => {
             ],
             prefix: "Given $A =$",
             suffix: "($2 \\times 2$ matrix)",
-            cursorPosition: [1, 1],
-            static: true,
         });
 
         // Assert
@@ -40,8 +37,6 @@ describe("generateMatrixOptions", () => {
         ]);
         expect(options.prefix).toBe("Given $A =$");
         expect(options.suffix).toBe("($2 \\times 2$ matrix)");
-        expect(options.cursorPosition).toEqual([1, 1]);
-        expect(options.static).toBe(true);
     });
 });
 
@@ -74,7 +69,6 @@ describe("generateMatrixWidget", () => {
                 answers: [[5, -2, 1]],
                 prefix: "Row 1:",
                 suffix: "",
-                cursorPosition: [0, 0],
             },
         });
 

--- a/packages/perseus-core/src/widgets/matrix/index.ts
+++ b/packages/perseus-core/src/widgets/matrix/index.ts
@@ -6,7 +6,7 @@ import type {WidgetLogic} from "../logic-export.types";
 
 export type MatrixDefaultWidgetOptions = Pick<
     PerseusMatrixWidgetOptions,
-    "matrixBoardSize" | "answers" | "prefix" | "suffix" | "cursorPosition"
+    "matrixBoardSize" | "answers" | "prefix" | "suffix"
 >;
 
 const defaultWidgetOptions: MatrixDefaultWidgetOptions = {
@@ -14,7 +14,6 @@ const defaultWidgetOptions: MatrixDefaultWidgetOptions = {
     answers: [[]],
     prefix: "",
     suffix: "",
-    cursorPosition: [0, 0],
 };
 
 const matrixWidgetLogic: WidgetLogic<

--- a/packages/perseus-core/src/widgets/matrix/matrix-util.test.ts
+++ b/packages/perseus-core/src/widgets/matrix/matrix-util.test.ts
@@ -9,7 +9,6 @@ describe("getMatrixPublicWidgetOptions", () => {
                 [1, 2],
                 [3, 4],
             ],
-            cursorPosition: [0, 0],
             matrixBoardSize: [2, 2],
             prefix: "the prefix",
             suffix: "the suffix",
@@ -18,7 +17,6 @@ describe("getMatrixPublicWidgetOptions", () => {
         const publicOptions = getMatrixPublicWidgetOptions(options);
 
         expect(publicOptions).toEqual({
-            cursorPosition: [0, 0],
             matrixBoardSize: [2, 2],
             prefix: "the prefix",
             suffix: "the suffix",

--- a/packages/perseus-core/src/widgets/matrix/matrix-util.ts
+++ b/packages/perseus-core/src/widgets/matrix/matrix-util.ts
@@ -2,7 +2,7 @@ import type {PerseusMatrixWidgetOptions} from "../../data-schema";
 
 export type MatrixPublicWidgetOptions = Pick<
     PerseusMatrixWidgetOptions,
-    "prefix" | "suffix" | "cursorPosition" | "matrixBoardSize" | "static"
+    "prefix" | "suffix" | "matrixBoardSize"
 >;
 
 export function getMatrixPublicWidgetOptions(

--- a/packages/perseus-editor/src/__testdata__/all-widgets.testdata.ts
+++ b/packages/perseus-editor/src/__testdata__/all-widgets.testdata.ts
@@ -21,6 +21,7 @@ import {
     generateImageWidget,
     generateInteractiveGraphOptions,
     generateInteractiveGraphWidget,
+    generateMatrixOptions,
     generateNumericInputAnswer,
     generateNumericInputOptions,
     generateNumericInputWidget,
@@ -154,13 +155,13 @@ export const comprehensiveQuestion: PerseusRenderer = {
             version: {major: 0, minor: 0},
             static: false,
             type: "matrix",
-            options: {
+            options: generateMatrixOptions({
                 matrixBoardSize: [2, 2],
                 answers: [
                     [1, 0],
                     [0, 1],
                 ],
-            },
+            }),
         },
         "definition 1": generateDefinitionWidget({
             options: generateDefinitionOptions({

--- a/packages/perseus/src/widget-ai-utils/matrix/matrix-ai-utils.test.ts
+++ b/packages/perseus/src/widget-ai-utils/matrix/matrix-ai-utils.test.ts
@@ -22,15 +22,13 @@ const question: PerseusRenderer = {
             static: false,
             type: "matrix",
             options: {
-                cursorPosition: [0, 0],
+                prefix: "",
                 suffix: "",
                 answers: [
                     [5, -2, 1, 1],
                     [1, 1, 7, -3],
                     [3, 0, 0, -2],
                 ],
-                prefix: "",
-                static: false,
                 matrixBoardSize: [3, 4],
             },
             alignment: "default",

--- a/packages/perseus/src/widgets/matrix/matrix.test.ts
+++ b/packages/perseus/src/widgets/matrix/matrix.test.ts
@@ -138,10 +138,8 @@ describe("matrix widget", () => {
         const matrixOptions: PerseusMatrixWidgetOptions = {
             answers: [[5, -2]],
             matrixBoardSize: [1, 2],
-            cursorPosition: [0, 0],
             prefix: "",
             suffix: "",
-            static: false,
         };
 
         test("the answerless test data doesn't contain answers", () => {

--- a/packages/perseus/src/widgets/matrix/matrix.testdata.ts
+++ b/packages/perseus/src/widgets/matrix/matrix.testdata.ts
@@ -11,15 +11,13 @@ export const question1: PerseusRenderer = {
             static: false,
             type: "matrix",
             options: {
-                cursorPosition: [0, 0],
+                prefix: "",
                 suffix: "",
                 answers: [
                     [5, -2, 1, 1],
                     [1, 1, 7, -3],
                     [3, 0, 0, -2],
                 ],
-                prefix: "",
-                static: false,
                 matrixBoardSize: [3, 4],
             },
             alignment: "default",

--- a/packages/perseus/src/widgets/matrix/serialize-matrix.test.ts
+++ b/packages/perseus/src/widgets/matrix/serialize-matrix.test.ts
@@ -1,4 +1,5 @@
 import {
+    generateMatrixOptions,
     generateTestPerseusItem,
     generateTestPerseusRenderer,
 } from "@khanacademy/perseus-core";
@@ -39,13 +40,13 @@ describe("Matrix serialization", () => {
             widgets: {
                 "matrix 1": {
                     type: "matrix",
-                    options: {
+                    options: generateMatrixOptions({
                         answers: [
                             [1, 2],
                             [3, 4],
                         ],
                         matrixBoardSize: [2, 2],
-                    },
+                    }),
                 },
             },
         });


### PR DESCRIPTION
## Summary:

The defaultProps aren't needed; all widget options are always provided.

The `static` option had no effect — it gets overridden by the `static` field of
the widget object.

`cursorPosition` was completely unused, and looks to have gotten into the data
by accident and then been transferred to the schema.

Issue: LEMS-4354

## Test plan:

Test the Matrix and its editor in Storybook.