### PR TITLE
Migrate orderer widget to WidgetPropsV2

### DIFF
--- a/.changeset/fine-ends-brush.md
+++ b/.changeset/fine-ends-brush.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: The widget options of Orderer are now grouped under a single `options` prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -533,7 +533,7 @@ review and commit the changes.
 Migrate these **one at a time**, stopping after each step for the user to
 review and commit the changes.
 
-- [ ] Migrate `orderer` to `WidgetPropsV2` — ⚠ its options include a field named
+- [x] Migrate `orderer` to `WidgetPropsV2` — ⚠ its options include a field named
       `options` (`this.props.options[index]` → `this.props.options.options[index]`);
       it has two `static defaultProps` (the `Card` sub-component's and the widget's
       `userInput`-bearing one) — relocate only the option-field defaults.

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -39,4 +39,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "group",
     "graded-group-set",
     "graded-group",
+    "orderer",
 ];

--- a/packages/perseus/src/widget-ai-utils/orderer/orderer-ai-utils.test.ts
+++ b/packages/perseus/src/widget-ai-utils/orderer/orderer-ai-utils.test.ts
@@ -39,23 +39,25 @@ describe("Orderer AI utils", () => {
         };
 
         const widgetData: any = {
-            options: [
-                {
-                    content: "Third item",
-                    images: {},
-                    widgets: {},
-                },
-                {
-                    content: "First item",
-                    images: {},
-                    widgets: {},
-                },
-                {
-                    content: "Second item",
-                    images: {},
-                    widgets: {},
-                },
-            ],
+            options: {
+                options: [
+                    {
+                        content: "Third item",
+                        images: {},
+                        widgets: {},
+                    },
+                    {
+                        content: "First item",
+                        images: {},
+                        widgets: {},
+                    },
+                    {
+                        content: "Second item",
+                        images: {},
+                        widgets: {},
+                    },
+                ],
+            },
             userInput,
         };
 

--- a/packages/perseus/src/widget-ai-utils/orderer/orderer-ai-utils.ts
+++ b/packages/perseus/src/widget-ai-utils/orderer/orderer-ai-utils.ts
@@ -42,7 +42,7 @@ export const getPromptJSON = (
     return {
         type: "orderer",
         options: {
-            options: widgetData.options.map((option) => option.content),
+            options: widgetData.options.options.map((option) => option.content),
         },
         userInput: {
             values: widgetData.userInput.current,

--- a/packages/perseus/src/widgets/orderer/orderer.tsx
+++ b/packages/perseus/src/widgets/orderer/orderer.tsx
@@ -588,8 +588,8 @@ class Orderer
     getSerializedState(): any {
         const {userInput, options, ...rest} = this.props;
         return {
-            ...rest,
             ...options,
+            ...rest,
             current: userInput.current.map((e) => ({content: e})),
         };
     }

--- a/packages/perseus/src/widgets/orderer/orderer.tsx
+++ b/packages/perseus/src/widgets/orderer/orderer.tsx
@@ -15,16 +15,14 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetProps,
+    WidgetPropsV2,
 } from "../../types";
 import type {OrdererPromptJSON} from "../../widget-ai-utils/orderer/orderer-ai-utils";
 import type {
-    PerseusOrdererWidgetOptions,
     PerseusOrdererUserInput,
     OrdererPublicWidgetOptions,
 } from "@khanacademy/perseus-core";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
-import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 type PlaceholderCardProps = {
     width: number | null | undefined;
@@ -289,7 +287,7 @@ class Card extends React.Component<CardProps, CardState> {
     }
 }
 
-type OrdererProps = WidgetProps<
+type OrdererProps = WidgetPropsV2<
     OrdererPublicWidgetOptions,
     PerseusOrdererUserInput
 > & {dependencies: PerseusDependenciesV2};
@@ -308,19 +306,6 @@ type OrdererState = {
     animateTo: Position | null | undefined;
     onAnimationEnd?: (arg1: any) => void;
 };
-
-// TODO(LEMS-4354): Remove these type assertions from all widgets.
-// eslint-disable-next-line no-restricted-syntax
-0 as any as WidgetProps<
-    PerseusOrdererWidgetOptions,
-    PerseusOrdererUserInput
-> satisfies PropsFor<typeof WrappedOrderer>;
-
-// eslint-disable-next-line no-restricted-syntax
-0 as any as WidgetProps<
-    OrdererPublicWidgetOptions,
-    PerseusOrdererUserInput
-> satisfies PropsFor<typeof WrappedOrderer>;
 
 class Orderer
     extends React.Component<OrdererProps, OrdererState>
@@ -371,7 +356,7 @@ class Orderer
             // @ts-expect-error - TS2322 - Type 'number' is not assignable to type 'null'.
             placeholderIndex = index;
         } else if (type === "bank") {
-            opt = this.props.options[index];
+            opt = this.props.options.options[index];
         }
 
         this.props.handleUserInput({current: list});
@@ -438,7 +423,7 @@ class Orderer
         if (inCardBank) {
             // If we're in the card bank, go through the options to find the
             // one with the same content
-            this.props.options.forEach((opt, i) => {
+            this.props.options.options.forEach((opt, i) => {
                 if (opt.content === this.state.dragContent) {
                     const card = ReactDOM.findDOMNode(
                         // eslint-disable-next-line react/no-string-refs
@@ -500,7 +485,7 @@ class Orderer
 
     findCorrectIndex: (arg1: any, arg2: any) => any = (draggable, list) => {
         // Find the correct index for a card given the current cards.
-        const isHorizontal = this.props.layout === "horizontal";
+        const isHorizontal = this.props.options.layout === "horizontal";
         // eslint-disable-next-line react/no-string-refs
         // @ts-expect-error - TS2769 - No overload matches this call.
         const $dragList = $(ReactDOM.findDOMNode(this.refs.dragList));
@@ -554,7 +539,7 @@ class Orderer
             return false;
         }
 
-        const isHorizontal = this.props.layout === "horizontal";
+        const isHorizontal = this.props.options.layout === "horizontal";
         // @ts-expect-error - TS2769 - No overload matches this call.
         const $draggable = $(ReactDOM.findDOMNode(draggable));
         // eslint-disable-next-line react/no-string-refs
@@ -601,9 +586,10 @@ class Orderer
      * [LEMS-3185] do not trust serializedState
      */
     getSerializedState(): any {
-        const {userInput, ...rest} = this.props;
+        const {userInput, options, ...rest} = this.props;
         return {
             ...rest,
+            ...options,
             current: userInput.current.map((e) => ({content: e})),
         };
     }
@@ -691,7 +677,7 @@ class Orderer
         const bank = (
             // eslint-disable-next-line react/no-string-refs
             <div ref="bank" className="bank perseus-clearfix">
-                {this.props.options.map((opt, i) => {
+                {this.props.options.options.map((opt, i) => {
                     return (
                         <Card
                             ref={"bank" + i}
@@ -719,10 +705,10 @@ class Orderer
                 className={
                     "draggy-boxy-thing orderer " +
                     "height-" +
-                    this.props.height +
+                    this.props.options.height +
                     " " +
                     "layout-" +
-                    this.props.layout +
+                    this.props.options.layout +
                     " " +
                     "blank-background " +
                     "perseus-clearfix "


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit an Orderer widget in
  http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.