### PR TITLE
Migrate grapher widget to WidgetPropsV2

### DIFF
--- a/.changeset/tough-pianos-graph.md
+++ b/.changeset/tough-pianos-graph.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: The options of the Grapher widget are now grouped under a single `options` prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -507,7 +507,7 @@ review and commit the changes.
 - [x] Migrate `categorizer` to `WidgetPropsV2` (update its editor preview).
 - [x] Migrate `matcher` to `WidgetPropsV2`.
 - [x] Migrate `matrix` to `WidgetPropsV2` (update its editor preview).
-- [ ] Migrate `grapher` to `WidgetPropsV2` (update its editor preview and
+- [x] Migrate `grapher` to `WidgetPropsV2` (update its editor preview and
       `satisfies PropsFor` assertion).
 - [ ] Migrate `table` to `WidgetPropsV2` (update its editor preview).
 - [ ] Migrate `expression` to `WidgetPropsV2` (same `ExternalProps` pattern;

--- a/packages/perseus-editor/src/widgets/grapher-editor.tsx
+++ b/packages/perseus-editor/src/widgets/grapher-editor.tsx
@@ -72,9 +72,12 @@ class GrapherEditor extends React.Component<Props> {
             const graphProps: Partial<PropsFor<typeof Grapher>> = {
                 apiOptions: this.props.apiOptions,
                 containerSizeClass: sizeClass,
-                graph: this.props.graph,
+                options: {
+                    graph: this.props.graph,
+                    correct: this.props.correct,
+                    availableTypes: [...this.props.availableTypes],
+                },
                 userInput: this.props.correct,
-                correct: this.props.correct,
                 handleUserInput: (userInput) => {
                     let correct = this.props.correct;
                     if (correct.type === userInput?.type) {
@@ -85,7 +88,6 @@ class GrapherEditor extends React.Component<Props> {
                     }
                     this.props.onChange({correct: correct});
                 },
-                availableTypes: [...this.props.availableTypes],
                 trackInteraction: function () {},
                 // Set the "correct answer" graph to static when editing is disabled
                 static: this.props.apiOptions.editingDisabled,

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -31,4 +31,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "categorizer",
     "matcher",
     "matrix",
+    "grapher",
 ];

--- a/packages/perseus/src/widget-ai-utils/grapher/grapher-ai-utils.test.ts
+++ b/packages/perseus/src/widget-ai-utils/grapher/grapher-ai-utils.test.ts
@@ -66,14 +66,16 @@ describe("Grapher AI utils", () => {
         };
 
         const widgetData: any = {
-            availableTypes: ["linear"],
-            graph: {
-                range: [0, 10, 0, 10],
-                labels: ["x", "y"],
-                step: 1,
-                gridStep: 1,
-                snapStep: 1,
-                backgroundImage: {url: "http://khanaacademy.org/image.jpg"},
+            options: {
+                availableTypes: ["linear"],
+                graph: {
+                    range: [0, 10, 0, 10],
+                    labels: ["x", "y"],
+                    step: 1,
+                    gridStep: 1,
+                    snapStep: 1,
+                    backgroundImage: {url: "http://khanaacademy.org/image.jpg"},
+                },
             },
             userInput,
         };
@@ -112,14 +114,16 @@ describe("Grapher AI utils", () => {
         };
 
         const widgetData: any = {
-            availableTypes: ["lograithm"],
-            graph: {
-                range: [0, 10, 0, 10],
-                labels: ["x", "y"],
-                step: 1,
-                gridStep: 1,
-                snapStep: 1,
-                backgroundImage: {url: ""},
+            options: {
+                availableTypes: ["lograithm"],
+                graph: {
+                    range: [0, 10, 0, 10],
+                    labels: ["x", "y"],
+                    step: 1,
+                    gridStep: 1,
+                    snapStep: 1,
+                    backgroundImage: {url: ""},
+                },
             },
             userInput,
         };

--- a/packages/perseus/src/widget-ai-utils/grapher/grapher-ai-utils.ts
+++ b/packages/perseus/src/widget-ai-utils/grapher/grapher-ai-utils.ts
@@ -74,13 +74,13 @@ export const getPromptJSON = (
     return {
         type: "grapher",
         options: {
-            availableTypes: widgetData.availableTypes,
-            range: widgetData.graph.range,
-            labels: widgetData.graph.labels,
-            tickStep: widgetData.graph.step,
-            gridStep: widgetData.graph.gridStep,
-            snapStep: widgetData.graph.snapStep,
-            backgroundImageUrl: widgetData.graph.backgroundImage.url,
+            availableTypes: widgetData.options.availableTypes,
+            range: widgetData.options.graph.range,
+            labels: widgetData.options.graph.labels,
+            tickStep: widgetData.options.graph.step,
+            gridStep: widgetData.options.graph.gridStep,
+            snapStep: widgetData.options.graph.snapStep,
+            backgroundImageUrl: widgetData.options.graph.backgroundImage.url,
         },
         userInput: input,
     };

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -52,6 +52,7 @@ import type {
     PerseusGrapherUserInput,
     GrapherPublicWidgetOptions,
     GrapherFunctionType,
+    Interval,
 } from "@khanacademy/perseus-core";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
@@ -385,12 +386,12 @@ class Grapher extends React.Component<Props> implements Widget {
         this.props.handleUserInput(plot);
     };
 
-    _getGridConfig(
-        options: Props["options"]["graph"] & {
-            box: NonNullable<Props["options"]["graph"]["box"]>;
-            gridStep: NonNullable<Props["options"]["graph"]["gridStep"]>;
-        },
-    ): ReadonlyArray<GridDimensions> {
+    _getGridConfig(options: {
+        box: [width: number, height: number];
+        step: [x: number, y: number];
+        gridStep: [x: number, y: number];
+        range: [x: Interval, y: Interval];
+    }): ReadonlyArray<GridDimensions> {
         return options.step.map((step, i) => {
             return Util.gridDimensionConfig(
                 step,

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -43,7 +43,7 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetProps,
+    WidgetPropsV2,
 } from "../../types";
 import type {GridDimensions} from "../../util";
 import type {GrapherPromptJSON} from "../../widget-ai-utils/grapher/grapher-ai-utils";
@@ -350,7 +350,7 @@ class FunctionGrapher extends React.Component<FunctionGrapherProps> {
     }
 }
 
-type Props = WidgetProps<
+type Props = WidgetPropsV2<
     PerseusGrapherWidgetOptions,
     PerseusGrapherUserInput
 > & {dependencies: PerseusDependenciesV2};
@@ -377,7 +377,7 @@ class Grapher extends React.Component<Props> implements Widget {
     };
 
     handleActiveTypeChange: (arg1: any) => any = (newType) => {
-        const graph = this.props.graph;
+        const graph = this.props.options.graph;
         const plot = {
             ...this.props.userInput,
             ...defaultPlotProps(newType, graph),
@@ -386,9 +386,9 @@ class Grapher extends React.Component<Props> implements Widget {
     };
 
     _getGridConfig(
-        options: Props["graph"] & {
-            box: NonNullable<Props["graph"]["box"]>;
-            gridStep: NonNullable<Props["graph"]["gridStep"]>;
+        options: Props["options"]["graph"] & {
+            box: NonNullable<Props["options"]["graph"]["box"]>;
+            gridStep: NonNullable<Props["options"]["graph"]["gridStep"]>;
         },
     ): ReadonlyArray<GridDimensions> {
         return options.step.map((step, i) => {
@@ -500,20 +500,21 @@ class Grapher extends React.Component<Props> implements Widget {
     };
 
     showHairlines: (arg1: Coord) => void = (point) => {
+        const {graph} = this.props.options;
         if (this.props.apiOptions.isMobile) {
             // Hairlines are already initialized when the graph is loaded, so
             // here we just move them to the updated location and make them
             // visible.
             this.horizHairline.moveTo(
-                [this.props.graph.range[0][0], point[1]],
-                [this.props.graph.range[0][1], point[1]],
+                [graph.range[0][0], point[1]],
+                [graph.range[0][1], point[1]],
             );
 
             this.horizHairline.show();
 
             this.vertHairline.moveTo(
-                [point[0], this.props.graph.range[1][0]],
-                [point[0], this.props.graph.range[1][1]],
+                [point[0], graph.range[1][0]],
+                [point[0], graph.range[1][1]],
             );
 
             this.vertHairline.show();
@@ -536,22 +537,22 @@ class Grapher extends React.Component<Props> implements Widget {
      * [LEMS-3185] do not trust serializedState
      */
     getSerializedState() {
-        const {userInput: _, correct: __, ...rest} = this.props;
+        const {userInput: _, options, ...rest} = this.props;
+        const {correct: __, ...optionsRest} = options;
         return {
+            ...optionsRest,
             ...rest,
             plot: this.props.userInput,
         };
     }
 
     getAvailableTypes(): GrapherFunctionType[] {
+        const {correct, availableTypes} = this.props.options;
         if (this.props.static) {
-            invariant(
-                this.props.correct,
-                "static widgets must have a correct answer",
-            );
-            return [this.props.correct.type];
+            invariant(correct, "static widgets must have a correct answer");
+            return [correct.type];
         }
-        return this.props.availableTypes;
+        return availableTypes;
     }
 
     renderLegacyGrapher() {
@@ -581,13 +582,14 @@ class Grapher extends React.Component<Props> implements Widget {
 
         // Calculate additional graph properties so that the same values are
         // passed in to both FunctionGrapher and Graphie.
+        const graph = this.props.options.graph;
         const options = {
-            ...this.props.graph,
-            ...getGridAndSnapSteps(this.props.graph, box[0]),
+            ...graph,
+            ...getGridAndSnapSteps(graph, box[0]),
             gridConfig: this._getGridConfig({
-                ...this.props.graph,
+                ...graph,
                 box: box,
-                ...getGridAndSnapSteps(this.props.graph, box[0]),
+                ...getGridAndSnapSteps(graph, box[0]),
             }),
         } as const;
 
@@ -611,7 +613,7 @@ class Grapher extends React.Component<Props> implements Widget {
             asymptote: asymptote,
             static: this.props.static,
             isMobile: this.props.apiOptions.isMobile,
-            showTooltips: this.props.graph.showTooltips,
+            showTooltips: graph.showTooltips,
             showHairlines: this.showHairlines,
             hideHairlines: this.hideHairlines,
         } as const;
@@ -626,18 +628,20 @@ class Grapher extends React.Component<Props> implements Widget {
     }
 
     render(): React.ReactNode {
-        const interactiveGraphOptions = convertGrapherOptionsToInteractiveGraph(
-            this.props,
-        );
+        const {options, ...universalProps} = this.props;
+        const interactiveGraphOptions =
+            convertGrapherOptionsToInteractiveGraph(options);
         if (interactiveGraphOptions == null) {
             return this.renderLegacyGrapher();
         }
         const interactiveGraphUserInput =
             convertGrapherUserInputToInteractiveGraph(this.props.userInput);
 
+        // InteractiveGraph has not yet migrated to nested options, so it takes
+        // the converted options spread across its props.
         return (
             <InteractiveGraph.widget
-                {...this.props}
+                {...universalProps}
                 {...interactiveGraphOptions}
                 userInput={interactiveGraphUserInput}
                 handleUserInput={(interactiveGraphUserInput) =>
@@ -686,12 +690,6 @@ function getCorrectUserInput(
     );
     return options.correct;
 }
-
-// eslint-disable-next-line no-restricted-syntax
-0 as any as WidgetProps<
-    PerseusGrapherWidgetOptions,
-    PerseusGrapherUserInput
-> satisfies PropsFor<typeof WrappedGrapher>;
 
 const WrappedGrapher = withDependencies(Grapher);
 

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -377,7 +377,7 @@ class Grapher extends React.Component<Props> implements Widget {
     };
 
     handleActiveTypeChange: (arg1: any) => any = (newType) => {
-        const graph = this.props.options.graph;
+        const {graph} = this.props.options;
         const plot = {
             ...this.props.userInput,
             ...defaultPlotProps(newType, graph),
@@ -582,7 +582,7 @@ class Grapher extends React.Component<Props> implements Widget {
 
         // Calculate additional graph properties so that the same values are
         // passed in to both FunctionGrapher and Graphie.
-        const graph = this.props.options.graph;
+        const {graph} = this.props.options;
         const options = {
             ...graph,
             ...getGridAndSnapSteps(graph, box[0]),
@@ -637,6 +637,7 @@ class Grapher extends React.Component<Props> implements Widget {
         const interactiveGraphUserInput =
             convertGrapherUserInputToInteractiveGraph(this.props.userInput);
 
+        // TODO(LEMS-4354): delete the comment below.
         // InteractiveGraph has not yet migrated to nested options, so it takes
         // the converted options spread across its props.
         return (


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a Grapher widget in
  http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.