### PR TITLE
Fix type issues in WidgetEditor

### DIFF
--- a/.changeset/pink-sides-swim.md
+++ b/.changeset/pink-sides-swim.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Internal: Improved type safety in the WidgetEditor component

--- a/packages/perseus-editor/src/components/widget-editor.tsx
+++ b/packages/perseus-editor/src/components/widget-editor.tsx
@@ -11,7 +11,6 @@ import SectionControlButton from "./section-control-button";
 import ToggleableCaret from "./toggleable-caret";
 import WidgetEditorSettings from "./widget-editor-settings";
 
-import type Editor from "../editor";
 import type {APIOptions} from "@khanacademy/perseus";
 import type {Alignment, PerseusWidget} from "@khanacademy/perseus-core";
 
@@ -58,7 +57,10 @@ export function _upgradeWidgetInfo(widgetInfo: PerseusWidget): PerseusWidget {
 // with all available transforms applied, but the results of those
 // transforms will not be propogated upwards until serialization.
 class WidgetEditor extends React.Component<Props, State> {
-    widget: React.RefObject<Editor>;
+    widget: React.RefObject<{
+        serialize(): unknown;
+        getSaveWarnings?: () => unknown;
+    }>;
 
     constructor(props: Props) {
         super(props);
@@ -86,7 +88,7 @@ class WidgetEditor extends React.Component<Props, State> {
     };
 
     _handleWidgetChange = (
-        newProps: Props,
+        newOptions: PerseusWidget["options"],
         cb: () => unknown,
         silent: boolean,
     ) => {
@@ -96,7 +98,7 @@ class WidgetEditor extends React.Component<Props, State> {
             options: {
                 ...this.state.widgetInfo.options,
                 ...(this.widget.current?.serialize() ?? {}),
-                ...newProps,
+                ...newOptions,
             },
         } as PerseusWidget;
         this.props.onChange(newWidgetInfo, cb, silent);


### PR DESCRIPTION
## Summary:
The general lack of typechecking in the editors meant that these issues went
unnoticed.  The new types are more accurate.

Issue: none

## Test plan:

Typechecking should pass.