### PR TITLE
[Bug][Color][Label Image]Update tokens to fix contrast issues

### DIFF
--- a/.changeset/many-pants-divide.md
+++ b/.changeset/many-pants-divide.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix contrast issues with label image answer bubble

--- a/packages/perseus/src/widgets/label-image/answer-pill.tsx
+++ b/packages/perseus/src/widgets/label-image/answer-pill.tsx
@@ -94,5 +94,7 @@ const styles = StyleSheet.create({
         // Reset the Pill's default height in order to account
         // for multi-line pills.
         height: "auto",
+        color: semanticColor.core.foreground.knockout.default,
+        backgroundColor: semanticColor.core.background.instructive.strong,
     },
 });


### PR DESCRIPTION
## Summary:
Changed the font to a knockout token and general label image background to instructive strong to improve color contrast for accessibility.

Issue: LEMS-4449

## Test plan:
- Confirm color contrast of the label image answer bubbles is high enough
- Check snapshot changes are expected only
- Checks all pass