### PR TITLE
Set valid protractor coordinates in Measurer

### DIFF
--- a/.changeset/grumpy-dots-fold.md
+++ b/.changeset/grumpy-dots-fold.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fixes a bug where the protractor in the Measurer widget did not have a rotation handle.

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -389,6 +389,11 @@ export {
 } from "./utils/generators/matcher-widget-generator";
 /** @hidden */
 export {
+    generateMeasurerOptions,
+    generateMeasurerWidget,
+} from "./utils/generators/measurer-widget-generator";
+/** @hidden */
+export {
     generateCategorizerOptions,
     generateCategorizerWidget,
 } from "./utils/generators/categorizer-widget-generator";

--- a/packages/perseus-core/src/utils/generators/measurer-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/measurer-widget-generator.ts
@@ -1,0 +1,38 @@
+import type {
+    MeasurerWidget,
+    PerseusMeasurerWidgetOptions,
+} from "../../data-schema";
+
+export function generateMeasurerOptions(
+    options?: Partial<PerseusMeasurerWidgetOptions>,
+): PerseusMeasurerWidgetOptions {
+    const defaultMeasurerOptions: PerseusMeasurerWidgetOptions = {
+        image: {},
+        showProtractor: false,
+        showRuler: false,
+        rulerLabel: "cm",
+        rulerTicks: 10,
+        rulerPixels: 40,
+        rulerLength: 10,
+        box: [400, 400],
+    };
+
+    return {
+        ...defaultMeasurerOptions,
+        ...options,
+    };
+}
+
+export function generateMeasurerWidget(
+    measurerWidgetProperties?: Partial<Omit<MeasurerWidget, "type">>,
+): MeasurerWidget {
+    return {
+        type: "measurer",
+        graded: true,
+        version: {major: 0, minor: 0},
+        static: false,
+        alignment: "default",
+        options: generateMeasurerOptions({}),
+        ...measurerWidgetProperties,
+    };
+}

--- a/packages/perseus-core/src/utils/generators/measurer-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/measurer-widget-generator.ts
@@ -1,3 +1,5 @@
+import measurerWidgetLogic from "../../widgets/measurer";
+
 import type {
     MeasurerWidget,
     PerseusMeasurerWidgetOptions,
@@ -6,19 +8,8 @@ import type {
 export function generateMeasurerOptions(
     options?: Partial<PerseusMeasurerWidgetOptions>,
 ): PerseusMeasurerWidgetOptions {
-    const defaultMeasurerOptions: PerseusMeasurerWidgetOptions = {
-        image: {},
-        showProtractor: false,
-        showRuler: false,
-        rulerLabel: "cm",
-        rulerTicks: 10,
-        rulerPixels: 40,
-        rulerLength: 10,
-        box: [400, 400],
-    };
-
     return {
-        ...defaultMeasurerOptions,
+        ...measurerWidgetLogic.defaultWidgetOptions,
         ...options,
     };
 }
@@ -32,7 +23,7 @@ export function generateMeasurerWidget(
         version: {major: 0, minor: 0},
         static: false,
         alignment: "default",
-        options: generateMeasurerOptions({}),
+        options: generateMeasurerOptions(),
         ...measurerWidgetProperties,
     };
 }

--- a/packages/perseus/src/widgets/measurer/__docs__/measurer-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/measurer/__docs__/measurer-initial-state-regression.stories.tsx
@@ -1,0 +1,34 @@
+import {themeModes} from "../../../../../../.storybook/modes";
+
+import {measurerRendererDecorator} from "./measurer-renderer-decorator";
+
+import type {PerseusMeasurerWidgetOptions} from "@khanacademy/perseus-core";
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+const meta: Meta<PerseusMeasurerWidgetOptions> = {
+    title: "Widgets/Measurer/Visual Regression Tests/Initial State",
+    tags: ["!autodocs", "!manifest"],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    "Regression tests for the Measurer widget that do NOT " +
+                    "need any interactions to test.",
+            },
+        },
+        chromatic: {disableSnapshot: false, modes: themeModes},
+    },
+};
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Verifies that the protractor tool is drawn into the measurer's graphie
+// container. No background image is set, so the protractor renders over the
+// widget's blank background.
+export const WithProtractor: Story = {
+    decorators: [measurerRendererDecorator],
+    args: {
+        showProtractor: true,
+    },
+};

--- a/packages/perseus/src/widgets/measurer/__docs__/measurer-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/measurer/__docs__/measurer-initial-state-regression.stories.tsx
@@ -23,12 +23,10 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-// Verifies that the protractor tool is drawn into the measurer's graphie
-// container. No background image is set, so the protractor renders over the
-// widget's blank background.
-export const WithProtractor: Story = {
+export const WithProtractorAndRuler: Story = {
     decorators: [measurerRendererDecorator],
     args: {
         showProtractor: true,
+        showRuler: true,
     },
 };

--- a/packages/perseus/src/widgets/measurer/__docs__/measurer-renderer-decorator.tsx
+++ b/packages/perseus/src/widgets/measurer/__docs__/measurer-renderer-decorator.tsx
@@ -7,7 +7,12 @@ import * as React from "react";
 
 import QuestionRendererForStories from "../../__testutils__/question-renderer-for-stories";
 
-export const measurerRendererDecorator = (_, {args}) => {
+import type {PerseusMeasurerWidgetOptions} from "@khanacademy/perseus-core";
+
+export const measurerRendererDecorator = (
+    _: unknown,
+    {args}: {args: Partial<PerseusMeasurerWidgetOptions>},
+) => {
     return (
         <QuestionRendererForStories
             question={generateTestPerseusRenderer({

--- a/packages/perseus/src/widgets/measurer/__docs__/measurer-renderer-decorator.tsx
+++ b/packages/perseus/src/widgets/measurer/__docs__/measurer-renderer-decorator.tsx
@@ -1,0 +1,23 @@
+import {
+    generateMeasurerOptions,
+    generateMeasurerWidget,
+    generateTestPerseusRenderer,
+} from "@khanacademy/perseus-core";
+import * as React from "react";
+
+import QuestionRendererForStories from "../../__testutils__/question-renderer-for-stories";
+
+export const measurerRendererDecorator = (_, {args}) => {
+    return (
+        <QuestionRendererForStories
+            question={generateTestPerseusRenderer({
+                content: "[[☃ measurer 1]]",
+                widgets: {
+                    "measurer 1": generateMeasurerWidget({
+                        options: generateMeasurerOptions(args),
+                    }),
+                },
+            })}
+        />
+    );
+};

--- a/packages/perseus/src/widgets/measurer/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.tsx
@@ -13,10 +13,7 @@ import type {Widget, WidgetExports, WidgetProps} from "../../types";
 import type {Interval} from "../../util/interval";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
 
-type Props = WidgetProps<PerseusMeasurerWidgetOptions> & {
-    protractorX?: number;
-    protractorY?: number;
-};
+type Props = WidgetProps<PerseusMeasurerWidgetOptions>;
 
 class Measurer extends React.Component<Props> implements Widget {
     // this just helps with TS weak typing when a Widget
@@ -79,10 +76,7 @@ class Measurer extends React.Component<Props> implements Widget {
 
         if (this.props.showProtractor) {
             // @ts-expect-error - Property 'protractor' does not exist on type 'Graphie'.
-            this.protractor = graphie.protractor([
-                this.props.protractorX ?? 7.5,
-                this.props.protractorY ?? 0.5,
-            ]);
+            this.protractor = graphie.protractor([7.5, 0.5]);
         }
 
         if (this.ruler) {

--- a/packages/perseus/src/widgets/measurer/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.tsx
@@ -14,8 +14,8 @@ import type {Interval} from "../../util/interval";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
 
 type Props = WidgetProps<PerseusMeasurerWidgetOptions> & {
-    protractorX: number;
-    protractorY: number;
+    protractorX?: number;
+    protractorY?: number;
 };
 
 class Measurer extends React.Component<Props> implements Widget {

--- a/packages/perseus/src/widgets/measurer/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.tsx
@@ -15,9 +15,6 @@ import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupporte
 
 type Props = WidgetProps<PerseusMeasurerWidgetOptions>;
 
-// TODO-NEXT: Add a Storybook visual regression test for the matcher that
-//  sets `showProtractor: true` and shows the rendered protractor. See the
-//  other *-regression.stories.tsx files for examples.
 class Measurer extends React.Component<Props> implements Widget {
     // this just helps with TS weak typing when a Widget
     // doesn't implement any Widget methods

--- a/packages/perseus/src/widgets/measurer/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.tsx
@@ -15,6 +15,9 @@ import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupporte
 
 type Props = WidgetProps<PerseusMeasurerWidgetOptions>;
 
+// TODO-NEXT: Add a Storybook visual regression test for the matcher that
+//  sets `showProtractor: true` and shows the rendered protractor. See the
+//  other *-regression.stories.tsx files for examples.
 class Measurer extends React.Component<Props> implements Widget {
     // this just helps with TS weak typing when a Widget
     // doesn't implement any Widget methods

--- a/packages/perseus/src/widgets/measurer/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.tsx
@@ -80,8 +80,8 @@ class Measurer extends React.Component<Props> implements Widget {
         if (this.props.showProtractor) {
             // @ts-expect-error - Property 'protractor' does not exist on type 'Graphie'.
             this.protractor = graphie.protractor([
-                this.props.protractorX,
-                this.props.protractorY,
+                this.props.protractorX ?? 7.5,
+                this.props.protractorY ?? 0.5,
             ]);
         }
 


### PR DESCRIPTION
## Summary:
This fixes a bug where the protractor did not have a rotation handle.  I
introduced this bug in [0e0abbc] when removing the Measurer's default props.

The `protractorX` and `protractorY` props are not passed anywhere, so I
removed them.

The coordinates chosen are from the original default props.

[0e0abbc]: https://github.com/khan/perseus/commit/0e0abbc84f4c65a3b1750102f76823a7746f97c0

Issue: LEMS-4450

## Test plan:

- `pnpm storybook`
- `open http://localhost:6006/?path=/story/editors-editorpage--demo`
- Create a measurer widget. The protractor should display and have a handle
  that allows you to rotate it.