### PR TITLE
[Color][Categorizer] Convert font and colors to semantic tokens

### DIFF
--- a/.changeset/clear-suns-read.md
+++ b/.changeset/clear-suns-read.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus": patch
+---
+
+Update Categorizer to reflect the current theme using semantic tokens for colors and fonts

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -741,7 +741,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_10ojurn-o_O-checkedRadioSpan_tt866m"
+                                    class="radioSpan_1nbt5tl-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -767,7 +767,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_10ojurn"
+                                    class="radioSpan_1nbt5tl"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -811,7 +811,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_10ojurn"
+                                    class="radioSpan_1nbt5tl"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -837,7 +837,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_10ojurn-o_O-checkedRadioSpan_tt866m"
+                                    class="radioSpan_1nbt5tl-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -881,7 +881,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_10ojurn-o_O-checkedRadioSpan_tt866m"
+                                    class="radioSpan_1nbt5tl-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -907,7 +907,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_10ojurn"
+                                    class="radioSpan_1nbt5tl"
                                   >
                                     <svg
                                       aria-hidden="true"

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -734,14 +734,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_13aakpm"
+                                class="category cell_1sl942g"
                               >
                                 <div
                                   aria-label="Fruits"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1dzc0m3-o_O-checkedRadioSpan_a3qe0k"
+                                    class="radioSpan_1cqf8h5-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -760,14 +760,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_13aakpm"
+                                class="category cell_1sl942g"
                               >
                                 <div
                                   aria-label="Vegetables"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1dzc0m3"
+                                    class="radioSpan_1cqf8h5"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -804,14 +804,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_13aakpm"
+                                class="category cell_1sl942g"
                               >
                                 <div
                                   aria-label="Fruits"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1dzc0m3"
+                                    class="radioSpan_1cqf8h5"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -830,14 +830,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_13aakpm"
+                                class="category cell_1sl942g"
                               >
                                 <div
                                   aria-label="Vegetables"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1dzc0m3-o_O-checkedRadioSpan_a3qe0k"
+                                    class="radioSpan_1cqf8h5-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -874,14 +874,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_13aakpm"
+                                class="category cell_1sl942g"
                               >
                                 <div
                                   aria-label="Fruits"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1dzc0m3-o_O-checkedRadioSpan_a3qe0k"
+                                    class="radioSpan_1cqf8h5-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -900,14 +900,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_13aakpm"
+                                class="category cell_1sl942g"
                               >
                                 <div
                                   aria-label="Vegetables"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1dzc0m3"
+                                    class="radioSpan_1cqf8h5"
                                   >
                                     <svg
                                       aria-hidden="true"

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -741,7 +741,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1mq3xs9-o_O-checkedRadioSpan_a3qe0k"
+                                    class="radioSpan_ldmzts-o_O-checkedRadioSpan_a3qe0k"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -767,7 +767,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1mq3xs9"
+                                    class="radioSpan_ldmzts"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -811,7 +811,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1mq3xs9"
+                                    class="radioSpan_ldmzts"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -837,7 +837,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1mq3xs9-o_O-checkedRadioSpan_a3qe0k"
+                                    class="radioSpan_ldmzts-o_O-checkedRadioSpan_a3qe0k"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -881,7 +881,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1mq3xs9-o_O-checkedRadioSpan_a3qe0k"
+                                    class="radioSpan_ldmzts-o_O-checkedRadioSpan_a3qe0k"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -907,7 +907,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1mq3xs9"
+                                    class="radioSpan_ldmzts"
                                   >
                                     <svg
                                       aria-hidden="true"

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -741,7 +741,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1nbt5tl-o_O-checkedRadioSpan_tt866m"
+                                    class="radioSpan_buhzha-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -767,7 +767,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1nbt5tl"
+                                    class="radioSpan_buhzha"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -811,7 +811,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1nbt5tl"
+                                    class="radioSpan_buhzha"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -837,7 +837,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1nbt5tl-o_O-checkedRadioSpan_tt866m"
+                                    class="radioSpan_buhzha-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -881,7 +881,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1nbt5tl-o_O-checkedRadioSpan_tt866m"
+                                    class="radioSpan_buhzha-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -907,7 +907,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1nbt5tl"
+                                    class="radioSpan_buhzha"
                                   >
                                     <svg
                                       aria-hidden="true"

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -741,7 +741,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_ldmzts-o_O-checkedRadioSpan_a3qe0k"
+                                    class="radioSpan_1dzc0m3-o_O-checkedRadioSpan_a3qe0k"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -767,7 +767,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_ldmzts"
+                                    class="radioSpan_1dzc0m3"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -811,7 +811,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_ldmzts"
+                                    class="radioSpan_1dzc0m3"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -837,7 +837,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_ldmzts-o_O-checkedRadioSpan_a3qe0k"
+                                    class="radioSpan_1dzc0m3-o_O-checkedRadioSpan_a3qe0k"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -881,7 +881,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_ldmzts-o_O-checkedRadioSpan_a3qe0k"
+                                    class="radioSpan_1dzc0m3-o_O-checkedRadioSpan_a3qe0k"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -907,7 +907,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_ldmzts"
+                                    class="radioSpan_1dzc0m3"
                                   >
                                     <svg
                                       aria-hidden="true"

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -734,14 +734,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_1sl942g"
+                                class="category cell_1wviiqy"
                               >
                                 <div
                                   aria-label="Fruits"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1cqf8h5-o_O-checkedRadioSpan_tt866m"
+                                    class="radioSpan_10ojurn-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -760,14 +760,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_1sl942g"
+                                class="category cell_1wviiqy"
                               >
                                 <div
                                   aria-label="Vegetables"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1cqf8h5"
+                                    class="radioSpan_10ojurn"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -804,14 +804,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_1sl942g"
+                                class="category cell_1wviiqy"
                               >
                                 <div
                                   aria-label="Fruits"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1cqf8h5"
+                                    class="radioSpan_10ojurn"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -830,14 +830,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_1sl942g"
+                                class="category cell_1wviiqy"
                               >
                                 <div
                                   aria-label="Vegetables"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1cqf8h5-o_O-checkedRadioSpan_tt866m"
+                                    class="radioSpan_10ojurn-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -874,14 +874,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_1sl942g"
+                                class="category cell_1wviiqy"
                               >
                                 <div
                                   aria-label="Fruits"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1cqf8h5-o_O-checkedRadioSpan_tt866m"
+                                    class="radioSpan_10ojurn-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -900,14 +900,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_1sl942g"
+                                class="category cell_1wviiqy"
                               >
                                 <div
                                   aria-label="Vegetables"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1cqf8h5"
+                                    class="radioSpan_10ojurn"
                                   >
                                     <svg
                                       aria-hidden="true"

--- a/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
@@ -857,7 +857,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_10ojurn-o_O-checkedRadioSpan_tt866m"
+                                    class="radioSpan_1nbt5tl-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -883,7 +883,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_10ojurn"
+                                    class="radioSpan_1nbt5tl"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -927,7 +927,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_10ojurn"
+                                    class="radioSpan_1nbt5tl"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -953,7 +953,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_10ojurn-o_O-checkedRadioSpan_tt866m"
+                                    class="radioSpan_1nbt5tl-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -997,7 +997,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_10ojurn-o_O-checkedRadioSpan_tt866m"
+                                    class="radioSpan_1nbt5tl-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -1023,7 +1023,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_10ojurn"
+                                    class="radioSpan_1nbt5tl"
                                   >
                                     <svg
                                       aria-hidden="true"

--- a/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
@@ -857,7 +857,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1mq3xs9-o_O-checkedRadioSpan_a3qe0k"
+                                    class="radioSpan_ldmzts-o_O-checkedRadioSpan_a3qe0k"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -883,7 +883,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1mq3xs9"
+                                    class="radioSpan_ldmzts"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -927,7 +927,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1mq3xs9"
+                                    class="radioSpan_ldmzts"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -953,7 +953,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1mq3xs9-o_O-checkedRadioSpan_a3qe0k"
+                                    class="radioSpan_ldmzts-o_O-checkedRadioSpan_a3qe0k"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -997,7 +997,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1mq3xs9-o_O-checkedRadioSpan_a3qe0k"
+                                    class="radioSpan_ldmzts-o_O-checkedRadioSpan_a3qe0k"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -1023,7 +1023,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1mq3xs9"
+                                    class="radioSpan_ldmzts"
                                   >
                                     <svg
                                       aria-hidden="true"

--- a/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
@@ -857,7 +857,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_ldmzts-o_O-checkedRadioSpan_a3qe0k"
+                                    class="radioSpan_1dzc0m3-o_O-checkedRadioSpan_a3qe0k"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -883,7 +883,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_ldmzts"
+                                    class="radioSpan_1dzc0m3"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -927,7 +927,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_ldmzts"
+                                    class="radioSpan_1dzc0m3"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -953,7 +953,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_ldmzts-o_O-checkedRadioSpan_a3qe0k"
+                                    class="radioSpan_1dzc0m3-o_O-checkedRadioSpan_a3qe0k"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -997,7 +997,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_ldmzts-o_O-checkedRadioSpan_a3qe0k"
+                                    class="radioSpan_1dzc0m3-o_O-checkedRadioSpan_a3qe0k"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -1023,7 +1023,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_ldmzts"
+                                    class="radioSpan_1dzc0m3"
                                   >
                                     <svg
                                       aria-hidden="true"

--- a/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
@@ -850,14 +850,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_13aakpm"
+                                class="category cell_1sl942g"
                               >
                                 <div
                                   aria-label="Fruits"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1dzc0m3-o_O-checkedRadioSpan_a3qe0k"
+                                    class="radioSpan_1cqf8h5-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -876,14 +876,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_13aakpm"
+                                class="category cell_1sl942g"
                               >
                                 <div
                                   aria-label="Vegetables"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1dzc0m3"
+                                    class="radioSpan_1cqf8h5"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -920,14 +920,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_13aakpm"
+                                class="category cell_1sl942g"
                               >
                                 <div
                                   aria-label="Fruits"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1dzc0m3"
+                                    class="radioSpan_1cqf8h5"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -946,14 +946,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_13aakpm"
+                                class="category cell_1sl942g"
                               >
                                 <div
                                   aria-label="Vegetables"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1dzc0m3-o_O-checkedRadioSpan_a3qe0k"
+                                    class="radioSpan_1cqf8h5-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -990,14 +990,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_13aakpm"
+                                class="category cell_1sl942g"
                               >
                                 <div
                                   aria-label="Fruits"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1dzc0m3-o_O-checkedRadioSpan_a3qe0k"
+                                    class="radioSpan_1cqf8h5-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -1016,14 +1016,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_13aakpm"
+                                class="category cell_1sl942g"
                               >
                                 <div
                                   aria-label="Vegetables"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1dzc0m3"
+                                    class="radioSpan_1cqf8h5"
                                   >
                                     <svg
                                       aria-hidden="true"

--- a/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
@@ -857,7 +857,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1nbt5tl-o_O-checkedRadioSpan_tt866m"
+                                    class="radioSpan_buhzha-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -883,7 +883,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1nbt5tl"
+                                    class="radioSpan_buhzha"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -927,7 +927,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1nbt5tl"
+                                    class="radioSpan_buhzha"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -953,7 +953,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1nbt5tl-o_O-checkedRadioSpan_tt866m"
+                                    class="radioSpan_buhzha-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -997,7 +997,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1nbt5tl-o_O-checkedRadioSpan_tt866m"
+                                    class="radioSpan_buhzha-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -1023,7 +1023,7 @@ table: [[☃ table 1]]
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1nbt5tl"
+                                    class="radioSpan_buhzha"
                                   >
                                     <svg
                                       aria-hidden="true"

--- a/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page.test.tsx.snap
@@ -850,14 +850,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_1sl942g"
+                                class="category cell_1wviiqy"
                               >
                                 <div
                                   aria-label="Fruits"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1cqf8h5-o_O-checkedRadioSpan_tt866m"
+                                    class="radioSpan_10ojurn-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -876,14 +876,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_1sl942g"
+                                class="category cell_1wviiqy"
                               >
                                 <div
                                   aria-label="Vegetables"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1cqf8h5"
+                                    class="radioSpan_10ojurn"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -920,14 +920,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_1sl942g"
+                                class="category cell_1wviiqy"
                               >
                                 <div
                                   aria-label="Fruits"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1cqf8h5"
+                                    class="radioSpan_10ojurn"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -946,14 +946,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_1sl942g"
+                                class="category cell_1wviiqy"
                               >
                                 <div
                                   aria-label="Vegetables"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1cqf8h5-o_O-checkedRadioSpan_tt866m"
+                                    class="radioSpan_10ojurn-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -990,14 +990,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_1sl942g"
+                                class="category cell_1wviiqy"
                               >
                                 <div
                                   aria-label="Fruits"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1cqf8h5-o_O-checkedRadioSpan_tt866m"
+                                    class="radioSpan_10ojurn-o_O-checkedRadioSpan_tt866m"
                                   >
                                     <svg
                                       aria-hidden="true"
@@ -1016,14 +1016,14 @@ table: [[☃ table 1]]
                                 </div>
                               </td>
                               <td
-                                class="category cell_1sl942g"
+                                class="category cell_1wviiqy"
                               >
                                 <div
                                   aria-label="Vegetables"
                                   role="button"
                                 >
                                   <span
-                                    class="radioSpan_1cqf8h5"
+                                    class="radioSpan_10ojurn"
                                   >
                                     <svg
                                       aria-hidden="true"

--- a/packages/perseus/src/styles/constants.ts
+++ b/packages/perseus/src/styles/constants.ts
@@ -52,8 +52,5 @@ export const warningColorActive = "#c75300";
 
 export const publishBlockingErrorColor = "#be2612";
 
-export const radioBorderColor = "#BABEC2";
-export const checkedColor = "#71B307";
-
 export const articleMaxWidthInPx = 688;
 export const articleMaxWidthTableInPx = 512;

--- a/packages/perseus/src/styles/shared.ts
+++ b/packages/perseus/src/styles/shared.ts
@@ -89,6 +89,15 @@ export default StyleSheet.create({
         },
     },
 
+    responsiveRadioInputStatic: {
+        ":checked": {
+            backgroundColor: semanticColor.core.foreground.disabled.strong,
+            boxShadow:
+                `inset 0px 0px 0px 2px white, ` +
+                `0 0px 0px 2px ${semanticColor.core.foreground.disabled.strong}`,
+        },
+    },
+
     responsiveRadioInputActive: {
         backgroundColor: "#fff",
         border: "2px solid #fff",

--- a/packages/perseus/src/styles/shared.ts
+++ b/packages/perseus/src/styles/shared.ts
@@ -1,4 +1,4 @@
-import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 
 import * as constants from "./constants";
@@ -54,7 +54,7 @@ export default StyleSheet.create({
 
         backgroundColor: "#fff",
         border: "2px solid #fff",
-        boxShadow: `0 0px 0px 1px ${semanticColor.core.border.neutral.subtle}`,
+        boxShadow: `0 0px 0px ${border.width.medium} ${semanticColor.core.border.neutral.subtle}`,
         outline: "none",
 
         boxSizing: "border-box",

--- a/packages/perseus/src/styles/shared.ts
+++ b/packages/perseus/src/styles/shared.ts
@@ -1,3 +1,4 @@
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 
 import * as constants from "./constants";
@@ -5,8 +6,7 @@ import mediaQueries from "./media-queries";
 
 import type {StyleDeclaration} from "aphrodite";
 
-const {radioBorderColor, checkedColor, circleSize, radioMarginWidth} =
-    constants;
+const {circleSize, radioMarginWidth} = constants;
 
 // eslint-disable-next-line no-restricted-syntax
 export default StyleSheet.create({
@@ -54,7 +54,7 @@ export default StyleSheet.create({
 
         backgroundColor: "#fff",
         border: "2px solid #fff",
-        boxShadow: `0 0px 0px 1px ${radioBorderColor}`,
+        boxShadow: `0 0px 0px 1px ${semanticColor.core.border.neutral.subtle}`,
         outline: "none",
 
         boxSizing: "border-box",
@@ -72,12 +72,12 @@ export default StyleSheet.create({
         borderRadius: "50%",
 
         ":checked": {
-            backgroundColor: checkedColor,
+            backgroundColor: semanticColor.core.foreground.instructive.default,
             border: "none",
             borderRadius: "50%",
             boxShadow:
                 `inset 0px 0px 0px 2px white, ` +
-                `0 0px 0px 2px ${checkedColor}`,
+                `0 0px 0px 2px ${semanticColor.core.foreground.instructive.default}`,
 
             marginTop: radioMarginWidth,
             marginBottom: radioMarginWidth,
@@ -93,7 +93,7 @@ export default StyleSheet.create({
         backgroundColor: "#fff",
         border: "2px solid #fff",
         borderRadius: "50%",
-        boxShadow: `0 0px 0px 2px ${checkedColor}`,
+        boxShadow: `0 0px 0px 2px ${semanticColor.core.border.neutral.strong}`,
 
         marginTop: radioMarginWidth,
         marginBottom: radioMarginWidth,

--- a/packages/perseus/src/styles/widgets/categorizer.css
+++ b/packages/perseus/src/styles/widgets/categorizer.css
@@ -17,13 +17,13 @@ body.mobile
     td.category
     input[type="radio"]:checked
     + span:before {
-    color: #1c758a;
+    color: var(--wb-semanticColor-core-foreground-instructive-default);
 }
 body.mobile
     .categorizer-container
     td.category
     input[type="radio"]
     + span:active:before {
-    color: #666;
+    color: var(--wb-semanticColor-core-foreground-neutral-default);
     content: "\f111"; /* fa-circle */
 }

--- a/packages/perseus/src/widgets/categorizer/__docs__/categorizer-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/categorizer/__docs__/categorizer-initial-state-regression.stories.tsx
@@ -103,6 +103,16 @@ export const AnsweredMobile: Story = {
     },
 };
 
+export const StaticMobile: Story = {
+    decorators: [categorizerRendererDecorator, mobileDecorator],
+    args: categorizerOptions,
+    parameters: {
+        apiOptions: {isMobile: true},
+        static: true,
+        initialUserInput: answer,
+    },
+};
+
 export const RightToLeft: Story = {
     decorators: [categorizerRendererDecorator, rtlDecorator],
     args: categorizerOptions,

--- a/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
+++ b/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
@@ -590,7 +590,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_ldmzts"
+                        class="radioSpan_1dzc0m3"
                       >
                         <svg
                           aria-hidden="true"
@@ -616,7 +616,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_ldmzts"
+                        class="radioSpan_1dzc0m3"
                       >
                         <svg
                           aria-hidden="true"
@@ -642,7 +642,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_ldmzts"
+                        class="radioSpan_1dzc0m3"
                       >
                         <svg
                           aria-hidden="true"
@@ -668,7 +668,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_ldmzts"
+                        class="radioSpan_1dzc0m3"
                       >
                         <svg
                           aria-hidden="true"
@@ -723,7 +723,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_ldmzts"
+                        class="radioSpan_1dzc0m3"
                       >
                         <svg
                           aria-hidden="true"
@@ -749,7 +749,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_ldmzts"
+                        class="radioSpan_1dzc0m3"
                       >
                         <svg
                           aria-hidden="true"
@@ -775,7 +775,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_ldmzts"
+                        class="radioSpan_1dzc0m3"
                       >
                         <svg
                           aria-hidden="true"
@@ -801,7 +801,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_ldmzts"
+                        class="radioSpan_1dzc0m3"
                       >
                         <svg
                           aria-hidden="true"

--- a/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
+++ b/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
@@ -590,7 +590,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_1mq3xs9"
+                        class="radioSpan_ldmzts"
                       >
                         <svg
                           aria-hidden="true"
@@ -616,7 +616,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_1mq3xs9"
+                        class="radioSpan_ldmzts"
                       >
                         <svg
                           aria-hidden="true"
@@ -642,7 +642,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_1mq3xs9"
+                        class="radioSpan_ldmzts"
                       >
                         <svg
                           aria-hidden="true"
@@ -668,7 +668,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_1mq3xs9"
+                        class="radioSpan_ldmzts"
                       >
                         <svg
                           aria-hidden="true"
@@ -723,7 +723,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_1mq3xs9"
+                        class="radioSpan_ldmzts"
                       >
                         <svg
                           aria-hidden="true"
@@ -749,7 +749,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_1mq3xs9"
+                        class="radioSpan_ldmzts"
                       >
                         <svg
                           aria-hidden="true"
@@ -775,7 +775,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_1mq3xs9"
+                        class="radioSpan_ldmzts"
                       >
                         <svg
                           aria-hidden="true"
@@ -801,7 +801,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_1mq3xs9"
+                        class="radioSpan_ldmzts"
                       >
                         <svg
                           aria-hidden="true"

--- a/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
+++ b/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
@@ -590,7 +590,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_10ojurn"
+                        class="radioSpan_buhzha"
                       >
                         <svg
                           aria-hidden="true"
@@ -616,7 +616,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_10ojurn"
+                        class="radioSpan_buhzha"
                       >
                         <svg
                           aria-hidden="true"
@@ -642,7 +642,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_10ojurn"
+                        class="radioSpan_buhzha"
                       >
                         <svg
                           aria-hidden="true"
@@ -668,7 +668,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_10ojurn"
+                        class="radioSpan_buhzha"
                       >
                         <svg
                           aria-hidden="true"
@@ -723,7 +723,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_10ojurn"
+                        class="radioSpan_buhzha"
                       >
                         <svg
                           aria-hidden="true"
@@ -749,7 +749,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_10ojurn"
+                        class="radioSpan_buhzha"
                       >
                         <svg
                           aria-hidden="true"
@@ -775,7 +775,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_10ojurn"
+                        class="radioSpan_buhzha"
                       >
                         <svg
                           aria-hidden="true"
@@ -801,7 +801,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                       role="button"
                     >
                       <span
-                        class="radioSpan_10ojurn"
+                        class="radioSpan_buhzha"
                       >
                         <svg
                           aria-hidden="true"

--- a/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
+++ b/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
@@ -166,56 +166,56 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                     </div>
                   </td>
                   <td
-                    class="category cell_13aakpm"
+                    class="category cell_1sl942g"
                   >
                     <div
                       aria-label="No relationship"
                       role="button"
                     >
                       <input
-                        class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                        class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
                         name="perseus_radio_10_0"
                         type="radio"
                       />
                     </div>
                   </td>
                   <td
-                    class="category cell_13aakpm"
+                    class="category cell_1sl942g"
                   >
                     <div
                       aria-label="Positive linear relationship"
                       role="button"
                     >
                       <input
-                        class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                        class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
                         name="perseus_radio_10_0"
                         type="radio"
                       />
                     </div>
                   </td>
                   <td
-                    class="category cell_13aakpm"
+                    class="category cell_1sl942g"
                   >
                     <div
                       aria-label="Negative linear relationship"
                       role="button"
                     >
                       <input
-                        class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                        class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
                         name="perseus_radio_10_0"
                         type="radio"
                       />
                     </div>
                   </td>
                   <td
-                    class="category cell_13aakpm"
+                    class="category cell_1sl942g"
                   >
                     <div
                       aria-label="Nonlinear relationship"
                       role="button"
                     >
                       <input
-                        class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                        class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
                         name="perseus_radio_10_0"
                         type="radio"
                       />
@@ -251,56 +251,56 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                     </div>
                   </td>
                   <td
-                    class="category cell_13aakpm"
+                    class="category cell_1sl942g"
                   >
                     <div
                       aria-label="No relationship"
                       role="button"
                     >
                       <input
-                        class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                        class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
                         name="perseus_radio_10_1"
                         type="radio"
                       />
                     </div>
                   </td>
                   <td
-                    class="category cell_13aakpm"
+                    class="category cell_1sl942g"
                   >
                     <div
                       aria-label="Positive linear relationship"
                       role="button"
                     >
                       <input
-                        class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                        class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
                         name="perseus_radio_10_1"
                         type="radio"
                       />
                     </div>
                   </td>
                   <td
-                    class="category cell_13aakpm"
+                    class="category cell_1sl942g"
                   >
                     <div
                       aria-label="Negative linear relationship"
                       role="button"
                     >
                       <input
-                        class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                        class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
                         name="perseus_radio_10_1"
                         type="radio"
                       />
                     </div>
                   </td>
                   <td
-                    class="category cell_13aakpm"
+                    class="category cell_1sl942g"
                   >
                     <div
                       aria-label="Nonlinear relationship"
                       role="button"
                     >
                       <input
-                        class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                        class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
                         name="perseus_radio_10_1"
                         type="radio"
                       />
@@ -583,14 +583,14 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                     </div>
                   </td>
                   <td
-                    class="category cell_13aakpm"
+                    class="category cell_1sl942g"
                   >
                     <div
                       aria-label="No relationship"
                       role="button"
                     >
                       <span
-                        class="radioSpan_1dzc0m3"
+                        class="radioSpan_1cqf8h5"
                       >
                         <svg
                           aria-hidden="true"
@@ -609,14 +609,14 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                     </div>
                   </td>
                   <td
-                    class="category cell_13aakpm"
+                    class="category cell_1sl942g"
                   >
                     <div
                       aria-label="Positive linear relationship"
                       role="button"
                     >
                       <span
-                        class="radioSpan_1dzc0m3"
+                        class="radioSpan_1cqf8h5"
                       >
                         <svg
                           aria-hidden="true"
@@ -635,14 +635,14 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                     </div>
                   </td>
                   <td
-                    class="category cell_13aakpm"
+                    class="category cell_1sl942g"
                   >
                     <div
                       aria-label="Negative linear relationship"
                       role="button"
                     >
                       <span
-                        class="radioSpan_1dzc0m3"
+                        class="radioSpan_1cqf8h5"
                       >
                         <svg
                           aria-hidden="true"
@@ -661,14 +661,14 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                     </div>
                   </td>
                   <td
-                    class="category cell_13aakpm"
+                    class="category cell_1sl942g"
                   >
                     <div
                       aria-label="Nonlinear relationship"
                       role="button"
                     >
                       <span
-                        class="radioSpan_1dzc0m3"
+                        class="radioSpan_1cqf8h5"
                       >
                         <svg
                           aria-hidden="true"
@@ -716,14 +716,14 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                     </div>
                   </td>
                   <td
-                    class="category cell_13aakpm"
+                    class="category cell_1sl942g"
                   >
                     <div
                       aria-label="No relationship"
                       role="button"
                     >
                       <span
-                        class="radioSpan_1dzc0m3"
+                        class="radioSpan_1cqf8h5"
                       >
                         <svg
                           aria-hidden="true"
@@ -742,14 +742,14 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                     </div>
                   </td>
                   <td
-                    class="category cell_13aakpm"
+                    class="category cell_1sl942g"
                   >
                     <div
                       aria-label="Positive linear relationship"
                       role="button"
                     >
                       <span
-                        class="radioSpan_1dzc0m3"
+                        class="radioSpan_1cqf8h5"
                       >
                         <svg
                           aria-hidden="true"
@@ -768,14 +768,14 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                     </div>
                   </td>
                   <td
-                    class="category cell_13aakpm"
+                    class="category cell_1sl942g"
                   >
                     <div
                       aria-label="Negative linear relationship"
                       role="button"
                     >
                       <span
-                        class="radioSpan_1dzc0m3"
+                        class="radioSpan_1cqf8h5"
                       >
                         <svg
                           aria-hidden="true"
@@ -794,14 +794,14 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                     </div>
                   </td>
                   <td
-                    class="category cell_13aakpm"
+                    class="category cell_1sl942g"
                   >
                     <div
                       aria-label="Nonlinear relationship"
                       role="button"
                     >
                       <span
-                        class="radioSpan_1dzc0m3"
+                        class="radioSpan_1cqf8h5"
                       >
                         <svg
                           aria-hidden="true"

--- a/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
+++ b/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
@@ -166,7 +166,7 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                     </div>
                   </td>
                   <td
-                    class="category cell_1sl942g"
+                    class="category cell_1wviiqy"
                   >
                     <div
                       aria-label="No relationship"
@@ -180,7 +180,7 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                     </div>
                   </td>
                   <td
-                    class="category cell_1sl942g"
+                    class="category cell_1wviiqy"
                   >
                     <div
                       aria-label="Positive linear relationship"
@@ -194,7 +194,7 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                     </div>
                   </td>
                   <td
-                    class="category cell_1sl942g"
+                    class="category cell_1wviiqy"
                   >
                     <div
                       aria-label="Negative linear relationship"
@@ -208,7 +208,7 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                     </div>
                   </td>
                   <td
-                    class="category cell_1sl942g"
+                    class="category cell_1wviiqy"
                   >
                     <div
                       aria-label="Nonlinear relationship"
@@ -251,7 +251,7 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                     </div>
                   </td>
                   <td
-                    class="category cell_1sl942g"
+                    class="category cell_1wviiqy"
                   >
                     <div
                       aria-label="No relationship"
@@ -265,7 +265,7 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                     </div>
                   </td>
                   <td
-                    class="category cell_1sl942g"
+                    class="category cell_1wviiqy"
                   >
                     <div
                       aria-label="Positive linear relationship"
@@ -279,7 +279,7 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                     </div>
                   </td>
                   <td
-                    class="category cell_1sl942g"
+                    class="category cell_1wviiqy"
                   >
                     <div
                       aria-label="Negative linear relationship"
@@ -293,7 +293,7 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                     </div>
                   </td>
                   <td
-                    class="category cell_1sl942g"
+                    class="category cell_1wviiqy"
                   >
                     <div
                       aria-label="Nonlinear relationship"
@@ -583,14 +583,14 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                     </div>
                   </td>
                   <td
-                    class="category cell_1sl942g"
+                    class="category cell_1wviiqy"
                   >
                     <div
                       aria-label="No relationship"
                       role="button"
                     >
                       <span
-                        class="radioSpan_1cqf8h5"
+                        class="radioSpan_10ojurn"
                       >
                         <svg
                           aria-hidden="true"
@@ -609,14 +609,14 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                     </div>
                   </td>
                   <td
-                    class="category cell_1sl942g"
+                    class="category cell_1wviiqy"
                   >
                     <div
                       aria-label="Positive linear relationship"
                       role="button"
                     >
                       <span
-                        class="radioSpan_1cqf8h5"
+                        class="radioSpan_10ojurn"
                       >
                         <svg
                           aria-hidden="true"
@@ -635,14 +635,14 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                     </div>
                   </td>
                   <td
-                    class="category cell_1sl942g"
+                    class="category cell_1wviiqy"
                   >
                     <div
                       aria-label="Negative linear relationship"
                       role="button"
                     >
                       <span
-                        class="radioSpan_1cqf8h5"
+                        class="radioSpan_10ojurn"
                       >
                         <svg
                           aria-hidden="true"
@@ -661,14 +661,14 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                     </div>
                   </td>
                   <td
-                    class="category cell_1sl942g"
+                    class="category cell_1wviiqy"
                   >
                     <div
                       aria-label="Nonlinear relationship"
                       role="button"
                     >
                       <span
-                        class="radioSpan_1cqf8h5"
+                        class="radioSpan_10ojurn"
                       >
                         <svg
                           aria-hidden="true"
@@ -716,14 +716,14 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                     </div>
                   </td>
                   <td
-                    class="category cell_1sl942g"
+                    class="category cell_1wviiqy"
                   >
                     <div
                       aria-label="No relationship"
                       role="button"
                     >
                       <span
-                        class="radioSpan_1cqf8h5"
+                        class="radioSpan_10ojurn"
                       >
                         <svg
                           aria-hidden="true"
@@ -742,14 +742,14 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                     </div>
                   </td>
                   <td
-                    class="category cell_1sl942g"
+                    class="category cell_1wviiqy"
                   >
                     <div
                       aria-label="Positive linear relationship"
                       role="button"
                     >
                       <span
-                        class="radioSpan_1cqf8h5"
+                        class="radioSpan_10ojurn"
                       >
                         <svg
                           aria-hidden="true"
@@ -768,14 +768,14 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                     </div>
                   </td>
                   <td
-                    class="category cell_1sl942g"
+                    class="category cell_1wviiqy"
                   >
                     <div
                       aria-label="Negative linear relationship"
                       role="button"
                     >
                       <span
-                        class="radioSpan_1cqf8h5"
+                        class="radioSpan_10ojurn"
                       >
                         <svg
                           aria-hidden="true"
@@ -794,14 +794,14 @@ exports[`categorizer widget should snapshot: first render 1`] = `
                     </div>
                   </td>
                   <td
-                    class="category cell_1sl942g"
+                    class="category cell_1wviiqy"
                   >
                     <div
                       aria-label="Nonlinear relationship"
                       role="button"
                     >
                       <span
-                        class="radioSpan_1cqf8h5"
+                        class="radioSpan_10ojurn"
                       >
                         <svg
                           aria-hidden="true"

--- a/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
+++ b/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
@@ -173,7 +173,7 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                       role="button"
                     >
                       <input
-                        class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
+                        class="responsiveInput_10rqe3p-o_O-responsiveRadioInput_ky7gu6"
                         name="perseus_radio_10_0"
                         type="radio"
                       />
@@ -187,7 +187,7 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                       role="button"
                     >
                       <input
-                        class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
+                        class="responsiveInput_10rqe3p-o_O-responsiveRadioInput_ky7gu6"
                         name="perseus_radio_10_0"
                         type="radio"
                       />
@@ -201,7 +201,7 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                       role="button"
                     >
                       <input
-                        class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
+                        class="responsiveInput_10rqe3p-o_O-responsiveRadioInput_ky7gu6"
                         name="perseus_radio_10_0"
                         type="radio"
                       />
@@ -215,7 +215,7 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                       role="button"
                     >
                       <input
-                        class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
+                        class="responsiveInput_10rqe3p-o_O-responsiveRadioInput_ky7gu6"
                         name="perseus_radio_10_0"
                         type="radio"
                       />
@@ -258,7 +258,7 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                       role="button"
                     >
                       <input
-                        class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
+                        class="responsiveInput_10rqe3p-o_O-responsiveRadioInput_ky7gu6"
                         name="perseus_radio_10_1"
                         type="radio"
                       />
@@ -272,7 +272,7 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                       role="button"
                     >
                       <input
-                        class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
+                        class="responsiveInput_10rqe3p-o_O-responsiveRadioInput_ky7gu6"
                         name="perseus_radio_10_1"
                         type="radio"
                       />
@@ -286,7 +286,7 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                       role="button"
                     >
                       <input
-                        class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
+                        class="responsiveInput_10rqe3p-o_O-responsiveRadioInput_ky7gu6"
                         name="perseus_radio_10_1"
                         type="radio"
                       />
@@ -300,7 +300,7 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
                       role="button"
                     >
                       <input
-                        class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
+                        class="responsiveInput_10rqe3p-o_O-responsiveRadioInput_ky7gu6"
                         name="perseus_radio_10_1"
                         type="radio"
                       />

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
 import {shuffle} from "@khanacademy/perseus-core";
+import {font} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet, css} from "aphrodite";
 import classNames from "classnames";
 import * as React from "react";
@@ -269,7 +270,8 @@ const styles = StyleSheet.create({
     },
 
     radioSpan: {
-        fontSize: 30,
+        fontSize: font.heading.size.large,
+        fontWeight: font.weight.semi,
         paddingRight: 3,
 
         ":hover": {

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -262,9 +262,10 @@ const styles = StyleSheet.create({
     radioSpan: {
         fontSize: sizing.size_280,
         paddingRight: 3,
+        cursor: "pointer",
 
         ":hover": {
-            color: semanticColor.core.border.neutral.default,
+            color: semanticColor.core.foreground.instructive.subtle,
         },
     },
 

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -249,7 +249,7 @@ const styles = StyleSheet.create({
     cell: {
         textAlign: "center",
         padding: 0,
-        color: semanticColor.core.foreground.disabled.subtle,
+        color: semanticColor.core.border.neutral.subtle,
         verticalAlign: "middle",
     },
 
@@ -268,7 +268,7 @@ const styles = StyleSheet.create({
         paddingRight: 3,
 
         ":hover": {
-            color: semanticColor.core.foreground.disabled.strong,
+            color: semanticColor.core.border.neutral.default,
         },
     },
 

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -255,11 +255,7 @@ const styles = StyleSheet.create({
 
     emptyHeaderCell: {
         backgroundColor: "inherit",
-        // Left hardcoded intentionally — matches the shared, un-tokenized
-        // `table th` border-bottom color in perseus-renderer-part-1.css.
-        // Converting one without the other would split the header row's
-        // divider line into two different colors. Tracked for a follow-up
-        // ticket covering shared table styles.
+        // TODO(LEMS-4443): Convert shared table styling to semantic color tokens.
         borderBottom: "2px solid #ccc",
     },
 

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -1,6 +1,6 @@
 import {shuffle} from "@khanacademy/perseus-core";
 import {useOnMountEffect} from "@khanacademy/wonder-blocks-core";
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import {css, StyleSheet} from "aphrodite";
 import classNames from "classnames";
 import React, {forwardRef, useImperativeHandle, useMemo} from "react";
@@ -249,12 +249,17 @@ const styles = StyleSheet.create({
     cell: {
         textAlign: "center",
         padding: 0,
-        color: "#ccc",
+        color: semanticColor.core.foreground.disabled.subtle,
         verticalAlign: "middle",
     },
 
     emptyHeaderCell: {
         backgroundColor: "inherit",
+        // Left hardcoded intentionally — matches the shared, un-tokenized
+        // `table th` border-bottom color in perseus-renderer-part-1.css.
+        // Converting one without the other would split the header row's
+        // divider line into two different colors. Tracked for a follow-up
+        // ticket covering shared table styles.
         borderBottom: "2px solid #ccc",
     },
 
@@ -263,19 +268,19 @@ const styles = StyleSheet.create({
         paddingRight: 3,
 
         ":hover": {
-            color: "#999",
+            color: semanticColor.core.foreground.disabled.strong,
         },
     },
 
     checkedRadioSpan: {
-        color: "#333",
+        color: semanticColor.core.foreground.instructive.default,
     },
 
     // .static-mode is applied by the Categorizer when the rendered
     // widget is static; in this case we gray out the choices to show
     // the user that the widget can't be interacted with.
     staticCheckedRadioSpan: {
-        color: "#888",
+        color: semanticColor.core.foreground.disabled.strong,
     },
 });
 

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -1,6 +1,6 @@
 import {shuffle} from "@khanacademy/perseus-core";
 import {useOnMountEffect} from "@khanacademy/wonder-blocks-core";
-import {font} from "@khanacademy/wonder-blocks-tokens";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {css, StyleSheet} from "aphrodite";
 import classNames from "classnames";
 import React, {forwardRef, useImperativeHandle, useMemo} from "react";
@@ -259,8 +259,7 @@ const styles = StyleSheet.create({
     },
 
     radioSpan: {
-        fontSize: font.heading.size.large,
-        fontWeight: font.weight.semi,
+        fontSize: sizing.size_280,
         paddingRight: 3,
 
         ":hover": {

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -163,6 +163,8 @@ const Categorizer = forwardRef<Widget, Props>(function Categorizer(props, ref) {
                                                     className={css(
                                                         sharedStyles.responsiveInput,
                                                         sharedStyles.responsiveRadioInput,
+                                                        props.static &&
+                                                            sharedStyles.responsiveRadioInputStatic,
                                                     )}
                                                     checked={selected}
                                                     onChange={() =>

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -1,7 +1,7 @@
 import {shuffle} from "@khanacademy/perseus-core";
 import {useOnMountEffect} from "@khanacademy/wonder-blocks-core";
-import {css, StyleSheet} from "aphrodite";
 import {font} from "@khanacademy/wonder-blocks-tokens";
+import {css, StyleSheet} from "aphrodite";
 import classNames from "classnames";
 import React, {forwardRef, useImperativeHandle, useMemo} from "react";
 import _ from "underscore";

--- a/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
@@ -138,7 +138,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1mq3xs9"
+                                      class="radioSpan_ldmzts"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -164,7 +164,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1mq3xs9"
+                                      class="radioSpan_ldmzts"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -208,7 +208,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1mq3xs9"
+                                      class="radioSpan_ldmzts"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -234,7 +234,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1mq3xs9"
+                                      class="radioSpan_ldmzts"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -278,7 +278,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1mq3xs9"
+                                      class="radioSpan_ldmzts"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -304,7 +304,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1mq3xs9"
+                                      class="radioSpan_ldmzts"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -348,7 +348,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1mq3xs9"
+                                      class="radioSpan_ldmzts"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -374,7 +374,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1mq3xs9"
+                                      class="radioSpan_ldmzts"
                                     >
                                       <svg
                                         aria-hidden="true"

--- a/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
@@ -131,14 +131,14 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_13aakpm"
+                                  class="category cell_1sl942g"
                                 >
                                   <div
                                     aria-label="True"
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1dzc0m3"
+                                      class="radioSpan_1cqf8h5"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -157,14 +157,14 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_13aakpm"
+                                  class="category cell_1sl942g"
                                 >
                                   <div
                                     aria-label="False"
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1dzc0m3"
+                                      class="radioSpan_1cqf8h5"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -201,14 +201,14 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_13aakpm"
+                                  class="category cell_1sl942g"
                                 >
                                   <div
                                     aria-label="True"
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1dzc0m3"
+                                      class="radioSpan_1cqf8h5"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -227,14 +227,14 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_13aakpm"
+                                  class="category cell_1sl942g"
                                 >
                                   <div
                                     aria-label="False"
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1dzc0m3"
+                                      class="radioSpan_1cqf8h5"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -271,14 +271,14 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_13aakpm"
+                                  class="category cell_1sl942g"
                                 >
                                   <div
                                     aria-label="True"
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1dzc0m3"
+                                      class="radioSpan_1cqf8h5"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -297,14 +297,14 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_13aakpm"
+                                  class="category cell_1sl942g"
                                 >
                                   <div
                                     aria-label="False"
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1dzc0m3"
+                                      class="radioSpan_1cqf8h5"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -341,14 +341,14 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_13aakpm"
+                                  class="category cell_1sl942g"
                                 >
                                   <div
                                     aria-label="True"
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1dzc0m3"
+                                      class="radioSpan_1cqf8h5"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -367,14 +367,14 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_13aakpm"
+                                  class="category cell_1sl942g"
                                 >
                                   <div
                                     aria-label="False"
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1dzc0m3"
+                                      class="radioSpan_1cqf8h5"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -575,28 +575,28 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_13aakpm"
+                                  class="category cell_1sl942g"
                                 >
                                   <div
                                     aria-label="True"
                                     role="button"
                                   >
                                     <input
-                                      class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                                      class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
                                       name="perseus_radio_9_0"
                                       type="radio"
                                     />
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_13aakpm"
+                                  class="category cell_1sl942g"
                                 >
                                   <div
                                     aria-label="False"
                                     role="button"
                                   >
                                     <input
-                                      class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                                      class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
                                       name="perseus_radio_9_0"
                                       type="radio"
                                     />
@@ -621,28 +621,28 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_13aakpm"
+                                  class="category cell_1sl942g"
                                 >
                                   <div
                                     aria-label="True"
                                     role="button"
                                   >
                                     <input
-                                      class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                                      class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
                                       name="perseus_radio_9_1"
                                       type="radio"
                                     />
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_13aakpm"
+                                  class="category cell_1sl942g"
                                 >
                                   <div
                                     aria-label="False"
                                     role="button"
                                   >
                                     <input
-                                      class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                                      class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
                                       name="perseus_radio_9_1"
                                       type="radio"
                                     />
@@ -667,28 +667,28 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_13aakpm"
+                                  class="category cell_1sl942g"
                                 >
                                   <div
                                     aria-label="True"
                                     role="button"
                                   >
                                     <input
-                                      class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                                      class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
                                       name="perseus_radio_9_2"
                                       type="radio"
                                     />
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_13aakpm"
+                                  class="category cell_1sl942g"
                                 >
                                   <div
                                     aria-label="False"
                                     role="button"
                                   >
                                     <input
-                                      class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                                      class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
                                       name="perseus_radio_9_2"
                                       type="radio"
                                     />
@@ -713,28 +713,28 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_13aakpm"
+                                  class="category cell_1sl942g"
                                 >
                                   <div
                                     aria-label="True"
                                     role="button"
                                   >
                                     <input
-                                      class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                                      class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
                                       name="perseus_radio_9_3"
                                       type="radio"
                                     />
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_13aakpm"
+                                  class="category cell_1sl942g"
                                 >
                                   <div
                                     aria-label="False"
                                     role="button"
                                   >
                                     <input
-                                      class="responsiveInput_1q2zj3l-o_O-responsiveRadioInput_17um91a"
+                                      class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
                                       name="perseus_radio_9_3"
                                       type="radio"
                                     />

--- a/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
@@ -138,7 +138,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1nbt5tl"
+                                      class="radioSpan_buhzha"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -164,7 +164,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1nbt5tl"
+                                      class="radioSpan_buhzha"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -208,7 +208,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1nbt5tl"
+                                      class="radioSpan_buhzha"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -234,7 +234,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1nbt5tl"
+                                      class="radioSpan_buhzha"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -278,7 +278,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1nbt5tl"
+                                      class="radioSpan_buhzha"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -304,7 +304,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1nbt5tl"
+                                      class="radioSpan_buhzha"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -348,7 +348,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1nbt5tl"
+                                      class="radioSpan_buhzha"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -374,7 +374,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1nbt5tl"
+                                      class="radioSpan_buhzha"
                                     >
                                       <svg
                                         aria-hidden="true"

--- a/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
@@ -582,7 +582,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                     role="button"
                                   >
                                     <input
-                                      class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
+                                      class="responsiveInput_10rqe3p-o_O-responsiveRadioInput_ky7gu6"
                                       name="perseus_radio_9_0"
                                       type="radio"
                                     />
@@ -596,7 +596,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                     role="button"
                                   >
                                     <input
-                                      class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
+                                      class="responsiveInput_10rqe3p-o_O-responsiveRadioInput_ky7gu6"
                                       name="perseus_radio_9_0"
                                       type="radio"
                                     />
@@ -628,7 +628,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                     role="button"
                                   >
                                     <input
-                                      class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
+                                      class="responsiveInput_10rqe3p-o_O-responsiveRadioInput_ky7gu6"
                                       name="perseus_radio_9_1"
                                       type="radio"
                                     />
@@ -642,7 +642,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                     role="button"
                                   >
                                     <input
-                                      class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
+                                      class="responsiveInput_10rqe3p-o_O-responsiveRadioInput_ky7gu6"
                                       name="perseus_radio_9_1"
                                       type="radio"
                                     />
@@ -674,7 +674,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                     role="button"
                                   >
                                     <input
-                                      class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
+                                      class="responsiveInput_10rqe3p-o_O-responsiveRadioInput_ky7gu6"
                                       name="perseus_radio_9_2"
                                       type="radio"
                                     />
@@ -688,7 +688,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                     role="button"
                                   >
                                     <input
-                                      class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
+                                      class="responsiveInput_10rqe3p-o_O-responsiveRadioInput_ky7gu6"
                                       name="perseus_radio_9_2"
                                       type="radio"
                                     />
@@ -720,7 +720,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                     role="button"
                                   >
                                     <input
-                                      class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
+                                      class="responsiveInput_10rqe3p-o_O-responsiveRadioInput_ky7gu6"
                                       name="perseus_radio_9_3"
                                       type="radio"
                                     />
@@ -734,7 +734,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                     role="button"
                                   >
                                     <input
-                                      class="responsiveInput_a7j57b-o_O-responsiveRadioInput_ky7gu6"
+                                      class="responsiveInput_10rqe3p-o_O-responsiveRadioInput_ky7gu6"
                                       name="perseus_radio_9_3"
                                       type="radio"
                                     />

--- a/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
@@ -138,7 +138,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_10ojurn"
+                                      class="radioSpan_1nbt5tl"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -164,7 +164,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_10ojurn"
+                                      class="radioSpan_1nbt5tl"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -208,7 +208,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_10ojurn"
+                                      class="radioSpan_1nbt5tl"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -234,7 +234,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_10ojurn"
+                                      class="radioSpan_1nbt5tl"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -278,7 +278,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_10ojurn"
+                                      class="radioSpan_1nbt5tl"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -304,7 +304,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_10ojurn"
+                                      class="radioSpan_1nbt5tl"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -348,7 +348,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_10ojurn"
+                                      class="radioSpan_1nbt5tl"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -374,7 +374,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_10ojurn"
+                                      class="radioSpan_1nbt5tl"
                                     >
                                       <svg
                                         aria-hidden="true"

--- a/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
@@ -131,14 +131,14 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_1sl942g"
+                                  class="category cell_1wviiqy"
                                 >
                                   <div
                                     aria-label="True"
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1cqf8h5"
+                                      class="radioSpan_10ojurn"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -157,14 +157,14 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_1sl942g"
+                                  class="category cell_1wviiqy"
                                 >
                                   <div
                                     aria-label="False"
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1cqf8h5"
+                                      class="radioSpan_10ojurn"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -201,14 +201,14 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_1sl942g"
+                                  class="category cell_1wviiqy"
                                 >
                                   <div
                                     aria-label="True"
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1cqf8h5"
+                                      class="radioSpan_10ojurn"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -227,14 +227,14 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_1sl942g"
+                                  class="category cell_1wviiqy"
                                 >
                                   <div
                                     aria-label="False"
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1cqf8h5"
+                                      class="radioSpan_10ojurn"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -271,14 +271,14 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_1sl942g"
+                                  class="category cell_1wviiqy"
                                 >
                                   <div
                                     aria-label="True"
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1cqf8h5"
+                                      class="radioSpan_10ojurn"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -297,14 +297,14 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_1sl942g"
+                                  class="category cell_1wviiqy"
                                 >
                                   <div
                                     aria-label="False"
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1cqf8h5"
+                                      class="radioSpan_10ojurn"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -341,14 +341,14 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_1sl942g"
+                                  class="category cell_1wviiqy"
                                 >
                                   <div
                                     aria-label="True"
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1cqf8h5"
+                                      class="radioSpan_10ojurn"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -367,14 +367,14 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_1sl942g"
+                                  class="category cell_1wviiqy"
                                 >
                                   <div
                                     aria-label="False"
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_1cqf8h5"
+                                      class="radioSpan_10ojurn"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -575,7 +575,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_1sl942g"
+                                  class="category cell_1wviiqy"
                                 >
                                   <div
                                     aria-label="True"
@@ -589,7 +589,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_1sl942g"
+                                  class="category cell_1wviiqy"
                                 >
                                   <div
                                     aria-label="False"
@@ -621,7 +621,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_1sl942g"
+                                  class="category cell_1wviiqy"
                                 >
                                   <div
                                     aria-label="True"
@@ -635,7 +635,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_1sl942g"
+                                  class="category cell_1wviiqy"
                                 >
                                   <div
                                     aria-label="False"
@@ -667,7 +667,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_1sl942g"
+                                  class="category cell_1wviiqy"
                                 >
                                   <div
                                     aria-label="True"
@@ -681,7 +681,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_1sl942g"
+                                  class="category cell_1wviiqy"
                                 >
                                   <div
                                     aria-label="False"
@@ -713,7 +713,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_1sl942g"
+                                  class="category cell_1wviiqy"
                                 >
                                   <div
                                     aria-label="True"
@@ -727,7 +727,7 @@ exports[`graded-group should snapshot: initial render (mobile: true) 1`] = `
                                   </div>
                                 </td>
                                 <td
-                                  class="category cell_1sl942g"
+                                  class="category cell_1wviiqy"
                                 >
                                   <div
                                     aria-label="False"

--- a/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group/__snapshots__/graded-group.test.ts.snap
@@ -138,7 +138,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_ldmzts"
+                                      class="radioSpan_1dzc0m3"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -164,7 +164,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_ldmzts"
+                                      class="radioSpan_1dzc0m3"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -208,7 +208,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_ldmzts"
+                                      class="radioSpan_1dzc0m3"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -234,7 +234,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_ldmzts"
+                                      class="radioSpan_1dzc0m3"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -278,7 +278,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_ldmzts"
+                                      class="radioSpan_1dzc0m3"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -304,7 +304,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_ldmzts"
+                                      class="radioSpan_1dzc0m3"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -348,7 +348,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_ldmzts"
+                                      class="radioSpan_1dzc0m3"
                                     >
                                       <svg
                                         aria-hidden="true"
@@ -374,7 +374,7 @@ exports[`graded-group should snapshot: initial render (mobile: false) 1`] = `
                                     role="button"
                                   >
                                     <span
-                                      class="radioSpan_ldmzts"
+                                      class="radioSpan_1dzc0m3"
                                     >
                                       <svg
                                         aria-hidden="true"


### PR DESCRIPTION
## Summary:
Migrates Categorizer's colors and sizing from hardcoded values to Wonder Blocks semantic tokens. Coverage extends beyond the widget's own file to previously-undiscovered mobile-specific styling in `shared.ts`/`constants.ts` and `categorizer.css`, which surfaced an inconsistency: the native-mobile checked-radio color was a legacy brand green. Mobile now matches web's checked-state color in every theme, both of which have been updated to instructive blue. Also updated the hover ring and fill to instructive blue and added a cursor on hover. Finally, static mobile did not have styling, so it stayed blue even when static. Added styling so mobile static is gray, just like desktop mobile, and added a regression story to track this.

<img width="1183" height="564" alt="Before and after changes across SYL and Classic themes" src="https://github.com/user-attachments/assets/ea42ffb3-5c3a-4f59-88db-cdc5d70c4c6d" />


**New cursor on hover:**

https://github.com/user-attachments/assets/73df4f77-72ce-42de-ab43-8c9cd2994d09

Issue: LEMS-4272

## Test plan:
- [x] Chromatic diffs show only intentional color/font changes against the baseline
- [x] All checks pass