### PR TITLE
Update widget-container.new.tsx for WidgetPropsV2

### DIFF
--- a/.changeset/humble-cycles-film.md
+++ b/.changeset/humble-cycles-film.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Update widget-container.new.tsx for compatibility with WidgetPropsV2

--- a/packages/perseus/src/__tests__/widget-container.new.test.tsx
+++ b/packages/perseus/src/__tests__/widget-container.new.test.tsx
@@ -78,10 +78,12 @@ describe("widget-container", () => {
                     type="explanation"
                     id="explanation 1"
                     widgetProps={{
-                        showPrompt: "Explanation",
-                        hidePrompt: "Hide explanation",
-                        explanation: "This is an explanation",
-                        widgets: {},
+                        options: {
+                            showPrompt: "Explanation",
+                            hidePrompt: "Hide explanation",
+                            explanation: "This is an explanation",
+                            widgets: {},
+                        },
 
                         findWidgets: () => [],
 

--- a/packages/perseus/src/widget-container.new.tsx
+++ b/packages/perseus/src/widget-container.new.tsx
@@ -105,8 +105,15 @@ class WidgetContainer extends React.Component<Props, State> {
             return <div className={className} />;
         }
 
+        // During the WidgetProps redesign, a migrated widget nests its options
+        // under `widgetProps.options`; an un-migrated widget spreads them into
+        // the top level of `widgetProps`. Read from whichever shape applies.
+        // TODO(LEMS-4354): clean this up post-migration.
         const subType =
-            getWidgetSubType(type, this.props.widgetProps) ?? "null";
+            getWidgetSubType(
+                type,
+                this.props.widgetProps.options ?? this.props.widgetProps,
+            ) ?? "null";
 
         let alignment = this.props.widgetProps.alignment;
         if (alignment == null || alignment === "default") {


### PR DESCRIPTION
## Summary:
There's an ongoing series of PRs to pass all the `options` of each widget as a
single prop. This redesign required a change to the `WidgetContainer`. The redesign
is being done on a long-lived feature branch, `benc/widget-props-redesign`.

`widget-container.new.tsx` was recently introduced to allow inline widgets to
be rendered inside a span instead of a div. This component needs to be updated for the
new widget props design.

This PR will be landed on `benc/widget-props-redesign`, not `main`.

Issue: LEMS-4354

## Test plan:

Widgets should render correctly on this branch with the
`perseus-renderer-upgrade` feature flag turned on (test in Storybook).