### PR TITLE
Migrate mock-widget to WidgetPropsV2

### DIFF
--- a/.changeset/widget-props-v2-mock-widget.md
+++ b/.changeset/widget-props-v2-mock-widget.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Migrate the mock widget to group all `options` under a separate prop.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -489,7 +489,9 @@ review and commit the changes.
 - [x] Migrate `molecule` to `WidgetPropsV2`. WON'T DO - `molecule` will be deleted
 - [x] Migrate `measurer` to `WidgetPropsV2`.
 - [x] Convert `number-line` to a functional component, a la `dropdown`.
-- [x] Migrate `number-line` to `WidgetPropsV2`.
+- [ ] Migrate `number-line` to `WidgetPropsV2`. (Was checked off prematurely:
+      `number-line.tsx` still uses `WidgetProps` and the type isn't in
+      `MIGRATED_WIDGETS`. Must happen before the final cleanup.)
 - [x] Migrate `plotter` to `WidgetPropsV2` (update its editor preview).
 - [x] Convert `cs-program` to a functional component, a la `dropdown`.
 - [x] Migrate `cs-program` to `WidgetPropsV2`.
@@ -537,7 +539,7 @@ review and commit the changes.
       `options` (`this.props.options[index]` → `this.props.options.options[index]`);
       it has two `static defaultProps` (the `Card` sub-component's and the widget's
       `userInput`-bearing one) — relocate only the option-field defaults.
-- [ ] Migrate `mock-widget` (test-only) to `WidgetPropsV2`.
+- [x] Migrate `mock-widget` (test-only) to `WidgetPropsV2`.
 
 ### Final cleanup
 

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -40,4 +40,5 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "graded-group-set",
     "graded-group",
     "orderer",
+    "mock-widget",
 ];

--- a/packages/perseus/src/widget-ai-utils/mock-widget/prompt-utils.test.ts
+++ b/packages/perseus/src/widget-ai-utils/mock-widget/prompt-utils.test.ts
@@ -9,7 +9,7 @@ describe("InputNumber getPromptJSON", () => {
         };
 
         const widgetData: any = {
-            value: "42",
+            options: {value: "42"},
             userInput,
         };
 

--- a/packages/perseus/src/widget-ai-utils/mock-widget/prompt-utils.ts
+++ b/packages/perseus/src/widget-ai-utils/mock-widget/prompt-utils.ts
@@ -17,7 +17,7 @@ export const getPromptJSON = (
     return {
         type: "mock-widget",
         options: {
-            value: widgetData.value,
+            value: widgetData.options.value,
         },
         userInput: {
             value: widgetData.userInput.currentValue,

--- a/packages/perseus/src/widgets/mock-widgets/mock-widget.tsx
+++ b/packages/perseus/src/widgets/mock-widgets/mock-widget.tsx
@@ -6,11 +6,14 @@ import * as React from "react";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/mock-widget/prompt-utils";
 
 import type {MockWidgetOptions} from "./mock-widget-types";
-import type {WidgetProps, Widget, WidgetExports} from "../../types";
+import type {WidgetPropsV2, Widget, WidgetExports} from "../../types";
 import type {MockWidgetPromptJSON} from "../../widget-ai-utils/mock-widget/prompt-utils";
 import type {PerseusMockWidgetUserInput} from "@khanacademy/perseus-score";
 
-type ExternalProps = WidgetProps<MockWidgetOptions, PerseusMockWidgetUserInput>;
+type ExternalProps = WidgetPropsV2<
+    MockWidgetOptions,
+    PerseusMockWidgetUserInput
+>;
 
 type Props = ExternalProps;
 
@@ -67,8 +70,12 @@ class MockWidgetComponent extends React.Component<Props> implements Widget {
      * [LEMS-3185] do not trust serializedState
      */
     getSerializedState() {
-        const {userInput, ...rest} = this.props;
+        const {userInput, options, ...rest} = this.props;
         return {
+            // `rest` goes last because the renderer used to spread the universal
+            // props over the options, so the universal `static` — not the
+            // option of the same name — is the one that gets serialized.
+            ...options,
             ...rest,
             currentValue: userInput.currentValue,
         };


### PR DESCRIPTION
## Summary:
This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

CI checks should pass (MockWidget isn't used outside tests).