### PR TITLE
Lighten the background color used in Grapher, Measurer, and Orderer

### DIFF
--- a/.changeset/kind-hornets-work.md
+++ b/.changeset/kind-hornets-work.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fixes the tokenized background color of Grapher, Measurer, and Orderer to be more similar to the original background color (`#fdfdfd`) in the default theme.

--- a/packages/perseus/src/styles/perseus-renderer-part-1.css
+++ b/packages/perseus/src/styles/perseus-renderer-part-1.css
@@ -9,7 +9,7 @@
     user-select: none;
 }
 .blank-background {
-    background-color: var(--wb-semanticColor-core-background-neutral-subtle);
+    background-color: var(--wb-semanticColor-core-background-base-default);
 }
 .graphie {
     -webkit-user-select: none;


### PR DESCRIPTION
## Summary:
This fixes an issue introduced by https://github.com/Khan/perseus/pull/4071.

The `neutral-subtle` background color was too dark (in light mode). The original
color (`#fdfdfd`) is much closer to `background-base-default` (`#fff`).

Issue: none

## Test plan:

Review the Storybook docs and visual regression tests for the affected widgets.