### PR TITLE
Remove some more underscore uses

### DIFF
--- a/.changeset/lemon-dragons-play.md
+++ b/.changeset/lemon-dragons-play.md
@@ -1,0 +1,8 @@
+---
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus-score": patch
+"@khanacademy/perseus": patch
+"@khanacademy/kas": patch
+---
+
+Convert some uses of underscore to native JS functions

--- a/packages/kas/src/nodes.ts
+++ b/packages/kas/src/nodes.ts
@@ -149,7 +149,7 @@ abstract class Expr {
     // could be made more type-safe using overload signatures.
     recurse(method: string, ...passed: any[]): this {
         var args = this.args().map(function (arg) {
-            return _.isString(arg) || _.isNumber(arg)
+            return typeof arg === "string" || typeof arg === "number"
                 ? arg
                 : arg?.[method].apply(arg, passed);
         });
@@ -236,7 +236,7 @@ abstract class Expr {
             "(" +
             this.args()
                 .map(function (arg) {
-                    return _.isString(arg) || _.isNumber(arg)
+                    return typeof arg === "string" || typeof arg === "number"
                         ? arg
                         : arg?.repr();
                 })
@@ -2420,7 +2420,7 @@ export class Trig extends Expr {
     };
 
     isEven() {
-        return _.contains(["cos", "sec"], this.type);
+        return ["cos", "sec"].includes(this.type);
     }
 
     isInverse() {
@@ -2428,7 +2428,7 @@ export class Trig extends Expr {
     }
 
     isBasic() {
-        return _.contains(["sin", "cos"], this.type);
+        return ["sin", "cos"].includes(this.type);
     }
 
     eval(vars: Vars = {}, options?: ParseOptions) {
@@ -2688,7 +2688,7 @@ export class Eq extends Expr {
     normalize() {
         var eq = this.recurse("normalize");
 
-        if (_.contains([">", ">="], eq.type)) {
+        if ([">", ">="].includes(eq.type)) {
             // inequalities should have the smaller side on the left
             return new Eq(eq.right, eq.type.replace(">", "<"), eq.left);
         } else {
@@ -2813,7 +2813,7 @@ export class Eq extends Expr {
     }
 
     isEquality() {
-        return _.contains(["=", "<>"], this.type);
+        return ["=", "<>"].includes(this.type);
     }
 
     compare(other: Eq) {
@@ -2889,7 +2889,7 @@ export class Eq extends Expr {
         }
 
         var hasVar = (term: Expr) => {
-            return term.has(Var) && _.contains(term.getVars(), variable.symbol);
+            return term.has(Var) && term.getVars().includes(variable.symbol);
         };
 
         const termHasVar = hasVar(expr.terms[0]);

--- a/packages/perseus-editor/src/components/graph-settings.tsx
+++ b/packages/perseus-editor/src/components/graph-settings.tsx
@@ -463,7 +463,7 @@ class GraphSettings extends React.Component<Props, State> {
         const {TeX} = Dependencies.getDependencies();
         return (
             <div>
-                {_.contains(this.props.editableSettings, "canvas") && (
+                {this.props.editableSettings.includes("canvas") && (
                     <div className="graph-settings">
                         <div className="perseus-widget-row">
                             <label htmlFor="canvas-size">
@@ -484,7 +484,7 @@ class GraphSettings extends React.Component<Props, State> {
                     </div>
                 )}
 
-                {_.contains(this.props.editableSettings, "graph") && (
+                {this.props.editableSettings.includes("graph") && (
                     <div className="graph-settings">
                         <div className="perseus-widget-row">
                             <div className="perseus-widget-left-col">
@@ -553,7 +553,7 @@ class GraphSettings extends React.Component<Props, State> {
                                 />
                             </div>
                         </div>
-                        {_.contains(this.props.editableSettings, "snap") && (
+                        {this.props.editableSettings.includes("snap") && (
                             <div className="perseus-widget-row">
                                 <div className="perseus-widget-left-col">
                                     <label htmlFor="snap-step">Snap Step</label>
@@ -593,7 +593,7 @@ class GraphSettings extends React.Component<Props, State> {
                     </div>
                 )}
 
-                {_.contains(this.props.editableSettings, "image") && (
+                {this.props.editableSettings.includes("image") && (
                     <div className="image-settings">
                         <div>Background image:</div>
                         <div>
@@ -626,7 +626,7 @@ class GraphSettings extends React.Component<Props, State> {
                     </div>
                 )}
 
-                {_.contains(this.props.editableSettings, "measure") && (
+                {this.props.editableSettings.includes("measure") && (
                     <div className="misc-settings">
                         <div className="perseus-widget-row">
                             <div className="perseus-widget-left-col">

--- a/packages/perseus-editor/src/widgets/grapher-editor.tsx
+++ b/packages/perseus-editor/src/widgets/grapher-editor.tsx
@@ -46,7 +46,7 @@ class GrapherEditor extends React.Component<Props> {
 
         // If the currently 'correct' type is removed from the list of types,
         // we need to change it to avoid impossible questions.
-        if (!_.contains(newAvailableTypes, this.props.correct.type)) {
+        if (!newAvailableTypes.includes(this.props.correct.type)) {
             const graph = this.props.graph;
             const newType = chooseType(newAvailableTypes);
             correct = defaultPlotProps(newType, graph);

--- a/packages/perseus-editor/src/widgets/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor.tsx
@@ -7,7 +7,6 @@ import {
 } from "@khanacademy/perseus-core";
 import PropTypes from "prop-types";
 import * as React from "react";
-import _ from "underscore";
 
 const {InfoTip, TextListEditor} = components;
 
@@ -150,7 +149,9 @@ class OrdererEditor extends React.Component<Props> {
                     </InfoTip>
                 </div>
                 <TextListEditor
-                    options={_.pluck(this.props.correctOptions, "content")}
+                    options={this.props.correctOptions.map(
+                        (option) => option.content,
+                    )}
                     // eslint-disable-next-line react/jsx-no-bind
                     onChange={this.onOptionsChange.bind(this, "correctOptions")}
                     layout={this.props.layout}
@@ -164,7 +165,9 @@ class OrdererEditor extends React.Component<Props> {
                     </InfoTip>
                 </div>
                 <TextListEditor
-                    options={_.pluck(this.props.otherOptions, "content")}
+                    options={this.props.otherOptions.map(
+                        (option) => option.content,
+                    )}
                     // eslint-disable-next-line react/jsx-no-bind
                     onChange={this.onOptionsChange.bind(this, "otherOptions")}
                     layout={this.props.layout}

--- a/packages/perseus-editor/src/widgets/plotter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/plotter-editor.tsx
@@ -292,11 +292,10 @@ class PlotterEditor extends React.Component<Props, State> {
     };
 
     render(): React.ReactNode {
-        const setFromScale = _.contains(
-            ["line", "histogram", "dotplot"],
+        const setFromScale = ["line", "histogram", "dotplot"].includes(
             this.props.type,
         );
-        const canChangeSnaps = !_.contains(["pic", "dotplot"], this.props.type);
+        const canChangeSnaps = !["pic", "dotplot"].includes(this.props.type);
         const plotterProps: any = {
             ...this.props,
             trackInteraction: () => {},

--- a/packages/perseus-editor/src/widgets/radio/editor.tsx
+++ b/packages/perseus-editor/src/widgets/radio/editor.tsx
@@ -4,7 +4,6 @@ import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import plusIcon from "@phosphor-icons/core/bold/plus-bold.svg";
 import * as React from "react";
-import _ from "underscore";
 
 import LabeledSwitch from "../../components/labeled-switch";
 
@@ -293,7 +292,7 @@ class RadioEditor extends React.Component<RadioEditorProps> {
     // TODO(LEMS-3643): Remove `getSaveWarnings` once the frontend uses
     // the new linter rules for save warnings.
     getSaveWarnings: () => ReadonlyArray<string> = () => {
-        if (!_.some(_.pluck(this.props.choices, "correct"))) {
+        if (!this.props.choices.some((choice) => choice.correct)) {
             return ["No choice is marked as correct."];
         }
         return [];

--- a/packages/perseus-score/src/util/answer-types.ts
+++ b/packages/perseus-score/src/util/answer-types.ts
@@ -142,7 +142,7 @@ const KhanAnswerTypes = {
             // in the list so we don't prematurely complain about not having
             // a percent sign when the user entered the correct answer in a
             // different form (such as a decimal or fraction)
-            if (_.contains(acceptableForms, "percent")) {
+            if (acceptableForms.includes("percent")) {
                 acceptableForms = _.without(acceptableForms, "percent");
                 acceptableForms.push("percent");
             }

--- a/packages/perseus/src/components/graphie-classes.ts
+++ b/packages/perseus/src/components/graphie-classes.ts
@@ -141,7 +141,7 @@ const createSimpleClass = function (addFunction: any): any {
         toFront: function () {
             // @ts-expect-error - TS2554 - Expected 3 arguments, but got 2.
             nestedMap(this._elements, (elem) => {
-                if (elem && _.isFunction(elem.toFront)) {
+                if (elem && typeof elem.toFront === "function") {
                     elem.toFront();
                 }
             });

--- a/packages/perseus/src/components/number-input.tsx
+++ b/packages/perseus/src/components/number-input.tsx
@@ -188,7 +188,7 @@ class NumberInput extends React.Component<any, any> {
 
         if (
             !this.props.useArrowKeys ||
-            !_.contains(["ArrowUp", "ArrowDown"], e.key)
+            !["ArrowUp", "ArrowDown"].includes(e.key)
         ) {
             return;
         }

--- a/packages/perseus/src/components/sortable.tsx
+++ b/packages/perseus/src/components/sortable.tsx
@@ -765,7 +765,7 @@ class Sortable extends React.Component<SortableProps, SortableState> {
     }
 
     getOptions(): SortableOption[] {
-        return _.pluck(this.state.items, "option");
+        return this.state.items.map((item) => item.option);
     }
 
     render(): React.ReactNode {

--- a/packages/perseus/src/perseus-markdown.new.tsx
+++ b/packages/perseus/src/perseus-markdown.new.tsx
@@ -339,7 +339,7 @@ const getContent = (ast: any) => {
     }
 
     // Base case: This is where we actually extract text content
-    if (ast.content && _.isString(ast.content)) {
+    if (ast.content && typeof ast.content === "string") {
         // Collapse whitespace within content unless it is code
         if (ast.type.toLowerCase().indexOf("code") !== -1) {
             // In case this is the sole child of a paragraph,

--- a/packages/perseus/src/perseus-markdown.tsx
+++ b/packages/perseus/src/perseus-markdown.tsx
@@ -326,7 +326,7 @@ const getContent = (ast: any) => {
     }
 
     // Base case: This is where we actually extract text content
-    if (ast.content && _.isString(ast.content)) {
+    if (ast.content && typeof ast.content === "string") {
         // Collapse whitespace within content unless it is code
         if (ast.type.toLowerCase().indexOf("code") !== -1) {
             // In case this is the sole child of a paragraph,

--- a/packages/perseus/src/util/interactive.ts
+++ b/packages/perseus/src/util/interactive.ts
@@ -740,7 +740,7 @@ _.extend(GraphUtils.Graphie.prototype, {
                         // can be vetoed, providing custom constraints on where
                         // the point can be moved. By returning array [x, y], the
                         // move can be overridden
-                        if (_.isFunction(movablePoint.onMove)) {
+                        if (typeof movablePoint.onMove === "function") {
                             const result = movablePoint.onMove(coordX, coordY);
                             if (result === false) {
                                 doMove = false;
@@ -769,7 +769,7 @@ _.extend(GraphUtils.Graphie.prototype, {
                         $(document).unbind(".point");
                         movablePoint.dragging = false;
                         dragging = false;
-                        if (_.isFunction(movablePoint.onMoveEnd)) {
+                        if (typeof movablePoint.onMoveEnd === "function") {
                             const result = movablePoint.onMoveEnd(
                                 coordX,
                                 coordY,
@@ -902,7 +902,7 @@ _.extend(GraphUtils.Graphie.prototype, {
             this.visibleShape.animateTo([coordX, coordY], time, cb);
             this.mouseTarget.animateTo([coordX, coordY], time, cb);
             this.coord = [coordX, coordY];
-            if (_.isFunction(this.onMove)) {
+            if (typeof this.onMove === "function") {
                 this.onMove(coordX, coordY);
             }
         };
@@ -1537,7 +1537,9 @@ _.extend(GraphUtils.Graphie.prototype, {
                                         }
                                     }
 
-                                    if (_.isFunction(lineSegment.onMove)) {
+                                    if (
+                                        typeof lineSegment.onMove === "function"
+                                    ) {
                                         lineSegment.onMove(dX, dY);
                                     }
                                 } else if (event.type === "vmouseup") {
@@ -1561,7 +1563,10 @@ _.extend(GraphUtils.Graphie.prototype, {
                                         );
                                         lineSegment.transform();
                                     }
-                                    if (_.isFunction(lineSegment.onMoveEnd)) {
+                                    if (
+                                        typeof lineSegment.onMoveEnd ===
+                                        "function"
+                                    ) {
                                         lineSegment.onMoveEnd();
                                     }
                                 }
@@ -1677,10 +1682,10 @@ _.extend(GraphUtils.Graphie.prototype, {
             });
 
             // Calculate bounding box
-            polygon.left = _.min(_.pluck(polygon.coords, 0));
-            polygon.right = _.max(_.pluck(polygon.coords, 0));
-            polygon.top = _.max(_.pluck(polygon.coords, 1));
-            polygon.bottom = _.min(_.pluck(polygon.coords, 1));
+            polygon.left = _.min(polygon.coords.map((coord) => coord[0]));
+            polygon.right = _.max(polygon.coords.map((coord) => coord[0]));
+            polygon.top = _.max(polygon.coords.map((coord) => coord[1]));
+            polygon.bottom = _.min(polygon.coords.map((coord) => coord[1]));
 
             let scaledCoords = _.map(polygon.coords, function (coord) {
                 return graphie.scalePoint(coord);
@@ -1903,7 +1908,7 @@ _.extend(GraphUtils.Graphie.prototype, {
                                 50,
                             );
                             const points = _.filter(polygon.points, isPoint);
-                            if (!_.any(_.pluck(points, "dragging"))) {
+                            if (!_.any(points.map((point) => point.dragging))) {
                                 _.each(points, function (point) {
                                     point.visibleShape.animate(
                                         point.normalStyle,
@@ -2029,7 +2034,7 @@ _.extend(GraphUtils.Graphie.prototype, {
                                     let dY = currentY - startY;
 
                                     let doMove = true;
-                                    if (_.isFunction(polygon.onMove)) {
+                                    if (typeof polygon.onMove === "function") {
                                         const onMoveResult = polygon.onMove(
                                             dX,
                                             dY,
@@ -2101,7 +2106,9 @@ _.extend(GraphUtils.Graphie.prototype, {
                                             );
                                         });
                                     }
-                                    if (_.isFunction(polygon.onMoveEnd)) {
+                                    if (
+                                        typeof polygon.onMoveEnd === "function"
+                                    ) {
                                         polygon.onMoveEnd(
                                             lastX - startX,
                                             lastY - startY,
@@ -2448,7 +2455,7 @@ _.extend(GraphUtils.Graphie.prototype, {
                                     radius,
                                     oldRadius,
                                 );
-                                if (_.isNumber(onResizeResult)) {
+                                if (typeof onResizeResult === "number") {
                                     radius = onResizeResult;
                                 } else if (onResizeResult === false) {
                                     doResize = false;

--- a/packages/perseus/src/widgets/interaction/interaction.tsx
+++ b/packages/perseus/src/widgets/interaction/interaction.tsx
@@ -154,10 +154,10 @@ class Interaction extends React.Component<Props, State> implements Widget {
     _setupGraphie: (arg1: any, arg2: any) => void = (graphie, options) => {
         graphie.graphInit(
             _.extend({}, options, {
-                grid: _.contains(["graph", "grid"], this.props.graph.markings),
-                axes: _.contains(["graph"], this.props.graph.markings),
-                ticks: _.contains(["graph"], this.props.graph.markings),
-                labels: _.contains(["graph"], this.props.graph.markings),
+                grid: ["graph", "grid"].includes(this.props.graph.markings),
+                axes: ["graph"].includes(this.props.graph.markings),
+                ticks: ["graph"].includes(this.props.graph.markings),
+                labels: ["graph"].includes(this.props.graph.markings),
                 labelFormat: function (s) {
                     return "\\small{" + s + "}";
                 },
@@ -204,7 +204,7 @@ class Interaction extends React.Component<Props, State> implements Widget {
         const func = KAScompile(expression, {functions: this.state.functions});
         const compiledVars = _.extend({}, this.state.variables, variables);
         _.each(Object.keys(compiledVars), (name) => {
-            if (_.isString(compiledVars[name])) {
+            if (typeof compiledVars[name] === "string") {
                 const func = KAScompile(compiledVars[name], {
                     functions: this.state.functions,
                 });

--- a/packages/perseus/src/widgets/interactive-graphs/get-equation-string.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/get-equation-string.ts
@@ -214,7 +214,7 @@ function getPolygonCoords(graph: PerseusGraphType, props: Props): Coord[] {
     ];
     coords = normalizeCoords(coords, ranges);
 
-    const snapToGrid = !_.contains(["angles", "sides"], graph.snapTo);
+    const snapToGrid = graph.snapTo !== "angles" && graph.snapTo !== "sides";
     coords = pointsFromNormalized(props, coords, /* noSnap */ !snapToGrid);
 
     return coords;


### PR DESCRIPTION
## Summary:

I asked the LLM to find 3-4 underscore uses that are the safest to remove, this is what it came up with.

- `_.isString`, `_.isNumber`, and `_.isFunction` -> `typeof`
- `_.contains` -> `includes`
- `_.some` -> `some`
- `_.pluck` -> `map`

It didn't remove 100% of the uses of these underscore methods, just the ones that seemed like drop-in replacements.