### PR TITLE
feat: confirmation buttons have ctrl/cmd+enter shortcuts

### DIFF
--- a/packages/perseus/src/util/keyboard-shortcuts.ts
+++ b/packages/perseus/src/util/keyboard-shortcuts.ts
@@ -1,0 +1,18 @@
+type KeyboardShortcutEvent = {
+    key: string;
+    ctrlKey: boolean;
+    metaKey: boolean;
+    altKey: boolean;
+};
+
+export const isCtrlOrCmdEnter = (event: KeyboardShortcutEvent): boolean => {
+    if (event.key !== "Enter") {
+        return false;
+    }
+
+    if (event.altKey) {
+        return false;
+    }
+
+    return event.ctrlKey || event.metaKey;
+};

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.test.ts
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.test.ts
@@ -1,5 +1,5 @@
 import {type PerseusRenderer} from "@khanacademy/perseus-core";
-import {act, screen} from "@testing-library/react";
+import {act, fireEvent, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 
 import * as Dependencies from "../../dependencies";
@@ -132,6 +132,23 @@ describe("graded group set widget", () => {
         await userEvent.click(
             screen.getByRole("button", {name: "Next question"}),
         );
+
+        // Assert
+        expect(screen.getByText("Problem 1b")).toBeVisible();
+    });
+
+    it("should advance to next group when Ctrl+Enter is pressed", async () => {
+        // Arrange
+        renderQuestion(article1);
+        await userEvent.type(screen.getByRole("textbox"), "0.9");
+        await userEvent.click(screen.getByRole("button", {name: "Check"}));
+
+        const nextQuestionButton = screen.getByRole("button", {
+            name: "Next question",
+        });
+
+        // Act
+        fireEvent.keyDown(nextQuestionButton, {ctrlKey: true, key: "Enter"});
 
         // Assert
         expect(screen.getByText("Problem 1b")).toBeVisible();

--- a/packages/perseus/src/widgets/graded-group/graded-group.test.ts
+++ b/packages/perseus/src/widgets/graded-group/graded-group.test.ts
@@ -9,7 +9,7 @@ import {
     generateTestPerseusRenderer,
     type PerseusArticle,
 } from "@khanacademy/perseus-core";
-import {act, screen} from "@testing-library/react";
+import {act, fireEvent, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 
 import {renderArticle} from "../../__tests__/article-renderer.test";
@@ -91,6 +91,52 @@ describe("graded-group", () => {
     });
 
     describe("on desktop", () => {
+        it("checks the answer when Ctrl+Enter is pressed", async () => {
+            // Arrange
+            renderQuestion(question1);
+
+            await userEvent.click(
+                screen.getAllByRole("button", {name: "True"})[0],
+            );
+            await userEvent.click(
+                screen.getAllByRole("button", {name: "False"})[1],
+            );
+            await userEvent.click(
+                screen.getAllByRole("button", {name: "True"})[2],
+            );
+            const lastChoice = screen.getAllByRole("button", {name: "True"})[3];
+            await userEvent.click(lastChoice);
+
+            // Act
+            fireEvent.keyDown(lastChoice, {ctrlKey: true, key: "Enter"});
+
+            // Assert
+            expect(screen.getByRole("alert", {name: "Correct"})).toBeVisible();
+        });
+
+        it("checks the answer when Cmd+Enter is pressed", async () => {
+            // Arrange
+            renderQuestion(question1);
+
+            await userEvent.click(
+                screen.getAllByRole("button", {name: "True"})[0],
+            );
+            await userEvent.click(
+                screen.getAllByRole("button", {name: "False"})[1],
+            );
+            await userEvent.click(
+                screen.getAllByRole("button", {name: "True"})[2],
+            );
+            const lastChoice = screen.getAllByRole("button", {name: "True"})[3];
+            await userEvent.click(lastChoice);
+
+            // Act
+            fireEvent.keyDown(lastChoice, {key: "Enter", metaKey: true});
+
+            // Assert
+            expect(screen.getByRole("alert", {name: "Correct"})).toBeVisible();
+        });
+
         it("should be able to be answered correctly", async () => {
             // Arrange
             renderQuestion(question1);

--- a/packages/perseus/src/widgets/graded-group/graded-group.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.tsx
@@ -183,10 +183,7 @@ export class GradedGroup
             return;
         }
 
-        if (
-            this.props.apiOptions.isMobile &&
-            answerBarState !== "ACTIVE"
-        ) {
+        if (this.props.apiOptions.isMobile && answerBarState !== "ACTIVE") {
             return;
         }
 
@@ -297,7 +294,10 @@ export class GradedGroup
         const showSolutions = isCorrect ? "all" : "none";
 
         return (
-            <div className={classes} onKeyDownCapture={this._handleConfirmationShortcut}>
+            <div
+                className={classes}
+                onKeyDownCapture={this._handleConfirmationShortcut}
+            >
                 {!!this.props.options.title && (
                     <div className={css(styles.title)}>
                         {this.props.options.title}

--- a/packages/perseus/src/widgets/graded-group/graded-group.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.tsx
@@ -16,6 +16,7 @@ import {mapErrorToString} from "../../strings";
 import {phoneMargin, negativePhoneMargin} from "../../styles/constants";
 import UserInputManager from "../../user-input-manager";
 import a11y from "../../util/a11y";
+import {isCtrlOrCmdEnter} from "../../util/keyboard-shortcuts";
 import {getPromptJSON} from "../../widget-ai-utils/graded-group/graded-group-ai-utils";
 
 import GradedGroupAnswerBar from "./graded-group-answer-bar";
@@ -164,6 +165,35 @@ export class GradedGroup
         });
     };
 
+    _handleConfirmationShortcut: (e: React.KeyboardEvent) => void = (e) => {
+        if (!isCtrlOrCmdEnter(e)) {
+            return;
+        }
+
+        if (this.props.apiOptions.readOnly) {
+            return;
+        }
+
+        const {answerBarState} = this.state;
+        const isCorrect = answerBarState === "CORRECT";
+
+        if (isCorrect && this.props.onNextQuestion) {
+            e.preventDefault();
+            this.props.onNextQuestion();
+            return;
+        }
+
+        if (
+            this.props.apiOptions.isMobile &&
+            answerBarState !== "ACTIVE"
+        ) {
+            return;
+        }
+
+        e.preventDefault();
+        this._checkAnswer();
+    };
+
     // Mobile API
     getInputPaths: () => ReadonlyArray<FocusPath> = () => {
         return this.rendererRef.current?.getInputPaths() || [];
@@ -267,7 +297,7 @@ export class GradedGroup
         const showSolutions = isCorrect ? "all" : "none";
 
         return (
-            <div className={classes}>
+            <div className={classes} onKeyDownCapture={this._handleConfirmationShortcut}>
                 {!!this.props.options.title && (
                     <div className={css(styles.title)}>
                         {this.props.options.title}


### PR DESCRIPTION
Confirmation buttons such as `Check` and `Next` are now able to be pressed via a keyboard shortcut of `ctrl+enter` or `meta(same as macos cmd)+enter`.