### PR TITLE
[Color][Graded Group] Update vertical bar to semantic color tokens

### DIFF
--- a/.changeset/silver-cooks-study.md
+++ b/.changeset/silver-cooks-study.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Update Graded Group vertical correctness bar to align with themes

--- a/packages/perseus/src/styles/widgets/graded-group.css
+++ b/packages/perseus/src/styles/widgets/graded-group.css
@@ -5,11 +5,11 @@
     padding-left: 5px;
 }
 .framework-perseus .perseus-graded-group.answer-correct {
-    border-left: 3px solid #76a005;
+    border-left: 3px solid var(--wb-semanticColor-core-border-success-default);
     margin-left: 0;
 }
 .framework-perseus .perseus-graded-group.answer-incorrect {
-    border-left: 3px solid #ff8787;
+    border-left: 3px solid var(--wb-semanticColor-core-border-critical-default);
     margin-left: 0;
 }
 .framework-perseus .perseus-graded-group .group-icon {


### PR DESCRIPTION
## Summary:
During the previous graded group color update, the vertical bars were missed as they were in a separate CSS file. This updates those colors to semantic tokens.

**Classic theme, main vs latest:**

<img width="1141" height="176" alt="Correct green vertical bar" src="https://github.com/user-attachments/assets/21a00940-acbf-41b4-9109-d303a8f8647f" />


<img width="1042" height="194" alt="Incorrect red vertical bar" src="https://github.com/user-attachments/assets/67bfc174-5e0f-4656-a531-6e41430de7df" />


Issue: LEMS-4438

## Test plan:
- Confirm chromatic snapshots show expected update
- Confirm all checks pass