### PR TITLE
Replace low-risk uses of _.map

### DIFF
--- a/.changeset/full-regions-rest.md
+++ b/.changeset/full-regions-rest.md
@@ -1,0 +1,8 @@
+---
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus": patch
+"@khanacademy/kas": patch
+---
+
+Replace low-risk uses of `_.map` with `Array.map`

--- a/packages/kas/src/__tests__/parsing.test.ts
+++ b/packages/kas/src/__tests__/parsing.test.ts
@@ -353,7 +353,7 @@ describe("parsing", () => {
     test("trig functions", () => {
         const functions = ["sin", "cos", "tan", "csc", "sec", "cot"];
 
-        const inverses = _.map(functions, function (func) {
+        const inverses = functions.map(function (func) {
             return "arc" + func;
         });
 

--- a/packages/perseus-core/src/utils/grapher-util.ts
+++ b/packages/perseus-core/src/utils/grapher-util.ts
@@ -349,10 +349,10 @@ const Exponential: ExponentialType = _.extend({}, PlotDefaults, {
         const oldY = oldCoord[1];
         const wasBelow = _.all(coords, (coord) => coord[1] > oldY);
         if (wasBelow) {
-            const bottomMost = _.min(_.map(coords, (coord) => coord[1]));
+            const bottomMost = _.min(coords.map((coord) => coord[1]));
             return [oldCoord[0], bottomMost - graph.snapStep[1]];
         }
-        const topMost = _.max(_.map(coords, (coord) => coord[1]));
+        const topMost = _.max(coords.map((coord) => coord[1]));
         return [oldCoord[0], topMost + graph.snapStep[1]];
     },
 
@@ -448,10 +448,10 @@ const Logarithm: LogarithmType = _.extend({}, PlotDefaults, {
         const oldX = oldCoord[0];
         const wasLeft = _.all(coords, (coord) => coord[0] > oldX);
         if (wasLeft) {
-            const leftMost = _.min(_.map(coords, (coord) => coord[0]));
+            const leftMost = _.min(coords.map((coord) => coord[0]));
             return [leftMost - graph.snapStep[0], oldCoord[1]];
         }
-        const rightMost = _.max(_.map(coords, (coord) => coord[0]));
+        const rightMost = _.max(coords.map((coord) => coord[0]));
         return [rightMost + graph.snapStep[0], oldCoord[1]];
     },
 
@@ -468,9 +468,9 @@ const Logarithm: LogarithmType = _.extend({}, PlotDefaults, {
         const flip = (coord: Coord): Coord => [coord[1], coord[0]];
         const inverseCoeffs = Exponential.getCoefficients(
             // eslint-disable-next-line no-restricted-syntax
-            _.map(coords, flip) as Coords,
+            coords.map(flip) as Coords,
             // eslint-disable-next-line no-restricted-syntax
-            _.map(asymptote, flip) as Coords,
+            asymptote.map(flip) as Coords,
         );
         if (inverseCoeffs) {
             const c = -inverseCoeffs[2] / inverseCoeffs[0];

--- a/packages/perseus-editor/src/components/graph-settings.tsx
+++ b/packages/perseus-editor/src/components/graph-settings.tsx
@@ -208,7 +208,7 @@ class GraphSettings extends React.Component<Props, State> {
     }
 
     renderLabelChoices(choices: ReadonlyArray<[string, string]>) {
-        return _.map(choices, function ([name, value]) {
+        return choices.map(function ([name, value]) {
             return (
                 <option key={value} value={value}>
                     {name}
@@ -398,7 +398,7 @@ class GraphSettings extends React.Component<Props, State> {
         this.setState(
             {
                 gridStepTextbox: gridStep,
-                snapStepTextbox: _.map(gridStep, function (step) {
+                snapStepTextbox: gridStep.map(function (step) {
                     return step / 2;
                 }),
             },
@@ -413,7 +413,7 @@ class GraphSettings extends React.Component<Props, State> {
             // eslint-disable-next-line no-restricted-syntax
             (range) => range.map(Number) as [number, number],
         ) as Coords;
-        const step = _.map(this.state.stepTextbox, Number);
+        const step = this.state.stepTextbox.map(Number);
         const gridStep = this.state.gridStepTextbox;
         const snapStep = this.state.snapStepTextbox;
         const image = this.state.backgroundImage;
@@ -688,8 +688,7 @@ class GraphSettings extends React.Component<Props, State> {
                                             onChange={this.changeRulerTicks}
                                             value={this.props.rulerTicks}
                                         >
-                                            {_.map(
-                                                [1, 2, 4, 8, 10, 16],
+                                            {[1, 2, 4, 8, 10, 16].map(
                                                 function (n) {
                                                     return (
                                                         <option

--- a/packages/perseus-editor/src/diffs/shared/diff-entry.tsx
+++ b/packages/perseus-editor/src/diffs/shared/diff-entry.tsx
@@ -70,7 +70,7 @@ class CollapsedRow extends React.Component<CollapsedRowProps> {
         const self = this;
         return (
             <div style={{clear: "both"}}>
-                {_.map([BEFORE, AFTER], function (side) {
+                {[BEFORE, AFTER].map(function (side) {
                     return (
                         <div
                             className={"diff-row collapsed " + side}
@@ -185,7 +185,7 @@ class DiffEntry extends React.Component<DiffEntryProps, DiffEntryState> {
                         />
                     </div>
                 )}
-                {_.map(shownChildren, function (child) {
+                {shownChildren.map(function (child) {
                     return (
                         <DiffEntry
                             key={child.key}

--- a/packages/perseus-editor/src/diffs/shared/string-array-diff.ts
+++ b/packages/perseus-editor/src/diffs/shared/string-array-diff.ts
@@ -32,7 +32,7 @@ function statusFor(chunk: ImageEntry): ImageStatus {
 // Turn a chunk (which contains an array of values and a status)
 // into an array of values, each with the same status
 function splitUpChunk(chunk: ImageEntry): ImageDiff[] {
-    return _.map(chunk.value, (value) => {
+    return chunk.value.map((value) => {
         return {
             value: value,
             status: statusFor(chunk),
@@ -46,7 +46,7 @@ function mapcat(
     lst: ImageEntry[],
     fn: (chunk: ImageEntry) => ImageDiff[],
 ): ImageDiff[] {
-    return _.flatten(_.map(lst, fn), true /* only flatten one level */);
+    return _.flatten(lst.map(fn), true /* only flatten one level */);
 }
 
 // > ArrayDiff.diff([1,2,3], [2,3,4]);
@@ -57,7 +57,7 @@ function mapcat(
 //      "added": true }]
 const ArrayDiff = new jsdiff.Diff();
 ArrayDiff.tokenize = (array: ImageEntry[]) =>
-    _.map(array, (elem: ImageEntry): ImageEntry[] => [elem]);
+    array.map((elem: ImageEntry): ImageEntry[] => [elem]);
 // The default is `+` for string concatenation, which doesn't work for array
 // concatenation.
 ArrayDiff.join = (a: ImageEntry[], b: ImageEntry[]) => a.concat(b);

--- a/packages/perseus-editor/src/diffs/shared/widget-diff-performer.ts
+++ b/packages/perseus-editor/src/diffs/shared/widget-diff-performer.ts
@@ -37,7 +37,7 @@ const objectEntry = function (before: any, after: any, key) {
     const afterKeys = _.isObject(after) ? _(after).keys() : [];
     const keys = _.union(beforeKeys, afterKeys);
 
-    const children = _.map(keys, function (key) {
+    const children = keys.map(function (key) {
         return performDiff((before || {})[key], (after || {})[key], key);
     });
 

--- a/packages/perseus-editor/src/diffs/text-diff.tsx
+++ b/packages/perseus-editor/src/diffs/text-diff.tsx
@@ -49,7 +49,7 @@ class ImageDiffSide extends React.Component<ImageDiffSideProps> {
     render(): React.ReactNode {
         return (
             <div>
-                {_.map(this.props.images, (entry, index) => {
+                {this.props.images.map((entry, index) => {
                     const className = classNames({
                         image: true,
                         "image-unchanged": entry.status === "unchanged",
@@ -122,7 +122,7 @@ class TextDiff extends React.Component<TextDiffProps, TextDiffState> {
             afterImages,
         );
 
-        const renderedLines = _.map(lines, (line) => {
+        const renderedLines = lines.map((line) => {
             const contents: ContentDiff = {before: [], after: []};
 
             contents.before = _(line).map(function (entry: Entry, i: number) {
@@ -164,11 +164,11 @@ class TextDiff extends React.Component<TextDiffProps, TextDiffState> {
                 <div className="diff-header">{this.props.title}</div>
                 <div className="diff-header">{this.props.title}</div>
                 <div className="diff-body ui-helper-clearfix">
-                    {_.map([BEFORE, AFTER], (side, index) => {
+                    {[BEFORE, AFTER].map((side, index) => {
                         return (
                             <div className={"diff-row " + side} key={index}>
                                 {!this.state.collapsed &&
-                                    _.map(renderedLines, (line, lineNum) => {
+                                    renderedLines.map((line, lineNum) => {
                                         const changed = line[side].length > 1;
                                         const lineClass = classNames({
                                             "diff-line": true,
@@ -191,7 +191,7 @@ class TextDiff extends React.Component<TextDiffProps, TextDiffState> {
                         );
                     })}
                 </div>
-                {_.map([BEFORE, AFTER], (side, index) => {
+                {[BEFORE, AFTER].map((side, index) => {
                     return (
                         <div
                             role="button"

--- a/packages/perseus-editor/src/hint-editor.tsx
+++ b/packages/perseus-editor/src/hint-editor.tsx
@@ -379,37 +379,33 @@ class CombinedHintsEditor extends React.Component<CombinedHintsEditorProps> {
     render(): React.ReactNode {
         const {itemId, hints} = this.props;
         const editingDisabled = this.props.apiOptions?.editingDisabled ?? false;
-        const hintElems = _.map(
-            hints,
-            (hint, i) => {
-                return (
-                    <fieldset disabled={editingDisabled} key={"hintEditor" + i}>
-                        <CombinedHintEditor
-                            ref={"hintEditor" + i}
-                            isFirst={i === 0}
-                            isLast={i + 1 === hints.length}
-                            itemId={itemId}
-                            hint={hint}
-                            pos={i}
-                            imageUploader={this.props.imageUploader}
-                            // eslint-disable-next-line react/jsx-no-bind
-                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                            onChange={this.handleHintChange.bind(this, i)}
-                            // eslint-disable-next-line react/jsx-no-bind
-                            onRemove={this.handleHintRemove.bind(this, i)}
-                            // eslint-disable-next-line react/jsx-no-bind
-                            onMove={this.handleHintMove.bind(this, i)}
-                            deviceType={this.props.deviceType}
-                            apiOptions={this.props.apiOptions}
-                            highlightLint={this.props.highlightLint}
-                            previewURL={this.props.previewURL}
-                            widgetIsOpen={this.props.widgetIsOpen}
-                        />
-                    </fieldset>
-                );
-            },
-            this,
-        );
+        const hintElems = hints.map((hint, i) => {
+            return (
+                <fieldset disabled={editingDisabled} key={"hintEditor" + i}>
+                    <CombinedHintEditor
+                        ref={"hintEditor" + i}
+                        isFirst={i === 0}
+                        isLast={i + 1 === hints.length}
+                        itemId={itemId}
+                        hint={hint}
+                        pos={i}
+                        imageUploader={this.props.imageUploader}
+                        // eslint-disable-next-line react/jsx-no-bind
+                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                        onChange={this.handleHintChange.bind(this, i)}
+                        // eslint-disable-next-line react/jsx-no-bind
+                        onRemove={this.handleHintRemove.bind(this, i)}
+                        // eslint-disable-next-line react/jsx-no-bind
+                        onMove={this.handleHintMove.bind(this, i)}
+                        deviceType={this.props.deviceType}
+                        apiOptions={this.props.apiOptions}
+                        highlightLint={this.props.highlightLint}
+                        previewURL={this.props.previewURL}
+                        widgetIsOpen={this.props.widgetIsOpen}
+                    />
+                </fieldset>
+            );
+        }, this);
 
         return (
             <div className="perseus-hints-editor perseus-editor-table">

--- a/packages/perseus-editor/src/hint-editor.tsx
+++ b/packages/perseus-editor/src/hint-editor.tsx
@@ -405,7 +405,7 @@ class CombinedHintsEditor extends React.Component<CombinedHintsEditorProps> {
                     />
                 </fieldset>
             );
-        }, this);
+        });
 
         return (
             <div className="perseus-hints-editor perseus-editor-table">

--- a/packages/perseus-editor/src/widgets/cs-program-editor.tsx
+++ b/packages/perseus-editor/src/widgets/cs-program-editor.tsx
@@ -14,7 +14,6 @@ import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import $ from "jquery";
 import PropTypes from "prop-types";
 import * as React from "react";
-import _ from "underscore";
 
 import BlurInput from "../components/blur-input";
 
@@ -108,7 +107,7 @@ class PairsEditor extends React.Component<any> {
     };
 
     render(): React.ReactNode {
-        const editors = _.map(this.props.pairs, (pair, i) => {
+        const editors = this.props.pairs.map((pair, i) => {
             return (
                 <PairEditor
                     key={i}

--- a/packages/perseus-editor/src/widgets/dropdown-editor.tsx
+++ b/packages/perseus-editor/src/widgets/dropdown-editor.tsx
@@ -53,7 +53,7 @@ class DropdownEditor extends React.Component<Props> {
     };
 
     onCorrectChange: (arg1: number) => void = (choiceIndex) => {
-        const choices = _.map(this.props.choices, function (choice, i) {
+        const choices = this.props.choices.map(function (choice, i) {
             return _.extend({}, choice, {
                 correct: i === choiceIndex,
             });

--- a/packages/perseus-editor/src/widgets/grapher-editor.tsx
+++ b/packages/perseus-editor/src/widgets/grapher-editor.tsx
@@ -150,7 +150,7 @@ class GrapherEditor extends React.Component<Props> {
                     <MultiButtonGroup
                         allowEmpty={false}
                         values={this.props.availableTypes}
-                        buttons={_.map(CoreGrapherUtil.allTypes, typeToButton)}
+                        buttons={CoreGrapherUtil.allTypes.map(typeToButton)}
                         onChange={this.handleAvailableTypesChange}
                     />
                 </div>

--- a/packages/perseus-editor/src/widgets/iframe-editor.tsx
+++ b/packages/perseus-editor/src/widgets/iframe-editor.tsx
@@ -7,7 +7,6 @@ import {
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import PropTypes from "prop-types";
 import * as React from "react";
-import _ from "underscore";
 
 import BlurInput from "../components/blur-input";
 
@@ -97,7 +96,7 @@ class PairsEditor extends React.Component<PairsEditorProps> {
     };
 
     render(): React.ReactNode {
-        const editors = _.map(this.props.pairs, (pair, i) => {
+        const editors = this.props.pairs.map((pair, i) => {
             return (
                 <PairEditor
                     key={i}

--- a/packages/perseus-editor/src/widgets/interaction-editor/color-picker.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/color-picker.tsx
@@ -1,6 +1,5 @@
 import {components, KhanColors} from "@khanacademy/perseus";
 import * as React from "react";
-import _ from "underscore";
 
 import type {Changeable} from "@khanacademy/perseus";
 
@@ -46,7 +45,7 @@ class ColorPicker extends React.Component<Props> {
             <ButtonGroup
                 value={this.props.value}
                 allowEmpty={false}
-                buttons={_.map(colors, (color) => {
+                buttons={colors.map((color) => {
                     return {
                         value: color,
                         content: (

--- a/packages/perseus-editor/src/widgets/interaction-editor/interaction-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/interaction-editor.tsx
@@ -69,27 +69,22 @@ class InteractionEditor extends React.Component<Props, State> {
     }
 
     _getAllVarSubscripts(elements: ReadonlyArray<any>): ReadonlyArray<any> {
-        return _.map(
-            _.where(elements, {type: "movable-point"}),
-            (element) => element.options.varSubscript,
-        )
+        return _.where(elements, {type: "movable-point"})
+            .map((element) => element.options.varSubscript)
             .concat(
-                _.map(
-                    _.where(elements, {type: "movable-line"}),
+                _.where(elements, {type: "movable-line"}).map(
                     (element) => element.options.startSubscript,
                 ),
             )
             .concat(
-                _.map(
-                    _.where(elements, {type: "movable-line"}),
+                _.where(elements, {type: "movable-line"}).map(
                     (element) => element.options.endSubscript,
                 ),
             );
     }
 
     _getAllFunctionNames(elements: ReadonlyArray<any>): ReadonlyArray<string> {
-        return _.map(
-            _.where(elements, {type: "function"}),
+        return _.where(elements, {type: "function"}).map(
             (element) => element.options.funcName,
         );
     }
@@ -158,7 +153,7 @@ class InteractionEditor extends React.Component<Props, State> {
             const nextLetter = String.fromCharCode(
                 _.max([
                     _.max(
-                        _.map(this.state.usedFunctionNames, function (c) {
+                        this.state.usedFunctionNames.map(function (c) {
                             return c.charCodeAt(0);
                         }),
                     ),
@@ -220,509 +215,475 @@ class InteractionEditor extends React.Component<Props, State> {
                         )}
                     </>
                 </ElementContainer>
-                {_.map(
-                    this.props.elements,
-                    function (element, n) {
-                        if (element.type === "movable-point") {
-                            return (
-                                <ElementContainer
-                                    title={
-                                        <span>
-                                            Movable point{" "}
-                                            <TeX>
-                                                {"(x_{" +
-                                                    element.options
-                                                        .varSubscript +
-                                                    "}, y_{" +
-                                                    element.options
-                                                        .varSubscript +
-                                                    "})"}
-                                            </TeX>
-                                        </span>
-                                    }
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    onUp={
-                                        n === 0
-                                            ? null
-                                            : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this._moveElementUp.bind(this, n)
-                                    }
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    onDown={
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        n === this.props.elements.length - 1
-                                            ? null
-                                            : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this._moveElementDown.bind(
-                                                  // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                  this,
-                                                  n,
-                                              )
-                                    }
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                    onDelete={this._deleteElement.bind(this, n)}
-                                    key={element.key}
-                                >
-                                    <MovablePointEditor
-                                        {...element.options}
-                                        onChange={(newProps) => {
-                                            const elements = JSON.parse(
-                                                JSON.stringify(
-                                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                    this.props.elements,
-                                                ),
-                                            );
-                                            _.extend(
-                                                elements[n].options,
-                                                newProps,
-                                            );
-                                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                            this.props.onChange({
-                                                elements: elements,
-                                            });
-                                        }}
-                                    />
-                                </ElementContainer>
-                            );
-                        }
-                        if (element.type === "movable-line") {
-                            return (
-                                <ElementContainer
-                                    title={
-                                        <span>
-                                            Movable line{" "}
-                                            <TeX>
-                                                {"(x_{" +
-                                                    element.options
-                                                        .startSubscript +
-                                                    "}, y_{" +
-                                                    element.options
-                                                        .startSubscript +
-                                                    "})"}
-                                            </TeX>{" "}
-                                            to{" "}
-                                            <TeX>
-                                                {"(x_{" +
-                                                    element.options
-                                                        .endSubscript +
-                                                    "}, y_{" +
-                                                    element.options
-                                                        .endSubscript +
-                                                    "})"}
-                                            </TeX>
-                                        </span>
-                                    }
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    onUp={
-                                        n === 0
-                                            ? null
-                                            : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this._moveElementUp.bind(this, n)
-                                    }
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    onDown={
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        n === this.props.elements.length - 1
-                                            ? null
-                                            : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this._moveElementDown.bind(
-                                                  // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                  this,
-                                                  n,
-                                              )
-                                    }
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                    onDelete={this._deleteElement.bind(this, n)}
-                                    key={element.key}
-                                >
-                                    <MovableLineEditor
-                                        {...element.options}
-                                        onChange={(newProps) => {
-                                            const elements = JSON.parse(
-                                                JSON.stringify(
-                                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                    this.props.elements,
-                                                ),
-                                            );
-                                            _.extend(
-                                                elements[n].options,
-                                                newProps,
-                                            );
-                                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                            this.props.onChange({
-                                                elements: elements,
-                                            });
-                                        }}
-                                    />
-                                </ElementContainer>
-                            );
-                        }
-                        if (element.type === "point") {
-                            return (
-                                <ElementContainer
-                                    title={
-                                        <span>
-                                            Point{" "}
-                                            <TeX>
-                                                {"(" +
-                                                    element.options.coordX +
-                                                    ", " +
-                                                    element.options.coordY +
-                                                    ")"}
-                                            </TeX>
-                                        </span>
-                                    }
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    onUp={
-                                        n === 0
-                                            ? null
-                                            : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this._moveElementUp.bind(this, n)
-                                    }
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    onDown={
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        n === this.props.elements.length - 1
-                                            ? null
-                                            : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this._moveElementDown.bind(
-                                                  // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                  this,
-                                                  n,
-                                              )
-                                    }
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                    onDelete={this._deleteElement.bind(this, n)}
-                                    key={element.key}
-                                >
-                                    <PointEditor
-                                        {...element.options}
-                                        onChange={(newProps) => {
-                                            const elements = JSON.parse(
-                                                JSON.stringify(
-                                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                    this.props.elements,
-                                                ),
-                                            );
-                                            _.extend(
-                                                elements[n].options,
-                                                newProps,
-                                            );
-                                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                            this.props.onChange({
-                                                elements: elements,
-                                            });
-                                        }}
-                                    />
-                                </ElementContainer>
-                            );
-                        }
-                        if (element.type === "line") {
-                            return (
-                                <ElementContainer
-                                    title={
-                                        <span>
-                                            Line{" "}
-                                            <TeX>
-                                                {"(" +
-                                                    element.options.startX +
-                                                    ", " +
-                                                    element.options.startY +
-                                                    ")"}
-                                            </TeX>{" "}
-                                            to{" "}
-                                            <TeX>
-                                                {"(" +
-                                                    element.options.endX +
-                                                    ", " +
-                                                    element.options.endY +
-                                                    ")"}
-                                            </TeX>
-                                        </span>
-                                    }
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    onUp={
-                                        n === 0
-                                            ? null
-                                            : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this._moveElementUp.bind(this, n)
-                                    }
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    onDown={
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        n === this.props.elements.length - 1
-                                            ? null
-                                            : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this._moveElementDown.bind(
-                                                  // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                  this,
-                                                  n,
-                                              )
-                                    }
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                    onDelete={this._deleteElement.bind(this, n)}
-                                    key={element.key}
-                                >
-                                    <LineEditor
-                                        {...element.options}
-                                        onChange={(newProps) => {
-                                            const elements = JSON.parse(
-                                                JSON.stringify(
-                                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                    this.props.elements,
-                                                ),
-                                            );
-                                            _.extend(
-                                                elements[n].options,
-                                                newProps,
-                                            );
-                                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                            this.props.onChange({
-                                                elements: elements,
-                                            });
-                                        }}
-                                    />
-                                </ElementContainer>
-                            );
-                        }
-                        if (element.type === "function") {
-                            return (
-                                <ElementContainer
-                                    title={
-                                        <span>
-                                            Function{" "}
-                                            <TeX>
-                                                {element.options.funcName +
-                                                    "(x) = " +
-                                                    element.options.value}
-                                            </TeX>
-                                        </span>
-                                    }
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    onUp={
-                                        n === 0
-                                            ? null
-                                            : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this._moveElementUp.bind(this, n)
-                                    }
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    onDown={
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        n === this.props.elements.length - 1
-                                            ? null
-                                            : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this._moveElementDown.bind(
-                                                  // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                  this,
-                                                  n,
-                                              )
-                                    }
+                {this.props.elements.map(function (element, n) {
+                    if (element.type === "movable-point") {
+                        return (
+                            <ElementContainer
+                                title={
+                                    <span>
+                                        Movable point{" "}
+                                        <TeX>
+                                            {"(x_{" +
+                                                element.options.varSubscript +
+                                                "}, y_{" +
+                                                element.options.varSubscript +
+                                                "})"}
+                                        </TeX>
+                                    </span>
+                                }
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onUp={
+                                    n === 0
+                                        ? null
+                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                          this._moveElementUp.bind(this, n)
+                                }
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onDown={
                                     // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                    onDelete={this._deleteElement}
-                                    key={element.key}
-                                >
-                                    <FunctionEditor
-                                        {...element.options}
-                                        onChange={(newProps) => {
-                                            const elements = JSON.parse(
-                                                JSON.stringify(
-                                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                    this.props.elements,
-                                                ),
-                                            );
-                                            _.extend(
-                                                elements[n].options,
-                                                newProps,
-                                            );
-                                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                            this.props.onChange({
-                                                elements: elements,
-                                            });
-                                        }}
-                                    />
-                                </ElementContainer>
-                            );
-                        }
-                        if (element.type === "parametric") {
-                            return (
-                                <ElementContainer
-                                    title={<span>Parametric</span>}
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    onUp={
-                                        n === 0
-                                            ? null
-                                            : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this._moveElementUp.bind(this, n)
-                                    }
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    onDown={
+                                    n === this.props.elements.length - 1
+                                        ? null
+                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                          this._moveElementDown.bind(
+                                              // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                              this,
+                                              n,
+                                          )
+                                }
+                                // eslint-disable-next-line react/jsx-no-bind
+                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                onDelete={this._deleteElement.bind(this, n)}
+                                key={element.key}
+                            >
+                                <MovablePointEditor
+                                    {...element.options}
+                                    onChange={(newProps) => {
+                                        const elements = JSON.parse(
+                                            JSON.stringify(
+                                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                                this.props.elements,
+                                            ),
+                                        );
+                                        _.extend(elements[n].options, newProps);
                                         // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        n === this.props.elements.length - 1
-                                            ? null
-                                            : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this._moveElementDown.bind(
-                                                  // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                  this,
-                                                  n,
-                                              )
-                                    }
+                                        this.props.onChange({
+                                            elements: elements,
+                                        });
+                                    }}
+                                />
+                            </ElementContainer>
+                        );
+                    }
+                    if (element.type === "movable-line") {
+                        return (
+                            <ElementContainer
+                                title={
+                                    <span>
+                                        Movable line{" "}
+                                        <TeX>
+                                            {"(x_{" +
+                                                element.options.startSubscript +
+                                                "}, y_{" +
+                                                element.options.startSubscript +
+                                                "})"}
+                                        </TeX>{" "}
+                                        to{" "}
+                                        <TeX>
+                                            {"(x_{" +
+                                                element.options.endSubscript +
+                                                "}, y_{" +
+                                                element.options.endSubscript +
+                                                "})"}
+                                        </TeX>
+                                    </span>
+                                }
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onUp={
+                                    n === 0
+                                        ? null
+                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                          this._moveElementUp.bind(this, n)
+                                }
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onDown={
                                     // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                    onDelete={this._deleteElement}
-                                    key={element.key}
-                                >
-                                    <ParametricEditor
-                                        {...element.options}
-                                        onChange={(newProps) => {
-                                            const elements = JSON.parse(
-                                                JSON.stringify(
-                                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                    this.props.elements,
-                                                ),
-                                            );
-                                            _.extend(
-                                                elements[n].options,
-                                                newProps,
-                                            );
-                                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                            this.props.onChange({
-                                                elements: elements,
-                                            });
-                                        }}
-                                    />
-                                </ElementContainer>
-                            );
-                        }
-                        if (element.type === "label") {
-                            return (
-                                <ElementContainer
-                                    title={
-                                        <span>
-                                            Label{" "}
-                                            <TeX>
-                                                {unescapeMathMode(
-                                                    element.options.label,
-                                                )}
-                                            </TeX>{" "}
-                                        </span>
-                                    }
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    onUp={
-                                        n === 0
-                                            ? null
-                                            : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this._moveElementUp.bind(this, n)
-                                    }
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    onDown={
+                                    n === this.props.elements.length - 1
+                                        ? null
+                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                          this._moveElementDown.bind(
+                                              // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                              this,
+                                              n,
+                                          )
+                                }
+                                // eslint-disable-next-line react/jsx-no-bind
+                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                onDelete={this._deleteElement.bind(this, n)}
+                                key={element.key}
+                            >
+                                <MovableLineEditor
+                                    {...element.options}
+                                    onChange={(newProps) => {
+                                        const elements = JSON.parse(
+                                            JSON.stringify(
+                                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                                this.props.elements,
+                                            ),
+                                        );
+                                        _.extend(elements[n].options, newProps);
                                         // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        n === this.props.elements.length - 1
-                                            ? null
-                                            : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this._moveElementDown.bind(
-                                                  // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                  this,
-                                                  n,
-                                              )
-                                    }
+                                        this.props.onChange({
+                                            elements: elements,
+                                        });
+                                    }}
+                                />
+                            </ElementContainer>
+                        );
+                    }
+                    if (element.type === "point") {
+                        return (
+                            <ElementContainer
+                                title={
+                                    <span>
+                                        Point{" "}
+                                        <TeX>
+                                            {"(" +
+                                                element.options.coordX +
+                                                ", " +
+                                                element.options.coordY +
+                                                ")"}
+                                        </TeX>
+                                    </span>
+                                }
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onUp={
+                                    n === 0
+                                        ? null
+                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                          this._moveElementUp.bind(this, n)
+                                }
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onDown={
                                     // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                    onDelete={this._deleteElement}
-                                    key={element.key}
-                                >
-                                    <LabelEditor
-                                        {...element.options}
-                                        onChange={(newProps) => {
-                                            const elements = JSON.parse(
-                                                JSON.stringify(
-                                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                    this.props.elements,
-                                                ),
-                                            );
-                                            _.extend(
-                                                elements[n].options,
-                                                newProps,
-                                            );
-                                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                            this.props.onChange({
-                                                elements: elements,
-                                            });
-                                        }}
-                                    />
-                                </ElementContainer>
-                            );
-                        }
-                        if (element.type === "rectangle") {
-                            return (
-                                <ElementContainer
-                                    title={
-                                        <span>
-                                            Rectangle{" "}
-                                            <TeX>
-                                                {"(" +
-                                                    element.options.coordX +
-                                                    ", " +
-                                                    element.options.coordY +
-                                                    ")"}
-                                            </TeX>
-                                            &nbsp;&mdash;&nbsp;
-                                            <TeX>
-                                                {element.options.width +
-                                                    " \\times " +
-                                                    element.options.height}
-                                            </TeX>
-                                        </span>
-                                    }
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    onUp={
-                                        n === 0
-                                            ? null
-                                            : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this._moveElementUp.bind(this, n)
-                                    }
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    onDown={
+                                    n === this.props.elements.length - 1
+                                        ? null
+                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                          this._moveElementDown.bind(
+                                              // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                              this,
+                                              n,
+                                          )
+                                }
+                                // eslint-disable-next-line react/jsx-no-bind
+                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                onDelete={this._deleteElement.bind(this, n)}
+                                key={element.key}
+                            >
+                                <PointEditor
+                                    {...element.options}
+                                    onChange={(newProps) => {
+                                        const elements = JSON.parse(
+                                            JSON.stringify(
+                                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                                this.props.elements,
+                                            ),
+                                        );
+                                        _.extend(elements[n].options, newProps);
                                         // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        n === this.props.elements.length - 1
-                                            ? null
-                                            : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this._moveElementDown.bind(
-                                                  // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                  this,
-                                                  n,
-                                              )
-                                    }
+                                        this.props.onChange({
+                                            elements: elements,
+                                        });
+                                    }}
+                                />
+                            </ElementContainer>
+                        );
+                    }
+                    if (element.type === "line") {
+                        return (
+                            <ElementContainer
+                                title={
+                                    <span>
+                                        Line{" "}
+                                        <TeX>
+                                            {"(" +
+                                                element.options.startX +
+                                                ", " +
+                                                element.options.startY +
+                                                ")"}
+                                        </TeX>{" "}
+                                        to{" "}
+                                        <TeX>
+                                            {"(" +
+                                                element.options.endX +
+                                                ", " +
+                                                element.options.endY +
+                                                ")"}
+                                        </TeX>
+                                    </span>
+                                }
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onUp={
+                                    n === 0
+                                        ? null
+                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                          this._moveElementUp.bind(this, n)
+                                }
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onDown={
                                     // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                    onDelete={this._deleteElement}
-                                    key={element.key}
-                                >
-                                    <RectangleEditor
-                                        {...element.options}
-                                        onChange={(newProps) => {
-                                            const elements = JSON.parse(
-                                                JSON.stringify(
-                                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                    this.props.elements,
-                                                ),
-                                            );
-                                            _.extend(
-                                                elements[n].options,
-                                                newProps,
-                                            );
-                                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                            this.props.onChange({
-                                                elements: elements,
-                                            });
-                                        }}
-                                    />
-                                </ElementContainer>
-                            );
-                        }
-                    },
-                    this,
-                )}
+                                    n === this.props.elements.length - 1
+                                        ? null
+                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                          this._moveElementDown.bind(
+                                              // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                              this,
+                                              n,
+                                          )
+                                }
+                                // eslint-disable-next-line react/jsx-no-bind
+                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                onDelete={this._deleteElement.bind(this, n)}
+                                key={element.key}
+                            >
+                                <LineEditor
+                                    {...element.options}
+                                    onChange={(newProps) => {
+                                        const elements = JSON.parse(
+                                            JSON.stringify(
+                                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                                this.props.elements,
+                                            ),
+                                        );
+                                        _.extend(elements[n].options, newProps);
+                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                        this.props.onChange({
+                                            elements: elements,
+                                        });
+                                    }}
+                                />
+                            </ElementContainer>
+                        );
+                    }
+                    if (element.type === "function") {
+                        return (
+                            <ElementContainer
+                                title={
+                                    <span>
+                                        Function{" "}
+                                        <TeX>
+                                            {element.options.funcName +
+                                                "(x) = " +
+                                                element.options.value}
+                                        </TeX>
+                                    </span>
+                                }
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onUp={
+                                    n === 0
+                                        ? null
+                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                          this._moveElementUp.bind(this, n)
+                                }
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onDown={
+                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                    n === this.props.elements.length - 1
+                                        ? null
+                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                          this._moveElementDown.bind(
+                                              // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                              this,
+                                              n,
+                                          )
+                                }
+                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                onDelete={this._deleteElement}
+                                key={element.key}
+                            >
+                                <FunctionEditor
+                                    {...element.options}
+                                    onChange={(newProps) => {
+                                        const elements = JSON.parse(
+                                            JSON.stringify(
+                                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                                this.props.elements,
+                                            ),
+                                        );
+                                        _.extend(elements[n].options, newProps);
+                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                        this.props.onChange({
+                                            elements: elements,
+                                        });
+                                    }}
+                                />
+                            </ElementContainer>
+                        );
+                    }
+                    if (element.type === "parametric") {
+                        return (
+                            <ElementContainer
+                                title={<span>Parametric</span>}
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onUp={
+                                    n === 0
+                                        ? null
+                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                          this._moveElementUp.bind(this, n)
+                                }
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onDown={
+                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                    n === this.props.elements.length - 1
+                                        ? null
+                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                          this._moveElementDown.bind(
+                                              // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                              this,
+                                              n,
+                                          )
+                                }
+                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                onDelete={this._deleteElement}
+                                key={element.key}
+                            >
+                                <ParametricEditor
+                                    {...element.options}
+                                    onChange={(newProps) => {
+                                        const elements = JSON.parse(
+                                            JSON.stringify(
+                                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                                this.props.elements,
+                                            ),
+                                        );
+                                        _.extend(elements[n].options, newProps);
+                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                        this.props.onChange({
+                                            elements: elements,
+                                        });
+                                    }}
+                                />
+                            </ElementContainer>
+                        );
+                    }
+                    if (element.type === "label") {
+                        return (
+                            <ElementContainer
+                                title={
+                                    <span>
+                                        Label{" "}
+                                        <TeX>
+                                            {unescapeMathMode(
+                                                element.options.label,
+                                            )}
+                                        </TeX>{" "}
+                                    </span>
+                                }
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onUp={
+                                    n === 0
+                                        ? null
+                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                          this._moveElementUp.bind(this, n)
+                                }
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onDown={
+                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                    n === this.props.elements.length - 1
+                                        ? null
+                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                          this._moveElementDown.bind(
+                                              // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                              this,
+                                              n,
+                                          )
+                                }
+                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                onDelete={this._deleteElement}
+                                key={element.key}
+                            >
+                                <LabelEditor
+                                    {...element.options}
+                                    onChange={(newProps) => {
+                                        const elements = JSON.parse(
+                                            JSON.stringify(
+                                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                                this.props.elements,
+                                            ),
+                                        );
+                                        _.extend(elements[n].options, newProps);
+                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                        this.props.onChange({
+                                            elements: elements,
+                                        });
+                                    }}
+                                />
+                            </ElementContainer>
+                        );
+                    }
+                    if (element.type === "rectangle") {
+                        return (
+                            <ElementContainer
+                                title={
+                                    <span>
+                                        Rectangle{" "}
+                                        <TeX>
+                                            {"(" +
+                                                element.options.coordX +
+                                                ", " +
+                                                element.options.coordY +
+                                                ")"}
+                                        </TeX>
+                                        &nbsp;&mdash;&nbsp;
+                                        <TeX>
+                                            {element.options.width +
+                                                " \\times " +
+                                                element.options.height}
+                                        </TeX>
+                                    </span>
+                                }
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onUp={
+                                    n === 0
+                                        ? null
+                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                          this._moveElementUp.bind(this, n)
+                                }
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onDown={
+                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                    n === this.props.elements.length - 1
+                                        ? null
+                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                          this._moveElementDown.bind(
+                                              // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                              this,
+                                              n,
+                                          )
+                                }
+                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                onDelete={this._deleteElement}
+                                key={element.key}
+                            >
+                                <RectangleEditor
+                                    {...element.options}
+                                    onChange={(newProps) => {
+                                        const elements = JSON.parse(
+                                            JSON.stringify(
+                                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                                this.props.elements,
+                                            ),
+                                        );
+                                        _.extend(elements[n].options, newProps);
+                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                        this.props.onChange({
+                                            elements: elements,
+                                        });
+                                    }}
+                                />
+                            </ElementContainer>
+                        );
+                    }
+                }, this)}
                 <div className="perseus-widget-interaction-editor-select-element">
                     {/* @ts-expect-error - TS2322 - Type '(arg1: ChangeEvent<HTMLInputElement>) => void' is not assignable to type 'ChangeEventHandler<HTMLSelectElement>'. */}
                     <select onChange={this._addNewElement}>

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/components/interactive-graph-settings.tsx
@@ -482,7 +482,7 @@ class InteractiveGraphSettings extends React.Component<Props, State> {
             {
                 gridStepTextbox: gridStep,
                 // eslint-disable-next-line no-restricted-syntax
-                snapStepTextbox: _.map(gridStep, function (step) {
+                snapStepTextbox: gridStep.map(function (step) {
                     return step / 2;
                 }) as [number, number],
             },

--- a/packages/perseus-editor/src/widgets/measurer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/measurer-editor.tsx
@@ -70,7 +70,7 @@ class MeasurerEditor extends React.Component<Props> {
     ) => ReadonlyArray<React.ReactElement<React.ComponentProps<"option">>> = (
         choices,
     ) => {
-        return _.map(choices, function (nameAndValue) {
+        return choices.map(function (nameAndValue) {
             const [name, value] = nameAndValue;
             return (
                 <option key={value} value={value}>
@@ -208,7 +208,7 @@ class MeasurerEditor extends React.Component<Props> {
                                     }
                                     value={this.props.rulerTicks}
                                 >
-                                    {_.map([1, 2, 4, 8, 10, 16], function (n) {
+                                    {[1, 2, 4, 8, 10, 16].map(function (n) {
                                         return (
                                             <option key={n} value={n}>
                                                 {n}

--- a/packages/perseus-editor/src/widgets/plotter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/plotter-editor.tsx
@@ -217,8 +217,8 @@ class PlotterEditor extends React.Component<Props, State> {
         this.props.onChange({
             scaleY: newScale,
             maxY: maxY,
-            correct: _.map(this.props.correct, scale),
-            starting: _.map(this.props.starting, scale),
+            correct: this.props.correct.map(scale),
+            starting: this.props.starting.map(scale),
         });
 
         // @ts-expect-error - TS2531 - Object is possibly 'null'. | TS2339 - Property 'value' does not exist on type 'Element | Text'.
@@ -257,8 +257,8 @@ class PlotterEditor extends React.Component<Props, State> {
             categories = _.range(scale, length + scale, scale);
         }
 
-        categories = _.map(categories, (num) => num + min);
-        categories = _.map(categories, formatNumber);
+        categories = categories.map((num) => num + min);
+        categories = categories.map(formatNumber);
 
         this.changeCategories(categories);
 

--- a/packages/perseus-editor/src/widgets/table-editor.tsx
+++ b/packages/perseus-editor/src/widgets/table-editor.tsx
@@ -85,7 +85,7 @@ class TableEditor extends React.Component<Props> {
         const json = _.pick(this.props, "headers", "rows", "columns");
 
         return _.extend({}, json, {
-            answers: _.map(this.props.answers, _.clone),
+            answers: this.props.answers.map(_.clone),
         });
     };
 

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -17,7 +17,6 @@ import {StyleSheet} from "aphrodite";
 import classNames from "classnames";
 import $ from "jquery";
 import * as React from "react";
-import _ from "underscore";
 import {v4 as uuid} from "uuid";
 
 import a11y from "../util/a11y";
@@ -174,7 +173,7 @@ class InnerMathInput extends React.Component<InnerProps, State> {
         // but it fails tests when I remove it and the way we call
         // methods directly on components makes it difficult to confirm
         // if it's dead code
-        if (_(value).isFunction()) {
+        if (typeof value === "function") {
             value(input);
         } else if (value[0] === "\\") {
             input?.cmd(value).focus();

--- a/packages/perseus/src/components/sortable.tsx
+++ b/packages/perseus/src/components/sortable.tsx
@@ -560,11 +560,11 @@ class Sortable extends React.Component<SortableProps, SortableState> {
         let items: ReadonlyArray<SortableItem> = [...this.state.items];
 
         // Fetches a jQuery list of elements for each item
-        const $items = items.map(function (item) {
+        const $items = items.map((item) => {
             // eslint-disable-next-line react/no-string-refs
-            // @ts-expect-error - TS2769 - No overload matches this call. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+            // @ts-expect-error - TS2769 - No overload matches this call.
             return $(ReactDOM.findDOMNode(this.refs[item.key]));
-        }, this);
+        });
 
         const widths: ReadonlyArray<number> = _.invoke($items, "outerWidth");
         const heights: ReadonlyArray<number> = _.invoke($items, "outerHeight");
@@ -710,14 +710,13 @@ class Sortable extends React.Component<SortableProps, SortableState> {
         // TODO(jeff, CP-3128): Use Wonder Blocks Timing API.
         // eslint-disable-next-line no-restricted-syntax
         const nextAnimationFrame = requestAnimationFrame(() => {
-            const items = this.state.items.map(function (item) {
+            const items = this.state.items.map((item) => {
                 if (item.key === key) {
                     item.state = ItemState.ANIMATING;
                     const $placeholder = $(
                         // @ts-expect-error - TS2769 - No overload matches this call.
                         ReactDOM.findDOMNode(
                             // eslint-disable-next-line react/no-string-refs
-                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                             this.refs["placeholder_" + key],
                         ),
                     );

--- a/packages/perseus/src/components/sortable.tsx
+++ b/packages/perseus/src/components/sortable.tsx
@@ -560,15 +560,11 @@ class Sortable extends React.Component<SortableProps, SortableState> {
         let items: ReadonlyArray<SortableItem> = [...this.state.items];
 
         // Fetches a jQuery list of elements for each item
-        const $items = _.map(
-            items,
-            function (item) {
-                // eslint-disable-next-line react/no-string-refs
-                // @ts-expect-error - TS2769 - No overload matches this call. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                return $(ReactDOM.findDOMNode(this.refs[item.key]));
-            },
-            this,
-        );
+        const $items = items.map(function (item) {
+            // eslint-disable-next-line react/no-string-refs
+            // @ts-expect-error - TS2769 - No overload matches this call. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+            return $(ReactDOM.findDOMNode(this.refs[item.key]));
+        }, this);
 
         const widths: ReadonlyArray<number> = _.invoke($items, "outerWidth");
         const heights: ReadonlyArray<number> = _.invoke($items, "outerHeight");
@@ -593,7 +589,7 @@ class Sortable extends React.Component<SortableProps, SortableState> {
             syncHeight = _.max(heights);
         }
 
-        items = _.map(items, function (item, i) {
+        items = items.map(function (item, i) {
             item.width = syncWidth || widths[i];
             item.height = syncHeight || heights[i];
             return item;
@@ -606,7 +602,7 @@ class Sortable extends React.Component<SortableProps, SortableState> {
 
     onMouseDown(key: SortableItem["key"]) {
         // Static -> Dragging
-        const items = _.map(this.state.items, function (item) {
+        const items = this.state.items.map(function (item) {
             if (item.key === key) {
                 item.state = ItemState.DRAGGING;
             }
@@ -714,31 +710,27 @@ class Sortable extends React.Component<SortableProps, SortableState> {
         // TODO(jeff, CP-3128): Use Wonder Blocks Timing API.
         // eslint-disable-next-line no-restricted-syntax
         const nextAnimationFrame = requestAnimationFrame(() => {
-            const items = _.map(
-                this.state.items,
-                function (item) {
-                    if (item.key === key) {
-                        item.state = ItemState.ANIMATING;
-                        const $placeholder = $(
-                            // @ts-expect-error - TS2769 - No overload matches this call.
-                            ReactDOM.findDOMNode(
-                                // eslint-disable-next-line react/no-string-refs
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                this.refs["placeholder_" + key],
-                            ),
-                        );
-                        // @ts-expect-error - TS2339 - Property 'position' does not exist on type 'JQueryStatic'.
-                        const position = $placeholder.position();
-                        const endPosition = addOffsetParentScroll(
-                            $placeholder,
-                            position,
-                        );
-                        item.endPosition = endPosition;
-                    }
-                    return item;
-                },
-                this,
-            );
+            const items = this.state.items.map(function (item) {
+                if (item.key === key) {
+                    item.state = ItemState.ANIMATING;
+                    const $placeholder = $(
+                        // @ts-expect-error - TS2769 - No overload matches this call.
+                        ReactDOM.findDOMNode(
+                            // eslint-disable-next-line react/no-string-refs
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            this.refs["placeholder_" + key],
+                        ),
+                    );
+                    // @ts-expect-error - TS2339 - Property 'position' does not exist on type 'JQueryStatic'.
+                    const position = $placeholder.position();
+                    const endPosition = addOffsetParentScroll(
+                        $placeholder,
+                        position,
+                    );
+                    item.endPosition = endPosition;
+                }
+                return item;
+            }, this);
 
             this.setState({items: items}, () => {
                 // HACK (LEMS-3224) We need to know *that* the widget changed, but currently it's
@@ -754,7 +746,7 @@ class Sortable extends React.Component<SortableProps, SortableState> {
 
     onAnimationEnd(key: SortableItem["key"]) {
         // Animating -> Static
-        const items = _.map(this.state.items, function (item) {
+        const items = this.state.items.map(function (item) {
             if (item.key === key) {
                 item.state = ItemState.STATIC;
             }

--- a/packages/perseus/src/components/text-list-editor.tsx
+++ b/packages/perseus/src/components/text-list-editor.tsx
@@ -136,7 +136,7 @@ class TextListEditor extends React.Component<any, any> {
             "layout-" + this.props.layout,
         ].join(" ");
 
-        const inputs = this.state.items.map(function (item, i) {
+        const inputs = this.state.items.map((item, i) => {
             return (
                 <li key={i}>
                     <input
@@ -144,16 +144,14 @@ class TextListEditor extends React.Component<any, any> {
                         type="text"
                         value={item}
                         // eslint-disable-next-line react/jsx-no-bind
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                         onChange={this.onChange.bind(this, i)}
                         // eslint-disable-next-line react/jsx-no-bind
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                         onKeyDown={this.onKeyDown.bind(this, i)}
                         style={{width: getTextWidth(item)}}
                     />
                 </li>
             );
-        }, this);
+        });
 
         return <ul className={className}>{inputs}</ul>;
     }

--- a/packages/perseus/src/components/text-list-editor.tsx
+++ b/packages/perseus/src/components/text-list-editor.tsx
@@ -136,28 +136,24 @@ class TextListEditor extends React.Component<any, any> {
             "layout-" + this.props.layout,
         ].join(" ");
 
-        const inputs = _.map(
-            this.state.items,
-            function (item, i) {
-                return (
-                    <li key={i}>
-                        <input
-                            ref={"input_" + i}
-                            type="text"
-                            value={item}
-                            // eslint-disable-next-line react/jsx-no-bind
-                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                            onChange={this.onChange.bind(this, i)}
-                            // eslint-disable-next-line react/jsx-no-bind
-                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                            onKeyDown={this.onKeyDown.bind(this, i)}
-                            style={{width: getTextWidth(item)}}
-                        />
-                    </li>
-                );
-            },
-            this,
-        );
+        const inputs = this.state.items.map(function (item, i) {
+            return (
+                <li key={i}>
+                    <input
+                        ref={"input_" + i}
+                        type="text"
+                        value={item}
+                        // eslint-disable-next-line react/jsx-no-bind
+                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                        onChange={this.onChange.bind(this, i)}
+                        // eslint-disable-next-line react/jsx-no-bind
+                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                        onKeyDown={this.onKeyDown.bind(this, i)}
+                        style={{width: getTextWidth(item)}}
+                    />
+                </li>
+            );
+        }, this);
 
         return <ul className={className}>{inputs}</ul>;
     }

--- a/packages/perseus/src/interactive2/movable-line-options.ts
+++ b/packages/perseus/src/interactive2/movable-line-options.ts
@@ -238,15 +238,15 @@ const constraints = {
             }
 
             // Calculate the bounds for the delta.
-            const deltaBounds = _.map(
-                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                this.coords(),
-                function (coord: Coord, i: number) {
-                    const max = kvector.subtract(absoluteUpper, coord);
-                    const min = kvector.subtract(absoluteLower, coord);
-                    return [min, max];
-                },
-            );
+            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+            const deltaBounds = this.coords().map(function (
+                coord: Coord,
+                i: number,
+            ) {
+                const max = kvector.subtract(absoluteUpper, coord);
+                const min = kvector.subtract(absoluteLower, coord);
+                return [min, max];
+            });
 
             // bound the delta by the calculated bounds
             const boundedDelta = _.reduce(

--- a/packages/perseus/src/interactive2/movable-polygon-options.ts
+++ b/packages/perseus/src/interactive2/movable-polygon-options.ts
@@ -20,7 +20,7 @@ function sum(array: any) {
 
 function clockwise(points: any) {
     const segments = _.zip(points, points.slice(1).concat(points.slice(0, 1)));
-    const areas = _.map(segments, function (segment) {
+    const areas = segments.map(function (segment) {
         const p1 = segment[0];
         const p2 = segment[1];
         return (p2[0] - p1[0]) * (p2[1] + p1[1]);
@@ -153,8 +153,7 @@ const draw = {
             // @ts-expect-error - TS2339 - Property 'state' does not exist on type '{ readonly basic: (state: any, prevState: any) => void; readonly labels: (state: any, prevState: any) => void; readonly highlight: (state: any, prevState: any) => void; }'.
             if (self.state._labeledSides == null) {
                 // @ts-expect-error - TS2339 - Property 'state' does not exist on type '{ readonly basic: (state: any, prevState: any) => void; readonly labels: (state: any, prevState: any) => void; readonly highlight: (state: any, prevState: any) => void; }'.
-                self.state._labeledSides = _.map(
-                    state.sideLabels,
+                self.state._labeledSides = state.sideLabels.map(
                     function (label) {
                         return graphie.label(
                             [0, 0],
@@ -190,8 +189,7 @@ const draw = {
             // @ts-expect-error - TS2339 - Property 'state' does not exist on type '{ readonly basic: (state: any, prevState: any) => void; readonly labels: (state: any, prevState: any) => void; readonly highlight: (state: any, prevState: any) => void; }'.
             if (self.state._labeledVertices == null) {
                 // @ts-expect-error - TS2339 - Property 'state' does not exist on type '{ readonly basic: (state: any, prevState: any) => void; readonly labels: (state: any, prevState: any) => void; readonly highlight: (state: any, prevState: any) => void; }'.
-                self.state._labeledVertices = _.map(
-                    state.vertexLabels,
+                self.state._labeledVertices = state.vertexLabels.map(
                     function (label) {
                         return graphie.label(
                             [0, 0],
@@ -328,7 +326,7 @@ const constraints = {
 
             // Calculate the bounds for the delta.
             // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-            const deltaBounds = _.map(this.coords(), function (coord, i) {
+            const deltaBounds = this.coords().map(function (coord, i) {
                 const max = kvector.subtract(absoluteUpper, coord);
                 const min = kvector.subtract(absoluteLower, coord);
                 return [min, max];

--- a/packages/perseus/src/interactive2/movable-polygon.ts
+++ b/packages/perseus/src/interactive2/movable-polygon.ts
@@ -254,7 +254,7 @@ _.extend(MovablePolygon.prototype, {
         const graphie = this.graphie;
         state = state || this.state;
 
-        let coords = _.map(state.points, function (point) {
+        let coords = state.points.map(function (point) {
             return graphie.scalePoint(point.coord());
         });
 

--- a/packages/perseus/src/perseus-markdown.new.tsx
+++ b/packages/perseus/src/perseus-markdown.new.tsx
@@ -335,7 +335,7 @@ const inlineParser = (source: string, state: any): any => {
 const getContent = (ast: any) => {
     // Simplify logic by dealing with a single AST node at a time
     if (Array.isArray(ast)) {
-        return _.flatten(_.map(ast, getContent));
+        return _.flatten(ast.map(getContent));
     }
 
     // Base case: This is where we actually extract text content

--- a/packages/perseus/src/perseus-markdown.tsx
+++ b/packages/perseus/src/perseus-markdown.tsx
@@ -322,7 +322,7 @@ const inlineParser = (source: string, state: any): any => {
 const getContent = (ast: any) => {
     // Simplify logic by dealing with a single AST node at a time
     if (Array.isArray(ast)) {
-        return _.flatten(_.map(ast, getContent));
+        return _.flatten(ast.map(getContent));
     }
 
     // Base case: This is where we actually extract text content

--- a/packages/perseus/src/util.ts
+++ b/packages/perseus/src/util.ts
@@ -58,7 +58,7 @@ const nestedMap = function <T, M>(
 ): M | ReadonlyArray<M> {
     if (Array.isArray(children)) {
         // @ts-expect-error - TS2322 - Type '(M | readonly M[])[]' is not assignable to type 'M | readonly M[]'.
-        return _.map(children, function (child) {
+        return children.map(function (child) {
             // @ts-expect-error - TS2554 - Expected 3 arguments, but got 2.
             return nestedMap(child, func);
         });

--- a/packages/perseus/src/util/interactive.ts
+++ b/packages/perseus/src/util/interactive.ts
@@ -2856,13 +2856,13 @@ _.extend(GraphUtils.Graphie.prototype, {
                 return isHovering;
             };
 
-            const styles = _.map([0, 1], function (isHighlight) {
+            const styles = [0, 1].map(function (isHighlight) {
                 // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
                 const baseStyle = isHighlight
                     ? options.highlightStyle
                     : options.normalStyle;
 
-                return _.map([0, 1], function (opacity) {
+                return [0, 1].map(function (opacity) {
                     return _.defaults(
                         {
                             "fill-opacity": opacity,
@@ -3659,8 +3659,7 @@ function MovableAngle(graphie: any, options: any) {
     }
 
     // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-    this.rays = _.map(
-        [0, 2],
+    this.rays = [0, 2].map(
         function (i) {
             return graphie.addMovableLineSegment({
                 // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.

--- a/packages/perseus/src/widgets/interaction/interaction.tsx
+++ b/packages/perseus/src/widgets/interaction/interaction.tsx
@@ -285,430 +285,409 @@ class Interaction extends React.Component<Props, State> implements Widget {
                         direction="right"
                     />
                 )}
-                {_.map(
-                    this.props.elements,
-                    function (element, n) {
-                        if (element.type === "point") {
-                            return (
-                                <Point
-                                    key={element.key}
-                                    coord={[
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        this._eval(element.options.coordX),
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        this._eval(element.options.coordY),
-                                    ]}
-                                    color={element.options.color}
-                                />
-                            );
-                        }
-                        if (element.type === "line") {
-                            const start = [
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                this._eval(element.options.startX),
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                this._eval(element.options.startY),
-                            ];
-                            const end = [
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                this._eval(element.options.endX),
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                this._eval(element.options.endY),
-                            ];
-                            return (
-                                <Line
-                                    key={element.key}
-                                    start={start}
-                                    end={end}
-                                    style={{
-                                        stroke: element.options.color,
-                                        strokeWidth:
-                                            element.options.strokeWidth,
-                                        strokeDasharray:
-                                            element.options.strokeDasharray,
-                                        arrows: element.options.arrows,
-                                    }}
-                                />
-                            );
-                        }
-                        if (element.type === "movable-point") {
-                            const constraints = [
-                                (coord: any) => {
-                                    const coordX = Math.max(
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        this._eval(
-                                            element.options.constraintXMin,
-                                        ),
-                                        Math.min(
-                                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                            this._eval(
-                                                element.options.constraintXMax,
-                                            ),
-                                            coord[0],
-                                        ),
-                                    );
-                                    const coordY = Math.max(
+                {this.props.elements.map(function (element, n) {
+                    if (element.type === "point") {
+                        return (
+                            <Point
+                                key={element.key}
+                                coord={[
+                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                    this._eval(element.options.coordX),
+                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                    this._eval(element.options.coordY),
+                                ]}
+                                color={element.options.color}
+                            />
+                        );
+                    }
+                    if (element.type === "line") {
+                        const start = [
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            this._eval(element.options.startX),
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            this._eval(element.options.startY),
+                        ];
+                        const end = [
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            this._eval(element.options.endX),
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            this._eval(element.options.endY),
+                        ];
+                        return (
+                            <Line
+                                key={element.key}
+                                start={start}
+                                end={end}
+                                style={{
+                                    stroke: element.options.color,
+                                    strokeWidth: element.options.strokeWidth,
+                                    strokeDasharray:
+                                        element.options.strokeDasharray,
+                                    arrows: element.options.arrows,
+                                }}
+                            />
+                        );
+                    }
+                    if (element.type === "movable-point") {
+                        const constraints = [
+                            (coord: any) => {
+                                const coordX = Math.max(
+                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                    this._eval(element.options.constraintXMin),
+                                    Math.min(
                                         // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                         this._eval(
-                                            element.options.constraintYMin,
+                                            element.options.constraintXMax,
                                         ),
-                                        Math.min(
-                                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                            this._eval(
-                                                element.options.constraintYMax,
-                                            ),
-                                            coord[1],
-                                        ),
-                                    );
-                                    return [coordX, coordY];
-                                },
-                            ];
-                            if (element.options.constraint === "snap") {
-                                constraints.push(
-                                    MovablePoint.constraints.snap(
-                                        element.options.snap,
+                                        coord[0],
                                     ),
                                 );
-                            } else if (element.options.constraint === "x") {
-                                constraints.push((coord) => {
-                                    return [
+                                const coordY = Math.max(
+                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                    this._eval(element.options.constraintYMin),
+                                    Math.min(
                                         // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                         this._eval(
-                                            element.options.constraintFn,
-                                            {y: coord[1]},
+                                            element.options.constraintYMax,
                                         ),
                                         coord[1],
-                                    ];
-                                });
-                            } else if (element.options.constraint === "y") {
-                                constraints.push((coord) => {
-                                    return [
-                                        coord[0],
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        this._eval(
-                                            element.options.constraintFn,
-                                            {x: coord[0]},
-                                        ),
-                                    ];
-                                });
-                            }
-
-                            // NOTE(eater): foo_[xyz] are hacky non-props to
-                            // get the component to update when constraints
-                            // change
-                            return (
-                                <MovablePoint
-                                    key={element.key}
-                                    coord={[
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        this.state.variables[
-                                            "x_" + element.options.varSubscript
-                                        ],
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        this.state.variables[
-                                            "y_" + element.options.varSubscript
-                                        ],
-                                    ]}
-                                    constraints={constraints}
-                                    foo_x={element.options.constraint}
-                                    foo_y={element.options.constraintFn}
-                                    foo_z={element.options.snap}
-                                    onMove={_.partial(
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        this._updatePointLocation,
-                                        element.options.varSubscript,
-                                    )}
-                                />
-                            );
-                        }
-                        if (element.type === "movable-line") {
-                            const constraints = [
-                                (coord: any) => {
-                                    const coordX = Math.max(
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        this._eval(
-                                            element.options.constraintXMin,
-                                        ),
-                                        Math.min(
-                                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                            this._eval(
-                                                element.options.constraintXMax,
-                                            ),
-                                            coord[0],
-                                        ),
-                                    );
-                                    const coordY = Math.max(
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        this._eval(
-                                            element.options.constraintYMin,
-                                        ),
-                                        Math.min(
-                                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                            this._eval(
-                                                element.options.constraintYMax,
-                                            ),
-                                            coord[1],
-                                        ),
-                                    );
-                                    return [coordX, coordY];
-                                },
-                            ];
-                            if (element.options.constraint === "snap") {
-                                constraints.push(
-                                    MovablePoint.constraints.snap(
-                                        element.options.snap,
                                     ),
                                 );
-                            } else if (element.options.constraint === "x") {
-                                constraints.push((coord) => {
-                                    return [
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        this._eval(
-                                            element.options.constraintFn,
-                                            {y: coord[1]},
-                                        ),
-                                        coord[1],
-                                    ];
-                                });
-                            } else if (element.options.constraint === "y") {
-                                constraints.push((coord) => {
-                                    return [
-                                        coord[0],
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        this._eval(
-                                            element.options.constraintFn,
-                                            {x: coord[0]},
-                                        ),
-                                    ];
-                                });
-                            }
-                            const start = [
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                this.state.variables[
-                                    "x_" + element.options.startSubscript
-                                ],
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                this.state.variables[
-                                    "y_" + element.options.startSubscript
-                                ],
-                            ];
-                            const end = [
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                this.state.variables[
-                                    "x_" + element.options.endSubscript
-                                ],
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                this.state.variables[
-                                    "y_" + element.options.endSubscript
-                                ],
-                            ];
-                            return (
-                                <MovableLine
-                                    key={element.key}
-                                    constraints={constraints}
-                                    // eslint-disable-next-line react/jsx-no-bind
-                                    onMove={_.bind(
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        this._updateLineLocation,
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        this,
-                                        element.options,
-                                    )}
-                                    foo_x={element.options.constraint}
-                                    foo_y={element.options.constraintFn}
-                                    foo_z={element.options.snap}
-                                >
-                                    <MovablePoint
-                                        coord={start}
-                                        static={true}
-                                        normalStyle={{
-                                            stroke: "none",
-                                            fill: "none",
-                                        }}
-                                    />
-                                    <MovablePoint
-                                        coord={end}
-                                        static={true}
-                                        normalStyle={{
-                                            stroke: "none",
-                                            fill: "none",
-                                        }}
-                                    />
-                                </MovableLine>
-                            );
-                        }
-                        if (element.type === "function") {
-                            const fn = (x: any) => {
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                return this._eval(element.options.value, {
-                                    x: x,
-                                });
-                            };
-                            // find all the variables referenced by this
-                            // function
-                            const vars = _.without(
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                this._extractVars(
-                                    // @ts-expect-error - TS2554 - Expected 2 arguments, but got 1.
-                                    KASparse(element.options.value).expr,
+                                return [coordX, coordY];
+                            },
+                        ];
+                        if (element.options.constraint === "snap") {
+                            constraints.push(
+                                MovablePoint.constraints.snap(
+                                    element.options.snap,
                                 ),
-                                "x",
                             );
-                            // and find their values, so we redraw if any
-                            // change
-                            const varValues = _.object(
-                                vars,
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                _.map(vars, (v) => this.state.variables[v]),
-                            );
-
-                            const range = [
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                this._eval(
-                                    element.options.rangeMin,
-                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                    this.state.variables,
-                                ),
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                this._eval(
-                                    element.options.rangeMax,
-                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                    this.state.variables,
-                                ),
-                            ];
-
-                            return (
-                                <Plot
-                                    key={element.key}
-                                    fn={fn}
-                                    foo_fn={element.options.value}
-                                    foo_varvalues={varValues}
-                                    range={range}
-                                    style={{
-                                        stroke: element.options.color,
-                                        strokeWidth:
-                                            element.options.strokeWidth,
-                                        strokeDasharray:
-                                            element.options.strokeDasharray,
-                                        plotPoints: 100,
-                                    }}
-                                />
-                            );
-                        }
-                        if (element.type === "parametric") {
-                            const fn = (t: any) => {
+                        } else if (element.options.constraint === "x") {
+                            constraints.push((coord) => {
                                 return [
                                     // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                    this._eval(element.options.x, {t: t}),
-                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                    this._eval(element.options.y, {t: t}),
+                                    this._eval(element.options.constraintFn, {
+                                        y: coord[1],
+                                    }),
+                                    coord[1],
                                 ];
-                            };
-                            // find all the variables referenced by this
-                            // function
-                            const vars = _.without(
+                            });
+                        } else if (element.options.constraint === "y") {
+                            constraints.push((coord) => {
+                                return [
+                                    coord[0],
+                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                    this._eval(element.options.constraintFn, {
+                                        x: coord[0],
+                                    }),
+                                ];
+                            });
+                        }
+
+                        // NOTE(eater): foo_[xyz] are hacky non-props to
+                        // get the component to update when constraints
+                        // change
+                        return (
+                            <MovablePoint
+                                key={element.key}
+                                coord={[
+                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                    this.state.variables[
+                                        "x_" + element.options.varSubscript
+                                    ],
+                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                    this.state.variables[
+                                        "y_" + element.options.varSubscript
+                                    ],
+                                ]}
+                                constraints={constraints}
+                                foo_x={element.options.constraint}
+                                foo_y={element.options.constraintFn}
+                                foo_z={element.options.snap}
+                                onMove={_.partial(
+                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                    this._updatePointLocation,
+                                    element.options.varSubscript,
+                                )}
+                            />
+                        );
+                    }
+                    if (element.type === "movable-line") {
+                        const constraints = [
+                            (coord: any) => {
+                                const coordX = Math.max(
+                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                    this._eval(element.options.constraintXMin),
+                                    Math.min(
+                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                        this._eval(
+                                            element.options.constraintXMax,
+                                        ),
+                                        coord[0],
+                                    ),
+                                );
+                                const coordY = Math.max(
+                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                    this._eval(element.options.constraintYMin),
+                                    Math.min(
+                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                        this._eval(
+                                            element.options.constraintYMax,
+                                        ),
+                                        coord[1],
+                                    ),
+                                );
+                                return [coordX, coordY];
+                            },
+                        ];
+                        if (element.options.constraint === "snap") {
+                            constraints.push(
+                                MovablePoint.constraints.snap(
+                                    element.options.snap,
+                                ),
+                            );
+                        } else if (element.options.constraint === "x") {
+                            constraints.push((coord) => {
+                                return [
+                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                    this._eval(element.options.constraintFn, {
+                                        y: coord[1],
+                                    }),
+                                    coord[1],
+                                ];
+                            });
+                        } else if (element.options.constraint === "y") {
+                            constraints.push((coord) => {
+                                return [
+                                    coord[0],
+                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                    this._eval(element.options.constraintFn, {
+                                        x: coord[0],
+                                    }),
+                                ];
+                            });
+                        }
+                        const start = [
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            this.state.variables[
+                                "x_" + element.options.startSubscript
+                            ],
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            this.state.variables[
+                                "y_" + element.options.startSubscript
+                            ],
+                        ];
+                        const end = [
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            this.state.variables[
+                                "x_" + element.options.endSubscript
+                            ],
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            this.state.variables[
+                                "y_" + element.options.endSubscript
+                            ],
+                        ];
+                        return (
+                            <MovableLine
+                                key={element.key}
+                                constraints={constraints}
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onMove={_.bind(
+                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                    this._updateLineLocation,
+                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                    this,
+                                    element.options,
+                                )}
+                                foo_x={element.options.constraint}
+                                foo_y={element.options.constraintFn}
+                                foo_z={element.options.snap}
+                            >
+                                <MovablePoint
+                                    coord={start}
+                                    static={true}
+                                    normalStyle={{
+                                        stroke: "none",
+                                        fill: "none",
+                                    }}
+                                />
+                                <MovablePoint
+                                    coord={end}
+                                    static={true}
+                                    normalStyle={{
+                                        stroke: "none",
+                                        fill: "none",
+                                    }}
+                                />
+                            </MovableLine>
+                        );
+                    }
+                    if (element.type === "function") {
+                        const fn = (x: any) => {
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            return this._eval(element.options.value, {
+                                x: x,
+                            });
+                        };
+                        // find all the variables referenced by this
+                        // function
+                        const vars = _.without(
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            this._extractVars(
+                                // @ts-expect-error - TS2554 - Expected 2 arguments, but got 1.
+                                KASparse(element.options.value).expr,
+                            ),
+                            "x",
+                        );
+                        // and find their values, so we redraw if any
+                        // change
+                        const varValues = _.object(
+                            vars,
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            vars.map((v) => this.state.variables[v]),
+                        );
+
+                        const range = [
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            this._eval(
+                                element.options.rangeMin,
+                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                this.state.variables,
+                            ),
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            this._eval(
+                                element.options.rangeMax,
+                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                this.state.variables,
+                            ),
+                        ];
+
+                        return (
+                            <Plot
+                                key={element.key}
+                                fn={fn}
+                                foo_fn={element.options.value}
+                                foo_varvalues={varValues}
+                                range={range}
+                                style={{
+                                    stroke: element.options.color,
+                                    strokeWidth: element.options.strokeWidth,
+                                    strokeDasharray:
+                                        element.options.strokeDasharray,
+                                    plotPoints: 100,
+                                }}
+                            />
+                        );
+                    }
+                    if (element.type === "parametric") {
+                        const fn = (t: any) => {
+                            return [
+                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                this._eval(element.options.x, {t: t}),
+                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                                this._eval(element.options.y, {t: t}),
+                            ];
+                        };
+                        // find all the variables referenced by this
+                        // function
+                        const vars = _.without(
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            this._extractVars(
+                                // @ts-expect-error - TS2554 - Expected 2 arguments, but got 1.
+                                KASparse(element.options.x).expr,
+                            ).concat(
                                 // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                 this._extractVars(
                                     // @ts-expect-error - TS2554 - Expected 2 arguments, but got 1.
-                                    KASparse(element.options.x).expr,
-                                ).concat(
-                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                    this._extractVars(
-                                        // @ts-expect-error - TS2554 - Expected 2 arguments, but got 1.
-                                        KASparse(element.options.y).expr,
-                                    ),
+                                    KASparse(element.options.y).expr,
                                 ),
-                                "t",
-                            );
-                            // and find their values, so we redraw if any change
-                            const varValues = _.object(
-                                vars,
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                _.map(vars, (v) => this.state.variables[v]),
-                            );
+                            ),
+                            "t",
+                        );
+                        // and find their values, so we redraw if any change
+                        const varValues = _.object(
+                            vars,
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            vars.map((v) => this.state.variables[v]),
+                        );
 
-                            const range = [
+                        const range = [
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            this._eval(
+                                element.options.rangeMin,
                                 // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                this._eval(
-                                    element.options.rangeMin,
-                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                    this.state.variables,
-                                ),
+                                this.state.variables,
+                            ),
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            this._eval(
+                                element.options.rangeMax,
                                 // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                this._eval(
-                                    element.options.rangeMax,
-                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                    this.state.variables,
-                                ),
-                            ];
+                                this.state.variables,
+                            ),
+                        ];
 
-                            return (
-                                <PlotParametric
-                                    key={element.key}
-                                    fn={fn}
-                                    foo_fnx={element.options.x}
-                                    foo_fny={element.options.y}
-                                    foo_varvalues={varValues}
-                                    range={range}
-                                    style={{
-                                        stroke: element.options.color,
-                                        strokeWidth:
-                                            element.options.strokeWidth,
-                                        strokeDasharray:
-                                            element.options.strokeDasharray,
-                                        plotPoints: 100,
-                                    }}
-                                />
-                            );
-                        }
-                        if (element.type === "label") {
-                            const coord = [
+                        return (
+                            <PlotParametric
+                                key={element.key}
+                                fn={fn}
+                                foo_fnx={element.options.x}
+                                foo_fny={element.options.y}
+                                foo_varvalues={varValues}
+                                range={range}
+                                style={{
+                                    stroke: element.options.color,
+                                    strokeWidth: element.options.strokeWidth,
+                                    strokeDasharray:
+                                        element.options.strokeDasharray,
+                                    plotPoints: 100,
+                                }}
+                            />
+                        );
+                    }
+                    if (element.type === "label") {
+                        const coord = [
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            this._eval(element.options.coordX),
+                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                            this._eval(element.options.coordY),
+                        ];
+                        return (
+                            <Label
+                                key={n + 1}
+                                coord={coord}
+                                text={unescapeMathMode(element.options.label)}
+                                style={{
+                                    color: element.options.color,
+                                }}
+                            />
+                        );
+                    }
+                    if (element.type === "rectangle") {
+                        return (
+                            <Rect
+                                key={n + 1}
                                 // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                this._eval(element.options.coordX),
+                                x={this._eval(element.options.coordX)}
                                 // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                this._eval(element.options.coordY),
-                            ];
-                            return (
-                                <Label
-                                    key={n + 1}
-                                    coord={coord}
-                                    text={unescapeMathMode(
-                                        element.options.label,
-                                    )}
-                                    style={{
-                                        color: element.options.color,
-                                    }}
-                                />
-                            );
-                        }
-                        if (element.type === "rectangle") {
-                            return (
-                                <Rect
-                                    key={n + 1}
+                                y={this._eval(element.options.coordY)}
+                                width={_.max([
                                     // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                    x={this._eval(element.options.coordX)}
+                                    this._eval(element.options.width),
+                                    0,
+                                ])}
+                                height={_.max([
                                     // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                    y={this._eval(element.options.coordY)}
-                                    width={_.max([
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        this._eval(element.options.width),
-                                        0,
-                                    ])}
-                                    height={_.max([
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                        this._eval(element.options.height),
-                                        0,
-                                    ])}
-                                    style={{
-                                        stroke: "none",
-                                        fill: element.options.color,
-                                    }}
-                                />
-                            );
-                        }
-                    },
-                    this,
-                )}
+                                    this._eval(element.options.height),
+                                    0,
+                                ])}
+                                style={{
+                                    stroke: "none",
+                                    fill: element.options.color,
+                                }}
+                            />
+                        );
+                    }
+                }, this)}
             </Graphie>
         );
     }
@@ -780,8 +759,7 @@ const _getInitialVariables: (
 const _getInitialFunctions: (
     arg1: ReadonlyArray<PerseusInteractionElement>,
 ) => ReadonlyArray<string> = (elements) => {
-    return _.map(
-        _.where(elements, {type: "function"}),
+    return _.where(elements, {type: "function"}).map(
         // @ts-expect-error - TS2339 - Property 'funcName' does not exist on type 'PerseusInteractionFunctionElementOptions | PerseusInteractionLabelElementOptions | ... 5 more ... | PerseusInteractionRectangleElementOptions'.
         (element) => element.options.funcName,
     );

--- a/packages/perseus/src/widgets/interactive-graphs/get-equation-string.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/get-equation-string.ts
@@ -151,26 +151,23 @@ function getLinearSystemCoords(
     graph: PerseusGraphType,
     props: Props,
 ): [Coord, Coord][] {
+    const defaultCoords: Coord[][] = [
+        [
+            [0.25, 0.75],
+            [0.75, 0.75],
+        ],
+        [
+            [0.25, 0.25],
+            [0.75, 0.25],
+        ],
+    ];
     return (
         // The callers assume that we're return an array of points
         // @ts-expect-error - TS2339 - Property 'coords' does not exist on type 'PerseusGraphType'.
         graph.coords ||
-        _.map(
-            // eslint-disable-next-line no-restricted-syntax
-            [
-                [
-                    [0.25, 0.75],
-                    [0.75, 0.75],
-                ],
-                [
-                    [0.25, 0.25],
-                    [0.75, 0.25],
-                ],
-            ] as Coord[][],
-            (coords) => {
-                return pointsFromNormalized(props, coords);
-            },
-        )
+        defaultCoords.map((coords) => {
+            return pointsFromNormalized(props, coords);
+        })
     );
 }
 
@@ -309,8 +306,8 @@ function getAngleCoords(
 
 function normalizeCoords(coordsList: Coord[], ranges: [Range, Range]): Coord[] {
     // @ts-expect-error - TS2322 - Type 'number[][]' is not assignable to type 'readonly Coord[]'.
-    return _.map(coordsList, function (coords) {
-        return _.map(coords, function (coord, i) {
+    return coordsList.map(function (coords) {
+        return coords.map(function (coord, i) {
             const extent = ranges[i][1] - ranges[i][0];
             return (coord + ranges[i][1]) / extent;
         });
@@ -323,8 +320,8 @@ function pointsFromNormalized(
     noSnap?: boolean,
 ): Coord[] {
     // @ts-expect-error - TS2322 - Type 'number[][]' is not assignable to type 'readonly Coord[]'.
-    return _.map(coordsList, function (coords) {
-        return _.map(coords, function (coord, i) {
+    return coordsList.map(function (coords) {
+        return coords.map(function (coord, i) {
             const range: Range = props.range[i];
             if (noSnap) {
                 return range[0] + (range[1] - range[0]) * coord;
@@ -558,15 +555,19 @@ function getSegmentEquationString(props: Props): string {
     }
 
     const segments = getSegmentCoords(props.userInput, props);
-    return _.map(segments, function (segment) {
-        return (
-            "[" +
-            _.map(segment, function (coord) {
-                return "(" + coord.join(", ") + ")";
-            }).join(" ") +
-            "]"
-        );
-    }).join(" ");
+    return segments
+        .map(function (segment) {
+            return (
+                "[" +
+                segment
+                    .map(function (coord) {
+                        return "(" + coord.join(", ") + ")";
+                    })
+                    .join(" ") +
+                "]"
+            );
+        })
+        .join(" ");
 }
 
 function getRayEquationString(props: Props): string {
@@ -597,9 +598,11 @@ function getPolygonEquationString(props: Props): string {
         throw makeInvalidTypeError("getPolygonEquationString", "polygon");
     }
     const coords = getPolygonCoords(props.userInput, props);
-    return _.map(coords, function (coord) {
-        return "(" + coord.join(", ") + ")";
-    }).join(" ");
+    return coords
+        .map(function (coord) {
+            return "(" + coord.join(", ") + ")";
+        })
+        .join(" ");
 }
 
 function getAngleEquationString(props: Props): string {

--- a/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/reducer/interactive-graph-reducer.ts
@@ -1571,17 +1571,14 @@ export function calculateSideSnap(
     const rel = (j): number => {
         return (index + j + coords.length) % coords.length;
     };
-    const sides = _.map(
-        [
-            [coords[rel(-1)], boundedDestinationPoint],
-            [boundedDestinationPoint, coords[rel(1)]],
-            [coords[rel(-1)], coords[rel(1)]],
-        ],
-        function (coords) {
-            // @ts-expect-error - TS2345 - Argument of type 'number[]' is not assignable to parameter of type 'readonly Coord[]'. | TS2556 - A spread argument must either have a tuple type or be passed to a rest parameter.
-            return magnitude(vector(...coords));
-        },
-    );
+    const sides = [
+        [coords[rel(-1)], boundedDestinationPoint],
+        [boundedDestinationPoint, coords[rel(1)]],
+        [coords[rel(-1)], coords[rel(1)]],
+    ].map(function (coords) {
+        // @ts-expect-error - TS2345 - Argument of type 'number[]' is not assignable to parameter of type 'readonly Coord[]'. | TS2556 - A spread argument must either have a tuple type or be passed to a rest parameter.
+        return magnitude(vector(...coords));
+    });
 
     // Round the sides to left and right of the current point
     _.each([0, 1], function (j) {

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -241,7 +241,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 (plotDimensions[1] - (padTop + padBottom)) / c.dimY,
             ];
         } else {
-            c.scale = _.map([c.dimX, c.dimY], function (dim, i) {
+            c.scale = [c.dimX, c.dimY].map(function (dim, i) {
                 return plotDimensions[i] / dim;
             });
         }


### PR DESCRIPTION
## Summary:

I asked the LLM to convert simple, low-risk uses of `_.map` to `Array.map`. This is the result.

Sorry this is long, it's basically just doing a sophisticated find-and-replace though. If you select "Hide whitespace" in the review settings it's much, much shorter.