### PR TITLE
Remove defaultProps from Orderer

### DIFF
--- a/.changeset/tired-wasps-taste.md
+++ b/.changeset/tired-wasps-taste.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Orderer no longer has defaultProps.

--- a/packages/perseus/src/widgets/orderer/orderer.tsx
+++ b/packages/perseus/src/widgets/orderer/orderer.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
 /* eslint-disable @typescript-eslint/no-invalid-this, react/no-unsafe */
-import {linterContextDefault} from "@khanacademy/perseus-linter";
 import $ from "jquery";
 import * as React from "react";
 import ReactDOM from "react-dom";
@@ -90,7 +89,6 @@ type CardProps = {
 type CardDefaultProps = {
     stack: CardProps["stack"];
     animating: CardProps["animating"];
-    linterContext: CardProps["linterContext"];
 };
 
 type CardState = {
@@ -107,7 +105,6 @@ class Card extends React.Component<CardProps, CardState> {
     static defaultProps: CardDefaultProps = {
         stack: false,
         animating: false,
-        linterContext: linterContextDefault,
     };
 
     state = {dragging: false};
@@ -297,11 +294,6 @@ type OrdererProps = WidgetProps<
     PerseusOrdererUserInput
 > & {dependencies: PerseusDependenciesV2};
 
-type OrdererDefaultProps = Pick<
-    OrdererProps,
-    "options" | "height" | "layout" | "linterContext" | "userInput"
->;
-
 type OrdererState = {
     dragging: boolean;
     placeholderIndex: number | null | undefined;
@@ -333,16 +325,6 @@ class Orderer
     extends React.Component<OrdererProps, OrdererState>
     implements Widget
 {
-    static defaultProps: OrdererDefaultProps = {
-        options: [],
-        height: "normal",
-        layout: "horizontal",
-        linterContext: linterContextDefault,
-        userInput: {
-            current: [],
-        },
-    };
-
     state: OrdererState = {
         dragging: false,
         placeholderIndex: null,


### PR DESCRIPTION
## Summary:
All props are always passed.

This change prepares to group the widget options of Orderer under a separate
`options` prop (see the linked ticket).

Issue: LEMS-4354

## Test plan:

You should be able to create, edit, and preview an Orderer widget in the EditorPage storybook.