### PR TITLE
Migrate table widget to WidgetPropsV2

### DIFF
--- a/.changeset/large-mammals-double.md
+++ b/.changeset/large-mammals-double.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus": patch
+---
+
+Internal: The options of the Table widget are now grouped under a single `options` prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -509,7 +509,7 @@ review and commit the changes.
 - [x] Migrate `matrix` to `WidgetPropsV2` (update its editor preview).
 - [x] Migrate `grapher` to `WidgetPropsV2` (update its editor preview and
       `satisfies PropsFor` assertion).
-- [ ] Migrate `table` to `WidgetPropsV2` (update its editor preview).
+- [x] Migrate `table` to `WidgetPropsV2` (update its editor preview).
 - [ ] Migrate `expression` to `WidgetPropsV2` (same `ExternalProps` pattern;
       update its editor preview).
 

--- a/packages/perseus-editor/src/widgets/table-editor.tsx
+++ b/packages/perseus-editor/src/widgets/table-editor.tsx
@@ -91,7 +91,12 @@ class TableEditor extends React.Component<Props> {
 
     render(): React.ReactNode {
         const tableProps: Partial<PropsFor<typeof Table>> = {
-            headers: this.props.headers,
+            options: {
+                headers: this.props.headers,
+                rows: this.props.rows,
+                columns: this.props.columns,
+                answers: this.props.answers,
+            },
             onChange: this.props.onChange,
             userInput: this.props.answers,
             handleUserInput: (userInput) => {

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -32,4 +32,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "matcher",
     "matrix",
     "grapher",
+    "table",
 ];

--- a/packages/perseus/src/widgets/table/table.tsx
+++ b/packages/perseus/src/widgets/table/table.tsx
@@ -139,11 +139,9 @@ const Table = forwardRef<Widget, Props>(function Table(props, ref) {
 
     // this is for the editing experience
     function handleHeaderChange(index: number, e: {content: string}): void {
-        const headers = props.options.headers.slice();
+        const headers = [...props.options.headers];
         headers[index] = e.content;
-        props.onChange({
-            headers: headers,
-        });
+        props.onChange({headers});
     }
 
     let InputComponent;

--- a/packages/perseus/src/widgets/table/table.tsx
+++ b/packages/perseus/src/widgets/table/table.tsx
@@ -8,7 +8,12 @@ import SimpleKeypadInput from "../../components/simple-keypad-input";
 import Renderer from "../../renderer";
 import Util from "../../util";
 
-import type {FocusPath, Widget, WidgetExports, WidgetProps} from "../../types";
+import type {
+    FocusPath,
+    Widget,
+    WidgetExports,
+    WidgetPropsV2,
+} from "../../types";
 import type {
     PerseusTableWidgetOptions,
     PerseusTableUserInput,
@@ -20,7 +25,7 @@ type EditorProps = {
     onChange: (value: {headers: string[]}) => void;
 };
 
-type Props = WidgetProps<PerseusTableWidgetOptions, PerseusTableUserInput> &
+type Props = WidgetPropsV2<PerseusTableWidgetOptions, PerseusTableUserInput> &
     EditorProps;
 
 // A version of FocusPath that's specific to Table
@@ -102,8 +107,9 @@ const Table = forwardRef<Widget, Props>(function Table(props, ref) {
          * [LEMS-3185] do not trust serializedState
          */
         getSerializedState() {
-            const {userInput, editableHeaders, ...rest} = props;
+            const {userInput, editableHeaders, options, ...rest} = props;
             return {
+                ...options,
                 ...rest,
                 answers: userInput,
             };
@@ -133,7 +139,7 @@ const Table = forwardRef<Widget, Props>(function Table(props, ref) {
 
     // this is for the editing experience
     function handleHeaderChange(index: number, e: {content: string}): void {
-        const headers = props.headers.slice();
+        const headers = props.options.headers.slice();
         headers[index] = e.content;
         props.onChange({
             headers: headers,
@@ -156,7 +162,7 @@ const Table = forwardRef<Widget, Props>(function Table(props, ref) {
 
     const headerRow = (
         <tr>
-            {props.headers.map((header, i) => {
+            {props.options.headers.map((header, i) => {
                 if (props.editableHeaders) {
                     return (
                         <th key={i}>


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a Table widget in
  http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.