### PR TITLE
Fix image markdown conversion button

### DIFF
--- a/.changeset/flat-taxis-sell.md
+++ b/.changeset/flat-taxis-sell.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Fix image markdown conversion button

--- a/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
@@ -660,7 +660,7 @@ table: [[☃ table 1]]
                           <input
                             aria-disabled="true"
                             class="hidden_1tmfokp"
-                            id=":r18:"
+                            id=":r0:"
                             role="switch"
                             type="checkbox"
                           />
@@ -674,7 +674,7 @@ table: [[☃ table 1]]
                         />
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                          for=":r18:"
+                          for=":r0:"
                         >
                           Static
                         </label>
@@ -706,7 +706,7 @@ table: [[☃ table 1]]
                                   aria-checked="false"
                                   aria-invalid="false"
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1y2x28c"
-                                  id=":r1a:"
+                                  id=":r2:"
                                   type="checkbox"
                                 />
                               </div>
@@ -715,7 +715,7 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                             >
                               <label
-                                for=":r1a:"
+                                for=":r2:"
                               >
                                 Randomize item order
                               </label>
@@ -1190,7 +1190,7 @@ table: [[☃ table 1]]
                           <input
                             aria-disabled="true"
                             class="hidden_1tmfokp"
-                            id=":r1c:"
+                            id=":r4:"
                             role="switch"
                             type="checkbox"
                           />
@@ -1204,7 +1204,7 @@ table: [[☃ table 1]]
                         />
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                          for=":r1c:"
+                          for=":r4:"
                         >
                           Static
                         </label>
@@ -1242,7 +1242,7 @@ table: [[☃ table 1]]
                             aria-invalid="false"
                             aria-required="false"
                             class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                            id=":r1e:"
+                            id=":r6:"
                             type="text"
                             value=""
                           />
@@ -1264,7 +1264,7 @@ table: [[☃ table 1]]
                             aria-invalid="false"
                             aria-required="false"
                             class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                            id=":r1f:"
+                            id=":r7:"
                             type="text"
                             value=""
                           />
@@ -1286,7 +1286,7 @@ table: [[☃ table 1]]
                             aria-invalid="false"
                             aria-required="false"
                             class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                            id=":r1g:"
+                            id=":r8:"
                             placeholder="Placeholder value"
                             type="text"
                             value="choose one"
@@ -1314,7 +1314,7 @@ table: [[☃ table 1]]
                           >
                             <input
                               checked=""
-                              name="perseus_dropdown_13"
+                              name="perseus_dropdown_11"
                               type="radio"
                             />
                             <input
@@ -1323,7 +1323,7 @@ table: [[☃ table 1]]
                               aria-label="Choice 1 content"
                               aria-required="false"
                               class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-disabled_1f0idyc-o_O-inlineStyles_7ab65q"
-                              id=":r1h:"
+                              id=":r9:"
                               readonly=""
                               type="text"
                               value="greater"
@@ -1346,7 +1346,7 @@ table: [[☃ table 1]]
                             class="dropdown-choice"
                           >
                             <input
-                              name="perseus_dropdown_13"
+                              name="perseus_dropdown_11"
                               type="radio"
                             />
                             <input
@@ -1355,7 +1355,7 @@ table: [[☃ table 1]]
                               aria-label="Choice 2 content"
                               aria-required="false"
                               class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-disabled_1f0idyc-o_O-inlineStyles_1kumfom"
-                              id=":r1i:"
+                              id=":ra:"
                               readonly=""
                               type="text"
                               value="less"
@@ -1378,7 +1378,7 @@ table: [[☃ table 1]]
                             class="dropdown-choice"
                           >
                             <input
-                              name="perseus_dropdown_13"
+                              name="perseus_dropdown_11"
                               type="radio"
                             />
                             <input
@@ -1387,7 +1387,7 @@ table: [[☃ table 1]]
                               aria-label="Choice 3 content"
                               aria-required="false"
                               class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-disabled_1f0idyc-o_O-inlineStyles_1kumfom"
-                              id=":r1j:"
+                              id=":rb:"
                               readonly=""
                               type="text"
                               value="equal"
@@ -1479,7 +1479,7 @@ table: [[☃ table 1]]
                           <input
                             aria-disabled="true"
                             class="hidden_1tmfokp"
-                            id=":r1k:"
+                            id=":rc:"
                             role="switch"
                             type="checkbox"
                           />
@@ -1493,7 +1493,7 @@ table: [[☃ table 1]]
                         />
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                          for=":r1k:"
+                          for=":rc:"
                         >
                           Static
                         </label>
@@ -1519,7 +1519,7 @@ table: [[☃ table 1]]
                         >
                           <label
                             class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-label_ukwbex-o_O-labelSpacing_10n8xdq"
-                            for=":r1m:-field"
+                            for=":re:-field"
                           >
                             Visible label
                             <span
@@ -1531,12 +1531,12 @@ table: [[☃ table 1]]
                             class="default_7zhre1-o_O-fieldSpacing_k5e93x"
                           >
                             <input
-                              aria-describedby=":r1m:-error"
+                              aria-describedby=":re:-error"
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-required="false"
                               class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                              id=":r1m:-field"
+                              id=":re:-field"
                               type="text"
                               value=""
                             />
@@ -1551,7 +1551,7 @@ table: [[☃ table 1]]
                         >
                           <label
                             class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-label_ukwbex-o_O-labelSpacing_10n8xdq"
-                            for=":r1o:-field"
+                            for=":rg:-field"
                           >
                             Aria label
                             <span
@@ -1563,12 +1563,12 @@ table: [[☃ table 1]]
                             class="default_7zhre1-o_O-fieldSpacing_k5e93x"
                           >
                             <input
-                              aria-describedby=":r1o:-error"
+                              aria-describedby=":rg:-error"
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-required="false"
                               class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                              id=":r1o:-field"
+                              id=":rg:-field"
                               type="text"
                               value=""
                             />
@@ -1583,7 +1583,7 @@ table: [[☃ table 1]]
                         >
                           <label
                             class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-label_ukwbex-o_O-labelSpacing_10n8xdq"
-                            for=":r1q:-field"
+                            for=":ri:-field"
                           >
                             Function variables
                             <span
@@ -1595,12 +1595,12 @@ table: [[☃ table 1]]
                             class="default_7zhre1-o_O-fieldSpacing_k5e93x"
                           >
                             <input
-                              aria-describedby=":r1q:-error"
+                              aria-describedby=":ri:-error"
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-required="false"
                               class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                              id=":r1q:-field"
+                              id=":ri:-field"
                               type="text"
                               value="f g h"
                             />
@@ -1628,7 +1628,7 @@ table: [[☃ table 1]]
                                   aria-checked="false"
                                   aria-invalid="false"
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1y2x28c"
-                                  id=":r1s:"
+                                  id=":rk:"
                                   type="checkbox"
                                 />
                               </div>
@@ -1637,7 +1637,7 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                             >
                               <label
-                                for=":r1s:"
+                                for=":rk:"
                               >
                                 Use × instead of ⋅ for multiplication
                                 <span
@@ -1675,7 +1675,7 @@ table: [[☃ table 1]]
                                   aria-checked="false"
                                   aria-invalid="false"
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1y2x28c"
-                                  id=":r1t:"
+                                  id=":rl:"
                                   type="checkbox"
                                 />
                               </div>
@@ -1684,7 +1684,7 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                             >
                               <label
-                                for=":r1t:"
+                                for=":rl:"
                               >
                                 show ÷ button
                               </label>
@@ -1711,7 +1711,7 @@ table: [[☃ table 1]]
                                   checked=""
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_pah6bz"
                                   disabled=""
-                                  id=":r1u:"
+                                  id=":rm:"
                                   type="checkbox"
                                 />
                                 <span
@@ -1723,7 +1723,7 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy-o_O-disabledLabel_1d65n8m"
                             >
                               <label
-                                for=":r1u:"
+                                for=":rm:"
                               >
                                 basic
                               </label>
@@ -1748,7 +1748,7 @@ table: [[☃ table 1]]
                                   aria-checked="false"
                                   aria-invalid="false"
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1y2x28c"
-                                  id=":r1v:"
+                                  id=":rn:"
                                   type="checkbox"
                                 />
                               </div>
@@ -1757,7 +1757,7 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                             >
                               <label
-                                for=":r1v:"
+                                for=":rn:"
                               >
                                 trig
                               </label>
@@ -1782,7 +1782,7 @@ table: [[☃ table 1]]
                                   aria-checked="false"
                                   aria-invalid="false"
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1y2x28c"
-                                  id=":r20:"
+                                  id=":ro:"
                                   type="checkbox"
                                 />
                               </div>
@@ -1791,7 +1791,7 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                             >
                               <label
-                                for=":r20:"
+                                for=":ro:"
                               >
                                 prealgebra
                               </label>
@@ -1816,7 +1816,7 @@ table: [[☃ table 1]]
                                   aria-checked="false"
                                   aria-invalid="false"
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1y2x28c"
-                                  id=":r21:"
+                                  id=":rp:"
                                   type="checkbox"
                                 />
                               </div>
@@ -1825,7 +1825,7 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                             >
                               <label
-                                for=":r21:"
+                                for=":rp:"
                               >
                                 logarithms
                               </label>
@@ -1850,7 +1850,7 @@ table: [[☃ table 1]]
                                   aria-checked="false"
                                   aria-invalid="false"
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1y2x28c"
-                                  id=":r22:"
+                                  id=":rq:"
                                   type="checkbox"
                                 />
                               </div>
@@ -1859,7 +1859,7 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                             >
                               <label
-                                for=":r22:"
+                                for=":rq:"
                               >
                                 scientific
                               </label>
@@ -1884,7 +1884,7 @@ table: [[☃ table 1]]
                                   aria-checked="false"
                                   aria-invalid="false"
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1y2x28c"
-                                  id=":r23:"
+                                  id=":rr:"
                                   type="checkbox"
                                 />
                               </div>
@@ -1893,7 +1893,7 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                             >
                               <label
-                                for=":r23:"
+                                for=":rr:"
                               >
                                 basic relations
                               </label>
@@ -1918,7 +1918,7 @@ table: [[☃ table 1]]
                                   aria-checked="false"
                                   aria-invalid="false"
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1y2x28c"
-                                  id=":r24:"
+                                  id=":rs:"
                                   type="checkbox"
                                 />
                               </div>
@@ -1927,7 +1927,7 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                             >
                               <label
-                                for=":r24:"
+                                for=":rs:"
                               >
                                 advanced relations
                               </label>
@@ -2005,7 +2005,7 @@ table: [[☃ table 1]]
                                           autocapitalize="off"
                                           autocomplete="off"
                                           autocorrect="off"
-                                          id=":r25:"
+                                          id=":rt:"
                                           spellcheck="false"
                                           x-palm-disable-ste-all="true"
                                         />
@@ -2056,11 +2056,11 @@ table: [[☃ table 1]]
                                       </span>
                                     </span>
                                     <button
-                                      aria-controls=":r26:"
+                                      aria-controls=":ru:"
                                       aria-expanded="false"
                                       aria-label="open math keypad"
                                       class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4"
-                                      id=":r26:-anchor"
+                                      id=":ru:-anchor"
                                       role="button"
                                       type="button"
                                     >
@@ -2106,7 +2106,7 @@ table: [[☃ table 1]]
                                         aria-invalid="false"
                                         checked=""
                                         class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1ywap6u"
-                                        id=":r27:"
+                                        id=":rv:"
                                         type="checkbox"
                                       />
                                       <span
@@ -2118,7 +2118,7 @@ table: [[☃ table 1]]
                                     class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                                   >
                                     <label
-                                      for=":r27:"
+                                      for=":rv:"
                                     >
                                       Answer expression must have the same form.
                                       <span
@@ -2151,7 +2151,7 @@ table: [[☃ table 1]]
                                         aria-checked="false"
                                         aria-invalid="false"
                                         class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1y2x28c"
-                                        id=":r28:"
+                                        id=":r10:"
                                         type="checkbox"
                                       />
                                     </div>
@@ -2160,7 +2160,7 @@ table: [[☃ table 1]]
                                     class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                                   >
                                     <label
-                                      for=":r28:"
+                                      for=":r10:"
                                     >
                                       Answer expression must be fully expanded and simplified.
                                       <span
@@ -2516,8 +2516,8 @@ table: [[☃ table 1]]
                         >
                           <label
                             class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_qt7cw0-o_O-labelWithNoDescription_i032sc"
-                            for=":r2b:-labeled-field-field"
-                            id=":r2b:-labeled-field-label"
+                            for=":r13:-labeled-field-field"
+                            id=":r13:-labeled-field-label"
                           >
                             Question
                           </label>
@@ -2530,7 +2530,7 @@ table: [[☃ table 1]]
                             aria-invalid="false"
                             aria-required="false"
                             class="textarea_8jhb0l-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-inlineStyles_1jc4iz4"
-                            id=":r2b:-labeled-field-field"
+                            id=":r13:-labeled-field-field"
                           >
                             What do you think?
                           </textarea>
@@ -2539,7 +2539,7 @@ table: [[☃ table 1]]
                           aria-atomic="true"
                           aria-live="assertive"
                           class="default_7zhre1-o_O-helperTextWithIcon_1hmzxfl"
-                          id=":r2b:-labeled-field-error"
+                          id=":r13:-labeled-field-error"
                         />
                       </div>
                       <div
@@ -2550,8 +2550,8 @@ table: [[☃ table 1]]
                         >
                           <label
                             class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_qt7cw0-o_O-labelWithNoDescription_i032sc"
-                            for=":r2d:-labeled-field-field"
-                            id=":r2d:-labeled-field-label"
+                            for=":r15:-labeled-field-field"
+                            id=":r15:-labeled-field-label"
                           >
                             Placeholder
                           </label>
@@ -2564,7 +2564,7 @@ table: [[☃ table 1]]
                             aria-invalid="false"
                             aria-required="false"
                             class="textarea_8jhb0l-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-inlineStyles_1jc4iz4"
-                            id=":r2d:-labeled-field-field"
+                            id=":r15:-labeled-field-field"
                           >
                             Please provide response here
                           </textarea>
@@ -2573,7 +2573,7 @@ table: [[☃ table 1]]
                           aria-atomic="true"
                           aria-live="assertive"
                           class="default_7zhre1-o_O-helperTextWithIcon_1hmzxfl"
-                          id=":r2d:-labeled-field-error"
+                          id=":r15:-labeled-field-error"
                         />
                       </div>
                       <div
@@ -2584,8 +2584,8 @@ table: [[☃ table 1]]
                         >
                           <label
                             class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_qt7cw0-o_O-labelWithNoDescription_i032sc"
-                            for=":r2f:-labeled-field-field"
-                            id=":r2f:-labeled-field-label"
+                            for=":r17:-labeled-field-field"
+                            id=":r17:-labeled-field-label"
                           >
                             Allow unlimited characters
                           </label>
@@ -2608,7 +2608,7 @@ table: [[☃ table 1]]
                                   aria-checked="false"
                                   aria-invalid="false"
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1y2x28c"
-                                  id=":r2f:-labeled-field-field"
+                                  id=":r17:-labeled-field-field"
                                   type="checkbox"
                                 />
                               </div>
@@ -2619,7 +2619,7 @@ table: [[☃ table 1]]
                           aria-atomic="true"
                           aria-live="assertive"
                           class="default_7zhre1-o_O-helperTextWithIcon_1hmzxfl"
-                          id=":r2f:-labeled-field-error"
+                          id=":r17:-labeled-field-error"
                         />
                       </div>
                       <div
@@ -2630,8 +2630,8 @@ table: [[☃ table 1]]
                         >
                           <label
                             class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_qt7cw0-o_O-labelWithNoDescription_i032sc"
-                            for=":r2h:-labeled-field-field"
-                            id=":r2h:-labeled-field-label"
+                            for=":r19:-labeled-field-field"
+                            id=":r19:-labeled-field-label"
                           >
                             Character limit
                           </label>
@@ -2642,7 +2642,7 @@ table: [[☃ table 1]]
                           aria-invalid="false"
                           aria-required="false"
                           class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                          id=":r2h:-labeled-field-field"
+                          id=":r19:-labeled-field-field"
                           min="1"
                           type="number"
                           value="500"
@@ -2651,7 +2651,7 @@ table: [[☃ table 1]]
                           aria-atomic="true"
                           aria-live="assertive"
                           class="default_7zhre1-o_O-helperTextWithIcon_1hmzxfl"
-                          id=":r2h:-labeled-field-error"
+                          id=":r19:-labeled-field-error"
                         />
                       </div>
                       <div
@@ -2988,7 +2988,7 @@ table: [[☃ table 1]]
                                     <input
                                       aria-disabled="true"
                                       class="hidden_1tmfokp"
-                                      id=":r2k:"
+                                      id=":r1c:"
                                       role="switch"
                                       type="checkbox"
                                     />
@@ -3002,7 +3002,7 @@ table: [[☃ table 1]]
                                   />
                                   <label
                                     class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                                    for=":r2k:"
+                                    for=":r1c:"
                                   >
                                     Static
                                   </label>
@@ -3086,13 +3086,13 @@ table: [[☃ table 1]]
                                         class="default_7zhre1-o_O-menuWrapper_1rs652y"
                                       >
                                         <button
-                                          aria-controls=":r2m:"
+                                          aria-controls=":r1e:"
                                           aria-expanded="false"
                                           aria-haspopup="listbox"
                                           aria-invalid="false"
                                           aria-required="false"
                                           class="button_vr44p2-o_O-shared_1hhaz1q-o_O-default_znuyo8"
-                                          id=":r2n:"
+                                          id=":r1f:"
                                           role="combobox"
                                           type="button"
                                         >
@@ -3214,17 +3214,17 @@ table: [[☃ table 1]]
                                       >
                                         <div
                                           class="default_7zhre1-o_O-wrapper_13982vy-o_O-wrapperWithAnimation_t6xj9m-o_O-wrapper_m5h1c0-o_O-wrapperExpanded_nhpyf7-o_O-container_clqed8"
-                                          id=":r2p:"
+                                          id=":r1h:"
                                         >
                                           <h2
                                             class="text_f1191h-o_O-header_bicv4w-o_O-Heading_czb6bz-o_O-HeadingMediumBoldWeight_m3f5sj-o_O-heading_1wk4vy6"
                                           >
                                             <button
-                                              aria-controls=":r2r:"
+                                              aria-controls=":r1j:"
                                               aria-disabled="false"
                                               aria-expanded="true"
                                               class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f"
-                                              id=":r2q:"
+                                              id=":r1i:"
                                               type="button"
                                             >
                                               <div
@@ -3242,9 +3242,9 @@ table: [[☃ table 1]]
                                             </button>
                                           </h2>
                                           <div
-                                            aria-labelledby=":r2q:"
+                                            aria-labelledby=":r1i:"
                                             class="default_7zhre1-o_O-contentWrapper_y9ev9r-o_O-contentWrapperExpanded_xsrqq9-o_O-contentWrapper_m95ukg"
-                                            id=":r2r:"
+                                            id=":r1j:"
                                             role="region"
                                           >
                                             <div
@@ -4058,7 +4058,7 @@ table: [[☃ table 1]]
                                       <input
                                         aria-disabled="true"
                                         class="hidden_1tmfokp"
-                                        id=":r2t:"
+                                        id=":r1l:"
                                         role="switch"
                                         type="checkbox"
                                       />
@@ -4072,7 +4072,7 @@ table: [[☃ table 1]]
                                     />
                                     <label
                                       class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                                      for=":r2t:"
+                                      for=":r1l:"
                                     >
                                       Static
                                     </label>
@@ -4156,13 +4156,13 @@ table: [[☃ table 1]]
                                           class="default_7zhre1-o_O-menuWrapper_1rs652y"
                                         >
                                           <button
-                                            aria-controls=":r2v:"
+                                            aria-controls=":r1n:"
                                             aria-expanded="false"
                                             aria-haspopup="listbox"
                                             aria-invalid="false"
                                             aria-required="false"
                                             class="button_vr44p2-o_O-shared_1hhaz1q-o_O-default_znuyo8"
-                                            id=":r30:"
+                                            id=":r1o:"
                                             role="combobox"
                                             type="button"
                                           >
@@ -4284,17 +4284,17 @@ table: [[☃ table 1]]
                                         >
                                           <div
                                             class="default_7zhre1-o_O-wrapper_13982vy-o_O-wrapperWithAnimation_t6xj9m-o_O-wrapper_m5h1c0-o_O-wrapperExpanded_nhpyf7-o_O-container_clqed8"
-                                            id=":r32:"
+                                            id=":r1q:"
                                           >
                                             <h2
                                               class="text_f1191h-o_O-header_bicv4w-o_O-Heading_czb6bz-o_O-HeadingMediumBoldWeight_m3f5sj-o_O-heading_1wk4vy6"
                                             >
                                               <button
-                                                aria-controls=":r34:"
+                                                aria-controls=":r1s:"
                                                 aria-disabled="false"
                                                 aria-expanded="true"
                                                 class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f"
-                                                id=":r33:"
+                                                id=":r1r:"
                                                 type="button"
                                               >
                                                 <div
@@ -4312,9 +4312,9 @@ table: [[☃ table 1]]
                                               </button>
                                             </h2>
                                             <div
-                                              aria-labelledby=":r33:"
+                                              aria-labelledby=":r1r:"
                                               class="default_7zhre1-o_O-contentWrapper_y9ev9r-o_O-contentWrapperExpanded_xsrqq9-o_O-contentWrapper_m95ukg"
-                                              id=":r34:"
+                                              id=":r1s:"
                                               role="region"
                                             >
                                               <div
@@ -4704,7 +4704,7 @@ table: [[☃ table 1]]
                           <input
                             aria-disabled="true"
                             class="hidden_1tmfokp"
-                            id=":r35:"
+                            id=":r1t:"
                             role="switch"
                             type="checkbox"
                           />
@@ -4718,7 +4718,7 @@ table: [[☃ table 1]]
                         />
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                          for=":r35:"
+                          for=":r1t:"
                         >
                           Static
                         </label>
@@ -4965,7 +4965,7 @@ table: [[☃ table 1]]
                                       aria-checked="false"
                                       aria-invalid="false"
                                       class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1y2x28c"
-                                      id=":r37:"
+                                      id=":r1v:"
                                       type="checkbox"
                                     />
                                   </div>
@@ -4974,7 +4974,7 @@ table: [[☃ table 1]]
                                   class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                                 >
                                   <label
-                                    for=":r37:"
+                                    for=":r1v:"
                                   >
                                     Show tooltips
                                   </label>
@@ -5100,21 +5100,21 @@ table: [[☃ table 1]]
                         class="default_7zhre1 mafs-graph-container"
                       >
                         <div
-                          aria-describedby="interactive-graph-interactive-elements-description-:r38:"
+                          aria-describedby="interactive-graph-interactive-elements-description-:r20:"
                           class="default_7zhre1-o_O-inlineStyles_n0eqhk mafs-graph"
                           role="figure"
                           tabindex="0"
                         >
                           <div
                             class="default_7zhre1 mafs-sr-only"
-                            id="instructions-:r38:"
+                            id="instructions-:r20:"
                             tabindex="-1"
                           >
                             Enable Forms or Focus mode and use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Arrow keys to move it.
                           </div>
                           <div
                             class="default_7zhre1 mafs-sr-only"
-                            id="interactive-graph-interactive-elements-description-:r38:"
+                            id="interactive-graph-interactive-elements-description-:r20:"
                             tabindex="-1"
                           >
                             Interactive elements: A line on a coordinate plane. The line has two points, point 1 at 0 comma 0 and point 2 at 1 comma 1.
@@ -6181,11 +6181,11 @@ table: [[☃ table 1]]
                                   width="288"
                                 >
                                   <g
-                                    aria-describedby=":r39:-points :r39:-intercept :r39:-slope"
+                                    aria-describedby=":r21:-points :r21:-intercept :r21:-slope"
                                     aria-label="A line on a coordinate plane."
                                   >
                                     <g
-                                      aria-describedby=":r39:-intercept :r39:-slope"
+                                      aria-describedby=":r21:-intercept :r21:-slope"
                                       aria-disabled="true"
                                       aria-label="Point 1 at 0 comma 0."
                                       class="movable-point__focusable-handle"
@@ -6194,7 +6194,7 @@ table: [[☃ table 1]]
                                       tabindex="-1"
                                     />
                                     <g
-                                      aria-describedby=":r39:-intercept :r39:-slope"
+                                      aria-describedby=":r21:-intercept :r21:-slope"
                                       aria-disabled="true"
                                       aria-label="Line going through point 0 comma 0 and point 1 comma 1."
                                       class="movable-line"
@@ -6291,7 +6291,7 @@ table: [[☃ table 1]]
                                       </g>
                                     </g>
                                     <g
-                                      aria-describedby=":r39:-intercept :r39:-slope"
+                                      aria-describedby=":r21:-intercept :r21:-slope"
                                       aria-disabled="true"
                                       aria-label="Point 2 at 1 comma 1."
                                       class="movable-point__focusable-handle"
@@ -6360,7 +6360,7 @@ table: [[☃ table 1]]
                                     <foreignobject>
                                       <span
                                         aria-hidden="true"
-                                        id=":r39:-points"
+                                        id=":r21:-points"
                                       >
                                         The line has two points, point 1 at 0 comma 0 and point 2 at 1 comma 1.
                                       </span>
@@ -6368,7 +6368,7 @@ table: [[☃ table 1]]
                                     <foreignobject>
                                       <span
                                         aria-hidden="true"
-                                        id=":r39:-intercept"
+                                        id=":r21:-intercept"
                                       >
                                         The line crosses the X and Y axes at the graph's origin.
                                       </span>
@@ -6376,7 +6376,7 @@ table: [[☃ table 1]]
                                     <foreignobject>
                                       <span
                                         aria-hidden="true"
-                                        id=":r39:-slope"
+                                        id=":r21:-slope"
                                       >
                                         Its slope increases from left to right.
                                       </span>
@@ -6676,7 +6676,7 @@ table: [[☃ table 1]]
                                     <input
                                       aria-disabled="true"
                                       class="hidden_1tmfokp"
-                                      id=":r3a:"
+                                      id=":r22:"
                                       role="switch"
                                       type="checkbox"
                                     />
@@ -6690,7 +6690,7 @@ table: [[☃ table 1]]
                                   />
                                   <label
                                     class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                                    for=":r3a:"
+                                    for=":r22:"
                                   >
                                     Static
                                   </label>
@@ -6774,13 +6774,13 @@ table: [[☃ table 1]]
                                         class="default_7zhre1-o_O-menuWrapper_1rs652y"
                                       >
                                         <button
-                                          aria-controls=":r3c:"
+                                          aria-controls=":r24:"
                                           aria-expanded="false"
                                           aria-haspopup="listbox"
                                           aria-invalid="false"
                                           aria-required="false"
                                           class="button_vr44p2-o_O-shared_1hhaz1q-o_O-default_znuyo8"
-                                          id=":r3d:"
+                                          id=":r25:"
                                           role="combobox"
                                           type="button"
                                         >
@@ -6902,17 +6902,17 @@ table: [[☃ table 1]]
                                       >
                                         <div
                                           class="default_7zhre1-o_O-wrapper_13982vy-o_O-wrapperWithAnimation_t6xj9m-o_O-wrapper_m5h1c0-o_O-wrapperExpanded_nhpyf7-o_O-container_clqed8"
-                                          id=":r3f:"
+                                          id=":r27:"
                                         >
                                           <h2
                                             class="text_f1191h-o_O-header_bicv4w-o_O-Heading_czb6bz-o_O-HeadingMediumBoldWeight_m3f5sj-o_O-heading_1wk4vy6"
                                           >
                                             <button
-                                              aria-controls=":r3h:"
+                                              aria-controls=":r29:"
                                               aria-disabled="false"
                                               aria-expanded="true"
                                               class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f"
-                                              id=":r3g:"
+                                              id=":r28:"
                                               type="button"
                                             >
                                               <div
@@ -6930,9 +6930,9 @@ table: [[☃ table 1]]
                                             </button>
                                           </h2>
                                           <div
-                                            aria-labelledby=":r3g:"
+                                            aria-labelledby=":r28:"
                                             class="default_7zhre1-o_O-contentWrapper_y9ev9r-o_O-contentWrapperExpanded_xsrqq9-o_O-contentWrapper_m95ukg"
-                                            id=":r3h:"
+                                            id=":r29:"
                                             role="region"
                                           >
                                             <div
@@ -7293,25 +7293,25 @@ table: [[☃ table 1]]
                       >
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_qt7cw0-o_O-labelWithDescription_jspf4t-o_O-inlineStyles_19rjtmm"
-                          for=":r3j:-labeled-field-field"
-                          id=":r3j:-labeled-field-label"
+                          for=":r2b:-labeled-field-field"
+                          id=":r2b:-labeled-field-label"
                         >
                           Image URL
                         </label>
                       </div>
                       <p
                         class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-helperText_p81a7m-o_O-spacingBelowHelperText_grnrp-o_O-inlineStyles_fi5o4v"
-                        id=":r3j:-labeled-field-description"
+                        id=":r2b:-labeled-field-description"
                       >
                         Paste an image or graphie image URL.
                       </p>
                       <input
-                        aria-describedby=":r3j:-labeled-field-description"
+                        aria-describedby=":r2b:-labeled-field-description"
                         aria-disabled="false"
                         aria-invalid="false"
                         aria-required="false"
                         class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                        id=":r3j:-labeled-field-field"
+                        id=":r2b:-labeled-field-field"
                         type="text"
                         value="https://ka-perseus-images.s3.amazonaws.com/sample-diagram.png"
                       />
@@ -7319,7 +7319,7 @@ table: [[☃ table 1]]
                         aria-atomic="true"
                         aria-live="assertive"
                         class="default_7zhre1-o_O-helperTextWithIcon_1hmzxfl"
-                        id=":r3j:-labeled-field-error"
+                        id=":r2b:-labeled-field-error"
                       />
                     </div>
                     <div
@@ -7330,8 +7330,8 @@ table: [[☃ table 1]]
                       >
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_qt7cw0-o_O-labelWithNoDescription_i032sc-o_O-inlineStyles_1slo5sh"
-                          for=":r3l:-labeled-field-field"
-                          id=":r3l:-labeled-field-label"
+                          for=":r2d:-labeled-field-field"
+                          id=":r2d:-labeled-field-label"
                         >
                           Preview
                         </label>
@@ -7348,7 +7348,7 @@ table: [[☃ table 1]]
                             <input
                               aria-disabled="true"
                               class="hidden_1tmfokp"
-                              id=":r3m:"
+                              id=":r2e:"
                               role="switch"
                               type="checkbox"
                             />
@@ -7362,7 +7362,7 @@ table: [[☃ table 1]]
                           />
                           <label
                             class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                            for=":r3m:"
+                            for=":r2e:"
                           >
                             Show in Dark Mode
                           </label>
@@ -7379,7 +7379,7 @@ table: [[☃ table 1]]
                               <input
                                 aria-disabled="true"
                                 class="hidden_1tmfokp"
-                                id=":r3o:"
+                                id=":r2g:"
                                 role="switch"
                                 type="checkbox"
                               />
@@ -7393,7 +7393,7 @@ table: [[☃ table 1]]
                             />
                             <label
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                              for=":r3o:"
+                              for=":r2g:"
                             >
                               Suppress Dark Mode Filter
                             </label>
@@ -7439,7 +7439,7 @@ table: [[☃ table 1]]
                         aria-atomic="true"
                         aria-live="assertive"
                         class="default_7zhre1-o_O-helperTextWithIcon_1hmzxfl"
-                        id=":r3l:-labeled-field-error"
+                        id=":r2d:-labeled-field-error"
                       />
                     </div>
                     <div
@@ -7483,25 +7483,25 @@ table: [[☃ table 1]]
                         >
                           <label
                             class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_qt7cw0-o_O-labelWithDescription_jspf4t-o_O-disabledLabel_12or4dq-o_O-inlineStyles_1slo5sh"
-                            for=":r3q:-labeled-field-field"
-                            id=":r3q:-labeled-field-label"
+                            for=":r2i:-labeled-field-field"
+                            id=":r2i:-labeled-field-label"
                           >
                             Scale
                           </label>
                         </div>
                         <p
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-helperText_p81a7m-o_O-spacingBelowHelperText_grnrp-o_O-disabledHelperText_1dxxvir"
-                          id=":r3q:-labeled-field-description"
+                          id=":r2i:-labeled-field-description"
                         >
                           Use 1 to display image at original size.
                         </p>
                         <input
-                          aria-describedby=":r3q:-labeled-field-description"
+                          aria-describedby=":r2i:-labeled-field-description"
                           aria-disabled="true"
                           aria-invalid="false"
                           aria-required="false"
                           class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-disabled_1f0idyc"
-                          id=":r3q:-labeled-field-field"
+                          id=":r2i:-labeled-field-field"
                           min="0"
                           readonly=""
                           type="number"
@@ -7511,7 +7511,7 @@ table: [[☃ table 1]]
                           aria-atomic="true"
                           aria-live="assertive"
                           class="default_7zhre1-o_O-helperTextWithIcon_1hmzxfl"
-                          id=":r3q:-labeled-field-error"
+                          id=":r2i:-labeled-field-error"
                         />
                       </div>
                       <div
@@ -7525,8 +7525,8 @@ table: [[☃ table 1]]
                           >
                             <label
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_qt7cw0-o_O-labelWithNoDescription_i032sc-o_O-disabledLabel_12or4dq-o_O-inlineStyles_1slo5sh"
-                              for=":r3s:-labeled-field-field"
-                              id=":r3s:-labeled-field-label"
+                              for=":r2k:-labeled-field-field"
+                              id=":r2k:-labeled-field-label"
                             >
                               Scaled Width
                             </label>
@@ -7537,7 +7537,7 @@ table: [[☃ table 1]]
                             aria-invalid="false"
                             aria-required="false"
                             class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-disabled_1f0idyc"
-                            id=":r3s:-labeled-field-field"
+                            id=":r2k:-labeled-field-field"
                             min="0"
                             readonly=""
                             type="number"
@@ -7547,7 +7547,7 @@ table: [[☃ table 1]]
                             aria-atomic="true"
                             aria-live="assertive"
                             class="default_7zhre1-o_O-helperTextWithIcon_1hmzxfl"
-                            id=":r3s:-labeled-field-error"
+                            id=":r2k:-labeled-field-error"
                           />
                         </div>
                         <span
@@ -7563,8 +7563,8 @@ table: [[☃ table 1]]
                           >
                             <label
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_qt7cw0-o_O-labelWithNoDescription_i032sc-o_O-disabledLabel_12or4dq-o_O-inlineStyles_1slo5sh"
-                              for=":r3u:-labeled-field-field"
-                              id=":r3u:-labeled-field-label"
+                              for=":r2m:-labeled-field-field"
+                              id=":r2m:-labeled-field-label"
                             >
                               Scaled Height
                             </label>
@@ -7575,7 +7575,7 @@ table: [[☃ table 1]]
                             aria-invalid="false"
                             aria-required="false"
                             class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-disabled_1f0idyc"
-                            id=":r3u:-labeled-field-field"
+                            id=":r2m:-labeled-field-field"
                             min="0"
                             readonly=""
                             type="number"
@@ -7585,7 +7585,7 @@ table: [[☃ table 1]]
                             aria-atomic="true"
                             aria-live="assertive"
                             class="default_7zhre1-o_O-helperTextWithIcon_1hmzxfl"
-                            id=":r3u:-labeled-field-error"
+                            id=":r2m:-labeled-field-error"
                           />
                         </div>
                       </div>
@@ -7605,7 +7605,7 @@ table: [[☃ table 1]]
                             <input
                               aria-disabled="true"
                               class="hidden_1tmfokp"
-                              id=":r40:"
+                              id=":r2o:"
                               role="switch"
                               type="checkbox"
                             />
@@ -7619,7 +7619,7 @@ table: [[☃ table 1]]
                           />
                           <label
                             class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                            for=":r40:"
+                            for=":r2o:"
                           >
                             Decorative
                           </label>
@@ -7638,8 +7638,8 @@ table: [[☃ table 1]]
                       >
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_qt7cw0-o_O-labelWithNoDescription_i032sc-o_O-disabledLabel_12or4dq-o_O-inlineStyles_1slo5sh"
-                          for=":r42:-labeled-field-field"
-                          id=":r42:-labeled-field-label"
+                          for=":r2q:-labeled-field-field"
+                          id=":r2q:-labeled-field-label"
                         >
                           Title
                         </label>
@@ -7653,7 +7653,7 @@ table: [[☃ table 1]]
                           aria-invalid="false"
                           aria-required="false"
                           class="textarea_8jhb0l-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-disabled_1f0idyc-o_O-autoResize_1m0oq5d-o_O-inlineStyles_8zrxtn"
-                          id=":r42:-labeled-field-field"
+                          id=":r2q:-labeled-field-field"
                           readonly=""
                           style=""
                         />
@@ -7662,7 +7662,7 @@ table: [[☃ table 1]]
                         aria-atomic="true"
                         aria-live="assertive"
                         class="default_7zhre1-o_O-helperTextWithIcon_1hmzxfl"
-                        id=":r42:-labeled-field-error"
+                        id=":r2q:-labeled-field-error"
                       />
                     </div>
                     <div
@@ -7676,15 +7676,15 @@ table: [[☃ table 1]]
                         >
                           <label
                             class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_qt7cw0-o_O-labelWithDescription_jspf4t-o_O-disabledLabel_12or4dq-o_O-inlineStyles_19rjtmm"
-                            for=":r44:-labeled-field-field"
-                            id=":r44:-labeled-field-label"
+                            for=":r2s:-labeled-field-field"
+                            id=":r2s:-labeled-field-label"
                           >
                             Alt text
                           </label>
                         </div>
                         <p
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-helperText_p81a7m-o_O-spacingBelowHelperText_grnrp-o_O-disabledHelperText_1dxxvir-o_O-inlineStyles_fi5o4v"
-                          id=":r44:-labeled-field-description"
+                          id=":r2s:-labeled-field-description"
                         >
                           Summarize the image using up to 125 characters.
                         </p>
@@ -7692,12 +7692,12 @@ table: [[☃ table 1]]
                           class="default_7zhre1-o_O-inlineStyles_zdxht7"
                         >
                           <textarea
-                            aria-describedby=":r44:-labeled-field-description"
+                            aria-describedby=":r2s:-labeled-field-description"
                             aria-disabled="true"
                             aria-invalid="false"
                             aria-required="false"
                             class="textarea_8jhb0l-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-disabled_1f0idyc-o_O-autoResize_1m0oq5d-o_O-inlineStyles_8zrxtn"
-                            id=":r44:-labeled-field-field"
+                            id=":r2s:-labeled-field-field"
                             readonly=""
                             style=""
                           />
@@ -7706,7 +7706,7 @@ table: [[☃ table 1]]
                           aria-atomic="true"
                           aria-live="assertive"
                           class="default_7zhre1-o_O-helperTextWithIcon_1hmzxfl"
-                          id=":r44:-labeled-field-error"
+                          id=":r2s:-labeled-field-error"
                         />
                       </div>
                       <span
@@ -7724,8 +7724,8 @@ table: [[☃ table 1]]
                       >
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_qt7cw0-o_O-labelWithNoDescription_i032sc-o_O-disabledLabel_12or4dq-o_O-inlineStyles_1slo5sh"
-                          for=":r46:-labeled-field-field"
-                          id=":r46:-labeled-field-label"
+                          for=":r2u:-labeled-field-field"
+                          id=":r2u:-labeled-field-label"
                         >
                           Long description
                         </label>
@@ -7739,7 +7739,7 @@ table: [[☃ table 1]]
                           aria-invalid="false"
                           aria-required="false"
                           class="textarea_8jhb0l-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-disabled_1f0idyc-o_O-autoResize_1m0oq5d-o_O-inlineStyles_8zrxtn"
-                          id=":r46:-labeled-field-field"
+                          id=":r2u:-labeled-field-field"
                           readonly=""
                           style=""
                         />
@@ -7748,7 +7748,7 @@ table: [[☃ table 1]]
                         aria-atomic="true"
                         aria-live="assertive"
                         class="default_7zhre1-o_O-helperTextWithIcon_1hmzxfl"
-                        id=":r46:-labeled-field-error"
+                        id=":r2u:-labeled-field-error"
                       />
                     </div>
                     <div
@@ -7759,8 +7759,8 @@ table: [[☃ table 1]]
                       >
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_qt7cw0-o_O-labelWithNoDescription_i032sc-o_O-disabledLabel_12or4dq-o_O-inlineStyles_1slo5sh"
-                          for=":r48:-labeled-field-field"
-                          id=":r48:-labeled-field-label"
+                          for=":r30:-labeled-field-field"
+                          id=":r30:-labeled-field-label"
                         >
                           Caption
                         </label>
@@ -7774,7 +7774,7 @@ table: [[☃ table 1]]
                           aria-invalid="false"
                           aria-required="false"
                           class="textarea_8jhb0l-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-disabled_1f0idyc-o_O-autoResize_1m0oq5d-o_O-inlineStyles_8zrxtn"
-                          id=":r48:-labeled-field-field"
+                          id=":r30:-labeled-field-field"
                           readonly=""
                           style=""
                         />
@@ -7783,7 +7783,7 @@ table: [[☃ table 1]]
                         aria-atomic="true"
                         aria-live="assertive"
                         class="default_7zhre1-o_O-helperTextWithIcon_1hmzxfl"
-                        id=":r48:-labeled-field-error"
+                        id=":r30:-labeled-field-error"
                       />
                     </div>
                   </div>
@@ -7835,7 +7835,7 @@ table: [[☃ table 1]]
                           <input
                             aria-disabled="true"
                             class="hidden_1tmfokp"
-                            id=":r4a:"
+                            id=":r32:"
                             role="switch"
                             type="checkbox"
                           />
@@ -7849,7 +7849,7 @@ table: [[☃ table 1]]
                         />
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                          for=":r4a:"
+                          for=":r32:"
                         >
                           Static
                         </label>
@@ -7933,13 +7933,13 @@ table: [[☃ table 1]]
                               class="default_7zhre1-o_O-menuWrapper_1rs652y"
                             >
                               <button
-                                aria-controls=":r4c:"
+                                aria-controls=":r34:"
                                 aria-expanded="false"
                                 aria-haspopup="listbox"
                                 aria-invalid="false"
                                 aria-required="false"
                                 class="button_vr44p2-o_O-shared_1hhaz1q-o_O-default_znuyo8"
-                                id=":r4d:"
+                                id=":r35:"
                                 role="combobox"
                                 type="button"
                               >
@@ -8061,17 +8061,17 @@ table: [[☃ table 1]]
                             >
                               <div
                                 class="default_7zhre1-o_O-wrapper_13982vy-o_O-wrapperWithAnimation_t6xj9m-o_O-wrapper_m5h1c0-o_O-wrapperExpanded_nhpyf7-o_O-container_clqed8"
-                                id=":r4f:"
+                                id=":r37:"
                               >
                                 <h2
                                   class="text_f1191h-o_O-header_bicv4w-o_O-Heading_czb6bz-o_O-HeadingMediumBoldWeight_m3f5sj-o_O-heading_1wk4vy6"
                                 >
                                   <button
-                                    aria-controls=":r4h:"
+                                    aria-controls=":r39:"
                                     aria-disabled="false"
                                     aria-expanded="true"
                                     class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f"
-                                    id=":r4g:"
+                                    id=":r38:"
                                     type="button"
                                   >
                                     <div
@@ -8089,9 +8089,9 @@ table: [[☃ table 1]]
                                   </button>
                                 </h2>
                                 <div
-                                  aria-labelledby=":r4g:"
+                                  aria-labelledby=":r38:"
                                   class="default_7zhre1-o_O-contentWrapper_y9ev9r-o_O-contentWrapperExpanded_xsrqq9-o_O-contentWrapper_m95ukg"
-                                  id=":r4h:"
+                                  id=":r39:"
                                   role="region"
                                 >
                                   <div
@@ -8705,7 +8705,7 @@ table: [[☃ table 1]]
                                           aria-checked="false"
                                           aria-invalid="false"
                                           class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1y2x28c"
-                                          id=":r4i:"
+                                          id=":r3a:"
                                           type="checkbox"
                                         />
                                       </div>
@@ -8714,7 +8714,7 @@ table: [[☃ table 1]]
                                       class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                                     >
                                       <label
-                                        for=":r4i:"
+                                        for=":r3a:"
                                       >
                                         Show tooltips
                                       </label>
@@ -9184,7 +9184,7 @@ table: [[☃ table 1]]
                           <input
                             aria-disabled="true"
                             class="hidden_1tmfokp"
-                            id=":r4j:"
+                            id=":r3b:"
                             role="switch"
                             type="checkbox"
                           />
@@ -9198,7 +9198,7 @@ table: [[☃ table 1]]
                         />
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                          for=":r4j:"
+                          for=":r3b:"
                         >
                           Static
                         </label>
@@ -9212,7 +9212,7 @@ table: [[☃ table 1]]
                           <input
                             aria-disabled="true"
                             class="hidden_1tmfokp"
-                            id=":r4l:"
+                            id=":r3d:"
                             role="switch"
                             type="checkbox"
                           />
@@ -9226,7 +9226,7 @@ table: [[☃ table 1]]
                         />
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                          for=":r4l:"
+                          for=":r3d:"
                         >
                           Interactive but ungraded
                         </label>
@@ -9254,14 +9254,14 @@ table: [[☃ table 1]]
                             class="default_7zhre1-o_O-menuWrapper_1rs652y single-select-short"
                           >
                             <button
-                              aria-controls=":r4o:"
+                              aria-controls=":r3g:"
                               aria-disabled="true"
                               aria-expanded="false"
                               aria-haspopup="listbox"
                               aria-invalid="false"
                               aria-required="false"
                               class="button_vr44p2-o_O-shared_1hhaz1q-o_O-default_znuyo8-o_O-disabled_1bd2lp"
-                              id=":r4p:"
+                              id=":r3h:"
                               role="combobox"
                               type="button"
                             >
@@ -9318,7 +9318,7 @@ table: [[☃ table 1]]
                             aria-invalid="false"
                             aria-required="false"
                             class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-disabled_1f0idyc-o_O-inlineStyles_157hyer"
-                            id=":r4r:"
+                            id=":r3j:"
                             readonly=""
                             type="text"
                             value=""
@@ -9326,7 +9326,7 @@ table: [[☃ table 1]]
                         </label>
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumBoldWeight_uu4up7"
-                          for=":r4q:-description-textarea"
+                          for=":r3i:-description-textarea"
                         >
                           Description
                         </label>
@@ -9338,7 +9338,7 @@ table: [[☃ table 1]]
                             aria-invalid="false"
                             aria-required="false"
                             class="textarea_8jhb0l-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-disabled_1f0idyc-o_O-autoResize_1m0oq5d-o_O-inlineStyles_8zrxtn"
-                            id=":r4q:-description-textarea"
+                            id=":r3i:-description-textarea"
                             readonly=""
                             style=""
                           />
@@ -9361,7 +9361,7 @@ table: [[☃ table 1]]
                       </button>
                       <div
                         class="default_7zhre1"
-                        id=":r4n:"
+                        id=":r3f:"
                       >
                         <div
                           class="default_7zhre1"
@@ -9381,21 +9381,21 @@ table: [[☃ table 1]]
                           class="default_7zhre1 mafs-graph-container"
                         >
                           <div
-                            aria-describedby="interactive-graph-interactive-elements-description-:r4t:"
+                            aria-describedby="interactive-graph-interactive-elements-description-:r3l:"
                             class="default_7zhre1-o_O-inlineStyles_n0eqhk mafs-graph"
                             role="figure"
                             tabindex="0"
                           >
                             <div
                               class="default_7zhre1 mafs-sr-only"
-                              id="instructions-:r4t:"
+                              id="instructions-:r3l:"
                               tabindex="-1"
                             >
                               Enable Forms or Focus mode and use the Tab key to move through the interactive elements in the graph. When an interactive element has focus, use Arrow keys to move it.
                             </div>
                             <div
                               class="default_7zhre1 mafs-sr-only"
-                              id="interactive-graph-interactive-elements-description-:r4t:"
+                              id="interactive-graph-interactive-elements-description-:r3l:"
                               tabindex="-1"
                             >
                               Interactive elements: A line on a coordinate plane. The line has two points, point 1 at 0 comma 1 and point 2 at 1 comma 3.
@@ -10474,11 +10474,11 @@ table: [[☃ table 1]]
                                     width="288"
                                   >
                                     <g
-                                      aria-describedby=":r4u:-points :r4u:-intercept :r4u:-slope"
+                                      aria-describedby=":r3m:-points :r3m:-intercept :r3m:-slope"
                                       aria-label="A line on a coordinate plane."
                                     >
                                       <g
-                                        aria-describedby=":r4u:-intercept :r4u:-slope"
+                                        aria-describedby=":r3m:-intercept :r3m:-slope"
                                         aria-disabled="true"
                                         aria-label="Point 1 at 0 comma 1."
                                         class="movable-point__focusable-handle"
@@ -10487,7 +10487,7 @@ table: [[☃ table 1]]
                                         tabindex="-1"
                                       />
                                       <g
-                                        aria-describedby=":r4u:-intercept :r4u:-slope"
+                                        aria-describedby=":r3m:-intercept :r3m:-slope"
                                         aria-disabled="true"
                                         aria-label="Line going through point 0 comma 1 and point 1 comma 3."
                                         class="movable-line"
@@ -10584,7 +10584,7 @@ table: [[☃ table 1]]
                                         </g>
                                       </g>
                                       <g
-                                        aria-describedby=":r4u:-intercept :r4u:-slope"
+                                        aria-describedby=":r3m:-intercept :r3m:-slope"
                                         aria-disabled="true"
                                         aria-label="Point 2 at 1 comma 3."
                                         class="movable-point__focusable-handle"
@@ -10653,7 +10653,7 @@ table: [[☃ table 1]]
                                       <foreignobject>
                                         <span
                                           aria-hidden="true"
-                                          id=":r4u:-points"
+                                          id=":r3m:-points"
                                         >
                                           The line has two points, point 1 at 0 comma 1 and point 2 at 1 comma 3.
                                         </span>
@@ -10661,7 +10661,7 @@ table: [[☃ table 1]]
                                       <foreignobject>
                                         <span
                                           aria-hidden="true"
-                                          id=":r4u:-intercept"
+                                          id=":r3m:-intercept"
                                         >
                                           The line crosses the X-axis at -0.5 comma 0 and the Y-axis at 0 comma 1.
                                         </span>
@@ -10669,7 +10669,7 @@ table: [[☃ table 1]]
                                       <foreignobject>
                                         <span
                                           aria-hidden="true"
-                                          id=":r4u:-slope"
+                                          id=":r3m:-slope"
                                         >
                                           Its slope increases from left to right.
                                         </span>
@@ -10714,7 +10714,7 @@ table: [[☃ table 1]]
                             <input
                               aria-disabled="true"
                               class="hidden_1tmfokp"
-                              id=":r4v:"
+                              id=":r3n:"
                               role="switch"
                               type="checkbox"
                             />
@@ -10728,7 +10728,7 @@ table: [[☃ table 1]]
                           />
                           <label
                             class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                            for=":r4v:"
+                            for=":r3n:"
                           >
                             Show point labels
                           </label>
@@ -10783,7 +10783,7 @@ table: [[☃ table 1]]
                                 aria-invalid="false"
                                 aria-required="false"
                                 class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-inlineStyles_1asri2u"
-                                id=":r51:"
+                                id=":r3p:"
                                 type="number"
                                 value="0"
                               />
@@ -10801,7 +10801,7 @@ table: [[☃ table 1]]
                                 aria-invalid="false"
                                 aria-required="false"
                                 class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-inlineStyles_1asri2u"
-                                id=":r52:"
+                                id=":r3q:"
                                 type="number"
                                 value="1"
                               />
@@ -10824,7 +10824,7 @@ table: [[☃ table 1]]
                                 aria-label="Point 1 name"
                                 aria-required="false"
                                 class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                                id=":r53:"
+                                id=":r3r:"
                                 placeholder="1"
                                 type="text"
                                 value=""
@@ -10856,7 +10856,7 @@ table: [[☃ table 1]]
                                 aria-invalid="false"
                                 aria-required="false"
                                 class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-inlineStyles_1asri2u"
-                                id=":r54:"
+                                id=":r3s:"
                                 type="number"
                                 value="1"
                               />
@@ -10874,7 +10874,7 @@ table: [[☃ table 1]]
                                 aria-invalid="false"
                                 aria-required="false"
                                 class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-inlineStyles_1asri2u"
-                                id=":r55:"
+                                id=":r3t:"
                                 type="number"
                                 value="3"
                               />
@@ -10897,7 +10897,7 @@ table: [[☃ table 1]]
                                 aria-label="Point 2 name"
                                 aria-required="false"
                                 class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                                id=":r56:"
+                                id=":r3u:"
                                 placeholder="2"
                                 type="text"
                                 value=""
@@ -10956,7 +10956,7 @@ table: [[☃ table 1]]
                           <input
                             aria-disabled="true"
                             class="hidden_1tmfokp"
-                            id=":r57:"
+                            id=":r3v:"
                             role="switch"
                             type="checkbox"
                           />
@@ -10966,7 +10966,7 @@ table: [[☃ table 1]]
                         </div>
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf"
-                          for=":r57:"
+                          for=":r3v:"
                         >
                           Show HTML roles/tags
                         </label>
@@ -11375,7 +11375,7 @@ table: [[☃ table 1]]
                               >
                                 <label
                                   class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf"
-                                  for=":r59:"
+                                  for=":r41:"
                                 >
                                   x min
                                 </label>
@@ -11390,7 +11390,7 @@ table: [[☃ table 1]]
                                     aria-disabled="true"
                                     checked=""
                                     class="hidden_1tmfokp"
-                                    id=":r59:"
+                                    id=":r41:"
                                     role="switch"
                                     type="checkbox"
                                   />
@@ -11408,7 +11408,7 @@ table: [[☃ table 1]]
                               >
                                 <label
                                   class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf"
-                                  for=":r5b:"
+                                  for=":r43:"
                                 >
                                   y min
                                 </label>
@@ -11423,7 +11423,7 @@ table: [[☃ table 1]]
                                     aria-disabled="true"
                                     checked=""
                                     class="hidden_1tmfokp"
-                                    id=":r5b:"
+                                    id=":r43:"
                                     role="switch"
                                     type="checkbox"
                                   />
@@ -11446,7 +11446,7 @@ table: [[☃ table 1]]
                               >
                                 <label
                                   class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf"
-                                  for=":r5d:"
+                                  for=":r45:"
                                 >
                                   x max
                                 </label>
@@ -11461,7 +11461,7 @@ table: [[☃ table 1]]
                                     aria-disabled="true"
                                     checked=""
                                     class="hidden_1tmfokp"
-                                    id=":r5d:"
+                                    id=":r45:"
                                     role="switch"
                                     type="checkbox"
                                   />
@@ -11479,7 +11479,7 @@ table: [[☃ table 1]]
                               >
                                 <label
                                   class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf"
-                                  for=":r5f:"
+                                  for=":r47:"
                                 >
                                   y max
                                 </label>
@@ -11494,7 +11494,7 @@ table: [[☃ table 1]]
                                     aria-disabled="true"
                                     checked=""
                                     class="hidden_1tmfokp"
-                                    id=":r5f:"
+                                    id=":r47:"
                                     role="switch"
                                     type="checkbox"
                                   />
@@ -11522,7 +11522,7 @@ table: [[☃ table 1]]
                               >
                                 <label
                                   class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf"
-                                  for=":r5h:"
+                                  for=":r49:"
                                 >
                                   x-axis
                                 </label>
@@ -11537,7 +11537,7 @@ table: [[☃ table 1]]
                                     aria-disabled="true"
                                     checked=""
                                     class="hidden_1tmfokp"
-                                    id=":r5h:"
+                                    id=":r49:"
                                     role="switch"
                                     type="checkbox"
                                   />
@@ -11555,7 +11555,7 @@ table: [[☃ table 1]]
                               >
                                 <label
                                   class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallMediumWeight_1qmn0hf"
-                                  for=":r5j:"
+                                  for=":r4b:"
                                 >
                                   y-axis
                                 </label>
@@ -11570,7 +11570,7 @@ table: [[☃ table 1]]
                                     aria-disabled="true"
                                     checked=""
                                     class="hidden_1tmfokp"
-                                    id=":r5j:"
+                                    id=":r4b:"
                                     role="switch"
                                     type="checkbox"
                                   />
@@ -11773,7 +11773,7 @@ table: [[☃ table 1]]
                                       aria-invalid="false"
                                       class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_vfcxos"
                                       disabled=""
-                                      id=":r5l:"
+                                      id=":r4d:"
                                       type="checkbox"
                                     />
                                   </div>
@@ -11782,7 +11782,7 @@ table: [[☃ table 1]]
                                   class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy-o_O-disabledLabel_1d65n8m"
                                 >
                                   <label
-                                    for=":r5l:"
+                                    for=":r4d:"
                                   >
                                     Show tooltips
                                   </label>
@@ -11838,7 +11838,7 @@ table: [[☃ table 1]]
                                       aria-invalid="false"
                                       class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_vfcxos"
                                       disabled=""
-                                      id=":r5m:"
+                                      id=":r4e:"
                                       type="checkbox"
                                     />
                                   </div>
@@ -11847,7 +11847,7 @@ table: [[☃ table 1]]
                                   class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy-o_O-disabledLabel_1d65n8m"
                                 >
                                   <label
-                                    for=":r5m:"
+                                    for=":r4e:"
                                   >
                                     Show protractor
                                   </label>
@@ -11883,17 +11883,17 @@ table: [[☃ table 1]]
                         >
                           <div
                             class="default_7zhre1-o_O-wrapper_13982vy-o_O-wrapper_m5h1c0-o_O-wrapperExpanded_nhpyf7-o_O-container_clqed8"
-                            id=":r5o:"
+                            id=":r4g:"
                           >
                             <h2
                               class="text_f1191h-o_O-header_bicv4w-o_O-Heading_czb6bz-o_O-HeadingMediumBoldWeight_m3f5sj-o_O-heading_1wk4vy6"
                             >
                               <button
-                                aria-controls=":r5q:"
+                                aria-controls=":r4i:"
                                 aria-disabled="false"
                                 aria-expanded="true"
                                 class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f"
-                                id=":r5p:"
+                                id=":r4h:"
                                 type="button"
                               >
                                 <div
@@ -11919,9 +11919,9 @@ table: [[☃ table 1]]
                               </button>
                             </h2>
                             <div
-                              aria-labelledby=":r5p:"
+                              aria-labelledby=":r4h:"
                               class="default_7zhre1-o_O-contentWrapper_y9ev9r-o_O-contentWrapperExpanded_xsrqq9-o_O-contentWrapper_m95ukg"
-                              id=":r5q:"
+                              id=":r4i:"
                               role="region"
                             >
                               <div
@@ -11941,7 +11941,7 @@ table: [[☃ table 1]]
                                       aria-invalid="false"
                                       aria-required="false"
                                       class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-disabled_1f0idyc-o_O-inlineStyles_1asri2u"
-                                      id=":r5r:"
+                                      id=":r4j:"
                                       readonly=""
                                       type="number"
                                       value="5"
@@ -11958,7 +11958,7 @@ table: [[☃ table 1]]
                                       aria-invalid="false"
                                       aria-required="false"
                                       class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-disabled_1f0idyc-o_O-inlineStyles_1asri2u"
-                                      id=":r5s:"
+                                      id=":r4k:"
                                       readonly=""
                                       type="number"
                                       value="5"
@@ -11976,14 +11976,14 @@ table: [[☃ table 1]]
                                       class="default_7zhre1-o_O-menuWrapper_1rs652y"
                                     >
                                       <button
-                                        aria-controls=":r5t:"
+                                        aria-controls=":r4l:"
                                         aria-disabled="true"
                                         aria-expanded="false"
                                         aria-haspopup="listbox"
                                         aria-invalid="false"
                                         aria-required="false"
                                         class="button_vr44p2-o_O-shared_1hhaz1q-o_O-default_znuyo8-o_O-disabled_1bd2lp"
-                                        id=":r5u:"
+                                        id=":r4m:"
                                         role="combobox"
                                         type="button"
                                       >
@@ -12009,7 +12009,7 @@ table: [[☃ table 1]]
                                     <input
                                       aria-disabled="true"
                                       class="hidden_1tmfokp"
-                                      id=":r5v:"
+                                      id=":r4n:"
                                       role="switch"
                                       type="checkbox"
                                     />
@@ -12023,7 +12023,7 @@ table: [[☃ table 1]]
                                   />
                                   <label
                                     class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                                    for=":r5v:"
+                                    for=":r4n:"
                                   >
                                     open point
                                   </label>
@@ -12039,7 +12039,7 @@ table: [[☃ table 1]]
                                   >
                                     <label
                                       class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                                      for="aria-label-:r61:"
+                                      for="aria-label-:r4p:"
                                     >
                                       Aria label
                                     </label>
@@ -12065,7 +12065,7 @@ table: [[☃ table 1]]
                                       aria-invalid="false"
                                       aria-required="false"
                                       class="textarea_8jhb0l-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-vertical_1cx4zeh-o_O-default_j8cf2b-o_O-disabled_1f0idyc-o_O-inlineStyles_r0q6ib"
-                                      id="aria-label-:r61:"
+                                      id="aria-label-:r4p:"
                                       placeholder="Ex. Point at (x, y)"
                                       readonly=""
                                     />
@@ -12203,13 +12203,13 @@ table: [[☃ table 1]]
                               class="default_7zhre1-o_O-menuWrapper_1rs652y add-element-select"
                             >
                               <button
-                                aria-controls=":r64:"
+                                aria-controls=":r4s:"
                                 aria-disabled="true"
                                 aria-expanded="false"
                                 aria-haspopup="menu"
                                 class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1xfocwy-o_O-disabled_12emz8w"
                                 data-kind="tertiary"
-                                id=":r63:"
+                                id=":r4r:"
                                 tabindex="0"
                                 type="button"
                               >
@@ -12292,7 +12292,7 @@ table: [[☃ table 1]]
                           <input
                             aria-disabled="true"
                             class="hidden_1tmfokp"
-                            id=":r65:"
+                            id=":r4t:"
                             role="switch"
                             type="checkbox"
                           />
@@ -12306,7 +12306,7 @@ table: [[☃ table 1]]
                         />
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                          for=":r65:"
+                          for=":r4t:"
                         >
                           Static
                         </label>
@@ -12747,7 +12747,7 @@ table: [[☃ table 1]]
                                   aria-checked="false"
                                   aria-invalid="false"
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1y2x28c"
-                                  id=":r67:"
+                                  id=":r4v:"
                                   type="checkbox"
                                 />
                               </div>
@@ -12756,7 +12756,7 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                             >
                               <label
-                                for=":r67:"
+                                for=":r4v:"
                               >
                                 Order of the matched pairs matters:
                               </label>
@@ -12788,7 +12788,7 @@ table: [[☃ table 1]]
                                   aria-invalid="false"
                                   checked=""
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1ywap6u"
-                                  id=":r68:"
+                                  id=":r50:"
                                   type="checkbox"
                                 />
                                 <span
@@ -12800,7 +12800,7 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                             >
                               <label
-                                for=":r68:"
+                                for=":r50:"
                               >
                                 Padding:
                               </label>
@@ -12862,7 +12862,7 @@ table: [[☃ table 1]]
                           <input
                             aria-disabled="true"
                             class="hidden_1tmfokp"
-                            id=":r69:"
+                            id=":r51:"
                             role="switch"
                             type="checkbox"
                           />
@@ -12876,7 +12876,7 @@ table: [[☃ table 1]]
                         />
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                          for=":r69:"
+                          for=":r51:"
                         >
                           Static
                         </label>
@@ -13159,7 +13159,7 @@ table: [[☃ table 1]]
                                     aria-checked="false"
                                     aria-invalid="false"
                                     class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1y2x28c"
-                                    id=":r6f:"
+                                    id=":r57:"
                                     type="checkbox"
                                   />
                                 </div>
@@ -13168,7 +13168,7 @@ table: [[☃ table 1]]
                                 class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                               >
                                 <label
-                                  for=":r6f:"
+                                  for=":r57:"
                                 >
                                   Show ruler
                                 </label>
@@ -13198,7 +13198,7 @@ table: [[☃ table 1]]
                                     aria-invalid="false"
                                     checked=""
                                     class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1ywap6u"
-                                    id=":r6g:"
+                                    id=":r58:"
                                     type="checkbox"
                                   />
                                   <span
@@ -13210,7 +13210,7 @@ table: [[☃ table 1]]
                                 class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                               >
                                 <label
-                                  for=":r6g:"
+                                  for=":r58:"
                                 >
                                   Show protractor
                                 </label>
@@ -13269,7 +13269,7 @@ table: [[☃ table 1]]
                           <input
                             aria-disabled="true"
                             class="hidden_1tmfokp"
-                            id=":r6h:"
+                            id=":r59:"
                             role="switch"
                             type="checkbox"
                           />
@@ -13283,7 +13283,7 @@ table: [[☃ table 1]]
                         />
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                          for=":r6h:"
+                          for=":r59:"
                         >
                           Static
                         </label>
@@ -13481,7 +13481,7 @@ table: [[☃ table 1]]
                                     aria-checked="false"
                                     aria-invalid="false"
                                     class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1y2x28c"
-                                    id=":r6j:"
+                                    id=":r5b:"
                                     type="checkbox"
                                   />
                                 </div>
@@ -13490,7 +13490,7 @@ table: [[☃ table 1]]
                                 class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                               >
                                 <label
-                                  for=":r6j:"
+                                  for=":r5b:"
                                 >
                                   Show tick controller
                                 </label>
@@ -13520,7 +13520,7 @@ table: [[☃ table 1]]
                                     aria-invalid="false"
                                     checked=""
                                     class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1ywap6u"
-                                    id=":r6k:"
+                                    id=":r5c:"
                                     type="checkbox"
                                   />
                                   <span
@@ -13532,7 +13532,7 @@ table: [[☃ table 1]]
                                 class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                               >
                                 <label
-                                  for=":r6k:"
+                                  for=":r5c:"
                                 >
                                   Show label ticks
                                 </label>
@@ -13562,7 +13562,7 @@ table: [[☃ table 1]]
                                   aria-checked="false"
                                   aria-invalid="false"
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1y2x28c"
-                                  id=":r6l:"
+                                  id=":r5d:"
                                   type="checkbox"
                                 />
                               </div>
@@ -13571,7 +13571,7 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                             >
                               <label
-                                for=":r6l:"
+                                for=":r5d:"
                               >
                                 Show tooltips
                               </label>
@@ -13680,7 +13680,7 @@ table: [[☃ table 1]]
                           <input
                             aria-disabled="true"
                             class="hidden_1tmfokp"
-                            id=":r6m:"
+                            id=":r5e:"
                             role="switch"
                             type="checkbox"
                           />
@@ -13694,7 +13694,7 @@ table: [[☃ table 1]]
                         />
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                          for=":r6m:"
+                          for=":r5e:"
                         >
                           Static
                         </label>
@@ -13778,13 +13778,13 @@ table: [[☃ table 1]]
                               class="default_7zhre1-o_O-menuWrapper_1rs652y"
                             >
                               <button
-                                aria-controls=":r6o:"
+                                aria-controls=":r5g:"
                                 aria-expanded="false"
                                 aria-haspopup="listbox"
                                 aria-invalid="false"
                                 aria-required="false"
                                 class="button_vr44p2-o_O-shared_1hhaz1q-o_O-default_znuyo8"
-                                id=":r6p:"
+                                id=":r5h:"
                                 role="combobox"
                                 type="button"
                               >
@@ -13906,17 +13906,17 @@ table: [[☃ table 1]]
                             >
                               <div
                                 class="default_7zhre1-o_O-wrapper_13982vy-o_O-wrapperWithAnimation_t6xj9m-o_O-wrapper_m5h1c0-o_O-wrapperExpanded_nhpyf7-o_O-container_clqed8"
-                                id=":r6r:"
+                                id=":r5j:"
                               >
                                 <h2
                                   class="text_f1191h-o_O-header_bicv4w-o_O-Heading_czb6bz-o_O-HeadingMediumBoldWeight_m3f5sj-o_O-heading_1wk4vy6"
                                 >
                                   <button
-                                    aria-controls=":r6t:"
+                                    aria-controls=":r5l:"
                                     aria-disabled="false"
                                     aria-expanded="true"
                                     class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f"
-                                    id=":r6s:"
+                                    id=":r5k:"
                                     type="button"
                                   >
                                     <div
@@ -13934,9 +13934,9 @@ table: [[☃ table 1]]
                                   </button>
                                 </h2>
                                 <div
-                                  aria-labelledby=":r6s:"
+                                  aria-labelledby=":r5k:"
                                   class="default_7zhre1-o_O-contentWrapper_y9ev9r-o_O-contentWrapperExpanded_xsrqq9-o_O-contentWrapper_m95ukg"
-                                  id=":r6t:"
+                                  id=":r5l:"
                                   role="region"
                                 >
                                   <div
@@ -14447,7 +14447,7 @@ table: [[☃ table 1]]
                           <input
                             aria-disabled="true"
                             class="hidden_1tmfokp"
-                            id=":r6u:"
+                            id=":r5m:"
                             role="switch"
                             type="checkbox"
                           />
@@ -14461,7 +14461,7 @@ table: [[☃ table 1]]
                         />
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                          for=":r6u:"
+                          for=":r5m:"
                         >
                           Static
                         </label>
@@ -14952,7 +14952,7 @@ table: [[☃ table 1]]
                               aria-disabled="true"
                               checked=""
                               class="hidden_1tmfokp"
-                              id=":r70:"
+                              id=":r5o:"
                               role="switch"
                               type="checkbox"
                             />
@@ -14966,7 +14966,7 @@ table: [[☃ table 1]]
                           />
                           <label
                             class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                            for=":r70:"
+                            for=":r5o:"
                           >
                             Randomize order
                           </label>
@@ -14980,7 +14980,7 @@ table: [[☃ table 1]]
                             <input
                               aria-disabled="true"
                               class="hidden_1tmfokp"
-                              id=":r72:"
+                              id=":r5q:"
                               role="switch"
                               type="checkbox"
                             />
@@ -14994,7 +14994,7 @@ table: [[☃ table 1]]
                           />
                           <label
                             class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr"
-                            for=":r72:"
+                            for=":r5q:"
                           >
                             Multiple selections
                           </label>
@@ -15058,7 +15058,7 @@ table: [[☃ table 1]]
                         </fieldset>
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallBoldWeight_zklkdn-o_O-inlineStyles_10n8xdq"
-                          for=":r75:-content-textarea"
+                          for=":r5t:-content-textarea"
                         >
                           Content
                         </label>
@@ -15070,7 +15070,7 @@ table: [[☃ table 1]]
                             aria-invalid="false"
                             aria-required="false"
                             class="textarea_8jhb0l-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-disabled_1f0idyc-o_O-autoResize_1m0oq5d-o_O-inlineStyles_8zrxtn"
-                            id=":r75:-content-textarea"
+                            id=":r5t:-content-textarea"
                             placeholder="Type a choice here..."
                             readonly=""
                             style=""
@@ -15099,7 +15099,7 @@ table: [[☃ table 1]]
                         </button>
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallBoldWeight_zklkdn-o_O-inlineStyles_abgm0w"
-                          for=":r74:-rationale-textarea"
+                          for=":r5s:-rationale-textarea"
                         >
                           Rationale
                         </label>
@@ -15111,7 +15111,7 @@ table: [[☃ table 1]]
                             aria-invalid="false"
                             aria-required="false"
                             class="textarea_8jhb0l-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-disabled_1f0idyc-o_O-autoResize_1m0oq5d-o_O-inlineStyles_8zrxtn"
-                            id=":r74:-rationale-textarea"
+                            id=":r5s:-rationale-textarea"
                             placeholder="Why is this choice correct?"
                             readonly=""
                             style=""
@@ -15249,7 +15249,7 @@ table: [[☃ table 1]]
                         </fieldset>
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallBoldWeight_zklkdn-o_O-inlineStyles_10n8xdq"
-                          for=":r79:-content-textarea"
+                          for=":r61:-content-textarea"
                         >
                           Content
                         </label>
@@ -15261,7 +15261,7 @@ table: [[☃ table 1]]
                             aria-invalid="false"
                             aria-required="false"
                             class="textarea_8jhb0l-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-disabled_1f0idyc-o_O-autoResize_1m0oq5d-o_O-inlineStyles_8zrxtn"
-                            id=":r79:-content-textarea"
+                            id=":r61:-content-textarea"
                             placeholder="Type a choice here..."
                             readonly=""
                             style=""
@@ -15290,7 +15290,7 @@ table: [[☃ table 1]]
                         </button>
                         <label
                           class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextSmallBoldWeight_zklkdn-o_O-inlineStyles_abgm0w"
-                          for=":r78:-rationale-textarea"
+                          for=":r60:-rationale-textarea"
                         >
                           Rationale
                         </label>
@@ -15302,7 +15302,7 @@ table: [[☃ table 1]]
                             aria-invalid="false"
                             aria-required="false"
                             class="textarea_8jhb0l-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-disabled_1f0idyc-o_O-autoResize_1m0oq5d-o_O-inlineStyles_8zrxtn"
-                            id=":r78:-rationale-textarea"
+                            id=":r60:-rationale-textarea"
                             placeholder="Why is this choice incorrect?"
                             readonly=""
                             style=""
@@ -15561,7 +15561,7 @@ table: [[☃ table 1]]
                                   aria-invalid="false"
                                   checked=""
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1ywap6u"
-                                  id=":r7c:"
+                                  id=":r64:"
                                   type="checkbox"
                                 />
                                 <span
@@ -15573,7 +15573,7 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                             >
                               <label
-                                for=":r7c:"
+                                for=":r64:"
                               >
                                 Padding:
                               </label>
@@ -15848,7 +15848,7 @@ table: [[☃ table 1]]
                           aria-invalid="false"
                           class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_vfcxos"
                           disabled=""
-                          id=":r7d:"
+                          id=":r65:"
                           type="checkbox"
                         />
                       </div>
@@ -15857,7 +15857,7 @@ table: [[☃ table 1]]
                       class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy-o_O-disabledLabel_1d65n8m"
                     >
                       <label
-                        for=":r7d:"
+                        for=":r65:"
                       >
                         <div
                           class="default_7zhre1-o_O-inlineStyles_qb00m9"
@@ -15896,7 +15896,7 @@ table: [[☃ table 1]]
                           aria-invalid="false"
                           class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_vfcxos"
                           disabled=""
-                          id=":r7e:"
+                          id=":r66:"
                           type="checkbox"
                         />
                       </div>
@@ -15905,7 +15905,7 @@ table: [[☃ table 1]]
                       class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy-o_O-disabledLabel_1d65n8m"
                     >
                       <label
-                        for=":r7e:"
+                        for=":r66:"
                       >
                         <div
                           class="default_7zhre1-o_O-inlineStyles_qb00m9"
@@ -15944,7 +15944,7 @@ table: [[☃ table 1]]
                           aria-invalid="false"
                           class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_vfcxos"
                           disabled=""
-                          id=":r7f:"
+                          id=":r67:"
                           type="checkbox"
                         />
                       </div>
@@ -15953,7 +15953,7 @@ table: [[☃ table 1]]
                       class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy-o_O-disabledLabel_1d65n8m"
                     >
                       <label
-                        for=":r7f:"
+                        for=":r67:"
                       >
                         <div
                           class="default_7zhre1-o_O-inlineStyles_qb00m9"

--- a/packages/perseus-editor/src/editor-page-snapshot.test.tsx
+++ b/packages/perseus-editor/src/editor-page-snapshot.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * The snapshot test(s) are in a separate file to avoid IDs shifting
+ * from new tests being added above them.
+ *
+ * This is because a number of components use `React.useId()` to generate IDs,
+ * and `useId` counter is global, so changing any tests above the snapshot
+ * tests unnecessarily causes ID shifts and therefore snapshot updates.
+ *
+ * Note that adding new tests here that are not at the end of this file will
+ * also expectedly cause ID shifts.
+ *
+ * Non-snapshot tests for the editor page can be found in
+ * packages/perseus-editor/src/editor-page.test.tsx.
+ */
+import {Dependencies} from "@khanacademy/perseus";
+import {render} from "@testing-library/react";
+import * as React from "react";
+
+import {comprehensiveQuestion} from "./__testdata__/all-widgets.testdata";
+import EditorPage from "./editor-page";
+import {
+    testDependencies,
+    testDependenciesV2,
+} from "./testing/test-dependencies";
+import {registerAllWidgetsAndEditorsForTesting} from "./util/register-all-widgets-and-editors-for-testing";
+
+describe("EditorPage", () => {
+    beforeAll(() => {
+        registerAllWidgetsAndEditorsForTesting();
+    });
+
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+        Dependencies.setDependencies(testDependencies);
+    });
+
+    it("should match snapshot for editing disabled for all widgets", () => {
+        // Arrange, Act
+        const {container} = render(
+            <EditorPage
+                dependencies={testDependenciesV2}
+                question={comprehensiveQuestion} // question with all widgets
+                apiOptions={{editingDisabled: true}} // editing disabled
+                onChange={() => {}}
+                onPreviewDeviceChange={() => {}}
+                previewDevice="desktop"
+                previewURL=""
+                itemId="itemId"
+                developerMode={false}
+                jsonMode={false}
+                widgetsAreOpen={true}
+            />,
+        );
+
+        // Assert
+        // Note: the interactive-graph movable point renders fill/stroke="none"
+        // here because its color now comes from tokenValue(), which reads a CSS
+        // custom property. jsdom doesn't define those variables, so it resolves
+        // to "" and Raphael renders it as "none". The real color resolves in a
+        // browser (covered by Chromatic). See movable-point.tsx / .test.ts.
+        expect(container).toMatchSnapshot();
+    });
+});

--- a/packages/perseus-editor/src/editor-page.test.tsx
+++ b/packages/perseus-editor/src/editor-page.test.tsx
@@ -10,7 +10,6 @@ import * as React from "react";
 
 import {earthMoonImage} from "../../perseus/src/widgets/image/utils";
 
-import {comprehensiveQuestion} from "./__testdata__/all-widgets.testdata";
 import EditorPage from "./editor-page";
 import {
     testDependencies,
@@ -387,37 +386,6 @@ describe("EditorPage", () => {
         });
     });
 
-    it("should match snapshot for editing disabled for all widgets", () => {
-        // Arrange, Act
-        const {container} = render(
-            <EditorPage
-                dependencies={testDependenciesV2}
-                question={comprehensiveQuestion} // question with all widgets
-                apiOptions={{editingDisabled: true}} // editing disabled
-                onChange={() => {}}
-                onPreviewDeviceChange={() => {}}
-                previewDevice="desktop"
-                previewURL=""
-                itemId="itemId"
-                developerMode={false}
-                jsonMode={false}
-                widgetsAreOpen={true}
-            />,
-        );
-
-        // Assert
-        // Note: the interactive-graph movable point renders fill/stroke="none"
-        // here because its color now comes from tokenValue(), which reads a CSS
-        // custom property. jsdom doesn't define those variables, so it resolves
-        // to "" and Raphael renders it as "none". The real color resolves in a
-        // browser (covered by Chromatic). See movable-point.tsx / .test.ts.
-        expect(container).toMatchSnapshot();
-    });
-
-    // NOTE: This test must stay after the snapshot test above. Both React's
-    // useId counter and the perseus_dropdown_N counter are global to this file
-    // and are not reset between tests, so rendering ahead of the snapshot test
-    // shifts every generated ID in its snapshot.
     it("converts image markdown to an image widget when the issue CTA is clicked", async () => {
         // Arrange
         const imageUrl = earthMoonImage.url;
@@ -481,3 +449,10 @@ describe("EditorPage", () => {
         );
     });
 });
+
+/**********************************************************/
+/* NOTE: snapshot tests are in found in
+/* packages/perseus-editor/src/editor-page-snapshot.test.tsx
+/*
+/* Please add new snapshot tests there instead of this file!
+/**********************************************************/

--- a/packages/perseus-editor/src/editor-page.test.tsx
+++ b/packages/perseus-editor/src/editor-page.test.tsx
@@ -1,12 +1,14 @@
-import {Dependencies} from "@khanacademy/perseus";
+import {Dependencies, Util} from "@khanacademy/perseus";
 import {
     type PerseusOrdererWidgetOptions,
     type PerseusRenderer,
 } from "@khanacademy/perseus-core";
 import {getDefaultAnswerArea} from "@khanacademy/perseus-core";
-import {render, screen} from "@testing-library/react";
+import {render, screen, waitFor} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
+
+import {earthMoonImage} from "../../perseus/src/widgets/image/utils";
 
 import {comprehensiveQuestion} from "./__testdata__/all-widgets.testdata";
 import EditorPage from "./editor-page";
@@ -410,5 +412,72 @@ describe("EditorPage", () => {
         // to "" and Raphael renders it as "none". The real color resolves in a
         // browser (covered by Chromatic). See movable-point.tsx / .test.ts.
         expect(container).toMatchSnapshot();
+    });
+
+    // NOTE: This test must stay after the snapshot test above. Both React's
+    // useId counter and the perseus_dropdown_N counter are global to this file
+    // and are not reset between tests, so rendering ahead of the snapshot test
+    // shifts every generated ID in its snapshot.
+    it("converts image markdown to an image widget when the issue CTA is clicked", async () => {
+        // Arrange
+        const imageUrl = earthMoonImage.url;
+        jest.spyOn(Util, "getImageSizeModern").mockResolvedValue([
+            earthMoonImage.width,
+            earthMoonImage.height,
+        ]);
+
+        const onChangeMock = jest.fn();
+        const question: PerseusRenderer = {
+            content: `Which planet is this? ![The Earth](${imageUrl})`,
+            images: {},
+            widgets: {},
+        };
+
+        render(
+            <EditorPage
+                dependencies={testDependenciesV2}
+                question={question}
+                onChange={onChangeMock}
+                onPreviewDeviceChange={() => {}}
+                previewDevice="desktop"
+                previewURL=""
+                itemId="itemId"
+                developerMode={false}
+                jsonMode={false}
+                widgetsAreOpen={true}
+            />,
+        );
+
+        // The panel starts collapsed, so open it to reach the issue's CTA.
+        await userEvent.click(screen.getByText("Issues"));
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("button", {
+                name: "Convert all image markdown to widget",
+            }),
+        );
+
+        // Assert
+        // The conversion awaits the image's dimensions before it reports back.
+        await waitFor(() => expect(onChangeMock).toHaveBeenCalled());
+        expect(onChangeMock.mock.lastCall[0].question).toEqual(
+            expect.objectContaining({
+                content: "Which planet is this? [[☃ image 1]]",
+                widgets: expect.objectContaining({
+                    "image 1": expect.objectContaining({
+                        type: "image",
+                        options: expect.objectContaining({
+                            alt: "The Earth",
+                            backgroundImage: {
+                                url: imageUrl,
+                                width: earthMoonImage.width,
+                                height: earthMoonImage.height,
+                            },
+                        }),
+                    }),
+                }),
+            }),
+        );
     });
 });

--- a/packages/perseus-editor/src/editor-page.test.tsx
+++ b/packages/perseus-editor/src/editor-page.test.tsx
@@ -397,7 +397,12 @@ describe("EditorPage", () => {
         const onChangeMock = jest.fn();
         const question: PerseusRenderer = {
             content: `Which planet is this? ![The Earth](${imageUrl})`,
-            images: {},
+            images: {
+                [earthMoonImage.url]: {
+                    width: earthMoonImage.width,
+                    height: earthMoonImage.height,
+                },
+            },
             widgets: {},
         };
 

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -19,6 +19,7 @@ import CombinedHintsEditor from "./hint-editor";
 import ItemEditor from "./item-editor";
 import {runAxeCoreOnUpdate} from "./util/a11y-checker";
 import {gatherLinterIssues} from "./util/gather-linter-issues";
+import {ItemEditorContext} from "./util/item-editor-context";
 
 import type {Issue} from "./components/issues-panel";
 import type {
@@ -267,6 +268,19 @@ class EditorPage extends React.Component<Props, State> {
         this.props.onChange(newProps);
     };
 
+    /**
+     * Merges a partial update into the question and notifies the parent.
+     *
+     * This backs `ItemEditorContext`, which lets components rendered outside
+     * of `ItemEditor` (such as the Issues panel and its CTAs) edit the
+     * question.
+     */
+    handleEditorChange = (newProps: Partial<PerseusRenderer>) => {
+        this.handleChange({
+            question: {...this.props.question, ...newProps},
+        });
+    };
+
     changeJSON: (newJson: PerseusItem) => void = (newJson: PerseusItem) => {
         this.setState({
             json: newJson,
@@ -297,119 +311,129 @@ class EditorPage extends React.Component<Props, State> {
             <Dependencies.DependenciesContext.Provider
                 value={this.props.dependencies}
             >
-                <div id="perseus" className={className}>
-                    <div style={{marginBottom: 10}}>
-                        {this.props.developerMode && (
-                            <span>
-                                <label>
-                                    {" "}
-                                    Developer JSON Mode:{" "}
-                                    <input
-                                        type="checkbox"
-                                        checked={this.props.jsonMode}
-                                        disabled={
-                                            this.props.apiOptions
-                                                ?.editingDisabled
-                                        }
-                                        onChange={this.toggleJsonMode}
-                                    />
-                                </label>{" "}
-                            </span>
+                <ItemEditorContext.Provider
+                    value={{
+                        question: this.props.question,
+                        onEditorChange: this.handleEditorChange,
+                    }}
+                >
+                    <div id="perseus" className={className}>
+                        <div style={{marginBottom: 10}}>
+                            {this.props.developerMode && (
+                                <span>
+                                    <label>
+                                        {" "}
+                                        Developer JSON Mode:{" "}
+                                        <input
+                                            type="checkbox"
+                                            checked={this.props.jsonMode}
+                                            disabled={
+                                                this.props.apiOptions
+                                                    ?.editingDisabled
+                                            }
+                                            onChange={this.toggleJsonMode}
+                                        />
+                                    </label>{" "}
+                                </span>
+                            )}
+
+                            {!this.props.jsonMode && (
+                                <ViewportResizer
+                                    deviceType={this.props.previewDevice}
+                                    onViewportSizeChanged={
+                                        this.props.onPreviewDeviceChange
+                                    }
+                                />
+                            )}
+
+                            {!this.props.jsonMode && (
+                                <HUD
+                                    message="Style warnings"
+                                    enabled={this.state.highlightLint}
+                                    onClick={() => {
+                                        this.setState({
+                                            highlightLint:
+                                                !this.state.highlightLint,
+                                        });
+                                    }}
+                                />
+                            )}
+                        </div>
+                        {this.props.developerMode && this.props.jsonMode && (
+                            <div>
+                                <JsonEditor
+                                    multiLine={true}
+                                    value={this.state.json}
+                                    parser={parseAndMigratePerseusItem}
+                                    onChange={this.changeJSON}
+                                    editingDisabled={editingDisabled}
+                                />
+                            </div>
                         )}
 
-                        {!this.props.jsonMode && (
-                            <ViewportResizer
+                        {showEditor && (
+                            <div className="perseus-editor-table">
+                                <div className="perseus-editor-row">
+                                    <div className="perseus-editor-left-cell">
+                                        <IssuesPanel
+                                            issues={this.state.issues.concat(
+                                                this.state.showAxeCoreIssues
+                                                    ? this.state.axeCoreIssues
+                                                    : [],
+                                            )}
+                                            a11yCheck={{
+                                                callback: () =>
+                                                    this.setState({
+                                                        showAxeCoreIssues:
+                                                            !this.state
+                                                                .showAxeCoreIssues,
+                                                    }),
+                                                isChecked:
+                                                    this.state
+                                                        .showAxeCoreIssues,
+                                            }}
+                                        />
+                                    </div>
+                                </div>
+                            </div>
+                        )}
+
+                        {showEditor && (
+                            <ItemEditor
+                                ref={this.itemEditor}
+                                itemId={this.props.itemId}
+                                question={this.props.question}
+                                answerArea={this.props.answerArea}
+                                imageUploader={this.props.imageUploader}
+                                onChange={this.handleChange}
                                 deviceType={this.props.previewDevice}
-                                onViewportSizeChanged={
-                                    this.props.onPreviewDeviceChange
+                                widgetIsOpen={this.state.widgetsAreOpen}
+                                apiOptions={deviceBasedApiOptions}
+                                previewURL={this.props.previewURL}
+                                additionalTemplates={
+                                    this.props.additionalTemplates
                                 }
+                                highlightLint={this.state.highlightLint}
+                                problemNum={this.props.problemNum}
                             />
                         )}
 
-                        {!this.props.jsonMode && (
-                            <HUD
-                                message="Style warnings"
-                                enabled={this.state.highlightLint}
-                                onClick={() => {
-                                    this.setState({
-                                        highlightLint:
-                                            !this.state.highlightLint,
-                                    });
-                                }}
+                        {showEditor && (
+                            <CombinedHintsEditor
+                                ref={this.hintsEditor}
+                                itemId={this.props.itemId}
+                                hints={this.props.hints}
+                                imageUploader={this.props.imageUploader}
+                                onChange={this.handleChange}
+                                deviceType={this.props.previewDevice}
+                                apiOptions={deviceBasedApiOptions}
+                                previewURL={this.props.previewURL}
+                                highlightLint={this.state.highlightLint}
+                                widgetIsOpen={this.state.widgetsAreOpen}
                             />
                         )}
                     </div>
-                    {this.props.developerMode && this.props.jsonMode && (
-                        <div>
-                            <JsonEditor
-                                multiLine={true}
-                                value={this.state.json}
-                                parser={parseAndMigratePerseusItem}
-                                onChange={this.changeJSON}
-                                editingDisabled={editingDisabled}
-                            />
-                        </div>
-                    )}
-
-                    {showEditor && (
-                        <div className="perseus-editor-table">
-                            <div className="perseus-editor-row">
-                                <div className="perseus-editor-left-cell">
-                                    <IssuesPanel
-                                        issues={this.state.issues.concat(
-                                            this.state.showAxeCoreIssues
-                                                ? this.state.axeCoreIssues
-                                                : [],
-                                        )}
-                                        a11yCheck={{
-                                            callback: () =>
-                                                this.setState({
-                                                    showAxeCoreIssues:
-                                                        !this.state
-                                                            .showAxeCoreIssues,
-                                                }),
-                                            isChecked:
-                                                this.state.showAxeCoreIssues,
-                                        }}
-                                    />
-                                </div>
-                            </div>
-                        </div>
-                    )}
-
-                    {showEditor && (
-                        <ItemEditor
-                            ref={this.itemEditor}
-                            itemId={this.props.itemId}
-                            question={this.props.question}
-                            answerArea={this.props.answerArea}
-                            imageUploader={this.props.imageUploader}
-                            onChange={this.handleChange}
-                            deviceType={this.props.previewDevice}
-                            widgetIsOpen={this.state.widgetsAreOpen}
-                            apiOptions={deviceBasedApiOptions}
-                            previewURL={this.props.previewURL}
-                            additionalTemplates={this.props.additionalTemplates}
-                            highlightLint={this.state.highlightLint}
-                            problemNum={this.props.problemNum}
-                        />
-                    )}
-
-                    {showEditor && (
-                        <CombinedHintsEditor
-                            ref={this.hintsEditor}
-                            itemId={this.props.itemId}
-                            hints={this.props.hints}
-                            imageUploader={this.props.imageUploader}
-                            onChange={this.handleChange}
-                            deviceType={this.props.previewDevice}
-                            apiOptions={deviceBasedApiOptions}
-                            previewURL={this.props.previewURL}
-                            highlightLint={this.state.highlightLint}
-                            widgetIsOpen={this.state.widgetsAreOpen}
-                        />
-                    )}
-                </div>
+                </ItemEditorContext.Provider>
             </Dependencies.DependenciesContext.Provider>
         );
     }

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -268,13 +268,6 @@ class EditorPage extends React.Component<Props, State> {
         this.props.onChange(newProps);
     };
 
-    /**
-     * Merges a partial update into the question and notifies the parent.
-     *
-     * This backs `ItemEditorContext`, which lets components rendered outside
-     * of `ItemEditor` (such as the Issues panel and its CTAs) edit the
-     * question.
-     */
     handleEditorChange = (newProps: Partial<PerseusRenderer>) => {
         this.handleChange({
             question: {...this.props.question, ...newProps},

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -7,7 +7,6 @@ import DeviceFramer from "./components/device-framer";
 import Editor from "./editor";
 import ItemExtrasEditor from "./item-extras-editor";
 import PreviewWithIframe from "./preview-with-iframe";
-import {ItemEditorContext} from "./util/item-editor-context";
 
 import type {PreviewContent} from "./preview/message-types";
 import type {
@@ -142,73 +141,66 @@ class ItemEditor extends React.Component<Props> {
         const editingDisabled = this.props.apiOptions?.editingDisabled ?? false;
 
         return (
-            <ItemEditorContext.Provider
-                value={{
-                    question: this.props.question!,
-                    onEditorChange: this.handleEditorChange,
-                }}
-            >
-                <div className="perseus-editor-table">
-                    <div className="perseus-editor-row perseus-question-container">
-                        <div className="perseus-editor-left-cell">
-                            <div className="pod-title">Question</div>
-                            <fieldset disabled={editingDisabled}>
-                                <Editor
-                                    ref={this.questionEditor}
-                                    // Using the AssessmentItem content ID as the key
-                                    // ensures that when the user navigates to another
-                                    // item in the Sidebar, the question editor is
-                                    // re-rendered by React.
-                                    key={this.props.itemId}
-                                    placeholder="Type your question here..."
-                                    className="perseus-question-editor"
-                                    imageUploader={this.props.imageUploader}
-                                    onChange={this.handleEditorChange}
-                                    apiOptions={this.props.apiOptions}
-                                    showWordCount={true}
-                                    widgetIsOpen={this.props.widgetIsOpen}
-                                    additionalTemplates={
-                                        this.props.additionalTemplates
-                                    }
-                                    {...this.props.question}
-                                />
-                            </fieldset>
-                        </div>
-
-                        <div className="perseus-editor-right-cell">
-                            <div id="problemarea">
-                                <DeviceFramer
-                                    deviceType={this.props.deviceType}
-                                    nochrome={true}
-                                >
-                                    <PreviewWithIframe
-                                        key={this.props.deviceType}
-                                        isMobile={isMobile}
-                                        seamless={true}
-                                        url={this.props.previewURL}
-                                        content={this._derivePreviewContent()}
-                                    />
-                                </DeviceFramer>
-                            </div>
-                        </div>
+            <div className="perseus-editor-table">
+                <div className="perseus-editor-row perseus-question-container">
+                    <div className="perseus-editor-left-cell">
+                        <div className="pod-title">Question</div>
+                        <fieldset disabled={editingDisabled}>
+                            <Editor
+                                ref={this.questionEditor}
+                                // Using the AssessmentItem content ID as the key
+                                // ensures that when the user navigates to another
+                                // item in the Sidebar, the question editor is
+                                // re-rendered by React.
+                                key={this.props.itemId}
+                                placeholder="Type your question here..."
+                                className="perseus-question-editor"
+                                imageUploader={this.props.imageUploader}
+                                onChange={this.handleEditorChange}
+                                apiOptions={this.props.apiOptions}
+                                showWordCount={true}
+                                widgetIsOpen={this.props.widgetIsOpen}
+                                additionalTemplates={
+                                    this.props.additionalTemplates
+                                }
+                                {...this.props.question}
+                            />
+                        </fieldset>
                     </div>
 
-                    <div className="perseus-editor-row perseus-answer-container">
-                        <div className="perseus-editor-left-cell">
-                            <div className="pod-title">Question extras</div>
-                            <ItemExtrasEditor
-                                ref={this.itemExtrasEditor}
-                                apiOptions={this.props.apiOptions}
-                                onChange={this.handleItemExtrasChange}
-                                editingDisabled={editingDisabled}
-                                {...this.props.answerArea}
-                            />
+                    <div className="perseus-editor-right-cell">
+                        <div id="problemarea">
+                            <DeviceFramer
+                                deviceType={this.props.deviceType}
+                                nochrome={true}
+                            >
+                                <PreviewWithIframe
+                                    key={this.props.deviceType}
+                                    isMobile={isMobile}
+                                    seamless={true}
+                                    url={this.props.previewURL}
+                                    content={this._derivePreviewContent()}
+                                />
+                            </DeviceFramer>
                         </div>
-
-                        <div className="perseus-editor-right-cell" />
                     </div>
                 </div>
-            </ItemEditorContext.Provider>
+
+                <div className="perseus-editor-row perseus-answer-container">
+                    <div className="perseus-editor-left-cell">
+                        <div className="pod-title">Question extras</div>
+                        <ItemExtrasEditor
+                            ref={this.itemExtrasEditor}
+                            apiOptions={this.props.apiOptions}
+                            onChange={this.handleItemExtrasChange}
+                            editingDisabled={editingDisabled}
+                            {...this.props.answerArea}
+                        />
+                    </div>
+
+                    <div className="perseus-editor-right-cell" />
+                </div>
+            </div>
         );
     }
 }


### PR DESCRIPTION
## Summary:
The "Convert all image markdown to widget" button broke a few weeks ago.

Fixing it here by moving the context provider from the item editor to the editor page.

NOTE: I'd recommend reviewing this with the "hide whitespace" setting!

Issue: https://khanacademy.atlassian.net/browse/LEMS-4434

## Test plan:
`pnpm jest packages/perseus-editor/src/editor-page.test.tsx`

Storybook
- `/?path=/story/editors-editorpage--demo`
- Write the following markdown: `![earth and moon](https://cdn.kastatic.org/ka-content-images/61831c1329dbc32036d7dd0d03e06e7e2c622718.jpg)`
- Open the markdown issue in the issues panel and click the convert button
- Confirm that the markdown has been updated to a widget


https://github.com/user-attachments/assets/69cf53d0-7712-4ce2-9024-4e2107286ce3

