### PR TITLE
Add folder for FillInTheBlank widget and context notes for Drag and Drop work and Fill in the Blank widget

### DIFF
--- a/.changeset/neat-camels-double.md
+++ b/.changeset/neat-camels-double.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Add folder for FillInTheBlank widget and context notes for Drag and Drop work and Fill In The Blank widget

--- a/packages/perseus/src/widgets/fill-in-the-blank/notes/drag-and-drop-overview.md
+++ b/packages/perseus/src/widgets/fill-in-the-blank/notes/drag-and-drop-overview.md
@@ -1,0 +1,128 @@
+# Drag and Drop Widgets — Shared Context
+
+> Reusable context for anyone working on Khan Academy's Drag-and-Drop (DnD)
+> widget family ("Operation Dragon Drop"). Load this at the start of a Claude
+> session working on any DnD widget or shared component, alongside the
+> widget-specific doc.
+>
+> **Source of truth for behavior is the Confluence
+> [Overview](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4711973105/Overview).**
+> This file summarizes it and adds repo-specific grounding. When they disagree,
+> Confluence + Figma win; update this file.
+
+## Keeping this current
+
+This doc is only useful if it stays true. When editing it:
+
+- **Defer to live sources** — link Confluence/Figma/Jira for anything that
+  changes (behavior, status, tickets) rather than restating it here.
+- **Date volatile claims** — tag point-in-time facts with `(snapshot — <month
+  year>)` so readers know they may have moved.
+- **Separate durable from time-sensitive** — keep stable conventions apart from
+  phase/status, so one stale line doesn't make the whole doc read as stale.
+- **Update it in the PR that changes reality** — e.g. when the first @dnd-kit
+  wiring lands, refresh the affected notes as part of that change, like tests.
+
+## What this project is
+
+A new family of accessible drag-and-drop exercise widgets that share a common
+foundation (layout, components, interaction + a11y model). The widgets:
+
+| Widget | Answer-zone format | Confluence | Epic |
+| --- | --- | --- | --- |
+| **Fill in the Blank** | Inline blanks within content | [FITB](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4711972976/Fill+in+the+Blank) | [LEMS-4311](https://khanacademy.atlassian.net/browse/LEMS-4311) |
+| **Sorter** | Column(s) + optional legend | [Sorter](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4712005818/Sorter) | [LEMS-4312](https://khanacademy.atlassian.net/browse/LEMS-4312) |
+| **Categorizer** | Columns | [Categorizer](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4710040591/Categorizer) | TBD |
+| **Composer** | Columns | [Composer](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4711186826/Composer) | TBD |
+
+## Shared building blocks (built first, before wiring drag-and-drop)
+
+The strategy is to build the shared pieces first, then wire them to the DnD
+engine holistically once they all exist. The set isn't only components — it also
+includes a shared **widget** and reusable **logic**.
+
+| Piece | Type | What it is | Ticket |
+| --- | --- | --- | --- |
+| **Choice Bank** | Component | The container/drop-zone holding the available Answer Tiles | [LEMS-4365](https://khanacademy.atlassian.net/browse/LEMS-4365) |
+| **Answer Tile** | Component | The individual draggable item | [LEMS-4363](https://khanacademy.atlassian.net/browse/LEMS-4363) |
+| **Actions Menu** | Component | Per-tile control giving keyboard/SR users a way to move tiles | [LEMS-4362](https://khanacademy.atlassian.net/browse/LEMS-4362) |
+| **Blank** | Widget | The bay a tile is dropped into for scoring | [LEMS-4364](https://khanacademy.atlassian.net/browse/LEMS-4364) |
+| **Choice Bank randomization** | Logic | Reusable logic to randomize tile order in the Choice Bank | [LEMS-4388](https://khanacademy.atlassian.net/browse/LEMS-4388) |
+
+The shared **components** (Choice Bank, Answer Tile, Actions Menu) live in
+**`packages/perseus/src/components/drag-and-drop/`**.
+
+## Where things live in the repo
+
+- **Shared DnD components:** `packages/perseus/src/components/drag-and-drop/`
+- **`blank` widget:** `packages/perseus/src/widgets/blank/`
+- **@dnd-kit reference:** `@dnd-kit/react@^0.5.0` is installed in
+  `packages/perseus`. Working demo:
+  `packages/perseus/src/__docs__/dnd-kit-demo.stories.tsx` — it renders the
+  draggable as a native `<button>` (the a11y pattern to follow). Demo cleanup is
+  tracked by LEMS-4369.
+- **Do NOT model new work on legacy DnD** (`sorter`, `orderer`, `matcher`) —
+  they use the hand-rolled jQuery `components/sortable.tsx` with no keyboard
+  support. Useful only as prior art.
+
+## Tech & conventions
+
+- **New widgets are functional components** conforming to `WidgetExports<T>`.
+  See `packages/perseus/src/widgets/CLAUDE.md` for the full new-widget checklist
+  (files, registration, scoring, editor, schema, linter).
+- **Styling:** CSS modules with Wonder Blocks CSS custom properties
+  (`var(--wb-*)`), not Aphrodite. Tokens come from
+  `@khanacademy/wonder-blocks-tokens`.
+- **Designs:** before building any UI, ask the engineer whether they're working
+  from a design. If so, ask for the design link or offer to connect to the Figma
+  MCP to pull it.
+- **Accessibility is first-class.** Follow the repo `accessibility-instructions.md`
+  (native element → modified native → ARIA last). RTL support is required — avoid
+  hardcoded physical directions in CSS (use flow-relative properties / logical
+  properties so layout reverses automatically).
+- **User input** must flow through `handleUserInput` / the `userInput` prop, not
+  local state (see widgets/CLAUDE.md).
+
+## Shared behavior (highlights — see Overview for the authoritative detail)
+
+- **Information hierarchy:** Exercise Stimulus → Answer Zone → Choice Bank (bank
+  renders last).
+- **Choice Bank:** tiles live in an **unordered list**, display inline and wrap
+  to multiple lines; the bank is 100% of its parent's width with height hugging
+  its contents; tiles stack when the container is too narrow.
+- **Answer Tiles:** content types are Text / TeX / Image / Empty (not mixed,
+  except Empty). Max content width 200px; images use one of seven height presets
+  (24/36/48/60/72/84/96). Multi-use tiles show an SR-only "N remaining" count
+  and disappear when exhausted. Single- and multi-use tiles can't be mixed.
+- **Actions Menu:** because pointer drag isn't available to keyboard/SR users,
+  every tile has an Actions Menu button (also available to pointer users) to
+  move/clear tiles. It's the first focusable element in a tile, labeled by the
+  tile value with SR-only descriptive context ("Penny. 5 remaining. Actions
+  Menu."). Menu actions name their target ("Move to Blank 1" / "Clear Blank 1").
+- **Announcements:** tile moves are announced via the **Wonder Blocks Announcer**
+  (aria-live), e.g. "[Tile] moved to Blank 1" (and swap feedback when a blank was
+  already filled).
+- **Scored state (per Overview):** correct tiles switch to their correct state
+  (no Actions Menu); unused tiles become disabled; the Choice Bank drops its
+  dashed border, subdues the "Choices" label color, and collapses toward a single
+  line when empty — putting visual weight on the answer zone's correctness.
+
+## Boundaries / gotchas
+
+- **Build phase _(snapshot — Aug 2026; verify against the epic below)_:** the
+  shared pieces are being built **presentational-first**, before the
+  drag-and-drop engine is wired up (that happens holistically once they exist).
+  While this holds, a ticket to "build component X" usually does **not** include
+  hooking it to @dnd-kit. Once wiring begins this no longer applies — treat the
+  prework epic
+  [LEMS-4314](https://khanacademy.atlassian.net/browse/LEMS-4314) as the live
+  source of truth and update or drop this note.
+- Future changes to these components are expected as the parent widgets mature —
+  they're a starting foundation, not a frozen contract.
+
+## Key links
+
+- Overview (shared spec): https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4711973105/Overview
+- Figma (Drag and Drop Widgets): https://www.figma.com/design/kVVUz62ZEMflR7cJVuVBUS/Drag-and-Drop-Widgets
+- Overall epic (Drag and Drop): https://khanacademy.atlassian.net/browse/LEMS-4310
+- Prework epic (shared components / common building blocks): https://khanacademy.atlassian.net/browse/LEMS-4314

--- a/packages/perseus/src/widgets/fill-in-the-blank/notes/drag-and-drop-overview.md
+++ b/packages/perseus/src/widgets/fill-in-the-blank/notes/drag-and-drop-overview.md
@@ -53,11 +53,11 @@ The shared **components** (Choice Bank, Answer Tile, Actions Menu) live in
 ([LEMS-4365](https://khanacademy.atlassian.net/browse/LEMS-4365)) is the first
 built there — use it as the reference for structure and the conventions below.
 
-**The `blank` widget is _not_ one of these.** It's built alongside them under the
-same prework epic
-([LEMS-4364](https://khanacademy.atlassian.net/browse/LEMS-4364)), but it's the
-bay for FITB's inline blanks — the other widgets drop into columns. Treat it as
-FITB-specific.
+**The `blank` widget is _not_ one of these**, but a shared piece is expected to
+come out of it: the plan is to lift its **render-specific logic** into a shared
+component the other widgets can reuse. The widget itself
+([LEMS-4364](https://khanacademy.atlassian.net/browse/LEMS-4364)) is likely to
+stay **FITB-specific**, since it's the bay for FITB's *inline* blanks.
 
 ## Where things live in the repo
 
@@ -110,15 +110,32 @@ FITB-specific.
   except Empty). Max **content** width 200px (the content inside a tile, not the
   tile itself); images use one of seven height presets
   (24/36/48/60/72/84/96). Multi-use tiles show an SR-only "N remaining" count
-  and disappear when exhausted. Single- and multi-use tiles can't be mixed.
+  and disappear when exhausted. Single- and multi-use tiles can't be mixed within
+  one widget (an exercise may contain several).
+  - **The 200px cap is a design target, not an enforceable guarantee yet _(open —
+    Aug 2026)_.** Rendered **TeX** width isn't known until it renders, so treat
+    the cap as aspirational there. **Images** are more tractable, but the seven
+    height presets drive the height — width falls out of the aspect ratio and can
+    overflow. That math is computable at authoring time, so the likely answer for
+    images is a **linter warning** rather than a render-time guarantee.
 - **Actions Menu:** because pointer drag isn't available to keyboard/SR users,
   every tile has an Actions Menu button (also available to pointer users) to
   move/clear tiles. It's the first focusable element in a tile, labeled by the
   tile value with SR-only descriptive context ("Penny. 5 remaining. Actions
   Menu."). Menu actions name their target ("Move to Blank 1" / "Clear Blank 1").
+  - **These strings aren't final _(open — Aug 2026)_.** They show the intended
+    shape — value, then state, then control — not settled copy. Confirm the exact
+    wording with design/a11y before building against it.
 - **Announcements:** tile moves are announced via the **Wonder Blocks Announcer**
   (aria-live), e.g. "[Tile] moved to Blank 1" (and swap feedback when a blank was
   already filled).
+  - **@dnd-kit ships its own announcement system too** — the `Accessibility`
+    plugin in `@dnd-kit/dom` (v0.5) takes `announcements`
+    (`dragstart`/`dragmove`/`dragover`/`dragend` → string),
+    `screenReaderInstructions.draggable`, and a `debounce` (default 500ms, on the
+    move/over events). It covers **drags**, pointer and keyboard. An Actions Menu
+    move isn't a drag, so that path likely still needs the Announcer — pick one
+    owner per event, since both firing would double-announce.
 - **Scored state (per Overview):** correct tiles switch to their correct state
   (no Actions Menu); unused tiles become disabled; the Choice Bank drops its
   dashed border, subdues the "Choices" label color, and collapses toward a single
@@ -147,3 +164,6 @@ FITB-specific.
 - Figma (Drag and Drop Widgets): https://www.figma.com/design/kVVUz62ZEMflR7cJVuVBUS/Drag-and-Drop-Widgets
 - Overall epic (Drag and Drop): https://khanacademy.atlassian.net/browse/LEMS-4310
 - Prework epic (shared components / common building blocks): https://khanacademy.atlassian.net/browse/LEMS-4314
+- @dnd-kit React docs: https://dndkit.com/react/quickstart
+- @dnd-kit source — the types are ahead of the docs, so read the `.d.ts` when the
+  site is thin: https://github.com/clauderic/dnd-kit

--- a/packages/perseus/src/widgets/fill-in-the-blank/notes/drag-and-drop-overview.md
+++ b/packages/perseus/src/widgets/fill-in-the-blank/notes/drag-and-drop-overview.md
@@ -50,7 +50,9 @@ includes a shared **widget** and reusable **logic**.
 | **Choice Bank randomization** | Logic | Reusable logic to randomize tile order in the Choice Bank | [LEMS-4388](https://khanacademy.atlassian.net/browse/LEMS-4388) |
 
 The shared **components** (Choice Bank, Answer Tile, Actions Menu) live in
-**`packages/perseus/src/components/drag-and-drop/`**.
+**`packages/perseus/src/components/drag-and-drop/`**. **Choice Bank**
+([LEMS-4365](https://khanacademy.atlassian.net/browse/LEMS-4365)) is the first
+built there — use it as the reference for structure and the conventions below.
 
 ## Where things live in the repo
 
@@ -70,9 +72,15 @@ The shared **components** (Choice Bank, Answer Tile, Actions Menu) live in
 - **New widgets are functional components** conforming to `WidgetExports<T>`.
   See `packages/perseus/src/widgets/CLAUDE.md` for the full new-widget checklist
   (files, registration, scoring, editor, schema, linter).
+- **Component props:** prefer required props over optional-with-defaults; pass
+  user-facing labels as translatable strings (no hardcoded English default); and
+  represent an empty collection as an empty array (`[]`), not `null`.
 - **Styling:** CSS modules with Wonder Blocks CSS custom properties
   (`var(--wb-*)`), not Aphrodite. Tokens come from
   `@khanacademy/wonder-blocks-tokens`.
+- **Storybook stories:** group DnD component stories under the title
+  `Components/Drag and Drop/<Name>` (e.g. `Components/Drag and Drop/Choice Bank`)
+  so they nest consistently in the sidebar.
 - **Designs:** before building any UI, ask the engineer whether they're working
   from a design. If so, ask for the design link or offer to connect to the Figma
   MCP to pull it.
@@ -91,7 +99,8 @@ The shared **components** (Choice Bank, Answer Tile, Actions Menu) live in
   to multiple lines; the bank is 100% of its parent's width with height hugging
   its contents; tiles stack when the container is too narrow.
 - **Answer Tiles:** content types are Text / TeX / Image / Empty (not mixed,
-  except Empty). Max content width 200px; images use one of seven height presets
+  except Empty). Max **content** width 200px (the content inside a tile, not the
+  tile itself); images use one of seven height presets
   (24/36/48/60/72/84/96). Multi-use tiles show an SR-only "N remaining" count
   and disappear when exhausted. Single- and multi-use tiles can't be mixed.
 - **Actions Menu:** because pointer drag isn't available to keyboard/SR users,

--- a/packages/perseus/src/widgets/fill-in-the-blank/notes/drag-and-drop-overview.md
+++ b/packages/perseus/src/widgets/fill-in-the-blank/notes/drag-and-drop-overview.md
@@ -28,25 +28,24 @@ This doc is only useful if it stays true. When editing it:
 A new family of accessible drag-and-drop exercise widgets that share a common
 foundation (layout, components, interaction + a11y model). The widgets:
 
-| Widget | Answer-zone format | Confluence | Epic |
-| --- | --- | --- | --- |
-| **Fill in the Blank** | Inline blanks within content | [FITB](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4711972976/Fill+in+the+Blank) | [LEMS-4311](https://khanacademy.atlassian.net/browse/LEMS-4311) |
-| **Sorter** | Column(s) + optional legend | [Sorter](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4712005818/Sorter) | [LEMS-4312](https://khanacademy.atlassian.net/browse/LEMS-4312) |
-| **Categorizer** | Columns | [Categorizer](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4710040591/Categorizer) | TBD |
-| **Composer** | Columns | [Composer](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4711186826/Composer) | TBD |
+| Widget                                | Answer-zone format | Confluence | Epic |
+|---------------------------------------| --- | --- | --- |
+| **Fill in the Blank**                 | Inline blanks within content | [FITB](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4711972976/Fill+in+the+Blank) | [LEMS-4311](https://khanacademy.atlassian.net/browse/LEMS-4311) |
+| **Sorter** _(existing — to refactor)_ | Column(s) + optional legend | [Sorter](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4712005818/Sorter) | [LEMS-4312](https://khanacademy.atlassian.net/browse/LEMS-4312) |
+| **Categorizer**                       | Columns | [Categorizer](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4710040591/Categorizer) | TBD |
+| **Composer**                          | Columns | [Composer](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4711186826/Composer) | TBD |
 
 ## Shared building blocks (built first, before wiring drag-and-drop)
 
 The strategy is to build the shared pieces first, then wire them to the DnD
 engine holistically once they all exist. The set isn't only components — it also
-includes a shared **widget** and reusable **logic**.
+includes reusable **logic**.
 
 | Piece | Type | What it is | Ticket |
 | --- | --- | --- | --- |
 | **Choice Bank** | Component | The container/drop-zone holding the available Answer Tiles | [LEMS-4365](https://khanacademy.atlassian.net/browse/LEMS-4365) |
 | **Answer Tile** | Component | The individual draggable item | [LEMS-4363](https://khanacademy.atlassian.net/browse/LEMS-4363) |
 | **Actions Menu** | Component | Per-tile control giving keyboard/SR users a way to move tiles | [LEMS-4362](https://khanacademy.atlassian.net/browse/LEMS-4362) |
-| **Blank** | Widget | The bay a tile is dropped into for scoring | [LEMS-4364](https://khanacademy.atlassian.net/browse/LEMS-4364) |
 | **Choice Bank randomization** | Logic | Reusable logic to randomize tile order in the Choice Bank | [LEMS-4388](https://khanacademy.atlassian.net/browse/LEMS-4388) |
 
 The shared **components** (Choice Bank, Answer Tile, Actions Menu) live in
@@ -54,10 +53,17 @@ The shared **components** (Choice Bank, Answer Tile, Actions Menu) live in
 ([LEMS-4365](https://khanacademy.atlassian.net/browse/LEMS-4365)) is the first
 built there — use it as the reference for structure and the conventions below.
 
+**The `blank` widget is _not_ one of these.** It's built alongside them under the
+same prework epic
+([LEMS-4364](https://khanacademy.atlassian.net/browse/LEMS-4364)), but it's the
+bay for FITB's inline blanks — the other widgets drop into columns. Treat it as
+FITB-specific.
+
 ## Where things live in the repo
 
 - **Shared DnD components:** `packages/perseus/src/components/drag-and-drop/`
-- **`blank` widget:** `packages/perseus/src/widgets/blank/`
+- **`blank` widget (FITB-specific, not shared):**
+  `packages/perseus/src/widgets/blank/`
 - **@dnd-kit reference:** `@dnd-kit/react@^0.5.0` is installed in
   `packages/perseus`. Working demo:
   `packages/perseus/src/__docs__/dnd-kit-demo.stories.tsx` — it renders the
@@ -65,7 +71,9 @@ built there — use it as the reference for structure and the conventions below.
   tracked by LEMS-4369.
 - **Do NOT model new work on legacy DnD** (`sorter`, `orderer`, `matcher`) —
   they use the hand-rolled jQuery `components/sortable.tsx` with no keyboard
-  support. Useful only as prior art.
+  support. Useful only as prior art — except `sorter`, which is the live widget
+  being refactored onto the new components, so it's the starting point for that
+  work rather than a pattern to copy.
 
 ## Tech & conventions
 
@@ -118,14 +126,18 @@ built there — use it as the reference for structure and the conventions below.
 
 ## Boundaries / gotchas
 
-- **Build phase _(snapshot — Aug 2026; verify against the epic below)_:** the
-  shared pieces are being built **presentational-first**, before the
-  drag-and-drop engine is wired up (that happens holistically once they exist).
-  While this holds, a ticket to "build component X" usually does **not** include
-  hooking it to @dnd-kit. Once wiring begins this no longer applies — treat the
-  prework epic
+- **Build phase, FITB only _(snapshot — Aug 2026; verify against the epic
+  below)_:** the shared pieces and Fill in the Blank are being built
+  **presentational-first**, before the drag-and-drop engine is wired up (that
+  happens holistically once they exist). While this holds, a ticket to "build
+  component X" usually does **not** include hooking it to @dnd-kit. Once wiring
+  begins this no longer applies — treat the prework epic
   [LEMS-4314](https://khanacademy.atlassian.net/browse/LEMS-4314) as the live
   source of truth and update or drop this note.
+- **Sorter is different: it already ships.** It gets **refactored live**, in
+  place, onto the new components rather than built up presentationally and wired
+  at the end. Confirm the approach per widget rather than assuming the FITB plan
+  applies.
 - Future changes to these components are expected as the parent widgets mature —
   they're a starting foundation, not a frozen contract.
 

--- a/packages/perseus/src/widgets/fill-in-the-blank/notes/fill-in-the-blank.md
+++ b/packages/perseus/src/widgets/fill-in-the-blank/notes/fill-in-the-blank.md
@@ -62,12 +62,14 @@ standalone blocks so line breaks/reflow can be controlled precisely:
 - In the Choice Bank, tiles hug their contents; the whole **tile** should not
   exceed **256px** (the max choice-bank width at the 320px smallest viewport).
   This is the *tile* width, distinct from the family-wide **200px** max *content*
-  width in the shared spec. Watch i18n — some languages have long words; the max
-  may need to flex.
+  width in the shared spec — which isn't enforceable yet for TeX or images (see
+  the shared overview). Watch i18n — some languages have long words; the max may
+  need to flex.
 - When placed in a blank at narrow viewports, the tile+blank fill the parent
   width (contents stay left-aligned), yielding a placed-tile max width of ~500px
   (depends on blank sizing).
-- Single- vs multi-use is configurable but can't be mixed within one exercise.
+- Single- vs multi-use is configurable but can't be mixed within one widget (an
+  exercise may contain several).
 
 ## Read-aloud for screen reader users (FITB-specific a11y)
 
@@ -91,8 +93,9 @@ entire answer-zone contents as one string.
   perseus-score, editor in perseus-editor, schema in perseus-core, linter rule).
 - **`blank` widget stub:** `packages/perseus/src/widgets/blank/` — the dropzone
   primitive FITB builds on. Built during the shared prework
-  ([LEMS-4364](https://khanacademy.atlassian.net/browse/LEMS-4364)) but **owned by
-  FITB, not shared**. Functional component, `forwardRef` +
+  ([LEMS-4364](https://khanacademy.atlassian.net/browse/LEMS-4364)) and likely to
+  stay **FITB-specific**, though its render-specific logic is expected to be
+  lifted into a shared component. Functional component, `forwardRef` +
   `useImperativeHandle`, CSS modules + `var(--wb-*)`, `hidden: true`. Schema in
   perseus-core: `PerseusBlankWidgetOptions` (`src/data-schema.ts`) and
   `PerseusBlankUserInput` (`src/validation.types.ts`).

--- a/packages/perseus/src/widgets/fill-in-the-blank/notes/fill-in-the-blank.md
+++ b/packages/perseus/src/widgets/fill-in-the-blank/notes/fill-in-the-blank.md
@@ -1,0 +1,113 @@
+# Fill in the Blank Widget — Context
+
+> Widget-specific context for the **Fill in the Blank (FITB)** widget. Read the
+> shared [`drag-and-drop-overview.md`](./drag-and-drop-overview.md) **first** —
+> this doc only covers what's specific to or extended by FITB.
+>
+> **Source of truth for behavior is the Confluence
+> [Fill in the Blank](https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4711972976/Fill+in+the+Blank)
+> page.** This file summarizes it and adds repo grounding; update it when they
+> diverge.
+
+## What it is
+
+Learners complete sentences, equations/formulas, or patterns by dragging Answer
+Tiles into empty **inline blanks**. Ideal for completing sentences and visual
+patterns, and for balancing/completing equations and formulas.
+
+- Figma: https://www.figma.com/design/kVVUz62ZEMflR7cJVuVBUS/Drag-and-Drop-Widgets?node-id=2663-5211
+- Figma Make prototype: https://www.figma.com/make/zWHzKU7VnXZEyA1UsJhbNS/Fill-in-the-Blank-Widget
+
+## Anatomy
+
+- **Answer Zone** — inline **content** blocks interleaved with inline **blank(s)**
+- **Choice Bank** — holds the **Answer Tiles** (shared component)
+
+## Answer Zone (the FITB-specific part)
+
+The answer zone is a sequence of inline elements — pre-filled **content** and
+**blanks** — laid out on the same line(s) to form a complete string (e.g. a
+paragraph). Allowed content types: Text, TeX, Images, Blank.
+
+**Authoring granularity drives reflow.** Content is authored as many small
+standalone blocks so line breaks/reflow can be controlled precisely:
+
+- Sentences: each sentence is its own block; when a blank splits a sentence,
+  each segment is its own block (e.g. `"The"` | `[blank]` | `"drum is a long-…"`).
+- Equations/formulas: operators are standalone blocks.
+- Image patterns: each piece is a standalone block.
+
+### Inline blanks — the hard part
+
+- A blank's default width = the **widest answer tile** (so size doesn't reveal
+  the answer). When a tile is placed, the blank shrinks to hug the tile.
+- **Reflow breakpoint at 504px line length:**
+  - **≥ 504px:** classic inline behavior — blank has a fixed width, text wraps
+    around it.
+  - **< 504px:** blanks **fill the parent width** and sit on their own line
+    (text no longer wraps around them). *Exception:* when only a single
+    word/character precedes or follows the blank (e.g. first/last word of a
+    sentence), it stays inline with the blank to reduce spacing exaggeration.
+- **Small-value exception:** when tile values are **≤ 3 characters** (e.g.
+  punctuation, single digits), keep the wide-viewport inline behavior even as the
+  viewport narrows — the fill-width behavior would be disruptive for tiny items.
+
+## Answer Tiles (FITB constraints on top of the shared tile spec)
+
+- All content types allowed: Text, TeX, Images, Empty. Empty tiles may be mixed
+  with others; Text/TeX/Images may **not** be mixed with each other. Avoid Empty
+  tiles unless unavoidable (e.g. balancing a chemical equation).
+- **Single word or standalone character only** — no multi-word tiles (readability
+  + reflow).
+- In the Choice Bank, tiles hug their contents and should not exceed **256px**
+  (the max choice-bank width at the 320px smallest viewport). Watch i18n — some
+  languages have long words; the max may need to flex.
+- When placed in a blank at narrow viewports, the tile+blank fill the parent
+  width (contents stay left-aligned), yielding a placed-tile max width of ~500px
+  (depends on blank sizing).
+- Single- vs multi-use is configurable but can't be mixed within one exercise.
+
+## Read-aloud for screen reader users (FITB-specific a11y)
+
+Because the answer zone is chunked into many labeled interactive elements, SR
+users can't easily hear the sentence as a whole. FITB adds a **screen-reader-only
+"read aloud" button** (`.sr-only`, placed in the DOM **between the Answer Zone
+and the Choice Bank**) that uses the **WB Announcer** (aria-live) to read the
+entire answer-zone contents as one string.
+
+- Maintain a separate **text-only** representation of the answer zone: the full
+  text with blank labels ("Blank 1"), updated to substitute a blank's label with
+  the placed tile's value as tiles are moved in.
+- Button label ("read aloud") is pending finalization.
+
+## Repo anchors
+
+- **Widget folder:** `packages/perseus/src/widgets/fill-in-the-blank/` (this
+  folder). Follow the new-widget checklist in
+  `packages/perseus/src/widgets/CLAUDE.md` (component, tests, `index.ts`,
+  `__docs__/` stories, registration in `extra-widgets.ts`, scoring in
+  perseus-score, editor in perseus-editor, schema in perseus-core, linter rule).
+- **`blank` widget stub:** `packages/perseus/src/widgets/blank/` — the dropzone
+  primitive FITB builds on. Functional component, `forwardRef` +
+  `useImperativeHandle`, CSS modules + `var(--wb-*)`, `hidden: true`. Schema in
+  perseus-core: `PerseusBlankWidgetOptions` (`src/data-schema.ts`) and
+  `PerseusBlankUserInput` (`src/validation.types.ts`).
+- **Choice Bank / Answer Tile:** shared components under
+  `packages/perseus/src/components/drag-and-drop/` (see the shared overview doc).
+  FITB composes them; it doesn't own them.
+
+## Boundaries
+
+- **Build order:** presentational structure and reflow first; drag wiring comes
+  later. See the shared overview's **Build phase** note (dated, defers to the
+  prework epic) for the current stance rather than relying on this line.
+- The 504px reflow rules and the read-aloud model are the two most subtle,
+  FITB-unique behaviors — treat the Confluence page as authoritative and design
+  the DOM/state to accommodate them early.
+
+## Key links
+
+- FITB spec: https://khanacademy.atlassian.net/wiki/spaces/LC/pages/4711972976/Fill+in+the+Blank
+- FITB epic: https://khanacademy.atlassian.net/browse/LEMS-4311
+- Prework epic (shared components / common building blocks): https://khanacademy.atlassian.net/browse/LEMS-4314
+- Shared overview doc: [`drag-and-drop-overview.md`](./drag-and-drop-overview.md)

--- a/packages/perseus/src/widgets/fill-in-the-blank/notes/fill-in-the-blank.md
+++ b/packages/perseus/src/widgets/fill-in-the-blank/notes/fill-in-the-blank.md
@@ -90,7 +90,9 @@ entire answer-zone contents as one string.
   `__docs__/` stories, registration in `extra-widgets.ts`, scoring in
   perseus-score, editor in perseus-editor, schema in perseus-core, linter rule).
 - **`blank` widget stub:** `packages/perseus/src/widgets/blank/` — the dropzone
-  primitive FITB builds on. Functional component, `forwardRef` +
+  primitive FITB builds on. Built during the shared prework
+  ([LEMS-4364](https://khanacademy.atlassian.net/browse/LEMS-4364)) but **owned by
+  FITB, not shared**. Functional component, `forwardRef` +
   `useImperativeHandle`, CSS modules + `var(--wb-*)`, `hidden: true`. Schema in
   perseus-core: `PerseusBlankWidgetOptions` (`src/data-schema.ts`) and
   `PerseusBlankUserInput` (`src/validation.types.ts`).

--- a/packages/perseus/src/widgets/fill-in-the-blank/notes/fill-in-the-blank.md
+++ b/packages/perseus/src/widgets/fill-in-the-blank/notes/fill-in-the-blank.md
@@ -59,9 +59,11 @@ standalone blocks so line breaks/reflow can be controlled precisely:
   tiles unless unavoidable (e.g. balancing a chemical equation).
 - **Single word or standalone character only** — no multi-word tiles (readability
   + reflow).
-- In the Choice Bank, tiles hug their contents and should not exceed **256px**
-  (the max choice-bank width at the 320px smallest viewport). Watch i18n — some
-  languages have long words; the max may need to flex.
+- In the Choice Bank, tiles hug their contents; the whole **tile** should not
+  exceed **256px** (the max choice-bank width at the 320px smallest viewport).
+  This is the *tile* width, distinct from the family-wide **200px** max *content*
+  width in the shared spec. Watch i18n — some languages have long words; the max
+  may need to flex.
 - When placed in a blank at narrow viewports, the tile+blank fill the parent
   width (contents stay left-aligned), yielding a placed-tile max width of ~500px
   (depends on blank sizing).


### PR DESCRIPTION
## Summary:
This PR creates the `fill-in-the-blank` folder that will be home for the new widget. And this also creates the context notes for the Drag and Drop and Fill in the Blank widget that can be used by the engineers of the team for Claude context.

Issue: LEMS-4317

## Test plan: