### PR TITLE
DnD editor cleanup

### DIFF
--- a/.changeset/curly-pets-allow.md
+++ b/.changeset/curly-pets-allow.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-core": minor
+"@khanacademy/perseus-editor": patch
+---
+
+Add Orderer generatore to perseus-core and refactor drag-and-drop widget editors

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -441,6 +441,12 @@ export {
 } from "./utils/generators/matrix-widget-generator";
 /** @hidden */
 export {
+    generateOrdererWidget,
+    generateOrdererOptions,
+    generateOrdererOption,
+} from "./utils/generators/orderer-widget-generator";
+/** @hidden */
+export {
     generatePlotterWidget,
     generatePlotterOptions,
 } from "./utils/generators/plotter-widget-generator";

--- a/packages/perseus-core/src/utils/generators/orderer-widget-generator.test.ts
+++ b/packages/perseus-core/src/utils/generators/orderer-widget-generator.test.ts
@@ -1,0 +1,91 @@
+import {
+    generateOrdererOption,
+    generateOrdererOptions,
+    generateOrdererWidget,
+} from "./orderer-widget-generator";
+
+describe("generateOrdererOption", () => {
+    it("wraps the content in an empty renderer", () => {
+        // Arrange, Act
+        const option = generateOrdererOption("Option 1");
+
+        // Assert
+        expect(option).toEqual({
+            content: "Option 1",
+            widgets: {},
+            images: {},
+        });
+    });
+});
+
+describe("generateOrdererOptions", () => {
+    it("overrides defaults with the provided options", () => {
+        // Arrange, Act
+        const options = generateOrdererOptions({
+            height: "auto",
+            layout: "vertical",
+        });
+
+        // Assert
+        expect(options.height).toBe("auto");
+        expect(options.layout).toBe("vertical");
+    });
+
+    it("derives the card bank from the correct and other options", () => {
+        // Arrange, Act
+        const options = generateOrdererOptions({
+            correctOptions: [generateOrdererOption("1")],
+            otherOptions: [generateOrdererOption("2")],
+        });
+
+        // Assert
+        expect(options.options).toEqual([
+            generateOrdererOption("1"),
+            generateOrdererOption("2"),
+        ]);
+    });
+
+    it("uses the provided card bank when one is given", () => {
+        // Arrange, Act
+        const options = generateOrdererOptions({
+            correctOptions: [generateOrdererOption("1")],
+            otherOptions: [generateOrdererOption("2")],
+            options: [generateOrdererOption("2"), generateOrdererOption("1")],
+        });
+
+        // Assert
+        expect(options.options).toEqual([
+            generateOrdererOption("2"),
+            generateOrdererOption("1"),
+        ]);
+    });
+});
+
+describe("generateOrdererWidget", () => {
+    it("overrides defaults with the provided properties", () => {
+        // Arrange, Act
+        const widget = generateOrdererWidget({
+            graded: false,
+            version: {major: 1, minor: 2},
+            static: true,
+            alignment: "block",
+            options: generateOrdererOptions({
+                correctOptions: [generateOrdererOption("$x$")],
+                otherOptions: [],
+                height: "auto",
+                layout: "vertical",
+            }),
+        });
+
+        // Assert
+        expect(widget.graded).toBe(false);
+        expect(widget.version).toEqual({major: 1, minor: 2});
+        expect(widget.static).toBe(true);
+        expect(widget.alignment).toBe("block");
+        expect(widget.options.correctOptions).toEqual([
+            generateOrdererOption("$x$"),
+        ]);
+        expect(widget.options.height).toBe("auto");
+        expect(widget.options.layout).toBe("vertical");
+    });
+});

--- a/packages/perseus-core/src/utils/generators/orderer-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/orderer-widget-generator.ts
@@ -1,0 +1,54 @@
+import ordererWidgetLogic from "../../widgets/orderer";
+
+import type {
+    OrdererWidget,
+    PerseusOrdererWidgetOptions,
+    PerseusRenderer,
+} from "../../data-schema";
+
+/**
+ * Builds a single orderer card. The orderer stores each card as a
+ * PerseusRenderer so that cards can contain math and images, but most tests
+ * only care about the card's text.
+ */
+export function generateOrdererOption(content: string): PerseusRenderer {
+    return {
+        content,
+        widgets: {},
+        images: {},
+    };
+}
+
+export function generateOrdererOptions(
+    options?: Partial<PerseusOrdererWidgetOptions>,
+): PerseusOrdererWidgetOptions {
+    const merged = {
+        ...ordererWidgetLogic.defaultWidgetOptions,
+        ...options,
+    };
+
+    return {
+        ...merged,
+        // `options` holds every card in the bank: the correct answer plus the
+        // distractors. We derive it so that overriding only `correctOptions`
+        // or `otherOptions` still produces a valid widget.
+        options: options?.options ?? [
+            ...merged.correctOptions,
+            ...merged.otherOptions,
+        ],
+    };
+}
+
+export function generateOrdererWidget(
+    ordererWidgetProperties?: Partial<Omit<OrdererWidget, "type">>,
+): OrdererWidget {
+    return {
+        type: "orderer",
+        graded: true,
+        version: {major: 0, minor: 0},
+        static: false,
+        alignment: "default",
+        ...ordererWidgetProperties,
+        options: generateOrdererOptions(ordererWidgetProperties?.options),
+    };
+}

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -14220,9 +14220,7 @@ table: [[☃ table 1]]
                   <div
                     class="perseus-widget-editor-content enter"
                   >
-                    <div
-                      class="perseus-widget-orderer"
-                    >
+                    <div>
                       <div>
                          
                         Correct answer:

--- a/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
@@ -14287,9 +14287,7 @@ table: [[☃ table 1]]
                   <div
                     class="perseus-widget-editor-content enter"
                   >
-                    <div
-                      class="perseus-widget-orderer"
-                    >
+                    <div>
                       <div>
                          
                         Correct answer:

--- a/packages/perseus-editor/src/editor-page.test.tsx
+++ b/packages/perseus-editor/src/editor-page.test.tsx
@@ -3,7 +3,10 @@ import {
     type PerseusOrdererWidgetOptions,
     type PerseusRenderer,
 } from "@khanacademy/perseus-core";
-import {getDefaultAnswerArea} from "@khanacademy/perseus-core";
+import {
+    generateOrdererOption,
+    getDefaultAnswerArea,
+} from "@khanacademy/perseus-core";
 import {render, screen, waitFor} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
@@ -170,16 +173,8 @@ describe("EditorPage", () => {
         // Verify the options were updated correctly
         expect(widgetOptions).toEqual(
             expect.objectContaining({
-                correctOptions: [
-                    {
-                        content: altImage,
-                    },
-                ],
-                options: [
-                    {
-                        content: altImage,
-                    },
-                ],
+                correctOptions: [generateOrdererOption(altImage)],
+                options: [generateOrdererOption(altImage)],
             }),
         );
     });

--- a/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.test.tsx
@@ -124,7 +124,7 @@ describe("matcher-editor", () => {
         );
     });
 
-    it("calls onChange with the updated labels when either label is edited", async () => {
+    it("calls onChange with the updated labels when the first label is edited", async () => {
         // Arrange
         const onChangeMock = jest.fn();
         render(
@@ -135,15 +135,34 @@ describe("matcher-editor", () => {
         );
 
         // Act
-        await userEvent.type(screen.getByDisplayValue("Animal"), "s");
-        await userEvent.type(screen.getByDisplayValue("Sound"), "s");
+        const firstLabel = screen.getByDisplayValue("Animal");
+        await userEvent.clear(firstLabel);
+        await userEvent.type(firstLabel, "Beast");
 
         // Assert
-        expect(onChangeMock).toHaveBeenCalledWith({
-            labels: ["Animals", "Sound"],
+        expect(onChangeMock).toHaveBeenLastCalledWith({
+            labels: ["Beast", "Sound"],
         });
-        expect(onChangeMock).toHaveBeenCalledWith({
-            labels: ["Animal", "Sounds"],
+    });
+
+    it("calls onChange with the updated labels when the second label is edited", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <MatcherEditor
+                onChange={onChangeMock}
+                {...generateMatcherOptions({labels: ["Animal", "Sound"]})}
+            />,
+        );
+
+        // Act
+        const secondLabel = screen.getByDisplayValue("Sound");
+        await userEvent.clear(secondLabel);
+        await userEvent.type(secondLabel, "Noise");
+
+        // Assert
+        expect(onChangeMock).toHaveBeenLastCalledWith({
+            labels: ["Animal", "Noise"],
         });
     });
 

--- a/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.test.tsx
@@ -74,6 +74,79 @@ describe("matcher-editor", () => {
         expect(screen.getByDisplayValue("Sound")).toBeInTheDocument();
     });
 
+    it("calls onChange with the updated cards when a left card is edited", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <MatcherEditor
+                onChange={onChangeMock}
+                {...generateMatcherOptions({
+                    left: ["Cat", "Dog"],
+                    right: ["Meow", "Woof"],
+                })}
+            />,
+        );
+
+        // Act
+        const leftCard = screen.getByDisplayValue("Dog");
+        await userEvent.clear(leftCard);
+        await userEvent.type(leftCard, "Emu");
+
+        // Assert
+        expect(onChangeMock).toHaveBeenLastCalledWith(
+            {left: ["Cat", "Emu"]},
+            undefined,
+        );
+    });
+
+    it("calls onChange with the updated cards when a right card is edited", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <MatcherEditor
+                onChange={onChangeMock}
+                {...generateMatcherOptions({
+                    left: ["Cat", "Dog"],
+                    right: ["Meow", "Woof"],
+                })}
+            />,
+        );
+
+        // Act
+        const rightCard = screen.getByDisplayValue("Woof");
+        await userEvent.clear(rightCard);
+        await userEvent.type(rightCard, "Purr");
+
+        // Assert
+        expect(onChangeMock).toHaveBeenLastCalledWith(
+            {right: ["Meow", "Purr"]},
+            undefined,
+        );
+    });
+
+    it("calls onChange with the updated labels when either label is edited", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <MatcherEditor
+                onChange={onChangeMock}
+                {...generateMatcherOptions({labels: ["Animal", "Sound"]})}
+            />,
+        );
+
+        // Act
+        await userEvent.type(screen.getByDisplayValue("Animal"), "s");
+        await userEvent.type(screen.getByDisplayValue("Sound"), "s");
+
+        // Assert
+        expect(onChangeMock).toHaveBeenCalledWith({
+            labels: ["Animals", "Sound"],
+        });
+        expect(onChangeMock).toHaveBeenCalledWith({
+            labels: ["Animal", "Sounds"],
+        });
+    });
+
     it("serializes the cards, labels, and options", () => {
         // Arrange
         const editorRef = React.createRef<MatcherEditor>();

--- a/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.test.tsx
@@ -1,4 +1,5 @@
 import {Dependencies} from "@khanacademy/perseus";
+import {generateMatcherOptions} from "@khanacademy/perseus-core";
 import {render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
@@ -49,5 +50,103 @@ describe("matcher-editor", () => {
         await userEvent.click(screen.getByRole("checkbox", {name: "Padding:"}));
 
         expect(onChangeMock).toHaveBeenCalledWith({padding: false});
+    });
+
+    it("renders an input for each card and label", () => {
+        // Arrange, Act
+        render(
+            <MatcherEditor
+                onChange={() => {}}
+                {...generateMatcherOptions({
+                    left: ["Cat", "Dog"],
+                    right: ["Meow", "Woof"],
+                    labels: ["Animal", "Sound"],
+                })}
+            />,
+        );
+
+        // Assert
+        expect(screen.getByDisplayValue("Cat")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("Dog")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("Meow")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("Woof")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("Animal")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("Sound")).toBeInTheDocument();
+    });
+
+    it("serializes the cards, labels, and options", () => {
+        // Arrange
+        const editorRef = React.createRef<MatcherEditor>();
+        render(
+            <MatcherEditor
+                ref={editorRef}
+                onChange={() => {}}
+                {...generateMatcherOptions({
+                    left: ["Cat", "Dog"],
+                    right: ["Meow", "Woof"],
+                    labels: ["Animal", "Sound"],
+                    orderMatters: true,
+                    padding: false,
+                })}
+            />,
+        );
+
+        // Act
+        const serialized = editorRef.current?.serialize();
+
+        // Assert
+        expect(serialized).toEqual({
+            left: ["Cat", "Dog"],
+            right: ["Meow", "Woof"],
+            labels: ["Animal", "Sound"],
+            orderMatters: true,
+            padding: false,
+        });
+    });
+
+    describe("getSaveWarnings", () => {
+        it("returns a warning when the two halves have different numbers of cards", () => {
+            // Arrange
+            const editorRef = React.createRef<MatcherEditor>();
+            render(
+                <MatcherEditor
+                    ref={editorRef}
+                    onChange={() => {}}
+                    {...generateMatcherOptions({
+                        left: ["Cat", "Dog"],
+                        right: ["Meow"],
+                    })}
+                />,
+            );
+
+            // Act
+            const warnings = editorRef.current?.getSaveWarnings();
+
+            // Assert
+            expect(warnings).toEqual([
+                "The two halves of the matcher have different numbers of cards.",
+            ]);
+        });
+
+        it("returns no warnings when the two halves have the same number of cards", () => {
+            // Arrange
+            const editorRef = React.createRef<MatcherEditor>();
+            render(
+                <MatcherEditor
+                    ref={editorRef}
+                    onChange={() => {}}
+                    {...generateMatcherOptions({
+                        left: ["Cat", "Dog"],
+                        right: ["Meow", "Woof"],
+                    })}
+                />,
+            );
+
+            // Act
+            const warnings = editorRef.current?.getSaveWarnings();
+
+            // Assert
+            expect(warnings).toEqual([]);
+        });
     });
 });

--- a/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.tsx
+++ b/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.tsx
@@ -25,10 +25,7 @@ class MatcherEditor extends React.Component<Props> {
     static defaultProps: PerseusMatcherWidgetOptions =
         matcherLogic.defaultWidgetOptions;
 
-    onLabelChange: (
-        arg1: number,
-        arg2: React.ChangeEvent<HTMLInputElement>,
-    ) => void = (index, e) => {
+    onLabelChange = (index: number, e: React.ChangeEvent<HTMLInputElement>) => {
         const labels = [...this.props.labels];
         labels[index] = e.target.value;
         this.props.onChange({labels: labels});
@@ -36,7 +33,7 @@ class MatcherEditor extends React.Component<Props> {
 
     // TODO(LEMS-3643): Remove `getSaveWarnings` once the frontend uses
     // the new linter rules for save warnings.
-    getSaveWarnings: () => ReadonlyArray<string> = () => {
+    getSaveWarnings = (): ReadonlyArray<string> => {
         if (this.props.left.length !== this.props.right.length) {
             return [
                 "The two halves of the matcher have different numbers" +
@@ -46,7 +43,7 @@ class MatcherEditor extends React.Component<Props> {
         return [];
     };
 
-    serialize: () => PerseusMatcherWidgetOptions = () => {
+    serialize = (): PerseusMatcherWidgetOptions => {
         return {
             left: this.props.left,
             right: this.props.right,

--- a/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.tsx
+++ b/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.tsx
@@ -4,7 +4,6 @@ import {
 } from "@khanacademy/perseus-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import * as React from "react";
-import _ from "underscore";
 
 import InfoTip from "../../components/info-tip";
 import TextListEditor from "../../components/text-list-editor";
@@ -30,7 +29,7 @@ class MatcherEditor extends React.Component<Props> {
         arg1: number,
         arg2: React.ChangeEvent<HTMLInputElement>,
     ) => void = (index, e) => {
-        const labels = _.clone(this.props.labels);
+        const labels = [...this.props.labels];
         labels[index] = e.target.value;
         this.props.onChange({labels: labels});
     };
@@ -48,14 +47,13 @@ class MatcherEditor extends React.Component<Props> {
     };
 
     serialize: () => MatcherDefaultWidgetOptions = () => {
-        return _.pick(
-            this.props,
-            "left",
-            "right",
-            "labels",
-            "orderMatters",
-            "padding",
-        );
+        return {
+            left: this.props.left,
+            right: this.props.right,
+            labels: this.props.labels,
+            orderMatters: this.props.orderMatters,
+            padding: this.props.padding,
+        };
     };
 
     render(): React.ReactNode {

--- a/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.tsx
+++ b/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.tsx
@@ -1,6 +1,7 @@
 import {
     matcherLogic,
     type MatcherDefaultWidgetOptions,
+    type PerseusMatcherWidgetOptions,
 } from "@khanacademy/perseus-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import * as React from "react";
@@ -46,7 +47,7 @@ class MatcherEditor extends React.Component<Props> {
         return [];
     };
 
-    serialize: () => MatcherDefaultWidgetOptions = () => {
+    serialize: () => PerseusMatcherWidgetOptions = () => {
         return {
             left: this.props.left,
             right: this.props.right,

--- a/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.tsx
+++ b/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.tsx
@@ -1,6 +1,5 @@
 import {
     matcherLogic,
-    type MatcherDefaultWidgetOptions,
     type PerseusMatcherWidgetOptions,
 } from "@khanacademy/perseus-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
@@ -9,9 +8,9 @@ import * as React from "react";
 import InfoTip from "../../components/info-tip";
 import TextListEditor from "../../components/text-list-editor";
 
-type Props = MatcherDefaultWidgetOptions & {
+type Props = PerseusMatcherWidgetOptions & {
     onChange: (
-        newOptions: Partial<MatcherDefaultWidgetOptions>,
+        newOptions: Partial<PerseusMatcherWidgetOptions>,
         callback?: () => void,
     ) => void;
 };
@@ -23,7 +22,7 @@ type Props = MatcherDefaultWidgetOptions & {
 class MatcherEditor extends React.Component<Props> {
     static widgetName = "matcher" as const;
 
-    static defaultProps: MatcherDefaultWidgetOptions =
+    static defaultProps: PerseusMatcherWidgetOptions =
         matcherLogic.defaultWidgetOptions;
 
     onLabelChange: (

--- a/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.tsx
+++ b/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.tsx
@@ -94,12 +94,16 @@ class MatcherEditor extends React.Component<Props> {
                     <input
                         type="text"
                         defaultValue={this.props.labels[0]}
-                        onChange={this.onLabelChange.bind(this, 0)}
+                        onChange={(e) => {
+                            this.onLabelChange(0, e);
+                        }}
                     />
                     <input
                         type="text"
                         defaultValue={this.props.labels[1]}
-                        onChange={this.onLabelChange.bind(this, 1)}
+                        onChange={(e) => {
+                            this.onLabelChange(1, e);
+                        }}
                     />
                 </div>
                 <div>

--- a/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.tsx
+++ b/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.tsx
@@ -1,31 +1,26 @@
-/* eslint-disable react/forbid-prop-types */
 import {
     matcherLogic,
     type MatcherDefaultWidgetOptions,
 } from "@khanacademy/perseus-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
-import PropTypes from "prop-types";
 import * as React from "react";
 import _ from "underscore";
 
 import InfoTip from "../../components/info-tip";
 import TextListEditor from "../../components/text-list-editor";
 
-type Props = any;
+type Props = MatcherDefaultWidgetOptions & {
+    onChange: (
+        newOptions: Partial<MatcherDefaultWidgetOptions>,
+        callback?: () => void,
+    ) => void;
+};
 
 // JSDoc will be shown in Storybook widget editor description
 /**
  * An editor for adding a matcher widget that allows users to match items from two different sets.
  */
 class MatcherEditor extends React.Component<Props> {
-    static propTypes = {
-        left: PropTypes.array,
-        right: PropTypes.array,
-        labels: PropTypes.array,
-        orderMatters: PropTypes.bool,
-        padding: PropTypes.bool,
-    };
-
     static widgetName = "matcher" as const;
 
     static defaultProps: MatcherDefaultWidgetOptions =
@@ -52,7 +47,7 @@ class MatcherEditor extends React.Component<Props> {
         return [];
     };
 
-    serialize: any = () => {
+    serialize: () => MatcherDefaultWidgetOptions = () => {
         return _.pick(
             this.props,
             "left",

--- a/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.tsx
+++ b/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.tsx
@@ -33,7 +33,7 @@ class MatcherEditor extends React.Component<Props> {
 
     // TODO(LEMS-3643): Remove `getSaveWarnings` once the frontend uses
     // the new linter rules for save warnings.
-    getSaveWarnings = (): ReadonlyArray<string> => {
+    getSaveWarnings = (): string[] => {
         if (this.props.left.length !== this.props.right.length) {
             return [
                 "The two halves of the matcher have different numbers" +

--- a/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.tsx
+++ b/packages/perseus-editor/src/widgets/matcher-editor/matcher-editor.tsx
@@ -28,7 +28,7 @@ class MatcherEditor extends React.Component<Props> {
     onLabelChange = (index: number, e: React.ChangeEvent<HTMLInputElement>) => {
         const labels = [...this.props.labels];
         labels[index] = e.target.value;
-        this.props.onChange({labels: labels});
+        this.props.onChange({labels});
     };
 
     // TODO(LEMS-3643): Remove `getSaveWarnings` once the frontend uses

--- a/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.test.tsx
@@ -1,4 +1,8 @@
 import {Dependencies} from "@khanacademy/perseus";
+import {
+    generateOrdererOption,
+    generateOrdererOptions,
+} from "@khanacademy/perseus-core";
 import {render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
@@ -130,6 +134,27 @@ describe("OrdererEditor", () => {
             height: "normal",
             layout: "horizontal",
         });
+    });
+
+    it("renders an input for each correct and other card", () => {
+        // Arrange, Act
+        render(
+            <OrdererEditor
+                onChange={() => {}}
+                {...generateOrdererOptions({
+                    correctOptions: [
+                        generateOrdererOption("Cat"),
+                        generateOrdererOption("Dog"),
+                    ],
+                    otherOptions: [generateOrdererOption("Emu")],
+                })}
+            />,
+        );
+
+        // Assert
+        expect(screen.getByDisplayValue("Cat")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("Dog")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("Emu")).toBeInTheDocument();
     });
 });
 

--- a/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.test.tsx
@@ -179,6 +179,46 @@ describe("OrdererEditor", () => {
         expect(screen.getByDisplayValue("Dog")).toBeInTheDocument();
         expect(screen.getByDisplayValue("Emu")).toBeInTheDocument();
     });
+
+    it("calls onChange with the new layout when the layout is changed", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <OrdererEditor
+                onChange={onChangeMock}
+                {...generateOrdererOptions({layout: "horizontal"})}
+            />,
+        );
+
+        // Act
+        await userEvent.selectOptions(
+            screen.getByRole("combobox", {name: "Layout:"}),
+            "vertical",
+        );
+
+        // Assert
+        expect(onChangeMock).toHaveBeenCalledWith({layout: "vertical"});
+    });
+
+    it("calls onChange with the new height when the height is changed", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <OrdererEditor
+                onChange={onChangeMock}
+                {...generateOrdererOptions({height: "normal"})}
+            />,
+        );
+
+        // Act
+        await userEvent.selectOptions(
+            screen.getByRole("combobox", {name: "Height:"}),
+            "auto",
+        );
+
+        // Assert
+        expect(onChangeMock).toHaveBeenCalledWith({height: "auto"});
+    });
 });
 
 describe("mergeCards", () => {

--- a/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.test.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 
 import {testDependencies} from "../../testing/test-dependencies";
 
-import OrdererEditor, {getUpdatedOptions} from "./orderer-editor";
+import OrdererEditor, {mergeCards} from "./orderer-editor";
 
 import type {PerseusOrdererWidgetOptions} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
@@ -75,17 +75,40 @@ describe("OrdererEditor", () => {
         // Verify the options were updated correctly
         expect(onChangeMock).toHaveBeenCalledWith(
             expect.objectContaining({
-                correctOptions: [
-                    {
-                        content: altImage,
-                    },
-                ],
-                options: [
-                    {
-                        content: altImage,
-                    },
-                ],
+                correctOptions: [generateOrdererOption(altImage)],
+                options: [generateOrdererOption(altImage)],
             }),
+            undefined,
+        );
+    });
+
+    it("calls onChange with the merged cards when an other card is edited", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <OrdererEditor
+                onChange={onChangeMock}
+                {...generateOrdererOptions({
+                    correctOptions: [generateOrdererOption("Cat")],
+                    otherOptions: [generateOrdererOption("Dog")],
+                })}
+            />,
+        );
+
+        // Act
+        const otherCard = screen.getByDisplayValue("Dog");
+        await userEvent.clear(otherCard);
+        await userEvent.type(otherCard, "Emu");
+
+        // Assert
+        expect(onChangeMock).toHaveBeenLastCalledWith(
+            {
+                otherOptions: [generateOrdererOption("Emu")],
+                options: [
+                    generateOrdererOption("Cat"),
+                    generateOrdererOption("Emu"),
+                ],
+            },
             undefined,
         );
     });
@@ -122,9 +145,9 @@ describe("OrdererEditor", () => {
         // Assert
         expect(serialized).toEqual({
             options: [
-                {content: "Option 1"},
-                {content: "Option 2"},
-                {content: "Option 3"},
+                generateOrdererOption("Option 1"),
+                generateOrdererOption("Option 2"),
+                generateOrdererOption("Option 3"),
             ],
             correctOptions: [
                 {content: "Option 1", widgets: {}, images: {}},
@@ -158,115 +181,80 @@ describe("OrdererEditor", () => {
     });
 });
 
-describe("getUpdatedOptions", () => {
-    it("correctly updates correctOptions", () => {
-        // Arrange
-        const existingCorrect = [{content: "existing correct"}];
-        const existingOther = [{content: "existing other"}];
-        const newOptions = ["new option"];
-
-        // Act
-        const props = getUpdatedOptions(
-            existingCorrect,
-            existingOther,
-            "correctOptions",
-            newOptions,
+describe("mergeCards", () => {
+    it("combines the correct cards and the other cards", () => {
+        // Arrange, Act
+        const cards = mergeCards(
+            [generateOrdererOption("a")],
+            [generateOrdererOption("b")],
         );
 
         // Assert
-        expect(props).toEqual({
-            correctOptions: [{content: "new option"}],
-            options: [{content: "existing other"}, {content: "new option"}],
-        });
-    });
-
-    it("correctly updates otherOptions", () => {
-        // Arrange
-        const existingCorrect = [{content: "existing correct"}];
-        const existingOther = [{content: "existing other"}];
-        const newOptions = ["new other"];
-
-        // Act
-        const props = getUpdatedOptions(
-            existingCorrect,
-            existingOther,
-            "otherOptions",
-            newOptions,
-        );
-
-        // Assert
-        expect(props).toEqual({
-            otherOptions: [{content: "new other"}],
-            options: [{content: "existing correct"}, {content: "new other"}],
-        });
-    });
-
-    it("sorts options correctly", () => {
-        // Arrange
-        const existingCorrect = [{content: "3"}, {content: "$b$"}];
-        const existingOther = [{content: "2"}, {content: "1"}];
-        const newOptions = ["2", "a"];
-
-        // Act
-        const props = getUpdatedOptions(
-            existingCorrect,
-            existingOther,
-            "otherOptions",
-            newOptions,
-        );
-
-        // Assert
-        // Sort order should be:
-        // 1. Numbers (2, 3)
-        // 2. $tex$ without numbers ($b$)
-        // 3. Everything else (a)
-        expect(props.options).toEqual([
-            {content: "2"},
-            {content: "3"},
-            {content: "$b$"},
-            {content: "a"},
+        expect(cards).toEqual([
+            generateOrdererOption("a"),
+            generateOrdererOption("b"),
         ]);
     });
 
-    it("removes duplicate options", () => {
-        // Arrange
-        const existingCorrect = [{content: "duplicate"}, {content: "unique"}];
-        const existingOther = [{content: "duplicate"}];
-        const newOptions = ["duplicate"];
-
-        // Act
-        const props = getUpdatedOptions(
-            existingCorrect,
-            existingOther,
-            "otherOptions",
-            newOptions,
+    it("sorts content with numbers ahead of content without", () => {
+        // Arrange, Act
+        const cards = mergeCards(
+            [generateOrdererOption("3"), generateOrdererOption("$b$")],
+            [generateOrdererOption("2"), generateOrdererOption("a")],
         );
 
         // Assert
-        expect(props.options).toEqual([
-            {content: "duplicate"},
-            {content: "unique"},
+        expect(cards).toEqual([
+            generateOrdererOption("2"),
+            generateOrdererOption("3"),
+            generateOrdererOption("$b$"),
+            generateOrdererOption("a"),
         ]);
     });
 
-    it("filters out empty strings", () => {
-        // Arrange
-        const existingCorrect = [{content: ""}, {content: "existing"}];
-        const existingOther = [{content: ""}];
-        const newOptions = ["", "valid"];
-
-        // Act
-        const props = getUpdatedOptions(
-            existingCorrect,
-            existingOther,
-            "otherOptions",
-            newOptions,
+    it("sorts bare variables last", () => {
+        // Arrange, Act
+        const cards = mergeCards(
+            [generateOrdererOption("x + 1"), generateOrdererOption("$y$")],
+            [generateOrdererOption("hello world")],
         );
 
         // Assert
-        expect(props.options).toEqual([
-            {content: "existing"},
-            {content: "valid"},
+        expect(cards).toEqual([
+            generateOrdererOption("x + 1"),
+            generateOrdererOption("hello world"),
+            generateOrdererOption("$y$"),
+        ]);
+    });
+
+    it("removes duplicate cards", () => {
+        // Arrange, Act
+        const cards = mergeCards(
+            [
+                generateOrdererOption("duplicate"),
+                generateOrdererOption("unique"),
+            ],
+            [generateOrdererOption("duplicate")],
+        );
+
+        // Assert
+        expect(cards).toEqual([
+            generateOrdererOption("duplicate"),
+            generateOrdererOption("unique"),
+        ]);
+    });
+
+    it("removes empty cards", () => {
+        // Arrange, Act
+        const cards = mergeCards(
+            [generateOrdererOption(""), generateOrdererOption("existing")],
+            [generateOrdererOption(""), generateOrdererOption("valid")],
+        );
+
+        // Assert
+        expect(cards).toEqual([
+            generateOrdererOption("existing"),
+            generateOrdererOption("valid"),
         ]);
     });
 });

--- a/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.tsx
@@ -141,7 +141,9 @@ class OrdererEditor extends React.Component<Props> {
                     options={this.props.correctOptions.map(
                         (option) => option.content,
                     )}
-                    onChange={this.onOptionsChange.bind(this, "correctOptions")}
+                    onChange={(options, cb) => {
+                        this.onOptionsChange("correctOptions", options, cb);
+                    }}
                     layout={this.props.layout}
                 />
 
@@ -156,7 +158,9 @@ class OrdererEditor extends React.Component<Props> {
                     options={this.props.otherOptions.map(
                         (option) => option.content,
                     )}
-                    onChange={this.onOptionsChange.bind(this, "otherOptions")}
+                    onChange={(options, cb) => {
+                        this.onOptionsChange("otherOptions", options, cb);
+                    }}
                     layout={this.props.layout}
                 />
 

--- a/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.tsx
@@ -1,10 +1,8 @@
-/* eslint-disable @khanacademy/ts-no-error-suppressions */
-/* eslint-disable react/forbid-prop-types */
 import {
     ordererLogic,
     type OrdererDefaultWidgetOptions,
+    type PerseusOrdererWidgetOptions,
 } from "@khanacademy/perseus-core";
-import PropTypes from "prop-types";
 import * as React from "react";
 
 import InfoTip from "../../components/info-tip";
@@ -15,7 +13,12 @@ const AUTO = "auto";
 const HORIZONTAL = "horizontal";
 const VERTICAL = "vertical";
 
-type Props = any;
+type Props = OrdererDefaultWidgetOptions & {
+    onChange: (
+        newOptions: Partial<PerseusOrdererWidgetOptions>,
+        callback?: () => void,
+    ) => void;
+};
 
 export const getUpdatedOptions = (
     correctOptions: Array<{content: string}>,
@@ -75,14 +78,6 @@ export const getUpdatedOptions = (
 };
 
 class OrdererEditor extends React.Component<Props> {
-    static propTypes = {
-        correctOptions: PropTypes.array,
-        otherOptions: PropTypes.array,
-        height: PropTypes.oneOf([NORMAL, AUTO]),
-        layout: PropTypes.oneOf([HORIZONTAL, VERTICAL]),
-        onChange: PropTypes.func.isRequired,
-    };
-
     static widgetName = "orderer" as const;
 
     static defaultProps: OrdererDefaultWidgetOptions =
@@ -90,12 +85,12 @@ class OrdererEditor extends React.Component<Props> {
 
     onOptionsChange: (
         arg1: "correctOptions" | "otherOptions",
-        arg2: any,
-        arg3: any,
-    ) => any = (whichOptions, options, cb) => {
+        arg2: string[],
+        arg3?: () => void,
+    ) => void = (whichOptions, options, cb) => {
         const updatedOptions = getUpdatedOptions(
-            this.props.correctOptions || [],
-            this.props.otherOptions || [],
+            this.props.correctOptions,
+            this.props.otherOptions,
             whichOptions,
             options,
         );
@@ -103,25 +98,33 @@ class OrdererEditor extends React.Component<Props> {
         this.props.onChange(updatedOptions, cb);
     };
 
-    onLayoutChange: (arg1: React.ChangeEvent<HTMLInputElement>) => void = (
+    onLayoutChange: (arg1: React.ChangeEvent<HTMLSelectElement>) => void = (
         e,
     ) => {
-        this.props.onChange({layout: e.target.value});
+        // The select below only offers these two values, so anything else
+        // falls back to the horizontal layout.
+        this.props.onChange({
+            layout: e.target.value === VERTICAL ? VERTICAL : HORIZONTAL,
+        });
     };
 
-    onHeightChange: (arg1: React.ChangeEvent<HTMLInputElement>) => void = (
+    onHeightChange: (arg1: React.ChangeEvent<HTMLSelectElement>) => void = (
         e,
     ) => {
-        this.props.onChange({height: e.target.value});
+        // The select below only offers these two values, so anything else
+        // falls back to the normal height.
+        this.props.onChange({
+            height: e.target.value === AUTO ? AUTO : NORMAL,
+        });
     };
 
-    serialize: () => any = () => {
+    serialize: () => PerseusOrdererWidgetOptions = () => {
         // We combine the correct answer and the other cards by merging them,
         // removing duplicates and empty cards, and sorting them into
         // categories based on their content
         const {options} = getUpdatedOptions(
-            this.props.correctOptions || [],
-            this.props.otherOptions || [],
+            this.props.correctOptions,
+            this.props.otherOptions,
         );
 
         return {
@@ -177,7 +180,6 @@ class OrdererEditor extends React.Component<Props> {
                         Layout:{" "}
                         <select
                             value={this.props.layout}
-                            // @ts-expect-error - TS2322 - Type '(arg1: ChangeEvent<HTMLInputElement>) => void' is not assignable to type 'ChangeEventHandler<HTMLSelectElement>'.
                             onChange={this.onLayoutChange}
                         >
                             <option value={HORIZONTAL}>Horizontal</option>
@@ -198,7 +200,6 @@ class OrdererEditor extends React.Component<Props> {
                         Height:{" "}
                         <select
                             value={this.props.height}
-                            // @ts-expect-error - TS2322 - Type '(arg1: ChangeEvent<HTMLInputElement>) => void' is not assignable to type 'ChangeEventHandler<HTMLSelectElement>'.
                             onChange={this.onHeightChange}
                         >
                             <option value={NORMAL}>Normal</option>

--- a/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.tsx
@@ -100,10 +100,6 @@ class OrdererEditor extends React.Component<Props> {
     onLayoutChange: (arg1: React.ChangeEvent<HTMLSelectElement>) => void = (
         e,
     ) => {
-        // `e.target.value` is typed as `string`, but the select below only
-        // renders options for the layouts in the widget options. The
-        // exhaustive switch makes TypeScript fail this code if a new layout
-        // is added to the schema without an option to select it.
         const layout = e.target.value;
         switch (layout) {
             case HORIZONTAL:
@@ -118,10 +114,6 @@ class OrdererEditor extends React.Component<Props> {
     onHeightChange: (arg1: React.ChangeEvent<HTMLSelectElement>) => void = (
         e,
     ) => {
-        // `e.target.value` is typed as `string`, but the select below only
-        // renders options for the heights in the widget options. The
-        // exhaustive switch makes TypeScript fail this code if a new height
-        // is added to the schema without an option to select it.
         const height = e.target.value;
         switch (height) {
             case NORMAL:

--- a/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.tsx
@@ -100,21 +100,37 @@ class OrdererEditor extends React.Component<Props> {
     onLayoutChange: (arg1: React.ChangeEvent<HTMLSelectElement>) => void = (
         e,
     ) => {
-        // The select below only offers these two values, so anything else
-        // falls back to the horizontal layout.
-        this.props.onChange({
-            layout: e.target.value === VERTICAL ? VERTICAL : HORIZONTAL,
-        });
+        // `e.target.value` is typed as `string`, but the select below only
+        // renders options for the layouts in the widget options. The
+        // exhaustive switch makes TypeScript fail this code if a new layout
+        // is added to the schema without an option to select it.
+        const layout = e.target.value;
+        switch (layout) {
+            case HORIZONTAL:
+            case VERTICAL:
+                this.props.onChange({layout});
+                break;
+            default:
+                throw new Error(`${layout} is not an available layout option`);
+        }
     };
 
     onHeightChange: (arg1: React.ChangeEvent<HTMLSelectElement>) => void = (
         e,
     ) => {
-        // The select below only offers these two values, so anything else
-        // falls back to the normal height.
-        this.props.onChange({
-            height: e.target.value === AUTO ? AUTO : NORMAL,
-        });
+        // `e.target.value` is typed as `string`, but the select below only
+        // renders options for the heights in the widget options. The
+        // exhaustive switch makes TypeScript fail this code if a new height
+        // is added to the schema without an option to select it.
+        const height = e.target.value;
+        switch (height) {
+            case NORMAL:
+            case AUTO:
+                this.props.onChange({height});
+                break;
+            default:
+                throw new Error(`${height} is not an available height option`);
+        }
     };
 
     serialize: () => PerseusOrdererWidgetOptions = () => {

--- a/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.tsx
@@ -124,7 +124,7 @@ class OrdererEditor extends React.Component<Props> {
 
     render(): React.ReactNode {
         return (
-            <div className="perseus-widget-orderer">
+            <div>
                 <div>
                     {" "}
                     Correct answer:{" "}

--- a/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.tsx
@@ -1,6 +1,5 @@
 import {
     ordererLogic,
-    type OrdererDefaultWidgetOptions,
     type PerseusOrdererWidgetOptions,
 } from "@khanacademy/perseus-core";
 import * as React from "react";
@@ -13,7 +12,7 @@ const AUTO = "auto";
 const HORIZONTAL = "horizontal";
 const VERTICAL = "vertical";
 
-type Props = OrdererDefaultWidgetOptions & {
+type Props = PerseusOrdererWidgetOptions & {
     onChange: (
         newOptions: Partial<PerseusOrdererWidgetOptions>,
         callback?: () => void,
@@ -80,7 +79,7 @@ export const getUpdatedOptions = (
 class OrdererEditor extends React.Component<Props> {
     static widgetName = "orderer" as const;
 
-    static defaultProps: OrdererDefaultWidgetOptions =
+    static defaultProps: PerseusOrdererWidgetOptions =
         ordererLogic.defaultWidgetOptions;
 
     onOptionsChange: (

--- a/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.tsx
@@ -61,11 +61,11 @@ class OrdererEditor extends React.Component<Props> {
     static defaultProps: PerseusOrdererWidgetOptions =
         ordererLogic.defaultWidgetOptions;
 
-    onOptionsChange: (
-        arg1: "correctOptions" | "otherOptions",
-        arg2: string[],
-        arg3?: () => void,
-    ) => void = (whichOptions, options, cb) => {
+    onOptionsChange = (
+        whichOptions: "correctOptions" | "otherOptions",
+        options: string[],
+        cb?: () => void,
+    ) => {
         const changedCards = options.map(toCard);
         const correctOptions =
             whichOptions === "correctOptions"
@@ -85,9 +85,7 @@ class OrdererEditor extends React.Component<Props> {
         );
     };
 
-    onLayoutChange: (arg1: React.ChangeEvent<HTMLSelectElement>) => void = (
-        e,
-    ) => {
+    onLayoutChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const layout = e.target.value;
         switch (layout) {
             case HORIZONTAL:
@@ -99,9 +97,7 @@ class OrdererEditor extends React.Component<Props> {
         }
     };
 
-    onHeightChange: (arg1: React.ChangeEvent<HTMLSelectElement>) => void = (
-        e,
-    ) => {
+    onHeightChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const height = e.target.value;
         switch (height) {
             case NORMAL:
@@ -113,7 +109,7 @@ class OrdererEditor extends React.Component<Props> {
         }
     };
 
-    serialize: () => PerseusOrdererWidgetOptions = () => {
+    serialize = (): PerseusOrdererWidgetOptions => {
         return {
             options: mergeCards(
                 this.props.correctOptions,

--- a/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.tsx
@@ -1,6 +1,7 @@
 import {
     ordererLogic,
     type PerseusOrdererWidgetOptions,
+    type PerseusRenderer,
 } from "@khanacademy/perseus-core";
 import * as React from "react";
 
@@ -19,61 +20,39 @@ type Props = PerseusOrdererWidgetOptions & {
     ) => void;
 };
 
-export const getUpdatedOptions = (
-    correctOptions: Array<{content: string}>,
-    otherOptions: Array<{content: string}>,
-    whichOptions?: string,
-    options?: string[],
-): Record<string, any> => {
-    // Update the changed options by mapping the options to an array of objects with a content property
-    const props: Record<string, any> = {};
-    if (whichOptions && options !== undefined) {
-        props[whichOptions] = options.map((option) => ({
-            content: option,
-        }));
+const toCard = (content: string): PerseusRenderer => ({
+    content,
+    widgets: {},
+    images: {},
+});
+
+// Cards are displayed grouped by content: numbers first, then everything
+// else, then bare variables and $tex$.
+const getCategoryScore = (content: string): number => {
+    if (/\d/.test(content)) {
+        return 0;
     }
+    if (/^\$?[a-zA-Z]+\$?$/.test(content)) {
+        return 2;
+    }
+    return 1;
+};
 
-    // Get content from correctOptions (either updated or existing)
-    const correctOptionsToUse =
-        whichOptions === "correctOptions"
-            ? props.correctOptions
-            : correctOptions;
+/**
+ * The cards the student picks from: the correct answer and the distractors,
+ * with duplicates and empty cards removed.
+ */
+export const mergeCards = (
+    correctOptions: PerseusRenderer[],
+    otherOptions: PerseusRenderer[],
+): PerseusRenderer[] => {
+    const allCards = [...correctOptions, ...otherOptions];
 
-    // Get content from otherOptions (either updated or existing)
-    const otherOptionsToUse =
-        whichOptions === "otherOptions" ? props.otherOptions : otherOptions;
-
-    // Combine all content items
-    const allOptions = [...correctOptionsToUse, ...otherOptionsToUse];
-
-    // Get unique content items
-    const updatedOptions = [...new Set(allOptions.map((item) => item.content))]
-        // filter out empty strings
+    return [...new Set(allCards.map((card) => card.content))]
         .filter((content) => content !== "")
-        // Alphabetical sort
         .sort()
-        // Category sort
-        .sort((a, b) => {
-            const getCategoryScore = (content) => {
-                // 1. Any content that contains numbers
-                if (/\d/.test(content)) {
-                    return 0;
-                }
-                // 2. $tex$ or variables without any numbers
-                if (/^\$?[a-zA-Z]+\$?$/.test(content)) {
-                    return 2;
-                }
-                // 3. Everything else
-                return 1;
-            };
-            return getCategoryScore(a) - getCategoryScore(b);
-        })
-        .map((content) => ({content}));
-
-    return {
-        ...props,
-        options: updatedOptions,
-    };
+        .sort((a, b) => getCategoryScore(a) - getCategoryScore(b))
+        .map(toCard);
 };
 
 class OrdererEditor extends React.Component<Props> {
@@ -87,14 +66,23 @@ class OrdererEditor extends React.Component<Props> {
         arg2: string[],
         arg3?: () => void,
     ) => void = (whichOptions, options, cb) => {
-        const updatedOptions = getUpdatedOptions(
-            this.props.correctOptions,
-            this.props.otherOptions,
-            whichOptions,
-            options,
-        );
+        const changedCards = options.map(toCard);
+        const correctOptions =
+            whichOptions === "correctOptions"
+                ? changedCards
+                : this.props.correctOptions;
+        const otherOptions =
+            whichOptions === "otherOptions"
+                ? changedCards
+                : this.props.otherOptions;
 
-        this.props.onChange(updatedOptions, cb);
+        this.props.onChange(
+            {
+                [whichOptions]: changedCards,
+                options: mergeCards(correctOptions, otherOptions),
+            },
+            cb,
+        );
     };
 
     onLayoutChange: (arg1: React.ChangeEvent<HTMLSelectElement>) => void = (
@@ -126,16 +114,11 @@ class OrdererEditor extends React.Component<Props> {
     };
 
     serialize: () => PerseusOrdererWidgetOptions = () => {
-        // We combine the correct answer and the other cards by merging them,
-        // removing duplicates and empty cards, and sorting them into
-        // categories based on their content
-        const {options} = getUpdatedOptions(
-            this.props.correctOptions,
-            this.props.otherOptions,
-        );
-
         return {
-            options: options,
+            options: mergeCards(
+                this.props.correctOptions,
+                this.props.otherOptions,
+            ),
             correctOptions: this.props.correctOptions,
             otherOptions: this.props.otherOptions,
             height: this.props.height,

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
@@ -1,4 +1,5 @@
 import {Dependencies} from "@khanacademy/perseus";
+import {generateSorterOptions} from "@khanacademy/perseus-core";
 import {render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
@@ -57,5 +58,46 @@ describe("sorter-editor", () => {
         await userEvent.click(screen.getByRole("checkbox", {name: "Padding:"}));
 
         expect(onChangeMock).toHaveBeenCalledWith({padding: false});
+    });
+
+    it("renders an input for each card in the correct answer", () => {
+        // Arrange, Act
+        render(
+            <SorterEditor
+                onChange={() => {}}
+                {...generateSorterOptions({correct: ["Cat", "Dog", "Emu"]})}
+            />,
+        );
+
+        // Assert
+        expect(screen.getByDisplayValue("Cat")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("Dog")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("Emu")).toBeInTheDocument();
+    });
+
+    it("serializes the correct answer, layout, and padding", () => {
+        // Arrange
+        const editorRef = React.createRef<SorterEditor>();
+        render(
+            <SorterEditor
+                ref={editorRef}
+                onChange={() => {}}
+                {...generateSorterOptions({
+                    correct: ["Cat", "Dog"],
+                    layout: "vertical",
+                    padding: false,
+                })}
+            />,
+        );
+
+        // Act
+        const serialized = editorRef.current?.serialize();
+
+        // Assert
+        expect(serialized).toEqual({
+            correct: ["Cat", "Dog"],
+            layout: "vertical",
+            padding: false,
+        });
     });
 });

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
@@ -75,6 +75,28 @@ describe("sorter-editor", () => {
         expect(screen.getByDisplayValue("Emu")).toBeInTheDocument();
     });
 
+    it("calls onChange with the updated correct answer when a card is edited", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <SorterEditor
+                onChange={onChangeMock}
+                {...generateSorterOptions({correct: ["Cat", "Dog"]})}
+            />,
+        );
+
+        // Act
+        const card = screen.getByDisplayValue("Dog");
+        await userEvent.clear(card);
+        await userEvent.type(card, "Emu");
+
+        // Assert
+        expect(onChangeMock).toHaveBeenLastCalledWith(
+            {correct: ["Cat", "Emu"]},
+            undefined,
+        );
+    });
+
     it("serializes the correct answer, layout, and padding", () => {
         // Arrange
         const editorRef = React.createRef<SorterEditor>();

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -1,5 +1,6 @@
 import {
     sorterLogic,
+    type PerseusSorterWidgetOptions,
     type SorterDefaultWidgetOptions,
 } from "@khanacademy/perseus-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
@@ -38,7 +39,7 @@ class SorterEditor extends React.Component<Props> {
         });
     };
 
-    serialize: () => SorterDefaultWidgetOptions = () => {
+    serialize: () => PerseusSorterWidgetOptions = () => {
         return {
             correct: this.props.correct,
             layout: this.props.layout,

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -28,9 +28,7 @@ class SorterEditor extends React.Component<Props> {
     static defaultProps: PerseusSorterWidgetOptions =
         sorterLogic.defaultWidgetOptions;
 
-    onLayoutChange: (arg1: React.ChangeEvent<HTMLSelectElement>) => void = (
-        e,
-    ) => {
+    onLayoutChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const layout = e.target.value;
         switch (layout) {
             case HORIZONTAL:
@@ -42,7 +40,7 @@ class SorterEditor extends React.Component<Props> {
         }
     };
 
-    serialize: () => PerseusSorterWidgetOptions = () => {
+    serialize = (): PerseusSorterWidgetOptions => {
         return {
             correct: this.props.correct,
             layout: this.props.layout,

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -4,7 +4,6 @@ import {
 } from "@khanacademy/perseus-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import * as React from "react";
-import _ from "underscore";
 
 import InfoTip from "../../components/info-tip";
 import TextListEditor from "../../components/text-list-editor";
@@ -40,7 +39,11 @@ class SorterEditor extends React.Component<Props> {
     };
 
     serialize: () => SorterDefaultWidgetOptions = () => {
-        return _.pick(this.props, "correct", "layout", "padding");
+        return {
+            correct: this.props.correct,
+            layout: this.props.layout,
+            padding: this.props.padding,
+        };
     };
 
     render(): React.ReactNode {

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -31,11 +31,19 @@ class SorterEditor extends React.Component<Props> {
     onLayoutChange: (arg1: React.ChangeEvent<HTMLSelectElement>) => void = (
         e,
     ) => {
-        // The select below only offers these two values, so anything else
-        // falls back to the horizontal layout.
-        this.props.onChange({
-            layout: e.target.value === VERTICAL ? VERTICAL : HORIZONTAL,
-        });
+        // `e.target.value` is typed as `string`, but the select below only
+        // renders options for the layouts in the widget options. The
+        // exhaustive switch makes TypeScript fail this code if a new layout
+        // is added to the schema without an option to select it.
+        const layout = e.target.value;
+        switch (layout) {
+            case HORIZONTAL:
+            case VERTICAL:
+                this.props.onChange({layout});
+                break;
+            default:
+                throw new Error(`${layout} is not an available layout option`);
+        }
     };
 
     serialize: () => PerseusSorterWidgetOptions = () => {

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -1,11 +1,8 @@
-/* eslint-disable @khanacademy/ts-no-error-suppressions */
-/* eslint-disable react/forbid-prop-types */
 import {
     sorterLogic,
     type SorterDefaultWidgetOptions,
 } from "@khanacademy/perseus-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
-import PropTypes from "prop-types";
 import * as React from "react";
 import _ from "underscore";
 
@@ -15,31 +12,34 @@ import TextListEditor from "../../components/text-list-editor";
 const HORIZONTAL = "horizontal";
 const VERTICAL = "vertical";
 
-type Props = any;
+type Props = SorterDefaultWidgetOptions & {
+    onChange: (
+        newOptions: Partial<SorterDefaultWidgetOptions>,
+        callback?: () => void,
+    ) => void;
+};
 
 // JSDoc will be shown in Storybook widget editor description
 /**
  * An editor for adding a sorter widget that allows users to arrange items in a specific order.
  */
 class SorterEditor extends React.Component<Props> {
-    static propTypes = {
-        correct: PropTypes.array,
-        layout: PropTypes.oneOf([HORIZONTAL, VERTICAL]),
-        padding: PropTypes.bool,
-    };
-
     static widgetName = "sorter" as const;
 
     static defaultProps: SorterDefaultWidgetOptions =
         sorterLogic.defaultWidgetOptions;
 
-    onLayoutChange: (arg1: React.ChangeEvent<HTMLInputElement>) => void = (
+    onLayoutChange: (arg1: React.ChangeEvent<HTMLSelectElement>) => void = (
         e,
     ) => {
-        this.props.onChange({layout: e.target.value});
+        // The select below only offers these two values, so anything else
+        // falls back to the horizontal layout.
+        this.props.onChange({
+            layout: e.target.value === VERTICAL ? VERTICAL : HORIZONTAL,
+        });
     };
 
-    serialize: (arg1: any) => void = () => {
+    serialize: () => SorterDefaultWidgetOptions = () => {
         return _.pick(this.props, "correct", "layout", "padding");
     };
 
@@ -73,7 +73,6 @@ class SorterEditor extends React.Component<Props> {
                         Layout:{" "}
                         <select
                             value={this.props.layout}
-                            // @ts-expect-error - TS2322 - Type '(arg1: ChangeEvent<HTMLInputElement>) => void' is not assignable to type 'ChangeEventHandler<HTMLSelectElement>'.
                             onChange={this.onLayoutChange}
                         >
                             <option value={HORIZONTAL}>Horizontal</option>

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -31,10 +31,6 @@ class SorterEditor extends React.Component<Props> {
     onLayoutChange: (arg1: React.ChangeEvent<HTMLSelectElement>) => void = (
         e,
     ) => {
-        // `e.target.value` is typed as `string`, but the select below only
-        // renders options for the layouts in the widget options. The
-        // exhaustive switch makes TypeScript fail this code if a new layout
-        // is added to the schema without an option to select it.
         const layout = e.target.value;
         switch (layout) {
             case HORIZONTAL:

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -51,8 +51,6 @@ class SorterEditor extends React.Component<Props> {
     };
 
     render(): React.ReactNode {
-        const editor = this;
-
         return (
             <div>
                 <div>
@@ -69,8 +67,8 @@ class SorterEditor extends React.Component<Props> {
                 </div>
                 <TextListEditor
                     options={this.props.correct}
-                    onChange={function (options, cb) {
-                        editor.props.onChange({correct: options}, cb);
+                    onChange={(options, cb) => {
+                        this.props.onChange({correct: options}, cb);
                     }}
                     layout={this.props.layout}
                 />

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -1,7 +1,6 @@
 import {
     sorterLogic,
     type PerseusSorterWidgetOptions,
-    type SorterDefaultWidgetOptions,
 } from "@khanacademy/perseus-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import * as React from "react";
@@ -12,9 +11,9 @@ import TextListEditor from "../../components/text-list-editor";
 const HORIZONTAL = "horizontal";
 const VERTICAL = "vertical";
 
-type Props = SorterDefaultWidgetOptions & {
+type Props = PerseusSorterWidgetOptions & {
     onChange: (
-        newOptions: Partial<SorterDefaultWidgetOptions>,
+        newOptions: Partial<PerseusSorterWidgetOptions>,
         callback?: () => void,
     ) => void;
 };
@@ -26,7 +25,7 @@ type Props = SorterDefaultWidgetOptions & {
 class SorterEditor extends React.Component<Props> {
     static widgetName = "sorter" as const;
 
-    static defaultProps: SorterDefaultWidgetOptions =
+    static defaultProps: PerseusSorterWidgetOptions =
         sorterLogic.defaultWidgetOptions;
 
     onLayoutChange: (arg1: React.ChangeEvent<HTMLSelectElement>) => void = (


### PR DESCRIPTION
## Summary:

Some cleanup for the drag-and-drop widget editors:

- Add generator for Orderer widget
- Refactored `OrdererEditor.getUpdatedOptions`
- Converted PropTypes to TS types
- Removed underscore
- Added test coverage
- Fixed types
- Removed `.bind`
- Remove unused class `perseus-widget-orderer`

But most of the changes are just adding tests.