### PR TITLE
Migrate group widget to WidgetPropsV2

### DIFF
--- a/.changeset/bold-brooms-repeat.md
+++ b/.changeset/bold-brooms-repeat.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Collect all options of the Group widget into a single `options` prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -523,7 +523,7 @@ review and commit the changes.
 - [x] Migrate `interactive-graph` to `WidgetPropsV2` (delete `satisfies PropsFor`
       assertion and update `interactive-graph-editor` preview; subtype lookup already
       handled by scaffolding).
-- [ ] Migrate `group` to `WidgetPropsV2` (renders a nested `Renderer`).
+- [x] Migrate `group` to `WidgetPropsV2` (renders a nested `Renderer`).
 - [ ] Migrate `graded-group` to `WidgetPropsV2` (delete `satisfies PropsFor`
       assertion).
 - [ ] Migrate `graded-group-set` to `WidgetPropsV2`.

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -36,4 +36,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "expression",
     "label-image",
     "interactive-graph",
+    "group",
 ];

--- a/packages/perseus/src/widgets/group/group.tsx
+++ b/packages/perseus/src/widgets/group/group.tsx
@@ -24,7 +24,7 @@ import type {
     FocusPath,
     Widget,
     WidgetExports,
-    WidgetProps,
+    WidgetPropsV2,
 } from "../../types";
 import type {GroupPromptJSON} from "../../widget-ai-utils/group/group-ai-utils";
 import type {
@@ -33,7 +33,7 @@ import type {
     PerseusRenderer,
 } from "@khanacademy/perseus-core";
 
-type Props = WidgetProps<PerseusGroupWidgetOptions, PerseusGroupUserInput>;
+type Props = WidgetPropsV2<PerseusGroupWidgetOptions, PerseusGroupUserInput>;
 
 class Group extends React.Component<Props> implements Widget {
     static contextType = PerseusI18nContext;
@@ -107,9 +107,9 @@ class Group extends React.Component<Props> implements Widget {
                             [widgetId]: userInput,
                         });
                     }}
-                    content={this.props.content}
-                    widgets={this.props.widgets}
-                    images={this.props.images}
+                    content={this.props.options.content}
+                    widgets={this.props.options.widgets}
+                    images={this.props.options.images}
                     ref={(ref) => (this.rendererRef = ref)}
                     apiOptions={apiOptions}
                     findExternalWidgets={this.props.findWidgets}


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a Group widget in
  http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.