### PR TITLE
Tokenize article colors and sizing

### DIFF
--- a/.changeset/young-stamps-send.md
+++ b/.changeset/young-stamps-send.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Perseus articles are now styled according to the current theme (Wonder Blocks or Shape Your Learning).

--- a/packages/perseus/src/styles/paragraph-styles.css
+++ b/packages/perseus/src/styles/paragraph-styles.css
@@ -95,7 +95,7 @@
     .perseus-formats-tooltip
     .paragraph
     ul:not([data-widget="radio"]) {
-    font-size: var(--wb-font-body-size-medium);
+    font-size: 15px;
     line-height: 1.5;
     margin: 0;
 }
@@ -140,7 +140,7 @@
     .perseus-renderer
     > .paragraph
     ul:not([data-widget="radio"], .indicatorContainer) {
-    margin: 0 0 0 var(--wb-sizing-size_160);
+    margin: 0 0 0 1em;
     padding: 0;
 }
 .framework-perseus.perseus-mobile

--- a/packages/perseus/src/styles/paragraph-styles.css
+++ b/packages/perseus/src/styles/paragraph-styles.css
@@ -14,7 +14,7 @@
     color: var(--wb-semanticColor-core-foreground-neutral-strong);
     font-size: 20px;
     line-height: 30px;
-    margin-bottom: 32px;
+    margin-bottom: var(--wb-sizing-size_320);
     margin-top: 0;
 }
 /* Reset the Renderer margins for the image widget.
@@ -56,13 +56,13 @@
     .paragraph
     ul {
     color: var(--wb-semanticColor-core-foreground-neutral-subtle);
-    font-size: 14px;
-    line-height: 19px;
+    font-size: var(--wb-font-body-size-small);
+    line-height: var(--wb-font-body-lineHeight-small);
     text-align: left;
 }
 .framework-perseus.perseus-article:not(.perseus-mobile)
     .paragraph.perseus-paragraph-full-width {
-    margin-bottom: 32px;
+    margin-bottom: var(--wb-sizing-size_320);
     margin-left: 0;
     margin-right: 0;
     max-width: none;
@@ -77,7 +77,7 @@
     .perseus-renderer
     > .paragraph
     .perseus-formats-tooltip {
-    padding: 8px 12px;
+    padding: var(--wb-sizing-size_080) var(--wb-sizing-size_120);
 }
 .framework-perseus.perseus-article:not(.perseus-mobile)
     .perseus-renderer
@@ -86,13 +86,16 @@
     .paragraph {
     margin-bottom: 0;
 }
+/* TODO(benchristel): .perseus-formats-tooltip doesn't seem to be used.
+ *  Perhaps this rule can be removed.
+ */
 .framework-perseus.perseus-article:not(.perseus-mobile)
     .perseus-renderer
     > .paragraph
     .perseus-formats-tooltip
     .paragraph
     ul:not([data-widget="radio"]) {
-    font-size: 15px;
+    font-size: var(--wb-font-body-size-medium);
     line-height: 1.5;
     margin: 0;
 }
@@ -137,7 +140,7 @@
     .perseus-renderer
     > .paragraph
     ul:not([data-widget="radio"], .indicatorContainer) {
-    margin: 0 0 0 1em;
+    margin: 0 0 0 var(--wb-sizing-size_160);
     padding: 0;
 }
 .framework-perseus.perseus-mobile
@@ -145,16 +148,16 @@
     > .paragraph
     ul:not([data-widget="radio"], .indicatorContainer)
     > li {
-    padding-left: 10px;
-    margin-bottom: 24px;
+    padding-left: var(--wb-sizing-size_100);
+    margin-bottom: var(--wb-sizing-size_240);
 }
 .framework-perseus.perseus-mobile .perseus-renderer > .paragraph ol {
     margin: 0;
-    padding-left: 32px;
+    padding-left: var(--wb-sizing-size_320);
 }
 .framework-perseus.perseus-mobile .perseus-renderer > .paragraph ol > li {
     list-style-type: decimal;
-    margin-bottom: 24px;
+    margin-bottom: var(--wb-sizing-size_240);
 }
 .framework-perseus.perseus-mobile .perseus-renderer > .paragraph ol ol,
 .framework-perseus.perseus-mobile
@@ -172,7 +175,7 @@
     > .paragraph
     ul:not([data-widget="radio"])
     ul:not([data-widget="radio"]) {
-    padding-top: 24px;
+    padding-top: var(--wb-sizing-size_240);
 }
 @media (max-width: 767px) {
     .framework-perseus.perseus-mobile .perseus-renderer > .paragraph {
@@ -321,7 +324,7 @@
     .perseus-renderer
     > .paragraph
     .perseus-formats-tooltip {
-    padding: 8px 12px;
+    padding: var(--wb-sizing-size_080) var(--wb-sizing-size_120);
 }
 .framework-perseus.perseus-mobile
     .perseus-renderer

--- a/packages/perseus/src/styles/perseus-renderer-part-1.css
+++ b/packages/perseus/src/styles/perseus-renderer-part-1.css
@@ -67,7 +67,7 @@ div.graphie {
 }
 .framework-perseus div.paragraph {
     font-family: "Lato", sans-serif;
-    font-weight: var(--wb-font-weight-medium);
+    font-weight: var(--wb-font-weight-regular);
     font-size: 18px;
     line-height: 22px;
     margin: 22px 0px;

--- a/packages/perseus/src/styles/perseus-renderer-part-1.css
+++ b/packages/perseus/src/styles/perseus-renderer-part-1.css
@@ -126,7 +126,8 @@ div.graphie {
     font-size: 14px;
 }
 .framework-perseus .number-input {
-    border: var(--wb-border-width-thin) solid var(--wb-semanticColor-core-border-neutral-default);
+    border: var(--wb-border-width-thin) solid
+        var(--wb-semanticColor-core-border-neutral-default);
     border-radius: var(--wb-border-radius-radius_040);
     margin: 0;
     padding: var(--wb-sizing-size_040) 0;
@@ -147,7 +148,8 @@ div.graphie {
     width: var(--wb-sizing-size_800);
 }
 .framework-perseus .graph-settings .graph-settings-axis-label {
-    border: var(--wb-border-width-thin) solid var(--wb-semanticColor-core-border-neutral-subtle);
+    border: var(--wb-border-width-thin) solid
+        var(--wb-semanticColor-core-border-neutral-subtle);
     border-radius: var(--wb-border-radius-radius_040);
     display: inline-block;
     padding: var(--wb-sizing-size_040);
@@ -168,7 +170,8 @@ div.graphie {
 }
 .framework-perseus .misc-settings,
 .framework-perseus .type-settings {
-    border-top: var(--wb-border-width-thin) solid var(--wb-semanticColor-core-border-neutral-strong);
+    border-top: var(--wb-border-width-thin) solid
+        var(--wb-semanticColor-core-border-neutral-strong);
     padding-top: var(--wb-sizing-size_040);
 }
 .framework-perseus .svg-image {

--- a/packages/perseus/src/styles/perseus-renderer-part-1.css
+++ b/packages/perseus/src/styles/perseus-renderer-part-1.css
@@ -2,14 +2,14 @@
     position: relative;
 }
 .framework-perseus.perseus-mobile {
-    margin-top: 48px;
+    margin-top: var(--wb-sizing-size_480);
 }
 .no-select {
     -webkit-user-select: none;
     user-select: none;
 }
 .blank-background {
-    background-color: #fdfdfd;
+    background-color: var(--wb-semanticColor-core-background-neutral-subtle);
 }
 .graphie {
     -webkit-user-select: none;
@@ -37,15 +37,15 @@ div.graphie {
 #answercontent input[type="number"].perseus-input-size-normal,
 .framework-perseus input[type="text"].perseus-input-size-normal,
 .framework-perseus input[type="number"].perseus-input-size-normal {
-    border: 1px solid #ccc;
-    width: 80px;
+    border: 1px solid var(--wb-semanticColor-core-border-neutral-subtle);
+    width: var(--wb-sizing-size_800);
 }
 #answercontent input[type="text"].perseus-input-size-small,
 #answercontent input[type="number"].perseus-input-size-small,
 .framework-perseus input[type="text"].perseus-input-size-small,
 .framework-perseus input[type="number"].perseus-input-size-small {
-    border: 1px solid #ccc;
-    width: 40px;
+    border: 1px solid var(--wb-semanticColor-core-border-neutral-subtle);
+    width: var(--wb-sizing-size_400);
 }
 #answercontent input[type="text"].perseus-input-right-align,
 #answercontent input[type="number"].perseus-input-right-align,
@@ -67,19 +67,15 @@ div.graphie {
 }
 .framework-perseus div.paragraph {
     font-family: "Lato", sans-serif;
-    font-weight: 400;
+    font-weight: var(--wb-font-weight-medium);
     font-size: 18px;
     line-height: 22px;
     margin: 22px 0px;
 }
-.framework-perseus .test-prep-blurb div.paragraph {
-    font-size: 16px;
-    line-height: 20px;
-}
 .framework-perseus div.instructions {
     display: block;
     font-family: "Noto Serif", serif;
-    font-weight: 800;
+    font-weight: var(--wb-font-weight-black);
     font-size: 18px;
     line-height: 22px;
     font-style: italic;
@@ -89,20 +85,20 @@ div.graphie {
     > .paragraph
     > ul:not([data-widget="radio"]),
 .framework-perseus .perseus-renderer > .paragraph > ol {
-    margin: 0px 0px 22px 0px;
+    margin: 0px 0px var(--wb-sizing-size_220) 0px;
 }
 .framework-perseus
     .paragraph
     ul:not([data-widget="radio"], .indicatorContainer) {
-    padding-left: 35px;
+    padding-left: var(--wb-sizing-size_360);
     list-style-type: disc;
 }
 .framework-perseus .paragraph ol {
     list-style: decimal;
-    padding-left: 2em;
+    padding-left: var(--wb-sizing-size_320);
 }
 .framework-perseus blockquote {
-    padding: 0 2.5em;
+    padding: 0 var(--wb-sizing-size_400);
 }
 .framework-perseus .zoomable {
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
@@ -114,10 +110,10 @@ div.graphie {
     line-height: 0;
 }
 .framework-perseus .range-input {
-    border: 1px solid #ccc;
-    border-radius: 5px;
+    border: 1px solid var(--wb-semanticColor-core-border-neutral-subtle);
+    border-radius: var(--wb-border-radius-radius_040);
     display: inline-block;
-    padding: 0px 5px;
+    padding: 0px var(--wb-sizing-size_040);
 }
 .framework-perseus .range-input > input {
     border: 0;
@@ -126,38 +122,38 @@ div.graphie {
     width: 30px;
 }
 .framework-perseus .range-input > span {
-    color: #999;
+    color: var(--wb-semanticColor-core-foreground-neutral-subtle);
     font-size: 14px;
 }
 .framework-perseus .number-input {
-    border: 1px solid #909296;
-    border-radius: 5px;
+    border: var(--wb-border-width-thin) solid var(--wb-semanticColor-core-border-neutral-default);
+    border-radius: var(--wb-border-radius-radius_040);
     margin: 0;
-    padding: 5px 0;
+    padding: var(--wb-sizing-size_040) 0;
     text-align: center;
-    width: 40px;
+    width: var(--wb-sizing-size_400);
 }
 .framework-perseus .number-input.invalid-input {
-    background-color: #ffbaba;
-    outline-color: red;
+    background-color: var(--wb-semanticColor-core-background-critical-subtle);
+    outline-color: var(--wb-semanticColor-core-border-critical-default);
 }
 .framework-perseus .number-input.mini {
-    width: 40px;
+    width: var(--wb-sizing-size_400);
 }
 .framework-perseus .number-input.small {
-    width: 60px;
+    width: var(--wb-sizing-size_640);
 }
 .framework-perseus .number-input.normal {
-    width: 80px;
+    width: var(--wb-sizing-size_800);
 }
 .framework-perseus .graph-settings .graph-settings-axis-label {
-    border: 1px solid #ccc;
-    border-radius: 5px;
+    border: var(--wb-border-width-thin) solid var(--wb-semanticColor-core-border-neutral-subtle);
+    border-radius: var(--wb-border-radius-radius_040);
     display: inline-block;
-    padding: 5px 5px;
+    padding: var(--wb-sizing-size_040);
     width: 70px;
     float: right;
-    margin: 0 5px;
+    margin: 0 var(--wb-sizing-size_040);
 }
 .framework-perseus .graph-settings .graph-settings-background-url {
     width: 250px;
@@ -168,12 +164,12 @@ div.graphie {
 .framework-perseus .graph-settings,
 .framework-perseus .image-settings,
 .framework-perseus .misc-settings {
-    padding-bottom: 5px;
+    padding-bottom: var(--wb-sizing-size_040);
 }
 .framework-perseus .misc-settings,
 .framework-perseus .type-settings {
-    border-top: 1px solid black;
-    padding-top: 5px;
+    border-top: var(--wb-border-width-thin) solid var(--wb-semanticColor-core-border-neutral-strong);
+    padding-top: var(--wb-sizing-size_040);
 }
 .framework-perseus .svg-image {
     display: block;
@@ -216,7 +212,7 @@ div.graphie {
 }
 .framework-perseus:not(.perseus-mobile) table th,
 .framework-perseus:not(.perseus-mobile) table td {
-    padding: 5px 10px;
+    padding: var(--wb-sizing-size_060) var(--wb-sizing-size_100);
     text-align: left;
 }
 .framework-perseus:not(.perseus-mobile) table th[align="center"],
@@ -230,8 +226,8 @@ div.graphie {
 .framework-perseus:not(.perseus-mobile) table th {
     border-bottom: var(--wb-border-width-medium) solid
         var(--wb-semanticColor-core-border-neutral-subtle);
-    font-weight: bold;
-    padding-bottom: 2px;
+    font-weight: var(--wb-font-weight-bold);
+    padding-bottom: var(--wb-sizing-size_020);
 }
 .framework-perseus:not(.perseus-mobile) table tr:nth-child(odd) td {
     background-color: var(--wb-semanticColor-core-background-base-subtle);
@@ -278,7 +274,7 @@ div.graphie {
 }
 .framework-perseus.perseus-mobile table th,
 .framework-perseus.perseus-mobile table td {
-    padding: 16px;
+    padding: var(--wb-sizing-size_160);
     text-align: left;
 }
 .framework-perseus.perseus-mobile table th[align="center"],
@@ -313,6 +309,7 @@ div.graphie {
     font-size: larger;
 }
 /* Widget CSS */
+/* TODO(benchristel): .perseus-graph-padding seems to be unused. Remove? */
 .perseus-graph-padding {
     box-sizing: content-box;
     padding: 25px 25px 0 0;

--- a/packages/perseus/src/styles/perseus-renderer-part-1.css
+++ b/packages/perseus/src/styles/perseus-renderer-part-1.css
@@ -95,10 +95,10 @@ div.graphie {
 }
 .framework-perseus .paragraph ol {
     list-style: decimal;
-    padding-left: var(--wb-sizing-size_320);
+    padding-left: 2em;
 }
 .framework-perseus blockquote {
-    padding: 0 var(--wb-sizing-size_400);
+    padding: 0 2.5em;
 }
 .framework-perseus .zoomable {
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);

--- a/packages/perseus/src/styles/perseus-renderer-part-2.css
+++ b/packages/perseus/src/styles/perseus-renderer-part-2.css
@@ -1,7 +1,8 @@
 /* All perseus-widget-container styles moved to widget-container.css */
 
 .bibliotron-exercise .perseus-hint-renderer {
-    border-left: var(--wb-border-width-thick) solid var(--wb-semanticColor-core-border-neutral-subtle);
+    border-left: var(--wb-border-width-thick) solid
+        var(--wb-semanticColor-core-border-neutral-subtle);
     padding-left: var(--wb-sizing-size_160);
     position: relative;
 }
@@ -94,7 +95,8 @@
 }
 .perseus-error {
     background: var(--wb-semanticColor-core-background-critical-subtle);
-    border: var(--wb-border-width-medium) solid var(--wb-semanticColor-core-border-critical-default);
+    border: var(--wb-border-width-medium) solid
+        var(--wb-semanticColor-core-border-critical-default);
     border-radius: var(--wb-border-radius-radius_040);
     padding: var(--wb-sizing-size_200);
     margin: var(--wb-sizing-size_160) 0 var(--wb-sizing-size_100);

--- a/packages/perseus/src/styles/perseus-renderer-part-2.css
+++ b/packages/perseus/src/styles/perseus-renderer-part-2.css
@@ -1,8 +1,8 @@
 /* All perseus-widget-container styles moved to widget-container.css */
 
 .bibliotron-exercise .perseus-hint-renderer {
-    border-left: 4px solid var(--wb-semanticColor-core-border-neutral-subtle);
-    padding-left: 16px;
+    border-left: var(--wb-border-width-thick) solid var(--wb-semanticColor-core-border-neutral-subtle);
+    padding-left: var(--wb-sizing-size_160);
     position: relative;
 }
 .bibliotron-exercise .perseus-hint-renderer:focus {
@@ -17,10 +17,10 @@
 }
 .bibliotron-exercise .perseus-hint-renderer div.paragraph {
     margin-top: 0px;
-    margin-bottom: 16px;
+    margin-bottom: var(--wb-sizing-size_160);
 }
 .bibliotron-exercise .perseus-hint-renderer.last-hint {
-    margin-bottom: 32px;
+    margin-bottom: var(--wb-sizing-size_320);
 }
 @media (max-width: 767px) {
     .bibliotron-exercise .perseus-hint-renderer.last-hint {
@@ -30,8 +30,8 @@
 .perseus-hint-label {
     color: var(--wb-semanticColor-core-foreground-instructive-strong);
     display: none;
-    font-weight: 600;
-    margin-right: 13px;
+    font-weight: var(--wb-font-weight-bold);
+    margin-right: var(--wb-sizing-size_120);
     position: absolute;
     right: 100%;
     white-space: nowrap;
@@ -67,7 +67,7 @@
     box-shadow: unset;
 }
 .perseus-math-input.mq-editable-field.mq-math-mode > .mq-root-block {
-    padding: 4px;
+    padding: var(--wb-sizing-size_040);
 }
 .perseus-math-input.mq-editable-field.mq-math-mode .mq-cursor {
     padding-left: 0;
@@ -87,21 +87,21 @@
 .perseus-widget-editor
     .perseus-math-input.mq-editable-field.mq-math-mode
     > .mq-root-block {
-    border-radius: 0;
+    border-radius: var(--wb-border-radius-radius_0);
 }
 .renderer-widget-error {
-    background-color: #fcc;
+    background-color: var(--wb-semanticColor-core-background-critical-subtle);
 }
 .perseus-error {
-    background: #ffbaba;
-    border: 2px solid red;
-    border-radius: 5px;
-    padding: 20px;
-    margin: 15px 0 10px;
+    background: var(--wb-semanticColor-core-background-critical-subtle);
+    border: var(--wb-border-width-medium) solid var(--wb-semanticColor-core-border-critical-default);
+    border-radius: var(--wb-border-radius-radius_040);
+    padding: var(--wb-sizing-size_200);
+    margin: var(--wb-sizing-size_160) 0 var(--wb-sizing-size_100);
 }
 @media (max-width: 767px) {
     .perseus-renderer-responsive {
-        margin: 0 16px;
+        margin: 0 var(--wb-sizing-size_160);
     }
     .perseus-renderer-responsive .perseus-renderer-responsive {
         margin: 0;

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -112,9 +112,7 @@
     margin-bottom: var(--wb-sizing-size_320);
 }
 .framework-perseus.perseus-mobile .perseus-block-math {
-    -webkit-tap-highlight-color: var(
-        --wb-semanticColor-core-background-base-strong
-    );
+    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
     -webkit-touch-callout: none;
 }
 @media (max-width: 767px) {
@@ -255,7 +253,7 @@
     }
     .framework-perseus.perseus-mobile pre {
         background-color: var(
-            --wb-semanticColor-core-background-neutral-subtle
+            --wb-semanticColor-core-background-base-subtle
         );
         border-radius: var(--wb-border-radius-radius_040);
         color: var(--wb-semanticColor-core-foreground-neutral-strong);
@@ -333,7 +331,7 @@
     }
     .framework-perseus.perseus-mobile pre {
         background-color: var(
-            --wb-semanticColor-core-background-neutral-subtle
+            --wb-semanticColor-core-background-base-subtle
         );
         border-radius: var(--wb-border-radius-radius_040);
         color: var(--wb-semanticColor-core-foreground-neutral-strong);

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -383,7 +383,7 @@
         filter: invert(1) hue-rotate(180deg) brightness(1.5);
     }
 
-    .mathjax-wrapper {
+    .mathjax-wrapper > mjx-container {
         /* Since we invert all MathJax colors (above), we need to force the
            default foreground color to dark so it will be light when inverted.
            If we don't do this, then math will inherit the theme's foreground

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -2,9 +2,9 @@
     font-family: Courier, monospace;
 }
 .framework-perseus pre {
-    background-color: #f0f1f2;
-    border-radius: 4px;
-    color: #21242c;
+    background-color: var(--wb-semanticColor-core-background-base-subtle);
+    border-radius: var(--wb-border-radius-radius_040);
+    color: var(--wb-semanticColor-core-foreground-neutral-strong);
     font-size: 18px;
     padding: 16px;
     white-space: pre;
@@ -13,23 +13,23 @@
 .framework-perseus.perseus-article:not(.perseus-mobile) table {
     font-size: 20px;
     line-height: 30px;
-    margin-bottom: 32px;
+    margin-bottom: var(--wb-sizing-size_320);
 }
 .framework-perseus.perseus-article:not(.perseus-mobile) h2 {
     font-family: inherit;
     font-size: 30px;
-    font-weight: 700;
+    font-weight: var(--wb-font-weight-bold);
     line-height: 1.1;
-    margin-bottom: 16px;
-    margin-top: 48px;
+    margin-bottom: var(--wb-sizing-size_160);
+    margin-top: var(--wb-sizing-size_480);
 }
 .framework-perseus.perseus-article:not(.perseus-mobile) h3 {
     font-family: inherit;
     font-size: 26px;
     font-weight: 700;
     line-height: 1.1;
-    margin-bottom: 16px;
-    margin-top: 32px;
+    margin-bottom: var(--wb-sizing-size_160);
+    margin-top: var(--wb-sizing-size_320);
 }
 .framework-perseus.perseus-article:not(.perseus-mobile) h4,
 .framework-perseus.perseus-article:not(.perseus-mobile) h5,
@@ -38,11 +38,11 @@
     font-size: 22px;
     font-weight: 700;
     line-height: 25px;
-    margin-bottom: 16px;
-    margin-top: 32px;
+    margin-bottom: var(--wb-sizing-size_160);
+    margin-top: var(--wb-sizing-size_320);
 }
 .framework-perseus.perseus-article:not(.perseus-mobile) blockquote {
-    padding: 0 32px;
+    padding: 0 var(--wb-sizing-size_320);
 }
 .framework-perseus.perseus-article:not(.perseus-mobile) .MathJax .math {
     color: inherit;
@@ -53,7 +53,7 @@
     line-height: 19.6px;
 }
 .framework-perseus.perseus-article:not(.perseus-mobile) .perseus-block-math {
-    margin-bottom: 32px;
+    margin-bottom: var(--wb-sizing-size_320);
     position: relative;
 }
 .framework-perseus.perseus-article:not(.perseus-mobile)
@@ -63,14 +63,14 @@
     position: absolute;
     right: 0;
     top: 0;
-    width: 30px;
+    width: var(--wb-sizing-size_320);
 }
 .framework-perseus.perseus-article:not(.perseus-mobile)
     .perseus-block-math-inner {
     overflow-x: auto;
-    padding-bottom: 8px;
-    padding-right: 20px;
-    padding-top: 8px;
+    padding-bottom: var(--wb-sizing-size_080);
+    padding-right: var(--wb-sizing-size_200);
+    padding-top: var(--wb-sizing-size_080);
 }
 .framework-perseus.perseus-article:not(.perseus-mobile)
     > .clearfix:first-child
@@ -105,64 +105,66 @@
     margin-top: 0;
 }
 .framework-perseus.perseus-article:not(.perseus-mobile) pre {
-    margin: 0 -16px 32px -16px;
+    margin: 0 calc(-1 * var(--wb-sizing-size_160)) var(--wb-sizing-size_320)
+        calc(-1 * var(--wb-sizing-size_160));
 }
 .framework-perseus.perseus-mobile .clearfix > .perseus-renderer {
-    margin-bottom: 32px;
+    margin-bottom: var(--wb-sizing-size_320);
 }
 .framework-perseus.perseus-mobile .perseus-block-math {
-    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+    -webkit-tap-highlight-color: var(
+        --wb-semanticColor-core-background-base-strong
+    );
     -webkit-touch-callout: none;
 }
 @media (max-width: 767px) {
     .framework-perseus.perseus-mobile h1 {
-        font-weight: 700;
+        font-weight: var(--wb-font-weight-bold);
         padding-top: 0px;
         font-family: inherit;
         font-size: 24px;
         line-height: 1.2;
-        color: #21242c;
+        color: var(--wb-semanticColor-core-foreground-neutral-strong);
     }
     .framework-perseus.perseus-mobile h2 {
-        font-weight: 700;
-        padding-top: 16px;
+        font-weight: var(--wb-font-weight-bold);
+        padding-top: var(--wb-sizing-size_160);
         font-family: inherit;
         font-size: 24px;
         line-height: 1.2;
-        color: #3b3e40;
+        color: var(--wb-semanticColor-core-foreground-neutral-strong);
     }
     .framework-perseus.perseus-mobile h3,
     .framework-perseus.perseus-mobile h4 {
-        font-weight: 700;
+        font-weight: var(--wb-font-weight-bold);
         padding-top: 0px;
         font-family: inherit;
         font-size: 22px;
         line-height: 1.1;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile .default-body-text {
         font-family: inherit;
         font-size: 18px;
         line-height: 1.4;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile blockquote {
         font-family: inherit;
         font-size: 18px;
         line-height: 1.4;
-        color: #626569;
-        color: #888d93;
+        color: var(--wb-semanticColor-core-foreground-neutral-subtle);
     }
     .framework-perseus.perseus-mobile table {
         font-family: inherit;
         font-size: 18px;
         line-height: 1.4;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile mjx-container:not(.mafs-graph *) {
         font-size: 21px;
         line-height: 1.2;
-        color: #21242c;
+        color: var(--wb-semanticColor-core-foreground-neutral-strong);
     }
     .framework-perseus.perseus-mobile .perseus-block-math mjx-container {
         font-size: 21px;
@@ -176,69 +178,69 @@
         font-family: Courier, monospace;
     }
     .framework-perseus.perseus-mobile pre {
-        background-color: #f0f1f2;
-        border-radius: 4px;
-        color: #21242c;
+        background-color: var(--wb-semanticColor-core-background-base-subtle);
+        border-radius: var(--wb-border-radius-radius_040);
+        color: var(--wb-semanticColor-core-foreground-neutral-strong);
         font-size: 18px;
         line-height: 1.6;
-        padding: 16px;
+        padding: var(--wb-sizing-size_160);
         white-space: pre;
         overflow: auto;
     }
     .framework-perseus.perseus-mobile blockquote {
         padding: 0 0 0 18px;
-        border-left: 4px solid #d8d8d8;
+        border-left: var(--wb-border-width-thick) solid
+            var(--wb-semanticColor-core-border-neutral-subtle);
     }
 }
 @media (min-width: 767px) and (max-width: 1199px) {
     .framework-perseus.perseus-mobile h1 {
-        font-weight: 700;
+        font-weight: var(--wb-font-weight-bold);
         padding-top: 0px;
         font-family: inherit;
         font-size: 30px;
         line-height: 1.1;
-        color: #21242c;
+        color: var(--wb-semanticColor-core-foreground-neutral-strong);
     }
     .framework-perseus.perseus-mobile h2 {
-        font-weight: 700;
-        padding-top: 32px;
+        font-weight: var(--wb-font-weight-bold);
+        padding-top: var(--wb-sizing-size_320);
         font-family: inherit;
         font-size: 30px;
         line-height: 1.1;
-        color: #3b3e40;
+        color: var(--wb-semanticColor-core-foreground-neutral-strong);
     }
     .framework-perseus.perseus-mobile h3,
     .framework-perseus.perseus-mobile h4 {
-        font-weight: 700;
-        padding-top: 16px;
+        font-weight: var(--wb-font-weight-bold);
+        padding-top: var(--wb-sizing-size_160);
         font-family: inherit;
         font-size: 28px;
         line-height: 1.1;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile .default-body-text {
         font-family: inherit;
         font-size: 20px;
         line-height: 1.5;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile blockquote {
         font-family: inherit;
         font-size: 20px;
         line-height: 1.5;
-        color: #626569;
-        color: #888d93;
+        color: var(--wb-semanticColor-core-foreground-neutral-subtle);
     }
     .framework-perseus.perseus-mobile table {
         font-family: inherit;
         font-size: 20px;
         line-height: 1.5;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile mjx-container:not(.mafs-graph *) {
         font-size: 23px;
         line-height: 1.3;
-        color: #21242c;
+        color: var(--wb-semanticColor-core-foreground-neutral-strong);
     }
     .framework-perseus.perseus-mobile .perseus-block-math mjx-container {
         font-size: 30px;
@@ -252,69 +254,71 @@
         font-family: Courier, monospace;
     }
     .framework-perseus.perseus-mobile pre {
-        background-color: #f0f1f2;
-        border-radius: 4px;
-        color: #21242c;
+        background-color: var(
+            --wb-semanticColor-core-background-neutral-subtle
+        );
+        border-radius: var(--wb-border-radius-radius_040);
+        color: var(--wb-semanticColor-core-foreground-neutral-strong);
         font-size: 18px;
         line-height: 1.6;
-        padding: 16px;
+        padding: var(--wb-sizing-size_160);
         white-space: pre;
         overflow: auto;
     }
     .framework-perseus.perseus-mobile blockquote {
-        padding: 0 0 0 20px;
-        border-left: 4px solid #d8d8d8;
+        padding: 0 0 0 var(--wb-sizing-size_200);
+        border-left: var(--wb-border-width-thick) solid
+            var(--wb-semanticColor-core-border-neutral-subtle);
     }
 }
 @media (min-width: 1200px) {
     .framework-perseus.perseus-mobile h1 {
-        font-weight: 700;
+        font-weight: var(--wb-font-weight-bold);
         padding-top: 0px;
         font-family: inherit;
         font-size: 35px;
         line-height: 1.1;
-        color: #21242c;
+        color: var(--wb-semanticColor-core-foreground-neutral-strong);
     }
     .framework-perseus.perseus-mobile h2 {
-        font-weight: 700;
-        padding-top: 32px;
+        font-weight: var(--wb-font-weight-bold);
+        padding-top: var(--wb-sizing-size_320);
         font-family: inherit;
         font-size: 35px;
         line-height: 1.1;
-        color: #3b3e40;
+        color: var(--wb-semanticColor-core-foreground-neutral-strong);
     }
     .framework-perseus.perseus-mobile h3,
     .framework-perseus.perseus-mobile h4 {
-        font-weight: 700;
-        padding-top: 16px;
+        font-weight: var(--wb-font-weight-bold);
+        padding-top: var(--wb-sizing-size_160);
         font-family: inherit;
         font-size: 30px;
         line-height: 1.1;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile .default-body-text {
         font-family: inherit;
         font-size: 22px;
         line-height: 1.4;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile blockquote {
         font-family: inherit;
         font-size: 22px;
         line-height: 1.4;
-        color: #626569;
-        color: #888d93;
+        color: var(--wb-semanticColor-core-foreground-neutral-subtle);
     }
     .framework-perseus.perseus-mobile table {
         font-family: inherit;
         font-size: 22px;
         line-height: 1.4;
-        color: #626569;
+        color: var(--wb-semanticColor-core-foreground-neutral-default);
     }
     .framework-perseus.perseus-mobile mjx-container:not(.mafs-graph *) {
         font-size: 25px;
         line-height: 1.2;
-        color: #21242c;
+        color: var(--wb-semanticColor-core-foreground-neutral-strong);
     }
     .framework-perseus.perseus-mobile .perseus-block-math mjx-container {
         font-size: 30px;
@@ -328,18 +332,21 @@
         font-family: Courier, monospace;
     }
     .framework-perseus.perseus-mobile pre {
-        background-color: #f0f1f2;
-        border-radius: 4px;
-        color: #21242c;
+        background-color: var(
+            --wb-semanticColor-core-background-neutral-subtle
+        );
+        border-radius: var(--wb-border-radius-radius_040);
+        color: var(--wb-semanticColor-core-foreground-neutral-strong);
         font-size: 18px;
         line-height: 1.6;
-        padding: 16px;
+        padding: var(--wb-sizing-size_160);
         white-space: pre;
         overflow: auto;
     }
     .framework-perseus.perseus-mobile blockquote {
-        padding: 0 0 0 20px;
-        border-left: 5px solid #d8d8d8;
+        padding: 0 0 0 var(--wb-sizing-size_200);
+        border-left: var(--wb-border-width-thick) solid
+            var(--wb-semanticColor-core-border-neutral-subtle);
     }
 }
 .framework-perseus.perseus-mobile .MathJax .math {
@@ -349,8 +356,8 @@
     text-align: center;
 }
 .framework-perseus.perseus-mobile .perseus-block-math {
-    padding-top: 16px;
-    padding-bottom: 16px;
+    padding-top: var(--wb-sizing-size_160);
+    padding-bottom: var(--wb-sizing-size_160);
 }
 .framework-perseus.perseus-mobile .unresponsive-svg-image,
 .framework-perseus.perseus-mobile .svg-image {

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -252,9 +252,7 @@
         font-family: Courier, monospace;
     }
     .framework-perseus.perseus-mobile pre {
-        background-color: var(
-            --wb-semanticColor-core-background-base-subtle
-        );
+        background-color: var(--wb-semanticColor-core-background-base-subtle);
         border-radius: var(--wb-border-radius-radius_040);
         color: var(--wb-semanticColor-core-foreground-neutral-strong);
         font-size: 18px;
@@ -330,9 +328,7 @@
         font-family: Courier, monospace;
     }
     .framework-perseus.perseus-mobile pre {
-        background-color: var(
-            --wb-semanticColor-core-background-base-subtle
-        );
+        background-color: var(--wb-semanticColor-core-background-base-subtle);
         border-radius: var(--wb-border-radius-radius_040);
         color: var(--wb-semanticColor-core-foreground-neutral-strong);
         font-size: 18px;


### PR DESCRIPTION
## Summary:
This PR migrates article-related CSS files to use Wonder Blocks styling.  Font
sizes and line heights are intentionally *not* migrated yet. The largest
tokenized body font size is 16px, which is quite a bit smaller than the current
article body size of 20px. We're waiting for design and Wonder Blocks to add a
larger body font size.

Issue: LEMS-3504

## Test plan:

Review the visual regression stories for ArticleRenderer. Check that they look
good in SYL dark and light modes.