### PR TITLE
Allow content creators to "Suppress Dark Mode Filter" for PNG and SVG images

### DIFF
--- a/.changeset/salty-facts-drum.md
+++ b/.changeset/salty-facts-drum.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus-editor": minor
 ---
 
-Content creators can now suppress value inversion in dark mode for SVG images as well as PNGs."
+Content creators can now exempt SVG and GIF images from being inverted in dark mode, in addition to PNGs.

--- a/.changeset/salty-facts-drum.md
+++ b/.changeset/salty-facts-drum.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+Content creators can now suppress value inversion in dark mode for SVG images as well as PNGs."

--- a/.changeset/salty-facts-drum.md
+++ b/.changeset/salty-facts-drum.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus-editor": minor
 ---
 
-Content creators can now exempt SVG and GIF images from being inverted in dark mode, in addition to PNGs.
+Content creators can now exempt SVG images from being inverted in dark mode, in addition to PNGs.

--- a/packages/perseus-editor/src/widgets/image-editor/components/dark-mode-toggle.test.ts
+++ b/packages/perseus-editor/src/widgets/image-editor/components/dark-mode-toggle.test.ts
@@ -11,10 +11,6 @@ describe("isGraphicalImage", () => {
         expect(isGraphicalImage("https://example.com/foo.svg")).toBe(true);
     });
 
-    it("is true for a GIF", () => {
-        expect(isGraphicalImage("https://example.com/foo.gif")).toBe(true);
-    });
-
     it("is false for a JPEG", () => {
         expect(isGraphicalImage("https://example.com/foo.jpg")).toBe(false);
     });

--- a/packages/perseus-editor/src/widgets/image-editor/components/dark-mode-toggle.test.ts
+++ b/packages/perseus-editor/src/widgets/image-editor/components/dark-mode-toggle.test.ts
@@ -1,0 +1,45 @@
+import {describe, it, expect} from "@jest/globals";
+
+import {isGraphicalImage} from "./dark-mode-toggle";
+
+describe("isGraphicalImage", () => {
+    it("is true for a PNG", () => {
+        expect(isGraphicalImage("https://example.com/foo.png")).toBe(true);
+    });
+
+    it("is true for an SVG", () => {
+        expect(isGraphicalImage("https://example.com/foo.svg")).toBe(true);
+    });
+
+    it("is false for a JPEG", () => {
+        expect(isGraphicalImage("https://example.com/foo.jpg")).toBe(false);
+    });
+
+    it("is false for null", () => {
+        expect(isGraphicalImage(null)).toBe(false);
+    });
+
+    it("is false for undefined", () => {
+        expect(isGraphicalImage(undefined)).toBe(false);
+    });
+
+    it("is false for a non-url string", () => {
+        expect(isGraphicalImage("!foo")).toBe(false);
+    });
+
+    it("is true for a PNG URL with a query param", () => {
+        expect(isGraphicalImage("https://example.com/foo.png?q=1")).toBe(true);
+    });
+
+    it("is true for an SVG URL with a query param", () => {
+        expect(isGraphicalImage("https://example.com/foo.svg?q=1")).toBe(true);
+    });
+
+    it("is false for a file with an unrecognized extension starting with .png", () => {
+        expect(isGraphicalImage("https://example.com/foo.pngqxz")).toBe(false);
+    });
+
+    it("is false for a file with another extension after .png", () => {
+        expect(isGraphicalImage("https://example.com/foo.png.qxz")).toBe(false);
+    });
+});

--- a/packages/perseus-editor/src/widgets/image-editor/components/dark-mode-toggle.test.ts
+++ b/packages/perseus-editor/src/widgets/image-editor/components/dark-mode-toggle.test.ts
@@ -11,6 +11,10 @@ describe("isGraphicalImage", () => {
         expect(isGraphicalImage("https://example.com/foo.svg")).toBe(true);
     });
 
+    it("is true for a GIF", () => {
+        expect(isGraphicalImage("https://example.com/foo.gif")).toBe(true);
+    });
+
     it("is false for a JPEG", () => {
         expect(isGraphicalImage("https://example.com/foo.jpg")).toBe(false);
     });
@@ -27,19 +31,15 @@ describe("isGraphicalImage", () => {
         expect(isGraphicalImage("!foo")).toBe(false);
     });
 
-    it("is true for a PNG URL with a query param", () => {
+    it("is true for a graphical image URL with a query param", () => {
         expect(isGraphicalImage("https://example.com/foo.png?q=1")).toBe(true);
     });
 
-    it("is true for an SVG URL with a query param", () => {
-        expect(isGraphicalImage("https://example.com/foo.svg?q=1")).toBe(true);
-    });
-
-    it("is false for a file with an unrecognized extension starting with .png", () => {
+    it("is false for an image with an unrecognized extension starting with .png", () => {
         expect(isGraphicalImage("https://example.com/foo.pngqxz")).toBe(false);
     });
 
-    it("is false for a file with another extension after .png", () => {
+    it("is false for an image with another extension after .png", () => {
         expect(isGraphicalImage("https://example.com/foo.png.qxz")).toBe(false);
     });
 });

--- a/packages/perseus-editor/src/widgets/image-editor/components/dark-mode-toggle.test.ts
+++ b/packages/perseus-editor/src/widgets/image-editor/components/dark-mode-toggle.test.ts
@@ -35,6 +35,14 @@ describe("isGraphicalImage", () => {
         expect(isGraphicalImage("https://example.com/foo.png?q=1")).toBe(true);
     });
 
+    it("is false for a non-graphical image URL with a query param containing a graphical filename", () => {
+        // This test forces us to actually parse the URL, not just pattern-match
+        // on the string.
+        expect(isGraphicalImage("https://example.com/foo.jpg?q=bar.png")).toBe(
+            false,
+        );
+    });
+
     it("is false for an image with an unrecognized extension starting with .png", () => {
         expect(isGraphicalImage("https://example.com/foo.pngqxz")).toBe(false);
     });

--- a/packages/perseus-editor/src/widgets/image-editor/components/dark-mode-toggle.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/components/dark-mode-toggle.tsx
@@ -33,9 +33,6 @@ export default function DarkModeToggle({
     })();
     const suppressFilter = imageUrl?.searchParams.has("dark-mode") ?? false;
 
-    // Determine if the image is a PNG, regardless of any possible query string.
-    const imageIsPng = /\.png(\?.*)?$/.test(backgroundImage.url ?? "");
-
     const toggleDarkMode = () => {
         onShowToggle(showDarkMode ? undefined : "syl-dark");
         setShowDarkMode(!showDarkMode);
@@ -83,14 +80,17 @@ export default function DarkModeToggle({
                 <LabeledSwitch
                     label="Suppress Dark Mode Filter"
                     checked={suppressFilter}
-                    disabled={editingDisabled || !imageIsPng}
+                    disabled={
+                        editingDisabled ||
+                        !isGraphicalImage(backgroundImage.url)
+                    }
                     onChange={toggleSuppressFilter}
                 />
                 <InfoTip>
                     When the color in the image is important (like in an image
                     of a flag), you can suppress the filter that is used to make
                     images compatible with dark mode.
-                    {!imageIsPng && (
+                    {!isGraphicalImage(backgroundImage.url) && (
                         <strong>
                             {" "}
                             This option is only available for PNG images!
@@ -100,4 +100,18 @@ export default function DarkModeToggle({
             </div>
         </div>
     );
+}
+
+/**
+ * Determines whether an image is a "graphical" type like PNG or SVG, with
+ * large flat areas of meaningful color.
+ */
+// exported for testing
+export function isGraphicalImage(url: string | null | undefined): boolean {
+    try {
+        const {pathname} = new URL(url ?? "");
+        return /\.(png|svg)$/.test(pathname);
+    } catch {
+        return false;
+    }
 }

--- a/packages/perseus-editor/src/widgets/image-editor/components/dark-mode-toggle.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/components/dark-mode-toggle.tsx
@@ -93,8 +93,8 @@ export default function DarkModeToggle({
                     {!isGraphicalImage(backgroundImage.url) && (
                         <strong>
                             {" "}
-                            This option is only available for PNG, SVG, and GIF
-                            images. Other types of images (e.g. JPG) never
+                            This option is only available for PNG and SVG
+                            images. Other types of images (e.g. JPG, GIF) never
                             change in dark mode.
                         </strong>
                     )}
@@ -105,14 +105,14 @@ export default function DarkModeToggle({
 }
 
 /**
- * Determines whether an image is a "graphical" type like PNG, SVG, or GIF,
- * with large flat areas of meaningful color.
+ * Determines whether an image is a "graphical" type (PNG or SVG) with large
+ * flat areas of meaningful color and potentially a transparent background.
  */
 // exported for testing
 export function isGraphicalImage(url: string | null | undefined): boolean {
     try {
         const {pathname} = new URL(url ?? "");
-        return /\.(png|svg|gif)$/.test(pathname);
+        return /\.(png|svg)$/.test(pathname);
     } catch {
         return false;
     }

--- a/packages/perseus-editor/src/widgets/image-editor/components/dark-mode-toggle.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/components/dark-mode-toggle.tsx
@@ -93,7 +93,9 @@ export default function DarkModeToggle({
                     {!isGraphicalImage(backgroundImage.url) && (
                         <strong>
                             {" "}
-                            This option is only available for PNG images!
+                            This option is only available for PNG, SVG, and GIF
+                            images. Other types of images (e.g. JPG) never
+                            change in dark mode.
                         </strong>
                     )}
                 </InfoTip>
@@ -103,14 +105,14 @@ export default function DarkModeToggle({
 }
 
 /**
- * Determines whether an image is a "graphical" type like PNG or SVG, with
- * large flat areas of meaningful color.
+ * Determines whether an image is a "graphical" type like PNG, SVG, or GIF,
+ * with large flat areas of meaningful color.
  */
 // exported for testing
 export function isGraphicalImage(url: string | null | undefined): boolean {
     try {
         const {pathname} = new URL(url ?? "");
-        return /\.(png|svg)$/.test(pathname);
+        return /\.(png|svg|gif)$/.test(pathname);
     } catch {
         return false;
     }

--- a/packages/perseus-editor/src/widgets/image-editor/image-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/image-editor.test.tsx
@@ -1174,7 +1174,7 @@ describe("image editor", () => {
             ).toHaveAttribute("aria-disabled", "true");
         });
 
-        it("tooltip shows note about image format for non-PNG images", async () => {
+        it("tooltip shows note about supported image formats", async () => {
             // Arrange
             render(
                 <ImageEditorWithDependencies
@@ -1197,10 +1197,9 @@ describe("image editor", () => {
             // Assert
             const tooltip = screen.getByRole("tooltip");
             expect(
-                within(tooltip).getByText(
-                    "This option is only available for PNG images!",
-                    {exact: false},
-                ),
+                within(tooltip).getByText("This option is only available for", {
+                    exact: false,
+                }),
             ).toBeInTheDocument();
         });
 

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -366,8 +366,14 @@
  * GLOBAL DARK MODE SETTINGS *
  *****************************/
 [data-wb-theme$="-dark"] .framework-perseus {
+    /* TODO(benchristel): this set of file extensions is duplicated in
+     * image.css and dark-mode-toggle.tsx. Replace these selectors with a
+     * class that gets added to images that should be inverted, so the set of
+     * extensions can have a single representation in TypeScript code.
+     */
     img[src$=".png"],
     img[src$=".svg"],
+    img[src$=".gif"],
     .graphie:not(.perseus-widget-plotter),
     .mathjax-wrapper:not(.graphie:not(.perseus-widget-plotter) *) {
         /* This filter is applied to PNG/SVG images, Graphie (excluding the

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -373,7 +373,6 @@
      */
     img[src$=".png"],
     img[src$=".svg"],
-    img[src$=".gif"],
     .graphie:not(.perseus-widget-plotter),
     .mathjax-wrapper:not(.graphie:not(.perseus-widget-plotter) *) {
         /* This filter is applied to PNG/SVG images, Graphie (excluding the

--- a/packages/perseus/src/styles/widgets/image.css
+++ b/packages/perseus/src/styles/widgets/image.css
@@ -49,7 +49,6 @@
 .perseus-image-preview-container[data-wb-theme$="-dark"] {
     img[src$=".png"],
     img[src$=".svg"],
-    img[src$=".gif"],
     .graphie,
     .perseus-block-math .mathjax-wrapper {
         filter: invert(1) hue-rotate(180deg) brightness(1.5);

--- a/packages/perseus/src/styles/widgets/image.css
+++ b/packages/perseus/src/styles/widgets/image.css
@@ -49,6 +49,7 @@
 .perseus-image-preview-container[data-wb-theme$="-dark"] {
     img[src$=".png"],
     img[src$=".svg"],
+    img[src$=".gif"],
     .graphie,
     .perseus-block-math .mathjax-wrapper {
         filter: invert(1) hue-rotate(180deg) brightness(1.5);


### PR DESCRIPTION
## Summary:
Context: In dark mode, we use a CSS filter to invert the lightness of each pixel
in an image.  This allows diagrams authored with a transparent background and
black foreground to be visible against the dark background of the page.

However, we don't want to invert all images. Photographs and paintings should
not be inverted in dark mode. We never invert JPG images, since those are likely
to be photographs, and we also don't invert GIFs. Content creators can also use
the "Suppress Dark Mode Filter" toggle in the image widget editor to turn off
the inversion for selected images.

Previously, this option was only available for PNGs. But we've encountered some
real-world examples where SVG images should not be inverted. Therefore, we
are expanding the setting to SVGs.

Issue: LEMS-4473

## Test plan:

- View the EditorPage story in Storybook
- Add an image widget
- Set the image URL to
  `https://ka-perseus-images.s3.amazonaws.com/34a448332ebd1515364999919ae1b646aaebba0f.svg`
- The "Suppress Dark Mode Filter" toggle should be enabled and effective.