### PR TITLE
Pass the linterContext and containerSizeClass to the WidgetContainer via WidgetProps

### DIFF
--- a/.changeset/quiet-knives-look.md
+++ b/.changeset/quiet-knives-look.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: the Renderer now passes the `linterContext` and `containerSizeClass` to the `WidgetContainer` as part of the widget props.

--- a/packages/perseus/src/renderer.new.tsx
+++ b/packages/perseus/src/renderer.new.tsx
@@ -48,6 +48,7 @@ import PerseusMarkdown from "./perseus-markdown.new";
 import QuestionParagraph from "./question-paragraph.new";
 import TranslationLinter from "./translation-linter";
 import Util from "./util";
+import {containerSizeClass} from "./util/sizing-utils";
 import preprocessTex from "./util/tex-preprocess";
 import WidgetContainer from "./widget-container.new";
 import * as Widgets from "./widgets";
@@ -60,6 +61,7 @@ import type {
     FilterCriterion,
     FindWidgetsFunction,
     FocusPath,
+    UniversalWidgetProps,
     Widget,
 } from "./types";
 import type {
@@ -497,10 +499,6 @@ class Renderer
                     }}
                     type={type}
                     widgetProps={this.getWidgetProps(id)}
-                    linterContext={PerseusLinter.pushContextStack(
-                        this.props.linterContext,
-                        "widget",
-                    )}
                 />
             );
         }
@@ -555,7 +553,7 @@ class Renderer
                 );
         }
 
-        const universalProps = {
+        const universalProps: UniversalWidgetProps = {
             userInput: this.props.userInput?.[widgetId],
             widgetId: widgetId,
             widgetIndex: this._getWidgetIndexById(widgetId),
@@ -569,7 +567,14 @@ class Renderer
             onFocus: _.partial(this._onWidgetFocus, widgetId),
             onBlur: _.partial(this._onWidgetBlur, widgetId),
             findWidgets: this.findWidgets,
-            reviewMode: this.props.reviewMode,
+            reviewMode: this.props.reviewMode ?? false,
+            // Default containerSizeClass; overridden in WidgetContainer based
+            // on the measured size of the DOM element.
+            containerSizeClass: containerSizeClass.MEDIUM,
+            linterContext: PerseusLinter.pushContextStack(
+                this.props.linterContext,
+                "widget",
+            ),
             handleUserInput: (newUserInput: UserInput) => {
                 // Calculate widgetsEmpty using the updated user input
                 const updatedUserInput = {

--- a/packages/perseus/src/renderer.new.tsx
+++ b/packages/perseus/src/renderer.new.tsx
@@ -530,7 +530,7 @@ class Renderer
     // TODO(LEMS-4354): add return type post-migration.
     getWidgetProps(widgetId: string): any {
         const apiOptions = this.getApiOptions();
-        const widgetProps = this.props.widgets[widgetId].options;
+        const widgetOptions = this.props.widgets[widgetId].options;
 
         // The widget needs access to its "scoring data" at all times when in review
         // mode (which is really just part of its widget info).
@@ -604,9 +604,9 @@ class Renderer
         // every widget is migrated, the un-migrated branch should be removed.
         // TODO(LEMS-4354): clean up post-migration.
         if (widgetInfo != null && MIGRATED_WIDGETS.includes(widgetInfo.type)) {
-            return {options: widgetProps, ...universalProps};
+            return {options: widgetOptions, ...universalProps};
         }
-        return {...widgetProps, ...universalProps};
+        return {...widgetOptions, ...universalProps};
     }
 
     /**

--- a/packages/perseus/src/renderer.old.tsx
+++ b/packages/perseus/src/renderer.old.tsx
@@ -522,7 +522,7 @@ class Renderer
     // TODO(LEMS-4354): add return type post-migration.
     getWidgetProps(widgetId: string): any {
         const apiOptions = this.getApiOptions();
-        const widgetProps = this.props.widgets[widgetId].options;
+        const widgetOptions = this.props.widgets[widgetId].options;
 
         // The widget needs access to its "scoring data" at all times when in review
         // mode (which is really just part of its widget info).
@@ -596,9 +596,9 @@ class Renderer
         // every widget is migrated, the un-migrated branch should be removed.
         // TODO(LEMS-4354): clean up post-migration.
         if (widgetInfo != null && MIGRATED_WIDGETS.includes(widgetInfo.type)) {
-            return {options: widgetProps, ...universalProps};
+            return {options: widgetOptions, ...universalProps};
         }
-        return {...widgetProps, ...universalProps};
+        return {...widgetOptions, ...universalProps};
     }
 
     /**

--- a/packages/perseus/src/renderer.old.tsx
+++ b/packages/perseus/src/renderer.old.tsx
@@ -48,6 +48,7 @@ import PerseusMarkdown from "./perseus-markdown";
 import QuestionParagraph from "./question-paragraph";
 import TranslationLinter from "./translation-linter";
 import Util from "./util";
+import {containerSizeClass} from "./util/sizing-utils";
 import preprocessTex from "./util/tex-preprocess";
 import WidgetContainer from "./widget-container.old";
 import * as Widgets from "./widgets";
@@ -60,6 +61,7 @@ import type {
     FilterCriterion,
     FindWidgetsFunction,
     FocusPath,
+    UniversalWidgetProps,
     Widget,
 } from "./types";
 import type {
@@ -489,10 +491,6 @@ class Renderer
                     }}
                     type={type}
                     widgetProps={this.getWidgetProps(id)}
-                    linterContext={PerseusLinter.pushContextStack(
-                        this.props.linterContext,
-                        "widget",
-                    )}
                 />
             );
         }
@@ -547,7 +545,7 @@ class Renderer
                 );
         }
 
-        const universalProps = {
+        const universalProps: UniversalWidgetProps = {
             userInput: this.props.userInput?.[widgetId],
             widgetId: widgetId,
             widgetIndex: this._getWidgetIndexById(widgetId),
@@ -561,7 +559,14 @@ class Renderer
             onFocus: _.partial(this._onWidgetFocus, widgetId),
             onBlur: _.partial(this._onWidgetBlur, widgetId),
             findWidgets: this.findWidgets,
-            reviewMode: this.props.reviewMode,
+            reviewMode: this.props.reviewMode ?? false,
+            // Default containerSizeClass; overridden in WidgetContainer based
+            // on the measured size of the DOM element.
+            containerSizeClass: containerSizeClass.MEDIUM,
+            linterContext: PerseusLinter.pushContextStack(
+                this.props.linterContext,
+                "widget",
+            ),
             handleUserInput: (newUserInput: UserInput) => {
                 // Calculate widgetsEmpty using the updated user input
                 const updatedUserInput = {

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -490,7 +490,10 @@ export type WidgetPropsV2<
 /**
  * The props passed to every widget, regardless of its `type`.
  */
-type UniversalWidgetProps<TUserInput = Empty, TrackingExtraArgs = Empty> = {
+export type UniversalWidgetProps<
+    TUserInput = Empty,
+    TrackingExtraArgs = Empty,
+> = {
     // This is slightly different from the `trackInteraction` function in
     // APIOptions. This provides the widget an easy way to notify the renderer
     // of an interaction. The Renderer then enriches the data provided with the

--- a/packages/perseus/src/widget-container.new.tsx
+++ b/packages/perseus/src/widget-container.new.tsx
@@ -11,7 +11,6 @@ import {
     CoreWidgetRegistry,
     type PerseusWidgetOptions,
 } from "@khanacademy/perseus-core";
-import {linterContextDefault} from "@khanacademy/perseus-linter";
 import classNames from "classnames";
 import * as React from "react";
 import ReactDOM from "react-dom";
@@ -23,18 +22,12 @@ import {getWidgetSubType} from "./widget-type-utils";
 import * as Widgets from "./widgets";
 
 import type {WidgetProps} from "./types";
-import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
 type Props = {
     type: string; // widget type/name,
     id: string; // widget id
     // TODO(LEMS-4354): change to WidgetPropsV2
     widgetProps: WidgetProps<any, PerseusWidgetOptions>;
-    linterContext: LinterContextProps;
-};
-
-type DefaultProps = {
-    linterContext: LinterContextProps;
 };
 
 type State = {
@@ -43,10 +36,6 @@ type State = {
 
 class WidgetContainer extends React.Component<Props, State> {
     widgetRef = React.createRef<React.ComponentType<any>>();
-
-    static defaultProps: DefaultProps = {
-        linterContext: linterContextDefault,
-    };
 
     state: State = {
         sizeClass: containerSizeClass.MEDIUM,
@@ -162,9 +151,12 @@ class WidgetContainer extends React.Component<Props, State> {
         // to default to false.
         // The linter context might be a constant object (and it isn't owned
         // by us anyway), so we copy it if we have to modify it.
+        // TODO(benchristel): Since linting logic varies by widget, it should
+        //  live in the individual widget components, not here. Refactor to
+        //  remove this `isLintable` check.
         const linterContext = Widgets.isLintable(type)
-            ? this.props.linterContext
-            : {...this.props.linterContext, highlightLint: false};
+            ? this.props.widgetProps.linterContext
+            : {...this.props.widgetProps.linterContext, highlightLint: false};
 
         // Note: if you add more props here, please consider whether or not
         // it should be auto-serialized.

--- a/packages/perseus/src/widget-container.new.tsx
+++ b/packages/perseus/src/widget-container.new.tsx
@@ -28,6 +28,7 @@ import type {LinterContextProps} from "@khanacademy/perseus-linter";
 type Props = {
     type: string; // widget type/name,
     id: string; // widget id
+    // TODO(LEMS-4354): change to WidgetPropsV2
     widgetProps: WidgetProps<any, PerseusWidgetOptions>;
     linterContext: LinterContextProps;
 };

--- a/packages/perseus/src/widget-container.old.tsx
+++ b/packages/perseus/src/widget-container.old.tsx
@@ -11,7 +11,6 @@ import {
     CoreWidgetRegistry,
     type PerseusWidgetOptions,
 } from "@khanacademy/perseus-core";
-import {linterContextDefault} from "@khanacademy/perseus-linter";
 import classNames from "classnames";
 import * as React from "react";
 import ReactDOM from "react-dom";
@@ -23,18 +22,12 @@ import {getWidgetSubType} from "./widget-type-utils";
 import * as Widgets from "./widgets";
 
 import type {WidgetProps} from "./types";
-import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
 type Props = {
     type: string; // widget type/name,
     id: string; // widget id
     // TODO(LEMS-4354): change to WidgetPropsV2
     widgetProps: WidgetProps<any, PerseusWidgetOptions>;
-    linterContext: LinterContextProps;
-};
-
-type DefaultProps = {
-    linterContext: LinterContextProps;
 };
 
 type State = {
@@ -43,10 +36,6 @@ type State = {
 
 class WidgetContainerOld extends React.Component<Props, State> {
     widgetRef = React.createRef<React.ComponentType<any>>();
-
-    static defaultProps: DefaultProps = {
-        linterContext: linterContextDefault,
-    };
 
     state: State = {
         sizeClass: containerSizeClass.MEDIUM,
@@ -151,9 +140,12 @@ class WidgetContainerOld extends React.Component<Props, State> {
         // to default to false.
         // The linter context might be a constant object (and it isn't owned
         // by us anyway), so we copy it if we have to modify it.
+        // TODO(benchristel): Since linting logic varies by widget, it should
+        //  live in the individual widget components, not here. Refactor to
+        //  remove this `isLintable` check.
         const linterContext = Widgets.isLintable(type)
-            ? this.props.linterContext
-            : {...this.props.linterContext, highlightLint: false};
+            ? this.props.widgetProps.linterContext
+            : {...this.props.widgetProps.linterContext, highlightLint: false};
 
         // Note: if you add more props here, please consider whether or not
         // it should be auto-serialized.

--- a/packages/perseus/src/widget-container.old.tsx
+++ b/packages/perseus/src/widget-container.old.tsx
@@ -28,6 +28,7 @@ import type {LinterContextProps} from "@khanacademy/perseus-linter";
 type Props = {
     type: string; // widget type/name,
     id: string; // widget id
+    // TODO(LEMS-4354): change to WidgetPropsV2
     widgetProps: WidgetProps<any, PerseusWidgetOptions>;
     linterContext: LinterContextProps;
 };


### PR DESCRIPTION
## Summary:
This cleans up some weirdness that `fixie` tripped over while doing cleanup
work for the linked ticket (grouping widget options into an `options` prop).

Issue: LEMS-4354

## Test plan:

Edit a widget in the EditorPage stories. Linting should work (linter errors
should appear as orange dots in the right margin) and old-style Grapher widgets
(e.g. Quadratic) should have fewer tick marks in the mobile preview vs.
desktop.