### PR TITLE
Migrate the number-line widget to WidgetPropsV2

### DIFF
--- a/.changeset/cuddly-birds-knock.md
+++ b/.changeset/cuddly-birds-knock.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: The Number Line widget's options are now grouped under a separate `options` prop.

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1690,6 +1690,7 @@ export type PerseusNumberLineWidgetOptions = {
      * The position of the endpoints of the number line. Setting the range
      * constrains the position of the answer and the labels.
      */
+    // TODO(benchristel): type `range` as `[number, number]`.
     range: number[];
     /**
      * This controls the position of the left / right labels. By default, the

--- a/packages/perseus/src/migrated-widgets.ts
+++ b/packages/perseus/src/migrated-widgets.ts
@@ -22,6 +22,7 @@ export const MIGRATED_WIDGETS: ReadonlyArray<string> = [
     "video",
     "image",
     "measurer",
+    "number-line",
     "plotter",
     "cs-program",
     "python-program",

--- a/packages/perseus/src/widget-ai-utils/number-line/number-line-ai-utils.test.ts
+++ b/packages/perseus/src/widget-ai-utils/number-line/number-line-ai-utils.test.ts
@@ -45,9 +45,11 @@ describe("NumberLine AI utils", () => {
         };
 
         const widgetData: any = {
-            range: [0, 10],
-            numDivisions: 10,
-            snapDivisions: 2,
+            options: {
+                range: [0, 10],
+                numDivisions: 10,
+                snapDivisions: 2,
+            },
             userInput,
         };
 

--- a/packages/perseus/src/widget-ai-utils/number-line/number-line-ai-utils.ts
+++ b/packages/perseus/src/widget-ai-utils/number-line/number-line-ai-utils.ts
@@ -78,8 +78,8 @@ export const getPromptJSON = (
     return {
         type: "number-line",
         options: {
-            range: widgetData.range,
-            snapDivisions: widgetData.snapDivisions,
+            range: widgetData.options.range,
+            snapDivisions: widgetData.options.snapDivisions,
         },
         userInput: {
             numLinePosition: userInput.numLinePosition,

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -233,6 +233,10 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
     const {strings} = usePerseusI18n();
     const propsRef = useLatestRef(props);
     const [numDivisionsEmpty, setNumDivisionsEmpty] = useState(false);
+    const tickStep = getTickStep(
+        props.options.range,
+        props.userInput.numDivisions,
+    );
 
     // Ref to the <Graphie> instance. Its `movables` map is populated by the
     // string `ref` on <MovablePoint> below (Graphie consumes those children
@@ -450,10 +454,6 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
     }
 
     function renderNumberLinePoint() {
-        const tickStep = getTickStep(
-            props.options.range,
-            props.userInput.numDivisions,
-        );
         const isOpen = ["lt", "gt"].includes(props.userInput.rel);
 
         // In static mode the point's fill and stroke is blue to signify that
@@ -557,11 +557,6 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
             range,
             isTickCtrl: props.options.isTickCtrl,
         };
-
-        const tickStep = getTickStep(
-            props.options.range,
-            props.userInput.numDivisions,
-        );
 
         return (
             <Graphie

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -461,22 +461,26 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
         });
     }
 
-    function renderNumberLinePoint(calculatedProps: CalculatedProps) {
-        const isOpen = ["lt", "gt"].includes(calculatedProps.userInput.rel);
+    function renderNumberLinePoint() {
+        const tickStep = getTickStep(
+            props.options.range,
+            props.userInput.numDivisions,
+        );
+        const isOpen = ["lt", "gt"].includes(props.userInput.rel);
 
         // In static mode the point's fill and stroke is blue to signify that
         // it can't be interacted with.
         let fill;
         if (isOpen) {
             fill = KhanColors._BACKGROUND;
-        } else if (calculatedProps.static) {
+        } else if (props.static) {
             fill = KhanColors.BLUE;
         } else {
             fill = KhanColors.GREEN;
         }
         const normalStyle = {
             fill: fill,
-            stroke: calculatedProps.static ? KhanColors.BLUE : KhanColors.GREEN,
+            stroke: props.static ? KhanColors.BLUE : KhanColors.GREEN,
             "stroke-width": isOpen ? 3 : 1,
         } as const;
         const highlightStyle = {
@@ -484,7 +488,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
             "stroke-width": isOpen ? 3 : 1,
         } as const;
 
-        const mobileDotStyle = calculatedProps.options.isInequality
+        const mobileDotStyle = props.options.isInequality
             ? {
                   stroke: KhanColors.GREEN,
                   "fill-opacity": isOpen ? 0 : 1,
@@ -496,7 +500,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
                 // eslint-disable-next-line react/no-string-refs
                 ref="numberLinePoint"
                 pointSize={6}
-                coord={[calculatedProps.userInput.numLinePosition, 0]}
+                coord={[props.userInput.numLinePosition, 0]}
                 constraints={[
                     (coord: any, prevCoord) => {
                         // constrain-y
@@ -505,9 +509,9 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
                     (coord: any, prevCoord) => {
                         // snap X
                         const x = snapNumLinePosition(
-                            calculatedProps.options.range,
-                            calculatedProps.options.snapDivisions,
-                            calculatedProps.tickStep,
+                            props.options.range,
+                            props.options.snapDivisions,
+                            tickStep,
                             coord[0],
                         );
                         return [x, coord[1]];
@@ -518,9 +522,9 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
                 onMove={(coord) => {
                     movePosition(coord[0]);
                 }}
-                isMobile={calculatedProps.apiOptions.isMobile}
+                isMobile={props.apiOptions.isMobile}
                 mobileStyleOverride={mobileDotStyle}
-                showTooltips={calculatedProps.options.showTooltips ?? false}
+                showTooltips={props.options.showTooltips ?? false}
                 xOnlyTooltip={true}
             />
         );
@@ -615,7 +619,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
                     isMobile={calculatedProps.apiOptions.isMobile}
                 />
                 {renderInequality()}
-                {renderNumberLinePoint(calculatedProps)}
+                {renderNumberLinePoint()}
             </Graphie>
         );
     }

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -377,10 +377,10 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
 
     function snapNumLinePosition(
         range: number[],
+        snapDivisions: number,
         calculatedProps: CalculatedProps,
         numLinePosition: number,
     ): number {
-        const {snapDivisions} = calculatedProps.options;
         const left = range[0];
         const right = range[1];
         const snapX = calculatedProps.tickStep / snapDivisions;
@@ -408,6 +408,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
 
             const newNumLinePosition = snapNumLinePosition(
                 nextProps.options.range,
+                nextProps.options.snapDivisions,
                 nextProps,
                 props.userInput.numLinePosition,
             );
@@ -505,6 +506,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
                         // snap X
                         const x = snapNumLinePosition(
                             calculatedProps.options.range,
+                            calculatedProps.options.snapDivisions,
                             calculatedProps,
                             coord[0],
                         );

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -567,6 +567,10 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
             isTickCtrl: props.options.isTickCtrl,
         };
 
+        // TODO(benchristel): CalculatedProps seems pretty weird. I think
+        //  `tickStep` should just be a const at the top level of the
+        //  component. Then we wouldn't need to pass these CalculatedProps
+        //  around.
         const calculatedProps: CalculatedProps = {
             ...props,
             tickStep: width / props.userInput.numDivisions,

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -378,12 +378,12 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
     function snapNumLinePosition(
         range: number[],
         snapDivisions: number,
-        calculatedProps: CalculatedProps,
+        tickStep: number,
         numLinePosition: number,
     ): number {
         const left = range[0];
         const right = range[1];
-        const snapX = calculatedProps.tickStep / snapDivisions;
+        const snapX = tickStep / snapDivisions;
 
         let x = bound(numLinePosition, left, right);
         x = left + knumber.roundTo(x - left, snapX);
@@ -409,7 +409,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
             const newNumLinePosition = snapNumLinePosition(
                 nextProps.options.range,
                 nextProps.options.snapDivisions,
-                nextProps,
+                nextProps.tickStep,
                 props.userInput.numLinePosition,
             );
 
@@ -507,7 +507,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
                         const x = snapNumLinePosition(
                             calculatedProps.options.range,
                             calculatedProps.options.snapDivisions,
-                            calculatedProps,
+                            calculatedProps.tickStep,
                             coord[0],
                         );
                         return [x, coord[1]];

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -376,10 +376,11 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
     );
 
     function snapNumLinePosition(
+        range: number[],
         calculatedProps: CalculatedProps,
         numLinePosition: number,
     ): number {
-        const {range, snapDivisions} = calculatedProps.options;
+        const {snapDivisions} = calculatedProps.options;
         const left = range[0];
         const right = range[1];
         const snapX = calculatedProps.tickStep / snapDivisions;
@@ -406,6 +407,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
             };
 
             const newNumLinePosition = snapNumLinePosition(
+                nextProps.options.range,
                 nextProps,
                 props.userInput.numLinePosition,
             );
@@ -502,6 +504,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
                     (coord: any, prevCoord) => {
                         // snap X
                         const x = snapNumLinePosition(
+                            calculatedProps.options.range,
                             calculatedProps,
                             coord[0],
                         );

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -395,15 +395,12 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
         // If the number of divisions isn't blank, update the number line
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (numDivisions) {
-            const nextProps = {
-                ...props,
-                tickStep: getTickStep(props.options.range, numDivisions),
-            };
+            const newTickStep = getTickStep(props.options.range, numDivisions);
 
             const newNumLinePosition = snapNumLinePosition(
-                nextProps.options.range,
-                nextProps.options.snapDivisions,
-                nextProps.tickStep,
+                props.options.range,
+                props.options.snapDivisions,
+                newTickStep,
                 props.userInput.numLinePosition,
             );
 

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -22,7 +22,7 @@ import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/number-line
 import type {
     WidgetExports,
     Widget,
-    WidgetProps,
+    WidgetPropsV2,
     PerseusDependenciesV2,
 } from "../../types";
 import type {NumberLinePromptJSON} from "../../widget-ai-utils/number-line/number-line-ai-utils";
@@ -204,7 +204,7 @@ const TickMarks: any = (Graphie as any).createSimpleClass((graphie, props) => {
 /**
  * The type of the props passed to the NumberLine widget.
  */
-type Props = WidgetProps<
+type Props = WidgetPropsV2<
     PerseusNumberLineWidgetOptions,
     PerseusNumberLineUserInput
 > & {
@@ -220,9 +220,8 @@ type CalculatedProps = Props & {
 // Whether the widget's configuration makes a drawable number line. An invalid
 // configuration would send the drawing code into an infinite loop.
 function isValid(props: Props): boolean {
-    const range = props.range;
+    const {range, divisionRange, snapDivisions} = props.options;
     let initialX = props.userInput?.numLinePosition;
-    const divisionRange = props.divisionRange;
 
     initialX = initialX == null ? range[0] : initialX;
 
@@ -232,7 +231,7 @@ function isValid(props: Props): boolean {
         knumber.sign(initialX - range[1]) <= 0 &&
         divisionRange[0] < divisionRange[1] &&
         0 < props.userInput?.numDivisions &&
-        0 < props.snapDivisions
+        0 < snapDivisions
     );
 }
 
@@ -262,7 +261,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
 
     useImperativeHandle(ref, () => ({
         focus: () => {
-            if (props.isTickCtrl) {
+            if (props.options.isTickCtrl) {
                 tickCtrlRef.current?.focus();
                 return true;
             }
@@ -282,7 +281,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
         },
 
         getInputPaths: () => {
-            if (props.isTickCtrl) {
+            if (props.options.isTickCtrl) {
                 return [["tick-ctrl"]];
             }
             return [];
@@ -302,15 +301,15 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
         getSerializedState: () => ({
             alignment: props.alignment,
             static: props.static,
-            range: props.range,
-            labelRange: props.labelRange,
-            labelStyle: props.labelStyle,
-            labelTicks: props.labelTicks,
-            divisionRange: props.divisionRange,
-            snapDivisions: props.snapDivisions,
-            isInequality: props.isInequality,
-            showTooltips: props.showTooltips,
-            isTickCtrl: props.isTickCtrl,
+            range: props.options.range,
+            labelRange: props.options.labelRange,
+            labelStyle: props.options.labelStyle,
+            labelTicks: props.options.labelTicks,
+            divisionRange: props.options.divisionRange,
+            snapDivisions: props.options.snapDivisions,
+            isInequality: props.options.isInequality,
+            showTooltips: props.options.showTooltips,
+            isTickCtrl: props.options.isTickCtrl,
             numDivisions: props.userInput.numDivisions,
             numLinePosition: props.userInput.numLinePosition,
             // this seems like a bug, but I'm maintaining the
@@ -351,10 +350,11 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
             const left = range[0] - buffer;
             const right = range[1] + buffer;
 
+            const {labelStyle} = latestProps.options;
             const hasFractionalLabels =
-                latestProps.labelStyle === "improper" ||
-                latestProps.labelStyle === "mixed" ||
-                latestProps.labelStyle === "non-reduced";
+                labelStyle === "improper" ||
+                labelStyle === "mixed" ||
+                labelStyle === "non-reduced";
             const bottom = hasFractionalLabels ? -1.5 : -1;
             const top = 1;
 
@@ -379,9 +379,10 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
         calculatedProps: CalculatedProps,
         numLinePosition: number,
     ): number {
-        const left = calculatedProps.range[0];
-        const right = calculatedProps.range[1];
-        const snapX = calculatedProps.tickStep / calculatedProps.snapDivisions;
+        const {range, snapDivisions} = calculatedProps.options;
+        const left = range[0];
+        const right = range[1];
+        const snapX = calculatedProps.tickStep / snapDivisions;
 
         let x = bound(numLinePosition, left, right);
         x = left + knumber.roundTo(x - left, snapX);
@@ -390,7 +391,8 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
     }
 
     function onNumDivisionsChange(numDivisions: number, cb?: () => void) {
-        const width = props.range[1] - props.range[0];
+        const {range} = props.options;
+        const width = range[1] - range[0];
 
         // Don't allow a fraction for the number of divisions
         numDivisions = Math.round(numDivisions);
@@ -479,7 +481,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
             "stroke-width": isOpen ? 3 : 1,
         } as const;
 
-        const mobileDotStyle = calculatedProps.isInequality
+        const mobileDotStyle = calculatedProps.options.isInequality
             ? {
                   stroke: KhanColors.GREEN,
                   "fill-opacity": isOpen ? 0 : 1,
@@ -513,7 +515,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
                 }}
                 isMobile={calculatedProps.apiOptions.isMobile}
                 mobileStyleOverride={mobileDotStyle}
-                showTooltips={calculatedProps.showTooltips ?? false}
+                showTooltips={calculatedProps.options.showTooltips ?? false}
                 xOnlyTooltip={true}
             />
         );
@@ -522,7 +524,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
     function getInequalityEndpoint(): [number, number] {
         const isGreater = ["ge", "gt"].includes(props.userInput.rel);
         const widthInPixels = 400;
-        const range = props.range;
+        const range = props.options.range;
         const scale = (range[1] - range[0]) / widthInPixels;
         const buffer = horizontalPadding * scale;
         const left = range[0] - buffer;
@@ -532,7 +534,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
     }
 
     function renderInequality() {
-        if (props.isInequality) {
+        if (props.options.isInequality) {
             const end = getInequalityEndpoint();
             const style = {
                 arrows: "->",
@@ -557,12 +559,12 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
 
     function renderGraphie() {
         // Position variables
-        const range = props.range;
+        const range = props.options.range;
         const width = range[1] - range[0];
 
         const options = {
-            range: props.range,
-            isTickCtrl: props.isTickCtrl,
+            range,
+            isTickCtrl: props.options.isTickCtrl,
         };
 
         const calculatedProps: CalculatedProps = {
@@ -577,7 +579,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
                 // when the label style changes we want to resize the graphie,
                 // which isn't doable without throwing away the graphie and
                 // making a new one.
-                key={props.labelStyle}
+                key={props.options.labelStyle}
                 box={[props.apiOptions.isMobile ? 288 : 460, 80]}
                 options={options}
                 onMouseDown={(coord) => {
@@ -593,10 +595,10 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
                 isMobile={props.apiOptions.isMobile}
             >
                 <TickMarks
-                    range={calculatedProps.range}
-                    labelTicks={calculatedProps.labelTicks}
-                    labelStyle={calculatedProps.labelStyle}
-                    labelRange={calculatedProps.labelRange}
+                    range={calculatedProps.options.range}
+                    labelTicks={calculatedProps.options.labelTicks}
+                    labelStyle={calculatedProps.options.labelStyle}
+                    labelRange={calculatedProps.options.labelRange}
                     tickStep={calculatedProps.tickStep}
                     numDivisions={calculatedProps.userInput.numDivisions}
                     isMobile={calculatedProps.apiOptions.isMobile}
@@ -607,7 +609,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
         );
     }
 
-    const divisionRange = props.divisionRange;
+    const {divisionRange, isTickCtrl, isInequality} = props.options;
     const divRangeString = divisionRange[0] + EN_DASH + divisionRange[1];
 
     const invalidNumDivisions =
@@ -636,7 +638,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
     );
 
     let tickCtrl;
-    if (props.isTickCtrl) {
+    if (isTickCtrl) {
         const Input = props.apiOptions.customKeypad
             ? SimpleKeypadInput
             : NumberInput;
@@ -675,14 +677,14 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
                 <div className="perseus-error">
                     Invalid number line configuration.
                 </div>
-            ) : props.isTickCtrl && invalidNumDivisions ? (
+            ) : isTickCtrl && invalidNumDivisions ? (
                 <div className="perseus-error">
                     {strings.divisions({divRangeString: divRangeString})}
                 </div>
             ) : (
                 renderGraphie()
             )}
-            {!props.static && props.isInequality && inequalityControls}
+            {!props.static && isInequality && inequalityControls}
         </div>
     );
 });

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -211,12 +211,6 @@ type Props = WidgetPropsV2<
     dependencies: PerseusDependenciesV2;
 };
 
-// Props with the derived `tickStep` mixed in, so render helpers have it
-// precomputed.
-type CalculatedProps = Props & {
-    tickStep: number;
-};
-
 // Whether the widget's configuration makes a drawable number line. An invalid
 // configuration would send the drawing code into an infinite loop.
 function isValid(props: Props): boolean {
@@ -575,17 +569,10 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
             isTickCtrl: props.options.isTickCtrl,
         };
 
-        // TODO(benchristel): CalculatedProps seems pretty weird. I think
-        //  `tickStep` should just be a const at the top level of the
-        //  component. Then we wouldn't need to pass these CalculatedProps
-        //  around.
-        const calculatedProps: CalculatedProps = {
-            ...props,
-            tickStep: getTickStep(
-                props.options.range,
-                props.userInput.numDivisions,
-            ),
-        };
+        const tickStep = getTickStep(
+            props.options.range,
+            props.userInput.numDivisions,
+        );
 
         return (
             <Graphie
@@ -610,13 +597,13 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
                 isMobile={props.apiOptions.isMobile}
             >
                 <TickMarks
-                    range={calculatedProps.options.range}
-                    labelTicks={calculatedProps.options.labelTicks}
-                    labelStyle={calculatedProps.options.labelStyle}
-                    labelRange={calculatedProps.options.labelRange}
-                    tickStep={calculatedProps.tickStep}
-                    numDivisions={calculatedProps.userInput.numDivisions}
-                    isMobile={calculatedProps.apiOptions.isMobile}
+                    range={props.options.range}
+                    labelTicks={props.options.labelTicks}
+                    labelStyle={props.options.labelStyle}
+                    labelRange={props.options.labelRange}
+                    tickStep={tickStep}
+                    numDivisions={props.userInput.numDivisions}
+                    isMobile={props.apiOptions.isMobile}
                 />
                 {renderInequality()}
                 {renderNumberLinePoint()}

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -370,11 +370,10 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
     );
 
     function snapNumLinePosition(
-        range: number[],
-        snapDivisions: number,
         tickStep: number,
         numLinePosition: number,
     ): number {
+        const {range, snapDivisions} = props.options;
         const left = range[0];
         const right = range[1];
         const snapX = tickStep / snapDivisions;
@@ -398,8 +397,6 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
             const newTickStep = getTickStep(props.options.range, numDivisions);
 
             const newNumLinePosition = snapNumLinePosition(
-                props.options.range,
-                props.options.snapDivisions,
                 newTickStep,
                 props.userInput.numLinePosition,
             );
@@ -499,12 +496,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
                     },
                     (coord: any, prevCoord) => {
                         // snap X
-                        const x = snapNumLinePosition(
-                            props.options.range,
-                            props.options.snapDivisions,
-                            tickStep,
-                            coord[0],
-                        );
+                        const x = snapNumLinePosition(tickStep, coord[0]);
                         return [x, coord[1]];
                     },
                 ]}

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -1,11 +1,11 @@
-import {number as knumber, KhanMath} from "@khanacademy/kmath";
+import {KhanMath, number as knumber} from "@khanacademy/kmath";
 import {useLatestRef, useOnMountEffect} from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
 import {
     forwardRef,
-    useRef,
     useCallback,
     useImperativeHandle,
+    useRef,
     useState,
 } from "react";
 import ReactDOM from "react-dom";
@@ -20,17 +20,17 @@ import KhanColors from "../../util/colors";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/number-line/number-line-ai-utils";
 
 import type {
-    WidgetExports,
-    Widget,
-    WidgetPropsV2,
     PerseusDependenciesV2,
+    Widget,
+    WidgetExports,
+    WidgetPropsV2,
 } from "../../types";
 import type {NumberLinePromptJSON} from "../../widget-ai-utils/number-line/number-line-ai-utils";
 import type {
-    Relationship,
+    NumberLinePublicWidgetOptions,
     PerseusNumberLineUserInput,
     PerseusNumberLineWidgetOptions,
-    NumberLinePublicWidgetOptions,
+    Relationship,
 } from "@khanacademy/perseus-core";
 
 // @ts-expect-error - TS2339 - Property 'MovablePoint' does not exist on type 'typeof Graphie'.
@@ -553,11 +553,6 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
         // Position variables
         const range = props.options.range;
 
-        const options = {
-            range,
-            isTickCtrl: props.options.isTickCtrl,
-        };
-
         return (
             <Graphie
                 ref={graphieRef}
@@ -567,7 +562,10 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
                 // making a new one.
                 key={props.options.labelStyle}
                 box={[props.apiOptions.isMobile ? 288 : 460, 80]}
-                options={options}
+                options={{
+                    range,
+                    isTickCtrl: props.options.isTickCtrl,
+                }}
                 onMouseDown={(coord) => {
                     // `grab` isn't declared on the Movable type; the movable
                     // is populated via the string ref on <MovablePoint>

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -391,9 +391,6 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
     }
 
     function onNumDivisionsChange(numDivisions: number, cb?: () => void) {
-        const {range} = props.options;
-        const width = range[1] - range[0];
-
         // Don't allow a fraction for the number of divisions
         numDivisions = Math.round(numDivisions);
 
@@ -403,7 +400,10 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
         // If the number of divisions isn't blank, update the number line
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         if (numDivisions) {
-            const nextProps = {...props, tickStep: width / numDivisions};
+            const nextProps = {
+                ...props,
+                tickStep: getTickStep(props.options.range, numDivisions),
+            };
 
             const newNumLinePosition = snapNumLinePosition(
                 nextProps,
@@ -560,7 +560,6 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
     function renderGraphie() {
         // Position variables
         const range = props.options.range;
-        const width = range[1] - range[0];
 
         const options = {
             range,
@@ -573,7 +572,10 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
         //  around.
         const calculatedProps: CalculatedProps = {
             ...props,
-            tickStep: width / props.userInput.numDivisions,
+            tickStep: getTickStep(
+                props.options.range,
+                props.userInput.numDivisions,
+            ),
         };
 
         return (
@@ -724,6 +726,14 @@ function getStartNumDivisions(options: NumberLinePublicWidgetOptions) {
     }
 
     return numDivisions;
+}
+
+// The `range` parameter to `getTickStep` should really be typed as `Interval`.
+// It's `number[]` for compatibility with PerseusNumberLineWidgetOptions.
+function getTickStep(range: number[], numDivisions: number) {
+    const [min, max] = range;
+    const width = max - min;
+    return width / numDivisions;
 }
 
 function getCorrectUserInput(


### PR DESCRIPTION
## Summary:

This continues the work started in https://github.com/Khan/perseus/pull/3869.

Issue: LEMS-4354

## Test plan:

- `pnpm storybook`
- You should be able to add and edit a Number Line widget in
  http://localhost:6006/?path=/docs/editors-editorpage--docs
- Test with and without the `perseus-renderer-upgrade` feature flag on.