### PR TITLE
Make jquery 2.1.1 a direct dep of Perseus to decouple from frontend

### DIFF
--- a/.changeset/early-apples-march.md
+++ b/.changeset/early-apples-march.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-editor": minor
+"@khanacademy/perseus": minor
+---
+
+jquery moves from a peer dep to a direct dep. Will not break any current or future consumers; just leaves a redundant dep in the consuming package config that the consuming app can remove.

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -45,7 +45,8 @@
         "axe-core": "^4.11.0",
         "katex": "0.11.1",
         "mafs": "^0.19.0",
-        "tiny-invariant": "catalog:prodDeps"
+        "tiny-invariant": "catalog:prodDeps",
+        "jquery": "catalog:prodDeps"
     },
     "devDependencies": {
         "@khanacademy/mathjax-renderer": "catalog:devDeps",
@@ -72,7 +73,6 @@
         "@phosphor-icons/core": "catalog:devDeps",
         "aphrodite": "catalog:devDeps",
         "classnames": "catalog:devDeps",
-        "jquery": "catalog:devDeps",
         "jsdiff": "workspace:*",
         "perseus-build-settings": "workspace:*",
         "prop-types": "catalog:devDeps",
@@ -105,7 +105,6 @@
         "@phosphor-icons/core": "catalog:peerDeps",
         "aphrodite": "catalog:peerDeps",
         "classnames": "catalog:peerDeps",
-        "jquery": "catalog:peerDeps",
         "prop-types": "catalog:peerDeps",
         "react": "catalog:peerDeps",
         "react-dom": "catalog:peerDeps",

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -55,7 +55,8 @@
         "gifuct-js": "^2.1.2",
         "mafs": "0.19.0",
         "tiny-invariant": "catalog:prodDeps",
-        "uuid": "^10.0.0"
+        "uuid": "^10.0.0",
+        "jquery": "catalog:prodDeps"
     },
     "devDependencies": {
         "@khanacademy/wonder-blocks-announcer": "catalog:devDeps",
@@ -85,7 +86,6 @@
         "@popperjs/core": "catalog:devDeps",
         "aphrodite": "catalog:devDeps",
         "classnames": "catalog:devDeps",
-        "jquery": "catalog:devDeps",
         "perseus-build-settings": "workspace:*",
         "prop-types": "catalog:devDeps",
         "raphael": "workspace:*",
@@ -122,7 +122,6 @@
         "@popperjs/core": "catalog:peerDeps",
         "aphrodite": "catalog:peerDeps",
         "classnames": "catalog:peerDeps",
-        "jquery": "catalog:peerDeps",
         "prop-types": "catalog:peerDeps",
         "react": "catalog:peerDeps",
         "react-dom": "catalog:peerDeps",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,9 +102,6 @@ catalogs:
     classnames:
       specifier: 1.1.4
       version: 1.1.4
-    jquery:
-      specifier: 2.1.1
-      version: 2.1.1
     prop-types:
       specifier: 15.8.1
       version: 15.8.1
@@ -131,6 +128,9 @@ catalogs:
       specifier: ^18.2.0
       version: 18.3.1
   prodDeps:
+    jquery:
+      specifier: ^2.1.1
+      version: 2.1.1
     tiny-invariant:
       specifier: 1.3.1
       version: 1.3.1
@@ -455,7 +455,7 @@ importers:
         version: 5.1.0(typescript@5.9.3)
       update-browserslist-db:
         specifier: ^1.2.3
-        version: 1.2.3(browserslist@4.28.1)
+        version: 1.2.3(browserslist@4.28.7)
       vite:
         specifier: catalog:devDeps
         version: 5.4.0(@types/node@20.17.6)(less@4.2.0)(sass@1.89.2)(stylus@0.62.0)(terser@5.49.2)
@@ -615,6 +615,9 @@ importers:
       gifuct-js:
         specifier: ^2.1.2
         version: 2.1.2
+      jquery:
+        specifier: catalog:prodDeps
+        version: 2.1.1
       mafs:
         specifier: 0.19.0
         version: 0.19.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -706,9 +709,6 @@ importers:
       classnames:
         specifier: catalog:devDeps
         version: 1.1.4
-      jquery:
-        specifier: catalog:devDeps
-        version: 2.1.1
       perseus-build-settings:
         specifier: workspace:*
         version: link:../../config/build
@@ -785,6 +785,9 @@ importers:
       axe-core:
         specifier: ^4.11.0
         version: 4.11.0
+      jquery:
+        specifier: catalog:prodDeps
+        version: 2.1.1
       katex:
         specifier: 0.11.1
         version: 0.11.1
@@ -867,9 +870,6 @@ importers:
       classnames:
         specifier: catalog:devDeps
         version: 1.1.4
-      jquery:
-        specifier: catalog:devDeps
-        version: 2.1.1
       jsdiff:
         specifier: workspace:*
         version: link:../../vendor/jsdiff
@@ -9688,7 +9688,7 @@ snapshots:
     dependencies:
       '@babel/compat-data': 7.29.7
       '@babel/helper-validator-option': 7.29.7
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -19594,6 +19594,12 @@ snapshots:
       escalade: 3.2.0
       picocolors: 1.1.1
 
+  update-browserslist-db@1.2.3(browserslist@4.28.7):
+    dependencies:
+      browserslist: 4.28.7
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   update-browserslist-db@1.3.0(browserslist@4.28.7):
     dependencies:
       browserslist: 4.28.7
@@ -19736,7 +19742,7 @@ snapshots:
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.18.0
-      browserslist: 4.28.1
+      browserslist: 4.28.7
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.24.5
       es-module-lexer: 1.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,7 +57,6 @@ catalogs:
         react-dom: ^18.2.0
         aphrodite: ^1.2.5
         classnames: ^1.1.4
-        jquery: ^2.1.1
         prop-types: ^15.8.1
         underscore: ^1.4.4
         "@phosphor-icons/core": ^2.0.2
@@ -97,7 +96,6 @@ catalogs:
         react-dom: 18.2.0
         aphrodite: 1.2.5
         classnames: 1.1.4
-        jquery: 2.1.1
         prop-types: 15.8.1
         tiny-invariant: 1.3.1
         underscore: 1.4.4
@@ -136,3 +134,4 @@ catalogs:
         "@khanacademy/wonder-stuff-core": 3.0.0
     prodDeps:
         tiny-invariant: 1.3.1
+        jquery: ^2.1.1


### PR DESCRIPTION
As part of [the jQuery upgrade project](https://khanacademy.atlassian.net/browse/TUT-4325), we need to bump the version on production. However, the dependency is coupled to Perseus, which designates jQuery 2.1.1 a peer dependency.

By making it a direct dependency, Perseus bundles its own version and no longer relies on it being provided by the consuming application. This frees us to make changes to frontend, and we can continue working to remove jQuery as a dependency entirely in the future.

Issue: TUT-4686