### PR TITLE
[Interactive Graph] Fix keyboard prompt appearing when dragging the polygon body

### DIFF
--- a/.changeset/dry-swans-cough.md
+++ b/.changeset/dry-swans-cough.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+[Interactive Graph] Fix keyboard prompt appearing when dragging the polygon body

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-graph.test.tsx
@@ -1,5 +1,5 @@
 import {getDefaultFigureForType} from "@khanacademy/perseus-core";
-import {screen, render, act} from "@testing-library/react";
+import {screen, render, act, fireEvent} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import {vec} from "mafs";
 import React from "react";
@@ -1508,6 +1508,85 @@ describe("MafsGraph", () => {
                 screen.queryByTestId("movable-point__visible-label"),
             ).not.toBeInTheDocument();
         });
+    });
+});
+
+describe("keyboard interaction invitation", () => {
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    const unlimitedPolygonState: InteractiveGraphState = {
+        type: "polygon",
+        numSides: "unlimited",
+        closedPolygon: true,
+        coords: [
+            [-1, 1],
+            [0, 0],
+            [1, 1],
+        ],
+        focusedPointIndex: null,
+        hasBeenInteractedWith: false,
+        interactionMode: "mouse",
+        showAngles: false,
+        showSides: false,
+        showKeyboardInteractionInvitation: false,
+        showRemovePointButton: false,
+        snapStep: [1, 1],
+        snapTo: "grid",
+        range: [
+            [-10, 10],
+            [-10, 10],
+        ],
+    };
+
+    function getGraphEl(container: HTMLElement): HTMLElement {
+        // eslint-disable-next-line testing-library/no-node-access
+        const graph = container.querySelector<HTMLElement>(".mafs-graph");
+        invariant(graph != null, "expected a .mafs-graph element");
+        return graph;
+    }
+
+    it("invites keyboard interaction when the graph is focused via keyboard", () => {
+        // Arrange
+        const dispatch = jest.fn();
+        const {container} = render(
+            <MafsGraph
+                {...baseMafsProps}
+                state={unlimitedPolygonState}
+                dispatch={dispatch}
+            />,
+        );
+
+        // Act: a real focus is keyboard-driven (`:focus-visible`).
+        act(() => getGraphEl(container).focus());
+
+        // Assert
+        expect(dispatch).toHaveBeenCalledWith(
+            actions.global.changeKeyboardInvitationVisibility(true),
+        );
+    });
+
+    it("does not invite keyboard interaction when the focus is not keyboard-driven", () => {
+        // Arrange
+        const dispatch = jest.fn();
+        const {container} = render(
+            <MafsGraph
+                {...baseMafsProps}
+                state={unlimitedPolygonState}
+                dispatch={dispatch}
+            />,
+        );
+
+        // Act
+        fireEvent.focus(getGraphEl(container));
+
+        // Assert
+        expect(dispatch).not.toHaveBeenCalledWith(
+            actions.global.changeKeyboardInvitationVisibility(true),
+        );
     });
 });
 

--- a/packages/perseus/src/widgets/interactive-graphs/utils/mafs-graph-utils.test.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/utils/mafs-graph-utils.test.tsx
@@ -193,11 +193,18 @@ describe("describedByIds", () => {
 });
 
 describe("handleFocusEvent", () => {
-    it("invites keyboard interaction when the graph itself is focused via mouse", () => {
+    it("invites keyboard interaction when the mouse-mode graph is focus-visible", () => {
         // Arrange
         const dispatch = jest.fn();
         const target = document.createElement("div");
         target.classList.add("mafs-graph");
+        // The invitation is gated on `:focus-visible`, so the element must
+        // actually be focused. jsdom lacks `:focus-visible`, so
+        // `hasFocusVisible` falls back to `:focus`, which only matches a
+        // focused, in-document element.
+        target.tabIndex = 0;
+        document.body.appendChild(target);
+        target.focus();
 
         // Act
         handleFocusEvent(focusEventOn(target), unlimitedPointState, dispatch);
@@ -206,6 +213,9 @@ describe("handleFocusEvent", () => {
         expect(dispatch).toHaveBeenCalledWith(
             actions.global.changeKeyboardInvitationVisibility(true),
         );
+
+        // Cleanup
+        target.remove();
     });
 
     it("does nothing when the graph is not an unlimited graph", () => {

--- a/packages/perseus/src/widgets/interactive-graphs/utils/mafs-graph-utils.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/utils/mafs-graph-utils.tsx
@@ -1,3 +1,4 @@
+import {hasFocusVisible} from "../graphs/polygon";
 import {actions} from "../reducer/interactive-graph-action";
 import {isUnlimitedGraphState} from "../utils";
 
@@ -52,7 +53,12 @@ export function handleFocusEvent(
     if (isUnlimitedGraphState(state)) {
         if (
             event.target.classList.contains("mafs-graph") &&
-            state.interactionMode === "mouse"
+            state.interactionMode === "mouse" &&
+            // Only invite keyboard interaction when the focus is keyboard-driven
+            // (`:focus-visible`). A pointer press on a non-focusable drag hitbox
+            // (e.g. the polygon body) bubbles focus up to `.mafs-graph`; without
+            // this guard that surfaces the invitation overlay mid-drag.
+            hasFocusVisible(event.target)
         ) {
             dispatch(actions.global.changeKeyboardInvitationVisibility(true));
         }


### PR DESCRIPTION
## Summary:
This PR will fix keyboard prompt appearing when dragging the polygon body. Dragging the body of an Unlimited Polygon surfaced the "Press Shift + Enter to interact with the graph" overlay on top of the graph. The whole-shape pointer drag is captured on a non-focusable HTML hitbox, so pressing the body bubbled focus up to the .mafs-graph container, whose mouse-mode focus handler shows the info. To fix it, gate the handleFocusEvent on :focus-visible (via the existing hasFocusVisible helper), so it only shows for keyboard-driven focus. Pointer-driven focus no longer triggers it. This covers both the closed polygon and the open polygon (while drawing), plus any other non-focusable hitbox. Clicking the empty graph area with a mouse no longer shows the prompt. It's a keyboard prompt — keyboard users still see it when tabbing into the graph.

Issue: LEMS-4451

## Test plan: