### PR TITLE
[Bug] [Color] Tokenize the drop-shadow on movable points of the line plot

### DIFF
--- a/.changeset/eleven-moons-shine.md
+++ b/.changeset/eleven-moons-shine.md
@@ -1,5 +1,0 @@
----
-"@khanacademy/perseus": patch
----
-
-On mobile, the number line's point now loses its halo as soon as the learner makes the circle open, instead of keeping the halo until the widget is re-rendered from scratch.

--- a/.changeset/eleven-moons-shine.md
+++ b/.changeset/eleven-moons-shine.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+On mobile, the number line's point now loses its halo as soon as the learner makes the circle open, instead of keeping the halo until the widget is re-rendered from scratch.

--- a/.changeset/witty-nights-throw.md
+++ b/.changeset/witty-nights-throw.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": minor
+---
+
+The style of the interactive points on Plotter's line plots has been updated. The points now have a colored "halo" that follows the theme, similar to Interactive Graph's points.

--- a/packages/perseus/src/components/graphie-movables.ts
+++ b/packages/perseus/src/components/graphie-movables.ts
@@ -38,7 +38,7 @@ const MovablePoint: any = GraphieClasses.createClass({
                 scale: 0.75,
                 ...(this.props.mobileStyleOverride || {}),
             },
-            shadow: true,
+            shadow: this.props.shadow ?? true,
             tooltip: this.props.showTooltips,
             pointSize: 7,
         });

--- a/packages/perseus/src/interactive2/movable-point-options.ts
+++ b/packages/perseus/src/interactive2/movable-point-options.ts
@@ -73,6 +73,11 @@ const draw = {
                 this.mouseTarget().toFront();
             }
         }
+        if (state.shadow !== prevState.shadow) {
+            // @ts-expect-error - TS2339 - Property 'state' does not exist on type '{ readonly basic: (state: any, prevState: any) => void; readonly highlight: (state: any, prevState: any) => void; }'.
+            this.state.visibleShape.setShadow(state.shadow);
+        }
+
         if (
             state.normalStyle !== prevState.normalStyle &&
             !_.isEqual(state.normalStyle, prevState.normalStyle)

--- a/packages/perseus/src/interactive2/movable-point.tsx
+++ b/packages/perseus/src/interactive2/movable-point.tsx
@@ -62,7 +62,7 @@ import Tex from "../util/tex";
 
 import InteractiveUtil from "./interactive-util";
 import MovablePointOptions from "./movable-point-options";
-import WrappedEllipse from "./wrapped-ellipse";
+import WrappedEllipse, {wrappedEllipseShadow} from "./wrapped-ellipse";
 
 import type {Movable} from "./movable";
 import type {Constraint, ConstraintCallbacks, Coord} from "./types";
@@ -356,8 +356,7 @@ export class MovablePoint {
                     const svgElem = state.visibleShape.wrapper;
 
                     if (state.shadow) {
-                        const filter =
-                            "drop-shadow(0px 0px 5px rgba(0, 0, 0, 0.5))";
+                        const filter = wrappedEllipseShadow;
                         svgElem.style.filter = filter;
                     }
 

--- a/packages/perseus/src/interactive2/wrapped-ellipse.ts
+++ b/packages/perseus/src/interactive2/wrapped-ellipse.ts
@@ -21,6 +21,7 @@ class WrappedEllipse extends WrappedDrawing {
     initialPoint: Coord;
     wrapper: HTMLDivElement;
     visibleShape: VisibleShape;
+    private hasShadow: boolean = false;
 
     constructor(
         graphie: any,
@@ -61,34 +62,45 @@ class WrappedEllipse extends WrappedDrawing {
             this.graphie.addToVisibleLayerWrapper(this.wrapper);
         }
 
-        if (options.shadow) {
-            const filter = wrappedEllipseShadow;
-            const wrapper = this.wrapper;
-            wrapper.style.filter = filter;
-
-            this.moveTo = function (point: any) {
-                const delta = kvector.subtract(
-                    this.graphie.scalePoint(point),
-                    this.graphie.scalePoint(this.initialPoint),
-                );
-                const do3dTransform = InteractiveUtil.getCanUse3dTransform();
-                const transform =
-                    "translateX(" +
-                    Math.round(delta[0]) +
-                    "px) " +
-                    "translateY(" +
-                    Math.round(delta[1]) +
-                    "px)" +
-                    (do3dTransform ? " translateZ(0)" : "");
-                this.transform(transform);
-            };
-        }
+        this.setShadow(options.shadow);
 
         if (options.disableMouseEventsOnWrapper) {
             this.wrapper.style.pointerEvents = "none";
             // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
             this.visibleShape.node.style.pointerEvents = "auto";
         }
+    }
+
+    /**
+     * Turns the ellipse's drop shadow on or off. Can be called at any time.
+     */
+    setShadow(shadow: boolean) {
+        this.hasShadow = shadow;
+        this.wrapper.style.filter = shadow ? wrappedEllipseShadow : "";
+    }
+
+    moveTo(point: Coord) {
+        if (!this.hasShadow) {
+            super.moveTo(point);
+            return;
+        }
+
+        // Round the translation to whole pixels; subpixel offsets make the
+        // drop shadow look blurry.
+        const delta = kvector.subtract(
+            this.graphie.scalePoint(point),
+            this.graphie.scalePoint(this.initialPoint),
+        );
+        const do3dTransform = InteractiveUtil.getCanUse3dTransform();
+        this.transform(
+            "translateX(" +
+                Math.round(delta[0]) +
+                "px) " +
+                "translateY(" +
+                Math.round(delta[1]) +
+                "px)" +
+                (do3dTransform ? " translateZ(0)" : ""),
+        );
     }
 }
 

--- a/packages/perseus/src/interactive2/wrapped-ellipse.ts
+++ b/packages/perseus/src/interactive2/wrapped-ellipse.ts
@@ -1,8 +1,6 @@
-import {vector as kvector} from "@khanacademy/kmath";
 import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import _ from "underscore";
 
-import InteractiveUtil from "./interactive-util";
 import WrappedDrawing from "./wrapped-drawing";
 
 import type {Coord} from "./types";
@@ -21,7 +19,6 @@ class WrappedEllipse extends WrappedDrawing {
     initialPoint: Coord;
     wrapper: HTMLDivElement;
     visibleShape: VisibleShape;
-    private hasShadow: boolean = false;
 
     constructor(
         graphie: any,
@@ -72,35 +69,10 @@ class WrappedEllipse extends WrappedDrawing {
     }
 
     /**
-     * Turns the ellipse's drop shadow on or off. Can be called at any time.
+     * Turns the ellipse's drop shadow on or off.
      */
     setShadow(shadow: boolean) {
-        this.hasShadow = shadow;
         this.wrapper.style.filter = shadow ? wrappedEllipseShadow : "";
-    }
-
-    moveTo(point: Coord) {
-        if (!this.hasShadow) {
-            super.moveTo(point);
-            return;
-        }
-
-        // Round the translation to whole pixels; subpixel offsets make the
-        // drop shadow look blurry.
-        const delta = kvector.subtract(
-            this.graphie.scalePoint(point),
-            this.graphie.scalePoint(this.initialPoint),
-        );
-        const do3dTransform = InteractiveUtil.getCanUse3dTransform();
-        this.transform(
-            "translateX(" +
-                Math.round(delta[0]) +
-                "px) " +
-                "translateY(" +
-                Math.round(delta[1]) +
-                "px)" +
-                (do3dTransform ? " translateZ(0)" : ""),
-        );
     }
 }
 

--- a/packages/perseus/src/interactive2/wrapped-ellipse.ts
+++ b/packages/perseus/src/interactive2/wrapped-ellipse.ts
@@ -13,6 +13,8 @@ const DEFAULT_OPTIONS = {
     disableMouseEventsOnWrapper: false,
 } as const;
 
+// NOTE: we're using a foreground color for the shadow here because
+// semanticColor.core.shadow.transparent.color isn't visible enough.
 export const wrappedEllipseShadow = `drop-shadow(0px 0px 2px ${semanticColor.core.foreground.instructive.default})`;
 
 class WrappedEllipse extends WrappedDrawing {

--- a/packages/perseus/src/interactive2/wrapped-ellipse.ts
+++ b/packages/perseus/src/interactive2/wrapped-ellipse.ts
@@ -1,4 +1,5 @@
 import {vector as kvector} from "@khanacademy/kmath";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import _ from "underscore";
 
 import InteractiveUtil from "./interactive-util";
@@ -13,6 +14,8 @@ const DEFAULT_OPTIONS = {
     shadow: false,
     disableMouseEventsOnWrapper: false,
 } as const;
+
+export const wrappedEllipseShadow = `drop-shadow(0px 0px 2px ${semanticColor.core.foreground.instructive.default})`;
 
 class WrappedEllipse extends WrappedDrawing {
     initialPoint: Coord;
@@ -59,7 +62,7 @@ class WrappedEllipse extends WrappedDrawing {
         }
 
         if (options.shadow) {
-            const filter = "drop-shadow(0px 0px 5px rgba(0, 0, 0, 0.5))";
+            const filter = wrappedEllipseShadow;
             const wrapper = this.wrapper;
             wrapper.style.filter = filter;
 

--- a/packages/perseus/src/widgets/number-line/__snapshots__/number-line.test.ts.snap
+++ b/packages/perseus/src/widgets/number-line/__snapshots__/number-line.test.ts.snap
@@ -2922,7 +2922,7 @@ exports[`number-line widget snapshots mobile: first mobile render 1`] = `
                   style="position: absolute; left: 0px; top: 0px;"
                 >
                   <div
-                    style="position: absolute; width: 24px; height: 24px; left: 17.999999999999993px; top: 28px; filter: drop-shadow(0px 0px 5px rgba(0, 0, 0, 0.5)); transform: translateX(0px) translateY(0px) translateZ(0);"
+                    style="position: absolute; width: 24px; height: 24px; left: 17.999999999999993px; top: 28px; filter: drop-shadow(0px 0px 2px var(--wb-semanticColor-core-foreground-instructive-default)); transform: translateX(0px) translateY(0px) translateZ(0);"
                   >
                     <svg
                       height="24"

--- a/packages/perseus/src/widgets/number-line/number-line.test.ts
+++ b/packages/perseus/src/widgets/number-line/number-line.test.ts
@@ -276,6 +276,29 @@ describe("number-line widget", () => {
             expect(postUserInput["number-line 1"].rel).toBe("gt");
         });
 
+        test("removes the point's drop shadow when the circle is made open on mobile", async () => {
+            // Arrange
+            const item = getAnswerfulItem(
+                "number-line",
+                getInequalityOptions(),
+            );
+            const {container} = renderQuestion(item.question, {isMobile: true});
+            // The shadow lives in an inline `filter` style on the point's
+            // wrapper; there's no accessible handle for it.
+            const shadowed = () =>
+                // eslint-disable-next-line testing-library/no-container, testing-library/no-node-access
+                container.querySelectorAll('[style*="drop-shadow"]');
+            expect(shadowed()).toHaveLength(1);
+
+            // Act
+            await userEvent.click(
+                screen.getByRole("button", {name: "Make circle open"}),
+            );
+
+            // Assert
+            expect(shadowed()).toHaveLength(0);
+        });
+
         // Regression (LEMS-3530)
         test("can have its divisions edited", async () => {
             renderQuestion(tickCtrl);

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -522,8 +522,6 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
                 ]}
                 // Only mobile points have shadows by default; desktop points
                 // have never had one, so don't turn one on here.
-                // FIXME: the shadow isn't updated when toggling isOpen via
-                //  handleToggleStrict().
                 shadow={!!props.apiOptions.isMobile && !isOpen}
                 normalStyle={normalStyle}
                 highlightStyle={highlightStyle}

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -520,6 +520,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
                         return [x, coord[1]];
                     },
                 ]}
+                shadow={!isOpen}
                 normalStyle={normalStyle}
                 highlightStyle={highlightStyle}
                 onMove={(coord) => {

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -520,6 +520,8 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
                         return [x, coord[1]];
                     },
                 ]}
+                // FIXME: the shadow isn't updated when toggling isOpen via
+                //  handleToggleStrict().
                 shadow={!isOpen}
                 normalStyle={normalStyle}
                 highlightStyle={highlightStyle}

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -520,8 +520,8 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
                         return [x, coord[1]];
                     },
                 ]}
-                // Only mobile points have shadows by default; desktop points
-                // have never had one, so don't turn one on here.
+                // Don't show a shadow on open points; it just makes the border
+                // look blurry.
                 shadow={!!props.apiOptions.isMobile && !isOpen}
                 normalStyle={normalStyle}
                 highlightStyle={highlightStyle}

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -520,9 +520,11 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
                         return [x, coord[1]];
                     },
                 ]}
+                // Only mobile points have shadows by default; desktop points
+                // have never had one, so don't turn one on here.
                 // FIXME: the shadow isn't updated when toggling isOpen via
                 //  handleToggleStrict().
-                shadow={!isOpen}
+                shadow={!!props.apiOptions.isMobile && !isOpen}
                 normalStyle={normalStyle}
                 highlightStyle={highlightStyle}
                 onMove={(coord) => {


### PR DESCRIPTION
## Summary:
Previously, the points had a black shadow, which was invisible in dark mode.
This PR changes the shadow to an `instructive` color to make the points stand
out more in every theme.

This also affects the movable points in the Grapher and Number Line widgets.

Issue: LEMS-4487

## Test plan:

Review the Plotter widget stories.