### PR TITLE
Remove unused serialize methods

### DIFF
--- a/.changeset/modern-crews-like.md
+++ b/.changeset/modern-crews-like.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Remove unused `serialize` methods

--- a/packages/perseus-editor/src/widgets/cs-program-editor.tsx
+++ b/packages/perseus-editor/src/widgets/cs-program-editor.tsx
@@ -46,10 +46,6 @@ class PairEditor extends React.Component<any> {
         return Changeable.change.apply(this, args);
     };
 
-    serialize = () => {
-        return EditorJsonify.serialize.call(this);
-    };
-
     render(): React.ReactNode {
         return (
             <fieldset className="pair-editor">
@@ -101,10 +97,6 @@ class PairsEditor extends React.Component<any> {
             pairs.push({name: "", value: ""});
         }
         this.change("pairs", pairs);
-    };
-
-    serialize = () => {
-        return EditorJsonify.serialize.call(this);
     };
 
     render(): React.ReactNode {

--- a/packages/perseus-editor/src/widgets/iframe-editor.tsx
+++ b/packages/perseus-editor/src/widgets/iframe-editor.tsx
@@ -34,10 +34,6 @@ class PairEditor extends React.Component<PairEditorProps> {
         return Changeable.change.apply(this, args);
     };
 
-    serialize = () => {
-        return EditorJsonify.serialize.call(this);
-    };
-
     render(): React.ReactNode {
         return (
             <fieldset>
@@ -90,10 +86,6 @@ class PairsEditor extends React.Component<PairsEditorProps> {
             pairs.push({name: "", value: ""});
         }
         this.change("pairs", pairs);
-    };
-
-    serialize = () => {
-        return EditorJsonify.serialize.call(this);
     };
 
     render(): React.ReactNode {

--- a/packages/perseus-editor/src/widgets/interaction-editor/function-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/function-editor.tsx
@@ -2,7 +2,6 @@ import {
     components,
     Changeable,
     Dependencies,
-    EditorJsonify,
     KhanColors,
 } from "@khanacademy/perseus";
 import * as React from "react";
@@ -44,10 +43,6 @@ class FunctionEditor extends React.Component<Props> {
 
     change: (arg1: any, arg2?: any, arg3?: any) => any = (...args) => {
         return Changeable.change.apply(this, args);
-    };
-
-    serialize = () => {
-        return EditorJsonify.serialize.call(this);
     };
 
     render(): React.ReactNode {

--- a/packages/perseus-editor/src/widgets/interaction-editor/label-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/label-editor.tsx
@@ -2,7 +2,6 @@ import {
     components,
     Changeable,
     Dependencies,
-    EditorJsonify,
     KhanColors,
 } from "@khanacademy/perseus";
 import * as React from "react";
@@ -37,10 +36,6 @@ class LabelEditor extends React.Component<Props> {
 
     change: (arg1: any, arg2?: any, arg3?: any) => any = (...args) => {
         return Changeable.change.apply(this, args);
-    };
-
-    serialize = () => {
-        return EditorJsonify.serialize.call(this);
     };
 
     render(): React.ReactNode {

--- a/packages/perseus-editor/src/widgets/interaction-editor/line-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/line-editor.tsx
@@ -2,7 +2,6 @@ import {
     components,
     Changeable,
     Dependencies,
-    EditorJsonify,
     KhanColors,
 } from "@khanacademy/perseus";
 import * as React from "react";
@@ -51,10 +50,6 @@ class LineEditor extends React.Component<Props> {
 
     change: (arg1: any, arg2?: any, arg3?: any) => any = (...args) => {
         return Changeable.change.apply(this, args);
-    };
-
-    serialize = () => {
-        return EditorJsonify.serialize.call(this);
     };
 
     render(): React.ReactNode {

--- a/packages/perseus-editor/src/widgets/interaction-editor/movable-line-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/movable-line-editor.tsx
@@ -1,9 +1,4 @@
-import {
-    components,
-    Changeable,
-    Dependencies,
-    EditorJsonify,
-} from "@khanacademy/perseus";
+import {components, Changeable, Dependencies} from "@khanacademy/perseus";
 import * as React from "react";
 
 import ConstraintEditor from "./constraint-editor";
@@ -54,10 +49,6 @@ class MovableLineEditor extends React.Component<Props> {
 
     change: ChangeFn = (...args) => {
         return Changeable.change.apply(this, args);
-    };
-
-    serialize = () => {
-        return EditorJsonify.serialize.call(this);
     };
 
     render(): React.ReactNode {

--- a/packages/perseus-editor/src/widgets/interaction-editor/movable-point-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/movable-point-editor.tsx
@@ -1,9 +1,4 @@
-import {
-    components,
-    Changeable,
-    Dependencies,
-    EditorJsonify,
-} from "@khanacademy/perseus";
+import {components, Changeable, Dependencies} from "@khanacademy/perseus";
 import * as React from "react";
 
 import ConstraintEditor from "./constraint-editor";
@@ -47,10 +42,6 @@ class MovablePointEditor extends React.Component<Props> {
 
     change: ChangeFn = (...args) => {
         return Changeable.change.apply(this, args);
-    };
-
-    serialize = () => {
-        return EditorJsonify.serialize.call(this);
     };
 
     render(): React.ReactNode {

--- a/packages/perseus-editor/src/widgets/interaction-editor/parametric-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/parametric-editor.tsx
@@ -2,7 +2,6 @@ import {
     components,
     Changeable,
     Dependencies,
-    EditorJsonify,
     KhanColors,
 } from "@khanacademy/perseus";
 import * as React from "react";
@@ -47,10 +46,6 @@ class ParametricEditor extends React.Component<Props> {
 
     change: (arg1: any, arg2?: any, arg3?: any) => any = (...args) => {
         return Changeable.change.apply(this, args);
-    };
-
-    serialize = () => {
-        return EditorJsonify.serialize.call(this);
     };
 
     render(): React.ReactNode {

--- a/packages/perseus-editor/src/widgets/interaction-editor/point-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/point-editor.tsx
@@ -1,9 +1,4 @@
-import {
-    Changeable,
-    Dependencies,
-    EditorJsonify,
-    KhanColors,
-} from "@khanacademy/perseus";
+import {Changeable, Dependencies, KhanColors} from "@khanacademy/perseus";
 import * as React from "react";
 
 import ColorPicker from "./color-picker";
@@ -31,10 +26,6 @@ class PointEditor extends React.Component<Props> {
 
     change: (arg1: any, arg2?: any, arg3?: any) => any = (...args) => {
         return Changeable.change.apply(this, args);
-    };
-
-    serialize = () => {
-        return EditorJsonify.serialize.call(this);
     };
 
     render(): React.ReactNode {

--- a/packages/perseus-editor/src/widgets/interaction-editor/rectangle-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/rectangle-editor.tsx
@@ -1,9 +1,4 @@
-import {
-    Changeable,
-    Dependencies,
-    EditorJsonify,
-    KhanColors,
-} from "@khanacademy/perseus";
+import {Changeable, Dependencies, KhanColors} from "@khanacademy/perseus";
 import * as React from "react";
 
 import ColorPicker from "./color-picker";
@@ -37,10 +32,6 @@ class RectangleEditor extends React.Component<Props> {
 
     change: (arg1: any, arg2?: any, arg3?: any) => any = (...args) => {
         return Changeable.change.apply(this, args);
-    };
-
-    serialize = () => {
-        return EditorJsonify.serialize.call(this);
     };
 
     render(): React.ReactNode {


### PR DESCRIPTION
## Summary:

I was looking at uses of `EditorJsonify` since it's deprecated and the LLM mentioned that these uses are dead code. It claimed this is supported by two things:

1. These widgets don't have anything referencing them directly, so there's nothing to call the method
2. The functionality is redundant because of `Changeable`

It's also fairly low-risk - it's the editing experience for:

- CSProgram
- IFrame
- Interaction

---

From the LLM:

> Remove 12 unreachable serialize() methods from nested widget editors
>
> Clears the subset of deprecated EditorJsonify uses (LEMS-4108) that needs no replacement, because nothing can call it. 56 lines, no behavior change.
>
> - 8 sub-editors under interaction-editor/: method + now-unused import.
> - PairEditor/PairsEditor in iframe-editor.tsx and cs-program-editor.tsx: method only; each file's top-level editor still uses the mixin.
>
> Why it's safe. serialize() is only invoked via a ref, and exactly one component per widget gets one — WidgetEditor refs whatever Widgets.getEditor(type) returns (widget-editor.tsx:158). All 12 are private nested components: not in the registry, not exported, no ref=/this.refs pointing at them, no test or story callers. They also don't need one — Changeable.change already pushes their props up on every edit (changeable.ts:46).