### PR TITLE
[Color Sync] Exclude visual regression stories from Storybook autodocs

### DIFF
--- a/packages/perseus/src/__docs__/renderer-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/__docs__/renderer-initial-state-regression.stories.tsx
@@ -18,7 +18,7 @@ type Story = StoryObj;
 
 const meta: Meta<PerseusRenderer> = {
     title: "Renderers/Visual Regression Tests",
-    tags: ["!manifest"],
+    tags: ["!autodocs", "!manifest"],
     parameters: {
         docs: {
             description: {


### PR DESCRIPTION
## Summary
Updated the visual regression test stories to exclude them from Storybook's autodocs generation, in addition to the existing manifest exclusion.

### Changes
- Added `"!autodocs"` tag to the renderer initial state regression stories metadata
- This prevents these visual regression test stories from appearing in the Storybook documentation while maintaining the existing `"!manifest"` exclusion

### Rationale
Visual regression test stories are internal testing utilities and should not be included in the generated Storybook documentation. The `!autodocs` tag ensures they're properly hidden from the docs UI while keeping them available for testing purposes.

https://claude.ai/code/session_01KbpCWTumk7dnfT1bKkFFVX

Docs tab on the right (before) is now removed on the left (after):
<img height="391" alt="image" src="https://github.com/user-attachments/assets/55510e36-d5fc-4616-9060-c2542fddd821" />


Issue: LEMS-4047

## Test Plan:
- Confirm no changes to renderer initial state chromatic stories
- Confirm renderer initial state stories conform to setup of other visual regression stories