### PR TITLE
Parse `$$...$$` as display math in pure-markdown

### DIFF
--- a/.changeset/tex-double-dollar-display-math.md
+++ b/.changeset/tex-double-dollar-display-math.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/pure-markdown": minor
+---
+
+Parse `$$…$$` as (display) math. Double-dollar is the standard delimiter for display math — it originates in plain TeX and is the de-facto convention across the Markdown/MathJax ecosystem (MathJax, KaTeX auto-render, remark-math, Jupyter, Pandoc, GitHub). Previously a leading `$$` parsed as an empty `$…$` math span, causing the enclosed TeX to leak out as literal source (e.g. `$$\frac12$$` rendered an empty span followed by the text `\frac12`). It is now treated as a single math span: a block-positioned `$$…$$` becomes block math and an inline `$$…$$` becomes inline math. Single-dollar behavior and adjacent inline spans (`$a$$b$`) are unchanged.

--- a/packages/pure-markdown/src/index.test.ts
+++ b/packages/pure-markdown/src/index.test.ts
@@ -231,6 +231,60 @@ describe("pure markdown", () => {
 
         it.each([
             {
+                // `$$…$$` (display) math renders instead of leaking as
+                // literal source. Previously the leading `$$` parsed as an
+                // empty math span and the body leaked out as `text`.
+                content: "$$x + y = 7$$",
+                expected: [{type: "blockMath", content: "x + y = 7"}],
+            },
+            {
+                content: "hello $$\\frac{1}{2}$$ world",
+                expected: [
+                    {
+                        type: "paragraph",
+                        content: [
+                            {type: "text", content: "hello "},
+                            {type: "math", content: "\\frac{1}{2}"},
+                            {type: "text", content: " world"},
+                        ],
+                    },
+                ],
+            },
+            {
+                // multi-line environment: braces balance, so the span scan
+                // captures the whole `\begin{aligned}…\end{aligned}` body.
+                content: "$$\\begin{aligned} 3 &= 8x \\end{aligned}$$",
+                expected: [
+                    {
+                        type: "blockMath",
+                        content: "\\begin{aligned} 3 &= 8x \\end{aligned}",
+                    },
+                ],
+            },
+            {
+                // adjacency guard: `$a$$b$` is two inline spans, NOT a
+                // display block — must be unaffected by `$$` handling.
+                content: "$a$$b$",
+                expected: [
+                    {
+                        type: "paragraph",
+                        content: [
+                            {type: "math", content: "a"},
+                            {type: "math", content: "b"},
+                        ],
+                    },
+                ],
+            },
+        ])("should parse double-dollar display math", ({content, expected}) => {
+            // Arrange, Act
+            const parsed = parse(content);
+
+            // Assert
+            expect(parsed).toEqual(expected);
+        });
+
+        it.each([
+            {
                 content: "hello $ single dollar paragraph\n\n not math $",
                 expected: [
                     {

--- a/packages/pure-markdown/src/index.ts
+++ b/packages/pure-markdown/src/index.ts
@@ -54,6 +54,17 @@ const mathMatcher = (source: any, state: any, isBlock: boolean) => {
     }
 
     index++;
+
+    // Support `$$...$$` as (display) math. Authors and LLM-generated
+    // content frequently wrap math in double-dollar delimiters; without
+    // this, a leading `$$` parses as an empty `$…$` math span and the TeX
+    // that follows leaks out as literal source (e.g. `$$\frac12$$` renders
+    // an empty span + the text "\frac12"). When we open on a doubled `$$`,
+    // only a closing `$$` ends the span — a lone `$` is treated as content.
+    const isDoubleDollar = index < length && source[index] === "$";
+    if (isDoubleDollar) {
+        index++;
+    }
     const startIndex = index;
     let braceLevel = 0;
 
@@ -73,8 +84,12 @@ const mathMatcher = (source: any, state: any, isBlock: boolean) => {
             // This also handles the case of escaping `$`s or
             // braces `\{`
             index++;
-        } else if (braceLevel <= 0 && character === "$") {
-            let endIndex = index + 1;
+        } else if (
+            braceLevel <= 0 &&
+            character === "$" &&
+            (!isDoubleDollar || source[index + 1] === "$")
+        ) {
+            let endIndex = index + (isDoubleDollar ? 2 : 1);
             if (isBlock) {
                 // Look for two trailing newlines after the closing `$`
                 const match = /^(?: *\n){2,}/.exec(source.slice(endIndex));


### PR DESCRIPTION
## Summary

**`$$…$$` is the standard delimiter for display math.** It originates in plain TeX (`$…$` inline, `$$…$$` display) and is the de-facto convention across the entire Markdown/MathJax ecosystem — MathJax and KaTeX's auto-render extension both default to it, as do remark-math, Jupyter, Pandoc, and GitHub.

Perseus's `pure-markdown`, however, parsed a leading `$$` as an **empty** `$…$` math span, so the enclosed TeX leaked out as literal source: `$$\frac12$$` rendered an empty math span followed by the plain text `\frac12`. This is a frequent cause of broken diagrams in AI-generated Perseus content, since models emit the `$$` convention they were trained on.

## Change

`mathMatcher` now recognizes an opening `$$`, scans to the closing `$$` (reusing the existing escape and brace-nesting handling), and emits the body as a single math node:

- block-positioned `$$…$$` → **block math**
- inline `$$…$$` → **inline math**

Single-`$` parsing is untouched, and the one genuinely ambiguous case — adjacent inline spans `$a$$b$` (which is two spans, **not** a display block) — is explicitly preserved and guarded by a test. The core change is +13 lines in `mathMatcher`.

## Scope — what this is and isn't

This renders `$$` content correctly through the existing `TeX` path; it **does not** set MathJax display-mode sizing (centered, `\displaystyle`). That is enough to eliminate the literal-source leak. True display-mode styling would be a follow-up — it requires threading a `display` flag through `TeXProps` → the renderer → the host-injected `MathJax` component, plus a decision on whether existing single-`$` block math should also switch to display mode.

## Testing

- `packages/pure-markdown/src/index.test.ts` — **31/31** (27 existing unchanged + 4 new, including the `$a$$b$` adjacency guard)
- `packages/perseus/src/__tests__/perseus-markdown.test.ts` — **56 pass, 7 snapshots unchanged**

No existing test pinned the `$$` mis-parse, so nothing regresses.

## References

- `$$` display math in plain TeX (and discouraged-in-LaTeX in favor of `\[…\]`): [Wikibooks — LaTeX/Mathematics](https://en.wikibooks.org/wiki/LaTeX/Mathematics), [Illinois — displayed math tips](https://faculty.math.illinois.edu/~hildebr/tex/tips-mathdisplays.html)
- `$$` as the MathJax / KaTeX auto-render default delimiter: [KaTeX discussion #3049](https://github.com/KaTeX/KaTeX/discussions/3049)

---

Note for reviewers: this changes rendering for **all** existing Perseus content containing `$$` (currently broken → now rendered as math). Code owner is Learning Experience – Math & Science (auto-requested via CODEOWNERS); flagging the content-wide behavior change for sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
