### PR TITLE
Migrate graded-group widget to WidgetPropsV2

### DIFF
--- a/.changeset/rotten-days-invite.md
+++ b/.changeset/rotten-days-invite.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Collect all options of the GradedGroup widget into a single `options` prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -524,7 +524,7 @@ review and commit the changes.
       assertion and update `interactive-graph-editor` preview; subtype lookup already
       handled by scaffolding).
 - [x] Migrate `group` to `WidgetPropsV2` (renders a nested `Renderer`).
-- [ ] Migrate `graded-group` to `WidgetPropsV2` (delete `satisfies PropsFor`
+- [x] Migrate `graded-group` to `WidgetPropsV2` (delete `satisfies PropsFor`
       assertion).
 - [x] Migrate `graded-group-set` to `WidgetPropsV2`.
 

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -38,4 +38,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "interactive-graph",
     "group",
     "graded-group-set",
+    "graded-group",
 ];

--- a/packages/perseus/src/widget-ai-utils/graded-group-set/graded-group-set-ai-utils.test.ts
+++ b/packages/perseus/src/widget-ai-utils/graded-group-set/graded-group-set-ai-utils.test.ts
@@ -149,7 +149,7 @@ describe("GradedGroupSet AI utils", () => {
                                     userInput: {value: ""},
                                 },
                             },
-                            title: null,
+                            title: "",
                             type: "graded-group",
                             hint: {
                                 content:
@@ -191,7 +191,7 @@ describe("GradedGroupSet AI utils", () => {
                                     userInput: {value: ""},
                                 },
                             },
-                            title: null,
+                            title: "",
                             type: "graded-group",
                             hint: {
                                 content:

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -220,8 +220,7 @@ class GradedGroupSet extends React.Component<Props, State> implements Widget {
                         ...currentGroup,
                         // The set renders the group's title itself, above the
                         // indicators, so the group must not render it again.
-                        // @ts-expect-error - TS2322 - Type 'null' is not assignable to type 'string'.
-                        title: null,
+                        title: "",
                     }}
                     inGradedGroupSet={true}
                     onNextQuestion={handleNextQuestion}

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -171,7 +171,7 @@ class GradedGroupSet extends React.Component<Props, State> implements Widget {
                             <GradedGroup
                                 key={i}
                                 {...this.props}
-                                {...gradedGroup}
+                                options={gradedGroup}
                                 inGradedGroupSet={false}
                                 linterContext={this.props.linterContext}
                             />
@@ -209,7 +209,6 @@ class GradedGroupSet extends React.Component<Props, State> implements Widget {
                         }
                     />
                 </div>
-                {/* @ts-expect-error - TS2769 - No overload matches this call. */}
                 <GradedGroup
                     key={this.state.currentGroup}
                     // @ts-expect-error - TS2322 - Type 'GradedGroup | null' is not assignable to type 'GradedGroup'.
@@ -217,10 +216,15 @@ class GradedGroupSet extends React.Component<Props, State> implements Widget {
                     ref={(comp) => (this._childGroup = comp)}
                     // We should pass in the set of props explicitly
                     {...this.props}
-                    {...currentGroup}
+                    options={{
+                        ...currentGroup,
+                        // The set renders the group's title itself, above the
+                        // indicators, so the group must not render it again.
+                        // @ts-expect-error - TS2322 - Type 'null' is not assignable to type 'string'.
+                        title: null,
+                    }}
                     inGradedGroupSet={true}
-                    title={null}
-                    onNextQuestion={handleNextQuestion}
+                    onNextQuestion={handleNextQuestion ?? undefined}
                     linterContext={this.props.linterContext}
                 />
             </div>

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -192,7 +192,7 @@ class GradedGroupSet extends React.Component<Props, State> implements Widget {
         const handleNextQuestion =
             this.state.currentGroup < numGroups - 1
                 ? this.handleNextQuestion
-                : null;
+                : undefined;
 
         return (
             <div className={css(styles.container)}>
@@ -224,7 +224,7 @@ class GradedGroupSet extends React.Component<Props, State> implements Widget {
                         title: null,
                     }}
                     inGradedGroupSet={true}
-                    onNextQuestion={handleNextQuestion ?? undefined}
+                    onNextQuestion={handleNextQuestion}
                     linterContext={this.props.linterContext}
                 />
             </div>

--- a/packages/perseus/src/widgets/graded-group/graded-group.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.tsx
@@ -27,7 +27,7 @@ import type {
     TrackingGradedGroupExtraArguments,
     Widget,
     WidgetExports,
-    WidgetProps,
+    WidgetPropsV2,
 } from "../../types";
 import type {GradedGroupPromptJSON} from "../../widget-ai-utils/graded-group/graded-group-ai-utils";
 import type {
@@ -36,7 +36,6 @@ import type {
     PerseusScore,
     UserInputMap,
 } from "@khanacademy/perseus-core";
-import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 const GRADING_STATUSES = {
     ungraded: "ungraded" as const,
@@ -63,7 +62,7 @@ const getNextState = (
     }
 };
 
-type Props = WidgetProps<
+type Props = WidgetPropsV2<
     PerseusGradedGroupWidgetOptions,
     Empty,
     TrackingGradedGroupExtraArguments
@@ -79,18 +78,6 @@ type State = {
     message: string;
     answerBarState: ANSWER_BAR_STATES;
 };
-
-// Assert that the PerseusGradedGroupWidgetOptions parsed from JSON can be
-// passed as props to this component. This ensures that the
-// PerseusGradedGroupWidgetOptions stays in sync with the prop types. The
-// PropsFor<Component> type takes defaultProps into account, which is important
-// because PerseusGradedGroupWidgetOptions has optional fields which receive defaults
-// via defaultProps.
-// eslint-disable-next-line no-restricted-syntax
-0 as any as WidgetProps<
-    PerseusGradedGroupWidgetOptions,
-    Empty
-> satisfies PropsFor<typeof WrappedGradedGroup>;
 
 // A Graded Group is more or less a Group widget that displays a check
 // answer button below the rendered content. When clicked, the widget grades
@@ -186,12 +173,12 @@ export class GradedGroup
         // If the hint isn't expanded, we can't get the prompt JSON from the rendered widgets.
         // We'll just pass in the hint content as a string instead.
         const hint = this.hintRendererRef.current?.getPromptJSON() || {
-            content: this.props.hint?.content || "",
+            content: this.props.options.hint?.content || "",
             widgets: {},
         };
 
         return getPromptJSON(
-            this.props.title,
+            this.props.options.title,
             this.rendererRef.current?.getPromptJSON(),
             hint,
         );
@@ -281,11 +268,13 @@ export class GradedGroup
 
         return (
             <div className={classes}>
-                {!!this.props.title && (
-                    <div className={css(styles.title)}>{this.props.title}</div>
+                {!!this.props.options.title && (
+                    <div className={css(styles.title)}>
+                        {this.props.options.title}
+                    </div>
                 )}
                 <UserInputManager
-                    widgets={this.props.widgets}
+                    widgets={this.props.options.widgets}
                     handleUserInput={(
                         userInput: UserInputMap,
                         widgetsEmpty: boolean,
@@ -294,9 +283,9 @@ export class GradedGroup
                 >
                     {({userInput, handleUserInput}) => (
                         <Renderer
-                            content={this.props.content}
-                            widgets={this.props.widgets}
-                            images={this.props.images}
+                            content={this.props.options.content}
+                            widgets={this.props.options.widgets}
+                            images={this.props.options.images}
                             userInput={userInput}
                             handleUserInput={handleUserInput}
                             problemNum={0}
@@ -363,7 +352,7 @@ export class GradedGroup
                     </>
                 )}
 
-                {this.props.hint?.content &&
+                {this.props.options.hint?.content &&
                     (this.state.showHint ? (
                         <div>
                             {/* Not using Button here bc the styles won't work. */}
@@ -382,7 +371,7 @@ export class GradedGroup
                             </button>
 
                             <UserInputManager
-                                widgets={this.props.hint.widgets}
+                                widgets={this.props.options.hint.widgets}
                                 problemNum={0}
                             >
                                 {({
@@ -393,7 +382,7 @@ export class GradedGroup
                                     // we did a check above to make sure hints exists
                                     // eslint-disable-next-line no-restricted-syntax
                                     const {content, widgets, images} = this
-                                        .props.hint as PerseusRenderer;
+                                        .props.options.hint as PerseusRenderer;
                                     return (
                                         <Renderer
                                             content={content}

--- a/packages/perseus/src/widgets/graded-group/graded-group.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.tsx
@@ -380,6 +380,8 @@ export class GradedGroup
                                     initializeUserInput,
                                 }) => {
                                     // we did a check above to make sure hints exists
+                                    // TODO(benchristel): extract a renderHint
+                                    //  function; then we can remove this cast.
                                     // eslint-disable-next-line no-restricted-syntax
                                     const {content, widgets, images} = this
                                         .props.options.hint as PerseusRenderer;


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a Graded Group widget in
  http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.