### PR TITLE
Use semantic color tokens in the Plotter widget

### DIFF
--- a/.changeset/dull-impalas-hunt.md
+++ b/.changeset/dull-impalas-hunt.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-editor": minor
+"@khanacademy/perseus": minor
+---
+
+The Plotter widget is now styled using Wonder Blocks semantic colors, which allow it to be themed.

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -14678,10 +14678,10 @@ table: [[☃ table 1]]
                           <ellipse
                             cx="225"
                             cy="187"
-                            fill="#dee1e3"
+                            fill="none"
                             rx="2"
                             ry="2"
-                            stroke="#dee1e3"
+                            stroke="none"
                             stroke-width="2"
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; display: none;"
                           />
@@ -14697,10 +14697,10 @@ table: [[☃ table 1]]
                           <ellipse
                             cx="225"
                             cy="151"
-                            fill="#dee1e3"
+                            fill="none"
                             rx="2"
                             ry="2"
-                            stroke="#dee1e3"
+                            stroke="none"
                             stroke-width="2"
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; display: none;"
                           />
@@ -14716,10 +14716,10 @@ table: [[☃ table 1]]
                           <ellipse
                             cx="225"
                             cy="115"
-                            fill="#dee1e3"
+                            fill="none"
                             rx="2"
                             ry="2"
-                            stroke="#dee1e3"
+                            stroke="none"
                             stroke-width="2"
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; display: none;"
                           />
@@ -14735,10 +14735,10 @@ table: [[☃ table 1]]
                           <ellipse
                             cx="225"
                             cy="79"
-                            fill="#dee1e3"
+                            fill="none"
                             rx="2"
                             ry="2"
-                            stroke="#dee1e3"
+                            stroke="none"
                             stroke-width="2"
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; display: none;"
                           />
@@ -14754,10 +14754,10 @@ table: [[☃ table 1]]
                           <ellipse
                             cx="225"
                             cy="43.00000000000001"
-                            fill="#dee1e3"
+                            fill="none"
                             rx="2"
                             ry="2"
-                            stroke="#dee1e3"
+                            stroke="none"
                             stroke-width="2"
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; display: none;"
                           />
@@ -14765,7 +14765,7 @@ table: [[☃ table 1]]
                             d="M225,205L225,211.00000000000003"
                             fill="none"
                             opacity="1"
-                            stroke="#000000"
+                            stroke="none"
                             stroke-width="2"
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
                           />
@@ -14773,7 +14773,7 @@ table: [[☃ table 1]]
                             d="M75,205L375,205"
                             fill="none"
                             opacity="1"
-                            stroke="#000000"
+                            stroke="none"
                             stroke-width="2"
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
                           />
@@ -14781,7 +14781,7 @@ table: [[☃ table 1]]
                             d="M75,205L75,25.000000000000007"
                             fill="none"
                             opacity="1"
-                            stroke="#000000"
+                            stroke="none"
                             stroke-width="2"
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
                           />
@@ -14794,19 +14794,19 @@ table: [[☃ table 1]]
                         />
                         <span
                           class="graphie-label"
-                          style="position: absolute; padding: 7px; color: black; left: 225px; top: 205px; margin-left: -0.5px; margin-top: 0px; font-size: 100%; fill: none; transform: none; transform-origin: 100%;"
+                          style="position: absolute; padding: 7px; left: 225px; top: 205px; margin-left: -0.5px; margin-top: 0px; font-size: 100%; fill: none; transform: none; transform-origin: 100%;"
                         >
                           blue
                         </span>
                         <span
                           class="graphie-label"
-                          style="position: absolute; padding: 7px; color: black; left: 225px; top: 240px; margin-left: -0.5px; margin-top: 0px; font-size: 100%; fill: none; font-weight: bold;"
+                          style="position: absolute; padding: 7px; left: 225px; top: 240px; margin-left: -0.5px; margin-top: 0px; font-size: 100%; fill: none; font-weight: var(--wb-font-weight-bold);"
                         >
                           x
                         </span>
                         <span
                           class="graphie-label rotate"
-                          style="position: absolute; padding: 7px; color: black; left: 14.999999999999996px; top: 115px; margin-left: -0.5px; margin-top: 0px; font-size: 100%; fill: none; font-weight: bold;"
+                          style="position: absolute; padding: 7px; left: 14.999999999999996px; top: 115px; margin-left: -0.5px; margin-top: 0px; font-size: 100%; fill: none; font-weight: var(--wb-font-weight-bold);"
                         >
                           y
                         </span>

--- a/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
@@ -14745,10 +14745,10 @@ table: [[☃ table 1]]
                           <ellipse
                             cx="225"
                             cy="187"
-                            fill="#dee1e3"
+                            fill="none"
                             rx="2"
                             ry="2"
-                            stroke="#dee1e3"
+                            stroke="none"
                             stroke-width="2"
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; display: none;"
                           />
@@ -14764,10 +14764,10 @@ table: [[☃ table 1]]
                           <ellipse
                             cx="225"
                             cy="151"
-                            fill="#dee1e3"
+                            fill="none"
                             rx="2"
                             ry="2"
-                            stroke="#dee1e3"
+                            stroke="none"
                             stroke-width="2"
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; display: none;"
                           />
@@ -14783,10 +14783,10 @@ table: [[☃ table 1]]
                           <ellipse
                             cx="225"
                             cy="115"
-                            fill="#dee1e3"
+                            fill="none"
                             rx="2"
                             ry="2"
-                            stroke="#dee1e3"
+                            stroke="none"
                             stroke-width="2"
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; display: none;"
                           />
@@ -14802,10 +14802,10 @@ table: [[☃ table 1]]
                           <ellipse
                             cx="225"
                             cy="79"
-                            fill="#dee1e3"
+                            fill="none"
                             rx="2"
                             ry="2"
-                            stroke="#dee1e3"
+                            stroke="none"
                             stroke-width="2"
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; display: none;"
                           />
@@ -14821,10 +14821,10 @@ table: [[☃ table 1]]
                           <ellipse
                             cx="225"
                             cy="43.00000000000001"
-                            fill="#dee1e3"
+                            fill="none"
                             rx="2"
                             ry="2"
-                            stroke="#dee1e3"
+                            stroke="none"
                             stroke-width="2"
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; display: none;"
                           />
@@ -14832,7 +14832,7 @@ table: [[☃ table 1]]
                             d="M225,205L225,211.00000000000003"
                             fill="none"
                             opacity="1"
-                            stroke="#000000"
+                            stroke="none"
                             stroke-width="2"
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
                           />
@@ -14840,7 +14840,7 @@ table: [[☃ table 1]]
                             d="M75,205L375,205"
                             fill="none"
                             opacity="1"
-                            stroke="#000000"
+                            stroke="none"
                             stroke-width="2"
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
                           />
@@ -14848,7 +14848,7 @@ table: [[☃ table 1]]
                             d="M75,205L75,25.000000000000007"
                             fill="none"
                             opacity="1"
-                            stroke="#000000"
+                            stroke="none"
                             stroke-width="2"
                             style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
                           />
@@ -14861,19 +14861,19 @@ table: [[☃ table 1]]
                         />
                         <span
                           class="graphie-label"
-                          style="position: absolute; padding: 7px; color: black; left: 225px; top: 205px; margin-left: -0.5px; margin-top: 0px; font-size: 100%; fill: none; transform: none; transform-origin: 100%;"
+                          style="position: absolute; padding: 7px; left: 225px; top: 205px; margin-left: -0.5px; margin-top: 0px; font-size: 100%; fill: none; transform: none; transform-origin: 100%;"
                         >
                           blue
                         </span>
                         <span
                           class="graphie-label"
-                          style="position: absolute; padding: 7px; color: black; left: 225px; top: 240px; margin-left: -0.5px; margin-top: 0px; font-size: 100%; fill: none; font-weight: bold;"
+                          style="position: absolute; padding: 7px; left: 225px; top: 240px; margin-left: -0.5px; margin-top: 0px; font-size: 100%; fill: none; font-weight: var(--wb-font-weight-bold);"
                         >
                           x
                         </span>
                         <span
                           class="graphie-label rotate"
-                          style="position: absolute; padding: 7px; color: black; left: 14.999999999999996px; top: 115px; margin-left: -0.5px; margin-top: 0px; font-size: 100%; fill: none; font-weight: bold;"
+                          style="position: absolute; padding: 7px; left: 14.999999999999996px; top: 115px; margin-left: -0.5px; margin-top: 0px; font-size: 100%; fill: none; font-weight: var(--wb-font-weight-bold);"
                         >
                           y
                         </span>

--- a/packages/perseus/src/interactive2.ts
+++ b/packages/perseus/src/interactive2.ts
@@ -24,7 +24,7 @@ const Interactive2 = {
 
     addMovablePointV2: function (widget: any, extraProps: any): any {
         const commonStyle = {
-            stroke: "#ffffff",
+            stroke: tokenValue(semanticColor.core.border.knockout.default),
             "stroke-width": 3,
             fill: tokenValue(semanticColor.core.foreground.instructive.default),
         };
@@ -34,7 +34,7 @@ const Interactive2 = {
         const highlightStyle = Object.assign(
             {
                 ...commonStyle,
-                "stroke-width": 0,
+                "stroke-width": 2,
                 scale: 0.75,
             },
             extraProps.highlightStyle,

--- a/packages/perseus/src/interactive2.ts
+++ b/packages/perseus/src/interactive2.ts
@@ -1,8 +1,9 @@
+import {semanticColor, tokenValue} from "@khanacademy/wonder-blocks-tokens";
+
 import {Movable} from "./interactive2/movable";
 import MovableLine from "./interactive2/movable-line";
 import {MovablePoint} from "./interactive2/movable-point";
 import MovablePolygon from "./interactive2/movable-polygon";
-import {semanticColor, tokenValue} from "@khanacademy/wonder-blocks-tokens";
 
 const Interactive2 = {
     MovablePoint: MovablePoint,

--- a/packages/perseus/src/interactive2.ts
+++ b/packages/perseus/src/interactive2.ts
@@ -2,7 +2,7 @@ import {Movable} from "./interactive2/movable";
 import MovableLine from "./interactive2/movable-line";
 import {MovablePoint} from "./interactive2/movable-point";
 import MovablePolygon from "./interactive2/movable-polygon";
-import KhanColors from "./util/colors";
+import {semanticColor, tokenValue} from "@khanacademy/wonder-blocks-tokens";
 
 const Interactive2 = {
     MovablePoint: MovablePoint,
@@ -21,30 +21,21 @@ const Interactive2 = {
         return new MovablePolygon(graphie, movable, options);
     },
 
-    addMaybeMobileMovablePoint: function (widget: any, extraProps: any): any {
-        const isMobile = widget.props.apiOptions.isMobile;
-
-        const commonStyle = isMobile
-            ? {
-                  stroke: "#ffffff",
-                  "stroke-width": 3,
-                  fill: KhanColors.INTERACTIVE,
-              }
-            : {
-                  stroke: KhanColors.INTERACTIVE,
-                  fill: KhanColors.INTERACTIVE,
-              };
+    addMovablePointV2: function (widget: any, extraProps: any): any {
+        const commonStyle = {
+            stroke: "#ffffff",
+            "stroke-width": 3,
+            fill: tokenValue(semanticColor.core.foreground.instructive.default),
+        };
 
         const normalStyle = Object.assign(commonStyle, extraProps.normalStyle);
 
         const highlightStyle = Object.assign(
-            isMobile
-                ? {
-                      ...commonStyle,
-                      "stroke-width": 0,
-                      scale: 0.75,
-                  }
-                : {},
+            {
+                ...commonStyle,
+                "stroke-width": 0,
+                scale: 0.75,
+            },
             extraProps.highlightStyle,
         );
 
@@ -52,12 +43,12 @@ const Interactive2 = {
             {
                 normalStyle: normalStyle,
                 highlightStyle: highlightStyle,
-                shadow: isMobile,
-                tooltip: isMobile && widget.props.showTooltips,
+                shadow: true,
+                tooltip: widget.props.showTooltips,
                 showHairlines: widget.showHairlines,
                 hideHairlines: widget.hideHairlines,
             },
-            isMobile ? {pointSize: 7} : {},
+            {pointSize: 7},
         );
 
         return Interactive2.addMovablePoint(

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -368,11 +368,12 @@
 [data-wb-theme$="-dark"] .framework-perseus {
     img[src$=".png"],
     img[src$=".svg"],
-    .graphie,
-    .mathjax-wrapper:not(.graphie *) {
-        /* This filter is applied to PNG/SVG images, Graphie (e.g. label
-           text), and MathJax. MathJax inside Graphie labels is excluded so it
-           doesn't get double-inverted. JPEGs & GIFs are untouched.
+    .graphie:not(.perseus-widget-plotter),
+    .mathjax-wrapper:not(.graphie:not(.perseus-widget-plotter) *) {
+        /* This filter is applied to PNG/SVG images, Graphie (excluding the
+           Plotter, which is themed), and MathJax. MathJax inside inverted
+           Graphies is excluded so it doesn't get double-inverted. JPEGs & GIFs
+           are untouched.
          */
         filter: invert(1) hue-rotate(180deg) brightness(1.5);
     }

--- a/packages/perseus/src/styles/widgets/plotter.css
+++ b/packages/perseus/src/styles/widgets/plotter.css
@@ -13,10 +13,3 @@
 .categories-title {
     font-size: 14px;
 }
-.perseus-mobile .perseus-widget-plotter {
-    border: solid 0.5px #babec2;
-    border-radius: 4px;
-}
-.perseus-mobile .perseus-widget-plotter .graphie-label mjx-container {
-    color: #626569;
-}

--- a/packages/perseus/src/util/interactive.ts
+++ b/packages/perseus/src/util/interactive.ts
@@ -32,6 +32,7 @@ import KhanColors from "./colors";
 import GraphUtils, {polar} from "./graphie";
 
 import type {Coord} from "../interactive2/types";
+import {semanticColor, tokenValue} from "@khanacademy/wonder-blocks-tokens";
 
 export type MouseHandler = (position: Coord) => void;
 
@@ -999,7 +1000,7 @@ _.extend(GraphUtils.Graphie.prototype, {
                 ticks: 0,
                 normalStyle: {},
                 highlightStyle: {
-                    stroke: KhanColors.INTERACTING,
+                    stroke: tokenValue(semanticColor.core.border.instructive.default),
                     "stroke-width": 6,
                 },
                 labelStyle: {
@@ -2152,6 +2153,8 @@ _.extend(GraphUtils.Graphie.prototype, {
     //   - movableAngle.coords
     //         The movableAngle's current coordinates (generated, don't edit).
     //
+    // TODO(benchristel): addMovableAngle is unused. Delete it. MovableAngle
+    //  might be deletable too.
     addMovableAngle: function (options) {
         return new MovableAngle(this, options);
     },
@@ -2160,6 +2163,7 @@ _.extend(GraphUtils.Graphie.prototype, {
     // radius: int
     // circ: graphie circle
     // perim: invisible mouse target for dragging/changing radius
+    // TODO(benchristel): addCircleGraph is unused. Delete it.
     addCircleGraph: function (options) {
         const graphie = this;
         const circle = $.extend(

--- a/packages/perseus/src/util/interactive.ts
+++ b/packages/perseus/src/util/interactive.ts
@@ -15,6 +15,7 @@ import {
     geometry,
 } from "@khanacademy/kmath";
 import {Errors, PerseusError} from "@khanacademy/perseus-core";
+import {semanticColor, tokenValue} from "@khanacademy/wonder-blocks-tokens";
 import $ from "jquery";
 import _ from "underscore";
 
@@ -32,7 +33,6 @@ import KhanColors from "./colors";
 import GraphUtils, {polar} from "./graphie";
 
 import type {Coord} from "../interactive2/types";
-import {semanticColor, tokenValue} from "@khanacademy/wonder-blocks-tokens";
 
 export type MouseHandler = (position: Coord) => void;
 
@@ -1000,7 +1000,9 @@ _.extend(GraphUtils.Graphie.prototype, {
                 ticks: 0,
                 normalStyle: {},
                 highlightStyle: {
-                    stroke: tokenValue(semanticColor.core.border.instructive.default),
+                    stroke: tokenValue(
+                        semanticColor.core.border.instructive.default,
+                    ),
                     "stroke-width": 6,
                 },
                 labelStyle: {

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -745,11 +745,6 @@ class Plotter extends React.Component<Props, State> implements Widget {
                             ];
                         },
                     ],
-                    onMoveStart: function () {
-                        // config.graph.bars[i].attr({
-                        //     fill: ,
-                        // });
-                    },
                     onMove: function () {
                         const y = config.graph.lines[i].coord()[1];
 
@@ -760,11 +755,6 @@ class Plotter extends React.Component<Props, State> implements Widget {
                         self._maybeHideDragPrompt();
 
                         scaleBar(i, y);
-                    },
-                    onMoveEnd: function () {
-                        // config.graph.bars[i].attr({
-                        //     fill: KhanColors.BLUE_C,
-                        // });
                     },
                 },
             );

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -13,7 +13,6 @@ import {PerseusI18nContext} from "../../components/i18n-context";
 import {withDependencies} from "../../components/with-dependencies";
 import Interactive2 from "../../interactive2";
 import WrappedLine from "../../interactive2/wrapped-line";
-import KhanColors from "../../util/colors";
 import GraphUtils from "../../util/graph-utils";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/plotter/plotter-ai-utils";
 
@@ -278,17 +277,20 @@ class Plotter extends React.Component<Props, State> implements Widget {
             // If we have isMobile, we skip the 0 label.
             const initialY = isMobile ? c.scaleY : 0;
             for (let y = initialY; y <= c.dimY; y += c.scaleY) {
+                // y-axis tick labels
                 graphie.label(
                     [0, y],
                     KhanMath.roundToApprox(y, 2),
                     "left",
                     /* isTeX */ true /* for the \approx symbol */,
                 );
+
+                // horizontal lines on graph
                 graphie.style(
                     {
-                        stroke: isMobile ? tokenValue(semanticColor.core.border.neutral.subtle) : tokenValue(semanticColor.core.border.neutral.strong),
+                        stroke: tokenValue(semanticColor.core.border.neutral.default),
                         strokeWidth: 1,
-                        opacity: isMobile ? 1 : 0.3,
+                        opacity: 1,
                     },
                     function () {
                         graphie.line([0, y], [c.dimX, y]);
@@ -321,7 +323,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
                     false,
                 )
                 .css("font-weight", font.weight.bold)
-                .css("color", semanticColor.core.foreground.instructive.default)
+                .css("color", semanticColor.core.foreground.neutral.default)
                 .css("display", "none");
         }
 
@@ -373,7 +375,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 isMobile ? "above" : "below",
                 false,
             )
-            .css("color", tokenValue(semanticColor.core.foreground.neutral.default))
+            .css("color", tokenValue(semanticColor.core.foreground.neutral.strong))
             .css("font-weight", font.weight.bold);
 
         // y-axis label
@@ -384,7 +386,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 "center",
                 false,
             )
-            .css("color", tokenValue(semanticColor.core.foreground.neutral.default))
+            .css("color", tokenValue(semanticColor.core.foreground.neutral.strong))
             .css("font-weight", font.weight.bold)
             .addClass("rotate");
 
@@ -453,7 +455,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
         return new Promise((resolve) => {
             graphie.style(
                 {
-                    color: isMobile ? KhanColors.GRAY_G : "inherit",
+                    color: tokenValue(semanticColor.core.foreground.neutral.strong),
                     transform: shouldRotate ? labelRotation : "none",
                     transformOrigin: "100%",
                 },
@@ -690,7 +692,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
         graphie.style(
             {
                 stroke: "none",
-                fill: tokenValue(semanticColor.core.background.instructive.default),
+                fill: tokenValue(semanticColor.core.foreground.instructive.subtle),
                 opacity: 1.0,
             },
             function () {
@@ -709,7 +711,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 // Don't draw a divider to the left of the first bucket
                 graphie.style(
                     {
-                        stroke: tokenValue(semanticColor.core.border.neutral.subtle),
+                        stroke: tokenValue(semanticColor.core.border.neutral.default),
                         strokeWidth: 1,
                         // opacity: 0.3,
                     },
@@ -727,7 +729,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
 
         if (isMobile) {
             const snap = config.scaleY / self.props.options.snapsPerLine;
-            config.graph.lines[i] = Interactive2.addMaybeMobileMovablePoint(
+            config.graph.lines[i] = Interactive2.addMovablePointV2(
                 this,
                 {
                     coord: [x, startHeight],
@@ -781,7 +783,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
                     constrainX: true,
                 },
                 normalStyle: {
-                    stroke: KhanColors.INTERACTIVE,
+                    stroke: tokenValue(semanticColor.core.foreground.instructive.default),
                     // Don't display graph handles in static mode
                     "stroke-width": this.props.static ? 0 : 4,
                 },
@@ -827,82 +829,47 @@ class Plotter extends React.Component<Props, State> implements Widget {
         const graphie = self.graphie;
         const x = i + (isMobile ? 0.4 : 1);
 
-        if (isMobile) {
-            const snap = config.scaleY / self.props.options.snapsPerLine;
-            c.graph.points[i] = Interactive2.addMaybeMobileMovablePoint(this, {
-                coord: [x, startHeight],
-                constraints: [
-                    (coord, prev, options: any) => {
-                        return [
-                            x,
-                            this._clampValue(
-                                Math.round(coord[1] / snap) * snap,
-                                0,
-                                config.dimY,
-                            ),
-                        ];
-                    },
-                ],
-                onMove: function () {
-                    const y = c.graph.points[i].coord()[1];
-
-                    const values = [...self.props.userInput];
-                    values[i] = y;
-                    self.changeAndTrack(values);
-
-                    self._maybeHideDragPrompt();
+        const snap = config.scaleY / self.props.options.snapsPerLine;
+        c.graph.points[i] = Interactive2.addMovablePointV2(this, {
+            coord: [x, startHeight],
+            constraints: [
+                (coord) => {
+                    return [
+                        x,
+                        this._clampValue(
+                            Math.round(coord[1] / snap) * snap,
+                            0,
+                            config.dimY,
+                        ),
+                    ];
                 },
-            });
+            ],
+            onMove: function () {
+                const y = c.graph.points[i].coord()[1];
 
-            self._maybeShowDragPrompt();
-
-            if (i > 0) {
-                c.graph.lines[i] = Interactive2.addMovableLine(graphie, {
-                    points: [c.graph.points[i - 1], c.graph.points[i]],
-                    constraints: Interactive2.MovablePoint.constraints.fixed(),
-                    normalStyle: {
-                        stroke: KhanColors.BLUE_C,
-                        "stroke-width": 2,
-                    },
-                    highlightStyle: {
-                        stroke: KhanColors.BLUE_C,
-                        "stroke-width": 2,
-                    },
-                });
-            }
-        } else {
-            c.graph.points[i] = graphie.addMovablePoint({
-                coord: [x, startHeight],
-                constraints: {
-                    constrainX: true,
-                },
-                normalStyle: {
-                    fill: tokenValue(semanticColor.core.border.instructive.default),
-                    stroke: tokenValue(semanticColor.core.border.instructive.default),
-                },
-                snapY: c.scaleY / self.props.options.snapsPerLine,
-            });
-            c.graph.points[i].onMove = function (x, y) {
-                y = Math.min(Math.max(y, 0), c.dimY);
                 const values = [...self.props.userInput];
                 values[i] = y;
                 self.changeAndTrack(values);
-                return [x, y];
-            };
 
-            if (i > 0) {
-                c.graph.lines[i] = graphie.addMovableLineSegment({
-                    pointA: c.graph.points[i - 1],
-                    pointZ: c.graph.points[i],
-                    constraints: {
-                        fixed: true,
-                    },
-                    normalStyle: {
-                        stroke: tokenValue(semanticColor.core.border.instructive.subtle),
-                        "stroke-width": 2,
-                    },
-                });
-            }
+                self._maybeHideDragPrompt();
+            },
+        });
+
+        self._maybeShowDragPrompt();
+
+        if (i > 0) {
+            c.graph.lines[i] = Interactive2.addMovableLine(graphie, {
+                points: [c.graph.points[i - 1], c.graph.points[i]],
+                constraints: Interactive2.MovablePoint.constraints.fixed(),
+                normalStyle: {
+                    stroke: tokenValue(semanticColor.core.border.instructive.default),
+                    "stroke-width": 2,
+                },
+                highlightStyle: {
+                    stroke: tokenValue(semanticColor.core.border.instructive.default),
+                    "stroke-width": 2,
+                },
+            });
         }
 
         return x;

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -5,6 +5,11 @@ import {
     type PerseusPlotterWidgetOptions,
     type PlotterPublicWidgetOptions,
 } from "@khanacademy/perseus-core";
+import {
+    semanticColor,
+    font,
+    tokenValue,
+} from "@khanacademy/wonder-blocks-tokens";
 import $ from "jquery";
 import * as React from "react";
 import _ from "underscore";
@@ -23,7 +28,6 @@ import type {
     WidgetProps,
 } from "../../types";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
-import {semanticColor, font, tokenValue} from "@khanacademy/wonder-blocks-tokens";
 
 type Props = WidgetProps<
     PlotterPublicWidgetOptions,
@@ -288,7 +292,9 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 // horizontal lines on graph
                 graphie.style(
                     {
-                        stroke: tokenValue(semanticColor.core.border.neutral.default),
+                        stroke: tokenValue(
+                            semanticColor.core.border.neutral.default,
+                        ),
                         strokeWidth: 1,
                         opacity: 1,
                     },
@@ -308,7 +314,10 @@ class Plotter extends React.Component<Props, State> implements Widget {
                     false,
                 )
                 .css("font-weight", font.weight.bold)
-                .css("color", tokenValue(semanticColor.core.foreground.neutral.subtle))
+                .css(
+                    "color",
+                    tokenValue(semanticColor.core.foreground.neutral.subtle),
+                )
                 .css("display", "none");
         }
 
@@ -332,7 +341,11 @@ class Plotter extends React.Component<Props, State> implements Widget {
         }
 
         graphie.style(
-            {stroke: tokenValue(semanticColor.core.border.neutral.strong), strokeWidth: 2, opacity: 1.0},
+            {
+                stroke: tokenValue(semanticColor.core.border.neutral.strong),
+                strokeWidth: 2,
+                opacity: 1.0,
+            },
             function () {
                 if (isTiledPlot) {
                     if (isDotplot) {
@@ -375,7 +388,10 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 isMobile ? "above" : "below",
                 false,
             )
-            .css("color", tokenValue(semanticColor.core.foreground.neutral.strong))
+            .css(
+                "color",
+                tokenValue(semanticColor.core.foreground.neutral.strong),
+            )
             .css("font-weight", font.weight.bold);
 
         // y-axis label
@@ -386,7 +402,10 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 "center",
                 false,
             )
-            .css("color", tokenValue(semanticColor.core.foreground.neutral.strong))
+            .css(
+                "color",
+                tokenValue(semanticColor.core.foreground.neutral.strong),
+            )
             .css("font-weight", font.weight.bold)
             .addClass("rotate");
 
@@ -398,7 +417,9 @@ class Plotter extends React.Component<Props, State> implements Widget {
             });
 
             this.horizHairline.attr({
-                stroke: tokenValue(semanticColor.core.border.instructive.default),
+                stroke: tokenValue(
+                    semanticColor.core.border.instructive.default,
+                ),
             });
             this.horizHairline.hide();
 
@@ -455,7 +476,9 @@ class Plotter extends React.Component<Props, State> implements Widget {
         return new Promise((resolve) => {
             graphie.style(
                 {
-                    color: tokenValue(semanticColor.core.foreground.neutral.strong),
+                    color: tokenValue(
+                        semanticColor.core.foreground.neutral.strong,
+                    ),
                     transform: shouldRotate ? labelRotation : "none",
                     transformOrigin: "100%",
                 },
@@ -514,7 +537,9 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 const tickHeight = 6 / c.scale[1];
                 graphie.style(
                     {
-                        stroke: tokenValue(semanticColor.core.foreground.neutral.default),
+                        stroke: tokenValue(
+                            semanticColor.core.foreground.neutral.default,
+                        ),
                         strokeWidth: 2,
                         opacity: 1.0,
                     },
@@ -575,7 +600,9 @@ class Plotter extends React.Component<Props, State> implements Widget {
 
                 graphie.style(
                     {
-                        stroke: tokenValue(semanticColor.core.foreground.neutral.default),
+                        stroke: tokenValue(
+                            semanticColor.core.foreground.neutral.default,
+                        ),
                         strokeWidth: 2,
                         opacity: 1.0,
                     },
@@ -692,7 +719,9 @@ class Plotter extends React.Component<Props, State> implements Widget {
         graphie.style(
             {
                 stroke: "none",
-                fill: tokenValue(semanticColor.core.foreground.instructive.subtle),
+                fill: tokenValue(
+                    semanticColor.core.foreground.instructive.subtle,
+                ),
                 opacity: 1.0,
             },
             function () {
@@ -711,7 +740,9 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 // Don't draw a divider to the left of the first bucket
                 graphie.style(
                     {
-                        stroke: tokenValue(semanticColor.core.border.neutral.default),
+                        stroke: tokenValue(
+                            semanticColor.core.border.neutral.default,
+                        ),
                         strokeWidth: 1,
                         // opacity: 0.3,
                     },
@@ -729,35 +760,32 @@ class Plotter extends React.Component<Props, State> implements Widget {
 
         if (isMobile) {
             const snap = config.scaleY / self.props.options.snapsPerLine;
-            config.graph.lines[i] = Interactive2.addMovablePointV2(
-                this,
-                {
-                    coord: [x, startHeight],
-                    constraints: [
-                        (coord: any, prev: any, options: any) => {
-                            return [
-                                x,
-                                this._clampValue(
-                                    Math.round(coord[1] / snap) * snap,
-                                    0,
-                                    config.dimY,
-                                ),
-                            ];
-                        },
-                    ],
-                    onMove: function () {
-                        const y = config.graph.lines[i].coord()[1];
-
-                        const values = [...self.props.userInput];
-                        values[i] = y;
-                        self.changeAndTrack(values);
-
-                        self._maybeHideDragPrompt();
-
-                        scaleBar(i, y);
+            config.graph.lines[i] = Interactive2.addMovablePointV2(this, {
+                coord: [x, startHeight],
+                constraints: [
+                    (coord: any, prev: any, options: any) => {
+                        return [
+                            x,
+                            this._clampValue(
+                                Math.round(coord[1] / snap) * snap,
+                                0,
+                                config.dimY,
+                            ),
+                        ];
                     },
+                ],
+                onMove: function () {
+                    const y = config.graph.lines[i].coord()[1];
+
+                    const values = [...self.props.userInput];
+                    values[i] = y;
+                    self.changeAndTrack(values);
+
+                    self._maybeHideDragPrompt();
+
+                    scaleBar(i, y);
                 },
-            );
+            });
 
             // We set the z-index to 1 here so that the hairlines cover up the
             // points
@@ -773,7 +801,9 @@ class Plotter extends React.Component<Props, State> implements Widget {
                     constrainX: true,
                 },
                 normalStyle: {
-                    stroke: tokenValue(semanticColor.core.foreground.instructive.default),
+                    stroke: tokenValue(
+                        semanticColor.core.foreground.instructive.default,
+                    ),
                     // Don't display graph handles in static mode
                     "stroke-width": this.props.static ? 0 : 4,
                 },
@@ -852,11 +882,15 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 points: [c.graph.points[i - 1], c.graph.points[i]],
                 constraints: Interactive2.MovablePoint.constraints.fixed(),
                 normalStyle: {
-                    stroke: tokenValue(semanticColor.core.border.instructive.default),
+                    stroke: tokenValue(
+                        semanticColor.core.border.instructive.default,
+                    ),
                     "stroke-width": 2,
                 },
                 highlightStyle: {
-                    stroke: tokenValue(semanticColor.core.border.instructive.default),
+                    stroke: tokenValue(
+                        semanticColor.core.border.instructive.default,
+                    ),
                     "stroke-width": 2,
                 },
             });
@@ -877,8 +911,12 @@ class Plotter extends React.Component<Props, State> implements Widget {
                     this.DOT_PLOT_POINT_SIZE() / graphie.scale[1],
                 ],
                 {
-                    fill: tokenValue(semanticColor.core.border.instructive.default),
-                    stroke: tokenValue(semanticColor.core.border.instructive.default),
+                    fill: tokenValue(
+                        semanticColor.core.border.instructive.default,
+                    ),
+                    stroke: tokenValue(
+                        semanticColor.core.border.instructive.default,
+                    ),
                 },
             );
         });
@@ -983,7 +1021,9 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 ],
                 {
                     fill: tokenValue(semanticColor.core.border.neutral.subtle),
-                    stroke: tokenValue(semanticColor.core.border.neutral.subtle),
+                    stroke: tokenValue(
+                        semanticColor.core.border.neutral.subtle,
+                    ),
                 },
             );
         });

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -334,7 +334,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
                     false,
                 )
                 .css("font-weight", font.weight.bold)
-                .css("color", semanticColor.core.foreground.neutral.default)
+                .css("color", semanticColor.core.foreground.neutral.strong)
                 .css("display", "none");
         }
 

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -24,6 +24,7 @@ import type {
     WidgetProps,
 } from "../../types";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
+import {semanticColor, font, tokenValue} from "@khanacademy/wonder-blocks-tokens";
 
 type Props = WidgetProps<
     PlotterPublicWidgetOptions,
@@ -285,7 +286,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 );
                 graphie.style(
                     {
-                        stroke: isMobile ? "#e9ebec" : "#000",
+                        stroke: isMobile ? tokenValue(semanticColor.core.border.neutral.subtle) : tokenValue(semanticColor.core.border.neutral.strong),
                         strokeWidth: 1,
                         opacity: isMobile ? 1 : 0.3,
                     },
@@ -304,8 +305,8 @@ class Plotter extends React.Component<Props, State> implements Widget {
                     "center",
                     false,
                 )
-                .css("font-weight", "bold")
-                .css("color", KhanColors.KA_GREEN)
+                .css("font-weight", font.weight.bold)
+                .css("color", tokenValue(semanticColor.core.foreground.neutral.subtle))
                 .css("display", "none");
         }
 
@@ -319,8 +320,8 @@ class Plotter extends React.Component<Props, State> implements Widget {
                     "center",
                     false,
                 )
-                .css("font-weight", "bold")
-                .css("color", KhanColors.KA_GREEN)
+                .css("font-weight", font.weight.bold)
+                .css("color", semanticColor.core.foreground.instructive.default)
                 .css("display", "none");
         }
 
@@ -329,22 +330,15 @@ class Plotter extends React.Component<Props, State> implements Widget {
         }
 
         graphie.style(
-            {stroke: "#000", strokeWidth: 2, opacity: 1.0},
+            {stroke: tokenValue(semanticColor.core.border.neutral.strong), strokeWidth: 2, opacity: 1.0},
             function () {
                 if (isTiledPlot) {
                     if (isDotplot) {
                         // Dotplot is a subtype of tiled plot, here we only draw
                         // the x-axis
-                        graphie.style(
-                            {
-                                stroke: isMobile ? KhanColors.GRAY_G : "#000",
-                                strokeWidth: isMobile ? 1 : 2,
-                            },
-                            () =>
-                                graphie.line(
-                                    [isMobile ? 0 : 0.5, 0],
-                                    [c.dimX - (isMobile ? 0 : 0.5), 0],
-                                ),
+                        graphie.line(
+                            [isMobile ? 0 : 0.5, 0],
+                            [c.dimX - (isMobile ? 0 : 0.5), 0],
                         );
                     } else {
                         graphie.line([0, 0], [c.dimX, 0]);
@@ -354,68 +348,45 @@ class Plotter extends React.Component<Props, State> implements Widget {
                             self.props.options.labels[1].length !== 0 ||
                             !isMobile
                         ) {
-                            graphie.style(
-                                {
-                                    stroke: isMobile
-                                        ? KhanColors.GRAY_G
-                                        : "#000",
-                                    strokeWidth: isMobile ? 1 : 2,
-                                },
-                                () => graphie.line([0, 0], [0, c.dimY]),
-                            );
+                            graphie.line([0, 0], [0, c.dimY]);
                         }
                     }
                 } else {
                     // Draw normal axes
-                    graphie.style(
-                        {
-                            stroke: isMobile ? KhanColors.GRAY_G : "#000",
-                            strokeWidth: isMobile ? 1 : 2,
-                        },
-                        () =>
-                            graphie.line(
-                                [isMobile ? -padX * 3 : 0, 0],
-                                [c.dimX + (isMobile ? padX : 0), 0],
-                            ),
+                    graphie.line(
+                        [isMobile ? -padX * 3 : 0, 0],
+                        [c.dimX + (isMobile ? padX : 0), 0],
                     );
 
                     if (!((isBar || isLine) && isMobile)) {
-                        graphie.style(
-                            {
-                                stroke: isMobile ? KhanColors.GRAY_G : "#000",
-                                strokeWidth: isMobile ? 1 : 2,
-                            },
-                            () => graphie.line([0, 0], [0, c.dimY]),
-                        );
+                        graphie.line([0, 0], [0, c.dimY]);
                     }
                 }
             },
         );
 
-        const xAxisLabel = graphie
+        // x-axis label
+        graphie
             .label(
                 [c.dimX / 2, isMobile ? -padBottom : -35 / c.scale[1]],
                 self.props.options.labels[0],
                 isMobile ? "above" : "below",
                 false,
             )
-            .css("font-weight", "bold");
-        if (isMobile) {
-            xAxisLabel.css("color", KhanColors.GRAY_F);
-        }
+            .css("color", tokenValue(semanticColor.core.foreground.neutral.default))
+            .css("font-weight", font.weight.bold);
 
-        const yAxisLabel = graphie
+        // y-axis label
+        graphie
             .label(
                 [(isMobile ? -35 : -60) / c.scale[0], c.dimY / 2],
                 self.props.options.labels[1],
                 "center",
                 false,
             )
-            .css("font-weight", "bold")
+            .css("color", tokenValue(semanticColor.core.foreground.neutral.default))
+            .css("font-weight", font.weight.bold)
             .addClass("rotate");
-        if (isMobile) {
-            yAxisLabel.css("color", KhanColors.GRAY_F);
-        }
 
         if (this.props.apiOptions.isMobile) {
             this.horizHairline = new WrappedLine(this.graphie, [0, 0], [0, 0], {
@@ -425,7 +396,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
             });
 
             this.horizHairline.attr({
-                stroke: KhanColors.INTERACTIVE,
+                stroke: tokenValue(semanticColor.core.border.instructive.default),
             });
             this.horizHairline.hide();
 
@@ -541,8 +512,8 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 const tickHeight = 6 / c.scale[1];
                 graphie.style(
                     {
-                        stroke: "#000",
-                        strokeWidth: isMobile ? 1 : 2,
+                        stroke: tokenValue(semanticColor.core.foreground.neutral.default),
+                        strokeWidth: 2,
                         opacity: 1.0,
                     },
                     function () {
@@ -602,8 +573,8 @@ class Plotter extends React.Component<Props, State> implements Widget {
 
                 graphie.style(
                     {
-                        stroke: isMobile ? KhanColors.GRAY_G : "#000",
-                        strokeWidth: isMobile ? 1 : 2,
+                        stroke: tokenValue(semanticColor.core.foreground.neutral.default),
+                        strokeWidth: 2,
                         opacity: 1.0,
                     },
                     function () {
@@ -719,7 +690,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
         graphie.style(
             {
                 stroke: "none",
-                fill: isMobile ? KhanColors.BLUE_C : KhanColors.LIGHT_BLUE,
+                fill: tokenValue(semanticColor.core.background.instructive.default),
                 opacity: 1.0,
             },
             function () {
@@ -738,9 +709,9 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 // Don't draw a divider to the left of the first bucket
                 graphie.style(
                     {
-                        stroke: "#000",
+                        stroke: tokenValue(semanticColor.core.border.neutral.subtle),
                         strokeWidth: 1,
-                        opacity: 0.3,
+                        // opacity: 0.3,
                     },
                     function () {
                         config.graph.dividers.push(
@@ -773,9 +744,9 @@ class Plotter extends React.Component<Props, State> implements Widget {
                         },
                     ],
                     onMoveStart: function () {
-                        config.graph.bars[i].attr({
-                            fill: KhanColors.INTERACTIVE,
-                        });
+                        // config.graph.bars[i].attr({
+                        //     fill: ,
+                        // });
                     },
                     onMove: function () {
                         const y = config.graph.lines[i].coord()[1];
@@ -789,9 +760,9 @@ class Plotter extends React.Component<Props, State> implements Widget {
                         scaleBar(i, y);
                     },
                     onMoveEnd: function () {
-                        config.graph.bars[i].attr({
-                            fill: KhanColors.BLUE_C,
-                        });
+                        // config.graph.bars[i].attr({
+                        //     fill: KhanColors.BLUE_C,
+                        // });
                     },
                 },
             );
@@ -906,8 +877,8 @@ class Plotter extends React.Component<Props, State> implements Widget {
                     constrainX: true,
                 },
                 normalStyle: {
-                    fill: KhanColors.INTERACTIVE,
-                    stroke: KhanColors.INTERACTIVE,
+                    fill: tokenValue(semanticColor.core.border.instructive.default),
+                    stroke: tokenValue(semanticColor.core.border.instructive.default),
                 },
                 snapY: c.scaleY / self.props.options.snapsPerLine,
             });
@@ -927,7 +898,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
                         fixed: true,
                     },
                     normalStyle: {
-                        stroke: "#9ab8ed",
+                        stroke: tokenValue(semanticColor.core.border.instructive.subtle),
                         "stroke-width": 2,
                     },
                 });
@@ -949,8 +920,8 @@ class Plotter extends React.Component<Props, State> implements Widget {
                     this.DOT_PLOT_POINT_SIZE() / graphie.scale[1],
                 ],
                 {
-                    fill: KhanColors.INTERACTIVE,
-                    stroke: KhanColors.INTERACTIVE,
+                    fill: tokenValue(semanticColor.core.border.instructive.default),
+                    stroke: tokenValue(semanticColor.core.border.instructive.default),
                 },
             );
         });
@@ -1054,8 +1025,8 @@ class Plotter extends React.Component<Props, State> implements Widget {
                     self.DOT_TICK_POINT_SIZE() / graphie.scale[1],
                 ],
                 {
-                    fill: "#dee1e3",
-                    stroke: "#dee1e3",
+                    fill: tokenValue(semanticColor.core.border.neutral.subtle),
+                    stroke: tokenValue(semanticColor.core.border.neutral.subtle),
                 },
             );
         });

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -540,7 +540,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 graphie.style(
                     {
                         stroke: tokenValue(
-                            semanticColor.core.foreground.neutral.default,
+                            semanticColor.core.border.neutral.strong,
                         ),
                         strokeWidth: 2,
                         opacity: 1.0,
@@ -603,7 +603,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 graphie.style(
                     {
                         stroke: tokenValue(
-                            semanticColor.core.foreground.neutral.default,
+                            semanticColor.core.border.neutral.strong,
                         ),
                         strokeWidth: 2,
                         opacity: 1.0,
@@ -914,10 +914,10 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 ],
                 {
                     fill: tokenValue(
-                        semanticColor.core.border.instructive.default,
+                        semanticColor.core.foreground.instructive.default,
                     ),
                     stroke: tokenValue(
-                        semanticColor.core.border.instructive.default,
+                        semanticColor.core.foreground.instructive.default,
                     ),
                 },
             );

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -305,6 +305,8 @@ class Plotter extends React.Component<Props, State> implements Widget {
             }
         }
 
+        // Set up the instruction text that tells the learner how to interact
+        // with the plot.
         if ((isBar || isLine) && isMobile && !this.props.static) {
             self.graphie.dragPrompt = graphie
                 .label(
@@ -316,7 +318,7 @@ class Plotter extends React.Component<Props, State> implements Widget {
                 .css("font-weight", font.weight.bold)
                 .css(
                     "color",
-                    tokenValue(semanticColor.core.foreground.neutral.subtle),
+                    tokenValue(semanticColor.core.foreground.neutral.strong),
                 )
                 .css("display", "none");
         }

--- a/packages/perseus/src/widgets/plotter/plotter.tsx
+++ b/packages/perseus/src/widgets/plotter/plotter.tsx
@@ -735,16 +735,16 @@ class Plotter extends React.Component<Props, State> implements Widget {
             },
         );
 
+        // Divider lines between histogram bars
         if (isHistogram) {
             if (i > 0) {
                 // Don't draw a divider to the left of the first bucket
                 graphie.style(
                     {
                         stroke: tokenValue(
-                            semanticColor.core.border.neutral.default,
+                            semanticColor.core.border.knockout.default,
                         ),
                         strokeWidth: 1,
-                        // opacity: 0.3,
                     },
                     function () {
                         config.graph.dividers.push(


### PR DESCRIPTION
## Summary:
This allows Plotter to be styled consistently for all themes (Wonder Blocks and
Shape Your Learning, including dark mode).

Issue: LEMS-4274

## Test plan:

Review the regression stories in Storybook:
http://localhost:6006/?path=/story/widgets-plotter-visual-regression-tests-initial-state--bar-chart&globals=theme:syl-dark

Compare the code to the design mocks:
https://www.figma.com/design/dpEbtoeF5obxMN4VDifUna/Project-Color-Sync?node-id=38-3&t=Tktd6tF3AZ7mxCqz-0