### PR TITLE
Rename WidgetPropsV2 to WidgetProps; inline UniversalWidgetProps

### DIFF
--- a/.changeset/tall-owls-smile.md
+++ b/.changeset/tall-owls-smile.md
@@ -3,6 +3,4 @@
 "@khanacademy/perseus-editor": patch
 ---
 
-Internal: Finish the WidgetProps redesign. `WidgetPropsV2` is now `WidgetProps`; the old
-spread shape and `UniversalWidgetProps` are gone. Widget options arrive under a single
-`options` prop instead of being spread alongside the universal props.
+Internal: `WidgetPropsV2` has been renamed to `WidgetProps`, and `UniversalWidgetProps` has been inlined into `WidgetProps`.

--- a/.changeset/tall-owls-smile.md
+++ b/.changeset/tall-owls-smile.md
@@ -1,0 +1,8 @@
+---
+"@khanacademy/perseus": patch
+"@khanacademy/perseus-editor": patch
+---
+
+Internal: Finish the WidgetProps redesign. `WidgetPropsV2` is now `WidgetProps`; the old
+spread shape and `UniversalWidgetProps` are gone. Widget options arrive under a single
+`options` prop instead of being spread alongside the universal props.

--- a/.fixie/goal.md
+++ b/.fixie/goal.md
@@ -551,7 +551,7 @@ review and commit the changes.
       `getWidgetSubType(type, this.props.widgetProps.options)` and update the
       `widgetProps` prop type (and any lingering
       `WidgetProps<any, PerseusWidgetOptions>` annotations).
-- [ ] Rename `WidgetPropsV2` → `WidgetProps` across the repo; delete the old
+- [x] Rename `WidgetPropsV2` → `WidgetProps` across the repo; delete the old
       spread `WidgetProps` and `UniversalWidgetProps` (inlining its members into
       `WidgetProps`); restore the real return type on both `getWidgetProps`
       methods.

--- a/__docs__/introduction.mdx
+++ b/__docs__/introduction.mdx
@@ -208,10 +208,10 @@ The code strives to use the following conventions to shape the various concepts 
     {`
 | Type | Description |
 | ---- | ----------- |
-| \`WidgetProps\<T\>\` | All widgets receive a common set of props from the parent \`Renderer\` component This set of props is defined by the \`WidgetProps\<T\>\` type (\`T\` being the specific render props the widget uses). |
+| \`WidgetProps\<T\>\` | All widgets receive a common set of props from the parent \`Renderer\` component This set of props is defined by the \`WidgetProps\<T\>\` type (\`T\` being the type of the widget's own options, which arrive under the \`options\` prop). |
 | External Props | In a few rare cases, this type is defined as the sum of specific WidgetOptions wrapped in the shared \`WidgetOptions\`. |
 | Scoring Data | This type defines the data that the scoring function needs in order to score the learner's guess (aka user input). |
-| \`Props\` | This form the entire set of props that widget's component supports. Typically, it is defined as \`type Props = WidgetProps<WidgetOptions, Rubric>\`. In cases where there are \`WidgetOptions\` that are optional that are provided via \`DefaultProps\`, this \`Props\` type "redefines" these props as \`myProp: NonNullable<ExternalProps["myProps"]>;\`. |
+| \`Props\` | This form the entire set of props that widget's component supports. Typically, it is defined as \`type Props = WidgetProps<WidgetOptions, Rubric>\`. In cases where there are \`WidgetOptions\` that are optional that are provided via \`DefaultProps\`, this \`Props\` type "redefines" these props as \`myProp: NonNullable<ExternalProps["options"]["myProp"]>;\`. |
     `}
 </Markdown>
 

--- a/__docs__/introduction.mdx
+++ b/__docs__/introduction.mdx
@@ -201,19 +201,7 @@ Each widget defines its set of options through an options type (always defined i
 
 ### React Types
 
-Each widget is implemented as a React component. As is common with React, the component receives data via render props.
-The code strives to use the following conventions to shape the various concepts of props.
-
-<Markdown>
-    {`
-| Type | Description |
-| ---- | ----------- |
-| \`WidgetProps\<T\>\` | All widgets receive a common set of props from the parent \`Renderer\` component This set of props is defined by the \`WidgetProps\<T\>\` type (\`T\` being the type of the widget's own options, which arrive under the \`options\` prop). |
-| External Props | In a few rare cases, this type is defined as the sum of specific WidgetOptions wrapped in the shared \`WidgetOptions\`. |
-| Scoring Data | This type defines the data that the scoring function needs in order to score the learner's guess (aka user input). |
-| \`Props\` | This forms the entire set of props that widget's component supports. Typically, it is defined as \`type Props = WidgetProps<WidgetOptions, Rubric>\`. |
-    `}
-</Markdown>
+Each widget is implemented as a React component. Each widget's `Props` type is derived from `WidgetProps<T>`, where `T` is the type of the widget's `options` in the Perseus JSON.
 
 ## Content Editing
 

--- a/__docs__/introduction.mdx
+++ b/__docs__/introduction.mdx
@@ -211,7 +211,7 @@ The code strives to use the following conventions to shape the various concepts 
 | \`WidgetProps\<T\>\` | All widgets receive a common set of props from the parent \`Renderer\` component This set of props is defined by the \`WidgetProps\<T\>\` type (\`T\` being the type of the widget's own options, which arrive under the \`options\` prop). |
 | External Props | In a few rare cases, this type is defined as the sum of specific WidgetOptions wrapped in the shared \`WidgetOptions\`. |
 | Scoring Data | This type defines the data that the scoring function needs in order to score the learner's guess (aka user input). |
-| \`Props\` | This form the entire set of props that widget's component supports. Typically, it is defined as \`type Props = WidgetProps<WidgetOptions, Rubric>\`. In cases where there are \`WidgetOptions\` that are optional that are provided via \`DefaultProps\`, this \`Props\` type "redefines" these props as \`myProp: NonNullable<ExternalProps["options"]["myProp"]>;\`. |
+| \`Props\` | This forms the entire set of props that widget's component supports. Typically, it is defined as \`type Props = WidgetProps<WidgetOptions, Rubric>\`. |
     `}
 </Markdown>
 

--- a/packages/perseus-editor/src/widgets/expression-editor/expression-editor.tsx
+++ b/packages/perseus-editor/src/widgets/expression-editor/expression-editor.tsx
@@ -307,8 +307,6 @@ class ExpressionEditor extends React.Component<Props, State> {
                         answerForms: this.props.answerForms,
                     },
                     userInput: ans.value,
-                    // TODO: UniversalWidgetProps should have a generic type arg
-                    // to help scope what user input a widget consumes
                     handleUserInput: (input: PerseusExpressionUserInput) =>
                         this.changeExpressionWidget(index, input),
                     trackInteraction: () => {},

--- a/packages/perseus/src/__tests__/widget-container.new.test.tsx
+++ b/packages/perseus/src/__tests__/widget-container.new.test.tsx
@@ -22,11 +22,7 @@ import {registerWidget} from "../widgets";
 import Explanation from "../widgets/explanation";
 import Image from "../widgets/image";
 
-import type {
-    PerseusDependenciesV2,
-    WidgetExports,
-    WidgetPropsV2,
-} from "../types";
+import type {PerseusDependenciesV2, WidgetExports, WidgetProps} from "../types";
 
 const MockWidgetComponent = ({
     options: {text, fail = false},
@@ -49,8 +45,8 @@ const MockWidget: WidgetExports<typeof MockWidgetComponent> = {
 const getBaseProps = (
     // TODO(benchristel): Pass real type arguments here. Maybe getBaseProps can
     //  be generic.
-    overrides?: Partial<WidgetPropsV2<any, any>>,
-): WidgetPropsV2<any, any> => ({
+    overrides?: Partial<WidgetProps<any, any>>,
+): WidgetProps<any, any> => ({
     options: {},
     trackInteraction: () => {},
     widgetId: "widget 1",
@@ -134,7 +130,7 @@ describe("widget-container", () => {
 
         const renderContainer = (
             type: string,
-            widgetProps: Partial<WidgetPropsV2<any, any>>,
+            widgetProps: Partial<WidgetProps<any, any>>,
         ) => {
             const {container} = render(
                 <Dependencies.DependenciesContext.Provider

--- a/packages/perseus/src/__tests__/widget-container.old.test.tsx
+++ b/packages/perseus/src/__tests__/widget-container.old.test.tsx
@@ -21,11 +21,7 @@ import WidgetContainer from "../widget-container.old";
 import {registerWidget} from "../widgets";
 import Explanation from "../widgets/explanation";
 
-import type {
-    PerseusDependenciesV2,
-    WidgetExports,
-    WidgetPropsV2,
-} from "../types";
+import type {PerseusDependenciesV2, WidgetExports, WidgetProps} from "../types";
 
 const MockWidgetComponent = ({
     options: {text, fail = false},
@@ -48,8 +44,8 @@ const MockWidget: WidgetExports<typeof MockWidgetComponent> = {
 const getBaseProps = (
     // TODO(benchristel): Pass real type arguments here. Maybe getBaseProps can
     //  be generic.
-    overrides?: Partial<WidgetPropsV2<any, any>>,
-): WidgetPropsV2<any, any> => ({
+    overrides?: Partial<WidgetProps<any, any>>,
+): WidgetProps<any, any> => ({
     options: {},
     trackInteraction: () => {},
     widgetId: "widget 1",

--- a/packages/perseus/src/renderer.new.tsx
+++ b/packages/perseus/src/renderer.new.tsx
@@ -9,11 +9,11 @@
 /* eslint-disable max-lines */
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
 import {
-    Errors,
-    PerseusError,
     applyDefaultsToWidgets,
+    Errors,
     getDefaultAnswerArea,
     mapObject,
+    PerseusError,
     splitPerseusItem,
 } from "@khanacademy/perseus-core";
 import * as PerseusLinter from "@khanacademy/perseus-linter";
@@ -41,7 +41,7 @@ import InteractionTracker from "./interaction-tracker";
 import JiptParagraphs from "./jipt-paragraphs";
 import {Log} from "./logging/log";
 import {excludeDenylistKeys} from "./mixins/widget-prop-denylist";
-import {ClassNames as ApiClassNames, ApiOptions} from "./perseus-api";
+import {ApiOptions, ClassNames as ApiClassNames} from "./perseus-api";
 import PerseusMarkdown from "./perseus-markdown.new";
 import QuestionParagraph from "./question-paragraph.new";
 import TranslationLinter from "./translation-linter";
@@ -72,15 +72,15 @@ import type {
 } from "./widget-ai-utils/prompt-types";
 import type {KeypadAPI} from "@khanacademy/math-input";
 import type {
+    PerseusItem,
     PerseusRenderer,
+    PerseusScore,
     PerseusWidget,
     PerseusWidgetOptions,
     PerseusWidgetsMap,
     ShowSolutions,
-    PerseusScore,
-    UserInputMap,
     UserInput,
-    PerseusItem,
+    UserInputMap,
 } from "@khanacademy/perseus-core";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
@@ -549,7 +549,8 @@ class Renderer
                 );
         }
 
-        const universalProps = {
+        return {
+            options: widgetOptions,
             userInput: this.props.userInput?.[widgetId],
             widgetId: widgetId,
             widgetIndex: this._getWidgetIndexById(widgetId),
@@ -593,8 +594,6 @@ class Renderer
             },
             trackInteraction: interactionTracker.track,
         };
-
-        return {options: widgetOptions, ...universalProps};
     }
 
     /**

--- a/packages/perseus/src/renderer.new.tsx
+++ b/packages/perseus/src/renderer.new.tsx
@@ -59,8 +59,8 @@ import type {
     FilterCriterion,
     FindWidgetsFunction,
     FocusPath,
-    UniversalWidgetProps,
     Widget,
+    WidgetProps,
 } from "./types";
 import type {
     HandleUserInputCallback,
@@ -74,6 +74,7 @@ import type {KeypadAPI} from "@khanacademy/math-input";
 import type {
     PerseusRenderer,
     PerseusWidget,
+    PerseusWidgetOptions,
     PerseusWidgetsMap,
     ShowSolutions,
     PerseusScore,
@@ -521,8 +522,9 @@ class Renderer
         return widgetIndex;
     }
 
-    // TODO(LEMS-4354): add return type post-migration.
-    getWidgetProps(widgetId: string): any {
+    getWidgetProps(
+        widgetId: string,
+    ): WidgetProps<PerseusWidgetOptions, UserInput> {
         const apiOptions = this.getApiOptions();
         const widgetOptions = this.props.widgets[widgetId].options;
 
@@ -547,7 +549,7 @@ class Renderer
                 );
         }
 
-        const universalProps: UniversalWidgetProps = {
+        const universalProps = {
             userInput: this.props.userInput?.[widgetId],
             widgetId: widgetId,
             widgetIndex: this._getWidgetIndexById(widgetId),

--- a/packages/perseus/src/renderer.old.tsx
+++ b/packages/perseus/src/renderer.old.tsx
@@ -9,11 +9,11 @@
 /* eslint-disable max-lines */
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
 import {
-    Errors,
-    PerseusError,
     applyDefaultsToWidgets,
+    Errors,
     getDefaultAnswerArea,
     mapObject,
+    PerseusError,
     splitPerseusItem,
 } from "@khanacademy/perseus-core";
 import * as PerseusLinter from "@khanacademy/perseus-linter";
@@ -41,7 +41,7 @@ import InteractionTracker from "./interaction-tracker";
 import JiptParagraphs from "./jipt-paragraphs";
 import {Log} from "./logging/log";
 import {excludeDenylistKeys} from "./mixins/widget-prop-denylist";
-import {ClassNames as ApiClassNames, ApiOptions} from "./perseus-api";
+import {ApiOptions, ClassNames as ApiClassNames} from "./perseus-api";
 import PerseusMarkdown from "./perseus-markdown";
 import QuestionParagraph from "./question-paragraph";
 import TranslationLinter from "./translation-linter";
@@ -72,15 +72,15 @@ import type {
 } from "./widget-ai-utils/prompt-types";
 import type {KeypadAPI} from "@khanacademy/math-input";
 import type {
+    PerseusItem,
     PerseusRenderer,
+    PerseusScore,
     PerseusWidget,
     PerseusWidgetOptions,
     PerseusWidgetsMap,
     ShowSolutions,
-    PerseusScore,
-    UserInputMap,
     UserInput,
-    PerseusItem,
+    UserInputMap,
 } from "@khanacademy/perseus-core";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
 
@@ -541,7 +541,8 @@ class Renderer
                 );
         }
 
-        const universalProps = {
+        return {
+            options: widgetOptions,
             userInput: this.props.userInput?.[widgetId],
             widgetId: widgetId,
             widgetIndex: this._getWidgetIndexById(widgetId),
@@ -585,8 +586,6 @@ class Renderer
             },
             trackInteraction: interactionTracker.track,
         };
-
-        return {options: widgetOptions, ...universalProps};
     }
 
     /**

--- a/packages/perseus/src/renderer.old.tsx
+++ b/packages/perseus/src/renderer.old.tsx
@@ -59,8 +59,8 @@ import type {
     FilterCriterion,
     FindWidgetsFunction,
     FocusPath,
-    UniversalWidgetProps,
     Widget,
+    WidgetProps,
 } from "./types";
 import type {
     HandleUserInputCallback,
@@ -74,6 +74,7 @@ import type {KeypadAPI} from "@khanacademy/math-input";
 import type {
     PerseusRenderer,
     PerseusWidget,
+    PerseusWidgetOptions,
     PerseusWidgetsMap,
     ShowSolutions,
     PerseusScore,
@@ -513,8 +514,9 @@ class Renderer
         return widgetIndex;
     }
 
-    // TODO(LEMS-4354): add return type post-migration.
-    getWidgetProps(widgetId: string): any {
+    getWidgetProps(
+        widgetId: string,
+    ): WidgetProps<PerseusWidgetOptions, UserInput> {
         const apiOptions = this.getApiOptions();
         const widgetOptions = this.props.widgets[widgetId].options;
 
@@ -539,7 +541,7 @@ class Renderer
                 );
         }
 
-        const universalProps: UniversalWidgetProps = {
+        const universalProps = {
             userInput: this.props.userInput?.[widgetId],
             widgetId: widgetId,
             widgetIndex: this._getWidgetIndexById(widgetId),

--- a/packages/perseus/src/types.ts
+++ b/packages/perseus/src/types.ts
@@ -454,17 +454,12 @@ export type FilterCriterion =
       ) => boolean);
 
 /**
- * The full set of props provided to a widget whose widget-specific options are
- * nested under a single `options` prop, rather than spread into the top level
- * of props alongside the universal props.
- *
- * This is the target shape of the in-progress WidgetProps redesign. Widgets are
- * migrated to it one at a time; once every widget is migrated this will replace
- * `WidgetProps` and `UniversalWidgetProps` will be inlined here.
- *
- * TODO(LEMS-4354): revise this doc comment post-migration.
+ * The full set of props provided to all widgets when they are rendered. The
+ * widget-specific options that originate from the PerseusItem are nested under
+ * the `options` prop; everything else is provided to every widget regardless of
+ * its `type`.
  */
-export type WidgetPropsV2<
+export type WidgetProps<
     TWidgetOptions,
     TUserInput = Empty,
     // Defines the arguments that can be passed to the `trackInteraction`
@@ -472,15 +467,6 @@ export type WidgetPropsV2<
     TrackingExtraArgs = Empty,
 > = {
     options: TWidgetOptions;
-} & UniversalWidgetProps<TUserInput, TrackingExtraArgs>;
-
-/**
- * The props passed to every widget, regardless of its `type`.
- */
-export type UniversalWidgetProps<
-    TUserInput = Empty,
-    TrackingExtraArgs = Empty,
-> = {
     // This is slightly different from the `trackInteraction` function in
     // APIOptions. This provides the widget an easy way to notify the renderer
     // of an interaction. The Renderer then enriches the data provided with the

--- a/packages/perseus/src/widget-container.new.tsx
+++ b/packages/perseus/src/widget-container.new.tsx
@@ -17,13 +17,13 @@ import {containerSizeClass, getClassFromWidth} from "./util/sizing-utils";
 import {getWidgetSubType} from "./widget-type-utils";
 import * as Widgets from "./widgets";
 
-import type {WidgetPropsV2} from "./types";
+import type {WidgetProps} from "./types";
 
 type Props = {
     type: string; // widget type/name,
     id: string; // widget id
     // TODO(benchristel): Pass real type arguments here.
-    widgetProps: WidgetPropsV2<any, any>;
+    widgetProps: WidgetProps<any, any>;
 };
 
 type State = {

--- a/packages/perseus/src/widget-container.old.tsx
+++ b/packages/perseus/src/widget-container.old.tsx
@@ -17,13 +17,13 @@ import {containerSizeClass, getClassFromWidth} from "./util/sizing-utils";
 import {getWidgetSubType} from "./widget-type-utils";
 import * as Widgets from "./widgets";
 
-import type {WidgetPropsV2} from "./types";
+import type {WidgetProps} from "./types";
 
 type Props = {
     type: string; // widget type/name,
     id: string; // widget id
     // TODO(benchristel): Pass real type arguments here.
-    widgetProps: WidgetPropsV2<any, any>;
+    widgetProps: WidgetProps<any, any>;
 };
 
 type State = {

--- a/packages/perseus/src/widget-type-utils.test.ts
+++ b/packages/perseus/src/widget-type-utils.test.ts
@@ -73,18 +73,6 @@ describe("widget-type-utils", () => {
             const subType = getWidgetSubType(widget.type, widget.options);
             expect(subType).toBeNull();
         });
-
-        it("doesn't throw an error given the `options` option of an orderer", () => {
-            // This test verifies that orderer widgets (which have an `options`
-            // option) are handled when they haven't yet been migrated to
-            // WidgetPropsV2. Orderer widgets don't have subtypes, so we just
-            // have to make sure that getWidgetSubType won't blow up.
-            // TODO(LEMS-4354): delete this test once all widgets are using
-            //  WidgetPropsV2
-            const options: any = [];
-            const subType = getWidgetSubType("orderer", options);
-            expect(subType).toBeNull();
-        });
     });
 
     describe("getWidgetSubTypeByWidgetId", () => {

--- a/packages/perseus/src/widgets/blank/blank.tsx
+++ b/packages/perseus/src/widgets/blank/blank.tsx
@@ -3,16 +3,13 @@ import {forwardRef, useImperativeHandle} from "react";
 
 import styles from "./blank-widget.module.css";
 
-import type {WidgetExports, WidgetPropsV2, Widget} from "../../types";
+import type {WidgetExports, WidgetProps, Widget} from "../../types";
 import type {
     PerseusBlankWidgetOptions,
     PerseusBlankUserInput,
 } from "@khanacademy/perseus-core";
 
-type BlankProps = WidgetPropsV2<
-    PerseusBlankWidgetOptions,
-    PerseusBlankUserInput
->;
+type BlankProps = WidgetProps<PerseusBlankWidgetOptions, PerseusBlankUserInput>;
 
 const BlankWidget = forwardRef<Widget, BlankProps>(
     function BlankWidget(props, ref) {

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -19,7 +19,7 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetPropsV2,
+    WidgetProps,
 } from "../../types";
 import type {CategorizerPromptJSON} from "../../widget-ai-utils/categorizer/categorizer-ai-utils";
 import type {
@@ -28,11 +28,11 @@ import type {
 } from "@khanacademy/perseus-core";
 
 interface Props
-    extends WidgetPropsV2<
+    extends WidgetProps<
         PerseusCategorizerWidgetOptions,
         PerseusCategorizerUserInput
     > {
-    // TODO(LEMS-4354): Make `dependencies` part of WidgetPropsV2.
+    // TODO(LEMS-4354): Make `dependencies` part of WidgetProps.
     dependencies: PerseusDependenciesV2;
 }
 

--- a/packages/perseus/src/widgets/cs-program/cs-program.tsx
+++ b/packages/perseus/src/widgets/cs-program/cs-program.tsx
@@ -13,7 +13,7 @@ import {isFileProtocol} from "../../util/mobile-native-utils";
 import {toAbsoluteUrl} from "../../util/url-utils";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/cs-program/cs-program-ai-utils";
 
-import type {Widget, WidgetExports, WidgetPropsV2} from "../../types";
+import type {Widget, WidgetExports, WidgetProps} from "../../types";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
 import type {
     PerseusCSProgramWidgetOptions,
@@ -22,7 +22,7 @@ import type {
 
 const {updateQueryString} = Util;
 
-type Props = WidgetPropsV2<
+type Props = WidgetProps<
     PerseusCSProgramWidgetOptions,
     PerseusCSProgramUserInput
 >;

--- a/packages/perseus/src/widgets/definition/definition.tsx
+++ b/packages/perseus/src/widgets/definition/definition.tsx
@@ -16,7 +16,7 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetPropsV2,
+    WidgetProps,
 } from "../../types";
 import type {DefinitionPromptJSON} from "../../widget-ai-utils/definition/definition-ai-utils";
 import type {
@@ -24,7 +24,7 @@ import type {
     PerseusRenderer,
 } from "@khanacademy/perseus-core";
 
-type DefinitionProps = WidgetPropsV2<PerseusDefinitionWidgetOptions> & {
+type DefinitionProps = WidgetProps<PerseusDefinitionWidgetOptions> & {
     widgets: PerseusRenderer["widgets"];
     dependencies: PerseusDependenciesV2;
 };

--- a/packages/perseus/src/widgets/dropdown/dropdown.tsx
+++ b/packages/perseus/src/widgets/dropdown/dropdown.tsx
@@ -20,7 +20,7 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetPropsV2,
+    WidgetProps,
 } from "../../types";
 import type {DropdownPromptJSON} from "../../widget-ai-utils/dropdown/dropdown-ai-utils";
 import type {
@@ -28,7 +28,7 @@ import type {
     PerseusDropdownWidgetOptions,
 } from "@khanacademy/perseus-core";
 
-type Props = WidgetPropsV2<
+type Props = WidgetProps<
     PerseusDropdownWidgetOptions,
     PerseusDropdownUserInput
 > & {

--- a/packages/perseus/src/widgets/explanation/explanation.tsx
+++ b/packages/perseus/src/widgets/explanation/explanation.tsx
@@ -18,12 +18,12 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetPropsV2,
+    WidgetProps,
 } from "../../types";
 import type {ExplanationPromptJSON} from "../../widget-ai-utils/explanation/explanation-ai-utils";
 import type {PerseusExplanationWidgetOptions} from "@khanacademy/perseus-core";
 
-type Props = WidgetPropsV2<PerseusExplanationWidgetOptions> & {
+type Props = WidgetProps<PerseusExplanationWidgetOptions> & {
     dependencies: PerseusDependenciesV2;
 };
 

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -19,12 +19,7 @@ import {useDependencies} from "../../dependencies";
 import {ApiOptions} from "../../perseus-api";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/expression/expression-ai-utils";
 
-import type {
-    Widget,
-    WidgetExports,
-    FocusPath,
-    WidgetPropsV2,
-} from "../../types";
+import type {Widget, WidgetExports, FocusPath, WidgetProps} from "../../types";
 import type {ExpressionPromptJSON} from "../../widget-ai-utils/expression/expression-ai-utils";
 import type {
     KeypadConfiguration,
@@ -59,7 +54,7 @@ const normalizeTex = (tex: string): string => {
     return anglicizeOperators(tex);
 };
 
-type Props = WidgetPropsV2<
+type Props = WidgetProps<
     PerseusExpressionWidgetOptions,
     PerseusExpressionUserInput
 >;

--- a/packages/perseus/src/widgets/free-response/free-response.tsx
+++ b/packages/perseus/src/widgets/free-response/free-response.tsx
@@ -18,13 +18,13 @@ import * as React from "react";
 import {PerseusI18nContext} from "../../components/i18n-context";
 import Renderer from "../../renderer";
 
-import type {Widget, WidgetExports, WidgetPropsV2} from "../../types";
+import type {Widget, WidgetExports, WidgetProps} from "../../types";
 import type {
     PerseusFreeResponseUserInput,
     PerseusFreeResponseWidgetOptions,
 } from "@khanacademy/perseus-core";
 
-type Props = WidgetPropsV2<
+type Props = WidgetProps<
     PerseusFreeResponseWidgetOptions,
     PerseusFreeResponseUserInput
 >;

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -18,7 +18,7 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetPropsV2,
+    WidgetProps,
 } from "../../types";
 import type {GradedGroupSetPromptJSON} from "../../widget-ai-utils/graded-group-set/graded-group-set-ai-utils";
 import type {
@@ -91,7 +91,7 @@ class Indicators extends React.Component<IndicatorsProps> {
     }
 }
 
-type Props = WidgetPropsV2<PerseusGradedGroupSetWidgetOptions> & {
+type Props = WidgetProps<PerseusGradedGroupSetWidgetOptions> & {
     trackInteraction: () => void;
     dependencies: PerseusDependenciesV2;
 };

--- a/packages/perseus/src/widgets/graded-group/graded-group.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.tsx
@@ -27,7 +27,7 @@ import type {
     TrackingGradedGroupExtraArguments,
     Widget,
     WidgetExports,
-    WidgetPropsV2,
+    WidgetProps,
 } from "../../types";
 import type {GradedGroupPromptJSON} from "../../widget-ai-utils/graded-group/graded-group-ai-utils";
 import type {
@@ -62,7 +62,7 @@ const getNextState = (
     }
 };
 
-type Props = WidgetPropsV2<
+type Props = WidgetProps<
     PerseusGradedGroupWidgetOptions,
     Empty,
     TrackingGradedGroupExtraArguments

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -43,7 +43,7 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetPropsV2,
+    WidgetProps,
 } from "../../types";
 import type {GridDimensions} from "../../util";
 import type {GrapherPromptJSON} from "../../widget-ai-utils/grapher/grapher-ai-utils";
@@ -351,7 +351,7 @@ class FunctionGrapher extends React.Component<FunctionGrapherProps> {
     }
 }
 
-type Props = WidgetPropsV2<
+type Props = WidgetProps<
     PerseusGrapherWidgetOptions,
     PerseusGrapherUserInput
 > & {dependencies: PerseusDependenciesV2};

--- a/packages/perseus/src/widgets/group/group.tsx
+++ b/packages/perseus/src/widgets/group/group.tsx
@@ -24,7 +24,7 @@ import type {
     FocusPath,
     Widget,
     WidgetExports,
-    WidgetPropsV2,
+    WidgetProps,
 } from "../../types";
 import type {GroupPromptJSON} from "../../widget-ai-utils/group/group-ai-utils";
 import type {
@@ -33,7 +33,7 @@ import type {
     PerseusRenderer,
 } from "@khanacademy/perseus-core";
 
-type Props = WidgetPropsV2<PerseusGroupWidgetOptions, PerseusGroupUserInput>;
+type Props = WidgetProps<PerseusGroupWidgetOptions, PerseusGroupUserInput>;
 
 class Group extends React.Component<Props> implements Widget {
     static contextType = PerseusI18nContext;

--- a/packages/perseus/src/widgets/iframe/iframe.tsx
+++ b/packages/perseus/src/widgets/iframe/iframe.tsx
@@ -15,7 +15,7 @@ import {getDependencies} from "../../dependencies";
 import Util from "../../util";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/iframe/iframe-ai-utils";
 
-import type {WidgetExports, WidgetPropsV2, Widget} from "../../types";
+import type {WidgetExports, WidgetProps, Widget} from "../../types";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
 import type {
     PerseusIFrameUserInput,
@@ -24,7 +24,7 @@ import type {
 
 const {updateQueryString} = Util;
 
-type Props = WidgetPropsV2<PerseusIFrameWidgetOptions, PerseusIFrameUserInput>;
+type Props = WidgetProps<PerseusIFrameWidgetOptions, PerseusIFrameUserInput>;
 
 type DefaultProps = {
     userInput: Props["userInput"];

--- a/packages/perseus/src/widgets/image/image.tsx
+++ b/packages/perseus/src/widgets/image/image.tsx
@@ -12,12 +12,12 @@ import {ImageInfoArea} from "./components/image-info-area";
 import styles from "./image-widget.module.css";
 import {isGif, decodeGifFrames} from "./utils";
 
-import type {WidgetExports, Widget, WidgetPropsV2} from "../../types";
+import type {WidgetExports, Widget, WidgetProps} from "../../types";
 import type {ImagePromptJSON} from "../../widget-ai-utils/image/image-ai-utils";
 import type {PerseusImageWidgetOptions} from "@khanacademy/perseus-core";
 import type {ParsedFrame} from "gifuct-js";
 
-type ImageWidgetProps = WidgetPropsV2<PerseusImageWidgetOptions>;
+type ImageWidgetProps = WidgetProps<PerseusImageWidgetOptions>;
 
 const ImageWidget = forwardRef<Widget, ImageWidgetProps>(
     function ImageWidget(props, ref) {

--- a/packages/perseus/src/widgets/interaction/interaction.tsx
+++ b/packages/perseus/src/widgets/interaction/interaction.tsx
@@ -8,7 +8,7 @@ import Util from "../../util";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/interaction/interaction-ai-utils";
 
 import type {Coord} from "../../interactive2/types";
-import type {Widget, WidgetExports, WidgetPropsV2} from "../../types";
+import type {Widget, WidgetExports, WidgetProps} from "../../types";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
 import type {
     PerseusInteractionElement,
@@ -77,7 +77,7 @@ function KAScompile(expr: any, options: KASOptions) {
     return cached;
 }
 
-type Props = WidgetPropsV2<PerseusInteractionWidgetOptions>;
+type Props = WidgetProps<PerseusInteractionWidgetOptions>;
 
 type State = {
     variables: any;

--- a/packages/perseus/src/widgets/interactive-graphs/__docs__/notes/not-graded.md
+++ b/packages/perseus/src/widgets/interactive-graphs/__docs__/notes/not-graded.md
@@ -37,7 +37,7 @@ scoring time.
 | File | Role |
 |------|------|
 | `perseus-core/src/data-schema.ts` | `WidgetOptions.graded` field + JSDoc (ungraded sketchpad use case) |
-| `perseus/src/types.ts` | `graded?: boolean \| null` on `UniversalWidgetProps`; `supportsUngraded?: boolean` on `WidgetExports` |
+| `perseus/src/types.ts` | `graded?: boolean \| null` on `WidgetProps`; `supportsUngraded?: boolean` on `WidgetExports` |
 | `perseus/src/renderer.new.tsx` / `renderer.old.tsx` | `getWidgetProps()` passes `graded: widgetInfo?.graded`; default widget info sets `graded: true` (`renderer.tsx` is a feature-flag shim that delegates to these) |
 | `perseus/src/widgets.ts` | `supportsUngraded(type)` — reads the explicit `supportsUngraded === true` flag off the widget export |
 | `perseus/src/widgets/interactive-graphs/interactive-graph.tsx` | Sets `supportsUngraded: true` on the IG export; renders the "not graded" indicator; forwards `graded` + `ungradedDescriptionId` to `StatefulMafsGraph` |
@@ -67,7 +67,7 @@ The shipped API diverged from the original plan's names — be aware of both whe
 
 ### Learner (renderer)
 
-- `Renderer.getWidgetProps()` forwards `graded` to the widget via `UniversalWidgetProps`
+- `Renderer.getWidgetProps()` forwards `graded` to the widget as a top-level `WidgetProps` member
   (default `true`).
 - When `graded === false` (and the graph `type` is not `"none"`), the IG widget renders a visible
   `<p>` label — `strings.ungradedInteractiveGraph` — making it clear the graph won't be scored.

--- a/packages/perseus/src/widgets/interactive-graphs/interactive-graph.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/interactive-graph.tsx
@@ -9,7 +9,7 @@ import {getPromptJSON} from "../../widget-ai-utils/interactive-graph/interactive
 import {getEquationString} from "./get-equation-string";
 
 import type {StatefulMafsGraphType} from "./stateful-mafs-graph";
-import type {WidgetExports, WidgetPropsV2} from "../../types";
+import type {WidgetExports, WidgetProps} from "../../types";
 import type {InteractiveGraphPromptJSON} from "../../widget-ai-utils/interactive-graph/interactive-graph-ai-utils";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
 import type {
@@ -21,7 +21,7 @@ import type {
 
 import {StatefulMafsGraph} from "./index";
 
-export type Props = WidgetPropsV2<
+export type Props = WidgetProps<
     PerseusInteractiveGraphWidgetOptions,
     PerseusInteractiveGraphUserInput
 >;

--- a/packages/perseus/src/widgets/interactive-graphs/types.ts
+++ b/packages/perseus/src/widgets/interactive-graphs/types.ts
@@ -1,6 +1,6 @@
 import type {InteractiveGraphAction} from "./reducer/interactive-graph-action";
 import type {Coord} from "../../interactive2/types";
-import type {WidgetPropsV2} from "../../types";
+import type {WidgetProps} from "../../types";
 import type {QuadraticCoords} from "@khanacademy/kmath";
 import type {
     PerseusInteractiveGraphUserInput,
@@ -9,7 +9,7 @@ import type {
 import type {Interval, vec} from "mafs";
 import type {ReactNode} from "react";
 
-export type InteractiveGraphProps = WidgetPropsV2<
+export type InteractiveGraphProps = WidgetProps<
     PerseusInteractiveGraphWidgetOptions,
     PerseusInteractiveGraphUserInput
 >;

--- a/packages/perseus/src/widgets/label-image/label-image.tsx
+++ b/packages/perseus/src/widgets/label-image/label-image.tsx
@@ -29,7 +29,7 @@ import {HideAnswersToggle} from "./hide-answers-toggle";
 import Marker from "./marker";
 
 import type {DependencyProps} from "../../dependencies";
-import type {Widget, WidgetExports, WidgetPropsV2} from "../../types";
+import type {Widget, WidgetExports, WidgetProps} from "../../types";
 import type {LabelImagePromptJSON} from "../../widget-ai-utils/label-image/label-image-ai-utils";
 import type {
     InteractiveMarkerType,
@@ -88,7 +88,7 @@ type Options = Omit<PerseusLabelImageWidgetOptions, "markers"> & {
     preferredPopoverDirection?: PreferredPopoverDirection;
 };
 
-type Props = WidgetPropsV2<Options, PerseusLabelImageUserInput> & {
+type Props = WidgetProps<Options, PerseusLabelImageUserInput> & {
     analytics: DependencyProps["analytics"];
 };
 

--- a/packages/perseus/src/widgets/matcher/matcher.tsx
+++ b/packages/perseus/src/widgets/matcher/matcher.tsx
@@ -16,7 +16,7 @@ import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/matcher/mat
 import type {SortableOption} from "../../components/sortable";
 import type {
     WidgetExports,
-    WidgetPropsV2,
+    WidgetProps,
     Widget,
     PerseusDependenciesV2,
 } from "../../types";
@@ -29,7 +29,7 @@ import type {
 
 const HACKY_CSS_CLASSNAME = "perseus-widget-matcher";
 
-type Props = WidgetPropsV2<
+type Props = WidgetProps<
     PerseusMatcherWidgetOptions,
     PerseusMatcherUserInput
 > & {

--- a/packages/perseus/src/widgets/matrix/matrix.tsx
+++ b/packages/perseus/src/widgets/matrix/matrix.tsx
@@ -19,7 +19,7 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetPropsV2,
+    WidgetProps,
 } from "../../types";
 import type {MatrixPromptJSON} from "../../widget-ai-utils/matrix/matrix-ai-utils";
 import type {
@@ -77,10 +77,7 @@ const getRefForPath = function (path: FocusPath) {
     return "answer" + row + "," + column;
 };
 
-type Props = WidgetPropsV2<
-    MatrixPublicWidgetOptions,
-    PerseusMatrixUserInput
-> & {
+type Props = WidgetProps<MatrixPublicWidgetOptions, PerseusMatrixUserInput> & {
     dependencies: PerseusDependenciesV2;
 };
 

--- a/packages/perseus/src/widgets/measurer/measurer.tsx
+++ b/packages/perseus/src/widgets/measurer/measurer.tsx
@@ -8,11 +8,11 @@ import GraphUtils from "../../util/graph-utils";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/measurer/measurer-ai-utils";
 
 import type {Coord} from "../../interactive2/types";
-import type {Widget, WidgetExports, WidgetPropsV2} from "../../types";
+import type {Widget, WidgetExports, WidgetProps} from "../../types";
 import type {Interval} from "../../util/interval";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
 
-type Props = WidgetPropsV2<PerseusMeasurerWidgetOptions>;
+type Props = WidgetProps<PerseusMeasurerWidgetOptions>;
 
 class Measurer extends React.Component<Props> implements Widget {
     // this just helps with TS weak typing when a Widget

--- a/packages/perseus/src/widgets/mock-widgets/mock-widget.tsx
+++ b/packages/perseus/src/widgets/mock-widgets/mock-widget.tsx
@@ -6,14 +6,11 @@ import * as React from "react";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/mock-widget/prompt-utils";
 
 import type {MockWidgetOptions} from "./mock-widget-types";
-import type {WidgetPropsV2, Widget, WidgetExports} from "../../types";
+import type {WidgetProps, Widget, WidgetExports} from "../../types";
 import type {MockWidgetPromptJSON} from "../../widget-ai-utils/mock-widget/prompt-utils";
 import type {PerseusMockWidgetUserInput} from "@khanacademy/perseus-score";
 
-type ExternalProps = WidgetPropsV2<
-    MockWidgetOptions,
-    PerseusMockWidgetUserInput
->;
+type ExternalProps = WidgetProps<MockWidgetOptions, PerseusMockWidgetUserInput>;
 
 type Props = ExternalProps;
 

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -23,7 +23,7 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetPropsV2,
+    WidgetProps,
 } from "../../types";
 import type {NumberLinePromptJSON} from "../../widget-ai-utils/number-line/number-line-ai-utils";
 import type {
@@ -204,7 +204,7 @@ const TickMarks: any = (Graphie as any).createSimpleClass((graphie, props) => {
 /**
  * The type of the props passed to the NumberLine widget.
  */
-type Props = WidgetPropsV2<
+type Props = WidgetProps<
     PerseusNumberLineWidgetOptions,
     PerseusNumberLineUserInput
 > & {

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.tsx
@@ -26,19 +26,14 @@ import {
     shouldShowExamples,
 } from "./utils";
 
-import type {
-    Focusable,
-    Widget,
-    WidgetExports,
-    WidgetPropsV2,
-} from "../../types";
+import type {Focusable, Widget, WidgetExports, WidgetProps} from "../../types";
 import type {NumericInputPromptJSON} from "../../widget-ai-utils/numeric-input/prompt-utils";
 import type {
     PerseusNumericInputUserInput,
     PerseusNumericInputWidgetOptions,
 } from "@khanacademy/perseus-core";
 
-type Props = WidgetPropsV2<
+type Props = WidgetProps<
     PerseusNumericInputWidgetOptions,
     PerseusNumericInputUserInput
 >;

--- a/packages/perseus/src/widgets/orderer/orderer.tsx
+++ b/packages/perseus/src/widgets/orderer/orderer.tsx
@@ -13,7 +13,7 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetPropsV2,
+    WidgetProps,
 } from "../../types";
 import type {OrdererPromptJSON} from "../../widget-ai-utils/orderer/orderer-ai-utils";
 import type {
@@ -285,7 +285,7 @@ class Card extends React.Component<CardProps, CardState> {
     }
 }
 
-type OrdererProps = WidgetPropsV2<
+type OrdererProps = WidgetProps<
     OrdererPublicWidgetOptions,
     PerseusOrdererUserInput
 > & {dependencies: PerseusDependenciesV2};

--- a/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
+++ b/packages/perseus/src/widgets/phet-simulation/phet-simulation.tsx
@@ -18,11 +18,11 @@ import {PerseusI18nContext} from "../../components/i18n-context";
 import {phoneMargin} from "../../styles/constants";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/phet-simulation/phet-simulation-ai-utils";
 
-import type {WidgetExports, WidgetPropsV2, Widget} from "../../types";
+import type {WidgetExports, WidgetProps, Widget} from "../../types";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
 import type {PerseusPhetSimulationWidgetOptions} from "@khanacademy/perseus-core";
 
-type Props = WidgetPropsV2<PerseusPhetSimulationWidgetOptions>;
+type Props = WidgetProps<PerseusPhetSimulationWidgetOptions>;
 
 type State = {
     banner: {

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -21,11 +21,11 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetPropsV2,
+    WidgetProps,
 } from "../../types";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
 
-type Props = WidgetPropsV2<
+type Props = WidgetProps<
     PlotterPublicWidgetOptions,
     PerseusPlotterUserInput
 > & {

--- a/packages/perseus/src/widgets/python-program/python-program.tsx
+++ b/packages/perseus/src/widgets/python-program/python-program.tsx
@@ -13,7 +13,7 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetPropsV2,
+    WidgetProps,
 } from "../../types";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
 import type {PerseusPythonProgramWidgetOptions} from "@khanacademy/perseus-core";
@@ -22,7 +22,7 @@ function getUrlFromProgramID(programID: string) {
     return `/python-program/${programID}/embedded`;
 }
 
-type Props = WidgetPropsV2<PerseusPythonProgramWidgetOptions> & {
+type Props = WidgetProps<PerseusPythonProgramWidgetOptions> & {
     dependencies: PerseusDependenciesV2;
 };
 

--- a/packages/perseus/src/widgets/radio/__tests__/radio-widget.test.tsx
+++ b/packages/perseus/src/widgets/radio/__tests__/radio-widget.test.tsx
@@ -13,7 +13,7 @@ import {testDependencies} from "../../../testing/test-dependencies";
 import {containerSizeClass} from "../../../util/sizing-utils";
 import Radio from "../radio-widget";
 
-import type {WidgetPropsV2} from "../../../types";
+import type {WidgetProps} from "../../../types";
 import type {RadioChoiceWithMetadata, RadioProps} from "../radio-widget";
 import type {
     PerseusRadioRubric,
@@ -65,9 +65,9 @@ const getBaseOptions = (overrides?: Partial<RadioProps>): RadioProps => ({
 
 const getBaseProps = (
     overrides?: Partial<
-        WidgetPropsV2<RadioProps, PerseusRadioUserInput, PerseusRadioRubric>
+        WidgetProps<RadioProps, PerseusRadioUserInput, PerseusRadioRubric>
     >,
-): WidgetPropsV2<RadioProps, PerseusRadioUserInput, PerseusRadioRubric> => ({
+): WidgetProps<RadioProps, PerseusRadioUserInput, PerseusRadioRubric> => ({
     options: getBaseOptions(),
     trackInteraction: jest.fn(),
     widgetId: "radio-1",

--- a/packages/perseus/src/widgets/radio/radio-widget.tsx
+++ b/packages/perseus/src/widgets/radio/radio-widget.tsx
@@ -13,7 +13,7 @@ import RadioComponent from "./radio-component";
 import {choiceTransform} from "./util";
 import {getChoiceStates} from "./utils/general-utils";
 
-import type {WidgetPropsV2, ChoiceState, Widget} from "../../types";
+import type {WidgetProps, ChoiceState, Widget} from "../../types";
 import type {RadioPromptJSON} from "../../widget-ai-utils/radio/radio-ai-utils";
 import type {
     PerseusRadioChoice,
@@ -59,11 +59,7 @@ export interface RadioChoiceWithMetadata extends PerseusRadioChoice {
     correct?: boolean;
 }
 
-type Props = WidgetPropsV2<
-    RadioProps,
-    PerseusRadioUserInput,
-    PerseusRadioRubric
->;
+type Props = WidgetProps<RadioProps, PerseusRadioUserInput, PerseusRadioRubric>;
 
 /**
  * RadioWidget implements the Widget interface for multiple choice questions.

--- a/packages/perseus/src/widgets/sorter/sorter.tsx
+++ b/packages/perseus/src/widgets/sorter/sorter.tsx
@@ -11,7 +11,7 @@ import type {
     PerseusDependenciesV2,
     Widget,
     WidgetExports,
-    WidgetPropsV2,
+    WidgetProps,
 } from "../../types";
 import type {SorterPromptJSON} from "../../widget-ai-utils/sorter/sorter-ai-utils";
 import type {
@@ -20,10 +20,7 @@ import type {
     SorterPublicWidgetOptions,
 } from "@khanacademy/perseus-core";
 
-type Props = WidgetPropsV2<
-    PerseusSorterWidgetOptions,
-    PerseusSorterUserInput
-> & {
+type Props = WidgetProps<PerseusSorterWidgetOptions, PerseusSorterUserInput> & {
     dependencies: PerseusDependenciesV2;
 };
 

--- a/packages/perseus/src/widgets/table/table.tsx
+++ b/packages/perseus/src/widgets/table/table.tsx
@@ -8,12 +8,7 @@ import SimpleKeypadInput from "../../components/simple-keypad-input";
 import Renderer from "../../renderer";
 import Util from "../../util";
 
-import type {
-    FocusPath,
-    Widget,
-    WidgetExports,
-    WidgetPropsV2,
-} from "../../types";
+import type {FocusPath, Widget, WidgetExports, WidgetProps} from "../../types";
 import type {
     PerseusTableWidgetOptions,
     PerseusTableUserInput,
@@ -25,7 +20,7 @@ type EditorProps = {
     onChange: (value: {headers: string[]}) => void;
 };
 
-type Props = WidgetPropsV2<PerseusTableWidgetOptions, PerseusTableUserInput> &
+type Props = WidgetProps<PerseusTableWidgetOptions, PerseusTableUserInput> &
     EditorProps;
 
 // A version of FocusPath that's specific to Table

--- a/packages/perseus/src/widgets/video/video.tsx
+++ b/packages/perseus/src/widgets/video/video.tsx
@@ -13,7 +13,7 @@ import {
     type PerseusDependenciesV2,
     type Widget,
     type WidgetExports,
-    type WidgetPropsV2,
+    type WidgetProps,
 } from "../../types";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/video/video-ai-utils";
 
@@ -32,7 +32,7 @@ const IS_URL = /^https?:\/\//;
 const IS_KA_SITE = /(khanacademy\.org|localhost)/;
 const IS_VIMEO = /(vimeo\.com)/;
 
-type Props = WidgetPropsV2<PerseusVideoWidgetOptions> & {
+type Props = WidgetProps<PerseusVideoWidgetOptions> & {
     dependencies: PerseusDependenciesV2;
 };
 


### PR DESCRIPTION
## Summary:
This is the penultimate change to close out the widget props migration. All
widgets now accept their `options` as a separate prop, so the old `WidgetProps`
is no longer used. This PR deletes the old `WidgetProps` and renames
`WidgetPropsV2` to `WidgetProps`. We also inline `UniversalWidgetProps` into
`WidgetProps` since it doesn't need to be a separate type anymore.

Issue: LEMS-4354

## Test plan:

CI checks should pass.