### PR TITLE
Migrate matcher widget to WidgetPropsV2

### DIFF
--- a/.changeset/flat-bars-doubt.md
+++ b/.changeset/flat-bars-doubt.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: The options of the Matcher widget are now grouped under a single `options` prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -505,7 +505,7 @@ Migrate these **one at a time**, stopping after each step for the user to
 review and commit the changes.
 
 - [x] Migrate `categorizer` to `WidgetPropsV2` (update its editor preview).
-- [ ] Migrate `matcher` to `WidgetPropsV2`.
+- [x] Migrate `matcher` to `WidgetPropsV2`.
 - [ ] Migrate `matrix` to `WidgetPropsV2` (update its editor preview).
 - [ ] Migrate `grapher` to `WidgetPropsV2` (update its editor preview and
       `satisfies PropsFor` assertion).

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -29,4 +29,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "numeric-input",
     "input-number",
     "categorizer",
+    "matcher",
 ];

--- a/packages/perseus/src/widget-ai-utils/matcher/matcher-ai-utils.test.tsx
+++ b/packages/perseus/src/widget-ai-utils/matcher/matcher-ai-utils.test.tsx
@@ -1,3 +1,4 @@
+import {generateMatcherOptions} from "@khanacademy/perseus-core";
 import {screen, within} from "@testing-library/react";
 import * as React from "react";
 
@@ -71,10 +72,12 @@ describe("Matcher AI utils", () => {
         };
 
         const widgetData: widgetDataPartial = {
-            labels: ["Number", "Letter"],
-            left: ["1", "2", "3"],
-            right: ["a", "b", "c"],
-            orderMatters: false,
+            options: generateMatcherOptions({
+                labels: ["Number", "Letter"],
+                left: ["1", "2", "3"],
+                right: ["a", "b", "c"],
+                orderMatters: false,
+            }),
             userInput,
         };
 

--- a/packages/perseus/src/widget-ai-utils/matcher/matcher-ai-utils.ts
+++ b/packages/perseus/src/widget-ai-utils/matcher/matcher-ai-utils.ts
@@ -63,20 +63,20 @@ export type MatcherPromptJSON = {
 
 export type widgetDataPartial = Pick<
     React.ComponentProps<typeof matcher.widget>,
-    "userInput" | "labels" | "left" | "right" | "orderMatters"
+    "userInput" | "options"
 >;
 
 export const getPromptJSON = (
     widgetData: widgetDataPartial,
 ): MatcherPromptJSON => {
-    const {userInput} = widgetData;
+    const {userInput, options} = widgetData;
     return {
         type: "matcher",
         options: {
-            labels: widgetData.labels,
-            left: widgetData.left,
-            right: widgetData.right,
-            orderMatters: widgetData.orderMatters,
+            labels: options.labels,
+            left: options.left,
+            right: options.right,
+            orderMatters: options.orderMatters,
         },
         userInput: {
             left: userInput.left,

--- a/packages/perseus/src/widgets/matcher/matcher.tsx
+++ b/packages/perseus/src/widgets/matcher/matcher.tsx
@@ -16,7 +16,7 @@ import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/matcher/mat
 import type {SortableOption} from "../../components/sortable";
 import type {
     WidgetExports,
-    WidgetProps,
+    WidgetPropsV2,
     Widget,
     PerseusDependenciesV2,
 } from "../../types";
@@ -29,7 +29,7 @@ import type {
 
 const HACKY_CSS_CLASSNAME = "perseus-widget-matcher";
 
-type Props = WidgetProps<
+type Props = WidgetPropsV2<
     PerseusMatcherWidgetOptions,
     PerseusMatcherUserInput
 > & {
@@ -124,7 +124,9 @@ const Matcher = forwardRef<MatcherHandle, Props>(function Matcher(props, ref) {
         );
     }
 
-    const showLabels = props.labels.some(isTruthy);
+    const {labels, padding, orderMatters} = props.options;
+
+    const showLabels = labels.some(isTruthy);
     const constraints = {
         height: Math.max(leftHeight, rightHeight),
     };
@@ -138,7 +140,7 @@ const Matcher = forwardRef<MatcherHandle, Props>(function Matcher(props, ref) {
                     <tr className={css(styles.row)}>
                         <th className={css(styles.column, styles.columnLabel)}>
                             <Renderer
-                                content={props.labels[0] || "..."}
+                                content={labels[0] || "..."}
                                 linterContext={props.linterContext}
                                 strings={strings}
                             />
@@ -151,7 +153,7 @@ const Matcher = forwardRef<MatcherHandle, Props>(function Matcher(props, ref) {
                             )}
                         >
                             <Renderer
-                                content={props.labels[1] || "..."}
+                                content={labels[1] || "..."}
                                 linterContext={props.linterContext}
                                 strings={strings}
                             />
@@ -163,8 +165,8 @@ const Matcher = forwardRef<MatcherHandle, Props>(function Matcher(props, ref) {
                         <Sortable
                             options={props.userInput.left}
                             layout={"vertical"}
-                            padding={props.padding}
-                            disabled={!props.orderMatters}
+                            padding={padding}
+                            disabled={!orderMatters}
                             constraints={constraints}
                             onMeasure={(dimensions) =>
                                 setLeftHeight(Math.max(...dimensions.heights))
@@ -179,7 +181,7 @@ const Matcher = forwardRef<MatcherHandle, Props>(function Matcher(props, ref) {
                         <Sortable
                             options={props.userInput.right}
                             layout={"vertical"}
-                            padding={props.padding}
+                            padding={padding}
                             constraints={constraints}
                             onMeasure={(dimensions) =>
                                 setRightHeight(Math.max(...dimensions.heights))


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a Matcher widget in
  http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.