### PR TITLE
[CLASS-13991] Stop swapping scroll caret icons on isRTL

### DIFF
--- a/.changeset/shaggy-emus-bet.md
+++ b/.changeset/shaggy-emus-bet.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus": patch
+---
+
+Pass LTR-facing directional icons and let PhosphorIcon mirror them in RTL, opting the graph-editor's absolute-axis arrows out.

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -30,7 +30,7 @@ exports[`ArticleEditor should match snapshot for editing disabled for all widget
                     class="default_7zhre1-o_O-inlineStyles_d7xzml"
                   >
                     <span
-                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-collapsed_zgg88f-o_O-inlineStyles_u4fgyh"
+                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-collapsed_zgg88f-o_O-inlineStyles_u4fgyh"
                     />
                     <span>
                       Issues
@@ -518,7 +518,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           categorizer 1
@@ -953,7 +953,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           definition 1
@@ -1048,7 +1048,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           dropdown 1
@@ -1337,7 +1337,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           expression 1
@@ -2111,7 +2111,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           explanation 1
@@ -2375,7 +2375,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           free-response 1
@@ -2605,7 +2605,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           graded-group 1
@@ -2846,7 +2846,7 @@ table: [[☃ table 1]]
                                   class="default_7zhre1-o_O-inlineStyles_d7xzml"
                                 >
                                   <span
-                                    class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                                    class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                                   />
                                   <span>
                                     numeric-input 3
@@ -2921,7 +2921,7 @@ table: [[☃ table 1]]
                                       General Settings
                                     </span>
                                     <span
-                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                                     />
                                   </div>
                                 </button>
@@ -3088,7 +3088,7 @@ table: [[☃ table 1]]
                                       Answers
                                     </span>
                                     <span
-                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                                     />
                                   </div>
                                 </button>
@@ -3824,7 +3824,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           graded-group-set 1
@@ -4068,7 +4068,7 @@ table: [[☃ table 1]]
                                     class="default_7zhre1-o_O-inlineStyles_d7xzml"
                                   >
                                     <span
-                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                                     />
                                     <span>
                                       numeric-input 4
@@ -4143,7 +4143,7 @@ table: [[☃ table 1]]
                                         General Settings
                                       </span>
                                       <span
-                                        class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                                        class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                                       />
                                     </div>
                                   </button>
@@ -4310,7 +4310,7 @@ table: [[☃ table 1]]
                                         Answers
                                       </span>
                                       <span
-                                        class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                                        class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                                       />
                                     </div>
                                   </button>
@@ -4866,7 +4866,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           grapher 1
@@ -6711,7 +6711,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           group 1
@@ -6929,7 +6929,7 @@ table: [[☃ table 1]]
                                   class="default_7zhre1-o_O-inlineStyles_d7xzml"
                                 >
                                   <span
-                                    class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                                    class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                                   />
                                   <span>
                                     numeric-input 2
@@ -7004,7 +7004,7 @@ table: [[☃ table 1]]
                                       General Settings
                                     </span>
                                     <span
-                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                                     />
                                   </div>
                                 </button>
@@ -7171,7 +7171,7 @@ table: [[☃ table 1]]
                                       Answers
                                     </span>
                                     <span
-                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                                     />
                                   </div>
                                 </button>
@@ -7550,7 +7550,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           image 1
@@ -8137,7 +8137,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           input-number 1
@@ -8212,7 +8212,7 @@ table: [[☃ table 1]]
                             General Settings
                           </span>
                           <span
-                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                           />
                         </div>
                       </button>
@@ -8379,7 +8379,7 @@ table: [[☃ table 1]]
                             Answers
                           </span>
                           <span
-                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                           />
                         </div>
                       </button>
@@ -8755,7 +8755,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           interaction 1
@@ -9470,7 +9470,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           interactive-graph 1
@@ -9628,7 +9628,7 @@ table: [[☃ table 1]]
                             Description
                           </span>
                           <span
-                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                           />
                         </div>
                       </button>
@@ -11091,7 +11091,7 @@ table: [[☃ table 1]]
                               Start coordinates
                             </span>
                             <span
-                              class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                              class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                             />
                           </div>
                         </button>
@@ -11279,7 +11279,7 @@ table: [[☃ table 1]]
                             Screen reader tree
                           </span>
                           <span
-                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                           />
                         </div>
                       </button>
@@ -11535,7 +11535,7 @@ table: [[☃ table 1]]
                             Common Graph Settings
                           </span>
                           <span
-                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                           />
                         </div>
                       </button>
@@ -12207,7 +12207,7 @@ table: [[☃ table 1]]
                             Locked Figures
                           </span>
                           <span
-                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                           />
                         </div>
                       </button>
@@ -12594,7 +12594,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           label-image 1
@@ -12957,7 +12957,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           matcher 1
@@ -13164,7 +13164,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           matrix 1
@@ -13412,7 +13412,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           measurer 1
@@ -13571,7 +13571,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           number-line 1
@@ -13982,7 +13982,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           numeric-input 1
@@ -14057,7 +14057,7 @@ table: [[☃ table 1]]
                             General Settings
                           </span>
                           <span
-                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                           />
                         </div>
                       </button>
@@ -14224,7 +14224,7 @@ table: [[☃ table 1]]
                             Answers
                           </span>
                           <span
-                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                           />
                         </div>
                       </button>
@@ -14601,7 +14601,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           orderer 1
@@ -14747,7 +14747,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           plotter 1
@@ -15230,7 +15230,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           radio 1
@@ -15774,7 +15774,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           sorter 1
@@ -16184,7 +16184,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           table 1

--- a/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
@@ -153,7 +153,7 @@ exports[`EditorPage should match snapshot for editing disabled for all widgets 1
                   class="default_7zhre1-o_O-inlineStyles_d7xzml"
                 >
                   <span
-                    class="svg_1q6jc65-o_O-small_6q1hy-o_O-collapsed_zgg88f-o_O-inlineStyles_u4fgyh"
+                    class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-collapsed_zgg88f-o_O-inlineStyles_u4fgyh"
                   />
                   <span>
                     Issues
@@ -630,7 +630,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           categorizer 1
@@ -1065,7 +1065,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           definition 1
@@ -1160,7 +1160,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           dropdown 1
@@ -1449,7 +1449,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           expression 1
@@ -2223,7 +2223,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           explanation 1
@@ -2487,7 +2487,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           free-response 1
@@ -2717,7 +2717,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           graded-group 1
@@ -2958,7 +2958,7 @@ table: [[☃ table 1]]
                                   class="default_7zhre1-o_O-inlineStyles_d7xzml"
                                 >
                                   <span
-                                    class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                                    class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                                   />
                                   <span>
                                     numeric-input 3
@@ -3033,7 +3033,7 @@ table: [[☃ table 1]]
                                       General Settings
                                     </span>
                                     <span
-                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                                     />
                                   </div>
                                 </button>
@@ -3200,7 +3200,7 @@ table: [[☃ table 1]]
                                       Answers
                                     </span>
                                     <span
-                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                                     />
                                   </div>
                                 </button>
@@ -3936,7 +3936,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           graded-group-set 1
@@ -4180,7 +4180,7 @@ table: [[☃ table 1]]
                                     class="default_7zhre1-o_O-inlineStyles_d7xzml"
                                   >
                                     <span
-                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                                     />
                                     <span>
                                       numeric-input 4
@@ -4255,7 +4255,7 @@ table: [[☃ table 1]]
                                         General Settings
                                       </span>
                                       <span
-                                        class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                                        class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                                       />
                                     </div>
                                   </button>
@@ -4422,7 +4422,7 @@ table: [[☃ table 1]]
                                         Answers
                                       </span>
                                       <span
-                                        class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                                        class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                                       />
                                     </div>
                                   </button>
@@ -4978,7 +4978,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           grapher 1
@@ -6823,7 +6823,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           group 1
@@ -7041,7 +7041,7 @@ table: [[☃ table 1]]
                                   class="default_7zhre1-o_O-inlineStyles_d7xzml"
                                 >
                                   <span
-                                    class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                                    class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                                   />
                                   <span>
                                     numeric-input 2
@@ -7116,7 +7116,7 @@ table: [[☃ table 1]]
                                       General Settings
                                     </span>
                                     <span
-                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                                     />
                                   </div>
                                 </button>
@@ -7283,7 +7283,7 @@ table: [[☃ table 1]]
                                       Answers
                                     </span>
                                     <span
-                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                                     />
                                   </div>
                                 </button>
@@ -7662,7 +7662,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           image 1
@@ -8200,7 +8200,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           input-number 1
@@ -8275,7 +8275,7 @@ table: [[☃ table 1]]
                             General Settings
                           </span>
                           <span
-                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                           />
                         </div>
                       </button>
@@ -8442,7 +8442,7 @@ table: [[☃ table 1]]
                             Answers
                           </span>
                           <span
-                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                           />
                         </div>
                       </button>
@@ -8818,7 +8818,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           interaction 1
@@ -9533,7 +9533,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           interactive-graph 1
@@ -9691,7 +9691,7 @@ table: [[☃ table 1]]
                             Description
                           </span>
                           <span
-                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                           />
                         </div>
                       </button>
@@ -11154,7 +11154,7 @@ table: [[☃ table 1]]
                               Start coordinates
                             </span>
                             <span
-                              class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                              class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                             />
                           </div>
                         </button>
@@ -11342,7 +11342,7 @@ table: [[☃ table 1]]
                             Screen reader tree
                           </span>
                           <span
-                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                           />
                         </div>
                       </button>
@@ -11598,7 +11598,7 @@ table: [[☃ table 1]]
                             Common Graph Settings
                           </span>
                           <span
-                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                           />
                         </div>
                       </button>
@@ -12270,7 +12270,7 @@ table: [[☃ table 1]]
                             Locked Figures
                           </span>
                           <span
-                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                           />
                         </div>
                       </button>
@@ -12657,7 +12657,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           label-image 1
@@ -13020,7 +13020,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           matcher 1
@@ -13227,7 +13227,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           matrix 1
@@ -13475,7 +13475,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           measurer 1
@@ -13634,7 +13634,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           number-line 1
@@ -14045,7 +14045,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           numeric-input 1
@@ -14120,7 +14120,7 @@ table: [[☃ table 1]]
                             General Settings
                           </span>
                           <span
-                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                           />
                         </div>
                       </button>
@@ -14287,7 +14287,7 @@ table: [[☃ table 1]]
                             Answers
                           </span>
                           <span
-                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                           />
                         </div>
                       </button>
@@ -14664,7 +14664,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           orderer 1
@@ -14810,7 +14810,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           plotter 1
@@ -15293,7 +15293,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           radio 1
@@ -15837,7 +15837,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           sorter 1
@@ -16247,7 +16247,7 @@ table: [[☃ table 1]]
                         class="default_7zhre1-o_O-inlineStyles_d7xzml"
                       >
                         <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
+                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-mirroredInRtl_ugydfe-o_O-expanded_t9diki-o_O-inlineStyles_u4fgyh"
                         />
                         <span>
                           table 1

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-polygon-settings.tsx
@@ -8,6 +8,7 @@ import {
 } from "@khanacademy/perseus-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
+import {PhosphorIcon} from "@khanacademy/wonder-blocks-icon";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {Spring} from "@khanacademy/wonder-blocks-layout";
 import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
@@ -345,7 +346,14 @@ const LockedPolygonSettings = (props: Props) => {
 
                     <Spring />
 
-                    {/* Buttons to move the entire polygon */}
+                    {/* Buttons to move the entire polygon.
+
+                        The left/right arrows are passed as elements so they can
+                        set `mirrorInRtl={false}`. These point along the graph's
+                        x-axis, which is absolute — "left" means decreasing x in
+                        every locale — so they must not flip in RTL the way a
+                        "back" arrow would. The up/down arrows need nothing,
+                        since only the horizontal glyphs are mirrored. */}
                     <View className={styles.movementButtonsContainer}>
                         <IconButton
                             aria-label="Move polygon up"
@@ -359,7 +367,12 @@ const LockedPolygonSettings = (props: Props) => {
                             <IconButton
                                 aria-label="Move polygon left"
                                 size="small"
-                                icon={arrowFatLeft}
+                                icon={
+                                    <PhosphorIcon
+                                        icon={arrowFatLeft}
+                                        mirrorInRtl={false}
+                                    />
+                                }
                                 kind="tertiary"
                                 disabled={editingDisabled}
                                 onClick={() => handlePolygonMove("left")}
@@ -375,7 +388,12 @@ const LockedPolygonSettings = (props: Props) => {
                             <IconButton
                                 aria-label="Move polygon right"
                                 size="small"
-                                icon={arrowFatRight}
+                                icon={
+                                    <PhosphorIcon
+                                        icon={arrowFatRight}
+                                        mirrorInRtl={false}
+                                    />
+                                }
                                 kind="tertiary"
                                 disabled={editingDisabled}
                                 onClick={() => handlePolygonMove("right")}

--- a/packages/perseus/src/components/scrollable-view.tsx
+++ b/packages/perseus/src/components/scrollable-view.tsx
@@ -35,7 +35,6 @@ interface ScrollState {
     isScrollable: boolean;
     canScrollStart: boolean;
     canScrollEnd: boolean;
-    isRTL: boolean;
     scroll: (direction: "start" | "end") => void;
     scrollDescription: string;
 }
@@ -181,7 +180,6 @@ function ScrollableArea({
             isScrollable: newIsScrollable,
             canScrollStart: newCanScrollStart,
             canScrollEnd: newCanScrollEnd,
-            isRTL: newIsRtl,
             scroll,
             scrollDescription: scrollDescription || strings.scrollAnswers,
         };
@@ -294,7 +292,7 @@ function ScrollControls({
             aria-label={description}
         >
             <IconButton
-                icon={scrollState.isRTL ? caretRightIcon : caretLeftIcon}
+                icon={caretLeftIcon}
                 actionType="neutral"
                 kind="secondary"
                 size="small"
@@ -303,7 +301,7 @@ function ScrollControls({
                 disabled={!scrollState.canScrollStart}
             />
             <IconButton
-                icon={scrollState.isRTL ? caretLeftIcon : caretRightIcon}
+                icon={caretRightIcon}
                 actionType="neutral"
                 kind="secondary"
                 size="small"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ catalogs:
       specifier: 7.6.10
       version: 7.6.10
     '@khanacademy/wonder-blocks-icon':
-      specifier: 5.3.23
-      version: 5.3.23
+      specifier: 6.0.0
+      version: 6.0.0
     '@khanacademy/wonder-blocks-icon-button':
       specifier: 11.4.5
       version: 11.4.5
@@ -654,7 +654,7 @@ importers:
         version: 7.6.10(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon':
         specifier: catalog:devDeps
-        version: 5.3.23(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 6.0.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon-button':
         specifier: catalog:devDeps
         version: 11.4.5(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -824,7 +824,7 @@ importers:
         version: 7.6.10(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon':
         specifier: catalog:devDeps
-        version: 5.3.23(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 6.0.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon-button':
         specifier: catalog:devDeps
         version: 11.4.5(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -2521,6 +2521,13 @@ packages:
 
   '@khanacademy/wonder-blocks-icon@5.3.23':
     resolution: {integrity: sha512-6ush1EwUmCo9ysq9BVOMEfKEBzLshl4fVXl95UujOG9VULQYYGHEioriKOc3xvoMlWO7QjKxd5LMJ0ybST8BMQ==}
+    peerDependencies:
+      '@phosphor-icons/core': ^2.0.2
+      aphrodite: ^1.2.5
+      react: 18.2.0
+
+  '@khanacademy/wonder-blocks-icon@6.0.0':
+    resolution: {integrity: sha512-jEp9wZ0nKvZaHoUj1wrQwKvn/nVcQG919g5A1yJd2IBxDQGnwQBJhR65pCWKPB7yZOGpdC/lEOazeJ7JIq4ZHg==}
     peerDependencies:
       '@phosphor-icons/core': ^2.0.2
       aphrodite: ^1.2.5
@@ -11679,6 +11686,19 @@ snapshots:
       - react-dom
 
   '@khanacademy/wonder-blocks-icon@5.3.23(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@khanacademy/wonder-blocks-core': 12.4.4(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-tokens': 17.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@phosphor-icons/core': 2.0.2
+      aphrodite: 1.2.5
+      react: 18.2.0
+    transitivePeerDependencies:
+      - react-dom
+      - react-router
+      - react-router-dom
+      - react-router-dom-v5-compat
+
+  '@khanacademy/wonder-blocks-icon@6.0.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@khanacademy/wonder-blocks-core': 12.4.4(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 17.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -73,7 +73,7 @@ catalogs:
         "@khanacademy/wonder-blocks-dropdown": ^10.12.0
         "@khanacademy/wonder-blocks-form": ^7.6.10
         "@khanacademy/wonder-blocks-icon-button": ^11.4.5
-        "@khanacademy/wonder-blocks-icon": ^5.3.23
+        "@khanacademy/wonder-blocks-icon": ^6.0.0
         "@khanacademy/wonder-blocks-labeled-field": ^4.1.9
         "@khanacademy/wonder-blocks-layout": ^3.1.60
         "@khanacademy/wonder-blocks-link": ^10.3.9
@@ -114,7 +114,7 @@ catalogs:
         "@khanacademy/wonder-blocks-dropdown": 10.12.0
         "@khanacademy/wonder-blocks-form": 7.6.10
         "@khanacademy/wonder-blocks-icon-button": 11.4.5
-        "@khanacademy/wonder-blocks-icon": 5.3.23
+        "@khanacademy/wonder-blocks-icon": 6.0.0
         "@khanacademy/wonder-blocks-labeled-field": 4.1.9
         "@khanacademy/wonder-blocks-layout": 3.1.60
         "@khanacademy/wonder-blocks-link": 10.3.9


### PR DESCRIPTION
## Summary
`PhosphorIcon` now mirrors directional glyphs automatically in RTL
(`wonder-blocks-icon` 6.0.0), so choosing a caret from `isRTL` double-flips.
Two changes:

- **`scrollable-view.tsx`** — pass the LTR-facing carets and let mirroring
  handle direction. `isRTL` had no other readers on the file-local
  `ScrollState`, so it's dropped.
- **`locked-polygon-settings.tsx`** — the "move polygon left/right" arrows point
  along the graph's x-axis, which is absolute in every locale, so they opt out
  with `mirrorInRtl={false}`. `IconButton` doesn't forward that prop, so they
  pass a `PhosphorIcon` element as `icon`.

Also bumps `wonder-blocks-icon` to 6.0.0, which the override needs. Bumped by
hand rather than with `utils/sync-dependencies.ts`, since that syncs versions
*from* frontend and frontend stays on 5.3.23 until this release deploys there.

Issue: CLASS-13991

## Test plan

With `?lang=en-x-rtl`: scroll carets in a scrollable exercise point into the
content, and in the interactive-graph editor the left/right move arrows still
match the direction the polygon actually moves.
