### PR TITLE
docs(changeset): Inclusion of new dnd-kit dependency for upcoming widgets

### DIFF
--- a/.changeset/shaggy-hats-find.md
+++ b/.changeset/shaggy-hats-find.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": major
+---
+
+Inclusion of new dnd-kit dependency for upcoming widgets

--- a/.changeset/shaggy-hats-find.md
+++ b/.changeset/shaggy-hats-find.md
@@ -1,5 +1,5 @@
 ---
-"@khanacademy/perseus": major
+"@khanacademy/perseus": minor
 ---
 
-Inclusion of new dnd-kit dependency for upcoming widgets
+Inclusion of new dnd-kit dependency for upcoming widgets.

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -50,6 +50,7 @@
         "@khanacademy/perseus-utils": "workspace:*",
         "@khanacademy/pure-markdown": "workspace:*",
         "@khanacademy/simple-markdown": "workspace:*",
+        "@dnd-kit/react": "^0.5.0",
         "@use-gesture/react": "^10.2.27",
         "gifuct-js": "^2.1.2",
         "mafs": "0.19.0",

--- a/packages/perseus/src/__docs__/dnd-kit-demo.stories.tsx
+++ b/packages/perseus/src/__docs__/dnd-kit-demo.stories.tsx
@@ -1,0 +1,170 @@
+import {View} from "@khanacademy/wonder-blocks-core";
+import {BodyText, Heading} from "@khanacademy/wonder-blocks-typography";
+import {
+    DragDropProvider,
+    useDraggable,
+    useDroppable,
+} from "@dnd-kit/react";
+import {StyleSheet, css} from "aphrodite";
+import * as React from "react";
+
+import {
+    border,
+    semanticColor,
+    sizing,
+} from "@khanacademy/wonder-blocks-tokens";
+
+import type {DragEndEvent} from "@dnd-kit/react";
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+/**
+ * A minimal smoke-test of the `@dnd-kit/react` API. It wires up a
+ * `DragDropProvider` around a couple of droppable columns and some draggable
+ * cards so we exercise `useDraggable` / `useDroppable` and confirm the library
+ * is installed and behaves. This is a demo/dev utility rather than a shipping
+ * widget, so it's tagged `!manifest`.
+ */
+
+type ColumnId = "todo" | "done";
+
+const COLUMN_TITLES: Record<ColumnId, string> = {
+    todo: "To do",
+    done: "Done",
+};
+
+const CARD_LABELS: Record<string, string> = {
+    "card-1": "Write the parser",
+    "card-2": "Score the answer",
+    "card-3": "Ship the widget",
+};
+
+// A draggable card. We use a native <button> because it is focusable and
+// keyboard-operable by default, which lets dnd-kit's keyboard sensor drive it
+// without us adding any custom key handlers.
+function Card({id}: {id: string}) {
+    const {ref, isDragging} = useDraggable({id});
+
+    return (
+        <button
+            ref={ref}
+            type="button"
+            className={css(styles.card, isDragging && styles.cardDragging)}
+        >
+            {CARD_LABELS[id]}
+        </button>
+    );
+}
+
+// A droppable column. `isDropTarget` lets us highlight the column the pointer
+// is currently over during a drag.
+function Column({id, cardIds}: {id: ColumnId; cardIds: readonly string[]}) {
+    const {ref, isDropTarget} = useDroppable({id});
+
+    return (
+        <View
+            // A labelled region groups the cards it contains.
+            tag="section"
+            aria-label={COLUMN_TITLES[id]}
+            ref={ref}
+            style={[styles.column, isDropTarget && styles.columnActive]}
+        >
+            <Heading size="small" tag="h3">
+                {COLUMN_TITLES[id]}
+            </Heading>
+            {cardIds.length === 0 ? (
+                <BodyText size="small" style={styles.empty}>
+                    Drop a card here
+                </BodyText>
+            ) : (
+                cardIds.map((cardId) => <Card key={cardId} id={cardId} />)
+            )}
+        </View>
+    );
+}
+
+function DndKitDemo() {
+    const [columns, setColumns] = React.useState<Record<ColumnId, string[]>>({
+        todo: ["card-1", "card-2", "card-3"],
+        done: [],
+    });
+
+    const handleDragEnd = (event: DragEndEvent) => {
+        const {source, target} = event.operation;
+        if (source == null || target == null) {
+            return;
+        }
+
+        const cardId = String(source.id);
+        const destination = target.id as ColumnId;
+
+        setColumns((prev) => {
+            // Remove the card from whichever column currently holds it, then
+            // append it to the column it was dropped on.
+            const next: Record<ColumnId, string[]> = {
+                todo: prev.todo.filter((c) => c !== cardId),
+                done: prev.done.filter((c) => c !== cardId),
+            };
+            next[destination] = [...next[destination], cardId];
+            return next;
+        });
+    };
+
+    return (
+        <DragDropProvider onDragEnd={handleDragEnd}>
+            <View style={styles.board}>
+                <Column id="todo" cardIds={columns.todo} />
+                <Column id="done" cardIds={columns.done} />
+            </View>
+        </DragDropProvider>
+    );
+}
+
+const styles = StyleSheet.create({
+    board: {
+        flexDirection: "row",
+        gap: sizing.size_160,
+        alignItems: "flex-start",
+    },
+    column: {
+        gap: sizing.size_120,
+        padding: sizing.size_160,
+        minInlineSize: sizing.size_960,
+        borderRadius: border.radius.radius_040,
+        border: `${border.width.thin} dashed ${semanticColor.core.border.neutral.default}`,
+        backgroundColor: semanticColor.core.background.instructive.subtle,
+    },
+    columnActive: {
+        borderStyle: "solid",
+        borderColor: semanticColor.core.border.instructive.default,
+        backgroundColor: semanticColor.core.background.instructive.default,
+    },
+    empty: {
+        color: semanticColor.core.foreground.neutral.subtle,
+    },
+    card: {
+        textAlign: "start",
+        padding: sizing.size_120,
+        borderRadius: border.radius.radius_040,
+        border: `${border.width.thin} solid ${semanticColor.core.border.neutral.default}`,
+        backgroundColor: semanticColor.core.background.base.default,
+        color: semanticColor.core.foreground.neutral.strong,
+        cursor: "grab",
+    },
+    cardDragging: {
+        cursor: "grabbing",
+        opacity: 0.5,
+    },
+});
+
+const meta: Meta<typeof DndKitDemo> = {
+    title: "Playground/dnd-kit Demo",
+    component: DndKitDemo,
+    // Demo/dev utility — keep it out of the component manifest.
+    tags: ["!manifest"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DndKitDemo>;
+
+export const Default: Story = {};

--- a/packages/perseus/src/__docs__/dnd-kit-demo.stories.tsx
+++ b/packages/perseus/src/__docs__/dnd-kit-demo.stories.tsx
@@ -1,165 +1,75 @@
+import {DragDropProvider, useDraggable, useDroppable} from "@dnd-kit/react";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {BodyText, Heading} from "@khanacademy/wonder-blocks-typography";
-import {
-    DragDropProvider,
-    useDraggable,
-    useDroppable,
-} from "@dnd-kit/react";
-import {StyleSheet, css} from "aphrodite";
+import {border, semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import {StyleSheet} from "aphrodite";
 import * as React from "react";
-
-import {
-    border,
-    semanticColor,
-    sizing,
-} from "@khanacademy/wonder-blocks-tokens";
 
 import type {DragEndEvent} from "@dnd-kit/react";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 /**
- * A minimal smoke-test of the `@dnd-kit/react` API. It wires up a
- * `DragDropProvider` around a couple of droppable columns and some draggable
- * cards so we exercise `useDraggable` / `useDroppable` and confirm the library
- * is installed and behaves. This is a demo/dev utility rather than a shipping
- * widget, so it's tagged `!manifest`.
+ * This is a temporary example storybook demo of the new dnd-kit-react
+ * library, in order to appease knip. We can clean this up
+ * after we have real implementations of the library.
+ *
+ * TODO (LEMS-4369): Clean-up/remove this file
  */
 
-type ColumnId = "todo" | "done";
-
-const COLUMN_TITLES: Record<ColumnId, string> = {
-    todo: "To do",
-    done: "Done",
-};
-
-const CARD_LABELS: Record<string, string> = {
-    "card-1": "Write the parser",
-    "card-2": "Score the answer",
-    "card-3": "Ship the widget",
-};
-
-// A draggable card. We use a native <button> because it is focusable and
-// keyboard-operable by default, which lets dnd-kit's keyboard sensor drive it
-// without us adding any custom key handlers.
-function Card({id}: {id: string}) {
-    const {ref, isDragging} = useDraggable({id});
-
+function DraggableChip() {
+    const {ref} = useDraggable({id: "chip"});
     return (
-        <button
-            ref={ref}
-            type="button"
-            className={css(styles.card, isDragging && styles.cardDragging)}
-        >
-            {CARD_LABELS[id]}
+        <button ref={ref} type="button">
+            Drag me
         </button>
     );
 }
 
-// A droppable column. `isDropTarget` lets us highlight the column the pointer
-// is currently over during a drag.
-function Column({id, cardIds}: {id: ColumnId; cardIds: readonly string[]}) {
-    const {ref, isDropTarget} = useDroppable({id});
-
+function DropZone({children}: {children: React.ReactNode}) {
+    const {ref, isDropTarget} = useDroppable({id: "zone"});
     return (
         <View
-            // A labelled region groups the cards it contains.
             tag="section"
-            aria-label={COLUMN_TITLES[id]}
+            aria-label="Drop zone"
             ref={ref}
-            style={[styles.column, isDropTarget && styles.columnActive]}
+            style={[styles.zone, isDropTarget && styles.zoneActive]}
         >
-            <Heading size="small" tag="h3">
-                {COLUMN_TITLES[id]}
-            </Heading>
-            {cardIds.length === 0 ? (
-                <BodyText size="small" style={styles.empty}>
-                    Drop a card here
-                </BodyText>
-            ) : (
-                cardIds.map((cardId) => <Card key={cardId} id={cardId} />)
-            )}
+            {children}
         </View>
     );
 }
 
 function DndKitDemo() {
-    const [columns, setColumns] = React.useState<Record<ColumnId, string[]>>({
-        todo: ["card-1", "card-2", "card-3"],
-        done: [],
-    });
-
-    const handleDragEnd = (event: DragEndEvent) => {
-        const {source, target} = event.operation;
-        if (source == null || target == null) {
-            return;
-        }
-
-        const cardId = String(source.id);
-        const destination = target.id as ColumnId;
-
-        setColumns((prev) => {
-            // Remove the card from whichever column currently holds it, then
-            // append it to the column it was dropped on.
-            const next: Record<ColumnId, string[]> = {
-                todo: prev.todo.filter((c) => c !== cardId),
-                done: prev.done.filter((c) => c !== cardId),
-            };
-            next[destination] = [...next[destination], cardId];
-            return next;
-        });
-    };
-
+    const [dropped, setDropped] = React.useState(false);
     return (
-        <DragDropProvider onDragEnd={handleDragEnd}>
-            <View style={styles.board}>
-                <Column id="todo" cardIds={columns.todo} />
-                <Column id="done" cardIds={columns.done} />
-            </View>
+        <DragDropProvider
+            onDragEnd={({operation}: DragEndEvent) =>
+                setDropped(operation.target != null)
+            }
+        >
+            {!dropped && <DraggableChip />}
+            <DropZone>{dropped ? <DraggableChip /> : "Drop here"}</DropZone>
         </DragDropProvider>
     );
 }
 
 const styles = StyleSheet.create({
-    board: {
-        flexDirection: "row",
-        gap: sizing.size_160,
-        alignItems: "flex-start",
+    zone: {
+        marginBlockStart: sizing.size_160,
+        padding: sizing.size_320,
+        borderWidth: border.width.thin,
+        borderStyle: "dashed",
+        borderColor: semanticColor.core.border.neutral.default,
     },
-    column: {
-        gap: sizing.size_120,
-        padding: sizing.size_160,
-        minInlineSize: sizing.size_960,
-        borderRadius: border.radius.radius_040,
-        border: `${border.width.thin} dashed ${semanticColor.core.border.neutral.default}`,
-        backgroundColor: semanticColor.core.background.instructive.subtle,
-    },
-    columnActive: {
+    zoneActive: {
         borderStyle: "solid",
         borderColor: semanticColor.core.border.instructive.default,
-        backgroundColor: semanticColor.core.background.instructive.default,
-    },
-    empty: {
-        color: semanticColor.core.foreground.neutral.subtle,
-    },
-    card: {
-        textAlign: "start",
-        padding: sizing.size_120,
-        borderRadius: border.radius.radius_040,
-        border: `${border.width.thin} solid ${semanticColor.core.border.neutral.default}`,
-        backgroundColor: semanticColor.core.background.base.default,
-        color: semanticColor.core.foreground.neutral.strong,
-        cursor: "grab",
-    },
-    cardDragging: {
-        cursor: "grabbing",
-        opacity: 0.5,
+        backgroundColor: semanticColor.core.background.instructive.subtle,
     },
 });
 
 const meta: Meta<typeof DndKitDemo> = {
     title: "Playground/dnd-kit Demo",
     component: DndKitDemo,
-    // Demo/dev utility — keep it out of the component manifest.
     tags: ["!manifest"],
 };
 

--- a/packages/perseus/src/__docs__/dnd-kit-demo.stories.tsx
+++ b/packages/perseus/src/__docs__/dnd-kit-demo.stories.tsx
@@ -10,7 +10,7 @@ import type {Meta, StoryObj} from "@storybook/react-vite";
 /**
  * This is a temporary example storybook demo of the new dnd-kit-react
  * library, in order to appease knip. We can clean this up
- * after we have real implementations of the library.
+ * after we have real implementations of the dnd-kit library.
  *
  * TODO (LEMS-4369): Clean-up/remove this file
  */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,6 +576,9 @@ importers:
 
   packages/perseus:
     dependencies:
+      '@dnd-kit/react':
+        specifier: ^0.5.0
+        version: 0.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/kas':
         specifier: workspace:*
         version: link:../kas
@@ -1812,6 +1815,27 @@ packages:
   '@cypress/xvfb@1.2.4':
     resolution: {integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==}
 
+  '@dnd-kit/abstract@0.5.0':
+    resolution: {integrity: sha512-hi13iMJgjPX/KDYVKg5VeDIhmYiV6buc9bAX+tCLYf4QdyYjPbsXjn2sPo6m7fQ6SGJBEFgHJ2PemeKDUbwBaA==}
+
+  '@dnd-kit/collision@0.5.0':
+    resolution: {integrity: sha512-xUqRn3lS7oqLkT0AnnHS/STh/Czvwe1UapZFYiLbsUGxopMsQd4teaPCzPouOThoMdGEe+dHWjfqJl6t9iG4mQ==}
+
+  '@dnd-kit/dom@0.5.0':
+    resolution: {integrity: sha512-f2xFJp5SYQ8EW/Fbtaa8iBb66hpkWc7qa8vU826KW11/tb44sH+AisZnGtwOOTWTQ0GraqBDr5ixTErww+eKXw==}
+
+  '@dnd-kit/geometry@0.5.0':
+    resolution: {integrity: sha512-ubHQS1CiSDH8ssYH2xG5BnpwPSFP1tStXXjug7/Ba6qnQdu/EUH47l6QXKIksQnnanfVfDf0aGeevRxgZlj28A==}
+
+  '@dnd-kit/react@0.5.0':
+    resolution: {integrity: sha512-abQPLI8lmfVE+v/n+pqy5WFxrw6T2Yg0UQZsL78dp5DKci7dKTVDjvLWqvass+XTFtzJmsZEjk1NdqE6xG8Jiw==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@dnd-kit/state@0.5.0':
+    resolution: {integrity: sha512-y7XbabQqjF58Lk8YmDQuR8l6QjN+Kh4qlGEjUvHuIeasLk1QP+9L5diXS98VMxQIivyMmUtX2//f+3N7qPJX4w==}
+
   '@emnapi/core@1.4.0':
     resolution: {integrity: sha512-H+N/FqT07NmLmt6OFFtDfwe8PNygprzBikrEMyQfgqSmT0vzE515Pz7R8izwB9q/zsH/MA64AKoul3sA6/CzVg==}
 
@@ -2840,6 +2864,9 @@ packages:
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+
+  '@preact/signals-core@1.14.4':
+    resolution: {integrity: sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==}
 
   '@remix-run/router@1.23.0':
     resolution: {integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==}
@@ -10702,6 +10729,45 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@dnd-kit/abstract@0.5.0':
+    dependencies:
+      '@dnd-kit/geometry': 0.5.0
+      '@dnd-kit/state': 0.5.0
+      tslib: 2.8.1
+
+  '@dnd-kit/collision@0.5.0':
+    dependencies:
+      '@dnd-kit/abstract': 0.5.0
+      '@dnd-kit/geometry': 0.5.0
+      tslib: 2.8.1
+
+  '@dnd-kit/dom@0.5.0':
+    dependencies:
+      '@dnd-kit/abstract': 0.5.0
+      '@dnd-kit/collision': 0.5.0
+      '@dnd-kit/geometry': 0.5.0
+      '@dnd-kit/state': 0.5.0
+      tslib: 2.8.1
+
+  '@dnd-kit/geometry@0.5.0':
+    dependencies:
+      '@dnd-kit/state': 0.5.0
+      tslib: 2.8.1
+
+  '@dnd-kit/react@0.5.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@dnd-kit/abstract': 0.5.0
+      '@dnd-kit/dom': 0.5.0
+      '@dnd-kit/state': 0.5.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      tslib: 2.8.1
+
+  '@dnd-kit/state@0.5.0':
+    dependencies:
+      '@preact/signals-core': 1.14.4
+      tslib: 2.8.1
+
   '@emnapi/core@1.4.0':
     dependencies:
       '@emnapi/wasi-threads': 1.0.1
@@ -12020,6 +12086,8 @@ snapshots:
   '@popperjs/core@2.10.2': {}
 
   '@popperjs/core@2.11.8': {}
+
+  '@preact/signals-core@1.14.4': {}
 
   '@remix-run/router@1.23.0': {}
 


### PR DESCRIPTION
## Summary:
This PR adds dnd-kit-react as a dependency for our upcoming DnD Widgets. There's a temporary inclusion of a generic storybook demo, just to help avoid any issues with knip. 

We'll start integrating dnd-kit-react in future PRs, at which point we can cleanup the storybook demo. I've added a comment to cleanup this storybook demo as part of LEMS-4369.

Issue: LEMS-4320

## Test plan:
- Tests Pass