### PR TITLE
Tighten and parse the Alignment type

### DIFF
--- a/.changeset/dark-owls-add.md
+++ b/.changeset/dark-owls-add.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": major
+---
+
+The `alignment` property of `WidgetOptions` is now typed as a string union, instead of `string`.

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -316,6 +316,27 @@ export type PerseusImageDetail = {
     height: number;
 };
 
+// TODO(benchristel): as of 2026, only some of these alignments appear in our
+//  content corpus. Counts (for all locales):
+//     5955449  "block"
+//     20442080 "default"
+//     12622    "full-width"
+//     52       "wrap-left"
+//     35       "wrap-right"
+//  It seems possible that "wrap-left" and "wrap-right" are vestigial. "inline"
+//  and "inline-block" are definitely unused. Consider removing them from this
+//  type.
+export type Alignment =
+    | "default"
+    | "block"
+    | "inline-block"
+    | "inline"
+    // wrap alignments will be set to inline-block floated left or right this will
+    // allow text to wrap around the widget and not have large space on either side
+    | "wrap-left"
+    | "wrap-right"
+    | "full-width";
+
 /**
  * ItemExtras represent extra UI elements that help the learner in answering
  * the question (such as a calculator for questions where solving by hand is
@@ -409,7 +430,7 @@ export type WidgetOptions<
      * widget logic, which can be various other alignments (e.g.
      * "inline-block", "inline", etc).
      */
-    alignment?: string;
+    alignment?: Alignment;
     /**
      * Options specific to the type field of the widget. See Perseus*WidgetOptions for
      * more details

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -5,7 +5,6 @@ export type {
     MarkerType,
     InteractiveMarkerType,
     Relationship,
-    Alignment,
     RecursiveReadonly,
 } from "./types";
 export type {KeypadKey} from "./keypad";

--- a/packages/perseus-core/src/parse-perseus-json/general-purpose-parsers/object.ts
+++ b/packages/perseus-core/src/parse-perseus-json/general-purpose-parsers/object.ts
@@ -8,29 +8,6 @@ import type {Mismatch, ParsedValue, Parser} from "../parser-types";
 type ObjectSchema = Record<keyof any, Parser<any>>;
 
 /**
- * Creates an object parser for the given schema. At runtime,
- * `objectWithAllPropertiesRequired` behaves identically to `object`; the only
- * difference is in the return type of the parser. While `object` types
- * properties as optional if their values can be undefined,
- * `objectWithAllPropertiesRequired` types all properties as required.
- *
- * For example:
- * - `object({foo: optional(string), bar: string})` returns
- *   `Parser<{foo?: undefined | string; bar: string}>`.
- * - `objectWithAllPropertiesRequired({foo: optional(string), bar: string})` returns
- *   `Parser<{foo: undefined | string; bar: string}>`
- *   (note: no question mark on `foo`).
- *
- * @see object
- */
-export function objectWithAllPropertiesRequired<S extends ObjectSchema>(
-    schema: S,
-): Parser<{[K in keyof S]: ParsedValue<S[K]>}> {
-    // eslint-disable-next-line no-restricted-syntax
-    return object(schema) as any;
-}
-
-/**
  * Given a `schema`, returns an object parser. The parser accepts an object
  * iff each sub-parser in the `schema` accepts the object's corresponding
  * property value.

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.mockData.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.mockData.ts
@@ -1,6 +1,6 @@
 export const v0Widget = {
     type: "radio" as const,
-    version: {major: 0, minor: 0},
+    version: {major: 0, minor: 0} as const,
     graded: true,
     options: {
         choices: [
@@ -87,7 +87,7 @@ export const v1Widget = {
     version: {
         major: 1,
         minor: 0,
-    },
+    } as const,
 };
 
 export const v2Widget = {
@@ -134,7 +134,7 @@ export const v2Widget = {
     version: {
         major: 2,
         minor: 0,
-    },
+    } as const,
 };
 
 export const v2WidgetWithRationale = {
@@ -181,7 +181,7 @@ export const v2WidgetWithRationale = {
     version: {
         major: 2,
         minor: 0,
-    },
+    } as const,
 };
 
 export const v3Widget = {
@@ -227,5 +227,5 @@ export const v3Widget = {
     version: {
         major: 3,
         minor: 0,
-    },
+    } as const,
 };

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.mockData.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/radio-widget.mockData.ts
@@ -1,6 +1,6 @@
 export const v0Widget = {
     type: "radio" as const,
-    version: {major: 0, minor: 0} as const,
+    version: {major: 0, minor: 0},
     graded: true,
     options: {
         choices: [
@@ -87,7 +87,7 @@ export const v1Widget = {
     version: {
         major: 1,
         minor: 0,
-    } as const,
+    },
 };
 
 export const v2Widget = {
@@ -134,7 +134,7 @@ export const v2Widget = {
     version: {
         major: 2,
         minor: 0,
-    } as const,
+    },
 };
 
 export const v2WidgetWithRationale = {
@@ -181,7 +181,7 @@ export const v2WidgetWithRationale = {
     version: {
         major: 2,
         minor: 0,
-    } as const,
+    },
 };
 
 export const v3Widget = {
@@ -227,5 +227,5 @@ export const v3Widget = {
     version: {
         major: 3,
         minor: 0,
-    } as const,
+    },
 };

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.ts
@@ -40,11 +40,10 @@ export function parseWidget<Type extends string, Options extends object>(
 }
 
 export function parseWidgetWithVersion<
-    Version extends {major: number; minor: number} | undefined,
     Type extends string,
     Options extends object,
 >(
-    parseVersion: Parser<Version>,
+    parseVersion: Parser<{major: number; minor: number} | undefined>,
     parseType: Parser<Type>,
     parseOptions: Parser<Options>,
 ) {

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.ts
@@ -1,27 +1,33 @@
 import {
     boolean,
+    enumeration,
     nullable,
     number,
     object,
-    objectWithAllPropertiesRequired,
     optional,
-    string,
 } from "../general-purpose-parsers";
 
-// TODO(LEMS-4224): don't import from outside of the parser
-// eslint-disable-next-line import/no-restricted-paths
-import type {WidgetOptions} from "../../data-schema";
 import type {Parser} from "../parser-types";
+
+const parseAlignment = enumeration(
+    "default",
+    "block",
+    "inline-block",
+    "inline",
+    "wrap-left",
+    "wrap-right",
+    "full-width",
+);
 
 export function parseWidget<Type extends string, Options extends object>(
     parseType: Parser<Type>,
     parseOptions: Parser<Options>,
-): Parser<WidgetOptions<Type, Options>> {
-    return objectWithAllPropertiesRequired({
+) {
+    return object({
         type: parseType,
         static: optional(boolean),
         graded: optional(boolean),
-        alignment: optional(string),
+        alignment: optional(parseAlignment),
         options: parseOptions,
         key: optional(nullable(number)),
         version: optional(
@@ -41,12 +47,12 @@ export function parseWidgetWithVersion<
     parseVersion: Parser<Version>,
     parseType: Parser<Type>,
     parseOptions: Parser<Options>,
-): Parser<WidgetOptions<Type, Options>> {
-    return objectWithAllPropertiesRequired({
+) {
+    return object({
         type: parseType,
         static: optional(boolean),
         graded: optional(boolean),
-        alignment: optional(string),
+        alignment: optional(parseAlignment),
         options: parseOptions,
         key: optional(nullable(number)),
         version: parseVersion,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.ts
@@ -5,19 +5,25 @@ import {
     number,
     object,
     optional,
+    pipeParsers,
 } from "../general-purpose-parsers";
+import {convert} from "../general-purpose-parsers/convert";
 
 import type {Parser} from "../parser-types";
 
-const parseAlignment = enumeration(
-    "default",
-    "block",
-    "inline-block",
-    "inline",
-    "wrap-left",
-    "wrap-right",
-    "full-width",
-);
+const parseAlignment = pipeParsers(
+    enumeration(
+        "default",
+        "block",
+        "inline-block",
+        "inline",
+        "wrap-left",
+        "wrap-right",
+        "full-width",
+        "",
+        undefined,
+    ),
+).then(convert((value) => (value === "" ? "default" : value))).parser;
 
 export function parseWidget<Type extends string, Options extends object>(
     parseType: Parser<Type>,
@@ -27,7 +33,7 @@ export function parseWidget<Type extends string, Options extends object>(
         type: parseType,
         static: optional(boolean),
         graded: optional(boolean),
-        alignment: optional(parseAlignment),
+        alignment: parseAlignment,
         options: parseOptions,
         key: optional(nullable(number)),
         version: optional(
@@ -51,7 +57,7 @@ export function parseWidgetWithVersion<
         type: parseType,
         static: optional(boolean),
         graded: optional(boolean),
-        alignment: optional(parseAlignment),
+        alignment: parseAlignment,
         options: parseOptions,
         key: optional(nullable(number)),
         version: parseVersion,

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -5095,7 +5095,7 @@ exports[`parseAndMigratePerseusItem given input-number-with-null-version.ts retu
     "metadata": null,
     "widgets": {
       "input-number 1": {
-        "alignment": "",
+        "alignment": "default",
         "graded": true,
         "key": null,
         "options": {
@@ -5168,7 +5168,7 @@ exports[`parseAndMigratePerseusItem given input-number-with-null-version.ts retu
     "metadata": null,
     "widgets": {
       "input-number 1": {
-        "alignment": "",
+        "alignment": "default",
         "graded": true,
         "key": null,
         "options": {

--- a/packages/perseus-core/src/types.ts
+++ b/packages/perseus-core/src/types.ts
@@ -37,17 +37,6 @@ export type InteractiveMarkerType = MarkerType & {
 // Used for NumberLine
 export type Relationship = "eq" | "lt" | "gt" | "le" | "ge";
 
-export type Alignment =
-    | "default"
-    | "block"
-    | "inline-block"
-    | "inline"
-    // wrap alignments will be set to inline-block floated left or right this will
-    // allow text to wrap around the widget and not have large space on either side
-    | "wrap-left"
-    | "wrap-right"
-    | "full-width";
-
 export type RecursiveReadonly<T> = {
     readonly [K in keyof T]: RecursiveReadonly<T[K]>;
 };

--- a/packages/perseus-core/src/widgets/core-widget-registry.ts
+++ b/packages/perseus-core/src/widgets/core-widget-registry.ts
@@ -38,8 +38,11 @@ import type {
     PublicWidgetOptionsFunction,
     WidgetLogic,
 } from "./logic-export.types";
-import type {PerseusWidgetOptions, PerseusWidget} from "../data-schema";
-import type {Alignment} from "../types";
+import type {
+    PerseusWidgetOptions,
+    PerseusWidget,
+    Alignment,
+} from "../data-schema";
 
 const widgets = new Registry<WidgetLogic<any, any>>("Core widget registry");
 

--- a/packages/perseus-core/src/widgets/logic-export.types.ts
+++ b/packages/perseus-core/src/widgets/logic-export.types.ts
@@ -18,8 +18,7 @@ import type {getPlotterPublicWidgetOptions} from "./plotter/plotter-util";
 import type {getRadioPublicWidgetOptions} from "./radio/radio-util";
 import type {getSorterPublicWidgetOptions} from "./sorter/sorter-util";
 import type {getTablePublicWidgetOptions} from "./table/table-util";
-import type {Version} from "../data-schema";
-import type {Alignment} from "../types";
+import type {Alignment, Version} from "../data-schema";
 
 export type WidgetOptionsUpgradeMap = {
     // OldProps => NewProps,


### PR DESCRIPTION
## Summary:
An AI agent (fixie) tripped over the Alignment type while working on the linked
issue.  I took the cue to clean up this tech debt.

Issue: LEMS-4354

## Test plan:

CI checks should pass. The change is covered by typetests and parser regression
tests.