### PR TITLE
Migrate matrix widget to WidgetPropsV2

### DIFF
--- a/.changeset/shiny-moons-agree.md
+++ b/.changeset/shiny-moons-agree.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: The options of the Matrix widget are now grouped under a single `options` prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -506,7 +506,7 @@ review and commit the changes.
 
 - [x] Migrate `categorizer` to `WidgetPropsV2` (update its editor preview).
 - [x] Migrate `matcher` to `WidgetPropsV2`.
-- [ ] Migrate `matrix` to `WidgetPropsV2` (update its editor preview).
+- [x] Migrate `matrix` to `WidgetPropsV2` (update its editor preview).
 - [ ] Migrate `grapher` to `WidgetPropsV2` (update its editor preview and
       `satisfies PropsFor` assertion).
 - [ ] Migrate `table` to `WidgetPropsV2` (update its editor preview).

--- a/packages/perseus-editor/src/widgets/matrix-editor.tsx
+++ b/packages/perseus-editor/src/widgets/matrix-editor.tsx
@@ -80,6 +80,11 @@ class MatrixEditor extends React.Component<Props> {
                 this.change({answers: userInput.answers});
             },
             ...this.props,
+            options: {
+                matrixBoardSize: this.props.matrixBoardSize,
+                prefix: this.props.prefix,
+                suffix: this.props.suffix,
+            },
         };
 
         return (

--- a/packages/perseus-editor/src/widgets/matrix-editor.tsx
+++ b/packages/perseus-editor/src/widgets/matrix-editor.tsx
@@ -71,19 +71,20 @@ class MatrixEditor extends React.Component<Props> {
     };
 
     render(): React.ReactNode {
+        const {matrixBoardSize, prefix, suffix, answers} = this.props;
         const matrixProps: Partial<PropsFor<typeof Matrix>> = {
             onBlur: () => {},
             onFocus: () => {},
             trackInteraction: () => {},
-            userInput: {answers: this.props.answers},
+            userInput: {answers},
             handleUserInput: (userInput) => {
                 this.change({answers: userInput.answers});
             },
             ...this.props,
             options: {
-                matrixBoardSize: this.props.matrixBoardSize,
-                prefix: this.props.prefix,
-                suffix: this.props.suffix,
+                matrixBoardSize,
+                prefix,
+                suffix,
             },
         };
 

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -30,4 +30,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "input-number",
     "categorizer",
     "matcher",
+    "matrix",
 ];

--- a/packages/perseus/src/widget-ai-utils/matrix/matrix-ai-utils.test.ts
+++ b/packages/perseus/src/widget-ai-utils/matrix/matrix-ai-utils.test.ts
@@ -1,3 +1,4 @@
+import {generateMatrixOptions} from "@khanacademy/perseus-core";
 import {screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 
@@ -54,7 +55,7 @@ describe("Matrix AI utils", () => {
         };
 
         const widgetData: any = {
-            matrixBoardSize: [4, 3],
+            options: generateMatrixOptions({matrixBoardSize: [4, 3]}),
             userInput,
         };
 

--- a/packages/perseus/src/widget-ai-utils/matrix/matrix-ai-utils.ts
+++ b/packages/perseus/src/widget-ai-utils/matrix/matrix-ai-utils.ts
@@ -44,8 +44,8 @@ export const getPromptJSON = (
     return {
         type: "matrix",
         options: {
-            height: widgetData.matrixBoardSize[0],
-            width: widgetData.matrixBoardSize[1],
+            height: widgetData.options.matrixBoardSize[0],
+            width: widgetData.options.matrixBoardSize[1],
         },
         userInput: {
             answerRows: widgetData.userInput.answers,

--- a/packages/perseus/src/widgets/matrix/matrix.tsx
+++ b/packages/perseus/src/widgets/matrix/matrix.tsx
@@ -19,7 +19,7 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetProps,
+    WidgetPropsV2,
 } from "../../types";
 import type {MatrixPromptJSON} from "../../widget-ai-utils/matrix/matrix-ai-utils";
 import type {
@@ -80,17 +80,17 @@ const getRefForPath = function (path: FocusPath) {
 
 // Assert that the PerseusMatrixWidgetOptions parsed from JSON can be passed
 // as props to this component. This ensures that the PerseusMatrixWidgetOptions
-// stays in sync with the prop types. The PropsFor<Component> type takes
-// defaultProps into account, which is important because
-// PerseusMatrixWidgetOptions has optional fields which receive defaults via
-// defaultProps.
+// stays in sync with the prop types.
 // eslint-disable-next-line no-restricted-syntax
-0 as any as WidgetProps<
+0 as any as WidgetPropsV2<
     PerseusMatrixWidgetOptions,
     PerseusMatrixUserInput
 > satisfies PropsFor<typeof WrappedMatrix>;
 
-type Props = WidgetProps<MatrixPublicWidgetOptions, PerseusMatrixUserInput> & {
+type Props = WidgetPropsV2<
+    MatrixPublicWidgetOptions,
+    PerseusMatrixUserInput
+> & {
     dependencies: PerseusDependenciesV2;
 };
 
@@ -125,8 +125,8 @@ class Matrix extends React.Component<Props, State> implements Widget {
 
     getInputPaths: () => ReadonlyArray<ReadonlyArray<string>> = () => {
         const inputPaths: Array<ReadonlyArray<string>> = [];
-        const maxRows = this.props.matrixBoardSize[0];
-        const maxCols = this.props.matrixBoardSize[1];
+        const maxRows = this.props.options.matrixBoardSize[0];
+        const maxCols = this.props.options.matrixBoardSize[1];
 
         for (let row = 0; row < maxRows; row++) {
             for (let col = 0; col < maxCols; col++) {
@@ -180,8 +180,8 @@ class Matrix extends React.Component<Props, State> implements Widget {
         col,
         e,
     ) => {
-        const maxRow = this.props.matrixBoardSize[0];
-        const maxCol = this.props.matrixBoardSize[1];
+        const maxRow = this.props.options.matrixBoardSize[0];
+        const maxCol = this.props.options.matrixBoardSize[1];
 
         // eslint-disable-next-line react/no-string-refs
         const curInput = this.refs[getRefForPath(getInputPath(row, col))];
@@ -272,8 +272,9 @@ class Matrix extends React.Component<Props, State> implements Widget {
      * [LEMS-3185] do not trust serializedState
      */
     getSerializedState(): any {
-        const {userInput, ...rest} = this.props;
+        const {userInput, options, ...rest} = this.props;
         return {
+            ...options,
             ...rest,
             answers: userInput.answers,
             cursorPosition: this.state.cursorPosition,
@@ -293,8 +294,8 @@ class Matrix extends React.Component<Props, State> implements Widget {
         const {INPUT_MARGIN, INPUT_HEIGHT, INPUT_WIDTH} = dimensions;
 
         const matrixSize = getMatrixSize(this.props.userInput.answers);
-        const maxRows = this.props.matrixBoardSize[0];
-        const maxCols = this.props.matrixBoardSize[1];
+        const maxRows = this.props.options.matrixBoardSize[0];
+        const maxCols = this.props.options.matrixBoardSize[1];
         const cursorRow = this.state.cursorPosition[0];
         const cursorCol = this.state.cursorPosition[1];
 
@@ -318,10 +319,10 @@ class Matrix extends React.Component<Props, State> implements Widget {
 
         return (
             <div className={className}>
-                {this.props.prefix && (
+                {this.props.options.prefix && (
                     <div className="matrix-prefix">
                         <Renderer
-                            content={this.props.prefix}
+                            content={this.props.options.prefix}
                             linterContext={this.props.linterContext}
                             strings={this.context.strings}
                         />
@@ -467,10 +468,10 @@ class Matrix extends React.Component<Props, State> implements Widget {
                         );
                     })}
                 </div>
-                {this.props.suffix && (
+                {this.props.options.suffix && (
                     <div className="matrix-suffix">
                         <Renderer
-                            content={this.props.suffix}
+                            content={this.props.options.suffix}
                             linterContext={this.props.linterContext}
                             strings={this.context.strings}
                         />

--- a/packages/perseus/src/widgets/matrix/matrix.tsx
+++ b/packages/perseus/src/widgets/matrix/matrix.tsx
@@ -1,5 +1,4 @@
 import {getMatrixSize} from "@khanacademy/perseus-core";
-import {linterContextDefault} from "@khanacademy/perseus-linter";
 import {border} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import classNames from "classnames";
@@ -12,7 +11,6 @@ import SimpleKeypadInput from "../../components/simple-keypad-input";
 import TextInput from "../../components/text-input";
 import {withDependencies} from "../../components/with-dependencies";
 import InteractiveUtil from "../../interactive2/interactive-util";
-import {ApiOptions} from "../../perseus-api";
 import Renderer from "../../renderer";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/matrix/matrix-ai-utils";
 
@@ -96,15 +94,6 @@ type Props = WidgetProps<MatrixPublicWidgetOptions, PerseusMatrixUserInput> & {
     dependencies: PerseusDependenciesV2;
 };
 
-type DefaultProps = {
-    matrixBoardSize: Props["matrixBoardSize"];
-    prefix: string;
-    suffix: string;
-    apiOptions: Props["apiOptions"];
-    linterContext: Props["linterContext"];
-    userInput: PerseusMatrixUserInput;
-};
-
 type State = {
     // The coordinate location of the cursor position at start. default: [0, 0]
     cursorPosition: ReadonlyArray<number>;
@@ -116,17 +105,6 @@ class Matrix extends React.Component<Props, State> implements Widget {
 
     // @ts-expect-error - TS2564 - Property 'cursorPosition' has no initializer and is not definitely assigned in the constructor.
     cursorPosition: [number, number];
-
-    static defaultProps: DefaultProps = {
-        matrixBoardSize: [3, 3],
-        prefix: "",
-        suffix: "",
-        apiOptions: ApiOptions.defaults,
-        linterContext: linterContextDefault,
-        userInput: {
-            answers: [[]],
-        },
-    };
 
     state: State = {
         cursorPosition: [0, 0],

--- a/packages/perseus/src/widgets/matrix/matrix.tsx
+++ b/packages/perseus/src/widgets/matrix/matrix.tsx
@@ -27,7 +27,6 @@ import type {
     PerseusMatrixUserInput,
     PerseusMatrixWidgetOptions,
 } from "@khanacademy/perseus-core";
-import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 const {assert} = InteractiveUtil;
 
@@ -77,15 +76,6 @@ const getRefForPath = function (path: FocusPath) {
     const column = getColumnFromPath(path);
     return "answer" + row + "," + column;
 };
-
-// Assert that the PerseusMatrixWidgetOptions parsed from JSON can be passed
-// as props to this component. This ensures that the PerseusMatrixWidgetOptions
-// stays in sync with the prop types.
-// eslint-disable-next-line no-restricted-syntax
-0 as any as WidgetPropsV2<
-    PerseusMatrixWidgetOptions,
-    PerseusMatrixUserInput
-> satisfies PropsFor<typeof WrappedMatrix>;
 
 type Props = WidgetPropsV2<
     MatrixPublicWidgetOptions,


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a Matrix widget in
  http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.