### PR TITLE
Remove defaultProps from GradedGroupSet

### DIFF
--- a/.changeset/curly-results-smile.md
+++ b/.changeset/curly-results-smile.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: GradedGroupSet no longer has defaultProps.

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
-import {linterContextDefault} from "@khanacademy/perseus-linter";
 import Clickable from "@khanacademy/wonder-blocks-clickable";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {border, font, semanticColor} from "@khanacademy/wonder-blocks-tokens";
@@ -97,11 +96,6 @@ type Props = WidgetProps<PerseusGradedGroupSetWidgetOptions> & {
     dependencies: PerseusDependenciesV2;
 };
 
-type DefaultProps = {
-    gradedGroups: Props["gradedGroups"];
-    linterContext: Props["linterContext"];
-};
-
 type State = {
     currentGroup: number;
 };
@@ -109,11 +103,6 @@ type State = {
 class GradedGroupSet extends React.Component<Props, State> implements Widget {
     // @ts-expect-error - TS2564 - Property '_childGroup' has no initializer and is not definitely assigned in the constructor.
     _childGroup: GradedGroup;
-
-    static defaultProps: DefaultProps = {
-        gradedGroups: [],
-        linterContext: linterContextDefault,
-    };
 
     state: State = {
         currentGroup: 0,


### PR DESCRIPTION
## Summary:
The `gradedGroups` option was always passed (the parser guarantees it will be
set, and the editor defaults it via `defaultWidgetOptions`). `linterContext` is
also always present.

This change prepares to group all widget options under a separate `options`
prop (see the linked ticket).

Issue: LEMS-4354

## Test plan:

You should be able to create, edit, and preview a GradedGroupSet widget in the EditorPage storybook.