### PR TITLE
[Editor] Fix duplicate React key issue

### DIFF
--- a/.changeset/unique-issue-keys.md
+++ b/.changeset/unique-issue-keys.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus-editor": patch
 ---
 
-Give each linter issue a unique key so the Issues panel no longer renders duplicate React keys when one rule fires more than once in the same question or hint
+Fixes duplicate React keys warning in Issues panel

--- a/.changeset/unique-issue-keys.md
+++ b/.changeset/unique-issue-keys.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Give each linter issue a unique key so the Issues panel no longer renders duplicate React keys when one rule fires more than once in the same question or hint

--- a/packages/perseus-editor/src/util/gather-linter-issues.test.ts
+++ b/packages/perseus-editor/src/util/gather-linter-issues.test.ts
@@ -1,11 +1,34 @@
+import {generateCategorizerWidget} from "@khanacademy/perseus-core";
+
+import {getIssueKey} from "../components/issues-panel";
+
 import {gatherLinterIssues} from "./gather-linter-issues";
 
 import type {Issue} from "../components/issues-panel";
 
 const cleanQuestion = {content: "What is $2 + 2$?", images: {}, widgets: {}};
-const lintyQuestion = {content: "$\\invalid{x}$", images: {}, widgets: {}};
 const cleanHint = {content: "The answer is $4$.", images: {}, widgets: {}};
-const lintyHint = {content: "$\\invalid{x}$", images: {}, widgets: {}};
+
+// Reports through `detectTexErrors` rather than any linter rule.
+const badTexRenderer = {content: "$\\invalid{x}$", images: {}, widgets: {}};
+
+const twoImageRenderer = {
+    content: "![](https://example.com/a.png)\n\n![](https://example.com/b.png)",
+    images: {},
+    widgets: {},
+};
+
+function hostIssue(overrides?: Partial<Issue>): Issue {
+    return {
+        id: "host-issue",
+        description: "A host issue",
+        help: "Help text",
+        helpUrl: "https://example.com",
+        impact: "high",
+        message: "Something is wrong",
+        ...overrides,
+    };
+}
 
 describe("gatherLinterIssues", () => {
     it("returns empty array for clean question and no hints", () => {
@@ -16,12 +39,15 @@ describe("gatherLinterIssues", () => {
         expect(issues).toEqual([]);
     });
 
-    it("returns issues for a question with linting problems", () => {
+    it("returns TeX errors found in the question", () => {
         // Arrange, Act
-        const issues = gatherLinterIssues(lintyQuestion, []);
+        const issues = gatherLinterIssues(badTexRenderer, []);
 
         // Assert
         expect(issues.length).toBeGreaterThan(0);
+        issues.forEach((issue) => {
+            expect(issue.id).toMatch(/^tex-debug-info-/);
+        });
     });
 
     it("returns empty array when question is undefined", () => {
@@ -34,7 +60,7 @@ describe("gatherLinterIssues", () => {
 
     it("returns hint issues prefixed with 'Hint N:' in the message", () => {
         // Arrange, Act
-        const issues = gatherLinterIssues(cleanQuestion, [lintyHint]);
+        const issues = gatherLinterIssues(cleanQuestion, [badTexRenderer]);
 
         // Assert
         expect(issues.length).toBeGreaterThan(0);
@@ -47,7 +73,7 @@ describe("gatherLinterIssues", () => {
         // Arrange, Act
         const issues = gatherLinterIssues(cleanQuestion, [
             cleanHint,
-            lintyHint,
+            badTexRenderer,
         ]);
 
         // Assert
@@ -59,66 +85,124 @@ describe("gatherLinterIssues", () => {
 
     it("prefixes hint issue IDs with 'hint-N-'", () => {
         // Arrange, Act
-        const issues = gatherLinterIssues(cleanQuestion, [lintyHint]);
+        const issues = gatherLinterIssues(cleanQuestion, [badTexRenderer]);
 
         // Assert
+        expect(issues.length).toBeGreaterThan(0);
         issues.forEach((issue) => {
             expect(issue.id).toMatch(/^hint-1-/);
         });
     });
 
-    it("includes host-provided issues first", () => {
+    it("gives each issue a unique key when one rule fires more than once in the question", () => {
+        // Arrange, Act
+        const issues = gatherLinterIssues(twoImageRenderer, []);
+
+        // Assert
+        const keys = issues.map(getIssueKey);
+        expect(keys.length).toBeGreaterThan(1);
+        expect(new Set(keys).size).toBe(keys.length);
+    });
+
+    it("gives each issue a unique key when one rule fires more than once in a hint", () => {
+        // Arrange, Act
+        const issues = gatherLinterIssues(cleanQuestion, [twoImageRenderer]);
+
+        // Assert
+        const keys = issues.map(getIssueKey);
+        expect(keys.length).toBeGreaterThan(1);
+        expect(new Set(keys).size).toBe(keys.length);
+    });
+
+    it("gives each issue a unique key across the question and its hints", () => {
+        // Arrange, Act
+        const issues = gatherLinterIssues(twoImageRenderer, [
+            twoImageRenderer,
+            twoImageRenderer,
+        ]);
+
+        // Assert
+        const keys = issues.map(getIssueKey);
+        expect(new Set(keys).size).toBe(keys.length);
+    });
+
+    it("numbers each rule's occurrences from zero, independently per rule", () => {
+        // Arrange, Act
+        const issues = gatherLinterIssues(twoImageRenderer, []);
+
+        // Assert
+        const instanceIdsByRule = new Map<string, Array<string | undefined>>();
+        issues.forEach((issue) => {
+            const forRule = instanceIdsByRule.get(issue.id) ?? [];
+            forRule.push(issue.instanceId);
+            instanceIdsByRule.set(issue.id, forRule);
+        });
+
+        // The invariant only says something when more than one rule repeats:
+        // a counter shared across rules would number the second rule's
+        // occurrences 2 and 3 rather than restarting at 0.
+        const repeatedRules = [...instanceIdsByRule.values()].filter(
+            (instanceIds) => instanceIds.length > 1,
+        );
+        expect(repeatedRules.length).toBeGreaterThan(1);
+
+        instanceIdsByRule.forEach((instanceIds, id) => {
+            expect(instanceIds).toEqual(
+                instanceIds.map((_, occurrence) => `${id}-${occurrence}`),
+            );
+        });
+    });
+
+    it("keeps an instanceId the warning already provides", () => {
         // Arrange
-        const hostIssue: Issue = {
-            id: "host-issue",
-            description: "A host issue",
-            help: "Help text",
-            helpUrl: "https://example.com",
-            impact: "high",
-            message: "Something is wrong",
+        const widgetRenderer = {
+            content: "[[☃ categorizer 1]]",
+            images: {},
+            widgets: {"categorizer 1": generateCategorizerWidget()},
         };
 
         // Act
-        const issues = gatherLinterIssues(cleanQuestion, [], [hostIssue]);
+        const issues = gatherLinterIssues(widgetRenderer, []);
 
         // Assert
-        expect(issues[0]).toEqual(hostIssue);
+        expect(issues).toContainEqual(
+            expect.objectContaining({
+                instanceId: "inaccessible-widget-categorizer 1",
+            }),
+        );
+    });
+
+    it("includes host-provided issues first", () => {
+        // Arrange
+        const issue = hostIssue();
+
+        // Act
+        const issues = gatherLinterIssues(twoImageRenderer, [], [issue]);
+
+        // Assert
+        expect(issues[0]).toEqual(issue);
     });
 
     it("returns host issues even when content is clean", () => {
         // Arrange
-        const hostIssue: Issue = {
-            id: "host-issue",
-            description: "A host issue",
-            help: "Help text",
-            helpUrl: "https://example.com",
-            impact: "medium",
-            message: "Something is wrong",
-        };
+        const issue = hostIssue();
 
         // Act
-        const issues = gatherLinterIssues(cleanQuestion, [], [hostIssue]);
+        const issues = gatherLinterIssues(cleanQuestion, [], [issue]);
 
         // Assert
-        expect(issues).toContainEqual(hostIssue);
+        expect(issues).toContainEqual(issue);
     });
 
     it("orders issues: host issues, then question issues, then hint issues", () => {
         // Arrange
-        const hostIssue: Issue = {
-            id: "host-issue",
-            description: "A host issue",
-            help: "Help text",
-            helpUrl: "https://example.com",
-            impact: "high",
-            message: "Host problem",
-        };
+        const issue = hostIssue();
 
         // Act
         const issues = gatherLinterIssues(
-            lintyQuestion,
-            [lintyHint],
-            [hostIssue],
+            badTexRenderer,
+            [badTexRenderer],
+            [issue],
         );
 
         // Assert

--- a/packages/perseus-editor/src/util/gather-linter-issues.ts
+++ b/packages/perseus-editor/src/util/gather-linter-issues.ts
@@ -37,7 +37,22 @@ function lintRenderer(content: string, widgets?: PerseusWidgetsMap): Issue[] {
         WARNINGS.texError(error.math, error.message, i),
     );
 
-    return [...linterIssues, ...texIssues];
+    // A linter warning is identified by its rule name, so several occurrences
+    // of one rule in the same renderer arrive sharing an `id`. Stamp an
+    // occurrence ordinal to make each issue's key unique within this renderer,
+    // leaving alone the ids that are already unique (`inaccessible-widget-*`).
+    //
+    // The ordinal counts per rule rather than across the whole list, so a new
+    // warning of one rule doesn't renumber every issue after it.
+    const ruleCounts = new Map<string, number>();
+    return [...linterIssues, ...texIssues].map((issue) => {
+        const ordinal = ruleCounts.get(issue.id) ?? 0;
+        ruleCounts.set(issue.id, ordinal + 1);
+        return {
+            ...issue,
+            instanceId: issue.instanceId ?? `${issue.id}-${ordinal}`,
+        };
+    });
 }
 
 export function gatherLinterIssues(


### PR DESCRIPTION
## Summary 

This PR fixes a duplicate React key issue in the editor's Issues panel. 

## Background 

A linter warning is identified by its rule name, so when one rule fires more than once in the same question or hint, they all share the same `id` (rule name) — and `getIssueKey` had nothing unique to fall back on. 

## Fix 

The `lintRenderer` function now adds a "manufactured" `instanceId` onto each Issue the linter generates. It leaves already-unique ids (`inaccessible-widget-*`) alone. I've added several tests to nail down this new behaviour.

Issue: LEMS-4402

## Test plan:

- Run `pnpm test`
- Run `pnpm typecheck`
- In Storybook ("Editors/EditorPage"), give a question two images with no alt text, expand the Issues panel, and confirm both `image-alt-text` warnings render with no duplicate-key warning in the console.