### PR TITLE
Migrate graded-group-set widget to WidgetPropsV2

### DIFF
--- a/.changeset/famous-poems-clean.md
+++ b/.changeset/famous-poems-clean.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: The options of the Graded Group Set widget are now grouped under a single `options` prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -526,7 +526,7 @@ review and commit the changes.
 - [x] Migrate `group` to `WidgetPropsV2` (renders a nested `Renderer`).
 - [ ] Migrate `graded-group` to `WidgetPropsV2` (delete `satisfies PropsFor`
       assertion).
-- [ ] Migrate `graded-group-set` to `WidgetPropsV2`.
+- [x] Migrate `graded-group-set` to `WidgetPropsV2`.
 
 ### Special cases (do last)
 

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -37,4 +37,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "label-image",
     "interactive-graph",
     "group",
+    "graded-group-set",
 ];

--- a/packages/perseus/src/widget-ai-utils/graded-group-set/graded-group-set-ai-utils.test.ts
+++ b/packages/perseus/src/widget-ai-utils/graded-group-set/graded-group-set-ai-utils.test.ts
@@ -72,7 +72,9 @@ describe("GradedGroupSet AI utils", () => {
         };
 
         const widgetData: any = {
-            gradedGroups: [{title: "Problem 1a"}, {title: "Problem 1b"}],
+            options: {
+                gradedGroups: [{title: "Problem 1a"}, {title: "Problem 1b"}],
+            },
         };
 
         const result = getPromptJSON(widgetData, activeGroupJSON);

--- a/packages/perseus/src/widget-ai-utils/graded-group-set/graded-group-set-ai-utils.ts
+++ b/packages/perseus/src/widget-ai-utils/graded-group-set/graded-group-set-ai-utils.ts
@@ -29,7 +29,7 @@ export const getPromptJSON = (
     return {
         type: "graded-group-set",
         options: {
-            groupCount: widgetData.gradedGroups.length,
+            groupCount: widgetData.options.gradedGroups.length,
             currentGroup: activeGroupJSON,
         },
     };

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -18,7 +18,7 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetProps,
+    WidgetPropsV2,
 } from "../../types";
 import type {GradedGroupSetPromptJSON} from "../../widget-ai-utils/graded-group-set/graded-group-set-ai-utils";
 import type {
@@ -91,7 +91,7 @@ class Indicators extends React.Component<IndicatorsProps> {
     }
 }
 
-type Props = WidgetProps<PerseusGradedGroupSetWidgetOptions> & {
+type Props = WidgetPropsV2<PerseusGradedGroupSetWidgetOptions> & {
     trackInteraction: () => void;
     dependencies: PerseusDependenciesV2;
 };
@@ -148,7 +148,7 @@ class GradedGroupSet extends React.Component<Props, State> implements Widget {
 
     handleNextQuestion: () => void = () => {
         const {currentGroup} = this.state;
-        const numGroups = this.props.gradedGroups.length;
+        const numGroups = this.props.options.gradedGroups.length;
 
         if (currentGroup < numGroups - 1) {
             this.setState({currentGroup: currentGroup + 1});
@@ -161,11 +161,12 @@ class GradedGroupSet extends React.Component<Props, State> implements Widget {
         // to click and switch between different graded groups. Translators
         // prefer to see all strings/labels on all GradedGroups readily visible
         // together instead of clicking on indicators to switch between them.
+        const {gradedGroups} = this.props.options;
         const {JIPT} = getDependencies();
-        if (JIPT.useJIPT && this.props.gradedGroups.length > 1) {
+        if (JIPT.useJIPT && gradedGroups.length > 1) {
             return (
                 <div className={css(styles.container)}>
-                    {this.props.gradedGroups.map((gradedGroup, i) => {
+                    {gradedGroups.map((gradedGroup, i) => {
                         return (
                             <GradedGroup
                                 key={i}
@@ -180,14 +181,14 @@ class GradedGroupSet extends React.Component<Props, State> implements Widget {
             );
         }
 
-        const currentGroup = this.props.gradedGroups[this.state.currentGroup];
+        const currentGroup = gradedGroups[this.state.currentGroup];
 
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (!currentGroup) {
             return <span>No current group...</span>;
         }
 
-        const numGroups = this.props.gradedGroups.length;
+        const numGroups = gradedGroups.length;
         const handleNextQuestion =
             this.state.currentGroup < numGroups - 1
                 ? this.handleNextQuestion
@@ -202,7 +203,7 @@ class GradedGroupSet extends React.Component<Props, State> implements Widget {
                     <div className={css(styles.spacer)} />
                     <Indicators
                         currentGroup={this.state.currentGroup}
-                        gradedGroups={this.props.gradedGroups}
+                        gradedGroups={gradedGroups}
                         onChangeCurrentGroup={(currentGroup) =>
                             this.setState({currentGroup})
                         }


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a Graded Group Set widget in
  http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.