### PR TITLE
Update the `WidgetContainer` components to use `WidgetPropsV2`

### DIFF
--- a/.changeset/vast-wolves-joke.md
+++ b/.changeset/vast-wolves-joke.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Update the `WidgetContainer` components to use WidgetPropsV2

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -547,7 +547,7 @@ review and commit the changes.
 
 - [x] Remove the branch from both `getWidgetProps` methods (always emit the
       `options` shape) and delete the `MIGRATED_WIDGETS` module.
-- [ ] Simplify the `widget-container.tsx` subtype lookup to
+- [x] Simplify the `widget-container.tsx` subtype lookup to
       `getWidgetSubType(type, this.props.widgetProps.options)` and update the
       `widgetProps` prop type (and any lingering
       `WidgetProps<any, PerseusWidgetOptions>` annotations).

--- a/packages/perseus/src/__tests__/widget-container.new.test.tsx
+++ b/packages/perseus/src/__tests__/widget-container.new.test.tsx
@@ -6,27 +6,32 @@
 // TODO(LEMS-4304): feature flag cleanup - rename this file to widget-container.test.tsx.
 // This file is the new widget container test file that will replace the old container tests.
 
+import {linterContextDefault} from "@khanacademy/perseus-linter";
 import {render, screen} from "@testing-library/react";
 import * as React from "react";
 
 import * as Dependencies from "../dependencies";
+import {ApiOptions} from "../perseus-api";
 import {
     testDependencies,
     testDependenciesV2,
 } from "../testing/test-dependencies";
+import {containerSizeClass} from "../util/sizing-utils";
 import WidgetContainer from "../widget-container.new";
 import {registerWidget} from "../widgets";
 import Explanation from "../widgets/explanation";
 import Image from "../widgets/image";
 
-import type {PerseusDependenciesV2, WidgetExports} from "../types";
+import type {
+    PerseusDependenciesV2,
+    WidgetExports,
+    WidgetPropsV2,
+} from "../types";
 
 const MockWidgetComponent = ({
-    text,
-    fail = false,
+    options: {text, fail = false},
 }: {
-    text: string;
-    fail: boolean;
+    options: {text: string; fail: boolean};
 }) => {
     if (fail) {
         throw new Error("MockWidget failed to render");
@@ -41,6 +46,28 @@ const MockWidget: WidgetExports<typeof MockWidgetComponent> = {
     widget: MockWidgetComponent,
 };
 
+const getBaseProps = (
+    overrides?: Partial<WidgetPropsV2<any, any>>,
+): WidgetPropsV2<any, any> => ({
+    options: {},
+    trackInteraction: jest.fn(),
+    widgetId: "widget 1",
+    widgetIndex: 0,
+    alignment: null,
+    static: false,
+    problemNum: 0,
+    apiOptions: {...ApiOptions.defaults, isMobile: false},
+    onFocus: jest.fn(),
+    onBlur: jest.fn(),
+    findWidgets: () => [],
+    reviewMode: false,
+    handleUserInput: jest.fn(),
+    userInput: {},
+    linterContext: linterContextDefault,
+    containerSizeClass: containerSizeClass.MEDIUM,
+    ...overrides,
+});
+
 describe("widget-container", () => {
     it("should render nothing when requested widget not registered", () => {
         // Arrange
@@ -51,7 +78,7 @@ describe("widget-container", () => {
             <WidgetContainer
                 type="invalid-widget"
                 id="invalid-widget 1"
-                widgetProps={{apiOptions: {isMobile: false}}}
+                widgetProps={getBaseProps()}
             />,
         );
 
@@ -77,18 +104,14 @@ describe("widget-container", () => {
                 <WidgetContainer
                     type="explanation"
                     id="explanation 1"
-                    widgetProps={{
+                    widgetProps={getBaseProps({
                         options: {
                             showPrompt: "Explanation",
                             hidePrompt: "Hide explanation",
                             explanation: "This is an explanation",
                             widgets: {},
                         },
-
-                        findWidgets: () => [],
-
-                        apiOptions: {isMobile: false},
-                    }}
+                    })}
                 />
             </Dependencies.DependenciesContext.Provider>,
         );
@@ -109,7 +132,7 @@ describe("widget-container", () => {
 
         const renderContainer = (
             type: string,
-            widgetProps: Record<string, unknown>,
+            widgetProps: Partial<WidgetPropsV2<any, any>>,
         ) => {
             const {container} = render(
                 <Dependencies.DependenciesContext.Provider
@@ -118,11 +141,7 @@ describe("widget-container", () => {
                     <WidgetContainer
                         type={type}
                         id={`${type} 1`}
-                        widgetProps={{
-                            findWidgets: () => [],
-                            apiOptions: {isMobile: false},
-                            ...widgetProps,
-                        }}
+                        widgetProps={getBaseProps(widgetProps)}
                     />
                 </Dependencies.DependenciesContext.Provider>,
             );
@@ -134,8 +153,7 @@ describe("widget-container", () => {
         it("renders a <div> for a widget with no alignment specified", () => {
             // Arrange, Act
             const containerElement = renderContainer("mock-widget", {
-                text: "Hello world!",
-                fail: false,
+                options: {text: "Hello world!", fail: false},
             });
 
             // Assert
@@ -145,7 +163,7 @@ describe("widget-container", () => {
         it("renders a <div> for a block-aligned widget", () => {
             // Arrange, Act - the image widget's default alignment is "block".
             const containerElement = renderContainer("image", {
-                backgroundImage: {},
+                options: {backgroundImage: {}},
             });
 
             // Assert
@@ -155,10 +173,12 @@ describe("widget-container", () => {
         it("renders a <span> for an inline-aligned widget", () => {
             // Arrange, Act
             const containerElement = renderContainer("explanation", {
-                showPrompt: "Explanation",
-                hidePrompt: "Hide explanation",
-                explanation: "This is an explanation",
-                widgets: {},
+                options: {
+                    showPrompt: "Explanation",
+                    hidePrompt: "Hide explanation",
+                    explanation: "This is an explanation",
+                    widgets: {},
+                },
             });
 
             // Assert
@@ -169,10 +189,12 @@ describe("widget-container", () => {
             // Arrange, Act
             const containerElement = renderContainer("explanation", {
                 alignment: "default",
-                showPrompt: "Explanation",
-                hidePrompt: "Hide explanation",
-                explanation: "This is an explanation",
-                widgets: {},
+                options: {
+                    showPrompt: "Explanation",
+                    hidePrompt: "Hide explanation",
+                    explanation: "This is an explanation",
+                    widgets: {},
+                },
             });
 
             // Assert
@@ -183,10 +205,12 @@ describe("widget-container", () => {
             // Arrange, Act
             const containerElement = renderContainer("explanation", {
                 alignment: "block",
-                showPrompt: "Explanation",
-                hidePrompt: "Hide explanation",
-                explanation: "This is an explanation",
-                widgets: {},
+                options: {
+                    showPrompt: "Explanation",
+                    hidePrompt: "Hide explanation",
+                    explanation: "This is an explanation",
+                    widgets: {},
+                },
             });
 
             // Assert
@@ -218,14 +242,9 @@ describe("widget-container", () => {
                 <WidgetContainer
                     type="mock-widget"
                     id="mock-widget 1"
-                    widgetProps={{
-                        text: "Hello world!",
-                        fail: true,
-
-                        findWidgets: () => [],
-
-                        apiOptions: {isMobile: false},
-                    }}
+                    widgetProps={getBaseProps({
+                        options: {text: "Hello world!", fail: true},
+                    })}
                 />
             </Dependencies.DependenciesContext.Provider>,
         );

--- a/packages/perseus/src/__tests__/widget-container.new.test.tsx
+++ b/packages/perseus/src/__tests__/widget-container.new.test.tsx
@@ -47,21 +47,23 @@ const MockWidget: WidgetExports<typeof MockWidgetComponent> = {
 };
 
 const getBaseProps = (
+    // TODO(benchristel): Pass real type arguments here. Maybe getBaseProps can
+    //  be generic.
     overrides?: Partial<WidgetPropsV2<any, any>>,
 ): WidgetPropsV2<any, any> => ({
     options: {},
-    trackInteraction: jest.fn(),
+    trackInteraction: () => {},
     widgetId: "widget 1",
     widgetIndex: 0,
     alignment: null,
     static: false,
     problemNum: 0,
     apiOptions: {...ApiOptions.defaults, isMobile: false},
-    onFocus: jest.fn(),
-    onBlur: jest.fn(),
+    onFocus: () => {},
+    onBlur: () => {},
     findWidgets: () => [],
     reviewMode: false,
-    handleUserInput: jest.fn(),
+    handleUserInput: () => {},
     userInput: {},
     linterContext: linterContextDefault,
     containerSizeClass: containerSizeClass.MEDIUM,

--- a/packages/perseus/src/__tests__/widget-container.old.test.tsx
+++ b/packages/perseus/src/__tests__/widget-container.old.test.tsx
@@ -46,21 +46,23 @@ const MockWidget: WidgetExports<typeof MockWidgetComponent> = {
 };
 
 const getBaseProps = (
+    // TODO(benchristel): Pass real type arguments here. Maybe getBaseProps can
+    //  be generic.
     overrides?: Partial<WidgetPropsV2<any, any>>,
 ): WidgetPropsV2<any, any> => ({
     options: {},
-    trackInteraction: jest.fn(),
+    trackInteraction: () => {},
     widgetId: "widget 1",
     widgetIndex: 0,
     alignment: null,
     static: false,
     problemNum: 0,
     apiOptions: {...ApiOptions.defaults, isMobile: false},
-    onFocus: jest.fn(),
-    onBlur: jest.fn(),
+    onFocus: () => {},
+    onBlur: () => {},
     findWidgets: () => [],
     reviewMode: false,
-    handleUserInput: jest.fn(),
+    handleUserInput: () => {},
     userInput: {},
     linterContext: linterContextDefault,
     containerSizeClass: containerSizeClass.MEDIUM,
@@ -117,43 +119,6 @@ describe("widget-container", () => {
 
         // Assert - widget renders button
         expect(screen.getByText("Explanation")).toBeInTheDocument();
-    });
-
-    it("adds no alignment class when the widget has no alignment", () => {
-        // Arrange
-        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
-            testDependencies,
-        );
-
-        registerWidget("explanation", Explanation);
-
-        // Act
-        const {container} = render(
-            <Dependencies.DependenciesContext.Provider
-                value={testDependenciesV2}
-            >
-                <WidgetContainer
-                    type="explanation"
-                    id="explanation 1"
-                    widgetProps={getBaseProps({
-                        alignment: null,
-                        options: {
-                            showPrompt: "Explanation",
-                            hidePrompt: "Hide explanation",
-                            explanation: "This is an explanation",
-                            widgets: {},
-                        },
-                    })}
-                />
-            </Dependencies.DependenciesContext.Provider>,
-        );
-
-        // Assert
-        // eslint-disable-next-line testing-library/no-container,testing-library/no-node-access
-        const containerElement = container.querySelector(
-            ".perseus-widget-container",
-        );
-        expect(containerElement?.className).toBe("perseus-widget-container");
     });
 
     it("should send analytics even when widget rendering errors", () => {

--- a/packages/perseus/src/__tests__/widget-container.old.test.tsx
+++ b/packages/perseus/src/__tests__/widget-container.old.test.tsx
@@ -6,26 +6,31 @@
 // TODO(LEMS-4304): feature flag cleanup - remove this file
 // This file is the original widget-container test file that is being replaced by the new test file.
 
+import {linterContextDefault} from "@khanacademy/perseus-linter";
 import {render, screen} from "@testing-library/react";
 import * as React from "react";
 
 import * as Dependencies from "../dependencies";
+import {ApiOptions} from "../perseus-api";
 import {
     testDependencies,
     testDependenciesV2,
 } from "../testing/test-dependencies";
+import {containerSizeClass} from "../util/sizing-utils";
 import WidgetContainer from "../widget-container.old";
 import {registerWidget} from "../widgets";
 import Explanation from "../widgets/explanation";
 
-import type {PerseusDependenciesV2, WidgetExports} from "../types";
+import type {
+    PerseusDependenciesV2,
+    WidgetExports,
+    WidgetPropsV2,
+} from "../types";
 
 const MockWidgetComponent = ({
-    text,
-    fail = false,
+    options: {text, fail = false},
 }: {
-    text: string;
-    fail: boolean;
+    options: {text: string; fail: boolean};
 }) => {
     if (fail) {
         throw new Error("MockWidget failed to render");
@@ -40,6 +45,28 @@ const MockWidget: WidgetExports<typeof MockWidgetComponent> = {
     widget: MockWidgetComponent,
 };
 
+const getBaseProps = (
+    overrides?: Partial<WidgetPropsV2<any, any>>,
+): WidgetPropsV2<any, any> => ({
+    options: {},
+    trackInteraction: jest.fn(),
+    widgetId: "widget 1",
+    widgetIndex: 0,
+    alignment: null,
+    static: false,
+    problemNum: 0,
+    apiOptions: {...ApiOptions.defaults, isMobile: false},
+    onFocus: jest.fn(),
+    onBlur: jest.fn(),
+    findWidgets: () => [],
+    reviewMode: false,
+    handleUserInput: jest.fn(),
+    userInput: {},
+    linterContext: linterContextDefault,
+    containerSizeClass: containerSizeClass.MEDIUM,
+    ...overrides,
+});
+
 describe("widget-container", () => {
     it("should render nothing when requested widget not registered", () => {
         // Arrange
@@ -50,7 +77,7 @@ describe("widget-container", () => {
             <WidgetContainer
                 type="invalid-widget"
                 id="invalid-widget 1"
-                widgetProps={{apiOptions: {isMobile: false}}}
+                widgetProps={getBaseProps()}
             />,
         );
 
@@ -76,24 +103,57 @@ describe("widget-container", () => {
                 <WidgetContainer
                     type="explanation"
                     id="explanation 1"
-                    widgetProps={{
+                    widgetProps={getBaseProps({
                         options: {
                             showPrompt: "Explanation",
                             hidePrompt: "Hide explanation",
                             explanation: "This is an explanation",
                             widgets: {},
                         },
-
-                        findWidgets: () => [],
-
-                        apiOptions: {isMobile: false},
-                    }}
+                    })}
                 />
             </Dependencies.DependenciesContext.Provider>,
         );
 
         // Assert - widget renders button
         expect(screen.getByText("Explanation")).toBeInTheDocument();
+    });
+
+    it("adds no alignment class when the widget has no alignment", () => {
+        // Arrange
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+
+        registerWidget("explanation", Explanation);
+
+        // Act
+        const {container} = render(
+            <Dependencies.DependenciesContext.Provider
+                value={testDependenciesV2}
+            >
+                <WidgetContainer
+                    type="explanation"
+                    id="explanation 1"
+                    widgetProps={getBaseProps({
+                        alignment: null,
+                        options: {
+                            showPrompt: "Explanation",
+                            hidePrompt: "Hide explanation",
+                            explanation: "This is an explanation",
+                            widgets: {},
+                        },
+                    })}
+                />
+            </Dependencies.DependenciesContext.Provider>,
+        );
+
+        // Assert
+        // eslint-disable-next-line testing-library/no-container,testing-library/no-node-access
+        const containerElement = container.querySelector(
+            ".perseus-widget-container",
+        );
+        expect(containerElement?.className).toBe("perseus-widget-container");
     });
 
     it("should send analytics even when widget rendering errors", () => {
@@ -120,14 +180,9 @@ describe("widget-container", () => {
                 <WidgetContainer
                     type="mock-widget"
                     id="mock-widget 1"
-                    widgetProps={{
-                        text: "Hello world!",
-                        fail: true,
-
-                        findWidgets: () => [],
-
-                        apiOptions: {isMobile: false},
-                    }}
+                    widgetProps={getBaseProps({
+                        options: {text: "Hello world!", fail: true},
+                    })}
                 />
             </Dependencies.DependenciesContext.Provider>,
         );

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -454,20 +454,6 @@ export type FilterCriterion =
       ) => boolean);
 
 /**
- * The full set of props provided to all widgets when they are rendered. The
- * `TWidgetOptions` generic argument are the widget-specific props that originate
- * from the PerseusItem.
- */
-// TODO(LEMS-4354): clean this up post-migration.
-export type WidgetProps<
-    TWidgetOptions,
-    TUserInput = Empty,
-    // Defines the arguments that can be passed to the `trackInteraction`
-    // function from APIOptions for this widget.
-    TrackingExtraArgs = Empty,
-> = TWidgetOptions & UniversalWidgetProps<TUserInput, TrackingExtraArgs>;
-
-/**
  * The full set of props provided to a widget whose widget-specific options are
  * nested under a single `options` prop, rather than spread into the top level
  * of props alongside the universal props.

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -2,6 +2,7 @@ import type {ILogger} from "./logging/log";
 import type {SizeClass} from "./util/sizing-utils";
 import type {WidgetPromptJSON} from "./widget-ai-utils/prompt-types";
 import type {
+    Alignment,
     Hint,
     PerseusAnswerArea,
     PerseusFeatureFlags,
@@ -502,7 +503,7 @@ export type UniversalWidgetProps<
     // provided by renderer.jsx#getWidgetProps()
     widgetId: string;
     widgetIndex: number;
-    alignment: string | null | undefined;
+    alignment: Alignment | null | undefined;
     static: boolean | null | undefined;
     graded?: boolean | null;
     problemNum: number | null | undefined;

--- a/packages/perseus/src/widget-container.new.tsx
+++ b/packages/perseus/src/widget-container.new.tsx
@@ -6,10 +6,7 @@
 // TODO(LEMS-4304): feature flag cleanup - rename this file to widget-container.tsx.
 // This file is the new widget container that will replace the old container.
 
-import {
-    CoreWidgetRegistry,
-    type PerseusWidgetOptions,
-} from "@khanacademy/perseus-core";
+import {CoreWidgetRegistry} from "@khanacademy/perseus-core";
 import classNames from "classnames";
 import * as React from "react";
 import ReactDOM from "react-dom";
@@ -25,8 +22,9 @@ import type {WidgetProps} from "./types";
 type Props = {
     type: string; // widget type/name,
     id: string; // widget id
+    // TODO(benchristel): Pass real type arguments here.
     // TODO(LEMS-4354): change to WidgetPropsV2
-    widgetProps: WidgetProps<any, PerseusWidgetOptions>;
+    widgetProps: WidgetProps<any, any>;
 };
 
 type State = {

--- a/packages/perseus/src/widget-container.new.tsx
+++ b/packages/perseus/src/widget-container.new.tsx
@@ -17,14 +17,13 @@ import {containerSizeClass, getClassFromWidth} from "./util/sizing-utils";
 import {getWidgetSubType} from "./widget-type-utils";
 import * as Widgets from "./widgets";
 
-import type {WidgetProps} from "./types";
+import type {WidgetPropsV2} from "./types";
 
 type Props = {
     type: string; // widget type/name,
     id: string; // widget id
     // TODO(benchristel): Pass real type arguments here.
-    // TODO(LEMS-4354): change to WidgetPropsV2
-    widgetProps: WidgetProps<any, any>;
+    widgetProps: WidgetPropsV2<any, any>;
 };
 
 type State = {
@@ -90,15 +89,8 @@ class WidgetContainer extends React.Component<Props, State> {
             return <div className={className} />;
         }
 
-        // During the WidgetProps redesign, a migrated widget nests its options
-        // under `widgetProps.options`; an un-migrated widget spreads them into
-        // the top level of `widgetProps`. Read from whichever shape applies.
-        // TODO(LEMS-4354): clean this up post-migration.
         const subType =
-            getWidgetSubType(
-                type,
-                this.props.widgetProps.options ?? this.props.widgetProps,
-            ) ?? "null";
+            getWidgetSubType(type, this.props.widgetProps.options) ?? "null";
 
         let alignment = this.props.widgetProps.alignment;
         if (alignment == null || alignment === "default") {

--- a/packages/perseus/src/widget-container.old.tsx
+++ b/packages/perseus/src/widget-container.old.tsx
@@ -93,17 +93,12 @@ class WidgetContainerOld extends React.Component<Props, State> {
             getWidgetSubType(type, this.props.widgetProps.options) ?? "null";
 
         let alignment = this.props.widgetProps.alignment;
-        if (alignment === "default") {
+        if (alignment == null || alignment === "default") {
             alignment = CoreWidgetRegistry.getDefaultAlignment(type);
         }
 
         // This will set the WidgetContainer's alignment
-        if (alignment != null) {
-            className += CoreWidgetRegistry.getAlignmentClassName(
-                type,
-                alignment,
-            );
-        }
+        className += CoreWidgetRegistry.getAlignmentClassName(type, alignment);
 
         const apiOptions = this.props.widgetProps.apiOptions;
 

--- a/packages/perseus/src/widget-container.old.tsx
+++ b/packages/perseus/src/widget-container.old.tsx
@@ -6,10 +6,7 @@
 // TODO(LEMS-4304): feature flag cleanup - remove this file
 // This file is the original file that is being replaced by the new widget-container.
 
-import {
-    CoreWidgetRegistry,
-    type PerseusWidgetOptions,
-} from "@khanacademy/perseus-core";
+import {CoreWidgetRegistry} from "@khanacademy/perseus-core";
 import classNames from "classnames";
 import * as React from "react";
 import ReactDOM from "react-dom";
@@ -25,8 +22,9 @@ import type {WidgetProps} from "./types";
 type Props = {
     type: string; // widget type/name,
     id: string; // widget id
+    // TODO(benchristel): Pass real type arguments here.
     // TODO(LEMS-4354): change to WidgetPropsV2
-    widgetProps: WidgetProps<any, PerseusWidgetOptions>;
+    widgetProps: WidgetProps<any, any>;
 };
 
 type State = {

--- a/packages/perseus/src/widget-container.old.tsx
+++ b/packages/perseus/src/widget-container.old.tsx
@@ -17,14 +17,13 @@ import {containerSizeClass, getClassFromWidth} from "./util/sizing-utils";
 import {getWidgetSubType} from "./widget-type-utils";
 import * as Widgets from "./widgets";
 
-import type {WidgetProps} from "./types";
+import type {WidgetPropsV2} from "./types";
 
 type Props = {
     type: string; // widget type/name,
     id: string; // widget id
     // TODO(benchristel): Pass real type arguments here.
-    // TODO(LEMS-4354): change to WidgetPropsV2
-    widgetProps: WidgetProps<any, any>;
+    widgetProps: WidgetPropsV2<any, any>;
 };
 
 type State = {
@@ -90,15 +89,8 @@ class WidgetContainerOld extends React.Component<Props, State> {
             return <div className={className} />;
         }
 
-        // During the WidgetProps redesign, a migrated widget nests its options
-        // under `widgetProps.options`; an un-migrated widget spreads them into
-        // the top level of `widgetProps`. Read from whichever shape applies.
-        // TODO(LEMS-4354): clean this up post-migration.
         const subType =
-            getWidgetSubType(
-                type,
-                this.props.widgetProps.options ?? this.props.widgetProps,
-            ) ?? "null";
+            getWidgetSubType(type, this.props.widgetProps.options) ?? "null";
 
         let alignment = this.props.widgetProps.alignment;
         if (alignment === "default") {
@@ -106,7 +98,12 @@ class WidgetContainerOld extends React.Component<Props, State> {
         }
 
         // This will set the WidgetContainer's alignment
-        className += CoreWidgetRegistry.getAlignmentClassName(type, alignment);
+        if (alignment != null) {
+            className += CoreWidgetRegistry.getAlignmentClassName(
+                type,
+                alignment,
+            );
+        }
 
         const apiOptions = this.props.widgetProps.apiOptions;
 


### PR DESCRIPTION
## Summary:
This is the final stage of work for the linked ticket. We're switching over to
WidgetPropsV2 everywhere, in preparation for removing the old WidgetProps.

Issue: LEMS-4354

## Test plan:

CI checks should pass.