### PR TITLE
Delete the `serialize()` methods on the Renderers

### DIFF
--- a/.changeset/spotty-loops-stick.md
+++ b/.changeset/spotty-loops-stick.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": major
+"@khanacademy/perseus-editor": patch
+---
+
+The deprecated `Renderer#serialize()` method has been removed.

--- a/packages/perseus-editor/src/components/widget-editor.tsx
+++ b/packages/perseus-editor/src/components/widget-editor.tsx
@@ -57,7 +57,7 @@ export function _upgradeWidgetInfo(widgetInfo: PerseusWidget): PerseusWidget {
 // with all available transforms applied, but the results of those
 // transforms will not be propogated upwards until serialization.
 class WidgetEditor extends React.Component<Props, State> {
-    widget: React.RefObject<{
+    widgetSpecificEditor: React.RefObject<{
         serialize(): unknown;
         getSaveWarnings?: () => unknown;
     }>;
@@ -68,7 +68,7 @@ class WidgetEditor extends React.Component<Props, State> {
             showWidget: props.widgetIsOpen ?? true,
             widgetInfo: _upgradeWidgetInfo(props.widgetInfo),
         };
-        this.widget = React.createRef();
+        this.widgetSpecificEditor = React.createRef();
     }
 
     UNSAFE_componentWillReceiveProps(nextProps: Props) {
@@ -97,7 +97,7 @@ class WidgetEditor extends React.Component<Props, State> {
             ...this.state.widgetInfo,
             options: {
                 ...this.state.widgetInfo.options,
-                ...(this.widget.current?.serialize() ?? {}),
+                ...(this.widgetSpecificEditor.current?.serialize() ?? {}),
                 ...newOptions,
             },
         } as PerseusWidget;
@@ -136,7 +136,7 @@ class WidgetEditor extends React.Component<Props, State> {
     };
 
     getSaveWarnings = () => {
-        const issuesFunc = this.widget.current?.getSaveWarnings;
+        const issuesFunc = this.widgetSpecificEditor.current?.getSaveWarnings;
         return issuesFunc ? issuesFunc() : [];
     };
 
@@ -153,7 +153,9 @@ class WidgetEditor extends React.Component<Props, State> {
             // `{Ed && ...}` guard in render()). In that case fall back to the
             // last-known options rather than dereferencing a null ref, which
             // previously crashed the editor when toggling JSON mode.
-            options: this.widget.current?.serialize() ?? widgetInfo.options,
+            options:
+                this.widgetSpecificEditor.current?.serialize() ??
+                widgetInfo.options,
             version: widgetInfo.version,
         };
     };
@@ -235,7 +237,7 @@ class WidgetEditor extends React.Component<Props, State> {
                 >
                     {Ed && (
                         <Ed
-                            ref={this.widget}
+                            ref={this.widgetSpecificEditor}
                             onChange={this._handleWidgetChange}
                             static={widgetInfo.static}
                             graded={widgetInfo.graded}

--- a/packages/perseus/src/__tests__/renderer.new.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.new.test.tsx
@@ -1070,27 +1070,6 @@ describe("renderer", () => {
             // Act
             expect(widget2.getSerializedState).toHaveBeenCalled();
         });
-
-        it("should return each widget's state from serialize()", () => {
-            // Arrange
-            const {renderer} = renderQuestion(definitionItem);
-            const widgets = renderer.findWidgets((id) =>
-                ["definition 1", "definition 2", "definition 3"].includes(id),
-            );
-            widgets.forEach((w) => {
-                w.serialize = jest.fn(() => `State: ${w.props.widgetId}`);
-            });
-
-            // Act
-            const state = renderer.serialize();
-
-            // Assert
-            expect(state).toStrictEqual({
-                "definition 1": "State: definition 1",
-                "definition 2": "State: definition 2",
-                "definition 3": "State: definition 3",
-            });
-        });
     });
 
     describe("finding widgets", () => {

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -1067,27 +1067,6 @@ describe("renderer", () => {
             // Act
             expect(widget2.getSerializedState).toHaveBeenCalled();
         });
-
-        it("should return each widget's state from serialize()", () => {
-            // Arrange
-            const {renderer} = renderQuestion(definitionItem);
-            const widgets = renderer.findWidgets((id) =>
-                ["definition 1", "definition 2", "definition 3"].includes(id),
-            );
-            widgets.forEach((w) => {
-                w.serialize = jest.fn(() => `State: ${w.props.widgetId}`);
-            });
-
-            // Act
-            const state = renderer.serialize();
-
-            // Assert
-            expect(state).toStrictEqual({
-                "definition 1": "State: definition 1",
-                "definition 2": "State: definition 2",
-                "definition 3": "State: definition 3",
-            });
-        });
     });
 
     describe("finding widgets", () => {

--- a/packages/perseus/src/renderer.new.tsx
+++ b/packages/perseus/src/renderer.new.tsx
@@ -1420,30 +1420,6 @@ class Renderer
     };
 
     /**
-     * Serializes widget state. Seems to be used only by editors though.
-     *
-     * @deprecated and likely a very broken API
-     * [LEMS-3185] do not trust serializedState
-     */
-    serialize: () => Record<any, any> = () => {
-        const state: Record<string, any> = {};
-        _.each(
-            this.state.widgetInfo,
-            function (info, id) {
-                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                // eslint-disable-next-line @typescript-eslint/no-invalid-this
-                const widget = this.getWidgetInstance(id);
-                const s = widget.serialize();
-                if (!_.isEmpty(s)) {
-                    state[id] = s;
-                }
-            },
-            this,
-        );
-        return state;
-    };
-
-    /**
      * Returns an array of widget ids that are empty (meaning widgets where the
      * learner has not interacted with the widget yet or has not filled in all
      * fields).  For example, the `interactive-graph` widget is considered

--- a/packages/perseus/src/renderer.old.tsx
+++ b/packages/perseus/src/renderer.old.tsx
@@ -1413,30 +1413,6 @@ class Renderer
     };
 
     /**
-     * Serializes widget state. Seems to be used only by editors though.
-     *
-     * @deprecated and likely a very broken API
-     * [LEMS-3185] do not trust serializedState
-     */
-    serialize: () => Record<any, any> = () => {
-        const state: Record<string, any> = {};
-        _.each(
-            this.state.widgetInfo,
-            function (info, id) {
-                // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
-                // eslint-disable-next-line @typescript-eslint/no-invalid-this
-                const widget = this.getWidgetInstance(id);
-                const s = widget.serialize();
-                if (!_.isEmpty(s)) {
-                    state[id] = s;
-                }
-            },
-            this,
-        );
-        return state;
-    };
-
-    /**
      * Returns an array of widget ids that are empty (meaning widgets where the
      * learner has not interacted with the widget yet or has not filled in all
      * fields).  For example, the `interactive-graph` widget is considered


### PR DESCRIPTION
## Summary:
Nothing in Perseus or Frontend was calling these methods. They were only called
by the tests I deleted, and those tests were only passing because they were
using an unrealistic mock for the widget. None of the real widgets implement a
`serialize()` method.

I renamed the ref in the `WidgetEditor` to make it clearer that the
`serialize()` method it calls is implemented by the widget-specific editors,
not by the widgets themselves. Based on the doc comment on the deleted
`serialize` methods, this seems to have caused confusion in the past.

This unblocks #4106 — the deleted Renderer tests were failing on that branch.

Issue: none

## Test plan:

You should be able to add and edit a widget in the EditorPage stories.