### PR TITLE
Rewrite the Definition widget as a functional component

### DIFF
--- a/.changeset/huge-cases-knock.md
+++ b/.changeset/huge-cases-knock.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: The Definition widget is now a functional component.

--- a/packages/perseus/src/__tests__/renderer.new.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.new.test.tsx
@@ -6,6 +6,7 @@ import {
     generateImageOptions,
     generateTestPerseusItem,
     splitPerseusItem,
+    generateTestPerseusRenderer,
 } from "@khanacademy/perseus-core";
 import {act, screen, waitFor, within} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
@@ -906,12 +907,22 @@ describe("renderer", () => {
 
         it("should throw if widget provides invalid focus path", () => {
             // Arrange
-            const {renderer} = renderQuestion(definitionItem);
-            const [widget2] = renderer.findWidgets("definition 2");
+            const {renderer} = renderQuestion(
+                generateTestPerseusRenderer({
+                    content: "[[\u2603 mock-widget 1]]",
+                    widgets: {
+                        "mock-widget 1": {
+                            type: "mock-widget",
+                            options: {value: ""},
+                        },
+                    },
+                }),
+            );
+            const [widget] = renderer.findWidgets("mock-widget 1");
 
             // Act and Assert
             expect(() => {
-                widget2.props.onFocus("this is not an array");
+                widget.props.onFocus("this is not an array");
             }).toThrow("widget props.onFocus focusPath must be an Array");
         });
 

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -3,6 +3,7 @@ import {describe, beforeAll, beforeEach, afterEach, it} from "@jest/globals";
 import {
     generateImageOptions,
     generateTestPerseusItem,
+    generateTestPerseusRenderer,
     splitPerseusItem,
 } from "@khanacademy/perseus-core";
 import {act, screen, waitFor, within} from "@testing-library/react";
@@ -903,12 +904,22 @@ describe("renderer", () => {
 
         it("should throw if widget provides invalid focus path", () => {
             // Arrange
-            const {renderer} = renderQuestion(definitionItem);
-            const [widget2] = renderer.findWidgets("definition 2");
+            const {renderer} = renderQuestion(
+                generateTestPerseusRenderer({
+                    content: "[[\u2603 mock-widget 1]]",
+                    widgets: {
+                        "mock-widget 1": {
+                            type: "mock-widget",
+                            options: {value: ""},
+                        },
+                    },
+                }),
+            );
+            const [widget] = renderer.findWidgets("mock-widget 1");
 
             // Act and Assert
             expect(() => {
-                widget2.props.onFocus("this is not an array");
+                widget.props.onFocus("this is not an array");
             }).toThrow("widget props.onFocus focusPath must be an Array");
         });
 

--- a/packages/perseus/src/widgets/definition/definition.tsx
+++ b/packages/perseus/src/widgets/definition/definition.tsx
@@ -48,8 +48,8 @@ const Definition = forwardRef<Widget, Props>(function Definition(props, ref) {
                     dismissEnabled
                     content={
                         <PopoverContentCore
+                            // TODO: replace stylesLegacy with `className={styles.tooltipBody}` once 'className' is supported
                             style={stylesLegacy.tooltipBody}
-                            // className={styles.tooltipBody} - uncomment when 'className' is supported
                             closeButtonVisible={true}
                         >
                             <Renderer

--- a/packages/perseus/src/widgets/definition/definition.tsx
+++ b/packages/perseus/src/widgets/definition/definition.tsx
@@ -1,10 +1,12 @@
 import Clickable from "@khanacademy/wonder-blocks-clickable";
+import {useOnMountEffect} from "@khanacademy/wonder-blocks-core";
 import {Popover, PopoverContentCore} from "@khanacademy/wonder-blocks-popover";
 import * as React from "react";
+import {forwardRef, useImperativeHandle} from "react";
 
-import {PerseusI18nContext} from "../../components/i18n-context";
-import {withDependencies} from "../../components/with-dependencies";
+import {usePerseusI18n} from "../../components/i18n-context";
 import {DefinitionConsumer} from "../../definition-context";
+import {useDependencies} from "../../dependencies";
 import Renderer from "../../renderer";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/definition/definition-ai-utils";
 
@@ -12,96 +14,78 @@ import styles from "./definition.module.css";
 // TODO (LEMS-3815): Legacy styling - Remove this code
 import stylesLegacy from "./definition_legacy-styles";
 
-import type {
-    PerseusDependenciesV2,
-    Widget,
-    WidgetExports,
-    WidgetProps,
-} from "../../types";
+import type {Widget, WidgetExports, WidgetProps} from "../../types";
 import type {DefinitionPromptJSON} from "../../widget-ai-utils/definition/definition-ai-utils";
-import type {
-    PerseusDefinitionWidgetOptions,
-    PerseusRenderer,
-} from "@khanacademy/perseus-core";
+import type {PerseusDefinitionWidgetOptions} from "@khanacademy/perseus-core";
 
-type DefinitionProps = WidgetProps<PerseusDefinitionWidgetOptions> & {
-    widgets: PerseusRenderer["widgets"];
-    dependencies: PerseusDependenciesV2;
-};
+type Props = WidgetProps<PerseusDefinitionWidgetOptions>;
 
-class Definition extends React.Component<DefinitionProps> implements Widget {
-    static contextType = PerseusI18nContext;
-    declare context: React.ContextType<typeof PerseusI18nContext>;
+const Definition = forwardRef<Widget, Props>(function Definition(props, ref) {
+    const {strings} = usePerseusI18n();
+    const dependencies = useDependencies();
 
-    // this just helps with TS weak typing when a Widget
-    // doesn't implement any Widget methods
-    isWidget = true as const;
-
-    componentDidMount(): void {
-        this.props.dependencies.analytics.onAnalyticsEvent({
+    useOnMountEffect(() => {
+        dependencies.analytics.onAnalyticsEvent({
             type: "perseus:widget:rendered:ti",
             payload: {
                 widgetSubType: "null",
                 widgetType: "definition",
-                widgetId: this.props.widgetId,
+                widgetId: props.widgetId,
             },
         });
-    }
+    });
 
-    getPromptJSON(): DefinitionPromptJSON {
-        return _getPromptJSON(this.props);
-    }
+    useImperativeHandle(ref, () => ({
+        getPromptJSON(): DefinitionPromptJSON {
+            return _getPromptJSON(props);
+        },
+    }));
 
-    render(): React.ReactNode {
-        return (
-            <DefinitionConsumer>
-                {({activeDefinitionId, setActiveDefinitionId}) => (
-                    <Popover
-                        dismissEnabled
-                        content={
-                            <PopoverContentCore
-                                style={stylesLegacy.tooltipBody}
-                                // className={styles.tooltipBody} - uncomment when 'className' is supported
-                                closeButtonVisible={true}
-                            >
-                                <Renderer
-                                    apiOptions={this.props.apiOptions}
-                                    content={this.props.options.definition}
-                                    widgets={this.props.widgets}
-                                    strings={this.context.strings}
-                                />
-                            </PopoverContentCore>
-                        }
-                        opened={activeDefinitionId === this.props.widgetId}
-                        onClose={() => setActiveDefinitionId(null)}
-                        placement="top"
-                    >
-                        <Clickable
-                            onClick={() => {
-                                this.props.trackInteraction();
-                                setActiveDefinitionId(this.props.widgetId);
-                            }}
-                            aria-label={this.context.strings.definitionIdentifier(
-                                {word: this.props.options.togglePrompt},
-                            )}
+    return (
+        <DefinitionConsumer>
+            {({activeDefinitionId, setActiveDefinitionId}) => (
+                <Popover
+                    dismissEnabled
+                    content={
+                        <PopoverContentCore
+                            style={stylesLegacy.tooltipBody}
+                            // className={styles.tooltipBody} - uncomment when 'className' is supported
+                            closeButtonVisible={true}
                         >
-                            {() => (
-                                <span className={styles.definition}>
-                                    {this.props.options.togglePrompt}
-                                </span>
-                            )}
-                        </Clickable>
-                    </Popover>
-                )}
-            </DefinitionConsumer>
-        );
-    }
-}
-
-const WrappedDefinition = withDependencies(Definition);
+                            <Renderer
+                                apiOptions={props.apiOptions}
+                                content={props.options.definition}
+                                strings={strings}
+                            />
+                        </PopoverContentCore>
+                    }
+                    opened={activeDefinitionId === props.widgetId}
+                    onClose={() => setActiveDefinitionId(null)}
+                    placement="top"
+                >
+                    <Clickable
+                        onClick={() => {
+                            props.trackInteraction();
+                            setActiveDefinitionId(props.widgetId);
+                        }}
+                        aria-label={strings.definitionIdentifier({
+                            word: props.options.togglePrompt,
+                        })}
+                    >
+                        {() => (
+                            <span className={styles.definition}>
+                                {props.options.togglePrompt}
+                            </span>
+                        )}
+                    </Clickable>
+                </Popover>
+            )}
+        </DefinitionConsumer>
+    );
+});
 
 export default {
     name: "definition",
     displayName: "Definition",
-    widget: WrappedDefinition,
-} satisfies WidgetExports<typeof WrappedDefinition>;
+    widget: Definition,
+} satisfies WidgetExports<typeof Definition>;


### PR DESCRIPTION
## Summary:
This gets rid of the `withDependencies` HOC and simplifies the Props type.

Issue: LEMS-4426

## Test plan:

View the Definition stories in Storybook.