### PR TITLE
Migrate label-image widget to WidgetPropsV2

### DIFF
--- a/.changeset/olive-pans-invite.md
+++ b/.changeset/olive-pans-invite.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Migrate the label-image widget to group all `options` under a separate prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -518,7 +518,7 @@ review and commit the changes.
 Migrate these **one at a time**, stopping after each step for the user to
 review and commit the changes.
 
-- [ ] Migrate `label-image` to `WidgetPropsV2` (delete `satisfies PropsFor`
+- [x] Migrate `label-image` to `WidgetPropsV2` (delete `satisfies PropsFor`
       assertion).
 - [ ] Migrate `interactive-graph` to `WidgetPropsV2` (delete `satisfies PropsFor`
       assertion and update `interactive-graph-editor` preview; subtype lookup already

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -34,4 +34,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "grapher",
     "table",
     "expression",
+    "label-image",
 ];

--- a/packages/perseus/src/widget-ai-utils/label-image/label-image-ai-utils.test.ts
+++ b/packages/perseus/src/widget-ai-utils/label-image/label-image-ai-utils.test.ts
@@ -105,37 +105,39 @@ describe("LabelImage AI utils", () => {
         };
 
         const widgetData: any = {
-            markers: [
-                {
-                    answers: ["SUVs"],
-                    label: "The fourth unlabeled bar line.",
-                    x: 25,
-                    y: 17.7,
-                },
-                {
-                    answers: ["Trucks"],
-                    label: "The third unlabeled bar line.",
-                    x: 25,
-                    y: 35.3,
-                },
-                {
-                    answers: ["Cars"],
-                    label: "The second unlabeled bar line.",
-                    x: 25,
-                    y: 53,
-                },
-                {
-                    answers: ["Vans"],
-                    label: "The first unlabeled bar line.",
-                    x: 25,
-                    y: 70.3,
-                },
-            ],
-            choices: ["Trucks", "Vans", "Cars", "SUVs"],
-            imageUrl:
-                "web+graphie://ka-perseus-graphie.s3.amazonaws.com/56c60c72e96cd353e4a8b5434506cd3a21e717af",
-            imageAlt:
-                "A bar graph with four bar lines that shows the horizontal axis labeled Number in the parking lot and the vertical axis labeled Vehicle Type. The horizontal axis is labeled, from left to right: 0, 10, 20, 30, 40, and 50. The vertical axis has, from the bottom to the top, four unlabeled bar lines as follows: the first unlabeled bar line extends to the middle of 0 and 10, the second unlabeled bar line extends to 40, the third unlabeled bar line extends to the middle of 20 and 30, and fourth unlabeled bar line extends to 10.",
+            options: {
+                markers: [
+                    {
+                        answers: ["SUVs"],
+                        label: "The fourth unlabeled bar line.",
+                        x: 25,
+                        y: 17.7,
+                    },
+                    {
+                        answers: ["Trucks"],
+                        label: "The third unlabeled bar line.",
+                        x: 25,
+                        y: 35.3,
+                    },
+                    {
+                        answers: ["Cars"],
+                        label: "The second unlabeled bar line.",
+                        x: 25,
+                        y: 53,
+                    },
+                    {
+                        answers: ["Vans"],
+                        label: "The first unlabeled bar line.",
+                        x: 25,
+                        y: 70.3,
+                    },
+                ],
+                choices: ["Trucks", "Vans", "Cars", "SUVs"],
+                imageUrl:
+                    "web+graphie://ka-perseus-graphie.s3.amazonaws.com/56c60c72e96cd353e4a8b5434506cd3a21e717af",
+                imageAlt:
+                    "A bar graph with four bar lines that shows the horizontal axis labeled Number in the parking lot and the vertical axis labeled Vehicle Type. The horizontal axis is labeled, from left to right: 0, 10, 20, 30, 40, and 50. The vertical axis has, from the bottom to the top, four unlabeled bar lines as follows: the first unlabeled bar line extends to the middle of 0 and 10, the second unlabeled bar line extends to 40, the third unlabeled bar line extends to the middle of 20 and 30, and fourth unlabeled bar line extends to 10.",
+            },
             userInput,
         };
 

--- a/packages/perseus/src/widget-ai-utils/label-image/label-image-ai-utils.ts
+++ b/packages/perseus/src/widget-ai-utils/label-image/label-image-ai-utils.ts
@@ -99,7 +99,7 @@ export type LabelImagePromptJSON = {
 export const getPromptJSON = (
     widgetData: React.ComponentProps<typeof labelImage.widget>,
 ): LabelImagePromptJSON => {
-    const propMarkers = widgetData.markers.map((marker) => {
+    const propMarkers = widgetData.options.markers.map((marker) => {
         const userInputMarker: UserInputMarker = {
             label: marker.label,
         };
@@ -119,9 +119,9 @@ export const getPromptJSON = (
     return {
         type: "label-image",
         options: {
-            choices: widgetData.choices,
-            imageUrl: widgetData.imageUrl,
-            imageAlt: widgetData.imageAlt,
+            choices: widgetData.options.choices,
+            imageUrl: widgetData.options.imageUrl,
+            imageAlt: widgetData.options.imageAlt,
             markers: propMarkers,
         },
         userInput: {

--- a/packages/perseus/src/widgets/label-image/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image/label-image.tsx
@@ -699,11 +699,11 @@ export class LabelImage
      * [LEMS-3185] do not trust serializedState
      */
     getSerializedState(): any {
-        const {userInput, options, ...rest} = this.props;
-        const {markers, ...optionsRest} = options;
+        const {userInput, options, ...restOfProps} = this.props;
+        const {markers, ...restOfOptions} = options;
         return {
-            ...optionsRest,
-            ...rest,
+            ...restOfOptions,
+            ...restOfProps,
             markers: markers.map((marker, index) => ({
                 ...marker,
                 selected: userInput.markers[index].selected,

--- a/packages/perseus/src/widgets/label-image/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image/label-image.tsx
@@ -29,7 +29,7 @@ import {HideAnswersToggle} from "./hide-answers-toggle";
 import Marker from "./marker";
 
 import type {DependencyProps} from "../../dependencies";
-import type {Widget, WidgetExports, WidgetProps} from "../../types";
+import type {Widget, WidgetExports, WidgetPropsV2} from "../../types";
 import type {LabelImagePromptJSON} from "../../widget-ai-utils/label-image/label-image-ai-utils";
 import type {
     InteractiveMarkerType,
@@ -78,13 +78,16 @@ export type OptionalAnswersMarkerType = Omit<
 type Options = Omit<PerseusLabelImageWidgetOptions, "markers"> & {
     // The list of label markers on the question image.
     markers: ReadonlyArray<OptionalAnswersMarkerType>;
+    // Preferred placement for the popover (a preference, not a guarantee).
+    // The editor offers a control for this, but it is absent from
+    // PerseusLabelImageWidgetOptions and from parseLabelImageWidget, so the
+    // parser drops it from persisted content — only unparsed callers (e.g.
+    // Storybook) ever supply it.
+    preferredPopoverDirection?: PreferredPopoverDirection;
 };
 
-type Props = WidgetProps<Options, PerseusLabelImageUserInput> & {
+type Props = WidgetPropsV2<Options, PerseusLabelImageUserInput> & {
     analytics: DependencyProps["analytics"];
-    // preferred placement for popover (preference, not MUST)
-    // NOTE: this is sus, probably never passed in
-    preferredPopoverDirection?: PreferredPopoverDirection;
 };
 
 type LabelImageState = {
@@ -416,7 +419,7 @@ export class LabelImage
     }
 
     handleMarkerKeyDown(index: number, e: React.KeyboardEvent) {
-        const {markers} = this.props;
+        const {markers} = this.props.options;
 
         // One is the loneliest number.
         if (markers.length < 2) {
@@ -460,7 +463,7 @@ export class LabelImage
         index: number,
         selection: ReadonlyArray<boolean>,
     ) {
-        const {choices, markers} = this.props;
+        const {choices, markers} = this.props.options;
 
         // Compile the user selected answer choices.
         const selected = choices.filter((_, index) => selection[index]);
@@ -472,7 +475,9 @@ export class LabelImage
     }
 
     renderMarkers(): ReadonlyArray<React.ReactNode> {
-        const {markers, preferredPopoverDirection, userInput} = this.props;
+        const {markers, preferredPopoverDirection, choices, multipleAnswers} =
+            this.props.options;
+        const {userInput} = this.props;
         const {markersInteracted, activeMarkerIndex} = this.state;
 
         // Determine whether page is rendered in a narrow browser window.
@@ -482,7 +487,8 @@ export class LabelImage
                 .matches;
 
         // Determine whether the image is wider than it is tall.
-        const isWideImage = this.props.imageWidth / 2 > this.props.imageHeight;
+        const isWideImage =
+            this.props.options.imageWidth / 2 > this.props.options.imageHeight;
 
         // Render all markers for widget.
         return markers.map((marker, index): React.ReactElement => {
@@ -578,7 +584,7 @@ export class LabelImage
                 >
                     <AnswerChoices
                         key={`answers-${marker.x}.${marker.y}`}
-                        choices={this.props.choices.map((choice) => ({
+                        choices={choices.map((choice) => ({
                             content: choice,
                             checked: computedSelectedState.selected
                                 ? computedSelectedState.selected.includes(
@@ -586,7 +592,7 @@ export class LabelImage
                                   )
                                 : false,
                         }))}
-                        multipleSelect={this.props.multipleAnswers}
+                        multipleSelect={multipleAnswers}
                         onChange={(selection) => {
                             // TODO(LEMS-2829): Remove analytics event in LEMS-2829 in favor of ti below.
                             this.props.analytics?.onAnalyticsEvent({
@@ -643,10 +649,12 @@ export class LabelImage
     renderInstructions(): React.ReactNode {
         const {
             apiOptions: {isMobile},
+        } = this.props;
+        const {
             choices,
             multipleAnswers,
             hideChoicesFromInstructions: hideChoices,
-        } = this.props;
+        } = this.props.options;
         const {strings} = this.context;
 
         const promptString = isMobile
@@ -691,8 +699,10 @@ export class LabelImage
      * [LEMS-3185] do not trust serializedState
      */
     getSerializedState(): any {
-        const {userInput, markers, ...rest} = this.props;
+        const {userInput, options, ...rest} = this.props;
+        const {markers, ...optionsRest} = options;
         return {
+            ...optionsRest,
             ...rest,
             markers: markers.map((marker, index) => ({
                 ...marker,
@@ -702,7 +712,8 @@ export class LabelImage
     }
 
     render(): React.ReactNode {
-        const {imageAlt, imageUrl, imageWidth, imageHeight} = this.props;
+        const {imageAlt, imageUrl, imageWidth, imageHeight} =
+            this.props.options;
 
         const {activeMarkerIndex} = this.state;
 
@@ -771,18 +782,6 @@ const LabelImageWithDependencies = React.forwardRef<
     const deps = useDependencies();
     return <LabelImage ref={ref} analytics={deps.analytics} {...props} />;
 });
-
-// eslint-disable-next-line no-restricted-syntax
-({}) as WidgetProps<
-    PerseusLabelImageWidgetOptions,
-    PerseusLabelImageUserInput
-> satisfies PropsFor<typeof LabelImageWithDependencies>;
-
-// eslint-disable-next-line no-restricted-syntax
-({}) as WidgetProps<
-    LabelImagePublicWidgetOptions,
-    PerseusLabelImageUserInput
-> satisfies PropsFor<typeof LabelImageWithDependencies>;
 
 function getStartUserInput(
     options: LabelImagePublicWidgetOptions,

--- a/packages/perseus/src/widgets/label-image/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image/label-image.tsx
@@ -83,6 +83,8 @@ type Options = Omit<PerseusLabelImageWidgetOptions, "markers"> & {
     // PerseusLabelImageWidgetOptions and from parseLabelImageWidget, so the
     // parser drops it from persisted content — only unparsed callers (e.g.
     // Storybook) ever supply it.
+    // TODO(benchristel): parse preferredPopoverDirection so it has the
+    //  intended effect in production (or remove it if it's not needed).
     preferredPopoverDirection?: PreferredPopoverDirection;
 };
 
@@ -475,9 +477,15 @@ export class LabelImage
     }
 
     renderMarkers(): ReadonlyArray<React.ReactNode> {
-        const {markers, preferredPopoverDirection, choices, multipleAnswers} =
-            this.props.options;
-        const {userInput} = this.props;
+        const {userInput, options} = this.props;
+        const {
+            choices,
+            imageWidth,
+            imageHeight,
+            markers,
+            multipleAnswers,
+            preferredPopoverDirection,
+        } = options;
         const {markersInteracted, activeMarkerIndex} = this.state;
 
         // Determine whether page is rendered in a narrow browser window.
@@ -486,9 +494,8 @@ export class LabelImage
             window.matchMedia(mediaQueries.xsOrSmaller.replace("@media ", ""))
                 .matches;
 
-        // Determine whether the image is wider than it is tall.
-        const isWideImage =
-            this.props.options.imageWidth / 2 > this.props.options.imageHeight;
+        // Determine whether the image is more than twice as wide as it is tall.
+        const isWideImage = imageWidth / 2 > imageHeight;
 
         // Render all markers for widget.
         return markers.map((marker, index): React.ReactElement => {


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a Label Image widget in
  http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.