### PR TITLE
[Interactive Graph] Scale locked-figure dash pattern with stroke weight

### DIFF
--- a/.changeset/violet-grapes-tie.md
+++ b/.changeset/violet-grapes-tie.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Interactive Graph] Scale locked-figure dash pattern with stroke weight

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/interactive-graph-initial-state-regression.stories.tsx
@@ -5,6 +5,7 @@ import {
     generateIGExponentialGraph,
     generateIGLinearGraph,
     generateIGLinearSystemGraph,
+    generateIGLockedFunction,
     generateIGLockedLine,
     generateIGLockedPoint,
     generateIGLockedPolygon,
@@ -33,7 +34,12 @@ import {sinusoidWithPiTicks} from "../interactive-graph.testdata";
 import {interactiveGraphRendererDecorator} from "./interactive-graph-renderer-decorator";
 import {lockedFiguresWithWeight} from "./utils";
 
-import type {PerseusInteractiveGraphWidgetOptions} from "@khanacademy/perseus-core";
+import type {
+    LockedFigure,
+    LockedLineStyle,
+    PerseusInteractiveGraphWidgetOptions,
+    StrokeWeight,
+} from "@khanacademy/perseus-core";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 const meta: Meta<PerseusInteractiveGraphWidgetOptions> = {
@@ -368,6 +374,115 @@ export const LockedFiguresWithThickWeight: Story = {
         correct: generateIGNoneGraph(),
         lockedFigures: lockedFiguresWithWeight("thick"),
     },
+};
+
+const systemOfInequalitiesFigures = (
+    lineWeight: StrokeWeight,
+    polygonWeight: StrokeWeight = lineWeight,
+    polygonStrokeStyle: LockedLineStyle = "dashed",
+): LockedFigure[] => [
+    generateIGLockedFunction({
+        color: "blue",
+        strokeStyle: "dashed",
+        weight: lineWeight,
+        equation: "-0.5x",
+        directionalAxis: "x",
+        domain: [-10, 10],
+    }),
+    generateIGLockedFunction({
+        color: "green",
+        strokeStyle: "solid",
+        weight: lineWeight,
+        equation: "0.75x - 2",
+        directionalAxis: "x",
+        domain: [-10, 10],
+    }),
+    generateIGLockedPolygon({
+        points: [
+            [-6, 3],
+            [-6, 6],
+            [6, 6],
+            [6, -3],
+        ],
+        color: "blue",
+        showVertices: false,
+        fillStyle: "translucent",
+        strokeStyle: polygonStrokeStyle,
+        weight: polygonWeight,
+    }),
+    generateIGLockedPolygon({
+        points: [
+            [6, 2.5],
+            [6, -6],
+            [-5.3, -6],
+        ],
+        color: "green",
+        showVertices: false,
+        fillStyle: "translucent",
+        strokeStyle: polygonStrokeStyle,
+        weight: polygonWeight,
+    }),
+];
+
+const systemOfInequalitiesArgs = (
+    lineWeight: StrokeWeight,
+    polygonWeight: StrokeWeight = lineWeight,
+    polygonStrokeStyle: LockedLineStyle = "dashed",
+): Partial<PerseusInteractiveGraphWidgetOptions> => ({
+    correct: generateIGNoneGraph(),
+    range: [
+        [-6, 6],
+        [-6, 6],
+    ],
+    markings: "graph",
+    labels: ["$x$", "$y$"],
+    lockedFigures: systemOfInequalitiesFigures(
+        lineWeight,
+        polygonWeight,
+        polygonStrokeStyle,
+    ),
+});
+
+export const LockedFigureThinWeightSample: Story = {
+    args: {
+        correct: generateIGNoneGraph(),
+        range: [
+            [-6, 6],
+            [-6, 6],
+        ],
+        markings: "graph",
+        labels: ["$x$", "$y$"],
+        lockedFigures: [
+            generateIGLockedFunction({
+                color: "grayH",
+                strokeStyle: "dashed",
+                weight: "thin",
+                equation: "-0.5x",
+                directionalAxis: "x",
+                domain: [-10, 10],
+            }),
+            generateIGLockedPolygon({
+                points: [
+                    [1, 1],
+                    [5, 1],
+                    [5, 5],
+                ],
+                color: "gold",
+                showVertices: false,
+                fillStyle: "translucent",
+                strokeStyle: "dashed",
+                weight: "thin",
+            }),
+        ],
+    },
+};
+
+export const LockedFigureMediumWeightSample: Story = {
+    args: systemOfInequalitiesArgs("medium", "thin", "solid"),
+};
+
+export const LockedFigureThickWeightSample: Story = {
+    args: systemOfInequalitiesArgs("thick"),
 };
 
 // Verifies points on the graph boundary (corners and edge midpoints) render as

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -1812,6 +1812,132 @@ describe("Interactive Graph", function () {
         });
     });
 
+    describe("dashed locked figures scale the dash pattern with weight", () => {
+        // The dash pattern is applied via the `--mafs-line-stroke-dash-style`
+        // CSS variable set on each figure's wrapping <g>. mafs reads that
+        // variable when rendering the dashed line/polygon/ellipse/plot, so a
+        // weight-proportional value keeps the dashes clearly visible at every
+        // weight instead of collapsing toward solid on thick lines.
+        const dashStyleOf = (element: SVGElement | null): string =>
+            element?.style.getPropertyValue("--mafs-line-stroke-dash-style") ??
+            "";
+
+        it.each([
+            {weight: "thin", expected: "4, 3"},
+            {weight: "medium", expected: "8, 6"},
+            {weight: "thick", expected: "16, 12"},
+        ] satisfies {weight: StrokeWeight; expected: string}[])(
+            "dashed line/ray/polygon/ellipse/function render a $weight dash of $expected",
+            ({weight, expected}) => {
+                // Arrange, Act
+                const {container} = renderQuestion(
+                    generateInteractiveGraphQuestion({
+                        markings: "none",
+                        correct: generateIGSegmentGraph(),
+                        lockedFigures: [
+                            generateIGLockedLine({
+                                kind: "segment",
+                                weight,
+                                lineStyle: "dashed",
+                                points: [
+                                    generateIGLockedPoint({coord: [-5, 0]}),
+                                    generateIGLockedPoint({coord: [0, 5]}),
+                                ],
+                            }),
+                            // Rays apply the dash via a different path (an
+                            // explicit strokeDasharray on the custom Vector),
+                            // so they are covered separately from the segment.
+                            generateIGLockedLine({
+                                kind: "ray",
+                                weight,
+                                lineStyle: "dashed",
+                                points: [
+                                    generateIGLockedPoint({coord: [1, 0]}),
+                                    generateIGLockedPoint({coord: [1, 5]}),
+                                ],
+                            }),
+                            generateIGLockedPolygon({
+                                weight,
+                                strokeStyle: "dashed",
+                            }),
+                            generateIGLockedEllipse({
+                                weight,
+                                strokeStyle: "dashed",
+                            }),
+                            generateIGLockedFunction({
+                                weight,
+                                strokeStyle: "dashed",
+                                equation: "x^2",
+                            }),
+                        ],
+                    }),
+                    blankOptions,
+                );
+
+                // Assert
+                /* eslint-disable testing-library/no-container, testing-library/no-node-access */
+                expect(
+                    dashStyleOf(
+                        container.querySelector<SVGGElement>(".locked-line"),
+                    ),
+                ).toBe(expected);
+                expect(
+                    dashStyleOf(
+                        container.querySelector<SVGGElement>(".locked-ray"),
+                    ),
+                ).toBe(expected);
+                expect(
+                    dashStyleOf(
+                        container.querySelector<SVGGElement>(".locked-polygon"),
+                    ),
+                ).toBe(expected);
+                expect(
+                    dashStyleOf(
+                        container.querySelector<SVGGElement>(".locked-ellipse"),
+                    ),
+                ).toBe(expected);
+                expect(
+                    dashStyleOf(
+                        container.querySelector<SVGGElement>(
+                            ".locked-function",
+                        ),
+                    ),
+                ).toBe(expected);
+                /* eslint-enable testing-library/no-container, testing-library/no-node-access */
+            },
+        );
+
+        it("does not set a dash pattern on solid figures", () => {
+            // Arrange, Act
+            const {container} = renderQuestion(
+                generateInteractiveGraphQuestion({
+                    markings: "none",
+                    correct: generateIGSegmentGraph(),
+                    lockedFigures: [
+                        generateIGLockedLine({
+                            kind: "segment",
+                            weight: "thick",
+                            lineStyle: "solid",
+                            points: [
+                                generateIGLockedPoint({coord: [-5, 0]}),
+                                generateIGLockedPoint({coord: [0, 5]}),
+                            ],
+                        }),
+                    ],
+                }),
+                blankOptions,
+            );
+
+            // Assert
+            expect(
+                dashStyleOf(
+                    // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+                    container.querySelector<SVGGElement>(".locked-line"),
+                ),
+            ).toBe("");
+        });
+    });
+
     describe("interactive graph screen reader", () => {
         const limitedGraphQuestionRenderers: {
             [K in PerseusGraphType["type"][number]]: PerseusRenderer;

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.test.tsx
@@ -1813,99 +1813,93 @@ describe("Interactive Graph", function () {
     });
 
     describe("dashed locked figures scale the dash pattern with weight", () => {
-        // The dash pattern is applied via the `--mafs-line-stroke-dash-style`
-        // CSS variable set on each figure's wrapping <g>. mafs reads that
-        // variable when rendering the dashed line/polygon/ellipse/plot, so a
-        // weight-proportional value keeps the dashes clearly visible at every
-        // weight instead of collapsing toward solid on thick lines.
+        // These render tests only confirm that each renderer wires the
+        // `--mafs-line-stroke-dash-style` CSS variable onto its wrapping <g>
+        // (mafs reads that variable when drawing the dashed
+        // line/polygon/ellipse/plot). The weight-to-value math itself is
+        // covered directly by the `dashedStrokeStyle` unit tests, so a single
+        // representative weight is enough here.
         const dashStyleOf = (element: SVGElement | null): string =>
             element?.style.getPropertyValue("--mafs-line-stroke-dash-style") ??
             "";
 
-        it.each([
-            {weight: "thin", expected: "4, 3"},
-            {weight: "medium", expected: "8, 6"},
-            {weight: "thick", expected: "16, 12"},
-        ] satisfies {weight: StrokeWeight; expected: string}[])(
-            "dashed line/ray/polygon/ellipse/function render a $weight dash of $expected",
-            ({weight, expected}) => {
-                // Arrange, Act
-                const {container} = renderQuestion(
-                    generateInteractiveGraphQuestion({
-                        markings: "none",
-                        correct: generateIGSegmentGraph(),
-                        lockedFigures: [
-                            generateIGLockedLine({
-                                kind: "segment",
-                                weight,
-                                lineStyle: "dashed",
-                                points: [
-                                    generateIGLockedPoint({coord: [-5, 0]}),
-                                    generateIGLockedPoint({coord: [0, 5]}),
-                                ],
-                            }),
-                            // Rays apply the dash via a different path (an
-                            // explicit strokeDasharray on the custom Vector),
-                            // so they are covered separately from the segment.
-                            generateIGLockedLine({
-                                kind: "ray",
-                                weight,
-                                lineStyle: "dashed",
-                                points: [
-                                    generateIGLockedPoint({coord: [1, 0]}),
-                                    generateIGLockedPoint({coord: [1, 5]}),
-                                ],
-                            }),
-                            generateIGLockedPolygon({
-                                weight,
-                                strokeStyle: "dashed",
-                            }),
-                            generateIGLockedEllipse({
-                                weight,
-                                strokeStyle: "dashed",
-                            }),
-                            generateIGLockedFunction({
-                                weight,
-                                strokeStyle: "dashed",
-                                equation: "x^2",
-                            }),
-                        ],
-                    }),
-                    blankOptions,
-                );
+        it("wires the scaled dash pattern onto every dashed figure type", () => {
+            // Arrange, Act
+            const weight: StrokeWeight = "thick";
+            const expected = "16, 12";
+            const {container} = renderQuestion(
+                generateInteractiveGraphQuestion({
+                    markings: "none",
+                    correct: generateIGSegmentGraph(),
+                    lockedFigures: [
+                        generateIGLockedLine({
+                            kind: "segment",
+                            weight,
+                            lineStyle: "dashed",
+                            points: [
+                                generateIGLockedPoint({coord: [-5, 0]}),
+                                generateIGLockedPoint({coord: [0, 5]}),
+                            ],
+                        }),
+                        // Rays apply the dash via a different path (an
+                        // explicit strokeDasharray on the custom Vector),
+                        // so they are covered separately from the segment.
+                        generateIGLockedLine({
+                            kind: "ray",
+                            weight,
+                            lineStyle: "dashed",
+                            points: [
+                                generateIGLockedPoint({coord: [1, 0]}),
+                                generateIGLockedPoint({coord: [1, 5]}),
+                            ],
+                        }),
+                        generateIGLockedPolygon({
+                            weight,
+                            strokeStyle: "dashed",
+                        }),
+                        generateIGLockedEllipse({
+                            weight,
+                            strokeStyle: "dashed",
+                        }),
+                        generateIGLockedFunction({
+                            weight,
+                            strokeStyle: "dashed",
+                            equation: "x^2",
+                        }),
+                    ],
+                }),
+                blankOptions,
+            );
 
-                // Assert
-                /* eslint-disable testing-library/no-container, testing-library/no-node-access */
-                expect(
-                    dashStyleOf(
-                        container.querySelector<SVGGElement>(".locked-line"),
-                    ),
-                ).toBe(expected);
-                expect(
-                    dashStyleOf(
-                        container.querySelector<SVGGElement>(".locked-ray"),
-                    ),
-                ).toBe(expected);
-                expect(
-                    dashStyleOf(
-                        container.querySelector<SVGGElement>(".locked-polygon"),
-                    ),
-                ).toBe(expected);
-                expect(
-                    dashStyleOf(
-                        container.querySelector<SVGGElement>(".locked-ellipse"),
-                    ),
-                ).toBe(expected);
-                expect(
-                    dashStyleOf(
-                        container.querySelector<SVGGElement>(
-                            ".locked-function",
-                        ),
-                    ),
-                ).toBe(expected);
-                /* eslint-enable testing-library/no-container, testing-library/no-node-access */
-            },
-        );
+            // Assert
+            /* eslint-disable testing-library/no-container, testing-library/no-node-access */
+            expect(
+                dashStyleOf(
+                    container.querySelector<SVGGElement>(".locked-line"),
+                ),
+            ).toBe(expected);
+            expect(
+                dashStyleOf(
+                    container.querySelector<SVGGElement>(".locked-ray"),
+                ),
+            ).toBe(expected);
+            expect(
+                dashStyleOf(
+                    container.querySelector<SVGGElement>(".locked-polygon"),
+                ),
+            ).toBe(expected);
+            expect(
+                dashStyleOf(
+                    container.querySelector<SVGGElement>(".locked-ellipse"),
+                ),
+            ).toBe(expected);
+            expect(
+                dashStyleOf(
+                    container.querySelector<SVGGElement>(".locked-function"),
+                ),
+            ).toBe(expected);
+            /* eslint-enable testing-library/no-container, testing-library/no-node-access */
+        });
 
         it("does not set a dash pattern on solid figures", () => {
             // Arrange, Act

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-ellipse.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-ellipse.tsx
@@ -7,7 +7,7 @@ import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {Ellipse} from "mafs";
 import * as React from "react";
 
-import {strokeWeights} from "./utils";
+import {dashedStrokeStyle, strokeWeights} from "./utils";
 
 const LockedEllipse = (props: LockedEllipseType) => {
     const {
@@ -29,6 +29,8 @@ const LockedEllipse = (props: LockedEllipseType) => {
             aria-label={hasAria ? ariaLabel : undefined}
             aria-hidden={!hasAria}
             role="img"
+            // Weight-scaled dash pattern for dashed figures (see dashedStrokeStyle).
+            style={dashedStrokeStyle(strokeStyle === "dashed", weight)}
         >
             <Ellipse
                 center={center}

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-function.tsx
@@ -6,7 +6,7 @@ import {useState, useEffect} from "react";
 
 import useGraphConfig from "../reducer/use-graph-config";
 
-import {clampDomain, strokeWeights} from "./utils";
+import {clampDomain, dashedStrokeStyle, strokeWeights} from "./utils";
 
 import type {LockedFunctionType} from "@khanacademy/perseus-core";
 
@@ -55,6 +55,8 @@ const LockedFunction = (props: LockedFunctionType) => {
             aria-label={hasAria ? props.ariaLabel : undefined}
             aria-hidden={!hasAria}
             role="img"
+            // Weight-scaled dash pattern for dashed figures (see dashedStrokeStyle).
+            style={dashedStrokeStyle(strokeStyle === "dashed", weight)}
         >
             {directionalAxis === "x" && (
                 <Plot.OfX

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-line.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-line.tsx
@@ -10,7 +10,7 @@ import {useTransformVectorsToPixels} from "../graphs/use-transform";
 import {getIntersectionOfRayWithBox} from "../graphs/utils";
 import {X, Y} from "../math";
 
-import {strokeWeights} from "./utils";
+import {dashedStrokeStyle, strokeWeights} from "./utils";
 
 import type {LockedLineType} from "@khanacademy/perseus-core";
 import type {Interval} from "mafs";
@@ -126,6 +126,8 @@ const LockedLine = (props: Props) => {
             aria-label={hasAria ? ariaLabel : undefined}
             aria-hidden={!hasAria}
             role="img"
+            // Weight-scaled dash pattern for dashed figures (see dashedStrokeStyle).
+            style={dashedStrokeStyle(lineStyle === "dashed", weight)}
         >
             {line}
             {showPoint1 && (

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/locked-polygon.tsx
@@ -8,7 +8,7 @@ import * as React from "react";
 
 import {X, Y} from "../math";
 
-import {strokeWeights} from "./utils";
+import {dashedStrokeStyle, strokeWeights} from "./utils";
 
 import type {LockedPolygonType} from "@khanacademy/perseus-core";
 
@@ -23,6 +23,8 @@ const LockedPolygon = (props: LockedPolygonType) => {
             aria-label={hasAria ? props.ariaLabel : undefined}
             aria-hidden={!hasAria}
             role="img"
+            // Weight-scaled dash pattern for dashed figures (see dashedStrokeStyle).
+            style={dashedStrokeStyle(strokeStyle === "dashed", weight)}
         >
             <Polygon
                 points={[...points]}

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/utils.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/utils.test.ts
@@ -1,4 +1,4 @@
-import {clampDomain, getDashArrayForWeight} from "./utils";
+import {clampDomain, dashedStrokeStyle, getDashArrayForWeight} from "./utils";
 
 describe("clampDomain", () => {
     test.each`
@@ -46,4 +46,32 @@ describe("getDashArrayForWeight", () => {
             expect(dashArray).toBe(expected);
         },
     );
+});
+
+describe("dashedStrokeStyle", () => {
+    it.each`
+        weight      | expected
+        ${"thin"}   | ${"4, 3"}
+        ${"medium"} | ${"8, 6"}
+        ${"thick"}  | ${"16, 12"}
+    `(
+        "sets the weight-scaled dash pattern for a dashed $weight figure",
+        ({weight, expected}) => {
+            // Arrange, Act
+            const style = dashedStrokeStyle(true, weight);
+
+            // Assert
+            expect(style).toEqual({
+                "--mafs-line-stroke-dash-style": expected,
+            });
+        },
+    );
+
+    it("returns undefined for a solid figure so no inline style is emitted", () => {
+        // Arrange, Act
+        const style = dashedStrokeStyle(false, "thick");
+
+        // Assert
+        expect(style).toBeUndefined();
+    });
 });

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/utils.test.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/utils.test.ts
@@ -1,4 +1,4 @@
-import {clampDomain} from "./utils";
+import {clampDomain, getDashArrayForWeight} from "./utils";
 
 describe("clampDomain", () => {
     test.each`
@@ -26,6 +26,24 @@ describe("clampDomain", () => {
         "clampedDomain($domain, $graphXBounds) = $expected",
         ({domain, graphXBounds, expected}) => {
             expect(clampDomain(domain, graphXBounds)).toEqual(expected);
+        },
+    );
+});
+
+describe("getDashArrayForWeight", () => {
+    test.each`
+        weight      | expected
+        ${"thin"}   | ${"4, 3"}
+        ${"medium"} | ${"8, 6"}
+        ${"thick"}  | ${"16, 12"}
+    `(
+        "scales the dash pattern with the $weight stroke width -> $expected",
+        ({weight, expected}) => {
+            // Arrange, Act
+            const dashArray = getDashArrayForWeight(weight);
+
+            // Assert
+            expect(dashArray).toBe(expected);
         },
     );
 });

--- a/packages/perseus/src/widgets/interactive-graphs/locked-figures/utils.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/locked-figures/utils.ts
@@ -1,10 +1,43 @@
 import type {StrokeWeight} from "@khanacademy/perseus-core";
+import type * as React from "react";
 
 export const strokeWeights: Record<StrokeWeight, number> = {
     thin: 1,
     medium: 2,
     thick: 4,
 } as const;
+
+/**
+ * A dashed locked figure's `stroke-dasharray`, scaled to the stroke width so the
+ * dashes stay visible at every weight. mafs hardcodes `4, 3` regardless of
+ * width, making thick lines read as nearly solid; this restores legacy graphie's
+ * width-proportional pattern (Raphael's `[4, 3]` × width). Thin yields `4, 3`,
+ * unchanged.
+ */
+export function getDashArrayForWeight(weight: StrokeWeight): string {
+    const width = strokeWeights[weight];
+    return `${4 * width}, ${3 * width}`;
+}
+
+/**
+ * Inline `<g>` style that sets `--mafs-line-stroke-dash-style` to the
+ * weight-scaled dash pattern; mafs reads that variable for every dashed
+ * primitive (Line, Vector, Polygon, Ellipse, Plot) below. `undefined` for solid
+ * figures, so no inline style is emitted.
+ */
+export function dashedStrokeStyle(
+    isDashed: boolean,
+    weight: StrokeWeight,
+): React.CSSProperties | undefined {
+    if (!isDashed) {
+        return undefined;
+    }
+    // Custom properties aren't part of React.CSSProperties, so cast.
+    // eslint-disable-next-line no-restricted-syntax
+    return {
+        "--mafs-line-stroke-dash-style": getDashArrayForWeight(weight),
+    } as React.CSSProperties;
+}
 
 export function clampDomain(
     domain: [number | null, number | null],


### PR DESCRIPTION
## Summary:
This change will improve the visual of the dashed lines of the interactive graph locked figure so it will be more visible.

Dashed "locked figures" on the Interactive Graph (lines, rays, segments, polygons, ellipses, and functions) didn't read as clearly dashed it looked almost solid line. This scales the dash pattern with the stroke width so dashed figures render as clearly dashed at every weight.

Root cause: the dash pattern is not defined in Perseus — it inherits the mafs library default `--mafs-line-stroke-dash-style: 4, 3`, which is **fixed regardless of stroke width**. Stroke weight only changes the line's *width* (`thin: 1`, `medium: 2`, `thick: 4` px), so on a 4px-thick line a 4px dash with a 3px gap collapses toward looking solid. The fix restores the **legacy graphie proportion**. graphie rendered dashed lines with Raphael's `"- "` pattern `[4, 3]` **multiplied by the stroke width**, so the dash and gap grew with the line. We reproduce that here:

| weight | width | dash, gap | before |
|--------|-------|-----------|--------|
| thin   | 1px   | `4, 3`    | `4, 3` (unchanged) |
| medium | 2px   | `8, 6`    | `4, 3` |
| thick  | 4px   | `16, 12`  | `4, 3` |

Solid figures are unaffected (no inline style is emitted). The change is purely presentational — no data-schema change, backward compatible, no content migration

Issue: LEMS-4431

## Test plan: