### PR TITLE
Delete CSS related to TexButtons

### DIFF
--- a/.changeset/hip-gifts-sink.md
+++ b/.changeset/hip-gifts-sink.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Delete CSS styles related to the TexButtons component (removed in #838).

--- a/packages/perseus/src/styles/perseus-renderer-part-2.css
+++ b/packages/perseus/src/styles/perseus-renderer-part-2.css
@@ -89,48 +89,6 @@
     > .mq-root-block {
     border-radius: 0;
 }
-.math-input-buttons {
-    background-color: rgba(255, 255, 255, 0.7);
-    border-radius: 5px;
-    border: 1px solid #ddd;
-    box-sizing: border-box;
-    margin-top: 5px;
-    padding: 2px;
-    width: 201px;
-}
-.math-input-buttons.absolute {
-    left: -2px;
-    position: absolute;
-    top: -3px;
-    z-index: 5;
-}
-.tex-button {
-    display: block;
-    float: left;
-    width: 35px;
-    height: 35px;
-    margin: 2px;
-    border: 1px solid #1c758a;
-    background-color: white;
-    border-radius: 5px;
-}
-.tex-button:hover {
-    cursor: pointer;
-    background-color: #f0f0f0;
-}
-.tex-button:focus {
-    border: 2px solid #1c758a;
-    outline: none;
-}
-.tex-button-row {
-    margin: 5px 0;
-}
-.tex-button-row:first-child {
-    margin-top: 0;
-}
-.tex-button-row:last-child {
-    margin-bottom: 0;
-}
 .renderer-widget-error {
     background-color: #fcc;
 }


### PR DESCRIPTION
## Summary:
The TexButtons component was deleted in #838, and the CSS was never cleaned up.

This PR deletes the CSS so we don't have to migrate it to Wonder Blocks color
tokens.

Issue: none

## Test plan:

CI checks should pass. Searching for the deleted class names in Perseus and
frontend should return no results.