### PR TITLE
Convert unrecognized widget alignment values to 'default'

### DIFF
--- a/.changeset/frank-experts-hang.md
+++ b/.changeset/frank-experts-hang.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": minor
+---
+
+The Perseus parsers now handle unrecognized values for a widget's `alignment`, and convert them to `"default"`.

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.ts
@@ -13,8 +13,6 @@ import type {Parser} from "../parser-types";
 
 function alignmentToValidValue(alignment: string | undefined) {
     switch (alignment) {
-        case "":
-            return "default";
         case "default":
         case "block":
         case "inline-block":

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.ts
@@ -11,7 +11,7 @@ import {convert} from "../general-purpose-parsers/convert";
 
 import type {Parser} from "../parser-types";
 
-function alignmentToValidValue(alignment: string | undefined) {
+function toValidAlignment(alignment: string | undefined) {
     switch (alignment) {
         case "default":
         case "block":
@@ -28,7 +28,7 @@ function alignmentToValidValue(alignment: string | undefined) {
 }
 
 const parseAlignment = pipeParsers(optional(string)).then(
-    convert(alignmentToValidValue),
+    convert(toValidAlignment),
 ).parser;
 
 export function parseWidget<Type extends string, Options extends object>(

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.ts
@@ -1,29 +1,37 @@
 import {
     boolean,
-    enumeration,
     nullable,
     number,
     object,
     optional,
     pipeParsers,
+    string,
 } from "../general-purpose-parsers";
 import {convert} from "../general-purpose-parsers/convert";
 
 import type {Parser} from "../parser-types";
 
-const parseAlignment = pipeParsers(
-    enumeration(
-        "default",
-        "block",
-        "inline-block",
-        "inline",
-        "wrap-left",
-        "wrap-right",
-        "full-width",
-        "",
-        undefined,
-    ),
-).then(convert((value) => (value === "" ? "default" : value))).parser;
+function alignmentToValidValue(alignment: string | undefined) {
+    switch (alignment) {
+        case "":
+            return "default";
+        case "default":
+        case "block":
+        case "inline-block":
+        case "inline":
+        case "wrap-left":
+        case "wrap-right":
+        case "full-width":
+        case undefined:
+            return alignment;
+        default:
+            return "default";
+    }
+}
+
+const parseAlignment = pipeParsers(optional(string)).then(
+    convert(alignmentToValidValue),
+).parser;
 
 export function parseWidget<Type extends string, Options extends object>(
     parseType: Parser<Type>,

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -21724,6 +21724,207 @@ ___
 }
 `;
 
+exports[`parseAndMigratePerseusItem given radio-with-weird-alignment.ts returns the same result as before 1`] = `
+{
+  "answerArea": {
+    "calculator": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTimeToPayOff": false,
+    "financialCalculatorTotalAmount": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+  },
+  "hints": [],
+  "question": {
+    "content": "**In the given setup, only half of the pinhole is covered. Predict what the image on the screen will look like.**  
+
+[[☃ image 1]]
+
+
+[[☃ radio 1]] ",
+    "images": {},
+    "widgets": {
+      "image 1": {
+        "alignment": "block",
+        "graded": true,
+        "options": {
+          "alt": "A diagramatic setup of an object in front of the pinhole camera. The pinhole is covered 50%, and the image is captured on the screen inside the pinhole camera.",
+          "backgroundImage": {
+            "height": 230.42077230359527,
+            "url": "https://cdn.kastatic.org/ka-content-images/ab309c0f39b2f392e5651c44a7d5f96d7f23777b.png",
+            "width": 382,
+          },
+          "box": [
+            1502,
+            906,
+          ],
+          "caption": "",
+          "decorative": false,
+          "labels": [],
+          "longDescription": "",
+          "range": [
+            [
+              0,
+              10,
+            ],
+            [
+              0,
+              10,
+            ],
+          ],
+          "scale": 1,
+          "title": "",
+        },
+        "static": false,
+        "type": "image",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+      "radio 1": {
+        "alignment": "default",
+        "graded": true,
+        "options": {
+          "choices": [
+            {
+              "content": "The image disappears completely.",
+              "id": "radio-choice-0",
+            },
+            {
+              "content": "The image becomes dim or partly visible.",
+              "id": "radio-choice-1",
+            },
+            {
+              "content": "The image becomes larger.",
+              "id": "radio-choice-2",
+            },
+            {
+              "content": "The image remains unchanged.",
+              "id": "radio-choice-3",
+            },
+          ],
+          "countChoices": false,
+          "deselectEnabled": false,
+          "hasNoneOfTheAbove": false,
+          "multipleSelect": false,
+          "randomize": true,
+        },
+        "static": false,
+        "type": "radio",
+        "version": {
+          "major": 3,
+          "minor": 0,
+        },
+      },
+    },
+  },
+}
+`;
+
+exports[`parseAndMigratePerseusItem given radio-with-weird-alignment.ts returns the same result as before with answer information removed 1`] = `
+{
+  "answerArea": {
+    "calculator": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTimeToPayOff": false,
+    "financialCalculatorTotalAmount": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+  },
+  "hints": [],
+  "question": {
+    "content": "**In the given setup, only half of the pinhole is covered. Predict what the image on the screen will look like.**  
+
+[[☃ image 1]]
+
+
+[[☃ radio 1]] ",
+    "images": {},
+    "widgets": {
+      "image 1": {
+        "alignment": "block",
+        "graded": true,
+        "options": {
+          "alt": "A diagramatic setup of an object in front of the pinhole camera. The pinhole is covered 50%, and the image is captured on the screen inside the pinhole camera.",
+          "backgroundImage": {
+            "height": 230.42077230359527,
+            "url": "https://cdn.kastatic.org/ka-content-images/ab309c0f39b2f392e5651c44a7d5f96d7f23777b.png",
+            "width": 382,
+          },
+          "box": [
+            1502,
+            906,
+          ],
+          "caption": "",
+          "decorative": false,
+          "labels": [],
+          "longDescription": "",
+          "range": [
+            [
+              0,
+              10,
+            ],
+            [
+              0,
+              10,
+            ],
+          ],
+          "scale": 1,
+          "title": "",
+        },
+        "static": false,
+        "type": "image",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+      "radio 1": {
+        "alignment": "default",
+        "graded": true,
+        "options": {
+          "choices": [
+            {
+              "content": "The image disappears completely.",
+              "id": "radio-choice-0",
+              "isNoneOfTheAbove": undefined,
+            },
+            {
+              "content": "The image becomes dim or partly visible.",
+              "id": "radio-choice-1",
+              "isNoneOfTheAbove": undefined,
+            },
+            {
+              "content": "The image becomes larger.",
+              "id": "radio-choice-2",
+              "isNoneOfTheAbove": undefined,
+            },
+            {
+              "content": "The image remains unchanged.",
+              "id": "radio-choice-3",
+              "isNoneOfTheAbove": undefined,
+            },
+          ],
+          "countChoices": false,
+          "deselectEnabled": false,
+          "hasNoneOfTheAbove": false,
+          "multipleSelect": false,
+          "numCorrect": undefined,
+          "randomize": true,
+        },
+        "static": false,
+        "type": "radio",
+        "version": {
+          "major": 3,
+          "minor": 0,
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`parseAndMigratePerseusItem given simulator-widget.ts returns the same result as before 1`] = `
 {
   "answerArea": {

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/radio-with-weird-alignment.ts
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/radio-with-weird-alignment.ts
@@ -1,0 +1,83 @@
+// WARNING: Do not change or delete this file! If you do, Perseus might become
+// unable to parse the current data format, which will break clients.
+// If you need to add more regression tests, add a new file to this directory.
+export default {
+    question: {
+        content:
+            "**In the given setup, only half of the pinhole is covered. Predict what the image on the screen will look like.**  \n\n[[☃ image 1]]\n\n\n[[☃ radio 1]] ",
+        widgets: {
+            "image 1": {
+                type: "image",
+                alignment: "block",
+                static: false,
+                graded: true,
+                options: {
+                    title: "",
+                    range: [
+                        [0, 10],
+                        [0, 10],
+                    ],
+                    box: [1502, 906],
+                    backgroundImage: {
+                        url: "https://cdn.kastatic.org/ka-content-images/ab309c0f39b2f392e5651c44a7d5f96d7f23777b.png",
+                        width: 382,
+                        height: 230.42077230359527,
+                    },
+                    labels: [],
+                    alt: "A diagramatic setup of an object in front of the pinhole camera. The pinhole is covered 50%, and the image is captured on the screen inside the pinhole camera.",
+                    caption: "",
+                    static: false,
+                },
+                version: {
+                    major: 0,
+                    minor: 0,
+                },
+            },
+            "radio 1": {
+                options: {
+                    choices: [
+                        {
+                            id: "radio-choice-0",
+                            content: "The image disappears completely.",
+                        },
+                        {
+                            id: "radio-choice-1",
+                            content: "The image becomes dim or partly visible.",
+                        },
+                        {
+                            id: "radio-choice-2",
+                            content: "The image becomes larger.",
+                        },
+                        {
+                            id: "radio-choice-3",
+                            content: "The image remains unchanged.",
+                        },
+                    ],
+                    randomize: true,
+                    hasNoneOfTheAbove: false,
+                    multipleSelect: false,
+                    countChoices: false,
+                    deselectEnabled: false,
+                },
+                type: "radio",
+                version: {
+                    major: 3,
+                    minor: 0,
+                },
+                graded: true,
+                alignment: "NCERT Grade 7 Science – Chapter 11: Pinhole Camera",
+                static: false,
+            },
+        },
+        images: {},
+    },
+    hints: [],
+    answerArea: {
+        calculator: false,
+        financialCalculatorMonthlyPayment: false,
+        financialCalculatorTotalAmount: false,
+        financialCalculatorTimeToPayOff: false,
+        periodicTable: false,
+        periodicTableWithKey: false,
+    },
+};


### PR DESCRIPTION
## Summary:
This fixes a bug that was discovered when CP tried to deploy publish workers
with a new version of the Perseus parser.

We have some very odd `alignment` values in content that must have gotten in by
accident. Perseus doesn't recognize these, so we now convert them to the default
alignment, similar to how a missing alignment value is handled.

Issue: none

## Test plan:

CI checks should pass.