### PR TITLE
Remove defaultProps from the Group widget

### DIFF
--- a/.changeset/shiny-pets-melt.md
+++ b/.changeset/shiny-pets-melt.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: The Group widget no longer has defaultProps; all props are always passed.

--- a/packages/perseus/src/widgets/group/group.tsx
+++ b/packages/perseus/src/widgets/group/group.tsx
@@ -7,7 +7,6 @@
  * learner-facing, but new content cannot be made with Group.
  */
 
-import {linterContextDefault} from "@khanacademy/perseus-linter";
 import classNames from "classnames";
 import * as React from "react";
 
@@ -35,25 +34,12 @@ import type {
 } from "@khanacademy/perseus-core";
 
 type Props = WidgetProps<PerseusGroupWidgetOptions, PerseusGroupUserInput>;
-type DefaultProps = {
-    content: Props["content"];
-    widgets: Props["widgets"];
-    images: Props["images"];
-    linterContext: Props["linterContext"];
-};
 
 class Group extends React.Component<Props> implements Widget {
     static contextType = PerseusI18nContext;
     declare context: React.ContextType<typeof PerseusI18nContext>;
 
     rendererRef: Renderer | null | undefined;
-
-    static defaultProps: DefaultProps = {
-        content: "",
-        widgets: {},
-        images: {},
-        linterContext: linterContextDefault,
-    };
 
     componentDidMount() {
         // NOTE(marcia): See comment in render method about our cyclical


### PR DESCRIPTION
All options are always set, either by the parser or by the `defaultWidgetOptions`
in `perseus-core` (used to initialize the widget in the editor). The `linterContext`
is always passed as well.

This change is in preparation for grouping all widget options under a single
`options` prop (see the linked ticket).

## Summary:

Issue: LEMS-4354

## Test plan:

- You should be able to create, edit, and preview a Group widget in the
  EditorPage storybook.