### PR TITLE
Migrate categorizer widget to WidgetPropsV2

### DIFF
--- a/.changeset/widget-props-v2-categorizer.md
+++ b/.changeset/widget-props-v2-categorizer.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Internal: Migrate the categorizer widget to group all `options` under a separate prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -504,7 +504,7 @@ review and commit the changes.
 Migrate these **one at a time**, stopping after each step for the user to
 review and commit the changes.
 
-- [ ] Migrate `categorizer` to `WidgetPropsV2` (update its editor preview).
+- [x] Migrate `categorizer` to `WidgetPropsV2` (update its editor preview).
 - [ ] Migrate `matcher` to `WidgetPropsV2`.
 - [ ] Migrate `matrix` to `WidgetPropsV2` (update its editor preview).
 - [ ] Migrate `grapher` to `WidgetPropsV2` (update its editor preview and

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -504,7 +504,6 @@ review and commit the changes.
 Migrate these **one at a time**, stopping after each step for the user to
 review and commit the changes.
 
-- [ ] Convert `categorizer` to a functional component, a la `dropdown`.
 - [ ] Migrate `categorizer` to `WidgetPropsV2` (update its editor preview).
 - [ ] Migrate `matcher` to `WidgetPropsV2`.
 - [ ] Migrate `matrix` to `WidgetPropsV2` (update its editor preview).

--- a/packages/perseus-editor/src/widgets/categorizer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/categorizer-editor.tsx
@@ -48,8 +48,15 @@ class CategorizerEditor extends React.Component<Props> {
 
     render(): React.ReactNode {
         const categorizerProps: Partial<PropsFor<typeof Categorizer>> = {
-            items: this.props.items,
-            categories: this.props.categories,
+            options: {
+                items: this.props.items,
+                categories: this.props.categories,
+                // The preview keeps the authored item order so the editor's
+                // item list lines up with the rows of the preview table.
+                randomizeItems: false,
+                static: false,
+                values: [],
+            },
             userInput: {values: this.props.values},
             handleUserInput: (userInput) => {
                 this.props.onChange({values: userInput.values});

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -28,4 +28,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "interaction",
     "numeric-input",
     "input-number",
+    "categorizer",
 ];

--- a/packages/perseus/src/widget-ai-utils/categorizer/categorizer-ai-utils.test.ts
+++ b/packages/perseus/src/widget-ai-utils/categorizer/categorizer-ai-utils.test.ts
@@ -57,9 +57,11 @@ describe("Categorizer AI utils", () => {
         };
 
         const widgetData: any = {
-            items: ["Luke Skywalker", "Darth Vader", "Yoda", "Han Solo"],
-            categories: ["Galactic Empire", "Rebel Alliance"],
-            values: [1, 0, 1, 1],
+            options: {
+                items: ["Luke Skywalker", "Darth Vader", "Yoda", "Han Solo"],
+                categories: ["Galactic Empire", "Rebel Alliance"],
+                values: [1, 0, 1, 1],
+            },
             userInput,
         };
 

--- a/packages/perseus/src/widget-ai-utils/categorizer/categorizer-ai-utils.ts
+++ b/packages/perseus/src/widget-ai-utils/categorizer/categorizer-ai-utils.ts
@@ -50,8 +50,8 @@ export const getPromptJSON = (
     return {
         type: "categorizer",
         options: {
-            items: widgetData.items,
-            categories: widgetData.categories,
+            items: widgetData.options.items,
+            categories: widgetData.options.categories,
         },
         userInput: {
             itemToCategoryMapping: widgetData.userInput.values,

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -26,15 +26,14 @@ import type {
     PerseusCategorizerWidgetOptions,
 } from "@khanacademy/perseus-core";
 
-type ExternalProps = WidgetPropsV2<
-    PerseusCategorizerWidgetOptions,
-    PerseusCategorizerUserInput
->;
-
-type Props = ExternalProps & {
-    linterContext: NonNullable<ExternalProps["linterContext"]>;
+interface Props
+    extends WidgetPropsV2<
+        PerseusCategorizerWidgetOptions,
+        PerseusCategorizerUserInput
+    > {
+    // TODO(LEMS-4354): Make `dependencies` part of WidgetPropsV2.
     dependencies: PerseusDependenciesV2;
-};
+}
 
 const Categorizer = forwardRef<Widget, Props>(function Categorizer(props, ref) {
     const {items, categories, randomizeItems} = props.options;

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -18,7 +18,7 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetProps,
+    WidgetPropsV2,
 } from "../../types";
 import type {CategorizerPromptJSON} from "../../widget-ai-utils/categorizer/categorizer-ai-utils";
 import type {
@@ -26,7 +26,7 @@ import type {
     PerseusCategorizerWidgetOptions,
 } from "@khanacademy/perseus-core";
 
-type ExternalProps = WidgetProps<
+type ExternalProps = WidgetPropsV2<
     PerseusCategorizerWidgetOptions,
     PerseusCategorizerUserInput
 >;
@@ -37,10 +37,8 @@ type Props = ExternalProps & {
 };
 
 const Categorizer = forwardRef<Widget, Props>(function Categorizer(props, ref) {
+    const {items, categories, randomizeItems} = props.options;
     const {
-        items,
-        categories,
-        randomizeItems,
         userInput,
         problemNum,
         apiOptions,
@@ -71,8 +69,9 @@ const Categorizer = forwardRef<Widget, Props>(function Categorizer(props, ref) {
          * [LEMS-3185] do not trust serializedState
          */
         getSerializedState(): any {
-            const {userInput, ...rest} = props;
+            const {userInput, options, ...rest} = props;
             return {
+                ...options,
                 ...rest,
                 values: userInput.values,
             };


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a Categorizer widget in
  http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.