### PR TITLE
Preserve whole widgetInfo object in WidgetEditor props

### DIFF
--- a/.changeset/itchy-chicken-brush.md
+++ b/.changeset/itchy-chicken-brush.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Internal: the WidgetEditor now receives the entire `PerseusWidget` object via a `widgetInfo` prop, instead of having the properties of `PerseusWidget` spread into its props.

--- a/packages/perseus-editor/src/components/__tests__/widget-editor.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/widget-editor.test.tsx
@@ -2,8 +2,8 @@ import {ApiOptions, Dependencies} from "@khanacademy/perseus";
 import {
     CoreWidgetRegistry,
     generateDefinitionOptions,
-    generateImageOptions,
-    generateRadioOptions,
+    generateImageWidget,
+    generateRadioWidget,
 } from "@khanacademy/perseus-core";
 import {render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
@@ -48,14 +48,7 @@ describe("WidgetEditor", () => {
             render(
                 <WidgetEditor
                     id="radio 1"
-                    widgetInfo={{
-                        type: "radio",
-                        alignment: "default",
-                        static: false,
-                        graded: true,
-                        options: generateRadioOptions(),
-                        version: {major: 0, minor: 0},
-                    }}
+                    widgetInfo={generateRadioWidget()}
                     onChange={() => {}}
                     onRemove={() => {}}
                     apiOptions={{
@@ -84,14 +77,7 @@ describe("WidgetEditor", () => {
             render(
                 <WidgetEditor
                     id="image 1"
-                    widgetInfo={{
-                        type: "image",
-                        alignment: "block",
-                        static: false,
-                        graded: true,
-                        options: generateImageOptions(),
-                        version: {major: 0, minor: 0},
-                    }}
+                    widgetInfo={generateImageWidget()}
                     onChange={() => {}}
                     onRemove={() => {}}
                     apiOptions={{
@@ -119,14 +105,7 @@ describe("WidgetEditor", () => {
             render(
                 <WidgetEditor
                     id="radio 1"
-                    widgetInfo={{
-                        type: "radio",
-                        alignment: "default",
-                        static: false,
-                        graded: true,
-                        options: generateRadioOptions(),
-                        version: {major: 0, minor: 0},
-                    }}
+                    widgetInfo={generateRadioWidget()}
                     onChange={() => {}}
                     onRemove={() => {}}
                     apiOptions={{
@@ -153,14 +132,7 @@ describe("WidgetEditor", () => {
             render(
                 <WidgetEditor
                     id="image 1"
-                    widgetInfo={{
-                        type: "image",
-                        alignment: "block",
-                        static: false,
-                        graded: true,
-                        options: generateImageOptions(),
-                        version: {major: 0, minor: 0},
-                    }}
+                    widgetInfo={generateImageWidget()}
                     onChange={onChangeMock}
                     onRemove={() => {}}
                     apiOptions={{
@@ -196,14 +168,7 @@ describe("WidgetEditor", () => {
             render(
                 <WidgetEditor
                     id="image 1"
-                    widgetInfo={{
-                        type: "image",
-                        alignment: "block",
-                        static: false,
-                        graded: true,
-                        options: generateImageOptions(),
-                        version: {major: 0, minor: 0},
-                    }}
+                    widgetInfo={generateImageWidget()}
                     onChange={() => {}}
                     onRemove={() => {}}
                     apiOptions={{

--- a/packages/perseus-editor/src/components/__tests__/widget-editor.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/widget-editor.test.tsx
@@ -1,5 +1,10 @@
 import {ApiOptions, Dependencies} from "@khanacademy/perseus";
-import {CoreWidgetRegistry} from "@khanacademy/perseus-core";
+import {
+    CoreWidgetRegistry,
+    generateDefinitionOptions,
+    generateImageOptions,
+    generateRadioOptions,
+} from "@khanacademy/perseus-core";
 import {render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
@@ -8,8 +13,10 @@ import {testDependencies} from "../../testing/test-dependencies";
 import {registerAllWidgetsAndEditorsForTesting} from "../../util/register-all-widgets-and-editors-for-testing";
 import WidgetEditor, {_upgradeWidgetInfo} from "../widget-editor";
 
-import type {WidgetEditorProps} from "../widget-editor";
-import type {PerseusDefinitionWidgetOptions} from "@khanacademy/perseus-core";
+import type {
+    PerseusDefinitionWidgetOptions,
+    PerseusWidget,
+} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
 
 describe("WidgetEditor", () => {
@@ -41,12 +48,14 @@ describe("WidgetEditor", () => {
             render(
                 <WidgetEditor
                     id="radio 1"
-                    type="radio"
-                    alignment="default"
-                    static={false}
-                    graded={true}
-                    options={{}}
-                    version={{major: 0, minor: 0}}
+                    widgetInfo={{
+                        type: "radio",
+                        alignment: "default",
+                        static: false,
+                        graded: true,
+                        options: generateRadioOptions(),
+                        version: {major: 0, minor: 0},
+                    }}
                     onChange={() => {}}
                     onRemove={() => {}}
                     apiOptions={{
@@ -75,12 +84,14 @@ describe("WidgetEditor", () => {
             render(
                 <WidgetEditor
                     id="image 1"
-                    type="image"
-                    alignment="block"
-                    static={false}
-                    graded={true}
-                    options={{}}
-                    version={{major: 0, minor: 0}}
+                    widgetInfo={{
+                        type: "image",
+                        alignment: "block",
+                        static: false,
+                        graded: true,
+                        options: generateImageOptions(),
+                        version: {major: 0, minor: 0},
+                    }}
                     onChange={() => {}}
                     onRemove={() => {}}
                     apiOptions={{
@@ -108,12 +119,14 @@ describe("WidgetEditor", () => {
             render(
                 <WidgetEditor
                     id="radio 1"
-                    type="radio"
-                    alignment="default"
-                    static={false}
-                    graded={true}
-                    options={{}}
-                    version={{major: 0, minor: 0}}
+                    widgetInfo={{
+                        type: "radio",
+                        alignment: "default",
+                        static: false,
+                        graded: true,
+                        options: generateRadioOptions(),
+                        version: {major: 0, minor: 0},
+                    }}
                     onChange={() => {}}
                     onRemove={() => {}}
                     apiOptions={{
@@ -140,12 +153,14 @@ describe("WidgetEditor", () => {
             render(
                 <WidgetEditor
                     id="image 1"
-                    type="image"
-                    alignment="block"
-                    static={false}
-                    graded={true}
-                    options={{}}
-                    version={{major: 0, minor: 0}}
+                    widgetInfo={{
+                        type: "image",
+                        alignment: "block",
+                        static: false,
+                        graded: true,
+                        options: generateImageOptions(),
+                        version: {major: 0, minor: 0},
+                    }}
                     onChange={onChangeMock}
                     onRemove={() => {}}
                     apiOptions={{
@@ -181,12 +196,14 @@ describe("WidgetEditor", () => {
             render(
                 <WidgetEditor
                     id="image 1"
-                    type="image"
-                    alignment="block"
-                    static={false}
-                    graded={true}
-                    options={{}}
-                    version={{major: 0, minor: 0}}
+                    widgetInfo={{
+                        type: "image",
+                        alignment: "block",
+                        static: false,
+                        graded: true,
+                        options: generateImageOptions(),
+                        version: {major: 0, minor: 0},
+                    }}
                     onChange={() => {}}
                     onRemove={() => {}}
                     apiOptions={{
@@ -213,20 +230,16 @@ describe("WidgetEditor", () => {
                 static: false,
             };
 
-            const props: WidgetEditorProps = {
-                id: "definition 1",
-                onChange: () => {},
-                onRemove: () => {},
-                apiOptions: {},
+            const widgetInfo: PerseusWidget = {
                 type: "definition",
                 options,
             };
 
             // problemNum is in the denylist,
             // so we want to make sure it's removed
-            const dirtyProps = {...props, problemNum: 42};
+            const dirtyInfo: any = {...widgetInfo, problemNum: 42};
 
-            const output = _upgradeWidgetInfo(dirtyProps);
+            const output = _upgradeWidgetInfo(dirtyInfo);
 
             // make sure we filter as expected
             // eslint-disable-next-line no-restricted-syntax
@@ -244,23 +257,13 @@ describe("WidgetEditor", () => {
         });
 
         it("passes graded through", () => {
-            const options: PerseusDefinitionWidgetOptions = {
-                togglePrompt: "Neat prompt",
-                definition: "Cool definition",
-                static: false,
-            };
-
-            const props: WidgetEditorProps = {
-                id: "definition 1",
-                onChange: () => {},
-                onRemove: () => {},
-                apiOptions: {},
+            const widgetInfo: PerseusWidget = {
                 type: "definition",
-                options,
                 graded: true,
+                options: generateDefinitionOptions(),
             };
 
-            const output = _upgradeWidgetInfo(props);
+            const output = _upgradeWidgetInfo(widgetInfo);
 
             expect(output.graded).toBe(true);
         });

--- a/packages/perseus-editor/src/components/widget-editor.tsx
+++ b/packages/perseus-editor/src/components/widget-editor.tsx
@@ -27,7 +27,8 @@ export type WidgetEditorProps = {
     onRemove: () => unknown;
     apiOptions: APIOptions;
     widgetIsOpen?: boolean;
-} & Omit<PerseusWidget, "key">;
+    widgetInfo: PerseusWidget;
+};
 
 type WidgetEditorState = {
     showWidget: boolean;
@@ -35,22 +36,23 @@ type WidgetEditorState = {
 };
 
 // exported for tests
-export const _upgradeWidgetInfo = (props: WidgetEditorProps): PerseusWidget => {
+export function _upgradeWidgetInfo(widgetInfo: PerseusWidget): PerseusWidget {
     // We can't call serialize here because this.refs.widget
     // doesn't exist before this component is mounted.
-    const filteredProps = excludeDenylistKeys(props);
+    // eslint-disable-next-line no-restricted-syntax
+    const filteredWidget: PerseusWidget = excludeDenylistKeys(
+        widgetInfo,
+    ) as any;
 
     // This is circumventing an issue with excludeDenylistKeys;
     // it removes `graded` from WidgetOptions.options (good)
     // but it's also recursive so it removes `graded`
     // from the higher-up WidgetOptions (bad)
     // See: LEMS-4108 and https://khanacademy.slack.com/archives/C01AZ9H8TTQ/p1778089642003609
-    // eslint-disable-next-line no-restricted-syntax
-    (filteredProps as any).graded = props.graded;
+    filteredWidget.graded = widgetInfo.graded;
 
-    // eslint-disable-next-line no-restricted-syntax
-    return applyDefaultsToWidget(filteredProps as PerseusWidget);
-};
+    return applyDefaultsToWidget(filteredWidget);
+}
 
 // This component handles upgading widget editor props via prop
 // upgrade transforms. Widget editors will always be rendered
@@ -66,13 +68,13 @@ class WidgetEditor extends React.Component<
         super(props);
         this.state = {
             showWidget: props.widgetIsOpen ?? true,
-            widgetInfo: _upgradeWidgetInfo(props),
+            widgetInfo: _upgradeWidgetInfo(props.widgetInfo),
         };
         this.widget = React.createRef();
     }
 
     UNSAFE_componentWillReceiveProps(nextProps: WidgetEditorProps) {
-        this.setState({widgetInfo: _upgradeWidgetInfo(nextProps)});
+        this.setState({widgetInfo: _upgradeWidgetInfo(nextProps.widgetInfo)});
         // user can update internal state while the widget is handled globally
         if (
             nextProps.widgetIsOpen != null &&

--- a/packages/perseus-editor/src/components/widget-editor.tsx
+++ b/packages/perseus-editor/src/components/widget-editor.tsx
@@ -15,8 +15,7 @@ import type Editor from "../editor";
 import type {APIOptions} from "@khanacademy/perseus";
 import type {Alignment, PerseusWidget} from "@khanacademy/perseus-core";
 
-// exported for tests
-export type WidgetEditorProps = {
+type Props = {
     // Unserialized props
     id: string;
     onChange: (
@@ -30,7 +29,7 @@ export type WidgetEditorProps = {
     widgetInfo: PerseusWidget;
 };
 
-type WidgetEditorState = {
+type State = {
     showWidget: boolean;
     widgetInfo: PerseusWidget;
 };
@@ -58,13 +57,10 @@ export function _upgradeWidgetInfo(widgetInfo: PerseusWidget): PerseusWidget {
 // upgrade transforms. Widget editors will always be rendered
 // with all available transforms applied, but the results of those
 // transforms will not be propogated upwards until serialization.
-class WidgetEditor extends React.Component<
-    WidgetEditorProps,
-    WidgetEditorState
-> {
+class WidgetEditor extends React.Component<Props, State> {
     widget: React.RefObject<Editor>;
 
-    constructor(props: WidgetEditorProps) {
+    constructor(props: Props) {
         super(props);
         this.state = {
             showWidget: props.widgetIsOpen ?? true,
@@ -73,7 +69,7 @@ class WidgetEditor extends React.Component<
         this.widget = React.createRef();
     }
 
-    UNSAFE_componentWillReceiveProps(nextProps: WidgetEditorProps) {
+    UNSAFE_componentWillReceiveProps(nextProps: Props) {
         this.setState({widgetInfo: _upgradeWidgetInfo(nextProps.widgetInfo)});
         // user can update internal state while the widget is handled globally
         if (
@@ -90,7 +86,7 @@ class WidgetEditor extends React.Component<
     };
 
     _handleWidgetChange = (
-        newProps: WidgetEditorProps,
+        newProps: Props,
         cb: () => unknown,
         silent: boolean,
     ) => {

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -272,7 +272,7 @@ class Editor extends React.Component<Props, State> {
                 // widget data before specifying the `key` prop, to ensure the
                 // key overrides any `key` field on the widget (which might not
                 // be unique.
-                {...this.props.widgets[id]}
+                widgetInfo={this.props.widgets[id]}
                 ref={id}
                 id={id}
                 key={id}


### PR DESCRIPTION
## Summary:
This makes the editors slightly more typesafe, and gets us one step
closer to removing `excludeDenylistKeys`.

Issue: LEMS-4108

## Test plan:

Test the editors in Storybook, e.g.
http://localhost:6006/?path=/story/editors-editorpage--with-radio-widget