### PR TITLE
[DnD] Answer Tile Component

### DIFF
--- a/.changeset/answer-tile-component.md
+++ b/.changeset/answer-tile-component.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+Add AnswerTile component for the Drag-and-Drop widget family

--- a/packages/perseus/src/components/drag-and-drop/__docs__/answer-tile.stories.tsx
+++ b/packages/perseus/src/components/drag-and-drop/__docs__/answer-tile.stories.tsx
@@ -29,7 +29,6 @@ const meta: Meta<typeof AnswerTile> = {
         tileId: "tile-1",
         content: "Bongo",
         label: "Bongo",
-        state: "rest",
         menu: generateAnswerTileMenu(),
     },
 };
@@ -78,19 +77,19 @@ export const Empty: Story = {
 
 export const Correct: Story = {
     args: {
-        state: "correct",
+        showCorrectness: "correct",
     },
 };
 
 export const Incorrect: Story = {
     args: {
-        state: "incorrect",
+        showCorrectness: "incorrect",
     },
 };
 
 export const Disabled: Story = {
     args: {
-        state: "disabled",
+        disabled: true,
     },
 };
 
@@ -110,28 +109,28 @@ export const ScoredComposition: Story = {
                     tileId="tile-1"
                     content="2Mg"
                     label="2Mg"
-                    state="correct"
+                    showCorrectness="correct"
                     menu={null}
                 />
                 <AnswerTile
                     tileId="tile-2"
                     content="$O_2$"
                     label="O 2"
-                    state="correct"
+                    showCorrectness="correct"
                     menu={null}
                 />
                 <AnswerTile
                     tileId="tile-3"
                     content="acoustic"
                     label="acoustic"
-                    state="disabled"
+                    disabled={true}
                     menu={null}
                 />
                 <AnswerTile
                     tileId="tile-4"
                     content="steel"
                     label="steel"
-                    state="disabled"
+                    disabled={true}
                     menu={null}
                 />
             </ChoiceBank>

--- a/packages/perseus/src/components/drag-and-drop/__docs__/answer-tile.stories.tsx
+++ b/packages/perseus/src/components/drag-and-drop/__docs__/answer-tile.stories.tsx
@@ -138,30 +138,3 @@ export const ScoredComposition: Story = {
         </div>
     ),
 };
-
-/** Tiles of different widths wrap in a ChoiceBank. */
-export const InAChoiceBank: Story = {
-    render: () => (
-        <div style={{maxInlineSize: 480}}>
-            <ChoiceBank label="Choices">
-                {[
-                    "Numerator",
-                    "42",
-                    "Photosynthesis",
-                    "π",
-                    "Independent variable",
-                    "The mitochondria is the powerhouse of the cell",
-                ].map((value, index) => (
-                    <AnswerTile
-                        key={value}
-                        tileId={`tile-${index}`}
-                        content={value}
-                        label={value}
-                        state="rest"
-                        menu={generateAnswerTileMenu()}
-                    />
-                ))}
-            </ChoiceBank>
-        </div>
-    ),
-};

--- a/packages/perseus/src/components/drag-and-drop/__docs__/answer-tile.stories.tsx
+++ b/packages/perseus/src/components/drag-and-drop/__docs__/answer-tile.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import {AnswerTile} from "../answer-tile";
-import {generateAnswerTileMenu} from "../answer-tile/answer-tile.testdata";
+import {generateAnswerTileProps} from "../answer-tile/answer-tile.testdata";
 import {ChoiceBank} from "../choice-bank";
 
 import type {Meta, StoryObj} from "@storybook/react-vite";
@@ -26,12 +26,7 @@ const meta: Meta<typeof AnswerTile> = {
             </div>
         ),
     ],
-    args: {
-        tileId: "tile-1",
-        content: "Bongo",
-        label: "Bongo",
-        menu: generateAnswerTileMenu(),
-    },
+    args: generateAnswerTileProps(),
 };
 
 export default meta;
@@ -107,34 +102,47 @@ export const ScoredComposition: Story = {
         <div style={{maxInlineSize: 480}}>
             <ChoiceBank label="Choices">
                 <AnswerTile
-                    tileId="tile-1"
-                    content="2Mg"
-                    label="2Mg"
-                    showCorrectness="correct"
-                    menu={null}
+                    {...generateAnswerTileProps({
+                        tileId: "tile-1",
+                        content: "2Mg",
+                        label: "2Mg",
+                        showCorrectness: "correct",
+                    })}
                 />
                 <AnswerTile
-                    tileId="tile-2"
-                    content="$O_2$"
-                    label="O 2"
-                    showCorrectness="correct"
-                    menu={null}
+                    {...generateAnswerTileProps({
+                        tileId: "tile-2",
+                        content: "$O_2$",
+                        label: "O 2",
+                        showCorrectness: "correct",
+                    })}
                 />
                 <AnswerTile
-                    tileId="tile-3"
-                    content="acoustic"
-                    label="acoustic"
-                    disabled={true}
-                    menu={null}
+                    {...generateAnswerTileProps({
+                        tileId: "tile-3",
+                        content: "acoustic",
+                        label: "acoustic",
+                        disabled: true,
+                    })}
                 />
                 <AnswerTile
-                    tileId="tile-4"
-                    content="steel"
-                    label="steel"
-                    disabled={true}
-                    menu={null}
+                    {...generateAnswerTileProps({
+                        tileId: "tile-4",
+                        content: "steel",
+                        label: "steel",
+                        disabled: true,
+                    })}
                 />
             </ChoiceBank>
         </div>
     ),
+};
+
+/** A placed tile in a one-blank exercise: the menu only offers Clear. */
+export const OnlyClearAction: Story = {
+    args: {
+        moveTargets: [],
+        clearFromLabel: "Blank 1",
+        onClear: () => {},
+    },
 };

--- a/packages/perseus/src/components/drag-and-drop/__docs__/answer-tile.stories.tsx
+++ b/packages/perseus/src/components/drag-and-drop/__docs__/answer-tile.stories.tsx
@@ -1,0 +1,167 @@
+import * as React from "react";
+
+import {AnswerTile} from "../answer-tile";
+import {generateAnswerTileMenu} from "../answer-tile/answer-tile.testdata";
+import {ChoiceBank} from "../choice-bank";
+
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+/**
+ * `AnswerTile` is the card a learner moves into a blank in the Drag-and-Drop
+ * widget family. It renders authored markdown content (text, TeX, or an
+ * image), composes the `DndActionMenu` at its leading edge, and shows the
+ * parent-set scored states.
+ *
+ * Turn on Thunderblocks to match the provided designs.
+ */
+const meta: Meta<typeof AnswerTile> = {
+    title: "Components/Drag and Drop/Answer Tile",
+    component: AnswerTile,
+    decorators: [
+        (StoryComponent) => (
+            // Tiles hug their content; don't let the canvas stretch them.
+            <div style={{display: "flex", margin: 32}}>
+                <StoryComponent />
+            </div>
+        ),
+    ],
+    args: {
+        tileId: "tile-1",
+        content: "Bongo",
+        label: "Bongo",
+        state: "rest",
+        menu: generateAnswerTileMenu(),
+    },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AnswerTile>;
+
+export const Text: Story = {};
+
+/** Text wraps once it reaches the 200px content width cap. */
+export const WrappingText: Story = {
+    args: {
+        content: "The mitochondria is the powerhouse of the cell",
+        label: "The mitochondria is the powerhouse of the cell",
+    },
+};
+
+export const TeX: Story = {
+    args: {
+        content: "$\\sqrt{a^2 + b^2}$",
+        label: "square root of a squared plus b squared",
+    },
+};
+
+/**
+ * The image renders at its natural size, capped by the tile's content
+ * width. The authored height presets come later, from the widget, via
+ * the Renderer's `images` size mapping.
+ */
+export const Image: Story = {
+    args: {
+        content:
+            "![2 micron diameter cell](https://ka-perseus-images.s3.amazonaws.com/b17cfb6a3270c6f41f66099462e495c841cf6ca9.png)",
+        label: "2 micron diameter cell",
+    },
+};
+
+/** An empty tile keeps a minimum width and a spoken "(empty)" value. */
+export const Empty: Story = {
+    args: {
+        content: "",
+        label: "(empty)",
+    },
+};
+
+export const Correct: Story = {
+    args: {
+        state: "correct",
+    },
+};
+
+export const Incorrect: Story = {
+    args: {
+        state: "incorrect",
+    },
+};
+
+export const Disabled: Story = {
+    args: {
+        state: "disabled",
+    },
+};
+
+/** In an inline blank the menu shows only on hover or keyboard focus. */
+export const MenuOnHoverOrFocus: Story = {
+    args: {
+        menuVisibility: "on-hover-or-focus",
+    },
+};
+
+/** A scored bank: correct tiles beside disabled (unused) ones. */
+export const ScoredComposition: Story = {
+    render: () => (
+        <div style={{maxInlineSize: 480}}>
+            <ChoiceBank label="Choices">
+                <AnswerTile
+                    tileId="tile-1"
+                    content="2Mg"
+                    label="2Mg"
+                    state="correct"
+                    menu={null}
+                />
+                <AnswerTile
+                    tileId="tile-2"
+                    content="$O_2$"
+                    label="O 2"
+                    state="correct"
+                    menu={null}
+                />
+                <AnswerTile
+                    tileId="tile-3"
+                    content="acoustic"
+                    label="acoustic"
+                    state="disabled"
+                    menu={null}
+                />
+                <AnswerTile
+                    tileId="tile-4"
+                    content="steel"
+                    label="steel"
+                    state="disabled"
+                    menu={null}
+                />
+            </ChoiceBank>
+        </div>
+    ),
+};
+
+/** Mixed-width tiles wrapping in a ChoiceBank. */
+export const InAChoiceBank: Story = {
+    render: () => (
+        <div style={{maxInlineSize: 480}}>
+            <ChoiceBank label="Choices">
+                {[
+                    "Numerator",
+                    "42",
+                    "Photosynthesis",
+                    "π",
+                    "Independent variable",
+                    "The mitochondria is the powerhouse of the cell",
+                ].map((value, index) => (
+                    <AnswerTile
+                        key={value}
+                        tileId={`tile-${index}`}
+                        content={value}
+                        label={value}
+                        state="rest"
+                        menu={generateAnswerTileMenu()}
+                    />
+                ))}
+            </ChoiceBank>
+        </div>
+    ),
+};

--- a/packages/perseus/src/components/drag-and-drop/__docs__/answer-tile.stories.tsx
+++ b/packages/perseus/src/components/drag-and-drop/__docs__/answer-tile.stories.tsx
@@ -89,13 +89,6 @@ export const Disabled: Story = {
     },
 };
 
-/** In an inline blank, the menu shows only on hover or keyboard focus. */
-export const MenuOnHoverOrFocus: Story = {
-    args: {
-        menuVisibility: "on-hover-or-focus",
-    },
-};
-
 /** A scored bank: correct tiles next to disabled (unused) tiles. */
 export const ScoredComposition: Story = {
     render: () => (

--- a/packages/perseus/src/components/drag-and-drop/__docs__/answer-tile.stories.tsx
+++ b/packages/perseus/src/components/drag-and-drop/__docs__/answer-tile.stories.tsx
@@ -7,10 +7,10 @@ import {ChoiceBank} from "../choice-bank";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 /**
- * `AnswerTile` is the card a learner moves into a blank in the Drag-and-Drop
- * widget family. It renders authored markdown content (text, TeX, or an
- * image), composes the `DndActionMenu` at its leading edge, and shows the
- * parent-set scored states.
+ * `AnswerTile` is the card that a learner moves into a blank. It is part
+ * of the Drag-and-Drop widget family. The tile shows authored markdown
+ * content: text, TeX, or an image. It puts the `DndActionMenu` at its
+ * leading edge. The parent widget sets the scored states.
  *
  * Turn on Thunderblocks to match the provided designs.
  */
@@ -19,7 +19,7 @@ const meta: Meta<typeof AnswerTile> = {
     component: AnswerTile,
     decorators: [
         (StoryComponent) => (
-            // Tiles hug their content; don't let the canvas stretch them.
+            // Tiles hug their content. Do not let the canvas stretch them.
             <div style={{display: "flex", margin: 32}}>
                 <StoryComponent />
             </div>
@@ -40,7 +40,7 @@ type Story = StoryObj<typeof AnswerTile>;
 
 export const Text: Story = {};
 
-/** Text wraps once it reaches the 200px content width cap. */
+/** Text wraps when it is wider than the 200px content width limit. */
 export const WrappingText: Story = {
     args: {
         content: "The mitochondria is the powerhouse of the cell",
@@ -56,9 +56,9 @@ export const TeX: Story = {
 };
 
 /**
- * The image renders at its natural size, capped by the tile's content
- * width. The authored height presets come later, from the widget, via
- * the Renderer's `images` size mapping.
+ * The image shows at its natural size, up to the tile's content width.
+ * The authored height presets come later. The widget will supply them
+ * through the Renderer's `images` size mapping.
  */
 export const Image: Story = {
     args: {
@@ -68,7 +68,7 @@ export const Image: Story = {
     },
 };
 
-/** An empty tile keeps a minimum width and a spoken "(empty)" value. */
+/** An empty tile keeps a minimum width. It has a spoken "(empty)" value. */
 export const Empty: Story = {
     args: {
         content: "",
@@ -94,14 +94,14 @@ export const Disabled: Story = {
     },
 };
 
-/** In an inline blank the menu shows only on hover or keyboard focus. */
+/** In an inline blank, the menu shows only on hover or keyboard focus. */
 export const MenuOnHoverOrFocus: Story = {
     args: {
         menuVisibility: "on-hover-or-focus",
     },
 };
 
-/** A scored bank: correct tiles beside disabled (unused) ones. */
+/** A scored bank: correct tiles next to disabled (unused) tiles. */
 export const ScoredComposition: Story = {
     render: () => (
         <div style={{maxInlineSize: 480}}>
@@ -139,7 +139,7 @@ export const ScoredComposition: Story = {
     ),
 };
 
-/** Mixed-width tiles wrapping in a ChoiceBank. */
+/** Tiles of different widths wrap in a ChoiceBank. */
 export const InAChoiceBank: Story = {
     render: () => (
         <div style={{maxInlineSize: 480}}>

--- a/packages/perseus/src/components/drag-and-drop/__docs__/answer-tile.stories.tsx
+++ b/packages/perseus/src/components/drag-and-drop/__docs__/answer-tile.stories.tsx
@@ -51,15 +51,16 @@ export const TeX: Story = {
 };
 
 /**
- * The image shows at its natural size, up to the tile's content width.
- * The authored height presets come later. The widget will supply them
- * through the Renderer's `images` size mapping.
+ * The image renders at the authored height (the editor offers 24-96 in
+ * steps of 12). Without one, it shows at its natural size, up to the
+ * tile's content width.
  */
 export const Image: Story = {
     args: {
         content:
             "![2 micron diameter cell](https://ka-perseus-images.s3.amazonaws.com/b17cfb6a3270c6f41f66099462e495c841cf6ca9.png)",
         label: "2 micron diameter cell",
+        imageHeight: 48,
     },
 };
 

--- a/packages/perseus/src/components/drag-and-drop/__docs__/answer-tile.stories.tsx
+++ b/packages/perseus/src/components/drag-and-drop/__docs__/answer-tile.stories.tsx
@@ -10,8 +10,8 @@ import type {Meta, StoryObj} from "@storybook/react-vite";
  * `AnswerTile` is the card that a learner moves into a blank. It is part
  * of the Drag-and-Drop widget family. The tile shows authored markdown
  * content: text, TeX, or an image. It puts the `DndActionMenu` at its
- * leading edge. The parent widget sets showCorrectness and disabled
- * after scoring.
+ * leading edge. The parent widget sets `scoring` once the question is
+ * scored.
  *
  * Turn on Thunderblocks to match the provided designs.
  */
@@ -73,23 +73,24 @@ export const Empty: Story = {
 
 export const Correct: Story = {
     args: {
-        showCorrectness: "correct",
+        scoring: "correct",
     },
 };
 
 export const Incorrect: Story = {
     args: {
-        showCorrectness: "incorrect",
+        scoring: "incorrect",
     },
 };
 
-export const Disabled: Story = {
+/** A tile the learner left in the bank when the question was scored. */
+export const Unused: Story = {
     args: {
-        disabled: true,
+        scoring: "unused",
     },
 };
 
-/** A scored bank: correct tiles next to disabled (unused) tiles. */
+/** A scored bank: correct tiles next to unused ones. */
 export const ScoredComposition: Story = {
     render: () => (
         <div style={{maxInlineSize: 480}}>
@@ -99,7 +100,7 @@ export const ScoredComposition: Story = {
                         tileId: "tile-1",
                         content: "2Mg",
                         label: "2Mg",
-                        showCorrectness: "correct",
+                        scoring: "correct",
                     })}
                 />
                 <AnswerTile
@@ -107,7 +108,7 @@ export const ScoredComposition: Story = {
                         tileId: "tile-2",
                         content: "$O_2$",
                         label: "O 2",
-                        showCorrectness: "correct",
+                        scoring: "correct",
                     })}
                 />
                 <AnswerTile
@@ -115,7 +116,7 @@ export const ScoredComposition: Story = {
                         tileId: "tile-3",
                         content: "acoustic",
                         label: "acoustic",
-                        disabled: true,
+                        scoring: "unused",
                     })}
                 />
                 <AnswerTile
@@ -123,7 +124,7 @@ export const ScoredComposition: Story = {
                         tileId: "tile-4",
                         content: "steel",
                         label: "steel",
-                        disabled: true,
+                        scoring: "unused",
                     })}
                 />
             </ChoiceBank>

--- a/packages/perseus/src/components/drag-and-drop/__docs__/answer-tile.stories.tsx
+++ b/packages/perseus/src/components/drag-and-drop/__docs__/answer-tile.stories.tsx
@@ -10,7 +10,8 @@ import type {Meta, StoryObj} from "@storybook/react-vite";
  * `AnswerTile` is the card that a learner moves into a blank. It is part
  * of the Drag-and-Drop widget family. The tile shows authored markdown
  * content: text, TeX, or an image. It puts the `DndActionMenu` at its
- * leading edge. The parent widget sets the scored states.
+ * leading edge. The parent widget sets showCorrectness and disabled
+ * after scoring.
  *
  * Turn on Thunderblocks to match the provided designs.
  */

--- a/packages/perseus/src/components/drag-and-drop/__docs__/choice-bank.stories.tsx
+++ b/packages/perseus/src/components/drag-and-drop/__docs__/choice-bank.stories.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 
 import {AnswerTile} from "../answer-tile";
+import {generateAnswerTileMenu} from "../answer-tile/answer-tile.testdata";
 import {ChoiceBank} from "../choice-bank";
 
-import type {AnswerTileMenuConfig} from "../answer-tile";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 /**
@@ -18,14 +18,6 @@ const meta: Meta<typeof ChoiceBank> = {
 export default meta;
 
 type Story = StoryObj<typeof ChoiceBank>;
-
-const MENU: AnswerTileMenuConfig = {
-    moveTargets: [
-        {id: "blank-1", label: "Blank 1"},
-        {id: "blank-2", label: "Blank 2"},
-    ],
-    onMove: () => {},
-};
 
 const SAMPLE_TILES = [
     "Numerator",
@@ -48,7 +40,7 @@ function sampleTiles() {
             content={value}
             label={value}
             state="rest"
-            menu={MENU}
+            menu={generateAnswerTileMenu()}
         />
     ));
 }
@@ -87,7 +79,7 @@ export const ManyTiles: Story = {
                     content={`Tile ${i + 1}`}
                     label={`Tile ${i + 1}`}
                     state="rest"
-                    menu={MENU}
+                    menu={generateAnswerTileMenu()}
                 />
             ))}
         </ChoiceBank>

--- a/packages/perseus/src/components/drag-and-drop/__docs__/choice-bank.stories.tsx
+++ b/packages/perseus/src/components/drag-and-drop/__docs__/choice-bank.stories.tsx
@@ -1,15 +1,14 @@
 import * as React from "react";
 
+import {AnswerTile} from "../answer-tile";
 import {ChoiceBank} from "../choice-bank";
 
+import type {AnswerTileMenuConfig} from "../answer-tile";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 /**
  * `ChoiceBank` holds the draggable answer tiles for the Drag-and-Drop widget
  * family.
- *
- * TODO(LEMS-4363): The tiles below are throwaway placeholders standing in for
- * the real `AnswerTile` component; they only demonstrate how the bank wraps.
  */
 const meta: Meta<typeof ChoiceBank> = {
     title: "Components/Drag and Drop/Choice Bank",
@@ -20,29 +19,13 @@ export default meta;
 
 type Story = StoryObj<typeof ChoiceBank>;
 
-/** TODO(LEMS-4363): Placeholder tile to be replaced by the real `AnswerTile`. */
-function PlaceholderTile({children}: {children: React.ReactNode}) {
-    return (
-        <button
-            type="button"
-            style={{
-                display: "inline-flex",
-                alignItems: "center",
-                minBlockSize: 48,
-                paddingBlock: 8,
-                paddingInline: 12,
-                borderRadius: 8,
-                border: "1px solid var(--wb-semanticColor-core-border-neutral-default)",
-                background:
-                    "var(--wb-semanticColor-core-background-base-default)",
-                font: "inherit",
-                cursor: "grab",
-            }}
-        >
-            {children}
-        </button>
-    );
-}
+const MENU: AnswerTileMenuConfig = {
+    moveTargets: [
+        {id: "blank-1", label: "Blank 1"},
+        {id: "blank-2", label: "Blank 2"},
+    ],
+    onMove: () => {},
+};
 
 const SAMPLE_TILES = [
     "Numerator",
@@ -53,19 +36,26 @@ const SAMPLE_TILES = [
     "The mitochondria",
     "π",
     "Independent variable",
-    "\\sqrt{a^2 + b^2}",
+    "$\\sqrt{a^2 + b^2}$",
     "The mitochondria is the powerhouse of the cell",
 ];
 
+function sampleTiles() {
+    return SAMPLE_TILES.map((value, index) => (
+        <AnswerTile
+            key={value}
+            tileId={`tile-${index}`}
+            content={value}
+            label={value}
+            state="rest"
+            menu={MENU}
+        />
+    ));
+}
+
 /** The default bank: a handful of tiles of varying widths. */
 export const Default: Story = {
-    render: () => (
-        <ChoiceBank label="Choices">
-            {SAMPLE_TILES.map((label) => (
-                <PlaceholderTile key={label}>{label}</PlaceholderTile>
-            ))}
-        </ChoiceBank>
-    ),
+    render: () => <ChoiceBank label="Choices">{sampleTiles()}</ChoiceBank>,
 };
 
 /** Drag the bottom-right resize handle to watch the tiles wrap. */
@@ -81,11 +71,7 @@ export const Reflow: Story = {
                 border: "1px dashed #ccc",
             }}
         >
-            <ChoiceBank label="Choices">
-                {SAMPLE_TILES.map((label) => (
-                    <PlaceholderTile key={label}>{label}</PlaceholderTile>
-                ))}
-            </ChoiceBank>
+            <ChoiceBank label="Choices">{sampleTiles()}</ChoiceBank>
         </div>
     ),
 };
@@ -95,7 +81,14 @@ export const ManyTiles: Story = {
     render: () => (
         <ChoiceBank label="Choices">
             {Array.from({length: 24}, (_, i) => (
-                <PlaceholderTile key={i}>{`Tile ${i + 1}`}</PlaceholderTile>
+                <AnswerTile
+                    key={i}
+                    tileId={`tile-${i}`}
+                    content={`Tile ${i + 1}`}
+                    label={`Tile ${i + 1}`}
+                    state="rest"
+                    menu={MENU}
+                />
             ))}
         </ChoiceBank>
     ),
@@ -110,11 +103,7 @@ export const Empty: Story = {
 export const RightToLeft: Story = {
     render: () => (
         <div dir="rtl">
-            <ChoiceBank label="الخيارات">
-                {SAMPLE_TILES.map((label) => (
-                    <PlaceholderTile key={label}>{label}</PlaceholderTile>
-                ))}
-            </ChoiceBank>
+            <ChoiceBank label="الخيارات">{sampleTiles()}</ChoiceBank>
         </div>
     ),
 };

--- a/packages/perseus/src/components/drag-and-drop/__docs__/choice-bank.stories.tsx
+++ b/packages/perseus/src/components/drag-and-drop/__docs__/choice-bank.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import {AnswerTile} from "../answer-tile";
-import {generateAnswerTileMenu} from "../answer-tile/answer-tile.testdata";
+import {generateAnswerTileProps} from "../answer-tile/answer-tile.testdata";
 import {ChoiceBank} from "../choice-bank";
 
 import type {Meta, StoryObj} from "@storybook/react-vite";
@@ -36,10 +36,11 @@ function sampleTiles() {
     return SAMPLE_TILES.map((value, index) => (
         <AnswerTile
             key={value}
-            tileId={`tile-${index}`}
-            content={value}
-            label={value}
-            menu={generateAnswerTileMenu()}
+            {...generateAnswerTileProps({
+                tileId: `tile-${index}`,
+                content: value,
+                label: value,
+            })}
         />
     ));
 }
@@ -74,10 +75,11 @@ export const ManyTiles: Story = {
             {Array.from({length: 24}, (_, i) => (
                 <AnswerTile
                     key={i}
-                    tileId={`tile-${i}`}
-                    content={`Tile ${i + 1}`}
-                    label={`Tile ${i + 1}`}
-                    menu={generateAnswerTileMenu()}
+                    {...generateAnswerTileProps({
+                        tileId: `tile-${i}`,
+                        content: `Tile ${i + 1}`,
+                        label: `Tile ${i + 1}`,
+                    })}
                 />
             ))}
         </ChoiceBank>

--- a/packages/perseus/src/components/drag-and-drop/__docs__/choice-bank.stories.tsx
+++ b/packages/perseus/src/components/drag-and-drop/__docs__/choice-bank.stories.tsx
@@ -39,7 +39,6 @@ function sampleTiles() {
             tileId={`tile-${index}`}
             content={value}
             label={value}
-            state="rest"
             menu={generateAnswerTileMenu()}
         />
     ));
@@ -78,7 +77,6 @@ export const ManyTiles: Story = {
                     tileId={`tile-${i}`}
                     content={`Tile ${i + 1}`}
                     label={`Tile ${i + 1}`}
-                    state="rest"
                     menu={generateAnswerTileMenu()}
                 />
             ))}

--- a/packages/perseus/src/components/drag-and-drop/__docs__/dnd-action-menu.stories.tsx
+++ b/packages/perseus/src/components/drag-and-drop/__docs__/dnd-action-menu.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import {rtlDecorator} from "../../../widgets/__testutils__/story-decorators";
 import {AnswerTile} from "../answer-tile";
 import {DndActionMenu} from "../dnd-action-menu";
 import {
@@ -29,8 +30,8 @@ const meta: Meta<typeof DndActionMenu> = {
         <StoryPadding>
             <AnswerTile
                 tileId="tile-1"
-                content={args.label}
-                label={args.label}
+                content={args.tileLabel}
+                label={args.tileLabel}
                 moveTargets={args.moveTargets}
                 onMove={args.onMove}
                 clearFromLabel={args.clearFromLabel}
@@ -39,10 +40,7 @@ const meta: Meta<typeof DndActionMenu> = {
             />
         </StoryPadding>
     ),
-    args: {
-        ...generateActionMenuProps(),
-        moveTargets: generateTestBlanks(4),
-    },
+    args: generateActionMenuProps({moveTargets: generateTestBlanks(4)}),
 };
 
 export default meta;
@@ -55,33 +53,23 @@ type Story = StoryObj<typeof DndActionMenu>;
  */
 export const Default: Story = {};
 
-/** Parent tile is in the choice bank, which should list the available blanks, with no "Clear" option */
-// No overrides — the shared args on `meta` model this state already.
-export const InChoiceBank: Story = {};
-
 /** A tile placed in Blank 1, which should list the other blanks, and a "Clear" option. */
 export const PlacedInBlank: Story = {
     args: {
         moveTargets: generateTestBlanks(4).slice(1),
-        targetLabel: "Blank 1",
+        clearFromLabel: "Blank 1",
         onClear: () => {},
     },
 };
 
-/** Example of the menu being disabled, but still focusable.
- *  While the designs show the menu disappearing when the tile
- *  is disabled, it seemed good to have this logic anyway.
- *  This story shows the menu without a tile. AnswerTile never disables
- *  its menu, because scored tiles remove the menu instead.
+/**
+ * A tile with nowhere to move and nothing to clear. The opener disables
+ * itself rather than open an empty menu, and stays focusable so its
+ * position stays discoverable.
  */
-export const Disabled: Story = {
-    render: (args) => (
-        <StoryPadding>
-            <DndActionMenu {...args} />
-        </StoryPadding>
-    ),
+export const NoAvailableActions: Story = {
     args: {
-        disabled: true,
+        moveTargets: [],
     },
 };
 
@@ -91,12 +79,12 @@ export const Disabled: Story = {
  */
 export const LongCategoryLabels: Story = {
     args: {
-        label: "Iron",
+        tileLabel: "Iron",
         moveTargets: [
             {id: "col-1", label: "Physical changes to matter"},
             {id: "col-2", label: "Chemical changes to matter"},
         ],
-        targetLabel: "Physical changes to matter",
+        clearFromLabel: "Physical changes to matter",
         onClear: () => {},
     },
 };
@@ -107,7 +95,7 @@ export const LongCategoryLabels: Story = {
  */
 export const MultiUse: Story = {
     args: {
-        label: "Penny",
+        tileLabel: "Penny",
         remainingUses: 5,
     },
 };
@@ -115,7 +103,7 @@ export const MultiUse: Story = {
 /** Right-to-left */
 export const RightToLeft: Story = {
     args: {
-        label: "بونغو",
+        tileLabel: "بونغو",
         moveTargets: [
             {id: "blank-1", label: "الفراغ 1"},
             {id: "blank-2", label: "الفراغ 2"},
@@ -123,25 +111,10 @@ export const RightToLeft: Story = {
     },
     parameters: {
         // Render in a separate iframe on the docs page so the document-level
-        // dir below doesn't flip the surrounding stories.
+        // dir doesn't flip the surrounding stories.
         docs: {story: {inline: false, height: "620px"}},
     },
-    decorators: [
-        // The open menu renders in a portal to document.body, so a dir="rtl"
-        // wrapper around the story doesn't work here. Set dir on the document
-        // element instead, as a real RTL page does.
-        (StoryComponent) => {
-            React.useEffect(() => {
-                const previous = document.documentElement.dir;
-                document.documentElement.dir = "rtl";
-                return () => {
-                    document.documentElement.dir = previous;
-                };
-            }, []);
-            // Note: the fixed copy ("Move to", "Clear") renders in English
-            // here — the temporary strings module isn't swappable per story.
-            // Full RTL copy returns when the strings move into PerseusStrings.
-            return <StoryComponent />;
-        },
-    ],
+    // Note: the fixed copy ("Move to", "Clear") renders in English here —
+    // the temporary strings module isn't swappable per story.
+    decorators: [rtlDecorator],
 };

--- a/packages/perseus/src/components/drag-and-drop/__docs__/dnd-action-menu.stories.tsx
+++ b/packages/perseus/src/components/drag-and-drop/__docs__/dnd-action-menu.stories.tsx
@@ -31,7 +31,6 @@ const meta: Meta<typeof DndActionMenu> = {
                 tileId="tile-1"
                 content={args.label}
                 label={args.label}
-                state="rest"
                 menu={{
                     remainingUses: args.remainingUses,
                     moveTargets: args.moveTargets,

--- a/packages/perseus/src/components/drag-and-drop/__docs__/dnd-action-menu.stories.tsx
+++ b/packages/perseus/src/components/drag-and-drop/__docs__/dnd-action-menu.stories.tsx
@@ -35,7 +35,7 @@ const meta: Meta<typeof DndActionMenu> = {
                     remainingUses: args.remainingUses,
                     moveTargets: args.moveTargets,
                     onMove: args.onMove,
-                    targetLabel: args.targetLabel,
+                    clearFromLabel: args.clearFromLabel,
                     onClear: args.onClear,
                 }}
             />

--- a/packages/perseus/src/components/drag-and-drop/__docs__/dnd-action-menu.stories.tsx
+++ b/packages/perseus/src/components/drag-and-drop/__docs__/dnd-action-menu.stories.tsx
@@ -9,7 +9,7 @@ import {
 
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
-/** Leave the menu room to open in the story canvas. */
+/** Give the menu room to open in the story canvas. */
 function StoryPadding({children}: {children: React.ReactNode}) {
     return (
         <div style={{display: "flex", marginBlock: 240, marginInline: 32}}>
@@ -19,8 +19,8 @@ function StoryPadding({children}: {children: React.ReactNode}) {
 }
 
 /**
- * `DndActionMenu` is composed by `AnswerTile`, so these stories render the
- * menu through the tile, the way widgets consume it.
+ * `AnswerTile` contains the `DndActionMenu`. These stories show the menu
+ * inside the tile, because that is how widgets use it.
  */
 const meta: Meta<typeof DndActionMenu> = {
     title: "Components/Drag and Drop/Action Menu",
@@ -74,8 +74,8 @@ export const PlacedInBlank: Story = {
 /** Example of the menu being disabled, but still focusable.
  *  While the designs show the menu disappearing when the tile
  *  is disabled, it seemed good to have this logic anyway.
- *  Rendered directly — AnswerTile never disables its menu (scored
- *  tiles remove it instead), so the tile can't show this state.
+ *  This story shows the menu without a tile. AnswerTile never disables
+ *  its menu, because scored tiles remove the menu instead.
  */
 export const Disabled: Story = {
     render: (args) => (

--- a/packages/perseus/src/components/drag-and-drop/__docs__/dnd-action-menu.stories.tsx
+++ b/packages/perseus/src/components/drag-and-drop/__docs__/dnd-action-menu.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import {rtlDecorator} from "../../../widgets/__testutils__/story-decorators";
+import {AnswerTile} from "../answer-tile";
 import {DndActionMenu} from "../dnd-action-menu";
 import {
     generateActionMenuProps,
@@ -9,44 +9,43 @@ import {
 
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
-/** TODO(LEMS-4363): Placeholder answer tile until we create the real one */
-function PlaceholderTile({children}: {children: React.ReactNode}) {
+/** Leave the menu room to open in the story canvas. */
+function StoryPadding({children}: {children: React.ReactNode}) {
     return (
-        <div
-            style={{
-                display: "inline-flex",
-                alignItems: "center",
-                minBlockSize: 48,
-                paddingBlock: 8,
-                paddingInline: 8,
-                borderRadius: 8,
-                border: "1px solid var(--wb-semanticColor-core-border-neutral-default)",
-                background:
-                    "var(--wb-semanticColor-core-background-base-default)",
-                // Leave the menu room to open in the story canvas.
-                marginBlock: 240,
-                marginInline: 32,
-            }}
-        >
+        <div style={{display: "flex", marginBlock: 240, marginInline: 32}}>
             {children}
         </div>
     );
 }
 
 /**
- * TODO(LEMS-4363): The tile below is a throwaway placeholder standing in for
- * the real `AnswerTile`, which will be created next after this PR.
+ * `DndActionMenu` is composed by `AnswerTile`, so these stories render the
+ * menu through the tile, the way widgets consume it.
  */
 const meta: Meta<typeof DndActionMenu> = {
     title: "Components/Drag and Drop/Action Menu",
     component: DndActionMenu,
     render: (args) => (
-        <PlaceholderTile>
-            <DndActionMenu {...args} />
-            {args.tileLabel}
-        </PlaceholderTile>
+        <StoryPadding>
+            <AnswerTile
+                tileId="tile-1"
+                content={args.label}
+                label={args.label}
+                state="rest"
+                menu={{
+                    remainingUses: args.remainingUses,
+                    moveTargets: args.moveTargets,
+                    onMove: args.onMove,
+                    targetLabel: args.targetLabel,
+                    onClear: args.onClear,
+                }}
+            />
+        </StoryPadding>
     ),
-    args: generateActionMenuProps({moveTargets: generateTestBlanks(4)}),
+    args: {
+        ...generateActionMenuProps(),
+        moveTargets: generateTestBlanks(4),
+    },
 };
 
 export default meta;
@@ -59,23 +58,33 @@ type Story = StoryObj<typeof DndActionMenu>;
  */
 export const Default: Story = {};
 
+/** Parent tile is in the choice bank, which should list the available blanks, with no "Clear" option */
+// No overrides — the shared args on `meta` model this state already.
+export const InChoiceBank: Story = {};
+
 /** A tile placed in Blank 1, which should list the other blanks, and a "Clear" option. */
 export const PlacedInBlank: Story = {
     args: {
         moveTargets: generateTestBlanks(4).slice(1),
-        clearFromLabel: "Blank 1",
+        targetLabel: "Blank 1",
         onClear: () => {},
     },
 };
 
-/**
- * A tile with nowhere to move and nothing to clear. The opener disables
- * itself rather than open an empty menu, and stays focusable so its
- * position stays discoverable.
+/** Example of the menu being disabled, but still focusable.
+ *  While the designs show the menu disappearing when the tile
+ *  is disabled, it seemed good to have this logic anyway.
+ *  Rendered directly — AnswerTile never disables its menu (scored
+ *  tiles remove it instead), so the tile can't show this state.
  */
-export const NoAvailableActions: Story = {
+export const Disabled: Story = {
+    render: (args) => (
+        <StoryPadding>
+            <DndActionMenu {...args} />
+        </StoryPadding>
+    ),
     args: {
-        moveTargets: [],
+        disabled: true,
     },
 };
 
@@ -85,12 +94,12 @@ export const NoAvailableActions: Story = {
  */
 export const LongCategoryLabels: Story = {
     args: {
-        tileLabel: "Iron",
+        label: "Iron",
         moveTargets: [
             {id: "col-1", label: "Physical changes to matter"},
             {id: "col-2", label: "Chemical changes to matter"},
         ],
-        clearFromLabel: "Physical changes to matter",
+        targetLabel: "Physical changes to matter",
         onClear: () => {},
     },
 };
@@ -101,7 +110,7 @@ export const LongCategoryLabels: Story = {
  */
 export const MultiUse: Story = {
     args: {
-        tileLabel: "Penny",
+        label: "Penny",
         remainingUses: 5,
     },
 };
@@ -109,7 +118,7 @@ export const MultiUse: Story = {
 /** Right-to-left */
 export const RightToLeft: Story = {
     args: {
-        tileLabel: "بونغو",
+        label: "بونغو",
         moveTargets: [
             {id: "blank-1", label: "الفراغ 1"},
             {id: "blank-2", label: "الفراغ 2"},
@@ -117,10 +126,25 @@ export const RightToLeft: Story = {
     },
     parameters: {
         // Render in a separate iframe on the docs page so the document-level
-        // dir doesn't flip the surrounding stories.
+        // dir below doesn't flip the surrounding stories.
         docs: {story: {inline: false, height: "620px"}},
     },
-    // Note: the fixed copy ("Move to", "Clear") renders in English here —
-    // the temporary strings module isn't swappable per story.
-    decorators: [rtlDecorator],
+    decorators: [
+        // The open menu renders in a portal to document.body, so a dir="rtl"
+        // wrapper around the story doesn't work here. Set dir on the document
+        // element instead, as a real RTL page does.
+        (StoryComponent) => {
+            React.useEffect(() => {
+                const previous = document.documentElement.dir;
+                document.documentElement.dir = "rtl";
+                return () => {
+                    document.documentElement.dir = previous;
+                };
+            }, []);
+            // Note: the fixed copy ("Move to", "Clear") renders in English
+            // here — the temporary strings module isn't swappable per story.
+            // Full RTL copy returns when the strings move into PerseusStrings.
+            return <StoryComponent />;
+        },
+    ],
 };

--- a/packages/perseus/src/components/drag-and-drop/__docs__/dnd-action-menu.stories.tsx
+++ b/packages/perseus/src/components/drag-and-drop/__docs__/dnd-action-menu.stories.tsx
@@ -31,13 +31,11 @@ const meta: Meta<typeof DndActionMenu> = {
                 tileId="tile-1"
                 content={args.label}
                 label={args.label}
-                menu={{
-                    remainingUses: args.remainingUses,
-                    moveTargets: args.moveTargets,
-                    onMove: args.onMove,
-                    clearFromLabel: args.clearFromLabel,
-                    onClear: args.onClear,
-                }}
+                moveTargets={args.moveTargets}
+                onMove={args.onMove}
+                clearFromLabel={args.clearFromLabel}
+                onClear={args.onClear}
+                remainingUses={args.remainingUses}
             />
         </StoryPadding>
     ),

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
@@ -1,9 +1,9 @@
 /*
- * AnswerTile — the card a learner moves into a blank.
+ * AnswerTile — the card that a learner moves into a blank.
  *
- * The leading 6px gap between the menu/icon and the content is owned by the
- * leading element itself (the menu opener already carries a 6px trailing
- * margin; the state icon mirrors it), so the tile sets no gap of its own.
+ * The tile sets no gap of its own. The leading element owns the 6px gap
+ * before the content: the menu opener has a 6px trailing margin, and the
+ * state icon copies it.
  */
 .tile {
     display: flex;
@@ -19,7 +19,7 @@
     font-family: var(--wb-font-family-sans);
     font-size: var(--wb-font-body-size-medium);
     font-weight: var(--wb-font-weight-semi);
-    /* Per design, the medium body size pairs with the large line height. */
+    /* The design pairs the medium body size with the large line height. */
     line-height: var(--wb-font-body-lineHeight-large);
     word-break: break-word;
 }
@@ -31,9 +31,9 @@
     box-shadow: 0 2px 2px var(--wb-semanticColor-core-shadow-transparent-low);
 }
 
-/* Scored borders are thicker (2px vs 1px), so scored states give up that
- * extra width from their padding — the tile keeps the same overall size
- * and nothing shifts when the parent flips states. */
+/* Scored borders are 2px. The rest border is 1px. Scored states remove
+ * the extra 1px from their padding. The tile keeps the same size, so
+ * nothing moves when the state changes. */
 .correct,
 .incorrect {
     padding-block: calc(
@@ -68,9 +68,10 @@
     display: inline-flex;
 }
 
-/* In an inline blank the menu stays out of the way until the learner
- * hovers or tabs to it. Hidden visually only — the opener must stay
- * focusable and clickable for keyboard and screen reader users. */
+/* In an inline blank, the menu is hidden until the learner hovers on
+ * the tile or moves focus into it. The menu is only hidden visually.
+ * The opener stays focusable and clickable for keyboard and screen
+ * reader users. */
 .menuOnDemand {
     opacity: 0;
 }
@@ -80,8 +81,8 @@
     opacity: 1;
 }
 
-/* The check/x box matches the menu opener: a 24px square with a 6px
- * trailing margin, so scored and rest tiles align. */
+/* The check/x box has the same size as the menu opener: a 24px square
+ * with a 6px trailing margin. Scored and rest tiles align as a result. */
 .stateIcon {
     display: inline-flex;
     align-items: center;
@@ -94,29 +95,29 @@
 .content {
     display: flex;
     justify-content: center;
-    /* Text and TeX reflow past this width; content never scrolls. */
+    /* Text and TeX wrap at this width. Content never scrolls. */
     max-inline-size: 200px;
     padding-inline-end: var(--wb-sizing-size_060);
-    /* Scored colors recolor the rendered markdown. */
+    /* The rendered markdown gets its color from the tile's state. */
     color: inherit;
 }
 
-/* Images follow their preset height but never overflow the tile. */
+/* Images keep their set height. They must not overflow the tile. */
 .content img {
     max-inline-size: 100%;
 }
 
-/* The renderer wraps content in .paragraph divs that carry Perseus's
- * global page styles (Lato 18px, 22px vertical margins). The tile owns
- * its own typography, so undo them here. The .tile prefix keeps this
- * selector more specific than the global one. */
+/* The renderer puts content in .paragraph divs. Perseus gives those
+ * divs global page styles: Lato 18px and 22px vertical margins. The
+ * tile owns its own typography, so we remove those styles here. The
+ * .tile prefix makes this selector win against the global one. */
 .tile .content :global(div.paragraph) {
     margin: 0;
     font: inherit;
 }
 
-/* An empty tile keeps a minimum width so it's still a visible,
- * targetable card. 6.4rem = 64px at KA's 10px root font size. */
+/* An empty tile keeps a minimum width. The learner can then see it and
+ * select it. 6.4rem = 64px at KA's 10px root font size. */
 .emptyContent {
     min-inline-size: 6.4rem;
 }

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
@@ -60,7 +60,8 @@
     box-shadow: none;
 }
 
-.disabled {
+/* A tile the learner left in the bank when the question was scored. */
+.unused {
     color: var(--wb-semanticColor-core-foreground-disabled-strong);
     box-shadow: none;
 }
@@ -86,7 +87,7 @@
      * past this limit. Content never scrolls. */
     max-inline-size: 200px;
     padding-inline-end: var(--wb-sizing-size_060);
-    /* The rendered markdown inherits the scored or disabled text color. */
+    /* The rendered markdown inherits the scored text color. */
     color: inherit;
 }
 

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
@@ -1,9 +1,5 @@
 /*
  * AnswerTile — the card that a learner moves into a blank.
- *
- * The tile sets no gap of its own. The leading element owns the 6px gap
- * before the content: the menu opener has a 6px trailing margin, and the
- * state icon copies it.
  */
 .tile {
     display: flex;
@@ -64,8 +60,15 @@
     color: var(--wb-semanticColor-core-foreground-disabled-strong);
 }
 
-.menuContainer {
-    display: inline-flex;
+/* The box at the start of the tile. It holds the actions menu or the
+ * scored icon, and it owns the 6px gap before the content. */
+.startContainer {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-inline-size: var(--wb-sizing-size_240);
+    block-size: var(--wb-sizing-size_240);
+    margin-inline-end: var(--wb-sizing-size_060);
 }
 
 /* In an inline blank, the menu is hidden until the learner hovers on
@@ -79,17 +82,6 @@
 .tile:hover .menuOnDemand,
 .tile:focus-within .menuOnDemand {
     opacity: 1;
-}
-
-/* The check/x box has the same size as the menu opener: a 24px square
- * with a 6px trailing margin. Scored and rest tiles align as a result. */
-.stateIcon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    inline-size: var(--wb-sizing-size_240);
-    block-size: var(--wb-sizing-size_240);
-    margin-inline-end: var(--wb-sizing-size_060);
 }
 
 .content {

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
@@ -6,9 +6,11 @@
     align-items: center;
     box-sizing: border-box;
 
-    /* One-line tiles are 48px tall in the design. Taller content still
-     * grows the tile, because this is a minimum. */
+    /* One-line tiles are 48px tall and the narrowest tiles (empty and
+     * single-character) are 64px wide in the design. Larger content
+     * still grows the tile, because these are minimums. */
     min-block-size: var(--wb-sizing-size_480);
+    min-inline-size: var(--wb-sizing-size_640);
 
     padding-block: var(--wb-sizing-size_080);
     padding-inline: var(--wb-sizing-size_100);
@@ -77,6 +79,9 @@
 .content {
     display: flex;
     justify-content: center;
+    /* Fill the leftover width in a minimum-width tile, so narrow
+     * content stays centered. */
+    flex-grow: 1;
     /* Text wraps at this width. TeX does not wrap, so wide TeX can go
      * past this limit. Content never scrolls. */
     max-inline-size: 200px;
@@ -97,10 +102,4 @@
 .tile .content :global(div.paragraph) {
     margin: 0;
     font: inherit;
-}
-
-/* An empty tile keeps a minimum width. The learner can then see it and
- * select it. 6.4rem = 64px at KA's 10px root font size. */
-.emptyContent {
-    min-inline-size: 6.4rem;
 }

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
@@ -64,7 +64,7 @@
     color: var(--wb-semanticColor-core-foreground-disabled-strong);
 }
 
-.menuBox {
+.menuContainer {
     display: inline-flex;
 }
 

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
@@ -74,19 +74,6 @@
     margin-inline-end: var(--wb-sizing-size_060);
 }
 
-/* In an inline blank, the menu is hidden until the learner hovers on
- * the tile or moves focus into it. The menu is only hidden visually.
- * The opener stays focusable and clickable for keyboard and screen
- * reader users. */
-.menuOnDemand {
-    opacity: 0;
-}
-
-.tile:hover .menuOnDemand,
-.tile:focus-within .menuOnDemand {
-    opacity: 1;
-}
-
 .content {
     display: flex;
     justify-content: center;

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
@@ -95,7 +95,8 @@
 .content {
     display: flex;
     justify-content: center;
-    /* Text and TeX wrap at this width. Content never scrolls. */
+    /* Text wraps at this width. TeX does not wrap, so wide TeX can go
+     * past this limit. Content never scrolls. */
     max-inline-size: 200px;
     padding-inline-end: var(--wb-sizing-size_060);
     /* The rendered markdown gets its color from the tile's state. */

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
@@ -96,11 +96,14 @@
 }
 
 /* The renderer puts content in .paragraph divs, and Perseus gives
- * those divs global page styles. The tile owns its own typography, so
- * we remove those styles here. The repeated class outweighs the
- * heaviest global rule (the desktop-article paragraph rule matches at
- * five classes) in any stylesheet load order. */
-.tile.tile.tile .content :global(div.paragraph) {
+ * those divs global page styles (article paragraphs set their own font
+ * and color). The tile owns its typography, so we remove those styles
+ * here. The global sheets sit in the perseus-legacy cascade layer, so
+ * this rule wins wherever it is loaded. Color needs an explicit
+ * declaration: a scored tile sets its color on the tile, and an
+ * inherited value loses to any rule that names the paragraph. */
+.tile .content :global(div.paragraph) {
     margin: 0;
     font: inherit;
+    color: inherit;
 }

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
@@ -95,11 +95,12 @@
     max-inline-size: 100%;
 }
 
-/* The renderer puts content in .paragraph divs. Perseus gives those
- * divs global page styles: Lato 18px and 22px vertical margins. The
- * tile owns its own typography, so we remove those styles here. The
- * .tile prefix makes this selector win against the global one. */
-.tile .content :global(div.paragraph) {
+/* The renderer puts content in .paragraph divs, and Perseus gives
+ * those divs global page styles. The tile owns its own typography, so
+ * we remove those styles here. The repeated class outweighs the
+ * heaviest global rule (the desktop-article paragraph rule matches at
+ * five classes) in any stylesheet load order. */
+.tile.tile.tile .content :global(div.paragraph) {
     margin: 0;
     font: inherit;
 }

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
@@ -18,18 +18,16 @@
     /* The design pairs the medium body size with the large line height. */
     line-height: var(--wb-font-body-lineHeight-large);
     word-break: break-word;
-}
 
-.rest {
     border: var(--wb-border-width-thin) solid
         var(--wb-semanticColor-core-border-neutral-subtle);
     color: var(--wb-semanticColor-core-foreground-neutral-strong);
     box-shadow: 0 2px 2px var(--wb-semanticColor-core-shadow-transparent-low);
 }
 
-/* Scored borders are 2px. The rest border is 1px. Scored states remove
- * the extra 1px from their padding. The tile keeps the same size, so
- * nothing moves when the state changes. */
+/* Scored borders are 2px. The default border is 1px. Scored tiles
+ * remove the extra 1px from their padding. The tile keeps the same
+ * size, so nothing moves when the question is scored. */
 .correct,
 .incorrect {
     padding-block: calc(
@@ -46,18 +44,19 @@
     border: var(--wb-border-width-medium) solid
         var(--wb-semanticColor-core-border-success-default);
     color: var(--wb-semanticColor-core-foreground-success-default);
+    box-shadow: none;
 }
 
 .incorrect {
     border: var(--wb-border-width-medium) solid
         var(--wb-semanticColor-core-border-critical-default);
     color: var(--wb-semanticColor-core-foreground-critical-default);
+    box-shadow: none;
 }
 
 .disabled {
-    border: var(--wb-border-width-thin) solid
-        var(--wb-semanticColor-core-border-neutral-subtle);
     color: var(--wb-semanticColor-core-foreground-disabled-strong);
+    box-shadow: none;
 }
 
 /* The box at the start of the tile. It holds the actions menu or the

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
@@ -1,0 +1,122 @@
+/*
+ * AnswerTile — the card a learner moves into a blank.
+ *
+ * The leading 6px gap between the menu/icon and the content is owned by the
+ * leading element itself (the menu opener already carries a 6px trailing
+ * margin; the state icon mirrors it), so the tile sets no gap of its own.
+ */
+.tile {
+    display: flex;
+    align-items: center;
+    box-sizing: border-box;
+
+    padding-block: var(--wb-sizing-size_080);
+    padding-inline: var(--wb-sizing-size_100);
+
+    border-radius: var(--wb-border-radius-radius_080);
+    background: var(--wb-semanticColor-core-background-base-default);
+
+    font-family: var(--wb-font-family-sans);
+    font-size: var(--wb-font-body-size-medium);
+    font-weight: var(--wb-font-weight-semi);
+    /* Per design, the medium body size pairs with the large line height. */
+    line-height: var(--wb-font-body-lineHeight-large);
+    word-break: break-word;
+}
+
+.rest {
+    border: var(--wb-border-width-thin) solid
+        var(--wb-semanticColor-core-border-neutral-subtle);
+    color: var(--wb-semanticColor-core-foreground-neutral-strong);
+    box-shadow: 0 2px 2px var(--wb-semanticColor-core-shadow-transparent-low);
+}
+
+/* Scored borders are thicker (2px vs 1px), so scored states give up that
+ * extra width from their padding — the tile keeps the same overall size
+ * and nothing shifts when the parent flips states. */
+.correct,
+.incorrect {
+    padding-block: calc(
+        var(--wb-sizing-size_080) -
+            (var(--wb-border-width-medium) - var(--wb-border-width-thin))
+    );
+    padding-inline: calc(
+        var(--wb-sizing-size_100) -
+            (var(--wb-border-width-medium) - var(--wb-border-width-thin))
+    );
+}
+
+.correct {
+    border: var(--wb-border-width-medium) solid
+        var(--wb-semanticColor-core-border-success-default);
+    color: var(--wb-semanticColor-core-foreground-success-default);
+}
+
+.incorrect {
+    border: var(--wb-border-width-medium) solid
+        var(--wb-semanticColor-core-border-critical-default);
+    color: var(--wb-semanticColor-core-foreground-critical-default);
+}
+
+.disabled {
+    border: var(--wb-border-width-thin) solid
+        var(--wb-semanticColor-core-border-neutral-subtle);
+    color: var(--wb-semanticColor-core-foreground-disabled-strong);
+}
+
+.menuBox {
+    display: inline-flex;
+}
+
+/* In an inline blank the menu stays out of the way until the learner
+ * hovers or tabs to it. Hidden visually only — the opener must stay
+ * focusable and clickable for keyboard and screen reader users. */
+.menuOnDemand {
+    opacity: 0;
+}
+
+.tile:hover .menuOnDemand,
+.tile:focus-within .menuOnDemand {
+    opacity: 1;
+}
+
+/* The check/x box matches the menu opener: a 24px square with a 6px
+ * trailing margin, so scored and rest tiles align. */
+.stateIcon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    inline-size: var(--wb-sizing-size_240);
+    block-size: var(--wb-sizing-size_240);
+    margin-inline-end: var(--wb-sizing-size_060);
+}
+
+.content {
+    display: flex;
+    justify-content: center;
+    /* Text and TeX reflow past this width; content never scrolls. */
+    max-inline-size: 200px;
+    padding-inline-end: var(--wb-sizing-size_060);
+    /* Scored colors recolor the rendered markdown. */
+    color: inherit;
+}
+
+/* Images follow their preset height but never overflow the tile. */
+.content img {
+    max-inline-size: 100%;
+}
+
+/* The renderer wraps content in .paragraph divs that carry Perseus's
+ * global page styles (Lato 18px, 22px vertical margins). The tile owns
+ * its own typography, so undo them here. The .tile prefix keeps this
+ * selector more specific than the global one. */
+.tile .content :global(div.paragraph) {
+    margin: 0;
+    font: inherit;
+}
+
+/* An empty tile keeps a minimum width so it's still a visible,
+ * targetable card. 6.4rem = 64px at KA's 10px root font size. */
+.emptyContent {
+    min-inline-size: 6.4rem;
+}

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
@@ -94,7 +94,7 @@
      * past this limit. Content never scrolls. */
     max-inline-size: 200px;
     padding-inline-end: var(--wb-sizing-size_060);
-    /* The rendered markdown gets its color from the tile's state. */
+    /* The rendered markdown inherits the scored or disabled text color. */
     color: inherit;
 }
 

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
@@ -93,6 +93,7 @@
 
 /* Images keep their set height. They must not overflow the tile. */
 .content img {
+    block-size: var(--answer-tile-image-height, auto);
     max-inline-size: 100%;
 }
 

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.module.css
@@ -6,6 +6,10 @@
     align-items: center;
     box-sizing: border-box;
 
+    /* One-line tiles are 48px tall in the design. Taller content still
+     * grows the tile, because this is a minimum. */
+    min-block-size: var(--wb-sizing-size_480);
+
     padding-block: var(--wb-sizing-size_080);
     padding-inline: var(--wb-sizing-size_100);
 

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
@@ -143,23 +143,6 @@ describe("AnswerTile", () => {
                 screen.getByRole("button", {name: "Bongo"}),
             );
         });
-
-        it("keeps the menu opener focusable when visibility is on-hover-or-focus", async () => {
-            // Arrange
-            render(
-                <AnswerTile
-                    {...generateAnswerTileProps({
-                        menuVisibility: "on-hover-or-focus",
-                    })}
-                />,
-            );
-
-            // Act
-            await user.tab();
-
-            // Assert
-            expect(screen.getByRole("button", {name: "Bongo"})).toHaveFocus();
-        });
     });
 
     describe("scored states", () => {

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
@@ -1,0 +1,235 @@
+import {act, render, screen} from "@testing-library/react";
+import {userEvent} from "@testing-library/user-event";
+import * as React from "react";
+
+import * as Dependencies from "../../../dependencies";
+import {mockImageLoading} from "../../../testing/image-loader-utils";
+import {
+    testDependencies,
+    testDependenciesV2,
+} from "../../../testing/test-dependencies";
+
+import {AnswerTile} from "./answer-tile";
+import {generateAnswerTileMenu} from "./answer-tile.testdata";
+
+import type {UserEvent} from "@testing-library/user-event";
+
+function defaultProps() {
+    return {
+        tileId: "tile-1",
+        content: "Bongo",
+        label: "Bongo",
+        state: "rest",
+        menu: null,
+    } as const;
+}
+
+describe("AnswerTile", () => {
+    let user: UserEvent;
+
+    beforeEach(() => {
+        user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+        jest.spyOn(Dependencies, "useDependencies").mockReturnValue(
+            testDependenciesV2,
+        );
+    });
+
+    describe("content", () => {
+        it("renders text content from markdown", () => {
+            // Arrange, Act
+            render(<AnswerTile {...defaultProps()} content="Bongo" />);
+
+            expect(screen.getByText("Bongo")).toBeInTheDocument();
+        });
+
+        it("renders TeX content", () => {
+            // Arrange, Act
+            render(
+                <AnswerTile
+                    {...defaultProps()}
+                    content="$x^2$"
+                    label="x squared"
+                />,
+            );
+
+            expect(screen.getByText("x^2")).toBeInTheDocument();
+        });
+
+        it("renders image content with its alt text", async () => {
+            // Arrange
+            const unmockImageLoading = mockImageLoading();
+
+            // Act
+            render(
+                <AnswerTile
+                    {...defaultProps()}
+                    content="![a bongo drum](https://example.com/bongo.png)"
+                    label="a bongo drum"
+                />,
+            );
+
+            // The mocked image loader fires its load event on a timer.
+            act(() => {
+                jest.runOnlyPendingTimers();
+            });
+
+            // Assert
+            expect(screen.getByAltText("a bongo drum")).toBeInTheDocument();
+
+            unmockImageLoading();
+        });
+
+        it("renders the label for screen readers when content is empty", () => {
+            // Arrange, Act
+            render(
+                <AnswerTile {...defaultProps()} content="" label="(empty)" />,
+            );
+
+            expect(screen.getByText("(empty)")).toBeInTheDocument();
+        });
+    });
+
+    describe("menu integration", () => {
+        it("renders the action menu when menu data is provided", () => {
+            // Arrange, Act
+            render(
+                <AnswerTile
+                    {...defaultProps()}
+                    menu={generateAnswerTileMenu()}
+                />,
+            );
+
+            expect(
+                screen.getByRole("button", {name: "Bongo"}),
+            ).toBeInTheDocument();
+        });
+
+        it("renders no menu when menu is null", () => {
+            // Arrange, Act
+            render(<AnswerTile {...defaultProps()} menu={null} />);
+
+            expect(screen.queryByRole("button")).not.toBeInTheDocument();
+        });
+
+        it("calls onMove with the target id when a move action is selected", async () => {
+            // Arrange
+            const onMove = jest.fn();
+            render(
+                <AnswerTile
+                    {...defaultProps()}
+                    menu={generateAnswerTileMenu({onMove})}
+                />,
+            );
+
+            // Act
+            await user.click(screen.getByRole("button", {name: "Bongo"}));
+            await user.click(
+                await screen.findByRole("menuitem", {name: "Move to Blank 2"}),
+            );
+
+            // Assert
+            expect(onMove).toHaveBeenCalledWith("blank-2");
+        });
+
+        it("forwards menuRef to the opener button", () => {
+            // Arrange
+            const menuRef = React.createRef<HTMLButtonElement>();
+
+            // Act
+            render(
+                <AnswerTile
+                    {...defaultProps()}
+                    menu={generateAnswerTileMenu({menuRef})}
+                />,
+            );
+
+            // Assert
+            expect(menuRef.current).toBe(
+                screen.getByRole("button", {name: "Bongo"}),
+            );
+        });
+
+        it("keeps the menu opener focusable when visibility is on-hover-or-focus", async () => {
+            // Arrange
+            render(
+                <AnswerTile
+                    {...defaultProps()}
+                    menu={generateAnswerTileMenu()}
+                    menuVisibility="on-hover-or-focus"
+                />,
+            );
+
+            // Act
+            await user.tab();
+
+            // Assert
+            expect(screen.getByRole("button", {name: "Bongo"})).toHaveFocus();
+        });
+    });
+
+    describe("states", () => {
+        it("renders the check icon when the state is correct", () => {
+            // Arrange, Act
+            render(<AnswerTile {...defaultProps()} state="correct" />);
+
+            expect(
+                screen.getByTestId("answer-tile-state-icon-tile-1"),
+            ).toBeInTheDocument();
+        });
+
+        it("renders the x icon when the state is incorrect", () => {
+            // Arrange, Act
+            render(<AnswerTile {...defaultProps()} state="incorrect" />);
+
+            expect(
+                screen.getByTestId("answer-tile-state-icon-tile-1"),
+            ).toBeInTheDocument();
+        });
+
+        it("hides the state icons from assistive technology", () => {
+            // Arrange, Act
+            render(<AnswerTile {...defaultProps()} state="correct" />);
+
+            expect(
+                screen.getByTestId("answer-tile-state-icon-tile-1"),
+            ).toHaveAttribute("aria-hidden", "true");
+        });
+
+        it.each(["correct", "incorrect", "disabled"] as const)(
+            "does not render the action menu when the state is %s",
+            (state) => {
+                // Arrange, Act
+                render(
+                    <AnswerTile
+                        {...defaultProps()}
+                        state={state}
+                        menu={generateAnswerTileMenu()}
+                    />,
+                );
+
+                expect(screen.queryByRole("button")).not.toBeInTheDocument();
+            },
+        );
+
+        it("renders no state icon when the state is disabled", () => {
+            // Arrange, Act
+            render(<AnswerTile {...defaultProps()} state="disabled" />);
+
+            expect(
+                screen.queryByTestId("answer-tile-state-icon-tile-1"),
+            ).not.toBeInTheDocument();
+        });
+
+        it("marks the tile as disabled via its class when the state is disabled", () => {
+            // Arrange, Act
+            render(<AnswerTile {...defaultProps()} state="disabled" />);
+
+            expect(screen.getByTestId("answer-tile-tile-1")).toHaveClass(
+                "disabled",
+            );
+        });
+    });
+});

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
@@ -90,6 +90,15 @@ describe("AnswerTile", () => {
 
             expect(screen.getByText("(empty)")).toBeInTheDocument();
         });
+
+        it("treats whitespace-only content as empty", () => {
+            // Arrange, Act
+            render(
+                <AnswerTile {...defaultProps()} content="  " label="(empty)" />,
+            );
+
+            expect(screen.getByText("(empty)")).toBeInTheDocument();
+        });
     });
 
     describe("menu integration", () => {
@@ -171,23 +180,20 @@ describe("AnswerTile", () => {
     });
 
     describe("states", () => {
-        it("renders the check icon when the state is correct", () => {
-            // Arrange, Act
-            render(<AnswerTile {...defaultProps()} state="correct" />);
+        // The icon graphic (check vs x) lives in a generated stylesheet,
+        // so jsdom cannot tell the two apart. The stories cover which
+        // glyph shows for each state.
+        it.each(["correct", "incorrect"] as const)(
+            "renders a state icon when the state is %s",
+            (state) => {
+                // Arrange, Act
+                render(<AnswerTile {...defaultProps()} state={state} />);
 
-            expect(
-                screen.getByTestId("answer-tile-state-icon-tile-1"),
-            ).toBeInTheDocument();
-        });
-
-        it("renders the x icon when the state is incorrect", () => {
-            // Arrange, Act
-            render(<AnswerTile {...defaultProps()} state="incorrect" />);
-
-            expect(
-                screen.getByTestId("answer-tile-state-icon-tile-1"),
-            ).toBeInTheDocument();
-        });
+                expect(
+                    screen.getByTestId("answer-tile-state-icon-tile-1"),
+                ).toBeInTheDocument();
+            },
+        );
 
         it("hides the state icons from assistive technology", () => {
             // Arrange, Act

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
@@ -19,7 +19,6 @@ function defaultProps() {
         tileId: "tile-1",
         content: "Bongo",
         label: "Bongo",
-        state: "rest",
         menu: null,
     } as const;
 }
@@ -179,15 +178,20 @@ describe("AnswerTile", () => {
         });
     });
 
-    describe("states", () => {
+    describe("scored states", () => {
         // The icon graphic (check vs x) lives in a generated stylesheet,
         // so jsdom cannot tell the two apart. The stories cover which
-        // glyph shows for each state.
+        // glyph shows for each result.
         it.each(["correct", "incorrect"] as const)(
-            "renders a state icon when the state is %s",
-            (state) => {
+            "renders a scored icon when showCorrectness is %s",
+            (showCorrectness) => {
                 // Arrange, Act
-                render(<AnswerTile {...defaultProps()} state={state} />);
+                render(
+                    <AnswerTile
+                        {...defaultProps()}
+                        showCorrectness={showCorrectness}
+                    />,
+                );
 
                 expect(
                     screen.getByTestId("answer-tile-state-icon-tile-1"),
@@ -195,23 +199,25 @@ describe("AnswerTile", () => {
             },
         );
 
-        it("hides the state icons from assistive technology", () => {
+        it("hides the scored icons from assistive technology", () => {
             // Arrange, Act
-            render(<AnswerTile {...defaultProps()} state="correct" />);
+            render(
+                <AnswerTile {...defaultProps()} showCorrectness="correct" />,
+            );
 
             expect(
                 screen.getByTestId("answer-tile-state-icon-tile-1"),
             ).toHaveAttribute("aria-hidden", "true");
         });
 
-        it.each(["correct", "incorrect", "disabled"] as const)(
-            "does not render the action menu when the state is %s",
-            (state) => {
+        it.each(["correct", "incorrect"] as const)(
+            "does not render the action menu when showCorrectness is %s",
+            (showCorrectness) => {
                 // Arrange, Act
                 render(
                     <AnswerTile
                         {...defaultProps()}
-                        state={state}
+                        showCorrectness={showCorrectness}
                         menu={generateAnswerTileMenu()}
                     />,
                 );
@@ -220,18 +226,31 @@ describe("AnswerTile", () => {
             },
         );
 
-        it("renders no state icon when the state is disabled", () => {
+        it("does not render the action menu when the tile is disabled", () => {
             // Arrange, Act
-            render(<AnswerTile {...defaultProps()} state="disabled" />);
+            render(
+                <AnswerTile
+                    {...defaultProps()}
+                    disabled={true}
+                    menu={generateAnswerTileMenu()}
+                />,
+            );
+
+            expect(screen.queryByRole("button")).not.toBeInTheDocument();
+        });
+
+        it("renders no scored icon when the tile is disabled", () => {
+            // Arrange, Act
+            render(<AnswerTile {...defaultProps()} disabled={true} />);
 
             expect(
                 screen.queryByTestId("answer-tile-state-icon-tile-1"),
             ).not.toBeInTheDocument();
         });
 
-        it("marks the tile as disabled via its class when the state is disabled", () => {
+        it("marks a disabled tile via its class", () => {
             // Arrange, Act
-            render(<AnswerTile {...defaultProps()} state="disabled" />);
+            render(<AnswerTile {...defaultProps()} disabled={true} />);
 
             expect(screen.getByTestId("answer-tile-tile-1")).toHaveClass(
                 "disabled",

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
@@ -43,7 +43,7 @@ describe("AnswerTile", () => {
         render(
             <AnswerTile
                 {...generateAnswerTileProps({
-                    content: "![a bongo drum](https://example.com/bongo.png)",
+                    content: "![a bongo drum](http://localhost/bongo.png)",
                     label: "a bongo drum",
                 })}
             />,

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
@@ -60,6 +60,26 @@ describe("AnswerTile", () => {
         unmockImageLoading();
     });
 
+    it("sizes an image tile's image through the authored height", () => {
+        // Arrange, Act
+        const {container} = render(
+            <AnswerTile
+                {...generateAnswerTileProps({
+                    content: "![a bongo drum](http://localhost/bongo.png)",
+                    label: "a bongo drum",
+                    imageHeight: 48,
+                })}
+            />,
+        );
+
+        // Assert — the CSS reads the variable on the tile root, which
+        // is a semantics-free div with no query-friendly handle.
+        // eslint-disable-next-line testing-library/no-node-access, testing-library/no-container
+        expect(container.firstElementChild?.getAttribute("style")).toContain(
+            "--answer-tile-image-height: 48px",
+        );
+    });
+
     it.each(["", "  "])(
         "renders the label for screen readers when content is %j",
         (content) => {

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
@@ -10,18 +10,9 @@ import {
 } from "../../../testing/test-dependencies";
 
 import {AnswerTile} from "./answer-tile";
-import {generateAnswerTileMenu} from "./answer-tile.testdata";
+import {generateAnswerTileProps} from "./answer-tile.testdata";
 
 import type {UserEvent} from "@testing-library/user-event";
-
-function defaultProps() {
-    return {
-        tileId: "tile-1",
-        content: "Bongo",
-        label: "Bongo",
-        menu: null,
-    } as const;
-}
 
 describe("AnswerTile", () => {
     let user: UserEvent;
@@ -39,7 +30,9 @@ describe("AnswerTile", () => {
     describe("content", () => {
         it("renders text content from markdown", () => {
             // Arrange, Act
-            render(<AnswerTile {...defaultProps()} content="Bongo" />);
+            render(
+                <AnswerTile {...generateAnswerTileProps({content: "Bongo"})} />,
+            );
 
             expect(screen.getByText("Bongo")).toBeInTheDocument();
         });
@@ -48,9 +41,10 @@ describe("AnswerTile", () => {
             // Arrange, Act
             render(
                 <AnswerTile
-                    {...defaultProps()}
-                    content="$x^2$"
-                    label="x squared"
+                    {...generateAnswerTileProps({
+                        content: "$x^2$",
+                        label: "x squared",
+                    })}
                 />,
             );
 
@@ -64,9 +58,11 @@ describe("AnswerTile", () => {
             // Act
             render(
                 <AnswerTile
-                    {...defaultProps()}
-                    content="![a bongo drum](https://example.com/bongo.png)"
-                    label="a bongo drum"
+                    {...generateAnswerTileProps({
+                        content:
+                            "![a bongo drum](https://example.com/bongo.png)",
+                        label: "a bongo drum",
+                    })}
                 />,
             );
 
@@ -84,7 +80,12 @@ describe("AnswerTile", () => {
         it("renders the label for screen readers when content is empty", () => {
             // Arrange, Act
             render(
-                <AnswerTile {...defaultProps()} content="" label="(empty)" />,
+                <AnswerTile
+                    {...generateAnswerTileProps({
+                        content: "",
+                        label: "(empty)",
+                    })}
+                />,
             );
 
             expect(screen.getByText("(empty)")).toBeInTheDocument();
@@ -93,7 +94,12 @@ describe("AnswerTile", () => {
         it("treats whitespace-only content as empty", () => {
             // Arrange, Act
             render(
-                <AnswerTile {...defaultProps()} content="  " label="(empty)" />,
+                <AnswerTile
+                    {...generateAnswerTileProps({
+                        content: "  ",
+                        label: "(empty)",
+                    })}
+                />,
             );
 
             expect(screen.getByText("(empty)")).toBeInTheDocument();
@@ -101,36 +107,19 @@ describe("AnswerTile", () => {
     });
 
     describe("menu integration", () => {
-        it("renders the action menu when menu data is provided", () => {
+        it("renders the action menu labeled with the tile label", () => {
             // Arrange, Act
-            render(
-                <AnswerTile
-                    {...defaultProps()}
-                    menu={generateAnswerTileMenu()}
-                />,
-            );
+            render(<AnswerTile {...generateAnswerTileProps()} />);
 
             expect(
                 screen.getByRole("button", {name: "Bongo"}),
             ).toBeInTheDocument();
         });
 
-        it("renders no menu when menu is null", () => {
-            // Arrange, Act
-            render(<AnswerTile {...defaultProps()} menu={null} />);
-
-            expect(screen.queryByRole("button")).not.toBeInTheDocument();
-        });
-
         it("calls onMove with the target id when a move action is selected", async () => {
             // Arrange
             const onMove = jest.fn();
-            render(
-                <AnswerTile
-                    {...defaultProps()}
-                    menu={generateAnswerTileMenu({onMove})}
-                />,
-            );
+            render(<AnswerTile {...generateAnswerTileProps({onMove})} />);
 
             // Act
             await user.click(screen.getByRole("button", {name: "Bongo"}));
@@ -147,12 +136,7 @@ describe("AnswerTile", () => {
             const menuRef = React.createRef<HTMLButtonElement>();
 
             // Act
-            render(
-                <AnswerTile
-                    {...defaultProps()}
-                    menu={generateAnswerTileMenu({menuRef})}
-                />,
-            );
+            render(<AnswerTile {...generateAnswerTileProps({menuRef})} />);
 
             // Assert
             expect(menuRef.current).toBe(
@@ -164,9 +148,9 @@ describe("AnswerTile", () => {
             // Arrange
             render(
                 <AnswerTile
-                    {...defaultProps()}
-                    menu={generateAnswerTileMenu()}
-                    menuVisibility="on-hover-or-focus"
+                    {...generateAnswerTileProps({
+                        menuVisibility: "on-hover-or-focus",
+                    })}
                 />,
             );
 
@@ -188,8 +172,7 @@ describe("AnswerTile", () => {
                 // Arrange, Act
                 render(
                     <AnswerTile
-                        {...defaultProps()}
-                        showCorrectness={showCorrectness}
+                        {...generateAnswerTileProps({showCorrectness})}
                     />,
                 );
 
@@ -202,7 +185,9 @@ describe("AnswerTile", () => {
         it("hides the scored icons from assistive technology", () => {
             // Arrange, Act
             render(
-                <AnswerTile {...defaultProps()} showCorrectness="correct" />,
+                <AnswerTile
+                    {...generateAnswerTileProps({showCorrectness: "correct"})}
+                />,
             );
 
             expect(
@@ -216,9 +201,7 @@ describe("AnswerTile", () => {
                 // Arrange, Act
                 render(
                     <AnswerTile
-                        {...defaultProps()}
-                        showCorrectness={showCorrectness}
-                        menu={generateAnswerTileMenu()}
+                        {...generateAnswerTileProps({showCorrectness})}
                     />,
                 );
 
@@ -229,11 +212,7 @@ describe("AnswerTile", () => {
         it("does not render the action menu when the tile is disabled", () => {
             // Arrange, Act
             render(
-                <AnswerTile
-                    {...defaultProps()}
-                    disabled={true}
-                    menu={generateAnswerTileMenu()}
-                />,
+                <AnswerTile {...generateAnswerTileProps({disabled: true})} />,
             );
 
             expect(screen.queryByRole("button")).not.toBeInTheDocument();
@@ -241,7 +220,9 @@ describe("AnswerTile", () => {
 
         it("renders no scored icon when the tile is disabled", () => {
             // Arrange, Act
-            render(<AnswerTile {...defaultProps()} disabled={true} />);
+            render(
+                <AnswerTile {...generateAnswerTileProps({disabled: true})} />,
+            );
 
             expect(
                 screen.queryByTestId("answer-tile-state-icon-tile-1"),
@@ -250,7 +231,9 @@ describe("AnswerTile", () => {
 
         it("marks a disabled tile via its class", () => {
             // Arrange, Act
-            render(<AnswerTile {...defaultProps()} disabled={true} />);
+            render(
+                <AnswerTile {...generateAnswerTileProps({disabled: true})} />,
+            );
 
             expect(screen.getByTestId("answer-tile-tile-1")).toHaveClass(
                 "disabled",

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
@@ -29,9 +29,11 @@ describe("AnswerTile", () => {
 
     it("renders text content from markdown", () => {
         // Arrange, Act
-        render(<AnswerTile {...generateAnswerTileProps({content: "Bongo"})} />);
+        render(
+            <AnswerTile {...generateAnswerTileProps({content: "Banana"})} />,
+        );
 
-        expect(screen.getByText("Bongo")).toBeInTheDocument();
+        expect(screen.getByText("Banana")).toBeInTheDocument();
     });
 
     it("renders image content with its alt text", async () => {

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
@@ -109,7 +109,9 @@ describe("AnswerTile", () => {
     describe("menu integration", () => {
         it("renders the action menu labeled with the tile label", () => {
             // Arrange, Act
-            render(<AnswerTile {...generateAnswerTileProps()} />);
+            render(
+                <AnswerTile {...generateAnswerTileProps({label: "Bongo"})} />,
+            );
 
             expect(
                 screen.getByRole("button", {name: "Bongo"}),
@@ -119,7 +121,15 @@ describe("AnswerTile", () => {
         it("calls onMove with the target id when a move action is selected", async () => {
             // Arrange
             const onMove = jest.fn();
-            render(<AnswerTile {...generateAnswerTileProps({onMove})} />);
+            render(
+                <AnswerTile
+                    {...generateAnswerTileProps({
+                        label: "Bongo",
+                        moveTargets: [{id: "blank-2", label: "Blank 2"}],
+                        onMove,
+                    })}
+                />,
+            );
 
             // Act
             await user.click(screen.getByRole("button", {name: "Bongo"}));
@@ -131,12 +141,42 @@ describe("AnswerTile", () => {
             expect(onMove).toHaveBeenCalledWith("blank-2");
         });
 
+        it("calls onClear when the clear action is selected", async () => {
+            // Arrange
+            const onClear = jest.fn();
+            render(
+                <AnswerTile
+                    {...generateAnswerTileProps({
+                        label: "Bongo",
+                        moveTargets: [],
+                        clearFromLabel: "Blank 1",
+                        onClear,
+                    })}
+                />,
+            );
+
+            // Act
+            await user.click(screen.getByRole("button", {name: "Bongo"}));
+            await user.click(
+                await screen.findByRole("menuitem", {
+                    name: "Clear from Blank 1",
+                }),
+            );
+
+            // Assert
+            expect(onClear).toHaveBeenCalled();
+        });
+
         it("forwards menuRef to the opener button", () => {
             // Arrange
             const menuRef = React.createRef<HTMLButtonElement>();
 
             // Act
-            render(<AnswerTile {...generateAnswerTileProps({menuRef})} />);
+            render(
+                <AnswerTile
+                    {...generateAnswerTileProps({label: "Bongo", menuRef})}
+                />,
+            );
 
             // Assert
             expect(menuRef.current).toBe(
@@ -146,38 +186,6 @@ describe("AnswerTile", () => {
     });
 
     describe("scored states", () => {
-        // The icon graphic (check vs x) lives in a generated stylesheet,
-        // so jsdom cannot tell the two apart. The stories cover which
-        // glyph shows for each result.
-        it.each(["correct", "incorrect"] as const)(
-            "renders a scored icon when showCorrectness is %s",
-            (showCorrectness) => {
-                // Arrange, Act
-                render(
-                    <AnswerTile
-                        {...generateAnswerTileProps({showCorrectness})}
-                    />,
-                );
-
-                expect(
-                    screen.getByTestId("answer-tile-state-icon-tile-1"),
-                ).toBeInTheDocument();
-            },
-        );
-
-        it("hides the scored icons from assistive technology", () => {
-            // Arrange, Act
-            render(
-                <AnswerTile
-                    {...generateAnswerTileProps({showCorrectness: "correct"})}
-                />,
-            );
-
-            expect(
-                screen.getByTestId("answer-tile-state-icon-tile-1"),
-            ).toHaveAttribute("aria-hidden", "true");
-        });
-
         it.each(["correct", "incorrect"] as const)(
             "does not render the action menu when showCorrectness is %s",
             (showCorrectness) => {
@@ -199,28 +207,6 @@ describe("AnswerTile", () => {
             );
 
             expect(screen.queryByRole("button")).not.toBeInTheDocument();
-        });
-
-        it("renders no scored icon when the tile is disabled", () => {
-            // Arrange, Act
-            render(
-                <AnswerTile {...generateAnswerTileProps({disabled: true})} />,
-            );
-
-            expect(
-                screen.queryByTestId("answer-tile-state-icon-tile-1"),
-            ).not.toBeInTheDocument();
-        });
-
-        it("marks a disabled tile via its class", () => {
-            // Arrange, Act
-            render(
-                <AnswerTile {...generateAnswerTileProps({disabled: true})} />,
-            );
-
-            expect(screen.getByTestId("answer-tile-tile-1")).toHaveClass(
-                "disabled",
-            );
         });
     });
 });

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
@@ -81,11 +81,12 @@ describe("AnswerTile", () => {
         expect(screen.getByRole("button", {name: "Bongo"})).toBeInTheDocument();
     });
 
-    // The tile's one piece of logic: scored and disabled tiles have no menu.
+    // The tile's one piece of logic: a scored tile has no menu, whichever
+    // result it shows.
     it.each([
-        {showCorrectness: "correct"},
-        {showCorrectness: "incorrect"},
-        {disabled: true},
+        {scoring: "correct"},
+        {scoring: "incorrect"},
+        {scoring: "unused"},
     ] as const)("does not render the action menu for a %o tile", (props) => {
         // Arrange, Act
         render(<AnswerTile {...generateAnswerTileProps(props)} />);

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.test.tsx
@@ -27,186 +27,113 @@ describe("AnswerTile", () => {
         );
     });
 
-    describe("content", () => {
-        it("renders text content from markdown", () => {
-            // Arrange, Act
-            render(
-                <AnswerTile {...generateAnswerTileProps({content: "Bongo"})} />,
-            );
+    it("renders text content from markdown", () => {
+        // Arrange, Act
+        render(<AnswerTile {...generateAnswerTileProps({content: "Bongo"})} />);
 
-            expect(screen.getByText("Bongo")).toBeInTheDocument();
-        });
-
-        it("renders TeX content", () => {
-            // Arrange, Act
-            render(
-                <AnswerTile
-                    {...generateAnswerTileProps({
-                        content: "$x^2$",
-                        label: "x squared",
-                    })}
-                />,
-            );
-
-            expect(screen.getByText("x^2")).toBeInTheDocument();
-        });
-
-        it("renders image content with its alt text", async () => {
-            // Arrange
-            const unmockImageLoading = mockImageLoading();
-
-            // Act
-            render(
-                <AnswerTile
-                    {...generateAnswerTileProps({
-                        content:
-                            "![a bongo drum](https://example.com/bongo.png)",
-                        label: "a bongo drum",
-                    })}
-                />,
-            );
-
-            // The mocked image loader fires its load event on a timer.
-            act(() => {
-                jest.runOnlyPendingTimers();
-            });
-
-            // Assert
-            expect(screen.getByAltText("a bongo drum")).toBeInTheDocument();
-
-            unmockImageLoading();
-        });
-
-        it("renders the label for screen readers when content is empty", () => {
-            // Arrange, Act
-            render(
-                <AnswerTile
-                    {...generateAnswerTileProps({
-                        content: "",
-                        label: "(empty)",
-                    })}
-                />,
-            );
-
-            expect(screen.getByText("(empty)")).toBeInTheDocument();
-        });
-
-        it("treats whitespace-only content as empty", () => {
-            // Arrange, Act
-            render(
-                <AnswerTile
-                    {...generateAnswerTileProps({
-                        content: "  ",
-                        label: "(empty)",
-                    })}
-                />,
-            );
-
-            expect(screen.getByText("(empty)")).toBeInTheDocument();
-        });
+        expect(screen.getByText("Bongo")).toBeInTheDocument();
     });
 
-    describe("menu integration", () => {
-        it("renders the action menu labeled with the tile label", () => {
-            // Arrange, Act
-            render(
-                <AnswerTile {...generateAnswerTileProps({label: "Bongo"})} />,
-            );
-
-            expect(
-                screen.getByRole("button", {name: "Bongo"}),
-            ).toBeInTheDocument();
-        });
-
-        it("calls onMove with the target id when a move action is selected", async () => {
-            // Arrange
-            const onMove = jest.fn();
-            render(
-                <AnswerTile
-                    {...generateAnswerTileProps({
-                        label: "Bongo",
-                        moveTargets: [{id: "blank-2", label: "Blank 2"}],
-                        onMove,
-                    })}
-                />,
-            );
-
-            // Act
-            await user.click(screen.getByRole("button", {name: "Bongo"}));
-            await user.click(
-                await screen.findByRole("menuitem", {name: "Move to Blank 2"}),
-            );
-
-            // Assert
-            expect(onMove).toHaveBeenCalledWith("blank-2");
-        });
-
-        it("calls onClear when the clear action is selected", async () => {
-            // Arrange
-            const onClear = jest.fn();
-            render(
-                <AnswerTile
-                    {...generateAnswerTileProps({
-                        label: "Bongo",
-                        moveTargets: [],
-                        clearFromLabel: "Blank 1",
-                        onClear,
-                    })}
-                />,
-            );
-
-            // Act
-            await user.click(screen.getByRole("button", {name: "Bongo"}));
-            await user.click(
-                await screen.findByRole("menuitem", {
-                    name: "Clear from Blank 1",
-                }),
-            );
-
-            // Assert
-            expect(onClear).toHaveBeenCalled();
-        });
-
-        it("forwards menuRef to the opener button", () => {
-            // Arrange
-            const menuRef = React.createRef<HTMLButtonElement>();
-
-            // Act
-            render(
-                <AnswerTile
-                    {...generateAnswerTileProps({label: "Bongo", menuRef})}
-                />,
-            );
-
-            // Assert
-            expect(menuRef.current).toBe(
-                screen.getByRole("button", {name: "Bongo"}),
-            );
-        });
-    });
-
-    describe("scored states", () => {
-        it.each(["correct", "incorrect"] as const)(
-            "does not render the action menu when showCorrectness is %s",
-            (showCorrectness) => {
-                // Arrange, Act
-                render(
-                    <AnswerTile
-                        {...generateAnswerTileProps({showCorrectness})}
-                    />,
-                );
-
-                expect(screen.queryByRole("button")).not.toBeInTheDocument();
-            },
+    it("renders image content with its alt text", async () => {
+        // Arrange — the URL is never fetched: the mock stands in for the
+        // browser's image loading and fires the load event on a timer.
+        const unmockImageLoading = mockImageLoading();
+        render(
+            <AnswerTile
+                {...generateAnswerTileProps({
+                    content: "![a bongo drum](https://example.com/bongo.png)",
+                    label: "a bongo drum",
+                })}
+            />,
         );
 
-        it("does not render the action menu when the tile is disabled", () => {
+        // Act
+        act(() => {
+            jest.runOnlyPendingTimers();
+        });
+
+        // Assert
+        expect(screen.getByAltText("a bongo drum")).toBeInTheDocument();
+
+        unmockImageLoading();
+    });
+
+    it.each(["", "  "])(
+        "renders the label for screen readers when content is %j",
+        (content) => {
             // Arrange, Act
             render(
-                <AnswerTile {...generateAnswerTileProps({disabled: true})} />,
+                <AnswerTile
+                    {...generateAnswerTileProps({content, label: "(empty)"})}
+                />,
             );
 
-            expect(screen.queryByRole("button")).not.toBeInTheDocument();
-        });
+            expect(screen.getByText("(empty)")).toBeInTheDocument();
+        },
+    );
+
+    it("renders the action menu labeled with the tile label", () => {
+        // Arrange, Act
+        render(<AnswerTile {...generateAnswerTileProps({label: "Bongo"})} />);
+
+        expect(screen.getByRole("button", {name: "Bongo"})).toBeInTheDocument();
+    });
+
+    // The tile's one piece of logic: scored and disabled tiles have no menu.
+    it.each([
+        {showCorrectness: "correct"},
+        {showCorrectness: "incorrect"},
+        {disabled: true},
+    ] as const)("does not render the action menu for a %o tile", (props) => {
+        // Arrange, Act
+        render(<AnswerTile {...generateAnswerTileProps(props)} />);
+
+        expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    });
+
+    // onClear is optional on the tile and the menu, so dropping the tile's
+    // forwarding would compile and fail silently. This also covers the
+    // Clear-only menu of a placed tile in a one-blank exercise.
+    it("calls onClear when the clear action is selected", async () => {
+        // Arrange
+        const onClear = jest.fn();
+        render(
+            <AnswerTile
+                {...generateAnswerTileProps({
+                    label: "Bongo",
+                    moveTargets: [],
+                    clearFromLabel: "Blank 1",
+                    onClear,
+                })}
+            />,
+        );
+
+        // Act
+        await user.click(screen.getByRole("button", {name: "Bongo"}));
+        await user.click(
+            await screen.findByRole("menuitem", {name: "Clear from Blank 1"}),
+        );
+
+        // Assert
+        expect(onClear).toHaveBeenCalled();
+    });
+
+    // menuRef is optional too, and the widget's after-move focus return
+    // depends on it reaching the opener.
+    it("forwards menuRef to the opener button", () => {
+        // Arrange
+        const menuRef = React.createRef<HTMLButtonElement>();
+
+        // Act
+        render(
+            <AnswerTile
+                {...generateAnswerTileProps({label: "Bongo", menuRef})}
+            />,
+        );
+
+        // Assert
+        expect(menuRef.current).toBe(
+            screen.getByRole("button", {name: "Bongo"}),
+        );
     });
 });

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.testdata.ts
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.testdata.ts
@@ -2,7 +2,7 @@ import {generateTestBlanks} from "../dnd-action-menu/dnd-action-menu.testdata";
 
 import type {AnswerTileMenuConfig} from "./answer-tile";
 
-/** Generates the widget-owned menu data for a tile in the choice bank. */
+/** Generates the menu data that a widget supplies for a tile in the choice bank. */
 export function generateAnswerTileMenu(
     overrides: Partial<AnswerTileMenuConfig> = {},
 ): AnswerTileMenuConfig {

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.testdata.ts
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.testdata.ts
@@ -1,12 +1,15 @@
 import {generateTestBlanks} from "../dnd-action-menu/dnd-action-menu.testdata";
 
-import type {AnswerTileMenuConfig} from "./answer-tile";
+import type {AnswerTileProps} from "./answer-tile";
 
-/** Generates the menu data that a widget supplies for a tile in the choice bank. */
-export function generateAnswerTileMenu(
-    overrides: Partial<AnswerTileMenuConfig> = {},
-): AnswerTileMenuConfig {
+/** Generates a complete, valid set of props for a tile in the choice bank. */
+export function generateAnswerTileProps(
+    overrides: Partial<AnswerTileProps> = {},
+): AnswerTileProps {
     return {
+        tileId: "tile-1",
+        content: "Bongo",
+        label: "Bongo",
         moveTargets: generateTestBlanks(),
         onMove: () => {},
         ...overrides,

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.testdata.ts
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.testdata.ts
@@ -1,0 +1,14 @@
+import {generateTestBlanks} from "../dnd-action-menu/dnd-action-menu.testdata";
+
+import type {AnswerTileMenuConfig} from "./answer-tile";
+
+/** Generates the widget-owned menu data for a tile in the choice bank. */
+export function generateAnswerTileMenu(
+    overrides: Partial<AnswerTileMenuConfig> = {},
+): AnswerTileMenuConfig {
+    return {
+        moveTargets: generateTestBlanks(),
+        onMove: () => {},
+        ...overrides,
+    };
+}

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -11,28 +11,9 @@ import {DndActionMenu} from "../dnd-action-menu";
 
 import styles from "./answer-tile.module.css";
 
-import type {DndActionMenuProps} from "../dnd-action-menu";
+import type {MoveTarget} from "../dnd-action-menu";
 
-/**
- * The widget-supplied data for a tile's actions menu: the blanks the tile
- * can move to, the move/clear callbacks, and the remaining-use count.
- *
- * Derived from DndActionMenuProps minus the props the tile fills in
- * itself (label, disabled), so it tracks the menu's API automatically.
- */
-export type AnswerTileMenuConfig = Omit<
-    DndActionMenuProps,
-    "label" | "disabled"
-> & {
-    /**
-     * This ref points to the menu's opener button. The parent uses it to
-     * move focus after a tile moves. It is a separate field because a
-     * forwarded ref is not part of the menu's props type.
-     */
-    menuRef?: React.Ref<HTMLButtonElement>;
-};
-
-interface AnswerTileProps {
+export interface AnswerTileProps {
     /**
      * The unique identifier of this tile. It is used for scoring, drag
      * wiring, and test ids.
@@ -53,8 +34,8 @@ interface AnswerTileProps {
     /**
      * The scored result for a tile placed in a blank. Omit before
      * scoring. "correct" shows a green border and a check icon.
-     * "incorrect" shows a red border and an x icon. Both remove the
-     * menu and the shadow.
+     * "incorrect" shows a red border and an x icon. Both replace the
+     * menu and remove the shadow.
      *
      * A scored tile is either placed (showCorrectness) or unused
      * (disabled), never both. If both arrive, showCorrectness wins.
@@ -65,17 +46,37 @@ interface AnswerTileProps {
      * this for unused choice-bank tiles after scoring.
      */
     disabled?: boolean;
+
+    // The next six props feed the tile's DndActionMenu. The menu shows
+    // unless the tile is scored or disabled.
     /**
-     * Data for the tile's DndActionMenu. Pass null to show no menu, for
-     * example in a static preview. Ignored on scored and disabled tiles,
-     * which never show the menu.
+     * Blanks the tile can move to. An empty array is valid: a placed
+     * tile in a one-blank exercise can only be cleared, and the menu
+     * disables itself when it has no actions at all.
      */
-    menu: AnswerTileMenuConfig | null;
+    moveTargets: ReadonlyArray<MoveTarget>;
+    /** Called with the target blank's id when a move action is selected. */
+    onMove: (targetId: string) => void;
+    /**
+     * Visible label of the blank/column the tile currently sits in,
+     * spoken as "Clear from Blank 1". Provide with onClear when the
+     * tile is placed.
+     */
+    clearFromLabel?: string;
+    /** Callback for removing the tile from its blank. */
+    onClear?: () => void;
+    /** Remaining uses for a multi-use tile, spoken by the menu opener. */
+    remainingUses?: number;
+    /**
+     * This ref points to the menu's opener button. The parent uses it to
+     * move focus after a tile moves.
+     */
+    menuRef?: React.Ref<HTMLButtonElement>;
+
     /**
      * When the menu is visible. Use "always" (the default) in choice
      * banks and column blanks. Use "on-hover-or-focus" in an inline
-     * blank, so the sentence stays easy to read. This prop does nothing
-     * when no menu shows.
+     * blank, so the sentence stays easy to read.
      */
     menuVisibility?: "always" | "on-hover-or-focus";
 }
@@ -90,7 +91,7 @@ interface AnswerTileProps {
  * The tile is only visual for now. A later ticket adds the drag wiring.
  */
 export function AnswerTile(props: AnswerTileProps): React.ReactElement {
-    const {tileId, content, label, showCorrectness, disabled, menu} = props;
+    const {tileId, content, label, showCorrectness, disabled} = props;
     const {strings} = usePerseusI18n();
 
     // Whitespace-only content would render an invisible, unlabeled tile.
@@ -109,10 +110,15 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
             )}
             data-testid={`answer-tile-${tileId}`}
         >
-            {menu != null && !disabled && showCorrectness == null && (
+            {!disabled && showCorrectness == null && (
                 <TileActionsMenu
-                    menu={menu}
                     label={label}
+                    moveTargets={props.moveTargets}
+                    onMove={props.onMove}
+                    clearFromLabel={props.clearFromLabel}
+                    onClear={props.onClear}
+                    remainingUses={props.remainingUses}
+                    menuRef={props.menuRef}
                     visibility={props.menuVisibility}
                 />
             )}
@@ -139,25 +145,32 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
     );
 }
 
-/** The actions menu at the start of a resting tile. */
+/** The actions menu at the start of an unscored tile. */
 function TileActionsMenu(props: {
-    menu: AnswerTileMenuConfig;
     label: string;
+    moveTargets: ReadonlyArray<MoveTarget>;
+    onMove: (targetId: string) => void;
+    clearFromLabel?: string;
+    onClear?: () => void;
+    remainingUses?: number;
+    menuRef?: React.Ref<HTMLButtonElement>;
     visibility: AnswerTileProps["menuVisibility"];
 }): React.ReactElement {
-    const {menu, label, visibility} = props;
-    const {menuRef, ...menuProps} = menu;
     return (
         <span
             className={classNames(
                 styles.startContainer,
-                visibility === "on-hover-or-focus" && styles.menuOnDemand,
+                props.visibility === "on-hover-or-focus" && styles.menuOnDemand,
             )}
         >
             <DndActionMenu
-                ref={menuRef}
-                {...menuProps}
-                label={label}
+                ref={props.menuRef}
+                label={props.label}
+                moveTargets={props.moveTargets}
+                onMove={props.onMove}
+                clearFromLabel={props.clearFromLabel}
+                onClear={props.onClear}
+                remainingUses={props.remainingUses}
                 // Always false: scored tiles remove the menu instead
                 // of disabling it, so a rendered menu is never disabled.
                 disabled={false}

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -63,6 +63,12 @@ export interface AnswerTileProps {
      * move focus after a tile moves.
      */
     menuRef?: React.Ref<HTMLButtonElement>;
+    /**
+     * Display height in pixels for an image tile's image. The schema
+     * types this as a plain number; the editor offers 24-96 in steps
+     * of 12.
+     */
+    imageHeight?: number;
 }
 
 /**
@@ -84,6 +90,7 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
         onClear,
         remainingUses,
         menuRef,
+        imageHeight,
     } = props;
     const {strings} = usePerseusI18n();
 
@@ -139,8 +146,17 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
         return <Renderer content={content} strings={strings} />;
     };
 
+    const imageHeightStyle: React.CSSProperties | undefined =
+        imageHeight != null
+            ? {
+                  // @ts-expect-error TS2353: CSSProperties has no keys
+                  // for CSS custom properties.
+                  "--answer-tile-image-height": `${imageHeight}px`,
+              }
+            : undefined;
+
     return (
-        <div className={tileClasses}>
+        <div className={tileClasses} style={imageHeightStyle}>
             {renderTileStart()}
             <div className={styles.content}>{renderTileContent()}</div>
         </div>

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -16,67 +16,74 @@ import type {DndActionMenuProps} from "../dnd-action-menu";
 export type AnswerTileState = "rest" | "correct" | "incorrect" | "disabled";
 
 /**
- * Widget-owned data the tile forwards to its DndActionMenu — the menu's
- * props minus the ones the tile supplies itself. Derived so a new menu prop
- * automatically surfaces here (or fails compilation if the tile should own
- * it) instead of silently drifting.
+ * The widget owns this data. The tile passes it to the DndActionMenu.
+ * The type comes from the menu's own props, without the props that the
+ * tile supplies itself. When the menu gets a new prop, this type includes
+ * it automatically. The two components cannot go out of sync.
  */
 export type AnswerTileMenuConfig = Omit<
     DndActionMenuProps,
-    // keyof Pick<> (rather than bare string literals) makes a rename of one
-    // of these props in dnd-action-menu fail compilation HERE, instead of
-    // Omit silently accepting a stale key.
+    // We use keyof Pick<> here, not plain strings. If one of these prop
+    // names changes in dnd-action-menu, the code will not compile. A
+    // plain Omit would accept the old name without an error.
     keyof Pick<DndActionMenuProps, "label" | "disabled">
 > & {
     /**
-     * Reaches the menu's opener button (DndActionMenu's forwarded ref) —
-     * for the parent's after-move focus return. An added field because a
-     * forwarded ref isn't part of the menu's props type.
+     * This ref points to the menu's opener button. The parent uses it to
+     * move focus after a tile moves. It is a separate field because a
+     * forwarded ref is not part of the menu's props type.
      */
     menuRef?: React.Ref<HTMLButtonElement>;
 };
 
 interface AnswerTileProps {
-    /** Unique identifier for this tile; used for scoring, dnd wiring, test ids. */
+    /**
+     * The unique identifier of this tile. It is used for scoring, drag
+     * wiring, and test ids.
+     */
     tileId: string;
-    /** Perseus markdown for the tile face: text, TeX, or an image. "" for an Empty tile. */
+    /**
+     * Perseus markdown for the tile face: text, TeX, or an image.
+     * Use "" for an empty tile.
+     */
     content: string;
     /**
-     * Plain-text spoken value of the tile, translated — names the menu opener
-     * via aria-labelledby ("Bongo. Actions menu."). Not derivable from
-     * markdown (TeX/images), so it's authored/passed explicitly.
-     * For Empty tiles, pass the translated "(empty)".
+     * The spoken value of the tile, as translated plain text. It names
+     * the menu opener ("Bongo. Actions menu."). We cannot compute it
+     * from TeX or image markdown, so the caller must supply it.
+     * For an empty tile, pass the translated "(empty)".
      */
     label: string;
     /**
-     * Scored/interaction state, owned by the parent widget:
-     * - "rest": default chrome; the menu renders when `menu` is non-null.
-     * - "correct": green 2px border, check icon replaces the menu, no shadow.
-     * - "incorrect": red 2px border, x icon replaces the menu, no shadow.
-     * - "disabled": grey content, no shadow, leading control removed.
+     * The scored state of the tile. The parent widget owns it:
+     * - "rest": default look; the menu shows when `menu` is not null.
+     * - "correct": green 2px border and a check icon. No menu, no shadow.
+     * - "incorrect": red 2px border and an x icon. No menu, no shadow.
+     * - "disabled": grey content. No menu, no icon, no shadow.
      */
     state: AnswerTileState;
     /**
-     * Data for the tile's DndActionMenu. null = no menu (e.g. a static
-     * preview). Ignored unless state is "rest" — scored tiles never show it.
+     * Data for the tile's DndActionMenu. Pass null to show no menu, for
+     * example in a static preview. Scored tiles never show the menu, so
+     * this prop only applies when the state is "rest".
      */
     menu: AnswerTileMenuConfig | null;
     /**
-     * "always" (default) in choice banks and column blanks;
-     * "on-hover-or-focus" when the tile sits in an inline blank, so the
-     * string stays readable. Optional — it's meaningless when no menu
-     * renders, so scored/preview call sites shouldn't have to pass it.
+     * When the menu is visible. Use "always" (the default) in choice
+     * banks and column blanks. Use "on-hover-or-focus" in an inline
+     * blank, so the sentence stays easy to read. This prop does nothing
+     * when no menu shows.
      */
     menuVisibility?: "always" | "on-hover-or-focus";
 }
 
 /**
- * AnswerTile is the card a learner moves into a blank in the Drag-and-Drop
- * widget family. It renders authored markdown content (text, TeX, or an
- * image) inside the tile chrome, composes the DndActionMenu at its leading
- * edge, and shows the parent-set scored states.
+ * AnswerTile is the card that a learner moves into a blank. It is part of
+ * the Drag-and-Drop widget family. The tile shows authored markdown
+ * content: text, TeX, or an image. It puts the DndActionMenu at its
+ * leading edge. The parent widget sets the scored states.
  *
- * Purely presentational for now — dnd-kit wiring comes in a later ticket.
+ * The tile is only visual for now. A later ticket adds the drag wiring.
  */
 export function AnswerTile(props: AnswerTileProps): React.ReactElement {
     const {tileId, content, label, state, menu, menuVisibility} = props;
@@ -108,8 +115,8 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
         leadingBox = (
             <span
                 className={styles.stateIcon}
-                // Decorative — the widget's scored rendering announces
-                // correctness, not the tile.
+                // This icon is decorative. The widget announces the
+                // result to screen readers, not the tile.
                 aria-hidden="true"
                 data-testid={`answer-tile-state-icon-${tileId}`}
             >
@@ -131,7 +138,7 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
                 )}
             >
                 {content === "" ? (
-                    // An empty tile still needs a spoken value.
+                    // An empty tile must have a spoken value.
                     <span className={a11yStyles.srOnly}>{label}</span>
                 ) : (
                     <Renderer content={content} strings={strings} />
@@ -141,8 +148,8 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
     );
 }
 
-// These live at module scope so they keep a stable identity across renders,
-// and at the end of the file per convention.
+// These constants are at module scope, at the end of the file per
+// convention. They keep the same identity on each render.
 
 const stateClasses: Record<AnswerTileState, string> = {
     rest: styles.rest,

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -89,8 +89,11 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
     const {tileId, content, label, state, menu, menuVisibility} = props;
     const {strings} = usePerseusI18n();
 
+    // The icon for the current answer state, if one exists.
     const scoredIcon = scoredIcons[state];
     // Whitespace-only content would render an invisible, unlabeled tile.
+    // This protection might not be needed, depending on how we implement
+    // the Content Editor experience, but it seemed wise to add this for now.
     const isEmpty = content.trim() === "";
 
     // The tile starts with the actions menu or, when scored, an icon.

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -101,7 +101,8 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
     // only "correct" and "incorrect" have an icon.
     return (
         <div
-            className={classNames(styles.tile, stateClasses[state])}
+            // Each state has a CSS class with the same name.
+            className={classNames(styles.tile, styles[state])}
             data-testid={`answer-tile-${tileId}`}
         >
             {state === "rest" && menu != null && (
@@ -175,13 +176,6 @@ function TileScoredIcon(props: {
         </span>
     );
 }
-
-const stateClasses: Record<AnswerTileState, string> = {
-    rest: styles.rest,
-    correct: styles.correct,
-    incorrect: styles.incorrect,
-    disabled: styles.disabled,
-};
 
 const scoredIcons: Partial<Record<AnswerTileState, string>> = {
     correct: checkIcon,

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -142,7 +142,7 @@ function TileActionsMenu(props: {
     return (
         <span
             className={classNames(
-                styles.menuContainer,
+                styles.startContainer,
                 visibility === "on-hover-or-focus" && styles.menuOnDemand,
             )}
         >
@@ -165,7 +165,7 @@ function TileScoredIcon(props: {
 }): React.ReactElement {
     return (
         <span
-            className={styles.stateIcon}
+            className={styles.startContainer}
             // This icon is decorative. The widget announces the
             // result to screen readers, not the tile.
             aria-hidden="true"

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -13,6 +13,9 @@ import styles from "./answer-tile.module.css";
 
 import type {MoveTarget} from "../dnd-action-menu";
 
+/** What a scored tile shows. Each value names a CSS class in the module. */
+export type TileScoring = "correct" | "incorrect" | "unused";
+
 export interface AnswerTileProps {
     /**
      * The unique identifier of an Answer Tile, which is used
@@ -30,18 +33,14 @@ export interface AnswerTileProps {
      */
     label: string;
     /**
-     * Used to provide visible feedback regarding whether the user
-     * answered the question correctly or incorrectly.
+     * The result the tile shows once the question is scored. A placed tile
+     * is "correct" or "incorrect"; a tile the learner left in the choice
+     * bank is "unused", which dims it. Omit it before scoring.
      *
-     * Never pass this together with `disabled`: a scored tile is either
-     * placed (showCorrectness) or unused (disabled).
+     * A scored tile has no menu and cannot be dragged, whichever result
+     * it shows.
      */
-    showCorrectness?: "correct" | "incorrect";
-    /**
-     * Dims the tile and removes its menu and shadow. The widgets use
-     * this for unused choice-bank tiles after scoring.
-     */
-    disabled?: boolean;
+    scoring?: TileScoring;
     /**
      * Blanks the tile can move to, which populate the menu.
      * An empty array is valid: a placed tile in a one-blank exercise
@@ -70,8 +69,7 @@ export interface AnswerTileProps {
  * AnswerTile is the card that a learner moves into a blank. It is part of
  * the Drag-and-Drop widget family. The tile shows authored markdown
  * content: text, TeX, or an image. It puts the DndActionMenu at its
- * leading edge. The parent widget sets showCorrectness and disabled
- * after scoring.
+ * leading edge. The parent widget sets `scoring` after scoring.
  *
  * The tile is only visual for now. A later ticket adds the drag wiring.
  */
@@ -79,8 +77,7 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
     const {
         content,
         label,
-        showCorrectness,
-        disabled,
+        scoring,
         moveTargets,
         onMove,
         clearFromLabel,
@@ -93,19 +90,19 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
     // Whitespace-only content would render an invisible, unlabeled tile.
     const isEmpty = content.trim() === "";
 
+    const tileClasses = classNames(
+        styles.tile,
+        scoring != null && styles[scoring],
+    );
+
     // The tile starts with the actions menu or, when scored, an icon.
-    // The two never show together: a scored tile has no menu.
+    // The two never show together: a scored tile has no menu. An unused
+    // tile shows neither, because it names no result to report.
     return (
-        <div
-            className={classNames(
-                styles.tile,
-                showCorrectness != null && styles[showCorrectness],
-                disabled && styles.disabled,
-            )}
-        >
-            {!disabled && (
+        <div className={tileClasses}>
+            {scoring !== "unused" && (
                 <div className={styles.startContainer}>
-                    {showCorrectness == null ? (
+                    {scoring == null ? (
                         <DndActionMenu
                             ref={menuRef}
                             label={label}
@@ -124,7 +121,7 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
                         // result to screen readers, not the tile.
                         <PhosphorIcon
                             aria-hidden="true"
-                            icon={scoredIcons[showCorrectness]}
+                            icon={scoredIcons[scoring]}
                             size="medium"
                         />
                     )}

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -95,37 +95,42 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
         scoring != null && styles[scoring],
     );
 
-    // The tile starts with the actions menu or, when scored, an icon.
-    // The two never show together: a scored tile has no menu. An unused
-    // tile shows neither, because it names no result to report.
+    // What the tile leads with, one branch per scoring state.
+    const renderTileStart = () => {
+        // An unused tile leads with nothing: it has no action to offer
+        // and no result to report.
+        if (scoring === "unused") {
+            return null;
+        }
+        if (scoring == null) {
+            return (
+                <DndActionMenu
+                    ref={menuRef}
+                    tileLabel={label}
+                    moveTargets={moveTargets}
+                    onMove={onMove}
+                    clearFromLabel={clearFromLabel}
+                    onClear={onClear}
+                    remainingUses={remainingUses}
+                />
+            );
+        }
+        // The icon is decoration: the widget announces the result to
+        // screen readers, not the tile.
+        return (
+            <PhosphorIcon
+                aria-hidden="true"
+                icon={scoredIcons[scoring]}
+                size="medium"
+            />
+        );
+    };
+    const tileStart = renderTileStart();
+
     return (
         <div className={tileClasses}>
-            {scoring !== "unused" && (
-                <div className={styles.startContainer}>
-                    {scoring == null ? (
-                        <DndActionMenu
-                            ref={menuRef}
-                            label={label}
-                            moveTargets={moveTargets}
-                            onMove={onMove}
-                            clearFromLabel={clearFromLabel}
-                            onClear={onClear}
-                            remainingUses={remainingUses}
-                            // Always false: scored tiles remove the menu
-                            // instead of disabling it, so a rendered menu
-                            // is never disabled.
-                            disabled={false}
-                        />
-                    ) : (
-                        // The icon is decoration: the widget announces the
-                        // result to screen readers, not the tile.
-                        <PhosphorIcon
-                            aria-hidden="true"
-                            icon={scoredIcons[scoring]}
-                            size="medium"
-                        />
-                    )}
-                </div>
+            {tileStart != null && (
+                <div className={styles.startContainer}>{tileStart}</div>
             )}
             <div className={styles.content}>
                 {isEmpty ? (

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -14,16 +14,16 @@ import styles from "./answer-tile.module.css";
 import type {DndActionMenuProps} from "../dnd-action-menu";
 
 /**
- * The widget owns this data. The tile passes it to the DndActionMenu.
- * The type comes from the menu's own props, without the props that the
- * tile supplies itself. When the menu gets a new prop, this type includes
- * it automatically. The two components cannot go out of sync.
+ * The widget-supplied data for a tile's actions menu: the blanks the tile
+ * can move to, the move/clear callbacks, and the remaining-use count.
+ *
+ * Derived from DndActionMenuProps minus the props the tile fills in
+ * itself (label, disabled), so it tracks the menu's API automatically.
  */
 export type AnswerTileMenuConfig = Omit<
     DndActionMenuProps,
-    // We use keyof Pick<> here, not plain strings. If one of these prop
-    // names changes in dnd-action-menu, the code will not compile. A
-    // plain Omit would accept the old name without an error.
+    // keyof Pick<> instead of plain strings: if the menu renames one of
+    // these props, this line fails to compile instead of going stale.
     keyof Pick<DndActionMenuProps, "label" | "disabled">
 > & {
     /**
@@ -69,8 +69,8 @@ interface AnswerTileProps {
     disabled?: boolean;
     /**
      * Data for the tile's DndActionMenu. Pass null to show no menu, for
-     * example in a static preview. Scored tiles never show the menu, so
-     * this prop only applies when the state is "rest".
+     * example in a static preview. Ignored on scored and disabled tiles,
+     * which never show the menu.
      */
     menu: AnswerTileMenuConfig | null;
     /**
@@ -86,7 +86,8 @@ interface AnswerTileProps {
  * AnswerTile is the card that a learner moves into a blank. It is part of
  * the Drag-and-Drop widget family. The tile shows authored markdown
  * content: text, TeX, or an image. It puts the DndActionMenu at its
- * leading edge. The parent widget sets the scored states.
+ * leading edge. The parent widget sets showCorrectness and disabled
+ * after scoring.
  *
  * The tile is only visual for now. A later ticket adds the drag wiring.
  */

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -13,8 +13,6 @@ import styles from "./answer-tile.module.css";
 
 import type {DndActionMenuProps} from "../dnd-action-menu";
 
-export type AnswerTileState = "rest" | "correct" | "incorrect" | "disabled";
-
 /**
  * The widget owns this data. The tile passes it to the DndActionMenu.
  * The type comes from the menu's own props, without the props that the
@@ -55,13 +53,20 @@ interface AnswerTileProps {
      */
     label: string;
     /**
-     * The scored state of the tile. The parent widget owns it:
-     * - "rest": default look; the menu shows when `menu` is not null.
-     * - "correct": green 2px border and a check icon. No menu, no shadow.
-     * - "incorrect": red 2px border and an x icon. No menu, no shadow.
-     * - "disabled": grey content. No menu, no icon, no shadow.
+     * The scored result for a tile placed in a blank. Omit before
+     * scoring. "correct" shows a green border and a check icon.
+     * "incorrect" shows a red border and an x icon. Both remove the
+     * menu and the shadow.
+     *
+     * A scored tile is either placed (showCorrectness) or unused
+     * (disabled), never both. If both arrive, showCorrectness wins.
      */
-    state: AnswerTileState;
+    showCorrectness?: "correct" | "incorrect";
+    /**
+     * Dims the tile and removes its menu and shadow. The widgets use
+     * this for unused choice-bank tiles after scoring.
+     */
+    disabled?: boolean;
     /**
      * Data for the tile's DndActionMenu. Pass null to show no menu, for
      * example in a static preview. Scored tiles never show the menu, so
@@ -86,34 +91,37 @@ interface AnswerTileProps {
  * The tile is only visual for now. A later ticket adds the drag wiring.
  */
 export function AnswerTile(props: AnswerTileProps): React.ReactElement {
-    const {tileId, content, label, state, menu, menuVisibility} = props;
+    const {tileId, content, label, showCorrectness, disabled, menu} = props;
     const {strings} = usePerseusI18n();
 
-    // The icon for the current answer state, if one exists.
-    const scoredIcon = scoredIcons[state];
     // Whitespace-only content would render an invisible, unlabeled tile.
     // This protection might not be needed, depending on how we implement
     // the Content Editor experience, but it seemed wise to add this for now.
     const isEmpty = content.trim() === "";
 
     // The tile starts with the actions menu or, when scored, an icon.
-    // The two can never show together: only "rest" shows the menu, and
-    // only "correct" and "incorrect" have an icon.
+    // The two never show together: a scored tile has no menu.
     return (
         <div
-            // Each state has a CSS class with the same name.
-            className={classNames(styles.tile, styles[state])}
+            className={classNames(
+                styles.tile,
+                showCorrectness != null && styles[showCorrectness],
+                disabled && styles.disabled,
+            )}
             data-testid={`answer-tile-${tileId}`}
         >
-            {state === "rest" && menu != null && (
+            {menu != null && !disabled && showCorrectness == null && (
                 <TileActionsMenu
                     menu={menu}
                     label={label}
-                    visibility={menuVisibility}
+                    visibility={props.menuVisibility}
                 />
             )}
-            {scoredIcon != null && (
-                <TileScoredIcon icon={scoredIcon} tileId={tileId} />
+            {showCorrectness != null && (
+                <TileScoredIcon
+                    icon={scoredIcons[showCorrectness]}
+                    tileId={tileId}
+                />
             )}
             <span
                 className={classNames(
@@ -177,7 +185,7 @@ function TileScoredIcon(props: {
     );
 }
 
-const scoredIcons: Partial<Record<AnswerTileState, string>> = {
+const scoredIcons: Record<"correct" | "incorrect", string> = {
     correct: checkIcon,
     incorrect: xIcon,
 };

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -91,6 +91,8 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
 
     const stateIcon = stateIcons[state];
     const showMenu = state === "rest" && menu != null;
+    // Whitespace-only content would render an invisible, unlabeled tile.
+    const isEmpty = content.trim() === "";
 
     let leadingBox: React.ReactNode = null;
     if (showMenu) {
@@ -107,6 +109,8 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
                     ref={menuRef}
                     {...menuProps}
                     label={label}
+                    // Always false: scored tiles remove the menu instead
+                    // of disabling it, and they never reach this branch.
                     disabled={false}
                 />
             </span>
@@ -134,10 +138,10 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
             <span
                 className={classNames(
                     styles.content,
-                    content === "" && styles.emptyContent,
+                    isEmpty && styles.emptyContent,
                 )}
             >
-                {content === "" ? (
+                {isEmpty ? (
                     // An empty tile must have a spoken value.
                     <span className={a11yStyles.srOnly}>{label}</span>
                 ) : (
@@ -147,9 +151,6 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
         </div>
     );
 }
-
-// These constants are at module scope, at the end of the file per
-// convention. They keep the same identity on each render.
 
 const stateClasses: Record<AnswerTileState, string> = {
     rest: styles.rest,

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -25,7 +25,8 @@ export interface AnswerTileProps {
      */
     content: string;
     /**
-     * The aria-label of the tile, as translated plain text.
+     * Labels the tile's menu button for screen readers, as translated
+     * plain text.
      */
     label: string;
     /**
@@ -75,7 +76,18 @@ export interface AnswerTileProps {
  * The tile is only visual for now. A later ticket adds the drag wiring.
  */
 export function AnswerTile(props: AnswerTileProps): React.ReactElement {
-    const {tileId, content, label, showCorrectness, disabled} = props;
+    const {
+        content,
+        label,
+        showCorrectness,
+        disabled,
+        moveTargets,
+        onMove,
+        clearFromLabel,
+        onClear,
+        remainingUses,
+        menuRef,
+    } = props;
     const {strings} = usePerseusI18n();
 
     // Whitespace-only content would render an invisible, unlabeled tile.
@@ -90,28 +102,41 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
             className={classNames(
                 styles.tile,
                 showCorrectness != null && styles[showCorrectness],
-                disabled && styles.disabled,
+                // showCorrectness wins when both arrive.
+                disabled && showCorrectness == null && styles.disabled,
             )}
-            data-testid={`answer-tile-${tileId}`}
         >
             {!disabled && showCorrectness == null && (
-                <TileActionsMenu
-                    label={label}
-                    moveTargets={props.moveTargets}
-                    onMove={props.onMove}
-                    clearFromLabel={props.clearFromLabel}
-                    onClear={props.onClear}
-                    remainingUses={props.remainingUses}
-                    menuRef={props.menuRef}
-                />
+                <span className={styles.startContainer}>
+                    <DndActionMenu
+                        ref={menuRef}
+                        label={label}
+                        moveTargets={moveTargets}
+                        onMove={onMove}
+                        clearFromLabel={clearFromLabel}
+                        onClear={onClear}
+                        remainingUses={remainingUses}
+                        // Always false: scored tiles remove the menu instead
+                        // of disabling it, so a rendered menu is never
+                        // disabled.
+                        disabled={false}
+                    />
+                </span>
             )}
             {showCorrectness != null && (
-                <TileScoredIcon
-                    icon={scoredIcons[showCorrectness]}
-                    tileId={tileId}
-                />
+                <span
+                    className={styles.startContainer}
+                    // The icon is decorative. The widget announces the
+                    // result to screen readers, not the tile.
+                    aria-hidden="true"
+                >
+                    <PhosphorIcon
+                        icon={scoredIcons[showCorrectness]}
+                        size="medium"
+                    />
+                </span>
             )}
-            <span
+            <div
                 className={classNames(
                     styles.content,
                     isEmpty && styles.emptyContent,
@@ -123,54 +148,8 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
                 ) : (
                     <Renderer content={content} strings={strings} />
                 )}
-            </span>
+            </div>
         </div>
-    );
-}
-
-/** The actions menu at the start of an unscored tile. */
-function TileActionsMenu(props: {
-    label: string;
-    moveTargets: ReadonlyArray<MoveTarget>;
-    onMove: (targetId: string) => void;
-    clearFromLabel?: string;
-    onClear?: () => void;
-    remainingUses?: number;
-    menuRef?: React.Ref<HTMLButtonElement>;
-}): React.ReactElement {
-    return (
-        <span className={styles.startContainer}>
-            <DndActionMenu
-                ref={props.menuRef}
-                label={props.label}
-                moveTargets={props.moveTargets}
-                onMove={props.onMove}
-                clearFromLabel={props.clearFromLabel}
-                onClear={props.onClear}
-                remainingUses={props.remainingUses}
-                // Always false: scored tiles remove the menu instead
-                // of disabling it, so a rendered menu is never disabled.
-                disabled={false}
-            />
-        </span>
-    );
-}
-
-/** The check or x icon at the start of a scored tile. */
-function TileScoredIcon(props: {
-    icon: string;
-    tileId: string;
-}): React.ReactElement {
-    return (
-        <span
-            className={styles.startContainer}
-            // This icon is decorative. The widget announces the
-            // result to screen readers, not the tile.
-            aria-hidden="true"
-            data-testid={`answer-tile-state-icon-${props.tileId}`}
-        >
-            <PhosphorIcon icon={props.icon} size="medium" />
-        </span>
     );
 }
 

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -95,36 +95,36 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
         scoring != null && styles[scoring],
     );
 
-    // What the tile leads with, one branch per scoring state.
+    // What the tile leads with. The menu is the normal state; scoring
+    // replaces it with a result icon, or with nothing for an unused
+    // tile, which has no action to offer and no result to report.
     const renderTileStart = () => {
-        // An unused tile leads with nothing: it has no action to offer
-        // and no result to report.
         if (scoring === "unused") {
             return null;
         }
-        if (scoring == null) {
+        if (scoring != null) {
+            // The icon is decoration: the widget announces the result
+            // to screen readers, not the tile.
             return (
                 <div className={styles.startContainer}>
-                    <DndActionMenu
-                        ref={menuRef}
-                        tileLabel={label}
-                        moveTargets={moveTargets}
-                        onMove={onMove}
-                        clearFromLabel={clearFromLabel}
-                        onClear={onClear}
-                        remainingUses={remainingUses}
+                    <PhosphorIcon
+                        aria-hidden="true"
+                        icon={scoredIcons[scoring]}
+                        size="medium"
                     />
                 </div>
             );
         }
-        // The icon is decoration: the widget announces the result to
-        // screen readers, not the tile.
         return (
             <div className={styles.startContainer}>
-                <PhosphorIcon
-                    aria-hidden="true"
-                    icon={scoredIcons[scoring]}
-                    size="medium"
+                <DndActionMenu
+                    ref={menuRef}
+                    tileLabel={label}
+                    moveTargets={moveTargets}
+                    onMove={onMove}
+                    clearFromLabel={clearFromLabel}
+                    onClear={onClear}
+                    remainingUses={remainingUses}
                 />
             </div>
         );

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -15,8 +15,8 @@ import type {MoveTarget} from "../dnd-action-menu";
 
 export interface AnswerTileProps {
     /**
-     * The unique identifier of this tile. It is used for scoring, drag
-     * wiring, and test ids.
+     * The unique identifier of an Answer Tile, which is used
+     * for both scoring and dragging.
      */
     tileId: string;
     /**
@@ -25,17 +25,12 @@ export interface AnswerTileProps {
      */
     content: string;
     /**
-     * The spoken value of the tile, as translated plain text. It names
-     * the menu opener ("Bongo. Actions menu."). We cannot compute it
-     * from TeX or image markdown, so the caller must supply it.
-     * For an empty tile, pass the translated "(empty)".
+     * The aria-label of the tile, as translated plain text.
      */
     label: string;
     /**
-     * The scored result for a tile placed in a blank. Omit before
-     * scoring. "correct" shows a green border and a check icon.
-     * "incorrect" shows a red border and an x icon. Both replace the
-     * menu and remove the shadow.
+     * Used to provide visible feedback regarding whether the user
+     * answered the question correctly or incorrectly.
      *
      * A scored tile is either placed (showCorrectness) or unused
      * (disabled), never both. If both arrive, showCorrectness wins.
@@ -48,16 +43,14 @@ export interface AnswerTileProps {
     disabled?: boolean;
     /**
      * Blanks the tile can move to. An empty array is valid: a placed
-     * tile in a one-blank exercise can only be cleared, and the menu
-     * disables itself when it has no actions at all.
+     * tile in a one-blank exercise can only be cleared,
      */
     moveTargets: ReadonlyArray<MoveTarget>;
     /** Called with the target blank's id when a move action is selected. */
     onMove: (targetId: string) => void;
     /**
-     * Visible label of the blank/column the tile currently sits in,
-     * spoken as "Clear from Blank 1". Provide with onClear when the
-     * tile is placed.
+     * Label of the blank/column the tile currently sits in, which is used
+     * as part of the aria-label for the "Clear" button in the Action Menu.
      */
     clearFromLabel?: string;
     /** Callback for removing the tile from its blank. */

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -1,0 +1,157 @@
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
+import checkIcon from "@phosphor-icons/core/regular/check.svg";
+import xIcon from "@phosphor-icons/core/regular/x.svg";
+import classNames from "classnames";
+import * as React from "react";
+
+import Renderer from "../../../renderer";
+import a11yStyles from "../../../styles/a11y.module.css";
+import {usePerseusI18n} from "../../i18n-context";
+import {DndActionMenu} from "../dnd-action-menu";
+
+import styles from "./answer-tile.module.css";
+
+import type {DndActionMenuProps} from "../dnd-action-menu";
+
+export type AnswerTileState = "rest" | "correct" | "incorrect" | "disabled";
+
+/**
+ * Widget-owned data the tile forwards to its DndActionMenu — the menu's
+ * props minus the ones the tile supplies itself. Derived so a new menu prop
+ * automatically surfaces here (or fails compilation if the tile should own
+ * it) instead of silently drifting.
+ */
+export type AnswerTileMenuConfig = Omit<
+    DndActionMenuProps,
+    // keyof Pick<> (rather than bare string literals) makes a rename of one
+    // of these props in dnd-action-menu fail compilation HERE, instead of
+    // Omit silently accepting a stale key.
+    keyof Pick<DndActionMenuProps, "label" | "disabled">
+> & {
+    /**
+     * Reaches the menu's opener button (DndActionMenu's forwarded ref) —
+     * for the parent's after-move focus return. An added field because a
+     * forwarded ref isn't part of the menu's props type.
+     */
+    menuRef?: React.Ref<HTMLButtonElement>;
+};
+
+interface AnswerTileProps {
+    /** Unique identifier for this tile; used for scoring, dnd wiring, test ids. */
+    tileId: string;
+    /** Perseus markdown for the tile face: text, TeX, or an image. "" for an Empty tile. */
+    content: string;
+    /**
+     * Plain-text spoken value of the tile, translated — names the menu opener
+     * via aria-labelledby ("Bongo. Actions menu."). Not derivable from
+     * markdown (TeX/images), so it's authored/passed explicitly.
+     * For Empty tiles, pass the translated "(empty)".
+     */
+    label: string;
+    /**
+     * Scored/interaction state, owned by the parent widget:
+     * - "rest": default chrome; the menu renders when `menu` is non-null.
+     * - "correct": green 2px border, check icon replaces the menu, no shadow.
+     * - "incorrect": red 2px border, x icon replaces the menu, no shadow.
+     * - "disabled": grey content, no shadow, leading control removed.
+     */
+    state: AnswerTileState;
+    /**
+     * Data for the tile's DndActionMenu. null = no menu (e.g. a static
+     * preview). Ignored unless state is "rest" — scored tiles never show it.
+     */
+    menu: AnswerTileMenuConfig | null;
+    /**
+     * "always" (default) in choice banks and column blanks;
+     * "on-hover-or-focus" when the tile sits in an inline blank, so the
+     * string stays readable. Optional — it's meaningless when no menu
+     * renders, so scored/preview call sites shouldn't have to pass it.
+     */
+    menuVisibility?: "always" | "on-hover-or-focus";
+}
+
+/**
+ * AnswerTile is the card a learner moves into a blank in the Drag-and-Drop
+ * widget family. It renders authored markdown content (text, TeX, or an
+ * image) inside the tile chrome, composes the DndActionMenu at its leading
+ * edge, and shows the parent-set scored states.
+ *
+ * Purely presentational for now — dnd-kit wiring comes in a later ticket.
+ */
+export function AnswerTile(props: AnswerTileProps): React.ReactElement {
+    const {tileId, content, label, state, menu, menuVisibility} = props;
+    const {strings} = usePerseusI18n();
+
+    const stateIcon = stateIcons[state];
+    const showMenu = state === "rest" && menu != null;
+
+    let leadingBox: React.ReactNode = null;
+    if (showMenu) {
+        const {menuRef, ...menuProps} = menu;
+        leadingBox = (
+            <span
+                className={classNames(
+                    styles.menuBox,
+                    menuVisibility === "on-hover-or-focus" &&
+                        styles.menuOnDemand,
+                )}
+            >
+                <DndActionMenu
+                    ref={menuRef}
+                    {...menuProps}
+                    label={label}
+                    disabled={false}
+                />
+            </span>
+        );
+    } else if (stateIcon) {
+        leadingBox = (
+            <span
+                className={styles.stateIcon}
+                // Decorative — the widget's scored rendering announces
+                // correctness, not the tile.
+                aria-hidden="true"
+                data-testid={`answer-tile-state-icon-${tileId}`}
+            >
+                <PhosphorIcon icon={stateIcon} size="medium" />
+            </span>
+        );
+    }
+
+    return (
+        <div
+            className={classNames(styles.tile, stateClasses[state])}
+            data-testid={`answer-tile-${tileId}`}
+        >
+            {leadingBox}
+            <span
+                className={classNames(
+                    styles.content,
+                    content === "" && styles.emptyContent,
+                )}
+            >
+                {content === "" ? (
+                    // An empty tile still needs a spoken value.
+                    <span className={a11yStyles.srOnly}>{label}</span>
+                ) : (
+                    <Renderer content={content} strings={strings} />
+                )}
+            </span>
+        </div>
+    );
+}
+
+// These live at module scope so they keep a stable identity across renders,
+// and at the end of the file per convention.
+
+const stateClasses: Record<AnswerTileState, string> = {
+    rest: styles.rest,
+    correct: styles.correct,
+    incorrect: styles.incorrect,
+    disabled: styles.disabled,
+};
+
+const stateIcons: Partial<Record<AnswerTileState, string>> = {
+    correct: checkIcon,
+    incorrect: xIcon,
+};

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -106,34 +106,31 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
                 disabled && showCorrectness == null && styles.disabled,
             )}
         >
-            {!disabled && showCorrectness == null && (
+            {(showCorrectness != null || !disabled) && (
                 <span className={styles.startContainer}>
-                    <DndActionMenu
-                        ref={menuRef}
-                        label={label}
-                        moveTargets={moveTargets}
-                        onMove={onMove}
-                        clearFromLabel={clearFromLabel}
-                        onClear={onClear}
-                        remainingUses={remainingUses}
-                        // Always false: scored tiles remove the menu instead
-                        // of disabling it, so a rendered menu is never
-                        // disabled.
-                        disabled={false}
-                    />
-                </span>
-            )}
-            {showCorrectness != null && (
-                <span
-                    className={styles.startContainer}
-                    // The icon is decorative. The widget announces the
-                    // result to screen readers, not the tile.
-                    aria-hidden="true"
-                >
-                    <PhosphorIcon
-                        icon={scoredIcons[showCorrectness]}
-                        size="medium"
-                    />
+                    {showCorrectness != null ? (
+                        // An unlabeled PhosphorIcon is aria-hidden by
+                        // default. The widget announces the result to
+                        // screen readers, not the tile.
+                        <PhosphorIcon
+                            icon={scoredIcons[showCorrectness]}
+                            size="medium"
+                        />
+                    ) : (
+                        <DndActionMenu
+                            ref={menuRef}
+                            label={label}
+                            moveTargets={moveTargets}
+                            onMove={onMove}
+                            clearFromLabel={clearFromLabel}
+                            onClear={onClear}
+                            remainingUses={remainingUses}
+                            // Always false: scored tiles remove the menu
+                            // instead of disabling it, so a rendered menu
+                            // is never disabled.
+                            disabled={false}
+                        />
+                    )}
                 </span>
             )}
             <div

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -33,8 +33,8 @@ export interface AnswerTileProps {
      * Used to provide visible feedback regarding whether the user
      * answered the question correctly or incorrectly.
      *
-     * A scored tile is either placed (showCorrectness) or unused
-     * (disabled), never both. If both arrive, showCorrectness wins.
+     * Never pass this together with `disabled`: a scored tile is either
+     * placed (showCorrectness) or unused (disabled).
      */
     showCorrectness?: "correct" | "incorrect";
     /**
@@ -102,21 +102,12 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
             className={classNames(
                 styles.tile,
                 showCorrectness != null && styles[showCorrectness],
-                // showCorrectness wins when both arrive.
-                disabled && showCorrectness == null && styles.disabled,
+                disabled && styles.disabled,
             )}
         >
-            {(showCorrectness != null || !disabled) && (
+            {!disabled && (
                 <span className={styles.startContainer}>
-                    {showCorrectness != null ? (
-                        // An unlabeled PhosphorIcon is aria-hidden by
-                        // default. The widget announces the result to
-                        // screen readers, not the tile.
-                        <PhosphorIcon
-                            icon={scoredIcons[showCorrectness]}
-                            size="medium"
-                        />
-                    ) : (
+                    {showCorrectness == null ? (
                         <DndActionMenu
                             ref={menuRef}
                             label={label}
@@ -129,6 +120,14 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
                             // instead of disabling it, so a rendered menu
                             // is never disabled.
                             disabled={false}
+                        />
+                    ) : (
+                        // An unlabeled PhosphorIcon is aria-hidden by
+                        // default. The widget announces the result to
+                        // screen readers, not the tile.
+                        <PhosphorIcon
+                            icon={scoredIcons[showCorrectness]}
+                            size="medium"
                         />
                     )}
                 </span>

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -104,42 +104,45 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
         }
         if (scoring == null) {
             return (
-                <DndActionMenu
-                    ref={menuRef}
-                    tileLabel={label}
-                    moveTargets={moveTargets}
-                    onMove={onMove}
-                    clearFromLabel={clearFromLabel}
-                    onClear={onClear}
-                    remainingUses={remainingUses}
-                />
+                <div className={styles.startContainer}>
+                    <DndActionMenu
+                        ref={menuRef}
+                        tileLabel={label}
+                        moveTargets={moveTargets}
+                        onMove={onMove}
+                        clearFromLabel={clearFromLabel}
+                        onClear={onClear}
+                        remainingUses={remainingUses}
+                    />
+                </div>
             );
         }
         // The icon is decoration: the widget announces the result to
         // screen readers, not the tile.
         return (
-            <PhosphorIcon
-                aria-hidden="true"
-                icon={scoredIcons[scoring]}
-                size="medium"
-            />
+            <div className={styles.startContainer}>
+                <PhosphorIcon
+                    aria-hidden="true"
+                    icon={scoredIcons[scoring]}
+                    size="medium"
+                />
+            </div>
         );
     };
-    const tileStart = renderTileStart();
+
+    // The tile face: the authored markdown or, for an empty tile, a
+    // spoken value alone.
+    const renderTileContent = () => {
+        if (isEmpty) {
+            return <span className={a11yStyles.srOnly}>{label}</span>;
+        }
+        return <Renderer content={content} strings={strings} />;
+    };
 
     return (
         <div className={tileClasses}>
-            {tileStart != null && (
-                <div className={styles.startContainer}>{tileStart}</div>
-            )}
-            <div className={styles.content}>
-                {isEmpty ? (
-                    // An empty tile must have a spoken value.
-                    <span className={a11yStyles.srOnly}>{label}</span>
-                ) : (
-                    <Renderer content={content} strings={strings} />
-                )}
-            </div>
+            {renderTileStart()}
+            <div className={styles.content}>{renderTileContent()}</div>
         </div>
     );
 }

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -90,51 +90,27 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
     const {strings} = usePerseusI18n();
 
     const scoredIcon = scoredIcons[state];
-    const showMenu = state === "rest" && menu != null;
     // Whitespace-only content would render an invisible, unlabeled tile.
     const isEmpty = content.trim() === "";
 
-    let menuOrScoredIcon: React.ReactNode = null;
-    if (showMenu) {
-        const {menuRef, ...menuProps} = menu;
-        menuOrScoredIcon = (
-            <span
-                className={classNames(
-                    styles.menuContainer,
-                    menuVisibility === "on-hover-or-focus" &&
-                        styles.menuOnDemand,
-                )}
-            >
-                <DndActionMenu
-                    ref={menuRef}
-                    {...menuProps}
-                    label={label}
-                    // Always false: scored tiles remove the menu instead
-                    // of disabling it, and they never reach this branch.
-                    disabled={false}
-                />
-            </span>
-        );
-    } else if (scoredIcon) {
-        menuOrScoredIcon = (
-            <span
-                className={styles.stateIcon}
-                // This icon is decorative. The widget announces the
-                // result to screen readers, not the tile.
-                aria-hidden="true"
-                data-testid={`answer-tile-state-icon-${tileId}`}
-            >
-                <PhosphorIcon icon={scoredIcon} size="medium" />
-            </span>
-        );
-    }
-
+    // The tile starts with the actions menu or, when scored, an icon.
+    // The two can never show together: only "rest" shows the menu, and
+    // only "correct" and "incorrect" have an icon.
     return (
         <div
             className={classNames(styles.tile, stateClasses[state])}
             data-testid={`answer-tile-${tileId}`}
         >
-            {menuOrScoredIcon}
+            {state === "rest" && menu != null && (
+                <TileActionsMenu
+                    menu={menu}
+                    label={label}
+                    visibility={menuVisibility}
+                />
+            )}
+            {scoredIcon != null && (
+                <TileScoredIcon icon={scoredIcon} tileId={tileId} />
+            )}
             <span
                 className={classNames(
                     styles.content,
@@ -149,6 +125,51 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
                 )}
             </span>
         </div>
+    );
+}
+
+/** The actions menu at the start of a resting tile. */
+function TileActionsMenu(props: {
+    menu: AnswerTileMenuConfig;
+    label: string;
+    visibility: AnswerTileProps["menuVisibility"];
+}): React.ReactElement {
+    const {menu, label, visibility} = props;
+    const {menuRef, ...menuProps} = menu;
+    return (
+        <span
+            className={classNames(
+                styles.menuContainer,
+                visibility === "on-hover-or-focus" && styles.menuOnDemand,
+            )}
+        >
+            <DndActionMenu
+                ref={menuRef}
+                {...menuProps}
+                label={label}
+                // Always false: scored tiles remove the menu instead
+                // of disabling it, so a rendered menu is never disabled.
+                disabled={false}
+            />
+        </span>
+    );
+}
+
+/** The check or x icon at the start of a scored tile. */
+function TileScoredIcon(props: {
+    icon: string;
+    tileId: string;
+}): React.ReactElement {
+    return (
+        <span
+            className={styles.stateIcon}
+            // This icon is decorative. The widget announces the
+            // result to screen readers, not the tile.
+            aria-hidden="true"
+            data-testid={`answer-tile-state-icon-${props.tileId}`}
+        >
+            <PhosphorIcon icon={props.icon} size="medium" />
+        </span>
     );
 }
 

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -91,8 +91,6 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
     const {strings} = usePerseusI18n();
 
     // Whitespace-only content would render an invisible, unlabeled tile.
-    // This protection might not be needed, depending on how we implement
-    // the Content Editor experience, but it seemed wise to add this for now.
     const isEmpty = content.trim() === "";
 
     // The tile starts with the actions menu or, when scored, an icon.
@@ -106,7 +104,7 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
             )}
         >
             {!disabled && (
-                <span className={styles.startContainer}>
+                <div className={styles.startContainer}>
                     {showCorrectness == null ? (
                         <DndActionMenu
                             ref={menuRef}
@@ -122,15 +120,15 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
                             disabled={false}
                         />
                     ) : (
-                        // An unlabeled PhosphorIcon is aria-hidden by
-                        // default. The widget announces the result to
-                        // screen readers, not the tile.
+                        // The icon is decoration: the widget announces the
+                        // result to screen readers, not the tile.
                         <PhosphorIcon
+                            aria-hidden="true"
                             icon={scoredIcons[showCorrectness]}
                             size="medium"
                         />
                     )}
-                </span>
+                </div>
             )}
             <div className={styles.content}>
                 {isEmpty ? (

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -46,9 +46,6 @@ export interface AnswerTileProps {
      * this for unused choice-bank tiles after scoring.
      */
     disabled?: boolean;
-
-    // The next six props feed the tile's DndActionMenu. The menu shows
-    // unless the tile is scored or disabled.
     /**
      * Blanks the tile can move to. An empty array is valid: a placed
      * tile in a one-blank exercise can only be cleared, and the menu

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -72,13 +72,6 @@ export interface AnswerTileProps {
      * move focus after a tile moves.
      */
     menuRef?: React.Ref<HTMLButtonElement>;
-
-    /**
-     * When the menu is visible. Use "always" (the default) in choice
-     * banks and column blanks. Use "on-hover-or-focus" in an inline
-     * blank, so the sentence stays easy to read.
-     */
-    menuVisibility?: "always" | "on-hover-or-focus";
 }
 
 /**
@@ -119,7 +112,6 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
                     onClear={props.onClear}
                     remainingUses={props.remainingUses}
                     menuRef={props.menuRef}
-                    visibility={props.menuVisibility}
                 />
             )}
             {showCorrectness != null && (
@@ -154,15 +146,9 @@ function TileActionsMenu(props: {
     onClear?: () => void;
     remainingUses?: number;
     menuRef?: React.Ref<HTMLButtonElement>;
-    visibility: AnswerTileProps["menuVisibility"];
 }): React.ReactElement {
     return (
-        <span
-            className={classNames(
-                styles.startContainer,
-                props.visibility === "on-hover-or-focus" && styles.menuOnDemand,
-            )}
-        >
+        <span className={styles.startContainer}>
             <DndActionMenu
                 ref={props.menuRef}
                 label={props.label}

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -42,8 +42,9 @@ export interface AnswerTileProps {
      */
     disabled?: boolean;
     /**
-     * Blanks the tile can move to. An empty array is valid: a placed
-     * tile in a one-blank exercise can only be cleared,
+     * Blanks the tile can move to, which populate the menu.
+     * An empty array is valid: a placed tile in a one-blank exercise
+     * can only be cleared, due to no other legitimate moveTargets.
      */
     moveTargets: ReadonlyArray<MoveTarget>;
     /** Called with the target blank's id when a move action is selected. */

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -132,12 +132,7 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
                     )}
                 </span>
             )}
-            <div
-                className={classNames(
-                    styles.content,
-                    isEmpty && styles.emptyContent,
-                )}
-            >
+            <div className={styles.content}>
                 {isEmpty ? (
                     // An empty tile must have a spoken value.
                     <span className={a11yStyles.srOnly}>{label}</span>

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -22,9 +22,7 @@ import type {DndActionMenuProps} from "../dnd-action-menu";
  */
 export type AnswerTileMenuConfig = Omit<
     DndActionMenuProps,
-    // keyof Pick<> instead of plain strings: if the menu renames one of
-    // these props, this line fails to compile instead of going stale.
-    keyof Pick<DndActionMenuProps, "label" | "disabled">
+    "label" | "disabled"
 > & {
     /**
      * This ref points to the menu's opener button. The parent uses it to

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/answer-tile.tsx
@@ -89,18 +89,18 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
     const {tileId, content, label, state, menu, menuVisibility} = props;
     const {strings} = usePerseusI18n();
 
-    const stateIcon = stateIcons[state];
+    const scoredIcon = scoredIcons[state];
     const showMenu = state === "rest" && menu != null;
     // Whitespace-only content would render an invisible, unlabeled tile.
     const isEmpty = content.trim() === "";
 
-    let leadingBox: React.ReactNode = null;
+    let menuOrScoredIcon: React.ReactNode = null;
     if (showMenu) {
         const {menuRef, ...menuProps} = menu;
-        leadingBox = (
+        menuOrScoredIcon = (
             <span
                 className={classNames(
-                    styles.menuBox,
+                    styles.menuContainer,
                     menuVisibility === "on-hover-or-focus" &&
                         styles.menuOnDemand,
                 )}
@@ -115,8 +115,8 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
                 />
             </span>
         );
-    } else if (stateIcon) {
-        leadingBox = (
+    } else if (scoredIcon) {
+        menuOrScoredIcon = (
             <span
                 className={styles.stateIcon}
                 // This icon is decorative. The widget announces the
@@ -124,7 +124,7 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
                 aria-hidden="true"
                 data-testid={`answer-tile-state-icon-${tileId}`}
             >
-                <PhosphorIcon icon={stateIcon} size="medium" />
+                <PhosphorIcon icon={scoredIcon} size="medium" />
             </span>
         );
     }
@@ -134,7 +134,7 @@ export function AnswerTile(props: AnswerTileProps): React.ReactElement {
             className={classNames(styles.tile, stateClasses[state])}
             data-testid={`answer-tile-${tileId}`}
         >
-            {leadingBox}
+            {menuOrScoredIcon}
             <span
                 className={classNames(
                     styles.content,
@@ -159,7 +159,7 @@ const stateClasses: Record<AnswerTileState, string> = {
     disabled: styles.disabled,
 };
 
-const stateIcons: Partial<Record<AnswerTileState, string>> = {
+const scoredIcons: Partial<Record<AnswerTileState, string>> = {
     correct: checkIcon,
     incorrect: xIcon,
 };

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/index.ts
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/index.ts
@@ -1,0 +1,2 @@
+export {AnswerTile} from "./answer-tile";
+export type {AnswerTileMenuConfig, AnswerTileState} from "./answer-tile";

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/index.ts
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/index.ts
@@ -1,2 +1,2 @@
 export {AnswerTile} from "./answer-tile";
-export type {AnswerTileMenuConfig, AnswerTileState} from "./answer-tile";
+export type {AnswerTileMenuConfig} from "./answer-tile";

--- a/packages/perseus/src/components/drag-and-drop/answer-tile/index.ts
+++ b/packages/perseus/src/components/drag-and-drop/answer-tile/index.ts
@@ -1,2 +1,2 @@
 export {AnswerTile} from "./answer-tile";
-export type {AnswerTileMenuConfig} from "./answer-tile";
+export type {AnswerTileProps} from "./answer-tile";


### PR DESCRIPTION
## Summary:
This PR creates the new shared Answer Tile Component for our Operation Dragon Drop widgets. This answer tile consists of both the tile contents, and the action menu. This PR is stacked on the [Action Menu PR](https://github.com/Khan/perseus/pull/4091).

This PR also cleans up the Choice Bank and Action Menu stories to use our new Answer Tile Component. 

Issue: LEMS-4363

## Test plan:
- Tests Pass