### PR TITLE
Remove defaultProps from MockWidget

### DIFF
--- a/.changeset/free-lemons-help.md
+++ b/.changeset/free-lemons-help.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: MockWidget no longer has defaultProps.

--- a/packages/perseus/src/widgets/mock-widgets/mock-widget.tsx
+++ b/packages/perseus/src/widgets/mock-widgets/mock-widget.tsx
@@ -14,10 +14,6 @@ type ExternalProps = WidgetProps<MockWidgetOptions, PerseusMockWidgetUserInput>;
 
 type Props = ExternalProps;
 
-type DefaultProps = {
-    userInput: Props["userInput"];
-};
-
 /**
  * This is a Mock Perseus widget, which is used for our various rendering tests
  * both internally and in consuming projects. It is a simple widget that renders
@@ -31,12 +27,6 @@ type DefaultProps = {
  * You can register this widget for your tests by calling `registerWidget("mock-widget", MockWidget);`
  */
 class MockWidgetComponent extends React.Component<Props> implements Widget {
-    static defaultProps: DefaultProps = {
-        userInput: {
-            currentValue: "",
-        },
-    };
-
     inputRef: HTMLElement | null = null;
 
     getPromptJSON(): MockWidgetPromptJSON {


### PR DESCRIPTION
`userInput` is always provided. The initial user input is determined by
`getStartUserInput`.

## Summary:

Issue: LEMS-4354

## Test plan:

CI checks should pass.