### PR TITLE
[Preview axe-core]: Export missing A11yOverlays

### DIFF
--- a/.changeset/easy-days-drum.md
+++ b/.changeset/easy-days-drum.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Export A11yOverlays to support editor previews that enable axe-core scanning

--- a/packages/perseus-editor/src/index.ts
+++ b/packages/perseus-editor/src/index.ts
@@ -15,6 +15,7 @@ export type {Issue} from "./components/issues-panel";
 // Preview system hooks and utilities
 export {usePreviewController} from "./preview/use-preview-controller";
 export {usePreviewPresenter} from "./preview/use-preview-presenter";
+export {A11yOverlays} from "./preview/a11y/overlays";
 export {default as PreviewWithIframe} from "./preview-with-iframe";
 export type {PreviewContent} from "./preview/message-types";
 


### PR DESCRIPTION
## Summary:

Oops. Need this in the client app!

Issue: LEMS-4402

## Test plan: