### PR TITLE
[Color] Tokenize the left border of the open content in Explanation widget

### DIFF
--- a/.changeset/bold-dogs-retire.md
+++ b/.changeset/bold-dogs-retire.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Color] Tokenize the left border of the open content in Explanation widget

--- a/packages/perseus/src/widgets/explanation/__snapshots__/explanation.test.ts.snap
+++ b/packages/perseus/src/widgets/explanation/__snapshots__/explanation.test.ts.snap
@@ -40,7 +40,7 @@ exports[`Explanation should snapshot when expanded: expanded 1`] = `
           </button>
           <div
             aria-hidden="false"
-            class="default_7zhre1-o_O-inlineStyles_x0sbw3 content content-expanded transition-expanded"
+            class="default_7zhre1-o_O-inlineStyles_6oikar content content-expanded transition-expanded"
             data-testid="content-container"
             id=":r1:"
           >
@@ -112,7 +112,7 @@ exports[`Explanation should snapshot: initial render 1`] = `
           </button>
           <div
             aria-hidden="true"
-            class="default_7zhre1-o_O-inlineStyles_1xg5zgw content content-collapsed transition-collapsed"
+            class="default_7zhre1-o_O-inlineStyles_18lfa5c content content-collapsed transition-collapsed"
             data-testid="content-container"
             id=":r0:"
           >

--- a/packages/perseus/src/widgets/explanation/explanation.module.css
+++ b/packages/perseus/src/widgets/explanation/explanation.module.css
@@ -11,7 +11,7 @@
 }
 
 .content {
-    border-left: 0px solid #ccc;
+    border-left: 0px solid var(--wb-semanticColor-core-border-neutral-subtle);
     display: inline-grid;
     position: relative;
 }

--- a/packages/perseus/src/widgets/explanation/explanation_legacy-styles.js
+++ b/packages/perseus/src/widgets/explanation/explanation_legacy-styles.js
@@ -42,11 +42,11 @@ const styles = {
         textAlign: "left",
         whiteSpace: "normal",
     },
-    transitionCollapsed_mq_prefers_reduced_motion_no_preference: {
+    transitionCollapsed: {
         transition:
             "all 0.25s step-end, grid-template-rows 0.25s, margin-top 0.25s, margin-bottom 0.25s, padding-bottom 0.25s",
     },
-    transitionExpanded_mq_prefers_reduced_motion_no_preference: {
+    transitionExpanded: {
         transition:
             "grid-template-rows 0.5s, margin-top 0.5s, margin-bottom 0.5s, padding-bottom 0.5s",
     },

--- a/packages/perseus/src/widgets/explanation/explanation_legacy-styles.js
+++ b/packages/perseus/src/widgets/explanation/explanation_legacy-styles.js
@@ -8,7 +8,8 @@ const styles = {
         paddingLeft: "0.2rem",
     },
     content: {
-        borderLeft: "0px solid #ccc",
+        borderLeft:
+            "0px solid var(--wb-semanticColor-core-border-neutral-subtle)",
         display: "inline-grid",
         position: "relative",
     },
@@ -41,11 +42,11 @@ const styles = {
         textAlign: "left",
         whiteSpace: "normal",
     },
-    transitionCollapsed: {
+    transitionCollapsed_mq_prefers_reduced_motion_no_preference: {
         transition:
             "all 0.25s step-end, grid-template-rows 0.25s, margin-top 0.25s, margin-bottom 0.25s, padding-bottom 0.25s",
     },
-    transitionExpanded: {
+    transitionExpanded_mq_prefers_reduced_motion_no_preference: {
         transition:
             "grid-template-rows 0.5s, margin-top 0.5s, margin-bottom 0.5s, padding-bottom 0.5s",
     },

--- a/utils/sync-legacy-styles.js
+++ b/utils/sync-legacy-styles.js
@@ -28,9 +28,9 @@ const filesToSync = fs
             "_legacy-styles.js",
             ".module.css",
         );
-        const cssPathName = path.join(file["path"], cssFileName);
+        const cssPathName = path.join(file.parentPath, cssFileName);
         const variableName = getVariableName(
-            path.join(file["path"], file.name),
+            path.join(file.parentPath, file.name),
         );
         return {cssPathName, variableName};
     });


### PR DESCRIPTION
## Summary:
The Explanation widget's open-content left border used a hardcoded hex color (`#ccc`). This PR replaces it with the Wonder Blocks semantic color token `--wb-semanticColor-core-border-neutral-subtle`, keeping the styles consistent with the ongoing color-tokenization effort. The change also updates the legacy-style sync script to read `parentPath` instead of the deprecated `path` property on Node's `fs.Dirent`, so the migration script continues to work on current Node versions.

Issue: LEMS-4271

## Test plan:
1. In Storybook (`pnpm storybook`), open the Explanation widget and confirm it renders correctly.
2. Confirm the Explanation widget's `.content` left border uses `var(--wb-semanticColor-core-border-neutral-subtle)`.