### PR TITLE
Get rid of some TS errors and clean up some code

### DIFF
--- a/.changeset/perky-mails-flow.md
+++ b/.changeset/perky-mails-flow.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus": patch
+---
+
+Internal refactor to remove some TS exceptions along with some general code cleaning

--- a/packages/perseus-editor/src/widgets/interaction-editor/element-container.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/element-container.tsx
@@ -14,9 +14,9 @@ const {InlineIcon} = components;
 type Props = {
     children: React.ReactElement<any> | ReadonlyArray<React.ReactElement<any>>;
     initiallyVisible: boolean;
-    onDelete?: () => void | null | undefined;
-    onDown?: () => void | null | undefined;
-    onUp?: () => void | null | undefined;
+    onDelete?: (() => void) | null;
+    onDown?: (() => void) | null;
+    onUp?: (() => void) | null;
     title: string | React.ReactElement<any>;
 };
 

--- a/packages/perseus-editor/src/widgets/interaction-editor/interaction-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/interaction-editor.tsx
@@ -217,20 +217,17 @@ class InteractionEditor extends React.Component<Props, State> {
                                         </TeX>
                                     </span>
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
                                 onUp={
                                     n === 0
                                         ? null
-                                        : this._moveElementUp.bind(this, n)
+                                        : () => this._moveElementUp(n)
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
                                 onDown={
                                     n === this.props.elements.length - 1
                                         ? null
-                                        : this._moveElementDown.bind(this, n)
+                                        : () => this._moveElementDown(n)
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
-                                onDelete={this._deleteElement.bind(this, n)}
+                                onDelete={() => this._deleteElement(n)}
                                 key={element.key}
                             >
                                 <MovablePointEditor
@@ -274,20 +271,17 @@ class InteractionEditor extends React.Component<Props, State> {
                                         </TeX>
                                     </span>
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
                                 onUp={
                                     n === 0
                                         ? null
-                                        : this._moveElementUp.bind(this, n)
+                                        : () => this._moveElementUp(n)
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
                                 onDown={
                                     n === this.props.elements.length - 1
                                         ? null
-                                        : this._moveElementDown.bind(this, n)
+                                        : () => this._moveElementDown(n)
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
-                                onDelete={this._deleteElement.bind(this, n)}
+                                onDelete={() => this._deleteElement(n)}
                                 key={element.key}
                             >
                                 <MovableLineEditor
@@ -323,20 +317,17 @@ class InteractionEditor extends React.Component<Props, State> {
                                         </TeX>
                                     </span>
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
                                 onUp={
                                     n === 0
                                         ? null
-                                        : this._moveElementUp.bind(this, n)
+                                        : () => this._moveElementUp(n)
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
                                 onDown={
                                     n === this.props.elements.length - 1
                                         ? null
-                                        : this._moveElementDown.bind(this, n)
+                                        : () => this._moveElementDown(n)
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
-                                onDelete={this._deleteElement.bind(this, n)}
+                                onDelete={() => this._deleteElement(n)}
                                 key={element.key}
                             >
                                 <PointEditor
@@ -380,20 +371,17 @@ class InteractionEditor extends React.Component<Props, State> {
                                         </TeX>
                                     </span>
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
                                 onUp={
                                     n === 0
                                         ? null
-                                        : this._moveElementUp.bind(this, n)
+                                        : () => this._moveElementUp(n)
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
                                 onDown={
                                     n === this.props.elements.length - 1
                                         ? null
-                                        : this._moveElementDown.bind(this, n)
+                                        : () => this._moveElementDown(n)
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
-                                onDelete={this._deleteElement.bind(this, n)}
+                                onDelete={() => this._deleteElement(n)}
                                 key={element.key}
                             >
                                 <LineEditor
@@ -427,20 +415,17 @@ class InteractionEditor extends React.Component<Props, State> {
                                         </TeX>
                                     </span>
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
                                 onUp={
                                     n === 0
                                         ? null
-                                        : this._moveElementUp.bind(this, n)
+                                        : () => this._moveElementUp(n)
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
                                 onDown={
                                     n === this.props.elements.length - 1
                                         ? null
-                                        : this._moveElementDown.bind(this, n)
+                                        : () => this._moveElementDown(n)
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
-                                onDelete={this._deleteElement.bind(this, n)}
+                                onDelete={() => this._deleteElement(n)}
                                 key={element.key}
                             >
                                 <FunctionEditor
@@ -465,20 +450,17 @@ class InteractionEditor extends React.Component<Props, State> {
                         return (
                             <ElementContainer
                                 title={<span>Parametric</span>}
-                                // eslint-disable-next-line react/jsx-no-bind
                                 onUp={
                                     n === 0
                                         ? null
-                                        : this._moveElementUp.bind(this, n)
+                                        : () => this._moveElementUp(n)
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
                                 onDown={
                                     n === this.props.elements.length - 1
                                         ? null
-                                        : this._moveElementDown.bind(this, n)
+                                        : () => this._moveElementDown(n)
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
-                                onDelete={this._deleteElement.bind(this, n)}
+                                onDelete={() => this._deleteElement(n)}
                                 key={element.key}
                             >
                                 <ParametricEditor
@@ -512,20 +494,17 @@ class InteractionEditor extends React.Component<Props, State> {
                                         </TeX>{" "}
                                     </span>
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
                                 onUp={
                                     n === 0
                                         ? null
-                                        : this._moveElementUp.bind(this, n)
+                                        : () => this._moveElementUp(n)
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
                                 onDown={
                                     n === this.props.elements.length - 1
                                         ? null
-                                        : this._moveElementDown.bind(this, n)
+                                        : () => this._moveElementDown(n)
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
-                                onDelete={this._deleteElement.bind(this, n)}
+                                onDelete={() => this._deleteElement(n)}
                                 key={element.key}
                             >
                                 <LabelEditor
@@ -567,20 +546,17 @@ class InteractionEditor extends React.Component<Props, State> {
                                         </TeX>
                                     </span>
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
                                 onUp={
                                     n === 0
                                         ? null
-                                        : this._moveElementUp.bind(this, n)
+                                        : () => this._moveElementUp(n)
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
                                 onDown={
                                     n === this.props.elements.length - 1
                                         ? null
-                                        : this._moveElementDown.bind(this, n)
+                                        : () => this._moveElementDown(n)
                                 }
-                                // eslint-disable-next-line react/jsx-no-bind
-                                onDelete={this._deleteElement.bind(this, n)}
+                                onDelete={() => this._deleteElement(n)}
                                 key={element.key}
                             >
                                 <RectangleEditor

--- a/packages/perseus-editor/src/widgets/interaction-editor/interaction-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/interaction-editor.tsx
@@ -8,7 +8,6 @@ import {
     type MarkingsType,
 } from "@khanacademy/perseus-core";
 import * as React from "react";
-import _ from "underscore";
 
 import GraphSettings from "../../components/graph-settings";
 
@@ -69,34 +68,35 @@ class InteractionEditor extends React.Component<Props, State> {
     }
 
     _getAllVarSubscripts(elements: ReadonlyArray<any>): ReadonlyArray<any> {
-        return _.where(elements, {type: "movable-point"})
+        const movableLines = elements.filter(
+            (element) => element.type === "movable-line",
+        );
+        return elements
+            .filter((element) => element.type === "movable-point")
             .map((element) => element.options.varSubscript)
             .concat(
-                _.where(elements, {type: "movable-line"}).map(
-                    (element) => element.options.startSubscript,
-                ),
+                movableLines.map((element) => element.options.startSubscript),
             )
             .concat(
-                _.where(elements, {type: "movable-line"}).map(
-                    (element) => element.options.endSubscript,
-                ),
+                movableLines.map((element) => element.options.endSubscript),
             );
     }
 
     _getAllFunctionNames(elements: ReadonlyArray<any>): ReadonlyArray<string> {
-        return _.where(elements, {type: "function"}).map(
-            (element) => element.options.funcName,
-        );
+        return elements
+            .filter((element) => element.type === "function")
+            .map((element) => element.options.funcName);
     }
 
     // Spread existing graph props to preserve properties not included
     // in the GraphSettings onChange payload (e.g. box, markings).
     _updateGraphProps = (newProps: Record<string, unknown>) => {
+        const {step, ...rest} = newProps;
         this.props.onChange({
             graph: {
                 ...this.props.graph,
-                ..._.omit(newProps, "step"),
-                tickStep: newProps.step,
+                ...rest,
+                tickStep: step,
             },
         });
     };
@@ -118,47 +118,41 @@ class InteractionEditor extends React.Component<Props, State> {
                 ((Math.random() * 0xffffff) << 0).toString(16),
             options:
                 elementType === "point"
-                    ? _.clone(PointEditor.defaultProps)
+                    ? {...PointEditor.defaultProps}
                     : elementType === "line"
-                      ? _.clone(LineEditor.defaultProps)
+                      ? {...LineEditor.defaultProps}
                       : elementType === "movable-point"
-                        ? _.clone(MovablePointEditor.defaultProps)
+                        ? {...MovablePointEditor.defaultProps}
                         : elementType === "movable-line"
-                          ? _.clone(MovableLineEditor.defaultProps)
+                          ? {...MovableLineEditor.defaultProps}
                           : elementType === "function"
-                            ? _.clone(FunctionEditor.defaultProps)
+                            ? {...FunctionEditor.defaultProps}
                             : elementType === "parametric"
-                              ? _.clone(ParametricEditor.defaultProps)
+                              ? {...ParametricEditor.defaultProps}
                               : elementType === "label"
-                                ? _.clone(LabelEditor.defaultProps)
+                                ? {...LabelEditor.defaultProps}
                                 : elementType === "rectangle"
-                                  ? _.clone(RectangleEditor.defaultProps)
+                                  ? {...RectangleEditor.defaultProps}
                                   : {},
         } as const;
 
         let nextSubscript;
         if (elementType === "movable-point") {
-            nextSubscript =
-                _.max([_.max(this.state.usedVarSubscripts), -1]) + 1;
+            nextSubscript = Math.max(...this.state.usedVarSubscripts, -1) + 1;
             // @ts-expect-error - TS2339 - Property 'varSubscript' does not exist on type '{}'.
             newElement.options.varSubscript = nextSubscript;
         } else if (elementType === "movable-line") {
-            nextSubscript =
-                _.max([_.max(this.state.usedVarSubscripts), -1]) + 1;
+            nextSubscript = Math.max(...this.state.usedVarSubscripts, -1) + 1;
             // @ts-expect-error - TS2339 - Property 'startSubscript' does not exist on type '{}'.
             newElement.options.startSubscript = nextSubscript;
             // @ts-expect-error - TS2339 - Property 'endSubscript' does not exist on type '{}'.
             newElement.options.endSubscript = nextSubscript + 1;
         } else if (elementType === "function") {
             const nextLetter = String.fromCharCode(
-                _.max([
-                    _.max(
-                        this.state.usedFunctionNames.map(function (c) {
-                            return c.charCodeAt(0);
-                        }),
-                    ),
+                Math.max(
+                    ...this.state.usedFunctionNames.map((c) => c.charCodeAt(0)),
                     "e".charCodeAt(0),
-                ]) + 1,
+                ) + 1,
             );
             // @ts-expect-error - TS2339 - Property 'funcName' does not exist on type '{}'.
             newElement.options.funcName = nextLetter;
@@ -171,20 +165,20 @@ class InteractionEditor extends React.Component<Props, State> {
     _deleteElement: (arg1: number) => void = (index) => {
         const element = this.props.elements[index];
         this.props.onChange({
-            elements: _.without(this.props.elements, element),
+            elements: this.props.elements.filter((e) => e !== element),
         });
     };
 
     _moveElementUp: (arg1: number) => void = (index) => {
         const element = this.props.elements[index];
-        const newElements = _.without(this.props.elements, element);
+        const newElements = this.props.elements.filter((e) => e !== element);
         newElements.splice(index - 1, 0, element);
         this.props.onChange({elements: newElements});
     };
 
     _moveElementDown: (arg1: number) => void = (index) => {
         const element = this.props.elements[index];
-        const newElements = _.without(this.props.elements, element);
+        const newElements = this.props.elements.filter((e) => e !== element);
         newElements.splice(index + 1, 0, element);
         this.props.onChange({elements: newElements});
     };
@@ -253,7 +247,10 @@ class InteractionEditor extends React.Component<Props, State> {
                                         const elements = JSON.parse(
                                             JSON.stringify(this.props.elements),
                                         );
-                                        _.extend(elements[n].options, newProps);
+                                        Object.assign(
+                                            elements[n].options,
+                                            newProps,
+                                        );
                                         this.props.onChange({
                                             elements: elements,
                                         });
@@ -307,7 +304,10 @@ class InteractionEditor extends React.Component<Props, State> {
                                         const elements = JSON.parse(
                                             JSON.stringify(this.props.elements),
                                         );
-                                        _.extend(elements[n].options, newProps);
+                                        Object.assign(
+                                            elements[n].options,
+                                            newProps,
+                                        );
                                         this.props.onChange({
                                             elements: elements,
                                         });
@@ -353,7 +353,10 @@ class InteractionEditor extends React.Component<Props, State> {
                                         const elements = JSON.parse(
                                             JSON.stringify(this.props.elements),
                                         );
-                                        _.extend(elements[n].options, newProps);
+                                        Object.assign(
+                                            elements[n].options,
+                                            newProps,
+                                        );
                                         this.props.onChange({
                                             elements: elements,
                                         });
@@ -407,7 +410,10 @@ class InteractionEditor extends React.Component<Props, State> {
                                         const elements = JSON.parse(
                                             JSON.stringify(this.props.elements),
                                         );
-                                        _.extend(elements[n].options, newProps);
+                                        Object.assign(
+                                            elements[n].options,
+                                            newProps,
+                                        );
                                         this.props.onChange({
                                             elements: elements,
                                         });
@@ -451,7 +457,10 @@ class InteractionEditor extends React.Component<Props, State> {
                                         const elements = JSON.parse(
                                             JSON.stringify(this.props.elements),
                                         );
-                                        _.extend(elements[n].options, newProps);
+                                        Object.assign(
+                                            elements[n].options,
+                                            newProps,
+                                        );
                                         this.props.onChange({
                                             elements: elements,
                                         });
@@ -486,7 +495,10 @@ class InteractionEditor extends React.Component<Props, State> {
                                         const elements = JSON.parse(
                                             JSON.stringify(this.props.elements),
                                         );
-                                        _.extend(elements[n].options, newProps);
+                                        Object.assign(
+                                            elements[n].options,
+                                            newProps,
+                                        );
                                         this.props.onChange({
                                             elements: elements,
                                         });
@@ -530,7 +542,10 @@ class InteractionEditor extends React.Component<Props, State> {
                                         const elements = JSON.parse(
                                             JSON.stringify(this.props.elements),
                                         );
-                                        _.extend(elements[n].options, newProps);
+                                        Object.assign(
+                                            elements[n].options,
+                                            newProps,
+                                        );
                                         this.props.onChange({
                                             elements: elements,
                                         });
@@ -582,7 +597,10 @@ class InteractionEditor extends React.Component<Props, State> {
                                         const elements = JSON.parse(
                                             JSON.stringify(this.props.elements),
                                         );
-                                        _.extend(elements[n].options, newProps);
+                                        Object.assign(
+                                            elements[n].options,
+                                            newProps,
+                                        );
                                         this.props.onChange({
                                             elements: elements,
                                         });

--- a/packages/perseus-editor/src/widgets/interaction-editor/interaction-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/interaction-editor.tsx
@@ -23,6 +23,19 @@ import RectangleEditor from "./rectangle-editor";
 
 const {unescapeMathMode} = Util;
 
+// The starting options for each element type offered by the "Add an element"
+// dropdown. Element types with no entry here start out with no options.
+const defaultOptionsByElementType: Record<string, Record<string, unknown>> = {
+    point: PointEditor.defaultProps,
+    line: LineEditor.defaultProps,
+    "movable-point": MovablePointEditor.defaultProps,
+    "movable-line": MovableLineEditor.defaultProps,
+    function: FunctionEditor.defaultProps,
+    parametric: ParametricEditor.defaultProps,
+    label: LabelEditor.defaultProps,
+    rectangle: RectangleEditor.defaultProps,
+};
+
 type Graph = {
     box: ReadonlyArray<number>;
     labels: ReadonlyArray<string>;
@@ -116,36 +129,16 @@ class InteractionEditor extends React.Component<Props, State> {
                 "-" +
                 // eslint-disable-next-line no-restricted-properties
                 ((Math.random() * 0xffffff) << 0).toString(16),
-            options:
-                elementType === "point"
-                    ? {...PointEditor.defaultProps}
-                    : elementType === "line"
-                      ? {...LineEditor.defaultProps}
-                      : elementType === "movable-point"
-                        ? {...MovablePointEditor.defaultProps}
-                        : elementType === "movable-line"
-                          ? {...MovableLineEditor.defaultProps}
-                          : elementType === "function"
-                            ? {...FunctionEditor.defaultProps}
-                            : elementType === "parametric"
-                              ? {...ParametricEditor.defaultProps}
-                              : elementType === "label"
-                                ? {...LabelEditor.defaultProps}
-                                : elementType === "rectangle"
-                                  ? {...RectangleEditor.defaultProps}
-                                  : {},
-        } as const;
+            options: {...defaultOptionsByElementType[elementType]},
+        };
 
         let nextSubscript;
         if (elementType === "movable-point") {
             nextSubscript = Math.max(...this.state.usedVarSubscripts, -1) + 1;
-            // @ts-expect-error - TS2339 - Property 'varSubscript' does not exist on type '{}'.
             newElement.options.varSubscript = nextSubscript;
         } else if (elementType === "movable-line") {
             nextSubscript = Math.max(...this.state.usedVarSubscripts, -1) + 1;
-            // @ts-expect-error - TS2339 - Property 'startSubscript' does not exist on type '{}'.
             newElement.options.startSubscript = nextSubscript;
-            // @ts-expect-error - TS2339 - Property 'endSubscript' does not exist on type '{}'.
             newElement.options.endSubscript = nextSubscript + 1;
         } else if (elementType === "function") {
             const nextLetter = String.fromCharCode(
@@ -154,7 +147,6 @@ class InteractionEditor extends React.Component<Props, State> {
                     "e".charCodeAt(0),
                 ) + 1,
             );
-            // @ts-expect-error - TS2339 - Property 'funcName' does not exist on type '{}'.
             newElement.options.funcName = nextLetter;
         }
         this.props.onChange({

--- a/packages/perseus-editor/src/widgets/interaction-editor/interaction-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/interaction-editor.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
-/* eslint-disable @typescript-eslint/no-invalid-this, react/no-unsafe */
+/* eslint-disable react/no-unsafe */
 import {Dependencies, EditorJsonify, Util} from "@khanacademy/perseus";
 import {
     interactionLogic,
@@ -215,7 +215,7 @@ class InteractionEditor extends React.Component<Props, State> {
                         )}
                     </>
                 </ElementContainer>
-                {this.props.elements.map(function (element, n) {
+                {this.props.elements.map((element, n) => {
                     if (element.type === "movable-point") {
                         return (
                             <ElementContainer
@@ -235,23 +235,15 @@ class InteractionEditor extends React.Component<Props, State> {
                                 onUp={
                                     n === 0
                                         ? null
-                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                          this._moveElementUp.bind(this, n)
+                                        : this._moveElementUp.bind(this, n)
                                 }
                                 // eslint-disable-next-line react/jsx-no-bind
                                 onDown={
-                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                     n === this.props.elements.length - 1
                                         ? null
-                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                          this._moveElementDown.bind(
-                                              // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this,
-                                              n,
-                                          )
+                                        : this._moveElementDown.bind(this, n)
                                 }
                                 // eslint-disable-next-line react/jsx-no-bind
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                 onDelete={this._deleteElement.bind(this, n)}
                                 key={element.key}
                             >
@@ -259,13 +251,9 @@ class InteractionEditor extends React.Component<Props, State> {
                                     {...element.options}
                                     onChange={(newProps) => {
                                         const elements = JSON.parse(
-                                            JSON.stringify(
-                                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                this.props.elements,
-                                            ),
+                                            JSON.stringify(this.props.elements),
                                         );
                                         _.extend(elements[n].options, newProps);
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                         this.props.onChange({
                                             elements: elements,
                                         });
@@ -301,23 +289,15 @@ class InteractionEditor extends React.Component<Props, State> {
                                 onUp={
                                     n === 0
                                         ? null
-                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                          this._moveElementUp.bind(this, n)
+                                        : this._moveElementUp.bind(this, n)
                                 }
                                 // eslint-disable-next-line react/jsx-no-bind
                                 onDown={
-                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                     n === this.props.elements.length - 1
                                         ? null
-                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                          this._moveElementDown.bind(
-                                              // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this,
-                                              n,
-                                          )
+                                        : this._moveElementDown.bind(this, n)
                                 }
                                 // eslint-disable-next-line react/jsx-no-bind
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                 onDelete={this._deleteElement.bind(this, n)}
                                 key={element.key}
                             >
@@ -325,13 +305,9 @@ class InteractionEditor extends React.Component<Props, State> {
                                     {...element.options}
                                     onChange={(newProps) => {
                                         const elements = JSON.parse(
-                                            JSON.stringify(
-                                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                this.props.elements,
-                                            ),
+                                            JSON.stringify(this.props.elements),
                                         );
                                         _.extend(elements[n].options, newProps);
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                         this.props.onChange({
                                             elements: elements,
                                         });
@@ -359,23 +335,15 @@ class InteractionEditor extends React.Component<Props, State> {
                                 onUp={
                                     n === 0
                                         ? null
-                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                          this._moveElementUp.bind(this, n)
+                                        : this._moveElementUp.bind(this, n)
                                 }
                                 // eslint-disable-next-line react/jsx-no-bind
                                 onDown={
-                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                     n === this.props.elements.length - 1
                                         ? null
-                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                          this._moveElementDown.bind(
-                                              // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this,
-                                              n,
-                                          )
+                                        : this._moveElementDown.bind(this, n)
                                 }
                                 // eslint-disable-next-line react/jsx-no-bind
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                 onDelete={this._deleteElement.bind(this, n)}
                                 key={element.key}
                             >
@@ -383,13 +351,9 @@ class InteractionEditor extends React.Component<Props, State> {
                                     {...element.options}
                                     onChange={(newProps) => {
                                         const elements = JSON.parse(
-                                            JSON.stringify(
-                                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                this.props.elements,
-                                            ),
+                                            JSON.stringify(this.props.elements),
                                         );
                                         _.extend(elements[n].options, newProps);
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                         this.props.onChange({
                                             elements: elements,
                                         });
@@ -425,23 +389,15 @@ class InteractionEditor extends React.Component<Props, State> {
                                 onUp={
                                     n === 0
                                         ? null
-                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                          this._moveElementUp.bind(this, n)
+                                        : this._moveElementUp.bind(this, n)
                                 }
                                 // eslint-disable-next-line react/jsx-no-bind
                                 onDown={
-                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                     n === this.props.elements.length - 1
                                         ? null
-                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                          this._moveElementDown.bind(
-                                              // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this,
-                                              n,
-                                          )
+                                        : this._moveElementDown.bind(this, n)
                                 }
                                 // eslint-disable-next-line react/jsx-no-bind
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                 onDelete={this._deleteElement.bind(this, n)}
                                 key={element.key}
                             >
@@ -449,13 +405,9 @@ class InteractionEditor extends React.Component<Props, State> {
                                     {...element.options}
                                     onChange={(newProps) => {
                                         const elements = JSON.parse(
-                                            JSON.stringify(
-                                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                this.props.elements,
-                                            ),
+                                            JSON.stringify(this.props.elements),
                                         );
                                         _.extend(elements[n].options, newProps);
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                         this.props.onChange({
                                             elements: elements,
                                         });
@@ -481,36 +433,25 @@ class InteractionEditor extends React.Component<Props, State> {
                                 onUp={
                                     n === 0
                                         ? null
-                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                          this._moveElementUp.bind(this, n)
+                                        : this._moveElementUp.bind(this, n)
                                 }
                                 // eslint-disable-next-line react/jsx-no-bind
                                 onDown={
-                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                     n === this.props.elements.length - 1
                                         ? null
-                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                          this._moveElementDown.bind(
-                                              // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this,
-                                              n,
-                                          )
+                                        : this._moveElementDown.bind(this, n)
                                 }
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                onDelete={this._deleteElement}
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onDelete={this._deleteElement.bind(this, n)}
                                 key={element.key}
                             >
                                 <FunctionEditor
                                     {...element.options}
                                     onChange={(newProps) => {
                                         const elements = JSON.parse(
-                                            JSON.stringify(
-                                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                this.props.elements,
-                                            ),
+                                            JSON.stringify(this.props.elements),
                                         );
                                         _.extend(elements[n].options, newProps);
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                         this.props.onChange({
                                             elements: elements,
                                         });
@@ -527,36 +468,25 @@ class InteractionEditor extends React.Component<Props, State> {
                                 onUp={
                                     n === 0
                                         ? null
-                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                          this._moveElementUp.bind(this, n)
+                                        : this._moveElementUp.bind(this, n)
                                 }
                                 // eslint-disable-next-line react/jsx-no-bind
                                 onDown={
-                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                     n === this.props.elements.length - 1
                                         ? null
-                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                          this._moveElementDown.bind(
-                                              // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this,
-                                              n,
-                                          )
+                                        : this._moveElementDown.bind(this, n)
                                 }
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                onDelete={this._deleteElement}
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onDelete={this._deleteElement.bind(this, n)}
                                 key={element.key}
                             >
                                 <ParametricEditor
                                     {...element.options}
                                     onChange={(newProps) => {
                                         const elements = JSON.parse(
-                                            JSON.stringify(
-                                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                this.props.elements,
-                                            ),
+                                            JSON.stringify(this.props.elements),
                                         );
                                         _.extend(elements[n].options, newProps);
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                         this.props.onChange({
                                             elements: elements,
                                         });
@@ -582,36 +512,25 @@ class InteractionEditor extends React.Component<Props, State> {
                                 onUp={
                                     n === 0
                                         ? null
-                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                          this._moveElementUp.bind(this, n)
+                                        : this._moveElementUp.bind(this, n)
                                 }
                                 // eslint-disable-next-line react/jsx-no-bind
                                 onDown={
-                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                     n === this.props.elements.length - 1
                                         ? null
-                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                          this._moveElementDown.bind(
-                                              // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this,
-                                              n,
-                                          )
+                                        : this._moveElementDown.bind(this, n)
                                 }
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                onDelete={this._deleteElement}
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onDelete={this._deleteElement.bind(this, n)}
                                 key={element.key}
                             >
                                 <LabelEditor
                                     {...element.options}
                                     onChange={(newProps) => {
                                         const elements = JSON.parse(
-                                            JSON.stringify(
-                                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                this.props.elements,
-                                            ),
+                                            JSON.stringify(this.props.elements),
                                         );
                                         _.extend(elements[n].options, newProps);
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                         this.props.onChange({
                                             elements: elements,
                                         });
@@ -645,36 +564,25 @@ class InteractionEditor extends React.Component<Props, State> {
                                 onUp={
                                     n === 0
                                         ? null
-                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                          this._moveElementUp.bind(this, n)
+                                        : this._moveElementUp.bind(this, n)
                                 }
                                 // eslint-disable-next-line react/jsx-no-bind
                                 onDown={
-                                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                     n === this.props.elements.length - 1
                                         ? null
-                                        : // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                          this._moveElementDown.bind(
-                                              // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                              this,
-                                              n,
-                                          )
+                                        : this._moveElementDown.bind(this, n)
                                 }
-                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                onDelete={this._deleteElement}
+                                // eslint-disable-next-line react/jsx-no-bind
+                                onDelete={this._deleteElement.bind(this, n)}
                                 key={element.key}
                             >
                                 <RectangleEditor
                                     {...element.options}
                                     onChange={(newProps) => {
                                         const elements = JSON.parse(
-                                            JSON.stringify(
-                                                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                                                this.props.elements,
-                                            ),
+                                            JSON.stringify(this.props.elements),
                                         );
                                         _.extend(elements[n].options, newProps);
-                                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                                         this.props.onChange({
                                             elements: elements,
                                         });
@@ -683,7 +591,7 @@ class InteractionEditor extends React.Component<Props, State> {
                             </ElementContainer>
                         );
                     }
-                }, this)}
+                })}
                 <div className="perseus-widget-interaction-editor-select-element">
                     {/* @ts-expect-error - TS2322 - Type '(arg1: ChangeEvent<HTMLInputElement>) => void' is not assignable to type 'ChangeEventHandler<HTMLSelectElement>'. */}
                     <select onChange={this._addNewElement}>

--- a/packages/perseus/src/components/sortable.tsx
+++ b/packages/perseus/src/components/sortable.tsx
@@ -366,7 +366,11 @@ class Draggable extends React.Component<DraggableProps, DraggableState> {
             this.props.state === ItemState.DRAGGING ||
             this.props.state === ItemState.ANIMATING
         ) {
-            _.extend(style, {position: "absolute"}, this.getCurrentPosition());
+            Object.assign(
+                style,
+                {position: "absolute"},
+                this.getCurrentPosition(),
+            );
         }
 
         if (this.props.width) {
@@ -574,19 +578,19 @@ class Sortable extends React.Component<SortableProps, SortableState> {
         let syncWidth: number | null = null;
         if (constraints?.width) {
             // Items must be at least as wide as the specified constraint
-            syncWidth = _.max(widths.concat(constraints.width));
+            syncWidth = Math.max(...widths, constraints.width);
         } else if (layout === "vertical") {
             // Sync widths to get a clean column
-            syncWidth = _.max(widths);
+            syncWidth = Math.max(...widths);
         }
 
         let syncHeight: number | null = null;
         if (constraints?.height) {
             // Items must be at least as high as the specified constraint
-            syncHeight = _.max(heights.concat(constraints.height));
+            syncHeight = Math.max(...heights, constraints.height);
         } else if (layout === "horizontal") {
             // Sync widths to get a clean row
-            syncHeight = _.max(heights);
+            syncHeight = Math.max(...heights);
         }
 
         items = items.map(function (item, i) {
@@ -625,7 +629,7 @@ class Sortable extends React.Component<SortableProps, SortableState> {
             throw new Error(`index ${index} out of bounds`);
         }
 
-        const nextItems = _.clone(items);
+        const nextItems = [...items];
 
         const item = items.filter((item: SortableItem) => {
             return item.option === option;
@@ -639,9 +643,7 @@ class Sortable extends React.Component<SortableProps, SortableState> {
             return i.key === item.key;
         });
 
-        // @ts-expect-error - TS2551 - Property 'splice' does not exist on type 'readonly SortableItem[]'. Did you mean 'slice'?
         nextItems.splice(currentIndex, 1);
-        // @ts-expect-error - TS2551 - Property 'splice' does not exist on type 'readonly SortableItem[]'. Did you mean 'slice'?
         nextItems.splice(index, 0, item);
 
         this.setState({items: nextItems}, () => {
@@ -659,15 +661,14 @@ class Sortable extends React.Component<SortableProps, SortableState> {
         const $draggable = $(ReactDOM.findDOMNode(this.refs[key]));
         // @ts-expect-error - TS2769 - No overload matches this call.
         const $sortable = $(ReactDOM.findDOMNode(this));
-        const items = _.clone(this.state.items);
-        const item = _.findWhere(this.state.items, {key: key});
+        const items = [...this.state.items];
+        const item = this.state.items.find((item) => item.key === key);
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         const margin = this.props.margin || 0;
         // @ts-expect-error - TS2345 - Argument of type 'SortableItem | undefined' is not assignable to parameter of type 'SortableItem'.
         const currentIndex = items.indexOf(item);
         let newIndex = 0;
 
-        // @ts-expect-error - TS2551 - Property 'splice' does not exist on type 'readonly SortableItem[]'. Did you mean 'slice'?
         items.splice(currentIndex, 1);
 
         if (this.props.layout === "horizontal") {
@@ -676,7 +677,7 @@ class Sortable extends React.Component<SortableProps, SortableState> {
             let sumWidth = 0;
             let cardWidth;
 
-            _.each(items, function (item) {
+            items.forEach(function (item) {
                 cardWidth = item.width;
                 if (midWidth > sumWidth + cardWidth / 2) {
                     newIndex += 1;
@@ -689,7 +690,7 @@ class Sortable extends React.Component<SortableProps, SortableState> {
             let sumHeight = 0;
             let cardHeight;
 
-            _.each(items, function (item) {
+            items.forEach(function (item) {
                 cardHeight = item.height;
                 if (midHeight > sumHeight + cardHeight / 2) {
                     newIndex += 1;
@@ -699,7 +700,7 @@ class Sortable extends React.Component<SortableProps, SortableState> {
         }
 
         if (newIndex !== currentIndex) {
-            // @ts-expect-error - TS2551 - Property 'splice' does not exist on type 'readonly SortableItem[]'. Did you mean 'slice'?
+            // @ts-expect-error - TS2345 - Argument of type 'SortableItem | undefined' is not assignable to parameter of type 'SortableItem'.
             items.splice(newIndex, 0, item);
             this.setState({items: items});
         }

--- a/packages/perseus/src/components/sortable.tsx
+++ b/packages/perseus/src/components/sortable.tsx
@@ -807,92 +807,70 @@ class Sortable extends React.Component<SortableProps, SortableState> {
         const syncHeight =
             this.props.constraints?.height || layout === "horizontal";
 
-        _.each(
-            this.state.items,
-            function (item, i, items) {
-                const isLast = i === items.length - 1;
-                const isStatic =
-                    item.state === ItemState.STATIC ||
-                    item.state === ItemState.DISABLED;
-                let margin;
+        this.state.items.forEach((item, i, items) => {
+            const isLast = i === items.length - 1;
+            const isStatic =
+                item.state === ItemState.STATIC ||
+                item.state === ItemState.DISABLED;
+            let margin;
 
-                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                if (this.props.layout === "horizontal") {
-                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                    margin = "0 " + this.props.margin + "px 0 0"; // right
-                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                } else if (this.props.layout === "vertical") {
-                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                    margin = "0 0 " + this.props.margin + "px 0"; // bottom
-                }
+            if (this.props.layout === "horizontal") {
+                margin = "0 " + this.props.margin + "px 0 0"; // right
+            } else if (this.props.layout === "vertical") {
+                margin = "0 0 " + this.props.margin + "px 0"; // bottom
+            }
 
+            cards.push(
+                <Draggable
+                    content={item.option}
+                    key={item.key}
+                    state={item.state}
+                    // @ts-expect-error - TS2769 - No overload matches this call.
+                    ref={item.key}
+                    width={syncWidth ? item.width : undefined}
+                    height={syncHeight ? item.height : undefined}
+                    layout={layout}
+                    includePadding={this.props.padding}
+                    margin={isLast && isStatic ? 0 : margin}
+                    endPosition={item.endPosition}
+                    linterContext={PerseusLinter.pushContextStack(
+                        this.props.linterContext,
+                        "sortable",
+                    )}
+                    onRender={this.remeasureItems}
+                    // eslint-disable-next-line react/jsx-no-bind
+                    onMouseDown={this.onMouseDown.bind(this, item.key)}
+                    // eslint-disable-next-line react/jsx-no-bind
+                    onMouseMove={this.onMouseMove.bind(this, item.key)}
+                    // eslint-disable-next-line react/jsx-no-bind
+                    onMouseUp={this.onMouseUp.bind(this, item.key)}
+                    // eslint-disable-next-line react/jsx-no-bind
+                    onTouchMove={this.onMouseMove.bind(this, item.key)}
+                    // eslint-disable-next-line react/jsx-no-bind
+                    onTouchEnd={this.onMouseUp.bind(this, item.key)}
+                    // eslint-disable-next-line react/jsx-no-bind
+                    onTouchCancel={this.onMouseUp.bind(this, item.key)}
+                    // eslint-disable-next-line react/jsx-no-bind
+                    onAnimationEnd={this.onAnimationEnd.bind(this, item.key)}
+                />,
+            );
+
+            if (
+                item.state === ItemState.DRAGGING ||
+                item.state === ItemState.ANIMATING
+            ) {
                 cards.push(
-                    <Draggable
-                        content={item.option}
-                        key={item.key}
-                        state={item.state}
-                        // @ts-expect-error - TS2769 - No overload matches this call.
-                        ref={item.key}
-                        width={syncWidth ? item.width : undefined}
-                        height={syncHeight ? item.height : undefined}
+                    <Placeholder
+                        key={"placeholder_" + item.key}
+                        ref={"placeholder_" + item.key}
+                        width={item.width}
+                        height={item.height}
                         layout={layout}
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                        includePadding={this.props.padding}
-                        margin={isLast && isStatic ? 0 : margin}
-                        endPosition={item.endPosition}
-                        linterContext={PerseusLinter.pushContextStack(
-                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                            this.props.linterContext,
-                            "sortable",
-                        )}
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                        onRender={this.remeasureItems}
-                        // eslint-disable-next-line react/jsx-no-bind
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                        onMouseDown={this.onMouseDown.bind(this, item.key)}
-                        // eslint-disable-next-line react/jsx-no-bind
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                        onMouseMove={this.onMouseMove.bind(this, item.key)}
-                        // eslint-disable-next-line react/jsx-no-bind
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                        onMouseUp={this.onMouseUp.bind(this, item.key)}
-                        // eslint-disable-next-line react/jsx-no-bind
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                        onTouchMove={this.onMouseMove.bind(this, item.key)}
-                        // eslint-disable-next-line react/jsx-no-bind
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                        onTouchEnd={this.onMouseUp.bind(this, item.key)}
-                        // eslint-disable-next-line react/jsx-no-bind
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                        onTouchCancel={this.onMouseUp.bind(this, item.key)}
-                        // eslint-disable-next-line react/jsx-no-bind
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                        onAnimationEnd={this.onAnimationEnd.bind(
-                            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                            this,
-                            item.key,
-                        )}
+                        margin={isLast ? 0 : margin}
                     />,
                 );
-
-                if (
-                    item.state === ItemState.DRAGGING ||
-                    item.state === ItemState.ANIMATING
-                ) {
-                    cards.push(
-                        <Placeholder
-                            key={"placeholder_" + item.key}
-                            ref={"placeholder_" + item.key}
-                            width={item.width}
-                            height={item.height}
-                            layout={layout}
-                            margin={isLast ? 0 : margin}
-                        />,
-                    );
-                }
-            },
-            this,
-        );
+            }
+        }, this);
 
         return <ul className={className}>{cards}</ul>;
     }

--- a/packages/perseus/src/components/sortable.tsx
+++ b/packages/perseus/src/components/sortable.tsx
@@ -839,20 +839,13 @@ class Sortable extends React.Component<SortableProps, SortableState> {
                         "sortable",
                     )}
                     onRender={this.remeasureItems}
-                    // eslint-disable-next-line react/jsx-no-bind
-                    onMouseDown={this.onMouseDown.bind(this, item.key)}
-                    // eslint-disable-next-line react/jsx-no-bind
-                    onMouseMove={this.onMouseMove.bind(this, item.key)}
-                    // eslint-disable-next-line react/jsx-no-bind
-                    onMouseUp={this.onMouseUp.bind(this, item.key)}
-                    // eslint-disable-next-line react/jsx-no-bind
-                    onTouchMove={this.onMouseMove.bind(this, item.key)}
-                    // eslint-disable-next-line react/jsx-no-bind
-                    onTouchEnd={this.onMouseUp.bind(this, item.key)}
-                    // eslint-disable-next-line react/jsx-no-bind
-                    onTouchCancel={this.onMouseUp.bind(this, item.key)}
-                    // eslint-disable-next-line react/jsx-no-bind
-                    onAnimationEnd={this.onAnimationEnd.bind(this, item.key)}
+                    onMouseDown={() => this.onMouseDown(item.key)}
+                    onMouseMove={() => this.onMouseMove(item.key)}
+                    onMouseUp={() => this.onMouseUp(item.key)}
+                    onTouchMove={() => this.onMouseMove(item.key)}
+                    onTouchEnd={() => this.onMouseUp(item.key)}
+                    onTouchCancel={() => this.onMouseUp(item.key)}
+                    onAnimationEnd={() => this.onAnimationEnd(item.key)}
                 />,
             );
 

--- a/packages/perseus/src/util/interactive.ts
+++ b/packages/perseus/src/util/interactive.ts
@@ -123,13 +123,13 @@ _.extend(GraphUtils.Graphie.prototype, {
             sRadius *= Math.SQRT2;
             const v3 = kvector.add(sVertex, scaledPolarDeg(sRadius, halfAngle));
 
-            _.each([v1, v2], function (v) {
+            [v1, v2].forEach(function (v) {
                 // @ts-expect-error - TS2345 - Argument of type 'any' is not assignable to parameter of type 'never'.
                 temp.push(graphie.scaledPath([v, v3], options.style));
             });
         } else {
             // Draw arcs
-            _.times(options.numArcs, function (i) {
+            for (let i = 0; i < options.numArcs; i++) {
                 temp.push(
                     // @ts-expect-error - TS2345 - Argument of type 'any' is not assignable to parameter of type 'never'.
                     graphie.arc(
@@ -141,7 +141,7 @@ _.extend(GraphUtils.Graphie.prototype, {
                     ),
                 );
                 sRadius += 3;
-            });
+            }
         }
 
         if (text) {
@@ -207,11 +207,12 @@ _.extend(GraphUtils.Graphie.prototype, {
             const sSpacing = 5;
             const sHeight = 5;
 
-            const style = _.extend({}, options.style, {
+            const style = {
+                ...options.style,
                 strokeWidth: 2,
-            });
+            };
 
-            _.times(n, function (i) {
+            for (let i = 0; i < n; i++) {
                 const sOffset = sSpacing * (i - (n - 1) / 2);
 
                 const sOffsetVector = scaledPolarRad(sOffset, parallelAngle);
@@ -231,7 +232,7 @@ _.extend(GraphUtils.Graphie.prototype, {
 
                 // @ts-expect-error - TS2345 - Argument of type 'any' is not assignable to parameter of type 'never'.
                 temp.push(graphie.scaledPath(sPath, style));
-            });
+            }
 
             sCumulativeOffset += sSpacing * (n - 1) + 15;
         }
@@ -247,14 +248,15 @@ _.extend(GraphUtils.Graphie.prototype, {
             })[0];
             const sStart = graphie.scalePoint(start);
 
-            const style = _.extend({}, options.style, {
+            const style = {
+                ...options.style,
                 arrows: "->",
                 strokeWidth: 2,
-            });
+            };
 
             const sSpacing = 5;
 
-            _.times(n, function (i) {
+            for (let i = 0; i < n; i++) {
                 const sOffset = sCumulativeOffset + sSpacing * i;
                 let sOffsetVector = scaledPolarRad(sOffset, parallelAngle);
 
@@ -266,7 +268,7 @@ _.extend(GraphUtils.Graphie.prototype, {
 
                 // @ts-expect-error - TS2345 - Argument of type 'any' is not assignable to parameter of type 'never'.
                 temp.push(graphie.scaledPath([sStart, sEnd], style));
-            });
+            }
         }
 
         let text = options.text;
@@ -455,14 +457,11 @@ _.extend(GraphUtils.Graphie.prototype, {
         const normalColor = movablePoint.constraints.fixed
             ? KhanColors.DYNAMIC
             : KhanColors.INTERACTIVE;
-        movablePoint.normalStyle = _.extend(
-            {},
-            {
-                fill: normalColor,
-                stroke: normalColor,
-            },
-            options.normalStyle,
-        );
+        movablePoint.normalStyle = {
+            fill: normalColor,
+            stroke: normalColor,
+            ...options.normalStyle,
+        };
 
         // deprecated: don't use coordX/coordY; use coord[]
         if (options.coordX !== undefined) {
@@ -677,9 +676,8 @@ _.extend(GraphUtils.Graphie.prototype, {
                     radii,
                     options,
                 );
-                movablePoint.visibleShape.attr(
-                    _.omit(movablePoint.normalStyle, "scale"),
-                );
+                const {scale, ...styleWithoutScale} = movablePoint.normalStyle;
+                movablePoint.visibleShape.attr(styleWithoutScale);
                 movablePoint.visibleShape.toFront();
             });
         }
@@ -1030,18 +1028,16 @@ _.extend(GraphUtils.Graphie.prototype, {
         const normalColor = lineSegment.fixed
             ? KhanColors.DYNAMIC
             : KhanColors.INTERACTIVE;
-        lineSegment.normalStyle = _.extend(
-            {},
-            {
-                "stroke-width": 2,
-                stroke: normalColor,
-            },
-            options.normalStyle,
-        );
+        lineSegment.normalStyle = {
+            "stroke-width": 2,
+            stroke: normalColor,
+            ...options.normalStyle,
+        };
         // arrowStyle should be kept in sync with styling of the line
-        lineSegment.arrowStyle = _.extend({}, lineSegment.normalStyle, {
+        lineSegment.arrowStyle = {
+            ...lineSegment.normalStyle,
             color: lineSegment.normalStyle.stroke,
-        });
+        };
 
         // If the line segment is defined by movablePoints, coordA/coordZ are
         // owned by the points, otherwise they're owned by us
@@ -1170,7 +1166,7 @@ _.extend(GraphUtils.Graphie.prototype, {
             if (!this.fixed) {
                 elements.push(this.mouseTarget);
             }
-            _.each(elements, function (element) {
+            elements.forEach(function (element) {
                 element.moveTo(start, end);
             });
 
@@ -1188,7 +1184,7 @@ _.extend(GraphUtils.Graphie.prototype, {
 
             const coordForArrow = [this.coordA, this.coordZ];
             const angleForArrow = [360 - angle, (540 - angle) % 360];
-            _.each(this._arrows, function (arrow, i) {
+            this._arrows.forEach(function (arrow, i) {
                 arrow.toCoordAtAngle(coordForArrow[i], angleForArrow[i]);
             });
 
@@ -1238,7 +1234,7 @@ _.extend(GraphUtils.Graphie.prototype, {
                 });
             }
 
-            this.temp = _.flatten(this.temp);
+            this.temp = this.temp.flat(Infinity);
         };
 
         // Change z-order to back;
@@ -1306,8 +1302,7 @@ _.extend(GraphUtils.Graphie.prototype, {
         }
 
         if (lineSegment.vertexLabels.length) {
-            lineSegment.labeledVertices = _.map(
-                lineSegment.vertexLabels,
+            lineSegment.labeledVertices = lineSegment.vertexLabels.map(
                 (label) => {
                     return this.label(
                         [0, 0],
@@ -1332,14 +1327,11 @@ _.extend(GraphUtils.Graphie.prototype, {
                                 lineSegment.highlightStyle,
                                 50,
                             );
-                            lineSegment.arrowStyle = _.extend(
-                                {},
-                                lineSegment.arrowStyle,
-                                {
-                                    color: lineSegment.highlightStyle.stroke,
-                                    stroke: lineSegment.highlightStyle.stroke,
-                                },
-                            );
+                            lineSegment.arrowStyle = {
+                                ...lineSegment.arrowStyle,
+                                color: lineSegment.highlightStyle.stroke,
+                                stroke: lineSegment.highlightStyle.stroke,
+                            };
                             lineSegment.transform();
                         }
                     } else if (event.type === "vmouseout") {
@@ -1349,14 +1341,11 @@ _.extend(GraphUtils.Graphie.prototype, {
                                 lineSegment.normalStyle,
                                 50,
                             );
-                            lineSegment.arrowStyle = _.extend(
-                                {},
-                                lineSegment.arrowStyle,
-                                {
-                                    color: lineSegment.normalStyle.stroke,
-                                    stroke: lineSegment.normalStyle.stroke,
-                                },
-                            );
+                            lineSegment.arrowStyle = {
+                                ...lineSegment.arrowStyle,
+                                color: lineSegment.normalStyle.stroke,
+                                stroke: lineSegment.normalStyle.stroke,
+                            };
                             lineSegment.transform();
                         }
                     } else if (
@@ -1538,16 +1527,13 @@ _.extend(GraphUtils.Graphie.prototype, {
                                             lineSegment.normalStyle,
                                             50,
                                         );
-                                        lineSegment.arrowStyle = _.extend(
-                                            {},
-                                            lineSegment.arrowStyle,
-                                            {
-                                                color: lineSegment.normalStyle
-                                                    .stroke,
-                                                stroke: lineSegment.normalStyle
-                                                    .stroke,
-                                            },
-                                        );
+                                        lineSegment.arrowStyle = {
+                                            ...lineSegment.arrowStyle,
+                                            color: lineSegment.normalStyle
+                                                .stroke,
+                                            stroke: lineSegment.normalStyle
+                                                .stroke,
+                                        };
                                         lineSegment.transform();
                                     }
                                     if (
@@ -1601,6 +1587,8 @@ _.extend(GraphUtils.Graphie.prototype, {
     addMovablePolygon: function (options) {
         const graphie = this;
 
+        const {points, ...optionsWithoutPoints} = options;
+
         const polygon = $.extend(
             {
                 snapX: 0,
@@ -1633,21 +1621,19 @@ _.extend(GraphUtils.Graphie.prototype, {
                 updateOnPointMove: true,
                 closed: true,
             },
-            _.omit(options, "points"),
+            optionsWithoutPoints,
         );
 
         const normalColor = polygon.fixed
             ? KhanColors.DYNAMIC
             : KhanColors.INTERACTIVE;
-        polygon.normalStyle = _.extend(
-            {
-                "stroke-width": 2,
-                "fill-opacity": 0,
-                fill: normalColor,
-                stroke: normalColor,
-            },
-            options.normalStyle,
-        );
+        polygon.normalStyle = {
+            "stroke-width": 2,
+            "fill-opacity": 0,
+            fill: normalColor,
+            stroke: normalColor,
+            ...options.normalStyle,
+        };
 
         // don't deep copy the points array with $.extend;
         // we may want to append to it later for click-to-add-points
@@ -1661,7 +1647,7 @@ _.extend(GraphUtils.Graphie.prototype, {
             const n = polygon.points.length;
 
             // Update coords
-            polygon.coords = _.map(polygon.points, function (coordOrPoint, i) {
+            polygon.coords = polygon.points.map(function (coordOrPoint, i) {
                 if (isPoint(coordOrPoint)) {
                     return coordOrPoint.coord;
                 }
@@ -1669,12 +1655,16 @@ _.extend(GraphUtils.Graphie.prototype, {
             });
 
             // Calculate bounding box
-            polygon.left = _.min(polygon.coords.map((coord) => coord[0]));
-            polygon.right = _.max(polygon.coords.map((coord) => coord[0]));
-            polygon.top = _.max(polygon.coords.map((coord) => coord[1]));
-            polygon.bottom = _.min(polygon.coords.map((coord) => coord[1]));
+            polygon.left = Math.min(...polygon.coords.map((coord) => coord[0]));
+            polygon.right = Math.max(
+                ...polygon.coords.map((coord) => coord[0]),
+            );
+            polygon.top = Math.max(...polygon.coords.map((coord) => coord[1]));
+            polygon.bottom = Math.min(
+                ...polygon.coords.map((coord) => coord[1]),
+            );
 
-            let scaledCoords = _.map(polygon.coords, function (coord) {
+            let scaledCoords = polygon.coords.map(function (coord) {
                 return graphie.scalePoint(coord);
             });
 
@@ -1686,9 +1676,7 @@ _.extend(GraphUtils.Graphie.prototype, {
                 // to remove the inside area of the path, which would
                 // otherwise be clickable (even if the closing line segment
                 // wasn't drawn
-                scaledCoords = scaledCoords.concat(
-                    _.clone(scaledCoords).reverse(),
-                );
+                scaledCoords = scaledCoords.concat([...scaledCoords].reverse());
             }
             polygon.path = GraphUtils.unscaledSvgPath(scaledCoords);
 
@@ -1703,7 +1691,7 @@ _.extend(GraphUtils.Graphie.prototype, {
                 polygon.angleLabels.length ||
                 polygon.showRightAngleMarkers.length
             ) {
-                _.each(polygon.labeledAngles, function (label, i) {
+                polygon.labeledAngles.forEach(function (label, i) {
                     polygon.temp.push(
                         graphie.labelAngle({
                             point1: polygon.coords[(i - 1 + n) % n],
@@ -1723,7 +1711,7 @@ _.extend(GraphUtils.Graphie.prototype, {
 
             // Update side labels
             if (polygon.sideLabels.length) {
-                _.each(polygon.labeledSides, function (label, i) {
+                polygon.labeledSides.forEach(function (label, i) {
                     polygon.temp.push(
                         graphie.labelSide({
                             point1: polygon.coords[i],
@@ -1741,7 +1729,7 @@ _.extend(GraphUtils.Graphie.prototype, {
 
             // Update vertex labels
             if (polygon.vertexLabels.length) {
-                _.each(polygon.labeledVertices, function (label, i) {
+                polygon.labeledVertices.forEach(function (label, i) {
                     graphie.labelVertex({
                         point1: polygon.coords[(i - 1 + n) % n],
                         vertex: polygon.coords[i],
@@ -1754,7 +1742,7 @@ _.extend(GraphUtils.Graphie.prototype, {
                 });
             }
 
-            polygon.temp = _.flatten(polygon.temp);
+            polygon.temp = polygon.temp.flat(Infinity);
         };
 
         polygon.transform = function () {
@@ -1810,7 +1798,7 @@ _.extend(GraphUtils.Graphie.prototype, {
         // Setup
 
         if (polygon.updateOnPointMove) {
-            _.each(_.filter(polygon.points, isPoint), function (coordOrPoint) {
+            polygon.points.filter(isPoint).forEach(function (coordOrPoint) {
                 coordOrPoint.polygonVertices.push(polygon);
             });
         }
@@ -1822,19 +1810,19 @@ _.extend(GraphUtils.Graphie.prototype, {
                 polygon.angleLabels.length,
                 polygon.showRightAngleMarkers.length,
             );
-            polygon.labeledAngles = _.times(numLabels, () => {
+            polygon.labeledAngles = Array.from({length: numLabels}, () => {
                 return this.label([0, 0], "", "center", polygon.labelStyle);
             });
         }
 
         if (polygon.sideLabels.length) {
-            polygon.labeledSides = _.map(polygon.sideLabels, (label) => {
+            polygon.labeledSides = polygon.sideLabels.map((label) => {
                 return this.label([0, 0], "", "center", polygon.labelStyle);
             });
         }
 
         if (polygon.vertexLabels.length) {
-            polygon.labeledVertices = _.map(polygon.vertexLabels, (label) => {
+            polygon.labeledVertices = polygon.vertexLabels.map((label) => {
                 return this.label([0, 0], "", "center", polygon.labelStyle);
             });
         }
@@ -1862,15 +1850,14 @@ _.extend(GraphUtils.Graphie.prototype, {
                                 polygon.highlightStyle,
                                 50,
                             );
-                            _.each(
-                                _.filter(polygon.points, isPoint),
-                                function (point) {
+                            polygon.points
+                                .filter(isPoint)
+                                .forEach(function (point) {
                                     point.visibleShape.animate(
                                         polygon.pointHighlightStyle,
                                         50,
                                     );
-                                },
-                            );
+                                });
                         }
                     } else if (event.type === "vmouseout") {
                         polygon.highlight = false;
@@ -1879,9 +1866,9 @@ _.extend(GraphUtils.Graphie.prototype, {
                                 polygon.normalStyle,
                                 50,
                             );
-                            const points = _.filter(polygon.points, isPoint);
-                            if (!_.any(points.map((point) => point.dragging))) {
-                                _.each(points, function (point) {
+                            const points = polygon.points.filter(isPoint);
+                            if (!points.some((point) => point.dragging)) {
+                                points.forEach(function (point) {
                                     point.visibleShape.animate(
                                         point.normalStyle,
                                         50,
@@ -1895,12 +1882,11 @@ _.extend(GraphUtils.Graphie.prototype, {
                     ) {
                         event.preventDefault();
 
-                        _.each(
-                            _.filter(polygon.points, isPoint),
-                            function (point) {
+                        polygon.points
+                            .filter(isPoint)
+                            .forEach(function (point) {
                                 point.dragging = true;
-                            },
-                        );
+                            });
 
                         let startX =
                             // @ts-expect-error - TS2532 - Object is possibly 'undefined'.
@@ -2031,8 +2017,7 @@ _.extend(GraphUtils.Graphie.prototype, {
                                     };
 
                                     if (doMove) {
-                                        _.each(
-                                            polygon.points,
+                                        polygon.points.forEach(
                                             function (coordOrPoint, i) {
                                                 if (isPoint(coordOrPoint)) {
                                                     coordOrPoint.setCoord(
@@ -2055,11 +2040,9 @@ _.extend(GraphUtils.Graphie.prototype, {
                                 } else if (event.type === "vmouseup") {
                                     $(document).unbind(".polygon");
 
-                                    const points = _.filter(
-                                        polygon.points,
-                                        isPoint,
-                                    );
-                                    _.each(points, function (point) {
+                                    const points =
+                                        polygon.points.filter(isPoint);
+                                    points.forEach(function (point) {
                                         point.dragging = false;
                                     });
 
@@ -2071,7 +2054,7 @@ _.extend(GraphUtils.Graphie.prototype, {
                                             50,
                                         );
 
-                                        _.each(points, function (point) {
+                                        points.forEach(function (point) {
                                             point.visibleShape.animate(
                                                 point.normalStyle,
                                                 50,
@@ -2095,7 +2078,7 @@ _.extend(GraphUtils.Graphie.prototype, {
         }
 
         // Bring any movable points to the front
-        _.invoke(_.filter(polygon.points, isPoint), "toFront");
+        _.invoke(polygon.points.filter(isPoint), "toFront");
 
         return polygon;
     },
@@ -2210,14 +2193,11 @@ _.extend(GraphUtils.Graphie.prototype, {
             ? KhanColors.DYNAMIC
             : KhanColors.INTERACTIVE;
         const centerNormalStyle = options ? options.centerNormalStyle : null;
-        circle.centerNormalStyle = _.extend(
-            {},
-            {
-                fill: normalColor,
-                stroke: normalColor,
-            },
-            centerNormalStyle,
-        );
+        circle.centerNormalStyle = {
+            fill: normalColor,
+            stroke: normalColor,
+            ...centerNormalStyle,
+        };
 
         circle.centerPoint = graphie.addMovablePoint({
             graph: graphie,
@@ -3282,8 +3262,8 @@ function Ruler(graphie: any, options: any) {
         },
     });
 
-    const light = _.extend({}, options.style, {strokeWidth: 1});
-    const bold = _.extend({}, options.style, {strokeWidth: 2});
+    const light = {...options.style, strokeWidth: 1};
+    const bold = {...options.style, strokeWidth: 2};
 
     const width = options.units * options.pixelsPerUnit;
     const height = 50;
@@ -3351,7 +3331,7 @@ function Ruler(graphie: any, options: any) {
     set.push(graphie.line([left - px, bottom], [right + px, bottom], bold));
     set.push(graphie.line([left - px, top], [right + px, top], bold));
 
-    _.times(numTicks, function (i) {
+    for (let i = 0; i < numTicks; i++) {
         const n = i / options.ticksPerUnit;
         const x = left + n * graphieUnitsPerUnit;
         const height = getTickHeight(i) * graphieUnitsHeight;
@@ -3395,7 +3375,7 @@ function Ruler(graphie: any, options: any) {
             });
             set.push(label);
         }
-    });
+    }
 
     const mouseTarget = graphie.mouselayer.path(
         graphie.svgPath([
@@ -3560,7 +3540,7 @@ function MovableAngle(graphie: any, options: any) {
     this.graphie = graphie;
 
     // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-    _.extend(this, options);
+    Object.assign(this, options);
     // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     _.defaults(this, {
         normalStyle: {
@@ -3597,7 +3577,7 @@ function MovableAngle(graphie: any, options: any) {
 
     // Handle coordinates that are not MovablePoints (i.e. [2, 4])
     // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-    this.points = _.map(options.points, (point) => {
+    this.points = options.points.map((point) => {
         if (Array.isArray(point)) {
             return graphie.addMovablePoint({
                 coord: point,
@@ -3612,7 +3592,7 @@ function MovableAngle(graphie: any, options: any) {
         return point;
     });
     // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-    this.coords = _.pluck(this.points, "coord");
+    this.coords = this.points.map((point) => point.coord);
     // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     if (this.reflex == null) {
         // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
@@ -3684,7 +3664,7 @@ _.extend(MovableAngle.prototype, {
 
             let valid = true;
             const newPoints: Record<string, any> = {};
-            _.each([0, 2], function (i) {
+            [0, 2].forEach(function (i) {
                 const oldPoint = points[i].coord;
                 let newPoint = kvector.add(oldPoint, delta);
 
@@ -3705,7 +3685,7 @@ _.extend(MovableAngle.prototype, {
 
             // Only move points if all new positions are valid
             if (valid) {
-                _.each(newPoints, function (newPoint, i) {
+                Object.entries(newPoints).forEach(function ([i, newPoint]) {
                     points[i].setCoord(newPoint);
                 });
             }
@@ -3716,7 +3696,7 @@ _.extend(MovableAngle.prototype, {
         const snapOffset = this.snapOffsetDeg;
 
         // Drag ray control points to move each ray individually
-        _.each([0, 2], function (i) {
+        [0, 2].forEach(function (i) {
             points[i].onMove = function (x: number, y: number) {
                 const newPoint: Coord = [x, y];
                 const vertex = points[1].coord;
@@ -3751,40 +3731,44 @@ _.extend(MovableAngle.prototype, {
         const vertex = this.points[1];
 
         vertex.onHighlight = () => {
-            _.each(this.points, (point) => {
+            this.points.forEach((point) => {
                 point.visibleShape.animate(this.highlightStyle, 50);
             });
-            _.each(this.rays, (ray) => {
+            this.rays.forEach((ray) => {
                 ray.visibleLine.animate(this.highlightStyle, 50);
-                ray.arrowStyle = _.extend({}, ray.arrowStyle, {
+                ray.arrowStyle = {
+                    ...ray.arrowStyle,
                     color: this.highlightStyle.stroke,
                     stroke: this.highlightStyle.stroke,
-                });
+                };
             });
 
-            this.angleStyle = _.extend({}, this.angleStyle, {
+            this.angleStyle = {
+                ...this.angleStyle,
                 color: this.highlightStyle.stroke,
                 stroke: this.highlightStyle.stroke,
-            });
+            };
             this.update();
         };
 
         vertex.onUnhighlight = () => {
-            _.each(this.points, (point) => {
+            this.points.forEach((point) => {
                 point.visibleShape.animate(this.normalStyle, 50);
             });
-            _.each(this.rays, (ray) => {
+            this.rays.forEach((ray) => {
                 ray.visibleLine.animate(ray.normalStyle, 50);
-                ray.arrowStyle = _.extend({}, ray.arrowStyle, {
+                ray.arrowStyle = {
+                    ...ray.arrowStyle,
                     color: ray.normalStyle.stroke,
                     stroke: ray.normalStyle.stroke,
-                });
+                };
             });
 
-            this.angleStyle = _.extend({}, this.angleStyle, {
+            this.angleStyle = {
+                ...this.angleStyle,
                 color: KhanColors.DYNAMIC,
                 stroke: KhanColors.DYNAMIC,
-            });
+            };
             this.update();
         };
     },
@@ -3817,14 +3801,14 @@ _.extend(MovableAngle.prototype, {
 
     getClockwiseCoords: function () {
         if (this.isClockwise()) {
-            return _.clone(this.coords);
+            return [...this.coords];
         }
-        return _.clone(this.coords).reverse();
+        return [...this.coords].reverse();
     },
 
     update: function (shouldChangeReflexivity) {
         const prevCoords = this.coords;
-        this.coords = _.pluck(this.points, "coord");
+        this.coords = this.points.map((point) => point.coord);
 
         // Update lines
         _.invoke(this.points, "updateLineEnds");

--- a/packages/perseus/src/util/interactive.ts
+++ b/packages/perseus/src/util/interactive.ts
@@ -2529,7 +2529,8 @@ _.extend(GraphUtils.Graphie.prototype, {
                 });
         };
 
-        return function (this: any, options: any) {
+        return function (options: any) {
+            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
             const graph = this;
 
             let rotatePoint = options.center;
@@ -2795,7 +2796,8 @@ _.extend(GraphUtils.Graphie.prototype, {
             };
         };
 
-        return function (this: any, options: any) {
+        return function (options: any) {
+            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
             const graphie = this;
 
             const line = options.line;
@@ -2945,16 +2947,22 @@ _.extend(GraphUtils.Graphie.prototype, {
     addPoints: kvector.add,
 });
 
-function Protractor(this: any, graph: any, center: any) {
+function Protractor(graph: any, center: any) {
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.set = graph.raphael.set();
 
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.cx = center[0];
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.cy = center[1];
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     const pro = this;
 
     const r = graph.unscaleVector(180.5)[0];
     const imgPos = graph.scalePoint([
+        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
         this.cx - r,
+        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
         this.cy + r - graph.unscaleVector(10.5)[1],
     ]);
     const image = graph.mouselayer.image(
@@ -2964,6 +2972,7 @@ function Protractor(this: any, graph: any, center: any) {
         360,
         180,
     );
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.set.push(image);
 
     // Prevent the page from scrolling when we grab and drag the image on a
@@ -3032,18 +3041,23 @@ function Protractor(this: any, graph: any, center: any) {
         });
 
     // add it to the set so it translates with everything else
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.set.push(arrow);
 
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.centerPoint = graph.addMovablePoint({
         coord: center,
         visible: false,
     });
 
     // Use a movablePoint for rotation
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.rotateHandle = graph.addMovablePoint({
         bounded: false,
         coord: [
+            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
             Math.sin((275 * Math.PI) / 180) * r + this.cx,
+            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
             Math.cos((275 * Math.PI) / 180) * r + this.cy,
         ],
         onMove: function (x, y) {
@@ -3059,14 +3073,18 @@ function Protractor(this: any, graph: any, center: any) {
     });
 
     // Add a constraint so the point moves in a circle
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.rotateHandle.constraints.fixedDistance.dist = r;
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.rotateHandle.constraints.fixedDistance.point = this.centerPoint;
 
     // Remove the default dot added by the movablePoint since we have our
     // double-arrow thing
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.rotateHandle.visibleShape.remove();
     // Make the mouse target bigger to encompass the whole area around the
     // double-arrow thing
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.rotateHandle.mouseTarget.attr({scale: 2.0});
 
     let isDragging = false;
@@ -3075,6 +3093,7 @@ function Protractor(this: any, graph: any, center: any) {
         return isHovering || isDragging;
     };
 
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     const self = this;
     const $mouseTarget = $(self.rotateHandle.mouseTarget.getMouseTarget());
     $mouseTarget.on("vmousedown", function (event) {
@@ -3107,9 +3126,11 @@ function Protractor(this: any, graph: any, center: any) {
         }
     });
 
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     const setNodes = $.map(this.set, function (el) {
         return el.node;
     });
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.makeTranslatable = function makeTranslatable() {
         $(setNodes).css("cursor", "move");
         $mouseTarget.css("cursor", "-webkit-grab");
@@ -3163,8 +3184,10 @@ function Protractor(this: any, graph: any, center: any) {
         });
     };
 
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.rotation = 0;
 
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.rotate = function (offset: any, absolute: any) {
         const center = graph.scalePoint(this.centerPoint.coord);
 
@@ -3178,6 +3201,7 @@ function Protractor(this: any, graph: any, center: any) {
         return this;
     };
 
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.moveTo = function moveTo(x: any, y: any) {
         const start = graph.scalePoint(pro.centerPoint.coord);
         const end = graph.scalePoint([x, y]);
@@ -3211,6 +3235,7 @@ function Protractor(this: any, graph: any, center: any) {
         );
     };
 
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.rotateTo = function rotateTo(angle: any) {
         if (Math.abs(this.rotation - angle) > 180) {
             this.rotation += 360;
@@ -3233,15 +3258,18 @@ function Protractor(this: any, graph: any, center: any) {
         );
     };
 
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.remove = function () {
         this.set.remove();
     };
 
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.makeTranslatable();
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     return this;
 }
 
-function Ruler(this: any, graphie: any, options: any) {
+function Ruler(graphie: any, options: any) {
     _.defaults(options, {
         center: [0, 0],
         pixelsPerUnit: 40,
@@ -3516,19 +3544,24 @@ function Ruler(this: any, graphie: any, options: any) {
     rightBottomHandle.constraints.fixedDistance.dist = width / graphie.scale[0];
     rightBottomHandle.constraints.fixedDistance.point = leftBottomHandle;
 
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.remove = function () {
         set.remove();
         leftBottomHandle.remove();
         rightBottomHandle.remove();
     };
 
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     return this;
 }
 
-function MovableAngle(this: any, graphie: any, options: any) {
+function MovableAngle(graphie: any, options: any) {
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.graphie = graphie;
 
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     _.extend(this, options);
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     _.defaults(this, {
         normalStyle: {
             stroke: KhanColors.INTERACTIVE,
@@ -3554,6 +3587,7 @@ function MovableAngle(this: any, graphie: any, options: any) {
         // it is not overridden by undefined
     });
 
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     if (!this.points || this.points.length !== 3) {
         throw new PerseusError(
             "MovableAngle requires 3 points",
@@ -3562,6 +3596,7 @@ function MovableAngle(this: any, graphie: any, options: any) {
     }
 
     // Handle coordinates that are not MovablePoints (i.e. [2, 4])
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.points = _.map(options.points, (point) => {
         if (Array.isArray(point)) {
             return graphie.addMovablePoint({
@@ -3570,36 +3605,51 @@ function MovableAngle(this: any, graphie: any, options: any) {
                 constraints: {
                     fixed: true,
                 },
+                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                 normalStyle: this.normalStyle,
             });
         }
         return point;
     });
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.coords = _.pluck(this.points, "coord");
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     if (this.reflex == null) {
+        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
         if (this.allowReflex) {
+            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
             this.reflex = this._getClockwiseAngle(this.coords) > 180;
         } else {
+            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
             this.reflex = false;
         }
     }
 
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.rays = [0, 2].map((i) => {
         return graphie.addMovableLineSegment({
+            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
             pointA: this.points[1],
+            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
             pointZ: this.points[i],
             fixed: true,
             extendRay: true,
         });
     });
 
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.temp = [];
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.labeledAngle = graphie.label([0, 0], "", "center", this.labelStyle);
 
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     if (!this.fixed) {
+        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
         this.addMoveHandlers();
+        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
         this.addHighlightHandlers();
     }
+    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.update();
 }
 

--- a/packages/perseus/src/util/interactive.ts
+++ b/packages/perseus/src/util/interactive.ts
@@ -2860,7 +2860,7 @@ _.extend(GraphUtils.Graphie.prototype, {
                 redraw(buttonCoord, [coordA, coordZ]);
             };
 
-            $(line).on("move", update.bind(button, null, null));
+            $(line).on("move", () => update(null, null));
 
             const $mouseTarget = $(button.mouseTarget.getMouseTarget());
             $mouseTarget.on("vclick", function () {

--- a/packages/perseus/src/util/interactive.ts
+++ b/packages/perseus/src/util/interactive.ts
@@ -1308,8 +1308,7 @@ _.extend(GraphUtils.Graphie.prototype, {
         if (lineSegment.vertexLabels.length) {
             lineSegment.labeledVertices = _.map(
                 lineSegment.vertexLabels,
-                function (label) {
-                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+                (label) => {
                     return this.label(
                         [0, 0],
                         "",
@@ -1317,7 +1316,6 @@ _.extend(GraphUtils.Graphie.prototype, {
                         lineSegment.labelStyle,
                     );
                 },
-                this,
             );
         }
 
@@ -1824,36 +1822,21 @@ _.extend(GraphUtils.Graphie.prototype, {
                 polygon.angleLabels.length,
                 polygon.showRightAngleMarkers.length,
             );
-            polygon.labeledAngles = _.times(
-                numLabels,
-                function () {
-                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                    return this.label([0, 0], "", "center", polygon.labelStyle);
-                },
-                this,
-            );
+            polygon.labeledAngles = _.times(numLabels, () => {
+                return this.label([0, 0], "", "center", polygon.labelStyle);
+            });
         }
 
         if (polygon.sideLabels.length) {
-            polygon.labeledSides = _.map(
-                polygon.sideLabels,
-                function (label) {
-                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                    return this.label([0, 0], "", "center", polygon.labelStyle);
-                },
-                this,
-            );
+            polygon.labeledSides = _.map(polygon.sideLabels, (label) => {
+                return this.label([0, 0], "", "center", polygon.labelStyle);
+            });
         }
 
         if (polygon.vertexLabels.length) {
-            polygon.labeledVertices = _.map(
-                polygon.vertexLabels,
-                function (label) {
-                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                    return this.label([0, 0], "", "center", polygon.labelStyle);
-                },
-                this,
-            );
+            polygon.labeledVertices = _.map(polygon.vertexLabels, (label) => {
+                return this.label([0, 0], "", "center", polygon.labelStyle);
+            });
         }
 
         polygon.update();
@@ -2546,8 +2529,7 @@ _.extend(GraphUtils.Graphie.prototype, {
                 });
         };
 
-        return function (options: any) {
-            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+        return function (this: any, options: any) {
             const graph = this;
 
             let rotatePoint = options.center;
@@ -2813,8 +2795,7 @@ _.extend(GraphUtils.Graphie.prototype, {
             };
         };
 
-        return function (options: any) {
-            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+        return function (this: any, options: any) {
             const graphie = this;
 
             const line = options.line;
@@ -2964,22 +2945,16 @@ _.extend(GraphUtils.Graphie.prototype, {
     addPoints: kvector.add,
 });
 
-function Protractor(graph: any, center: any) {
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+function Protractor(this: any, graph: any, center: any) {
     this.set = graph.raphael.set();
 
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.cx = center[0];
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.cy = center[1];
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     const pro = this;
 
     const r = graph.unscaleVector(180.5)[0];
     const imgPos = graph.scalePoint([
-        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
         this.cx - r,
-        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
         this.cy + r - graph.unscaleVector(10.5)[1],
     ]);
     const image = graph.mouselayer.image(
@@ -2989,7 +2964,6 @@ function Protractor(graph: any, center: any) {
         360,
         180,
     );
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.set.push(image);
 
     // Prevent the page from scrolling when we grab and drag the image on a
@@ -3058,23 +3032,18 @@ function Protractor(graph: any, center: any) {
         });
 
     // add it to the set so it translates with everything else
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.set.push(arrow);
 
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.centerPoint = graph.addMovablePoint({
         coord: center,
         visible: false,
     });
 
     // Use a movablePoint for rotation
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.rotateHandle = graph.addMovablePoint({
         bounded: false,
         coord: [
-            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
             Math.sin((275 * Math.PI) / 180) * r + this.cx,
-            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
             Math.cos((275 * Math.PI) / 180) * r + this.cy,
         ],
         onMove: function (x, y) {
@@ -3090,18 +3059,14 @@ function Protractor(graph: any, center: any) {
     });
 
     // Add a constraint so the point moves in a circle
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.rotateHandle.constraints.fixedDistance.dist = r;
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.rotateHandle.constraints.fixedDistance.point = this.centerPoint;
 
     // Remove the default dot added by the movablePoint since we have our
     // double-arrow thing
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.rotateHandle.visibleShape.remove();
     // Make the mouse target bigger to encompass the whole area around the
     // double-arrow thing
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.rotateHandle.mouseTarget.attr({scale: 2.0});
 
     let isDragging = false;
@@ -3110,7 +3075,6 @@ function Protractor(graph: any, center: any) {
         return isHovering || isDragging;
     };
 
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     const self = this;
     const $mouseTarget = $(self.rotateHandle.mouseTarget.getMouseTarget());
     $mouseTarget.on("vmousedown", function (event) {
@@ -3143,11 +3107,9 @@ function Protractor(graph: any, center: any) {
         }
     });
 
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     const setNodes = $.map(this.set, function (el) {
         return el.node;
     });
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.makeTranslatable = function makeTranslatable() {
         $(setNodes).css("cursor", "move");
         $mouseTarget.css("cursor", "-webkit-grab");
@@ -3201,10 +3163,8 @@ function Protractor(graph: any, center: any) {
         });
     };
 
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.rotation = 0;
 
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.rotate = function (offset: any, absolute: any) {
         const center = graph.scalePoint(this.centerPoint.coord);
 
@@ -3218,7 +3178,6 @@ function Protractor(graph: any, center: any) {
         return this;
     };
 
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.moveTo = function moveTo(x: any, y: any) {
         const start = graph.scalePoint(pro.centerPoint.coord);
         const end = graph.scalePoint([x, y]);
@@ -3252,7 +3211,6 @@ function Protractor(graph: any, center: any) {
         );
     };
 
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.rotateTo = function rotateTo(angle: any) {
         if (Math.abs(this.rotation - angle) > 180) {
             this.rotation += 360;
@@ -3275,18 +3233,15 @@ function Protractor(graph: any, center: any) {
         );
     };
 
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.remove = function () {
         this.set.remove();
     };
 
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.makeTranslatable();
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     return this;
 }
 
-function Ruler(graphie: any, options: any) {
+function Ruler(this: any, graphie: any, options: any) {
     _.defaults(options, {
         center: [0, 0],
         pixelsPerUnit: 40,
@@ -3561,24 +3516,19 @@ function Ruler(graphie: any, options: any) {
     rightBottomHandle.constraints.fixedDistance.dist = width / graphie.scale[0];
     rightBottomHandle.constraints.fixedDistance.point = leftBottomHandle;
 
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.remove = function () {
         set.remove();
         leftBottomHandle.remove();
         rightBottomHandle.remove();
     };
 
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     return this;
 }
 
-function MovableAngle(graphie: any, options: any) {
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+function MovableAngle(this: any, graphie: any, options: any) {
     this.graphie = graphie;
 
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     _.extend(this, options);
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     _.defaults(this, {
         normalStyle: {
             stroke: KhanColors.INTERACTIVE,
@@ -3604,7 +3554,6 @@ function MovableAngle(graphie: any, options: any) {
         // it is not overridden by undefined
     });
 
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     if (!this.points || this.points.length !== 3) {
         throw new PerseusError(
             "MovableAngle requires 3 points",
@@ -3613,69 +3562,44 @@ function MovableAngle(graphie: any, options: any) {
     }
 
     // Handle coordinates that are not MovablePoints (i.e. [2, 4])
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-    this.points = _.map(
-        options.points,
-        function (point) {
-            if (Array.isArray(point)) {
-                return graphie.addMovablePoint({
-                    coord: point,
-                    visible: false,
-                    constraints: {
-                        fixed: true,
-                    },
-                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                    normalStyle: this.normalStyle,
-                });
-            }
-            return point;
-        },
-        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-        this,
-    );
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
+    this.points = _.map(options.points, (point) => {
+        if (Array.isArray(point)) {
+            return graphie.addMovablePoint({
+                coord: point,
+                visible: false,
+                constraints: {
+                    fixed: true,
+                },
+                normalStyle: this.normalStyle,
+            });
+        }
+        return point;
+    });
     this.coords = _.pluck(this.points, "coord");
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     if (this.reflex == null) {
-        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
         if (this.allowReflex) {
-            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
             this.reflex = this._getClockwiseAngle(this.coords) > 180;
         } else {
-            // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
             this.reflex = false;
         }
     }
 
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-    this.rays = [0, 2].map(
-        function (i) {
-            return graphie.addMovableLineSegment({
-                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                pointA: this.points[1],
-                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                pointZ: this.points[i],
-                fixed: true,
-                extendRay: true,
-            });
-        },
-        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-        this,
-    );
+    this.rays = [0, 2].map((i) => {
+        return graphie.addMovableLineSegment({
+            pointA: this.points[1],
+            pointZ: this.points[i],
+            fixed: true,
+            extendRay: true,
+        });
+    });
 
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.temp = [];
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.labeledAngle = graphie.label([0, 0], "", "center", this.labelStyle);
 
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     if (!this.fixed) {
-        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
         this.addMoveHandlers();
-        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
         this.addHighlightHandlers();
     }
-    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
     this.update();
 }
 
@@ -3777,28 +3701,16 @@ _.extend(MovableAngle.prototype, {
         const vertex = this.points[1];
 
         vertex.onHighlight = () => {
-            _.each(
-                this.points,
-                function (point) {
-                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                    point.visibleShape.animate(this.highlightStyle, 50);
-                },
-                this,
-            );
-            _.each(
-                this.rays,
-                function (ray) {
-                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                    ray.visibleLine.animate(this.highlightStyle, 50);
-                    ray.arrowStyle = _.extend({}, ray.arrowStyle, {
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                        color: this.highlightStyle.stroke,
-                        // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                        stroke: this.highlightStyle.stroke,
-                    });
-                },
-                this,
-            );
+            _.each(this.points, (point) => {
+                point.visibleShape.animate(this.highlightStyle, 50);
+            });
+            _.each(this.rays, (ray) => {
+                ray.visibleLine.animate(this.highlightStyle, 50);
+                ray.arrowStyle = _.extend({}, ray.arrowStyle, {
+                    color: this.highlightStyle.stroke,
+                    stroke: this.highlightStyle.stroke,
+                });
+            });
 
             this.angleStyle = _.extend({}, this.angleStyle, {
                 color: this.highlightStyle.stroke,
@@ -3808,25 +3720,16 @@ _.extend(MovableAngle.prototype, {
         };
 
         vertex.onUnhighlight = () => {
-            _.each(
-                this.points,
-                function (point) {
-                    // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                    point.visibleShape.animate(this.normalStyle, 50);
-                },
-                this,
-            );
-            _.each(
-                this.rays,
-                function (ray) {
-                    ray.visibleLine.animate(ray.normalStyle, 50);
-                    ray.arrowStyle = _.extend({}, ray.arrowStyle, {
-                        color: ray.normalStyle.stroke,
-                        stroke: ray.normalStyle.stroke,
-                    });
-                },
-                this,
-            );
+            _.each(this.points, (point) => {
+                point.visibleShape.animate(this.normalStyle, 50);
+            });
+            _.each(this.rays, (ray) => {
+                ray.visibleLine.animate(ray.normalStyle, 50);
+                ray.arrowStyle = _.extend({}, ray.arrowStyle, {
+                    color: ray.normalStyle.stroke,
+                    stroke: ray.normalStyle.stroke,
+                });
+            });
 
             this.angleStyle = _.extend({}, this.angleStyle, {
                 color: KhanColors.DYNAMIC,


### PR DESCRIPTION
## Summary:

I noticed we had a bunch of `// @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.` exceptions. I successfully removed some of them [in a previous PR](https://github.com/Khan/perseus/pull/4019) by converting `function`s to arrow functions, so I thought I'd have a crack at it. While I touched these files, I tried to do some other cleanup tasks:

- Convert `functions`s to arrow functions where appropriate (such as the callback for `map`)
- Convert underscore methods to native methods
- Utilize arrow functions instead of using `bind`
- Simplified a giant ternary

You probably want to enable "Hide whitespace". Sorry that this is long, but it's only four files and is mostly pretty repetitive.