### PR TITLE
docs(changeset): Fixing a forwardRef issue with the blank widget.

### DIFF
--- a/.changeset/bold-bars-find.md
+++ b/.changeset/bold-bars-find.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fixing a forwardRef issue with the blank widget.

--- a/packages/perseus/src/widgets/blank/blank.tsx
+++ b/packages/perseus/src/widgets/blank/blank.tsx
@@ -17,8 +17,8 @@ const BlankWidget = forwardRef<Widget, BlankProps>(
             .concat(props.displayType !== "normal" ? [styles["super-sub"]] : [])
             .join(" ");
 
-        // This is stubbed for now in order to ensure ref var is used until
-        // we have the FITB Widget and add the getPromptJSON function here.
+        // TODO(LEMS-4471): Write out the getPromptJSON function after checking
+        // with the TUT team about what data they need from this widget.
         useImperativeHandle(ref, () => ({}));
 
         //TO-DO (LEMS-4448): Remove testid once we have a better way to identify a blank-widget

--- a/packages/perseus/src/widgets/blank/blank.tsx
+++ b/packages/perseus/src/widgets/blank/blank.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {forwardRef} from "react";
+import {forwardRef, useImperativeHandle} from "react";
 
 import styles from "./blank-widget.module.css";
 
@@ -11,14 +11,20 @@ import type {
 
 type BlankProps = WidgetProps<PerseusBlankWidgetOptions, PerseusBlankUserInput>;
 
-const BlankWidget = forwardRef<Widget, BlankProps>(function BlankWidget(props) {
-    const classes = [styles.container]
-        .concat(props.displayType !== "normal" ? [styles["super-sub"]] : [])
-        .join(" ");
+const BlankWidget = forwardRef<Widget, BlankProps>(
+    function BlankWidget(props, ref) {
+        const classes = [styles.container]
+            .concat(props.displayType !== "normal" ? [styles["super-sub"]] : [])
+            .join(" ");
 
-    //TO-DO (LEMS-4448): Remove testid once we have a better way to identify a blank-widget
-    return <div className={classes} data-testid="blank-widget" />;
-});
+        // This is stubbed for now in order to ensure ref var is used until
+        // we have the FITB Widget and add the getPromptJSON function here.
+        useImperativeHandle(ref, () => ({}));
+
+        //TO-DO (LEMS-4448): Remove testid once we have a better way to identify a blank-widget
+        return <div className={classes} data-testid="blank-widget" />;
+    },
+);
 export default {
     name: "blank",
     displayName: "Blank",


### PR DESCRIPTION
## Summary:
Fixing an issue that arose from pushing getPromptJSON to a later date, as it caused several cascading issues. The fix is merely stubbing out the useImperative command. 

## Test plan:
- Tests pass 
- A test passes upstream (can't run all the tests currently) 