### PR TITLE
[Color][Phet] Update colors and fonts to semantic tokens

### DIFF
--- a/.changeset/goofy-impalas-stick.md
+++ b/.changeset/goofy-impalas-stick.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Update phet simulation to reflect the current user's theme by updating styling to tokens

--- a/.changeset/goofy-impalas-stick.md
+++ b/.changeset/goofy-impalas-stick.md
@@ -1,5 +1,6 @@
 ---
 "@khanacademy/perseus": patch
+"@khanacademy/perseus-core": patch
 ---
 
 Update phet simulation to reflect the current user's theme by updating styling to tokens

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -430,6 +430,11 @@ export {
     generatePlotterWidget,
     generatePlotterOptions,
 } from "./utils/generators/plotter-widget-generator";
+/** @hidden */
+export {
+    generatePhetSimulationWidget,
+    generatePhetSimulationOptions,
+} from "./utils/generators/phet-simulation-widget-generator";
 export {generateNumericInputWidget} from "./utils/generators/numeric-input-widget-generator";
 /** @hidden */
 export {

--- a/packages/perseus-core/src/utils/generators/phet-simulation-widget-generator.test.ts
+++ b/packages/perseus-core/src/utils/generators/phet-simulation-widget-generator.test.ts
@@ -1,0 +1,93 @@
+import {
+    generatePhetSimulationOptions,
+    generatePhetSimulationWidget,
+} from "./phet-simulation-widget-generator";
+
+import type {
+    PerseusPhetSimulationWidgetOptions,
+    PhetSimulationWidget,
+} from "../../data-schema";
+
+describe("generatePhetSimulationOptions", () => {
+    test("builds default phet-simulation options", () => {
+        const options: PerseusPhetSimulationWidgetOptions =
+            generatePhetSimulationOptions();
+
+        expect(options.url).toBe("");
+        expect(options.description).toBe("");
+    });
+
+    test("builds phet-simulation options with all props", () => {
+        const options: PerseusPhetSimulationWidgetOptions =
+            generatePhetSimulationOptions({
+                url: "https://phet.colorado.edu/sims/html/projectile-data-lab/latest/projectile-data-lab_all.html",
+                description: "Projectile Data Lab",
+            });
+
+        expect(options.url).toBe(
+            "https://phet.colorado.edu/sims/html/projectile-data-lab/latest/projectile-data-lab_all.html",
+        );
+        expect(options.description).toBe("Projectile Data Lab");
+    });
+});
+
+describe("generatePhetSimulationWidget", () => {
+    test("builds a default phet-simulation widget", () => {
+        const widget: PhetSimulationWidget = generatePhetSimulationWidget();
+
+        expect(widget.type).toBe("phet-simulation");
+        expect(widget.graded).toBe(false);
+        expect(widget.static).toBe(false);
+        expect(widget.version).toEqual({major: 0, minor: 0});
+        expect(widget.alignment).toBe("default");
+        expect(widget.options).toEqual({url: "", description: ""});
+    });
+
+    test("builds a phet-simulation widget with all props", () => {
+        const widget: PhetSimulationWidget = generatePhetSimulationWidget({
+            graded: true,
+            version: {major: 1, minor: 0},
+            static: true,
+            alignment: "block",
+            options: generatePhetSimulationOptions({
+                url: "https://phet.colorado.edu/sims/html/projectile-data-lab/latest/projectile-data-lab_all.html",
+                description: "Projectile Data Lab",
+            }),
+        });
+
+        expect(widget.graded).toBe(true);
+        expect(widget.static).toBe(true);
+        expect(widget.version).toEqual({major: 1, minor: 0});
+        expect(widget.alignment).toBe("block");
+        expect(widget.options).toEqual({
+            url: "https://phet.colorado.edu/sims/html/projectile-data-lab/latest/projectile-data-lab_all.html",
+            description: "Projectile Data Lab",
+        });
+    });
+
+    test("adds options when option builder is used", () => {
+        const widget: PhetSimulationWidget = generatePhetSimulationWidget({
+            static: true,
+            options: generatePhetSimulationOptions({
+                url: "https://google.com/",
+                description: "Google",
+            }),
+        });
+
+        expect(widget.static).toBe(true);
+        expect(widget.options.url).toBe("https://google.com/");
+        expect(widget.options.description).toBe("Google");
+    });
+
+    test("fills in missing option fields with defaults when a partial options object is passed directly, without going through the option builder", () => {
+        const widget: PhetSimulationWidget = generatePhetSimulationWidget({
+            // @ts-expect-error -- intentionally passing a partial options
+            // object directly (not via generatePhetSimulationOptions) to
+            // verify the widget generator still fills in defaults for it.
+            options: {url: "https://google.com/"},
+        });
+
+        expect(widget.options.url).toBe("https://google.com/");
+        expect(widget.options.description).toBe("");
+    });
+});

--- a/packages/perseus-core/src/utils/generators/phet-simulation-widget-generator.test.ts
+++ b/packages/perseus-core/src/utils/generators/phet-simulation-widget-generator.test.ts
@@ -10,20 +10,24 @@ import type {
 
 describe("generatePhetSimulationOptions", () => {
     test("builds default phet-simulation options", () => {
+        // Arrange, Act
         const options: PerseusPhetSimulationWidgetOptions =
             generatePhetSimulationOptions();
 
+        // Assert
         expect(options.url).toBe("");
         expect(options.description).toBe("");
     });
 
     test("builds phet-simulation options with all props", () => {
+        // Arrange, Act
         const options: PerseusPhetSimulationWidgetOptions =
             generatePhetSimulationOptions({
                 url: "https://phet.colorado.edu/sims/html/projectile-data-lab/latest/projectile-data-lab_all.html",
                 description: "Projectile Data Lab",
             });
 
+        // Assert
         expect(options.url).toBe(
             "https://phet.colorado.edu/sims/html/projectile-data-lab/latest/projectile-data-lab_all.html",
         );
@@ -33,8 +37,10 @@ describe("generatePhetSimulationOptions", () => {
 
 describe("generatePhetSimulationWidget", () => {
     test("builds a default phet-simulation widget", () => {
+        // Arrange, Act
         const widget: PhetSimulationWidget = generatePhetSimulationWidget();
 
+        // Assert
         expect(widget.type).toBe("phet-simulation");
         expect(widget.graded).toBe(false);
         expect(widget.static).toBe(false);
@@ -44,6 +50,7 @@ describe("generatePhetSimulationWidget", () => {
     });
 
     test("builds a phet-simulation widget with all props", () => {
+        // Arrange, Act
         const widget: PhetSimulationWidget = generatePhetSimulationWidget({
             graded: true,
             version: {major: 1, minor: 0},
@@ -55,6 +62,7 @@ describe("generatePhetSimulationWidget", () => {
             }),
         });
 
+        // Assert
         expect(widget.graded).toBe(true);
         expect(widget.static).toBe(true);
         expect(widget.version).toEqual({major: 1, minor: 0});
@@ -66,6 +74,7 @@ describe("generatePhetSimulationWidget", () => {
     });
 
     test("adds options when option builder is used", () => {
+        // Arrange, Act
         const widget: PhetSimulationWidget = generatePhetSimulationWidget({
             static: true,
             options: generatePhetSimulationOptions({
@@ -74,12 +83,14 @@ describe("generatePhetSimulationWidget", () => {
             }),
         });
 
+        // Assert
         expect(widget.static).toBe(true);
         expect(widget.options.url).toBe("https://google.com/");
         expect(widget.options.description).toBe("Google");
     });
 
     test("fills in missing option fields with defaults when a partial options object is passed directly, without going through the option builder", () => {
+        // Arrange, Act
         const widget: PhetSimulationWidget = generatePhetSimulationWidget({
             // @ts-expect-error -- intentionally passing a partial options
             // object directly (not via generatePhetSimulationOptions) to
@@ -87,6 +98,7 @@ describe("generatePhetSimulationWidget", () => {
             options: {url: "https://google.com/"},
         });
 
+        // Assert
         expect(widget.options.url).toBe("https://google.com/");
         expect(widget.options.description).toBe("");
     });

--- a/packages/perseus-core/src/utils/generators/phet-simulation-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/phet-simulation-widget-generator.ts
@@ -1,0 +1,33 @@
+import phetSimulationWidgetLogic from "../../widgets/phet-simulation";
+
+import type {
+    PerseusPhetSimulationWidgetOptions,
+    PhetSimulationWidget,
+} from "../../data-schema";
+
+export function generatePhetSimulationOptions(
+    options?: Partial<PerseusPhetSimulationWidgetOptions>,
+): PerseusPhetSimulationWidgetOptions {
+    return {
+        ...phetSimulationWidgetLogic.defaultWidgetOptions,
+        ...options,
+    };
+}
+
+export function generatePhetSimulationWidget(
+    phetSimulationWidgetProperties?: Partial<
+        Omit<PhetSimulationWidget, "type">
+    >,
+): PhetSimulationWidget {
+    return {
+        type: "phet-simulation",
+        graded: false,
+        version: {major: 0, minor: 0},
+        static: false,
+        alignment: "default",
+        ...phetSimulationWidgetProperties,
+        options: generatePhetSimulationOptions(
+            phetSimulationWidgetProperties?.options,
+        ),
+    };
+}

--- a/packages/perseus/src/widgets/phet-simulation/__docs__/phet-simulation-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/__docs__/phet-simulation-initial-state-regression.stories.tsx
@@ -1,0 +1,35 @@
+import {themeModes} from "../../../../../../.storybook/modes";
+
+import {phetSimulationRendererDecorator} from "./phet-simulation-renderer-decorator";
+
+import type {PerseusPhetSimulationWidgetOptions} from "@khanacademy/perseus-core";
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+const meta: Meta<PerseusPhetSimulationWidgetOptions> = {
+    title: "Widgets/PhET Simulation/Visual Regression Tests/Initial State",
+    tags: ["!autodocs", "!manifest"],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    "Regression tests for the PhET Simulation widget that do NOT " +
+                    "need any interactions to test.",
+            },
+        },
+        chromatic: {disableSnapshot: false, modes: themeModes},
+    },
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// A non-PhET URL is rejected before any network request is made, so this
+// renders the widget's container and iframe borders deterministically without
+// depending on a real fetch to phet.colorado.edu succeeding.
+export const LoadFailure: Story = {
+    decorators: [phetSimulationRendererDecorator],
+    args: {
+        url: "https://example.com/",
+        description: "Example",
+    } satisfies Partial<PerseusPhetSimulationWidgetOptions>,
+};

--- a/packages/perseus/src/widgets/phet-simulation/__docs__/phet-simulation-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/__docs__/phet-simulation-interactions-regression.stories.tsx
@@ -11,6 +11,13 @@ const meta: Meta<PerseusPhetSimulationWidgetOptions> = {
     title: "Widgets/PhET Simulation/Visual Regression Tests/Interactions",
     tags: ["!autodocs", "!manifest"],
     parameters: {
+        docs: {
+            description: {
+                component:
+                    "Regression tests for the PhET Simulation widget that DO " +
+                    "need interactions to test.",
+            },
+        },
         chromatic: {disableSnapshot: false, modes: themeModes},
     },
 };

--- a/packages/perseus/src/widgets/phet-simulation/__docs__/phet-simulation-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/__docs__/phet-simulation-interactions-regression.stories.tsx
@@ -1,0 +1,46 @@
+import {expect} from "storybook/test";
+
+import {themeModes} from "../../../../../../.storybook/modes";
+
+import {phetSimulationRendererDecorator} from "./phet-simulation-renderer-decorator";
+
+import type {PerseusPhetSimulationWidgetOptions} from "@khanacademy/perseus-core";
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+const meta: Meta<PerseusPhetSimulationWidgetOptions> = {
+    title: "Widgets/PhET Simulation/Visual Regression Tests/Interactions",
+    tags: ["!autodocs", "!manifest"],
+    parameters: {
+        chromatic: {disableSnapshot: false, modes: themeModes},
+    },
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const simArgs = {
+    url: "https://phet.colorado.edu/sims/html/projectile-data-lab/latest/projectile-data-lab_all.html",
+    description: "Projectile Data Lab",
+} satisfies Partial<PerseusPhetSimulationWidgetOptions>;
+
+// Clicking Fullscreen while running as the mobile app enters the "fake
+// fullscreen" mode (there's no Fullscreen API in the mobile app webview) —
+// the only state where the close button and fullscreen container render.
+// Requires a successful sim load, so this depends on a real fetch to
+// phet.colorado.edu succeeding.
+export const MobileAppFullscreen: Story = {
+    decorators: [phetSimulationRendererDecorator],
+    parameters: {
+        apiOptions: {isMobileApp: true},
+    },
+    args: simArgs,
+    play: async ({canvas, userEvent}) => {
+        const fullscreenButton = await canvas.findByRole("button", {
+            name: "Fullscreen",
+        });
+        await userEvent.click(fullscreenButton);
+        await expect(
+            await canvas.findByRole("button", {name: "Exit fullscreen"}),
+        ).toBeInTheDocument();
+    },
+};

--- a/packages/perseus/src/widgets/phet-simulation/__docs__/phet-simulation-renderer-decorator.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/__docs__/phet-simulation-renderer-decorator.tsx
@@ -1,0 +1,28 @@
+import {generateTestPerseusRenderer} from "@khanacademy/perseus-core";
+import * as React from "react";
+
+import QuestionRendererForStories from "../../__testutils__/question-renderer-for-stories";
+
+import type {PerseusPhetSimulationWidgetOptions} from "@khanacademy/perseus-core";
+
+export const phetSimulationRendererDecorator = (_, {args, parameters}) => {
+    const options = {
+        url: args.url,
+        description: args.description,
+    } satisfies PerseusPhetSimulationWidgetOptions;
+
+    return (
+        <QuestionRendererForStories
+            apiOptions={parameters?.apiOptions}
+            question={generateTestPerseusRenderer({
+                content: parameters?.content ?? "[[☃ phet-simulation 1]]",
+                widgets: {
+                    "phet-simulation 1": {
+                        type: "phet-simulation",
+                        options,
+                    },
+                },
+            })}
+        />
+    );
+};

--- a/packages/perseus/src/widgets/phet-simulation/__docs__/phet-simulation-renderer-decorator.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/__docs__/phet-simulation-renderer-decorator.tsx
@@ -1,26 +1,35 @@
-import {generateTestPerseusRenderer} from "@khanacademy/perseus-core";
+import {
+    generatePhetSimulationOptions,
+    generatePhetSimulationWidget,
+    generateTestPerseusRenderer,
+} from "@khanacademy/perseus-core";
 import * as React from "react";
 
 import QuestionRendererForStories from "../../__testutils__/question-renderer-for-stories";
 
+import type {APIOptions} from "../../../types";
 import type {PerseusPhetSimulationWidgetOptions} from "@khanacademy/perseus-core";
+import type {Decorator} from "@storybook/react-vite";
 
-export const phetSimulationRendererDecorator = (_, {args, parameters}) => {
-    const options = {
-        url: args.url,
-        description: args.description,
-    } satisfies PerseusPhetSimulationWidgetOptions;
-
+export const phetSimulationRendererDecorator: Decorator = (
+    _,
+    {
+        args,
+        parameters,
+    }: {
+        args: Partial<PerseusPhetSimulationWidgetOptions>;
+        parameters?: {apiOptions?: APIOptions; content?: string};
+    },
+) => {
     return (
         <QuestionRendererForStories
             apiOptions={parameters?.apiOptions}
             question={generateTestPerseusRenderer({
                 content: parameters?.content ?? "[[☃ phet-simulation 1]]",
                 widgets: {
-                    "phet-simulation 1": {
-                        type: "phet-simulation",
-                        options,
-                    },
+                    "phet-simulation 1": generatePhetSimulationWidget({
+                        options: generatePhetSimulationOptions({...args}),
+                    }),
                 },
             })}
         />

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.testdata.ts
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.testdata.ts
@@ -1,3 +1,8 @@
+import {
+    generatePhetSimulationOptions,
+    generatePhetSimulationWidget,
+} from "@khanacademy/perseus-core";
+
 import type {PerseusRenderer} from "@khanacademy/perseus-core";
 
 export const question1: PerseusRenderer = {
@@ -5,17 +10,12 @@ export const question1: PerseusRenderer = {
         "Do this fun PhET simulation! A projectile data lab!\n[[\u2603 phet-simulation 1]]\n",
     images: {},
     widgets: {
-        "phet-simulation 1": {
-            graded: false,
-            version: {major: 0, minor: 0},
-            static: false,
-            type: "phet-simulation",
-            options: {
+        "phet-simulation 1": generatePhetSimulationWidget({
+            options: generatePhetSimulationOptions({
                 url: "https://phet.colorado.edu/sims/html/projectile-data-lab/latest/projectile-data-lab_all.html",
                 description: "Projectile Data Lab",
-            },
-            alignment: "default",
-        },
+            }),
+        }),
     },
 };
 
@@ -23,16 +23,11 @@ export const nonPhetUrl: PerseusRenderer = {
     content: "This should display an error!\n[[\u2603 phet-simulation 2]]\n",
     images: {},
     widgets: {
-        "phet-simulation 2": {
-            graded: false,
-            version: {major: 0, minor: 0},
-            static: false,
-            type: "phet-simulation",
-            options: {
+        "phet-simulation 2": generatePhetSimulationWidget({
+            options: generatePhetSimulationOptions({
                 url: "https://google.com/",
                 description: "Google",
-            },
-            alignment: "default",
-        },
+            }),
+        }),
     },
 };

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -7,7 +7,7 @@ import {makeSafeUrl} from "@khanacademy/perseus-core";
 import Banner from "@khanacademy/wonder-blocks-banner";
 import {View} from "@khanacademy/wonder-blocks-core";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
-import {spacing} from "@khanacademy/wonder-blocks-tokens";
+import {border, spacing} from "@khanacademy/wonder-blocks-tokens";
 import arrowSquareOutIcon from "@phosphor-icons/core/regular/arrow-square-out.svg";
 import cornersOutIcon from "@phosphor-icons/core/regular/corners-out.svg";
 import xIcon from "@phosphor-icons/core/regular/x.svg";
@@ -353,8 +353,8 @@ export class PhetSimulation
 
 const styles = StyleSheet.create({
     widgetContainer: {
-        borderRadius: 6,
-        borderWidth: 1,
+        borderRadius: border.radius.radius_080,
+        borderWidth: border.width.thin,
         borderColor: "#CCC",
         padding: spacing.medium_16,
         paddingBottom: 0,
@@ -372,7 +372,7 @@ const styles = StyleSheet.create({
         paddingTop: "56.25%",
     },
     iframeResponsive: {
-        borderWidth: 0,
+        borderWidth: border.width.none,
         position: "absolute",
         top: 0,
         left: 0,
@@ -410,7 +410,7 @@ const styles = StyleSheet.create({
     },
     closeButton: {
         backgroundColor: "rgba(255, 255, 255, 0.8)",
-        borderRadius: "50%",
+        borderRadius: border.radius.radius_full,
     },
 });
 

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -7,7 +7,11 @@ import {makeSafeUrl} from "@khanacademy/perseus-core";
 import Banner from "@khanacademy/wonder-blocks-banner";
 import {View} from "@khanacademy/wonder-blocks-core";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
-import {border, spacing} from "@khanacademy/wonder-blocks-tokens";
+import {
+    border,
+    semanticColor,
+    spacing,
+} from "@khanacademy/wonder-blocks-tokens";
 import arrowSquareOutIcon from "@phosphor-icons/core/regular/arrow-square-out.svg";
 import cornersOutIcon from "@phosphor-icons/core/regular/corners-out.svg";
 import xIcon from "@phosphor-icons/core/regular/x.svg";
@@ -355,7 +359,7 @@ const styles = StyleSheet.create({
     widgetContainer: {
         borderRadius: border.radius.radius_080,
         borderWidth: border.width.thin,
-        borderColor: "#CCC",
+        borderColor: semanticColor.core.border.neutral.subtle,
         padding: spacing.medium_16,
         paddingBottom: 0,
     },
@@ -392,7 +396,7 @@ const styles = StyleSheet.create({
         width: "100%",
         height: "auto",
         zIndex: 1000,
-        backgroundColor: "white",
+        backgroundColor: semanticColor.core.background.base.default,
         display: "flex",
         flexDirection: "column",
     },
@@ -409,7 +413,7 @@ const styles = StyleSheet.create({
         zIndex: 1001,
     },
     closeButton: {
-        backgroundColor: "rgba(255, 255, 255, 0.8)",
+        backgroundColor: semanticColor.core.background.base.subtle,
         borderRadius: border.radius.radius_full,
     },
 });

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -7,11 +7,7 @@ import {makeSafeUrl} from "@khanacademy/perseus-core";
 import Banner from "@khanacademy/wonder-blocks-banner";
 import {View} from "@khanacademy/wonder-blocks-core";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
-import {
-    border,
-    semanticColor,
-    spacing,
-} from "@khanacademy/wonder-blocks-tokens";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import arrowSquareOutIcon from "@phosphor-icons/core/regular/arrow-square-out.svg";
 import cornersOutIcon from "@phosphor-icons/core/regular/corners-out.svg";
 import xIcon from "@phosphor-icons/core/regular/x.svg";
@@ -360,7 +356,7 @@ const styles = StyleSheet.create({
         borderRadius: border.radius.radius_080,
         borderWidth: border.width.thin,
         borderColor: semanticColor.core.border.neutral.subtle,
-        padding: spacing.medium_16,
+        padding: sizing.size_160,
         paddingBottom: 0,
     },
     cornerButton: {
@@ -408,8 +404,8 @@ const styles = StyleSheet.create({
     },
     closeButtonContainer: {
         position: "absolute",
-        top: spacing.xSmall_8,
-        right: spacing.xSmall_8,
+        top: sizing.size_080,
+        right: sizing.size_080,
         zIndex: 1001,
     },
     closeButton: {

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -250,7 +250,7 @@ export class PhetSimulation
                             ? this.toggleFullScreen
                             : this.requestIframeFullscreen
                     }
-                    kind="tertiary"
+                    kind="secondary"
                     actionType="neutral"
                     aria-label={this.context.strings.fullscreen}
                     style={styles.cornerButton}
@@ -266,7 +266,7 @@ export class PhetSimulation
                 icon={arrowSquareOutIcon}
                 href={url.toString()}
                 target="_blank"
-                kind="tertiary"
+                kind="secondary"
                 actionType="neutral"
                 aria-label={this.context.strings.openInNewTab}
                 style={styles.cornerButton}
@@ -318,10 +318,9 @@ export class PhetSimulation
                         <IconButton
                             icon={xIcon}
                             onClick={this.toggleFullScreen}
-                            kind="tertiary"
+                            kind="secondary"
                             actionType="neutral"
                             aria-label={this.context.strings.exitFullscreen}
-                            style={styles.closeButton}
                         />
                     </View>
                 )}
@@ -407,10 +406,6 @@ const styles = StyleSheet.create({
         top: sizing.size_080,
         right: sizing.size_080,
         zIndex: 1001,
-    },
-    closeButton: {
-        backgroundColor: semanticColor.core.background.base.subtle,
-        borderRadius: border.radius.radius_full,
     },
 });
 


### PR DESCRIPTION
## Summary:
Converts the PhET Simulation widget's hardcoded colors and border values to Wonder Blocks semantic tokens. Two of the seven converted values have actual visual changes rather than lossless token swaps — the container's corner radius increased from 6px to 8px, and the fullscreen close button's translucent background was replaced with a solid off-white, both confirmed with design. Additionally, the close button in fullscreen mobile was updated to the secondary kind for WB IconButton instead of the tertiary kind as discussed with our designer. This is the correct token, but it is currently not showing the correct fill and is getting fixed at the WB level.

<img height="600" alt="Phet token updates" src="https://github.com/user-attachments/assets/a5cc0f9f-cf9b-4794-a651-409fdfbcb176" />


Issue: LEMS-4270

## Test plan:
- [ ] Chromatic diffs show only intentional color/font changes against the baseline — expect real diffs on the widget container's corner radius and the fullscreen close button; every other converted value resolves identically to its hardcoded original
- [ ] All checks pass