### PR TITLE
Replace default widget options with regular widget options

### DIFF
--- a/.changeset/cool-monkeys-throw.md
+++ b/.changeset/cool-monkeys-throw.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus-core": major
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus": patch
+---
+
+Remove *DefaultWidgetOptions and use Perseus*WidgetOptions instead

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -85,27 +85,15 @@ export {default as blankLogic} from "./widgets/blank";
 /** @hidden */
 export {default as categorizerLogic} from "./widgets/categorizer";
 /** @hidden */
-export type {CategorizerDefaultWidgetOptions} from "./widgets/categorizer";
-/** @hidden */
 export {default as csProgramLogic} from "./widgets/cs-program";
-/** @hidden */
-export type {CSProgramDefaultWidgetOptions} from "./widgets/cs-program";
 /** @hidden */
 export {default as definitionLogic} from "./widgets/definition";
 /** @hidden */
-export type {DefinitionDefaultWidgetOptions} from "./widgets/definition";
-/** @hidden */
 export {default as dropdownLogic} from "./widgets/dropdown";
-/** @hidden */
-export type {DropdownDefaultWidgetOptions} from "./widgets/dropdown";
 /** @hidden */
 export {default as explanationLogic} from "./widgets/explanation";
 /** @hidden */
-export type {ExplanationDefaultWidgetOptions} from "./widgets/explanation";
-/** @hidden */
 export {default as expressionLogic} from "./widgets/expression";
-/** @hidden */
-export type {ExpressionDefaultWidgetOptions} from "./widgets/expression";
 /** @hidden */
 export {default as deriveExtraKeys} from "./widgets/expression/derive-extra-keys";
 /** @hidden */
@@ -113,99 +101,51 @@ export {default as gradedGroupLogic} from "./widgets/graded-group";
 /** @hidden */
 export {default as freeResponseLogic} from "./widgets/free-response";
 /** @hidden */
-export type {FreeResponseDefaultWidgetOptions} from "./widgets/free-response";
-/** @hidden */
-export type {GradedGroupDefaultWidgetOptions} from "./widgets/graded-group";
-/** @hidden */
 export {default as gradedGroupSetLogic} from "./widgets/graded-group-set";
-/** @hidden */
-export type {GradedGroupSetDefaultWidgetOptions} from "./widgets/graded-group-set";
 /** @hidden */
 export {default as grapherLogic} from "./widgets/grapher";
 /** @hidden */
-export type {GrapherDefaultWidgetOptions} from "./widgets/grapher";
-/** @hidden */
 export {default as groupLogic} from "./widgets/group";
-/** @hidden */
-export type {GroupDefaultWidgetOptions} from "./widgets/group";
 /** @hidden */
 export {default as iframeLogic} from "./widgets/iframe";
 /** @hidden */
-export type {IFrameDefaultWidgetOptions} from "./widgets/iframe";
-/** @hidden */
 export {default as imageLogic} from "./widgets/image";
-/** @hidden */
-export type {ImageDefaultWidgetOptions} from "./widgets/image";
 /** @hidden */
 export {default as inputNumberLogic} from "./widgets/input-number";
 /** @hidden */
-export type {InputNumberDefaultWidgetOptions} from "./widgets/input-number";
-/** @hidden */
 export {default as interactionLogic} from "./widgets/interaction";
-/** @hidden */
-export type {InteractionDefaultWidgetOptions} from "./widgets/interaction";
 /** @hidden */
 export {default as interactiveGraphLogic} from "./widgets/interactive-graph";
 /** @hidden */
-export type {InteractiveGraphDefaultWidgetOptions} from "./widgets/interactive-graph";
-/** @hidden */
 export {default as labelImageLogic} from "./widgets/label-image";
-/** @hidden */
-export type {LabelImageDefaultWidgetOptions} from "./widgets/label-image";
 /** @hidden */
 export {default as matcherLogic} from "./widgets/matcher";
 /** @hidden */
-export type {MatcherDefaultWidgetOptions} from "./widgets/matcher";
-/** @hidden */
 export {default as matrixLogic} from "./widgets/matrix";
-/** @hidden */
-export type {MatrixDefaultWidgetOptions} from "./widgets/matrix";
 /** @hidden */
 export {default as measurerLogic} from "./widgets/measurer";
 /** @hidden */
-export type {MeasurerDefaultWidgetOptions} from "./widgets/measurer";
-/** @hidden */
 export {default as numberLineLogic} from "./widgets/number-line";
-/** @hidden */
-export type {NumberLineDefaultWidgetOptions} from "./widgets/number-line";
 /** @hidden */
 export {default as numericInputLogic} from "./widgets/numeric-input";
 /** @hidden */
-export type {NumericInputDefaultWidgetOptions} from "./widgets/numeric-input";
-/** @hidden */
 export {default as ordererLogic} from "./widgets/orderer";
-/** @hidden */
-export type {OrdererDefaultWidgetOptions} from "./widgets/orderer";
 /** @hidden */
 export {default as phetSimulationLogic} from "./widgets/phet-simulation";
 /** @hidden */
-export type {PhetSimulationDefaultWidgetOptions} from "./widgets/phet-simulation";
-/** @hidden */
 export {default as plotterLogic} from "./widgets/plotter";
-/** @hidden */
-export type {PlotterDefaultWidgetOptions} from "./widgets/plotter";
 /** @hidden */
 export {default as pythonProgramLogic} from "./widgets/python-program";
 /** @hidden */
-export type {PythonProgramDefaultWidgetOptions} from "./widgets/python-program";
-/** @hidden */
 export {default as radioLogic} from "./widgets/radio";
-/** @hidden */
-export type {RadioDefaultWidgetOptions} from "./widgets/radio";
 /** @hidden */
 export {usesNumCorrect} from "./widgets/radio/radio-util";
 /** @hidden */
 export {default as sorterLogic} from "./widgets/sorter";
 /** @hidden */
-export type {SorterDefaultWidgetOptions} from "./widgets/sorter";
-/** @hidden */
 export {default as tableLogic} from "./widgets/table";
 /** @hidden */
-export type {TableDefaultWidgetOptions} from "./widgets/table";
-/** @hidden */
 export {default as videoLogic} from "./widgets/video";
-/** @hidden */
-export type {VideoDefaultWidgetOptions} from "./widgets/video";
 
 /** @hidden */
 export {

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -176,7 +176,11 @@ export type * from "./widgets/logic-export.types";
 export * as CoreWidgetRegistry from "./widgets/core-widget-registry";
 
 /** @hidden */
-export {getOrdererPublicWidgetOptions} from "./widgets/orderer/orderer-util";
+export {
+    getOrdererPublicWidgetOptions,
+    mergeCards,
+    toCard,
+} from "./widgets/orderer/orderer-util";
 /** @hidden */
 export type {OrdererPublicWidgetOptions} from "./widgets/orderer/orderer-util";
 /** @hidden */

--- a/packages/perseus-core/src/widgets/categorizer/index.ts
+++ b/packages/perseus-core/src/widgets/categorizer/index.ts
@@ -4,12 +4,7 @@ import type {CategorizerPublicWidgetOptions} from "./categorizer-util";
 import type {PerseusCategorizerWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type CategorizerDefaultWidgetOptions = Pick<
-    PerseusCategorizerWidgetOptions,
-    "items" | "categories" | "values" | "randomizeItems"
->;
-
-const defaultWidgetOptions: CategorizerDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusCategorizerWidgetOptions = {
     items: [],
     categories: [],
     values: [],

--- a/packages/perseus-core/src/widgets/cs-program/index.ts
+++ b/packages/perseus-core/src/widgets/cs-program/index.ts
@@ -3,19 +3,9 @@ import {getCSProgramPublicWidgetOptions} from "./cs-program-util";
 import type {PerseusCSProgramWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type CSProgramDefaultWidgetOptions = Pick<
-    PerseusCSProgramWidgetOptions,
-    | "programID"
-    | "programType"
-    | "settings"
-    | "showEditor"
-    | "showButtons"
-    | "height"
->;
-
 const DEFAULT_HEIGHT = 400;
 
-const defaultWidgetOptions: CSProgramDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusCSProgramWidgetOptions = {
     programID: "",
     programType: null,
     settings: [{name: "", value: ""}],

--- a/packages/perseus-core/src/widgets/definition/index.ts
+++ b/packages/perseus-core/src/widgets/definition/index.ts
@@ -1,12 +1,7 @@
 import type {PerseusDefinitionWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type DefinitionDefaultWidgetOptions = Pick<
-    PerseusDefinitionWidgetOptions,
-    "togglePrompt" | "definition"
->;
-
-const defaultWidgetOptions: DefinitionDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusDefinitionWidgetOptions = {
     togglePrompt: "",
     definition: "",
 };

--- a/packages/perseus-core/src/widgets/dropdown/index.ts
+++ b/packages/perseus-core/src/widgets/dropdown/index.ts
@@ -4,12 +4,7 @@ import type {DropdownPublicWidgetOptions} from "./dropdown-util";
 import type {PerseusDropdownWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type DropdownDefaultWidgetOptions = Pick<
-    PerseusDropdownWidgetOptions,
-    "placeholder" | "choices"
->;
-
-const defaultWidgetOptions: DropdownDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusDropdownWidgetOptions = {
     placeholder: "",
     choices: [
         {

--- a/packages/perseus-core/src/widgets/explanation/index.ts
+++ b/packages/perseus-core/src/widgets/explanation/index.ts
@@ -1,12 +1,7 @@
 import type {PerseusExplanationWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type ExplanationDefaultWidgetOptions = Pick<
-    PerseusExplanationWidgetOptions,
-    "showPrompt" | "hidePrompt" | "explanation" | "widgets"
->;
-
-const defaultWidgetOptions: ExplanationDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusExplanationWidgetOptions = {
     showPrompt: "Explain",
     hidePrompt: "Hide explanation",
     explanation: "explanation goes here\n\nmore explanation",

--- a/packages/perseus-core/src/widgets/expression/index.ts
+++ b/packages/perseus-core/src/widgets/expression/index.ts
@@ -6,12 +6,7 @@ import type {WidgetLogic} from "../logic-export.types";
 
 const currentVersion = {major: 2, minor: 0};
 
-export type ExpressionDefaultWidgetOptions = Pick<
-    PerseusExpressionWidgetOptions,
-    "answerForms" | "times" | "buttonSets" | "functions"
->;
-
-const defaultWidgetOptions: ExpressionDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusExpressionWidgetOptions = {
     answerForms: [],
     times: false,
     buttonSets: ["basic"],

--- a/packages/perseus-core/src/widgets/free-response/index.ts
+++ b/packages/perseus-core/src/widgets/free-response/index.ts
@@ -4,16 +4,7 @@ import type {FreeResponsePublicWidgetOptions} from "./free-response-util";
 import type {PerseusFreeResponseWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type FreeResponseDefaultWidgetOptions = Pick<
-    PerseusFreeResponseWidgetOptions,
-    | "allowUnlimitedCharacters"
-    | "characterLimit"
-    | "placeholder"
-    | "question"
-    | "scoringCriteria"
->;
-
-const defaultWidgetOptions: FreeResponseDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusFreeResponseWidgetOptions = {
     allowUnlimitedCharacters: false,
     characterLimit: 500,
     placeholder: "Please provide response here",

--- a/packages/perseus-core/src/widgets/graded-group-set/index.ts
+++ b/packages/perseus-core/src/widgets/graded-group-set/index.ts
@@ -1,12 +1,7 @@
 import type {PerseusGradedGroupSetWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type GradedGroupSetDefaultWidgetOptions = Pick<
-    PerseusGradedGroupSetWidgetOptions,
-    "gradedGroups"
->;
-
-const defaultWidgetOptions: GradedGroupSetDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusGradedGroupSetWidgetOptions = {
     gradedGroups: [],
 };
 

--- a/packages/perseus-core/src/widgets/graded-group/index.ts
+++ b/packages/perseus-core/src/widgets/graded-group/index.ts
@@ -1,12 +1,7 @@
 import type {PerseusGradedGroupWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type GradedGroupDefaultWidgetOptions = Pick<
-    PerseusGradedGroupWidgetOptions,
-    "title" | "content" | "widgets" | "images" | "hint"
->;
-
-const defaultWidgetOptions: GradedGroupDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusGradedGroupWidgetOptions = {
     title: "",
     content: "",
     widgets: {},

--- a/packages/perseus-core/src/widgets/grapher/index.ts
+++ b/packages/perseus-core/src/widgets/grapher/index.ts
@@ -4,12 +4,7 @@ import type {GrapherPublicWidgetOptions} from "./grapher-util";
 import type {PerseusGrapherWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type GrapherDefaultWidgetOptions = Pick<
-    PerseusGrapherWidgetOptions,
-    "graph" | "correct" | "availableTypes"
->;
-
-const defaultWidgetOptions: GrapherDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusGrapherWidgetOptions = {
     graph: {
         labels: ["x", "y"],
         range: [

--- a/packages/perseus-core/src/widgets/group/index.ts
+++ b/packages/perseus-core/src/widgets/group/index.ts
@@ -4,12 +4,7 @@ import type {GroupPublicWidgetOptions} from "./group-util";
 import type {PerseusGroupWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type GroupDefaultWidgetOptions = Pick<
-    PerseusGroupWidgetOptions,
-    "content" | "widgets" | "images"
->;
-
-const defaultWidgetOptions: GroupDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusGroupWidgetOptions = {
     content: "",
     widgets: {},
     images: {},

--- a/packages/perseus-core/src/widgets/iframe/index.ts
+++ b/packages/perseus-core/src/widgets/iframe/index.ts
@@ -3,17 +3,7 @@ import {getIFramePublicWidgetOptions} from "./iframe-util";
 import type {PerseusIFrameWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type IFrameDefaultWidgetOptions = Pick<
-    PerseusIFrameWidgetOptions,
-    | "url"
-    | "settings"
-    | "width"
-    | "height"
-    | "allowFullScreen"
-    | "allowTopNavigation"
->;
-
-const defaultWidgetOptions: IFrameDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusIFrameWidgetOptions = {
     url: "",
     settings: [{name: "", value: ""}],
     width: "400",

--- a/packages/perseus-core/src/widgets/image/index.ts
+++ b/packages/perseus-core/src/widgets/image/index.ts
@@ -1,19 +1,7 @@
 import type {PerseusImageWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type ImageDefaultWidgetOptions = Pick<
-    PerseusImageWidgetOptions,
-    | "title"
-    | "range"
-    | "box"
-    | "backgroundImage"
-    | "scale"
-    | "labels"
-    | "alt"
-    | "caption"
->;
-
-const defaultWidgetOptions: ImageDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusImageWidgetOptions = {
     title: "",
     range: [
         [0, 10],
@@ -29,6 +17,11 @@ const defaultWidgetOptions: ImageDefaultWidgetOptions = {
     labels: [],
     alt: "",
     caption: "",
+    longDescription: "",
+    // Images are not decorative by default: an image with no alt text is
+    // treated as inaccessible (see `accessible` below) until an author either
+    // writes alt text or explicitly marks the image as decorative.
+    decorative: false,
 };
 
 const imageWidgetLogic: WidgetLogic<PerseusImageWidgetOptions> = {

--- a/packages/perseus-core/src/widgets/image/index.ts
+++ b/packages/perseus-core/src/widgets/image/index.ts
@@ -18,10 +18,9 @@ const defaultWidgetOptions: PerseusImageWidgetOptions = {
     alt: "",
     caption: "",
     longDescription: "",
-    // Marking an image decorative (rendering it with `alt=""` and no caption,
-    // title, or long description) is an explicit author choice, so it starts
-    // off. Note these defaults are inaccessible either way until a background
-    // image is chosen -- see `accessible` below.
+    // Images are not decorative by default: an image with no alt text is
+    // treated as inaccessible (see `accessible` below) until an author either
+    // writes alt text or explicitly marks the image as decorative.
     decorative: false,
 };
 

--- a/packages/perseus-core/src/widgets/image/index.ts
+++ b/packages/perseus-core/src/widgets/image/index.ts
@@ -18,9 +18,10 @@ const defaultWidgetOptions: PerseusImageWidgetOptions = {
     alt: "",
     caption: "",
     longDescription: "",
-    // Images are not decorative by default: an image with no alt text is
-    // treated as inaccessible (see `accessible` below) until an author either
-    // writes alt text or explicitly marks the image as decorative.
+    // Marking an image decorative (rendering it with `alt=""` and no caption,
+    // title, or long description) is an explicit author choice, so it starts
+    // off. Note these defaults are inaccessible either way until a background
+    // image is chosen -- see `accessible` below.
     decorative: false,
 };
 

--- a/packages/perseus-core/src/widgets/input-number/index.ts
+++ b/packages/perseus-core/src/widgets/input-number/index.ts
@@ -4,9 +4,7 @@ import type {InputNumberPublicWidgetOptions} from "./input-number-util";
 import type {PerseusInputNumberWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type InputNumberDefaultWidgetOptions = PerseusInputNumberWidgetOptions;
-
-const defaultWidgetOptions: InputNumberDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusInputNumberWidgetOptions = {
     textAlign: "left",
     coefficient: false,
     size: "normal",

--- a/packages/perseus-core/src/widgets/interaction/index.ts
+++ b/packages/perseus-core/src/widgets/interaction/index.ts
@@ -1,12 +1,7 @@
 import type {PerseusInteractionWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type InteractionDefaultWidgetOptions = Pick<
-    PerseusInteractionWidgetOptions,
-    "graph" | "elements"
->;
-
-const defaultWidgetOptions: InteractionDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusInteractionWidgetOptions = {
     graph: {
         box: [400, 400],
         labels: ["x", "y"],

--- a/packages/perseus-core/src/widgets/interactive-graph/index.ts
+++ b/packages/perseus-core/src/widgets/interactive-graph/index.ts
@@ -5,24 +5,7 @@ import type {InteractiveGraphPublicWidgetOptions} from "./interactive-graph-util
 import type {PerseusInteractiveGraphWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type InteractiveGraphDefaultWidgetOptions = Pick<
-    PerseusInteractiveGraphWidgetOptions,
-    | "labels"
-    | "labelLocation"
-    | "lockedFigures"
-    | "range"
-    | "step"
-    | "backgroundImage"
-    | "markings"
-    | "showAxisArrows"
-    | "showAxisTicks"
-    | "showTooltips"
-    | "showProtractor"
-    | "graph"
-    | "correct"
->;
-
-const defaultWidgetOptions: InteractiveGraphDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusInteractiveGraphWidgetOptions = {
     labels: ["$x$", "$y$"],
     labelLocation: "onAxis",
     lockedFigures: [],

--- a/packages/perseus-core/src/widgets/label-image/index.ts
+++ b/packages/perseus-core/src/widgets/label-image/index.ts
@@ -7,19 +7,7 @@ import type {LabelImagePublicWidgetOptions} from "./label-image-util";
 import type {PerseusLabelImageWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type LabelImageDefaultWidgetOptions = Pick<
-    PerseusLabelImageWidgetOptions,
-    | "choices"
-    | "imageAlt"
-    | "imageUrl"
-    | "imageWidth"
-    | "imageHeight"
-    | "markers"
-    | "multipleAnswers"
-    | "hideChoicesFromInstructions"
->;
-
-const defaultWidgetOptions: LabelImageDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusLabelImageWidgetOptions = {
     choices: [],
     imageAlt: "",
     imageUrl: "",

--- a/packages/perseus-core/src/widgets/matcher/index.ts
+++ b/packages/perseus-core/src/widgets/matcher/index.ts
@@ -4,12 +4,7 @@ import type {MatcherPublicWidgetOptions} from "./matcher-util";
 import type {PerseusMatcherWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type MatcherDefaultWidgetOptions = Pick<
-    PerseusMatcherWidgetOptions,
-    "left" | "right" | "labels" | "orderMatters" | "padding"
->;
-
-const defaultWidgetOptions: MatcherDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusMatcherWidgetOptions = {
     left: ["$x$", "$y$", "$z$"],
     right: ["$1$", "$2$", "$3$"],
     labels: ["test", "label"],

--- a/packages/perseus-core/src/widgets/matrix/index.ts
+++ b/packages/perseus-core/src/widgets/matrix/index.ts
@@ -4,12 +4,7 @@ import type {MatrixPublicWidgetOptions} from "./matrix-util";
 import type {PerseusMatrixWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type MatrixDefaultWidgetOptions = Pick<
-    PerseusMatrixWidgetOptions,
-    "matrixBoardSize" | "answers" | "prefix" | "suffix"
->;
-
-const defaultWidgetOptions: MatrixDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusMatrixWidgetOptions = {
     matrixBoardSize: [3, 3],
     answers: [[]],
     prefix: "",

--- a/packages/perseus-core/src/widgets/measurer/index.ts
+++ b/packages/perseus-core/src/widgets/measurer/index.ts
@@ -1,19 +1,7 @@
 import type {PerseusMeasurerWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type MeasurerDefaultWidgetOptions = Pick<
-    PerseusMeasurerWidgetOptions,
-    | "box"
-    | "image"
-    | "showProtractor"
-    | "showRuler"
-    | "rulerLabel"
-    | "rulerTicks"
-    | "rulerPixels"
-    | "rulerLength"
->;
-
-const defaultWidgetOptions: MeasurerDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusMeasurerWidgetOptions = {
     box: [480, 480],
     image: {},
     showProtractor: true,

--- a/packages/perseus-core/src/widgets/number-line/index.ts
+++ b/packages/perseus-core/src/widgets/number-line/index.ts
@@ -4,28 +4,18 @@ import type {NumberLinePublicWidgetOptions} from "./number-line-util";
 import type {PerseusNumberLineWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type NumberLineDefaultWidgetOptions = Pick<
-    PerseusNumberLineWidgetOptions,
-    | "range"
-    | "labelRange"
-    | "labelStyle"
-    | "labelTicks"
-    | "divisionRange"
-    | "numDivisions"
-    | "snapDivisions"
-    | "tickStep"
-    | "correctRel"
-    | "correctX"
-    | "initialX"
-    | "showTooltips"
->;
-
-const defaultWidgetOptions: NumberLineDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusNumberLineWidgetOptions = {
     range: [0, 10],
 
     labelRange: [null, null],
     labelStyle: "decimal",
     labelTicks: true,
+    // The tick controller is opt-in: by default the author fixes the number of
+    // divisions rather than letting the student change it.
+    isTickCtrl: false,
+    // Derived from `correctRel` by the editor (`isInequality: correctRel !==
+    // "eq"`), so this must stay in sync with the `correctRel: "eq"` default.
+    isInequality: false,
 
     divisionRange: [1, 12],
     numDivisions: 5,

--- a/packages/perseus-core/src/widgets/number-line/index.ts
+++ b/packages/perseus-core/src/widgets/number-line/index.ts
@@ -10,8 +10,8 @@ const defaultWidgetOptions: PerseusNumberLineWidgetOptions = {
     labelRange: [null, null],
     labelStyle: "decimal",
     labelTicks: true,
-    // The tick controller is opt-in: by default the author fixes the number of
-    // divisions rather than letting the student change it.
+    // The tick controller is opt-in: by default the content creator fixes the number of
+    // divisions rather than letting the learner change it.
     isTickCtrl: false,
     // Derived from `correctRel` by the editor (`isInequality: correctRel !==
     // "eq"`), so this must stay in sync with the `correctRel: "eq"` default.

--- a/packages/perseus-core/src/widgets/numeric-input/index.ts
+++ b/packages/perseus-core/src/widgets/numeric-input/index.ts
@@ -4,12 +4,7 @@ import type {NumericInputPublicWidgetOptions} from "./numeric-input-util";
 import type {PerseusNumericInputWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type NumericInputDefaultWidgetOptions = Pick<
-    PerseusNumericInputWidgetOptions,
-    "answers" | "size" | "coefficient" | "labelText" | "textAlign"
->;
-
-const defaultWidgetOptions: NumericInputDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusNumericInputWidgetOptions = {
     answers: [
         {
             value: null,

--- a/packages/perseus-core/src/widgets/orderer/index.ts
+++ b/packages/perseus-core/src/widgets/orderer/index.ts
@@ -1,17 +1,12 @@
-import {getOrdererPublicWidgetOptions} from "./orderer-util";
+import {
+    getOrdererPublicWidgetOptions,
+    mergeCards,
+    toCard,
+} from "./orderer-util";
 
 import type {OrdererPublicWidgetOptions} from "./orderer-util";
-import type {
-    PerseusOrdererWidgetOptions,
-    PerseusRenderer,
-} from "../../data-schema";
+import type {PerseusOrdererWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
-
-const toCard = (content: string): PerseusRenderer => ({
-    content,
-    widgets: {},
-    images: {},
-});
 
 const defaultCorrectOptions = [toCard("$x$")];
 const defaultOtherOptions = [toCard("$y$")];
@@ -19,9 +14,9 @@ const defaultOtherOptions = [toCard("$y$")];
 const defaultWidgetOptions: PerseusOrdererWidgetOptions = {
     correctOptions: defaultCorrectOptions,
     otherOptions: defaultOtherOptions,
-    // `options` is the card bank the learner picks from, which the editor keeps in
-    // sync as the union of the correct answer and the distractors.
-    options: [...defaultCorrectOptions, ...defaultOtherOptions],
+    // `options` is the deck the student picks from, derived the same way the
+    // editor re-derives it on every edit.
+    options: mergeCards(defaultCorrectOptions, defaultOtherOptions),
     height: "normal",
     layout: "horizontal",
 };

--- a/packages/perseus-core/src/widgets/orderer/index.ts
+++ b/packages/perseus-core/src/widgets/orderer/index.ts
@@ -1,19 +1,27 @@
 import {getOrdererPublicWidgetOptions} from "./orderer-util";
 
 import type {OrdererPublicWidgetOptions} from "./orderer-util";
-import type {PerseusOrdererWidgetOptions} from "../../data-schema";
+import type {
+    PerseusOrdererWidgetOptions,
+    PerseusRenderer,
+} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type OrdererDefaultWidgetOptions = Pick<
-    PerseusOrdererWidgetOptions,
-    "correctOptions" | "otherOptions" | "height" | "layout"
->;
+const toCard = (content: string): PerseusRenderer => ({
+    content,
+    widgets: {},
+    images: {},
+});
 
-const defaultWidgetOptions: OrdererDefaultWidgetOptions = {
-    // eslint-disable-next-line no-restricted-syntax
-    correctOptions: [{content: "$x$"}] as any,
-    // eslint-disable-next-line no-restricted-syntax
-    otherOptions: [{content: "$y$"}] as any,
+const defaultCorrectOptions = [toCard("$x$")];
+const defaultOtherOptions = [toCard("$y$")];
+
+const defaultWidgetOptions: PerseusOrdererWidgetOptions = {
+    correctOptions: defaultCorrectOptions,
+    otherOptions: defaultOtherOptions,
+    // `options` is the deck the student picks from, which the editor keeps in
+    // sync as the union of the correct answer and the distractors.
+    options: [...defaultCorrectOptions, ...defaultOtherOptions],
     height: "normal",
     layout: "horizontal",
 };

--- a/packages/perseus-core/src/widgets/orderer/index.ts
+++ b/packages/perseus-core/src/widgets/orderer/index.ts
@@ -19,7 +19,7 @@ const defaultOtherOptions = [toCard("$y$")];
 const defaultWidgetOptions: PerseusOrdererWidgetOptions = {
     correctOptions: defaultCorrectOptions,
     otherOptions: defaultOtherOptions,
-    // `options` is the deck the student picks from, which the editor keeps in
+    // `options` is the card bank the learner picks from, which the editor keeps in
     // sync as the union of the correct answer and the distractors.
     options: [...defaultCorrectOptions, ...defaultOtherOptions],
     height: "normal",

--- a/packages/perseus-core/src/widgets/orderer/index.ts
+++ b/packages/perseus-core/src/widgets/orderer/index.ts
@@ -14,7 +14,7 @@ const defaultOtherOptions = [toCard("$y$")];
 const defaultWidgetOptions: PerseusOrdererWidgetOptions = {
     correctOptions: defaultCorrectOptions,
     otherOptions: defaultOtherOptions,
-    // `options` is the deck the student picks from, derived the same way the
+    // `options` is the card bank the learner picks from, derived the same way the
     // editor re-derives it on every edit.
     options: mergeCards(defaultCorrectOptions, defaultOtherOptions),
     height: "normal",

--- a/packages/perseus-core/src/widgets/orderer/orderer-util.test.ts
+++ b/packages/perseus-core/src/widgets/orderer/orderer-util.test.ts
@@ -1,4 +1,6 @@
-import {getOrdererPublicWidgetOptions} from "./orderer-util";
+import {generateOrdererOption} from "../../utils/generators/orderer-widget-generator";
+
+import {getOrdererPublicWidgetOptions, mergeCards} from "./orderer-util";
 
 import type {PerseusOrdererWidgetOptions} from "../../data-schema";
 
@@ -34,5 +36,83 @@ describe("getOrdererPublicWidgetOptions", () => {
             ],
             height: "normal",
         });
+    });
+});
+
+describe("mergeCards", () => {
+    it("combines the correct cards and the other cards", () => {
+        // Arrange, Act
+        const cards = mergeCards(
+            [generateOrdererOption("a")],
+            [generateOrdererOption("b")],
+        );
+
+        // Assert
+        expect(cards).toEqual([
+            generateOrdererOption("a"),
+            generateOrdererOption("b"),
+        ]);
+    });
+
+    it("sorts content with numbers ahead of content without", () => {
+        // Arrange, Act
+        const cards = mergeCards(
+            [generateOrdererOption("3"), generateOrdererOption("$b$")],
+            [generateOrdererOption("2"), generateOrdererOption("a")],
+        );
+
+        // Assert
+        expect(cards).toEqual([
+            generateOrdererOption("2"),
+            generateOrdererOption("3"),
+            generateOrdererOption("$b$"),
+            generateOrdererOption("a"),
+        ]);
+    });
+
+    it("sorts bare variables last", () => {
+        // Arrange, Act
+        const cards = mergeCards(
+            [generateOrdererOption("x + 1"), generateOrdererOption("$y$")],
+            [generateOrdererOption("hello world")],
+        );
+
+        // Assert
+        expect(cards).toEqual([
+            generateOrdererOption("x + 1"),
+            generateOrdererOption("hello world"),
+            generateOrdererOption("$y$"),
+        ]);
+    });
+
+    it("removes duplicate cards", () => {
+        // Arrange, Act
+        const cards = mergeCards(
+            [
+                generateOrdererOption("duplicate"),
+                generateOrdererOption("unique"),
+            ],
+            [generateOrdererOption("duplicate")],
+        );
+
+        // Assert
+        expect(cards).toEqual([
+            generateOrdererOption("duplicate"),
+            generateOrdererOption("unique"),
+        ]);
+    });
+
+    it("removes empty cards", () => {
+        // Arrange, Act
+        const cards = mergeCards(
+            [generateOrdererOption(""), generateOrdererOption("existing")],
+            [generateOrdererOption(""), generateOrdererOption("valid")],
+        );
+
+        // Assert
+        expect(cards).toEqual([
+            generateOrdererOption("existing"),
+            generateOrdererOption("valid"),
+        ]);
     });
 });

--- a/packages/perseus-core/src/widgets/orderer/orderer-util.ts
+++ b/packages/perseus-core/src/widgets/orderer/orderer-util.ts
@@ -1,4 +1,7 @@
-import type {PerseusOrdererWidgetOptions} from "../../data-schema";
+import type {
+    PerseusOrdererWidgetOptions,
+    PerseusRenderer,
+} from "../../data-schema";
 
 /**
  * For details on the individual options, see the
@@ -19,3 +22,42 @@ export function getOrdererPublicWidgetOptions(
     const {options, height, layout} = fullOptions;
     return {options, height, layout};
 }
+
+export const toCard = (content: string): PerseusRenderer => ({
+    content,
+    widgets: {},
+    images: {},
+});
+
+// Cards are displayed grouped by content: numbers first, then everything
+// else, then bare variables and $tex$.
+const getCategoryScore = (content: string): number => {
+    if (/\d/.test(content)) {
+        return 0;
+    }
+    if (/^\$?[a-zA-Z]+\$?$/.test(content)) {
+        return 2;
+    }
+    return 1;
+};
+
+/**
+ * The cards the student picks from: the correct answer and the distractors,
+ * with duplicates and empty cards removed.
+ *
+ * The sort is what keeps the answer ordering out of the card bank, so this is
+ * the only way `options` should ever be derived — it ships to the client
+ * verbatim via getOrdererPublicWidgetOptions.
+ */
+export const mergeCards = (
+    correctOptions: PerseusRenderer[],
+    otherOptions: PerseusRenderer[],
+): PerseusRenderer[] => {
+    const allCards = [...correctOptions, ...otherOptions];
+
+    return [...new Set(allCards.map((card) => card.content))]
+        .filter((content) => content !== "")
+        .sort()
+        .sort((a, b) => getCategoryScore(a) - getCategoryScore(b))
+        .map(toCard);
+};

--- a/packages/perseus-core/src/widgets/orderer/orderer-util.ts
+++ b/packages/perseus-core/src/widgets/orderer/orderer-util.ts
@@ -23,15 +23,17 @@ export function getOrdererPublicWidgetOptions(
     return {options, height, layout};
 }
 
-export const toCard = (content: string): PerseusRenderer => ({
-    content,
-    widgets: {},
-    images: {},
-});
+export function toCard(content: string): PerseusRenderer {
+    return {
+        content,
+        widgets: {},
+        images: {},
+    };
+}
 
 // Cards are displayed grouped by content: numbers first, then everything
 // else, then bare variables and $tex$.
-const getCategoryScore = (content: string): number => {
+function getCategoryScore(content: string): number {
     if (/\d/.test(content)) {
         return 0;
     }
@@ -39,7 +41,7 @@ const getCategoryScore = (content: string): number => {
         return 2;
     }
     return 1;
-};
+}
 
 /**
  * The cards the student picks from: the correct answer and the distractors,
@@ -49,10 +51,10 @@ const getCategoryScore = (content: string): number => {
  * the only way `options` should ever be derived — it ships to the client
  * verbatim via getOrdererPublicWidgetOptions.
  */
-export const mergeCards = (
+export function mergeCards(
     correctOptions: PerseusRenderer[],
     otherOptions: PerseusRenderer[],
-): PerseusRenderer[] => {
+): PerseusRenderer[] {
     const allCards = [...correctOptions, ...otherOptions];
 
     return [...new Set(allCards.map((card) => card.content))]
@@ -60,4 +62,4 @@ export const mergeCards = (
         .sort()
         .sort((a, b) => getCategoryScore(a) - getCategoryScore(b))
         .map(toCard);
-};
+}

--- a/packages/perseus-core/src/widgets/phet-simulation/index.ts
+++ b/packages/perseus-core/src/widgets/phet-simulation/index.ts
@@ -1,12 +1,7 @@
 import type {PerseusPhetSimulationWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type PhetSimulationDefaultWidgetOptions = Pick<
-    PerseusPhetSimulationWidgetOptions,
-    "url" | "description"
->;
-
-const defaultWidgetOptions: PhetSimulationDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusPhetSimulationWidgetOptions = {
     url: "",
     description: "",
 };

--- a/packages/perseus-core/src/widgets/plotter/index.ts
+++ b/packages/perseus-core/src/widgets/plotter/index.ts
@@ -4,24 +4,7 @@ import type {PlotterPublicWidgetOptions} from "./plotter-util";
 import type {PerseusPlotterWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type PlotterDefaultWidgetOptions = Pick<
-    PerseusPlotterWidgetOptions,
-    | "scaleY"
-    | "maxY"
-    | "snapsPerLine"
-    | "correct"
-    | "starting"
-    | "type"
-    | "labels"
-    | "categories"
-    | "picSize"
-    | "picBoxHeight"
-    | "plotDimensions"
-    | "labelInterval"
-    | "picUrl"
->;
-
-const defaultWidgetOptions: PlotterDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusPlotterWidgetOptions = {
     scaleY: 1,
     maxY: 10,
     snapsPerLine: 2,

--- a/packages/perseus-core/src/widgets/python-program/index.ts
+++ b/packages/perseus-core/src/widgets/python-program/index.ts
@@ -1,12 +1,7 @@
 import type {PerseusPythonProgramWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type PythonProgramDefaultWidgetOptions = Pick<
-    PerseusPythonProgramWidgetOptions,
-    "programID" | "height"
->;
-
-const defaultWidgetOptions: PythonProgramDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusPythonProgramWidgetOptions = {
     programID: "",
     height: 400,
 };

--- a/packages/perseus-core/src/widgets/radio/index.ts
+++ b/packages/perseus-core/src/widgets/radio/index.ts
@@ -6,17 +6,7 @@ import type {WidgetLogic} from "../logic-export.types";
 
 const currentVersion = {major: 3, minor: 0};
 
-export type RadioDefaultWidgetOptions = Pick<
-    PerseusRadioWidgetOptions,
-    | "choices"
-    | "randomize"
-    | "hasNoneOfTheAbove"
-    | "multipleSelect"
-    | "countChoices"
-    | "deselectEnabled"
->;
-
-const defaultWidgetOptions: RadioDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusRadioWidgetOptions = {
     choices: [
         {content: "", id: "radio-choice-0"},
         {content: "", id: "radio-choice-1"},

--- a/packages/perseus-core/src/widgets/sorter/index.ts
+++ b/packages/perseus-core/src/widgets/sorter/index.ts
@@ -4,12 +4,7 @@ import type {SorterPublicWidgetOptions} from "./sorter-util";
 import type {PerseusSorterWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type SorterDefaultWidgetOptions = Pick<
-    PerseusSorterWidgetOptions,
-    "correct" | "layout" | "padding"
->;
-
-const defaultWidgetOptions: SorterDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusSorterWidgetOptions = {
     correct: ["$x$", "$y$", "$z$"],
     layout: "horizontal",
     padding: true,

--- a/packages/perseus-core/src/widgets/table/index.ts
+++ b/packages/perseus-core/src/widgets/table/index.ts
@@ -4,11 +4,6 @@ import type {TablePublicWidgetOptions} from "./table-util";
 import type {PerseusTableWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type TableDefaultWidgetOptions = Pick<
-    PerseusTableWidgetOptions,
-    "headers" | "rows" | "columns" | "answers"
->;
-
 const defaultRows = 4;
 const defaultColumns = 1;
 
@@ -18,7 +13,7 @@ const answers = new Array(defaultRows)
     .fill(0)
     .map(() => new Array(defaultColumns).fill(""));
 
-const defaultWidgetOptions: TableDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusTableWidgetOptions = {
     headers: [""],
     rows: defaultRows,
     columns: defaultColumns,

--- a/packages/perseus-core/src/widgets/video/index.ts
+++ b/packages/perseus-core/src/widgets/video/index.ts
@@ -1,12 +1,7 @@
 import type {PerseusVideoWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-export type VideoDefaultWidgetOptions = Pick<
-    PerseusVideoWidgetOptions,
-    "location"
->;
-
-const defaultWidgetOptions: VideoDefaultWidgetOptions = {
+const defaultWidgetOptions: PerseusVideoWidgetOptions = {
     location: "",
 };
 

--- a/packages/perseus-editor/src/widgets/categorizer-editor/categorizer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/categorizer-editor/categorizer-editor.tsx
@@ -10,12 +10,12 @@ import EditorJsonify from "../../mixins/editor-jsonify";
 
 import type {ChangeableProps} from "../../mixins/changeable";
 import type {APIOptionsWithDefaults} from "@khanacademy/perseus";
-import type {CategorizerDefaultWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusCategorizerWidgetOptions} from "@khanacademy/perseus-core";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 const Categorizer = CategorizerWidget.widget;
 
-interface Props extends CategorizerDefaultWidgetOptions, ChangeableProps {
+interface Props extends PerseusCategorizerWidgetOptions, ChangeableProps {
     apiOptions?: APIOptionsWithDefaults;
 }
 
@@ -26,7 +26,7 @@ interface Props extends CategorizerDefaultWidgetOptions, ChangeableProps {
 class CategorizerEditor extends React.Component<Props> {
     static widgetName = "categorizer" as const;
 
-    static defaultProps: CategorizerDefaultWidgetOptions =
+    static defaultProps: PerseusCategorizerWidgetOptions =
         categorizerLogic.defaultWidgetOptions;
 
     change: (arg1: any, arg2: any, arg3: any) => any = (...args) => {

--- a/packages/perseus-editor/src/widgets/cs-program-editor/cs-program-editor.tsx
+++ b/packages/perseus-editor/src/widgets/cs-program-editor/cs-program-editor.tsx
@@ -14,7 +14,7 @@ import EditorJsonify from "../../mixins/editor-jsonify";
 
 import type {ChangeableProps, ChangeFn} from "../../mixins/changeable";
 import type {
-    CSProgramDefaultWidgetOptions,
+    PerseusCSProgramWidgetOptions,
     PerseusCSProgramSetting,
 } from "@khanacademy/perseus-core";
 
@@ -123,7 +123,7 @@ function isolateProgramID(programUrl: string) {
 }
 
 interface CSProgramEditorProps
-    extends CSProgramDefaultWidgetOptions,
+    extends PerseusCSProgramWidgetOptions,
         ChangeableProps {}
 
 /**

--- a/packages/perseus-editor/src/widgets/definition-editor/definition-editor.tsx
+++ b/packages/perseus-editor/src/widgets/definition-editor/definition-editor.tsx
@@ -11,11 +11,11 @@ import EditorJsonify from "../../mixins/editor-jsonify";
 import type {InitializeWidgetOptionsParams} from "../../editor";
 import type {ChangeableProps} from "../../mixins/changeable";
 import type {APIOptionsWithDefaults} from "@khanacademy/perseus";
-import type {DefinitionDefaultWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusDefinitionWidgetOptions} from "@khanacademy/perseus-core";
 
 const {TextInput} = components;
 
-interface Props extends DefinitionDefaultWidgetOptions, ChangeableProps {
+interface Props extends PerseusDefinitionWidgetOptions, ChangeableProps {
     apiOptions?: APIOptionsWithDefaults;
 }
 
@@ -27,12 +27,12 @@ interface Props extends DefinitionDefaultWidgetOptions, ChangeableProps {
 class DefinitionEditor extends React.Component<Props> {
     static widgetName = "definition" as const;
 
-    static defaultProps: DefinitionDefaultWidgetOptions =
+    static defaultProps: PerseusDefinitionWidgetOptions =
         definitionLogic.defaultWidgetOptions;
 
     static initializeWidgetOptions(
         params: InitializeWidgetOptionsParams,
-    ): DefinitionDefaultWidgetOptions {
+    ): PerseusDefinitionWidgetOptions {
         const defaultWidgetOptions = {
             ...definitionLogic.defaultWidgetOptions,
         };

--- a/packages/perseus-editor/src/widgets/dropdown-editor/dropdown-editor.tsx
+++ b/packages/perseus-editor/src/widgets/dropdown-editor/dropdown-editor.tsx
@@ -1,6 +1,6 @@
 import {
     dropdownLogic,
-    type DropdownDefaultWidgetOptions,
+    type PerseusDropdownWidgetOptions,
 } from "@khanacademy/perseus-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {TextField} from "@khanacademy/wonder-blocks-form";
@@ -36,7 +36,7 @@ class DropdownEditor extends React.Component<Props> {
 
     static widgetName = "dropdown" as const;
 
-    static defaultProps: DropdownDefaultWidgetOptions =
+    static defaultProps: PerseusDropdownWidgetOptions =
         dropdownLogic.defaultWidgetOptions;
 
     onVisibleLabelChange: (arg1: string) => void = (visibleLabel) => {

--- a/packages/perseus-editor/src/widgets/explanation-editor/explanation-editor.tsx
+++ b/packages/perseus-editor/src/widgets/explanation-editor/explanation-editor.tsx
@@ -10,11 +10,11 @@ import EditorJsonify from "../../mixins/editor-jsonify";
 
 import type {ChangeableProps} from "../../mixins/changeable";
 import type {APIOptionsWithDefaults} from "@khanacademy/perseus";
-import type {ExplanationDefaultWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusExplanationWidgetOptions} from "@khanacademy/perseus-core";
 
 const {TextInput} = components;
 
-interface Props extends ExplanationDefaultWidgetOptions, ChangeableProps {
+interface Props extends PerseusExplanationWidgetOptions, ChangeableProps {
     apiOptions?: APIOptionsWithDefaults;
 }
 
@@ -25,7 +25,7 @@ interface Props extends ExplanationDefaultWidgetOptions, ChangeableProps {
 class ExplanationEditor extends React.Component<Props> {
     static widgetName = "explanation" as const;
 
-    static defaultProps: ExplanationDefaultWidgetOptions =
+    static defaultProps: PerseusExplanationWidgetOptions =
         explanationLogic.defaultWidgetOptions;
 
     change: (arg1: any, arg2: any, arg3: any) => any = (...args) => {

--- a/packages/perseus-editor/src/widgets/graded-group-editor/graded-group-editor.tsx
+++ b/packages/perseus-editor/src/widgets/graded-group-editor/graded-group-editor.tsx
@@ -14,20 +14,20 @@ import styles from "./graded-group-editor.module.css";
 import type {ChangeableProps} from "../../mixins/changeable";
 import type {APIOptionsWithDefaults} from "@khanacademy/perseus";
 import type {
-    GradedGroupDefaultWidgetOptions,
+    PerseusGradedGroupWidgetOptions,
     PerseusRenderer,
 } from "@khanacademy/perseus-core";
 
 const {TextInput} = components;
 
-interface Props extends GradedGroupDefaultWidgetOptions, ChangeableProps {
+interface Props extends PerseusGradedGroupWidgetOptions, ChangeableProps {
     apiOptions?: APIOptionsWithDefaults;
 }
 
 class GradedGroupEditor extends React.Component<Props> {
     static widgetName = "graded-group" as const;
 
-    static defaultProps: GradedGroupDefaultWidgetOptions =
+    static defaultProps: PerseusGradedGroupWidgetOptions =
         gradedGroupLogic.defaultWidgetOptions;
 
     editor = React.createRef<Editor>();

--- a/packages/perseus-editor/src/widgets/graded-group-set-editor/graded-group-set-editor.tsx
+++ b/packages/perseus-editor/src/widgets/graded-group-set-editor/graded-group-set-editor.tsx
@@ -6,9 +6,9 @@ import GradedGroupEditor from "../graded-group-editor";
 
 import type {ChangeableProps} from "../../mixins/changeable";
 import type {APIOptionsWithDefaults} from "@khanacademy/perseus";
-import type {GradedGroupSetDefaultWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusGradedGroupSetWidgetOptions} from "@khanacademy/perseus-core";
 
-interface Props extends GradedGroupSetDefaultWidgetOptions, ChangeableProps {
+interface Props extends PerseusGradedGroupSetWidgetOptions, ChangeableProps {
     apiOptions?: APIOptionsWithDefaults;
 }
 
@@ -18,7 +18,7 @@ class GradedGroupSetEditor extends React.Component<Props> {
 
     static widgetName = "graded-group-set" as const;
 
-    static defaultProps: GradedGroupSetDefaultWidgetOptions =
+    static defaultProps: PerseusGradedGroupSetWidgetOptions =
         gradedGroupSetLogic.defaultWidgetOptions;
 
     // TODO(jangmi, CP-3288): Remove usage of `UNSAFE_componentWillMount`

--- a/packages/perseus-editor/src/widgets/grapher-editor/grapher-editor.tsx
+++ b/packages/perseus-editor/src/widgets/grapher-editor/grapher-editor.tsx
@@ -18,7 +18,6 @@ import InfoTip from "../../components/info-tip";
 import type {APIOptionsWithDefaults} from "@khanacademy/perseus";
 import type {
     GrapherAnswerTypes,
-    GrapherDefaultWidgetOptions,
     PerseusGrapherWidgetOptions,
 } from "@khanacademy/perseus-core";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
@@ -39,7 +38,7 @@ type Props = {
 class GrapherEditor extends React.Component<Props> {
     static widgetName = "grapher" as const;
 
-    static defaultProps: GrapherDefaultWidgetOptions =
+    static defaultProps: PerseusGrapherWidgetOptions =
         grapherLogic.defaultWidgetOptions;
 
     handleAvailableTypesChange = (newAvailableTypes: Array<any>) => {

--- a/packages/perseus-editor/src/widgets/group-editor/group-editor.tsx
+++ b/packages/perseus-editor/src/widgets/group-editor/group-editor.tsx
@@ -8,7 +8,7 @@ import invariant from "tiny-invariant";
 import Editor from "../../editor";
 
 import type {
-    GroupDefaultWidgetOptions,
+    PerseusGroupWidgetOptions,
     PerseusRenderer,
 } from "@khanacademy/perseus-core";
 
@@ -24,7 +24,7 @@ class GroupEditor extends React.Component<Props> {
 
     static widgetName = "group" as const;
 
-    static defaultProps: GroupDefaultWidgetOptions =
+    static defaultProps: PerseusGroupWidgetOptions =
         groupLogic.defaultWidgetOptions;
 
     editor = React.createRef<Editor>();

--- a/packages/perseus-editor/src/widgets/iframe-editor/iframe-editor.tsx
+++ b/packages/perseus-editor/src/widgets/iframe-editor/iframe-editor.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
 import {
     iframeLogic,
-    type IFrameDefaultWidgetOptions,
+    type PerseusIFrameWidgetOptions,
     type PerseusCSProgramSetting,
 } from "@khanacademy/perseus-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
@@ -93,7 +93,7 @@ class PairsEditor extends React.Component<PairsEditorProps> {
 }
 
 interface IframeEditorProps
-    extends IFrameDefaultWidgetOptions,
+    extends PerseusIFrameWidgetOptions,
         ChangeableProps {}
 
 /**
@@ -102,7 +102,7 @@ interface IframeEditorProps
 class IframeEditor extends React.Component<IframeEditorProps> {
     static widgetName = "iframe" as const;
 
-    static defaultProps: IFrameDefaultWidgetOptions =
+    static defaultProps: PerseusIFrameWidgetOptions =
         iframeLogic.defaultWidgetOptions;
 
     change: (arg1: any, arg2: any, arg3: any) => any = (...args) => {

--- a/packages/perseus-editor/src/widgets/image-editor/image-editor.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/image-editor.tsx
@@ -1,6 +1,5 @@
 import {
     imageLogic,
-    type ImageDefaultWidgetOptions,
     type PerseusImageWidgetOptions,
 } from "@khanacademy/perseus-core";
 import * as React from "react";
@@ -25,7 +24,7 @@ class ImageEditor extends React.Component<Props> {
     static displayName = "ImageEditor";
     static widgetName = "image";
 
-    static defaultProps: ImageDefaultWidgetOptions =
+    static defaultProps: PerseusImageWidgetOptions =
         imageLogic.defaultWidgetOptions;
 
     serialize() {

--- a/packages/perseus-editor/src/widgets/interaction-editor/interaction-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interaction-editor/interaction-editor.tsx
@@ -2,7 +2,7 @@ import {Dependencies, Util} from "@khanacademy/perseus";
 import {
     interactionLogic,
     type Coords,
-    type InteractionDefaultWidgetOptions,
+    type PerseusInteractionWidgetOptions,
     type MarkingsType,
 } from "@khanacademy/perseus-core";
 import * as React from "react";
@@ -64,7 +64,7 @@ type State = any;
  */
 class InteractionEditor extends React.Component<Props, State> {
     static widgetName = "interaction" as const;
-    static defaultProps: InteractionDefaultWidgetOptions =
+    static defaultProps: PerseusInteractionWidgetOptions =
         interactionLogic.defaultWidgetOptions;
 
     state: State = {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/interactive-graph-editor.tsx
@@ -12,7 +12,6 @@ import {
     type PerseusInteractiveGraphWidgetOptions,
     type PerseusGraphType,
     type MarkingsType,
-    type InteractiveGraphDefaultWidgetOptions,
     type AxisLabelLocation,
     interactiveGraphLogic,
     type ShowAxisArrows,
@@ -177,7 +176,7 @@ class InteractiveGraphEditor extends React.Component<Props> {
     displayName = "InteractiveGraphEditor";
     className = "perseus-widget-interactive-graph";
 
-    static defaultProps: InteractiveGraphDefaultWidgetOptions & {
+    static defaultProps: PerseusInteractiveGraphWidgetOptions & {
         valid: true | string;
     } = {
         ...interactiveGraphLogic.defaultWidgetOptions,

--- a/packages/perseus-editor/src/widgets/label-image-editor/label-image-editor.tsx
+++ b/packages/perseus-editor/src/widgets/label-image-editor/label-image-editor.tsx
@@ -13,10 +13,7 @@ import SelectImage from "./select-image";
 
 import type {PreferredPopoverDirection} from "./behavior";
 import type {APIOptions} from "@khanacademy/perseus";
-import type {
-    PerseusLabelImageWidgetOptions,
-    LabelImageDefaultWidgetOptions,
-} from "@khanacademy/perseus-core";
+import type {PerseusLabelImageWidgetOptions} from "@khanacademy/perseus-core";
 
 interface Props {
     apiOptions: APIOptions;
@@ -49,7 +46,7 @@ interface Props {
 class LabelImageEditor extends React.Component<Props> {
     private _questionMarkers: QuestionMarkers | null | undefined;
 
-    static defaultProps: LabelImageDefaultWidgetOptions =
+    static defaultProps: PerseusLabelImageWidgetOptions =
         labelImageLogic.defaultWidgetOptions;
 
     static widgetName = "label-image" as const;

--- a/packages/perseus-editor/src/widgets/matrix-editor/matrix-editor.tsx
+++ b/packages/perseus-editor/src/widgets/matrix-editor/matrix-editor.tsx
@@ -9,7 +9,7 @@ import EditorJsonify from "../../mixins/editor-jsonify";
 
 import type {ChangeableProps} from "../../mixins/changeable";
 import type {APIOptionsWithDefaults} from "@khanacademy/perseus";
-import type {MatrixDefaultWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusMatrixWidgetOptions} from "@khanacademy/perseus-core";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 const {RangeInput} = components;
@@ -19,14 +19,14 @@ const Matrix = MatrixWidget.widget;
 // have to cap it at some point.
 const MAX_BOARD_SIZE = 6;
 
-interface Props extends MatrixDefaultWidgetOptions, ChangeableProps {
+interface Props extends PerseusMatrixWidgetOptions, ChangeableProps {
     apiOptions: APIOptionsWithDefaults;
 }
 
 class MatrixEditor extends React.Component<Props> {
     static widgetName = "matrix" as const;
 
-    static defaultProps: MatrixDefaultWidgetOptions =
+    static defaultProps: PerseusMatrixWidgetOptions =
         matrixLogic.defaultWidgetOptions;
 
     change: (arg1: any, arg2?: any, arg3?: any) => any = (...args) => {

--- a/packages/perseus-editor/src/widgets/measurer-editor/measurer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/measurer-editor/measurer-editor.tsx
@@ -10,7 +10,7 @@ import {deprecatedChangeableChange} from "../../mixins/changeable";
 import EditorJsonify from "../../mixins/editor-jsonify";
 
 import type {ChangeableProps} from "../../mixins/changeable";
-import type {MeasurerDefaultWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusMeasurerWidgetOptions} from "@khanacademy/perseus-core";
 
 const {NumberInput, RangeInput} = components;
 
@@ -20,12 +20,12 @@ const defaultImage = {
     left: 0,
 } as const;
 
-interface Props extends MeasurerDefaultWidgetOptions, ChangeableProps {}
+interface Props extends PerseusMeasurerWidgetOptions, ChangeableProps {}
 
 class MeasurerEditor extends React.Component<Props> {
     static widgetName = "measurer" as const;
 
-    static defaultProps: MeasurerDefaultWidgetOptions =
+    static defaultProps: PerseusMeasurerWidgetOptions =
         measurerLogic.defaultWidgetOptions;
 
     className = "perseus-widget-measurer";

--- a/packages/perseus-editor/src/widgets/number-line-editor/number-line-editor.tsx
+++ b/packages/perseus-editor/src/widgets/number-line-editor/number-line-editor.tsx
@@ -3,7 +3,7 @@ import {number as knumber} from "@khanacademy/kmath";
 import {components} from "@khanacademy/perseus";
 import {
     numberLineLogic,
-    type NumberLineDefaultWidgetOptions,
+    type PerseusNumberLineWidgetOptions,
 } from "@khanacademy/perseus-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import * as React from "react";
@@ -52,7 +52,7 @@ type Props = {
 class NumberLineEditor extends React.Component<Props> {
     static widgetName = "number-line" as const;
 
-    static defaultProps: NumberLineDefaultWidgetOptions =
+    static defaultProps: PerseusNumberLineWidgetOptions =
         numberLineLogic.defaultWidgetOptions;
 
     onRangeChange: (arg1: Range) => void = (range) => {

--- a/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.test.tsx
@@ -9,7 +9,7 @@ import * as React from "react";
 
 import {testDependencies} from "../../testing/test-dependencies";
 
-import OrdererEditor, {mergeCards} from "./orderer-editor";
+import OrdererEditor from "./orderer-editor";
 
 import type {PerseusOrdererWidgetOptions} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
@@ -214,83 +214,5 @@ describe("OrdererEditor", () => {
 
         // Assert
         expect(onChangeMock).toHaveBeenCalledWith({height: "auto"});
-    });
-});
-
-describe("mergeCards", () => {
-    it("combines the correct cards and the other cards", () => {
-        // Arrange, Act
-        const cards = mergeCards(
-            [generateOrdererOption("a")],
-            [generateOrdererOption("b")],
-        );
-
-        // Assert
-        expect(cards).toEqual([
-            generateOrdererOption("a"),
-            generateOrdererOption("b"),
-        ]);
-    });
-
-    it("sorts content with numbers ahead of content without", () => {
-        // Arrange, Act
-        const cards = mergeCards(
-            [generateOrdererOption("3"), generateOrdererOption("$b$")],
-            [generateOrdererOption("2"), generateOrdererOption("a")],
-        );
-
-        // Assert
-        expect(cards).toEqual([
-            generateOrdererOption("2"),
-            generateOrdererOption("3"),
-            generateOrdererOption("$b$"),
-            generateOrdererOption("a"),
-        ]);
-    });
-
-    it("sorts bare variables last", () => {
-        // Arrange, Act
-        const cards = mergeCards(
-            [generateOrdererOption("x + 1"), generateOrdererOption("$y$")],
-            [generateOrdererOption("hello world")],
-        );
-
-        // Assert
-        expect(cards).toEqual([
-            generateOrdererOption("x + 1"),
-            generateOrdererOption("hello world"),
-            generateOrdererOption("$y$"),
-        ]);
-    });
-
-    it("removes duplicate cards", () => {
-        // Arrange, Act
-        const cards = mergeCards(
-            [
-                generateOrdererOption("duplicate"),
-                generateOrdererOption("unique"),
-            ],
-            [generateOrdererOption("duplicate")],
-        );
-
-        // Assert
-        expect(cards).toEqual([
-            generateOrdererOption("duplicate"),
-            generateOrdererOption("unique"),
-        ]);
-    });
-
-    it("removes empty cards", () => {
-        // Arrange, Act
-        const cards = mergeCards(
-            [generateOrdererOption(""), generateOrdererOption("existing")],
-            [generateOrdererOption(""), generateOrdererOption("valid")],
-        );
-
-        // Assert
-        expect(cards).toEqual([
-            generateOrdererOption("existing"),
-            generateOrdererOption("valid"),
-        ]);
     });
 });

--- a/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.tsx
+++ b/packages/perseus-editor/src/widgets/orderer-editor/orderer-editor.tsx
@@ -1,7 +1,8 @@
 import {
+    mergeCards,
     ordererLogic,
+    toCard,
     type PerseusOrdererWidgetOptions,
-    type PerseusRenderer,
 } from "@khanacademy/perseus-core";
 import * as React from "react";
 
@@ -18,41 +19,6 @@ type Props = PerseusOrdererWidgetOptions & {
         newOptions: Partial<PerseusOrdererWidgetOptions>,
         callback?: () => void,
     ) => void;
-};
-
-const toCard = (content: string): PerseusRenderer => ({
-    content,
-    widgets: {},
-    images: {},
-});
-
-// Cards are displayed grouped by content: numbers first, then everything
-// else, then bare variables and $tex$.
-const getCategoryScore = (content: string): number => {
-    if (/\d/.test(content)) {
-        return 0;
-    }
-    if (/^\$?[a-zA-Z]+\$?$/.test(content)) {
-        return 2;
-    }
-    return 1;
-};
-
-/**
- * The cards the student picks from: the correct answer and the distractors,
- * with duplicates and empty cards removed.
- */
-export const mergeCards = (
-    correctOptions: PerseusRenderer[],
-    otherOptions: PerseusRenderer[],
-): PerseusRenderer[] => {
-    const allCards = [...correctOptions, ...otherOptions];
-
-    return [...new Set(allCards.map((card) => card.content))]
-        .filter((content) => content !== "")
-        .sort()
-        .sort((a, b) => getCategoryScore(a) - getCategoryScore(b))
-        .map(toCard);
 };
 
 class OrdererEditor extends React.Component<Props> {

--- a/packages/perseus-editor/src/widgets/phet-simulation-editor/phet-simulation-editor.tsx
+++ b/packages/perseus-editor/src/widgets/phet-simulation-editor/phet-simulation-editor.tsx
@@ -2,13 +2,12 @@ import {makeSafeUrl} from "@khanacademy/perseus-core";
 import {
     phetSimulationLogic,
     type PerseusPhetSimulationWidgetOptions,
-    type PhetSimulationDefaultWidgetOptions,
 } from "@khanacademy/perseus-core";
 import {LabeledTextField} from "@khanacademy/wonder-blocks-form";
 import {spacing} from "@khanacademy/wonder-blocks-tokens";
 import * as React from "react";
 
-type Props = PhetSimulationDefaultWidgetOptions & {
+type Props = PerseusPhetSimulationWidgetOptions & {
     onChange: (arg1: {
         url?: Props["url"];
         description?: Props["description"];
@@ -21,7 +20,7 @@ type Props = PhetSimulationDefaultWidgetOptions & {
  * with physics simulations.
  */
 class PhetSimulationEditor extends React.Component<Props> {
-    static defaultProps: PhetSimulationDefaultWidgetOptions =
+    static defaultProps: PerseusPhetSimulationWidgetOptions =
         phetSimulationLogic.defaultWidgetOptions;
 
     static widgetName = "phet-simulation" as const;

--- a/packages/perseus-editor/src/widgets/plotter-editor/plotter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/plotter-editor/plotter-editor.tsx
@@ -10,10 +10,7 @@ import InfoTip from "../../components/info-tip";
 import TextListEditor from "../../components/text-list-editor";
 
 import type {APIOptions} from "@khanacademy/perseus";
-import type {
-    PerseusPlotterWidgetOptions,
-    PlotterDefaultWidgetOptions,
-} from "@khanacademy/perseus-core";
+import type {PerseusPlotterWidgetOptions} from "@khanacademy/perseus-core";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
 
 const {NumberInput, RangeInput} = components;
@@ -78,7 +75,7 @@ const formatNumber = (num) => "$" + knumber.round(num, 2) + "$";
 class PlotterEditor extends React.Component<Props, State> {
     static widgetName = "plotter" as const;
 
-    static defaultProps: PlotterDefaultWidgetOptions =
+    static defaultProps: PerseusPlotterWidgetOptions =
         plotterLogic.defaultWidgetOptions;
 
     state: State = {

--- a/packages/perseus-editor/src/widgets/python-program-editor/python-program-editor.tsx
+++ b/packages/perseus-editor/src/widgets/python-program-editor/python-program-editor.tsx
@@ -5,10 +5,7 @@ import * as React from "react";
 import {deprecatedChangeableChange} from "../../mixins/changeable";
 
 import type {ChangeableProps} from "../../mixins/changeable";
-import type {
-    PerseusPythonProgramWidgetOptions,
-    PythonProgramDefaultWidgetOptions,
-} from "@khanacademy/perseus-core";
+import type {PerseusPythonProgramWidgetOptions} from "@khanacademy/perseus-core";
 
 const {NumberInput, TextInput} = components;
 
@@ -41,7 +38,7 @@ export function validateOptions(
 class PythonProgramEditor extends React.Component<Props> {
     static widgetName = "python-program" as const;
 
-    static defaultProps: PythonProgramDefaultWidgetOptions =
+    static defaultProps: PerseusPythonProgramWidgetOptions =
         pythonProgramLogic.defaultWidgetOptions;
 
     change: (...args: ReadonlyArray<unknown>) => any = (...args) => {

--- a/packages/perseus-editor/src/widgets/radio-editor/radio-editor.tsx
+++ b/packages/perseus-editor/src/widgets/radio-editor/radio-editor.tsx
@@ -16,7 +16,6 @@ import type {APIOptions} from "@khanacademy/perseus";
 import type {
     PerseusRadioWidgetOptions,
     PerseusRadioChoice,
-    RadioDefaultWidgetOptions,
 } from "@khanacademy/perseus-core";
 
 // Exported for testing
@@ -46,7 +45,7 @@ class RadioEditor extends React.Component<RadioEditorProps> {
         label: "Multiple choice best practices",
     };
 
-    static defaultProps: RadioDefaultWidgetOptions =
+    static defaultProps: PerseusRadioWidgetOptions =
         radioLogic.defaultWidgetOptions;
 
     // Store refs to each choice editor for focus management

--- a/packages/perseus-editor/src/widgets/table-editor/table-editor.tsx
+++ b/packages/perseus-editor/src/widgets/table-editor/table-editor.tsx
@@ -1,7 +1,7 @@
 import {components, TableWidget, Util} from "@khanacademy/perseus";
 import {
     tableLogic,
-    type TableDefaultWidgetOptions,
+    type PerseusTableWidgetOptions,
 } from "@khanacademy/perseus-core";
 import PropTypes from "prop-types";
 import * as React from "react";
@@ -27,7 +27,7 @@ class TableEditor extends React.Component<Props> {
 
     static widgetName = "table" as const;
 
-    static defaultProps: TableDefaultWidgetOptions =
+    static defaultProps: PerseusTableWidgetOptions =
         tableLogic.defaultWidgetOptions;
 
     numberOfColumns = React.createRef<components.NumberInput>();

--- a/packages/perseus-editor/src/widgets/video-editor/video-editor.tsx
+++ b/packages/perseus-editor/src/widgets/video-editor/video-editor.tsx
@@ -1,6 +1,5 @@
 import {
     videoLogic,
-    type VideoDefaultWidgetOptions,
     type PerseusVideoWidgetOptions,
 } from "@khanacademy/perseus-core";
 import * as React from "react";
@@ -17,7 +16,7 @@ export interface VideoEditorProps extends PerseusVideoWidgetOptions {
 class VideoEditor extends React.Component<VideoEditorProps> {
     static widgetName = "video" as const;
 
-    static defaultProps: VideoDefaultWidgetOptions =
+    static defaultProps: PerseusVideoWidgetOptions =
         videoLogic.defaultWidgetOptions;
 
     serialize: () => PerseusVideoWidgetOptions = () => {

--- a/packages/perseus/src/widgets/definition/__docs__/definition-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/definition/__docs__/definition-initial-state-regression.stories.tsx
@@ -13,14 +13,14 @@ import {
 
 import {definitionRendererDecorator} from "./definition-renderer-decorator";
 
-import type {DefinitionDefaultWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusDefinitionWidgetOptions} from "@khanacademy/perseus-core";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 /**
  * This is a visual regression story for the definition widget.
  */
 
-const meta: Meta<DefinitionDefaultWidgetOptions> = {
+const meta: Meta<PerseusDefinitionWidgetOptions> = {
     title: "Widgets/Definition/Visual Regression Tests/Initial State",
     tags: ["!autodocs", "!manifest"],
     parameters: {

--- a/packages/perseus/src/widgets/definition/__docs__/definition-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/definition/__docs__/definition-interactions-regression.stories.tsx
@@ -7,10 +7,10 @@ import {
 
 import {definitionRendererDecorator} from "./definition-renderer-decorator";
 
-import type {DefinitionDefaultWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusDefinitionWidgetOptions} from "@khanacademy/perseus-core";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
-const meta: Meta<DefinitionDefaultWidgetOptions> = {
+const meta: Meta<PerseusDefinitionWidgetOptions> = {
     title: "Widgets/Definition/Visual Regression Tests/Interactions",
     tags: ["!autodocs", "!manifest"],
     parameters: {

--- a/packages/perseus/src/widgets/definition/__docs__/definition-renderer-decorator.tsx
+++ b/packages/perseus/src/widgets/definition/__docs__/definition-renderer-decorator.tsx
@@ -8,7 +8,7 @@ import * as React from "react";
 import QuestionRendererForStories from "../../__testutils__/question-renderer-for-stories";
 
 import type {APIOptions} from "../../../types";
-import type {DefinitionDefaultWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusDefinitionWidgetOptions} from "@khanacademy/perseus-core";
 import type {Decorator} from "@storybook/react-vite";
 
 export const definitionRendererDecorator: Decorator = (
@@ -17,7 +17,7 @@ export const definitionRendererDecorator: Decorator = (
         args,
         parameters,
     }: {
-        args: Partial<DefinitionDefaultWidgetOptions>;
+        args: Partial<PerseusDefinitionWidgetOptions>;
         parameters?: {
             content?: string;
             apiOptions?: APIOptions;

--- a/packages/perseus/src/widgets/definition/definition.testdata.ts
+++ b/packages/perseus/src/widgets/definition/definition.testdata.ts
@@ -5,7 +5,7 @@ import {
 } from "@khanacademy/perseus-core";
 
 import type {
-    DefinitionDefaultWidgetOptions,
+    PerseusDefinitionWidgetOptions,
     PerseusRenderer,
 } from "@khanacademy/perseus-core";
 
@@ -45,7 +45,7 @@ export const article = {
     },
 };
 
-export const definitionQuestionOptions: DefinitionDefaultWidgetOptions =
+export const definitionQuestionOptions: PerseusDefinitionWidgetOptions =
     generateDefinitionOptions({
         definition:
             "The Allies, led by the United Kingdom, the United States, and the Soviet Union, were the group of countries who opposed the Axis powers (Germany, Japan, and Italy) during World War II.",

--- a/packages/perseus/src/widgets/dropdown/__docs__/dropdown-renderer-decorator.tsx
+++ b/packages/perseus/src/widgets/dropdown/__docs__/dropdown-renderer-decorator.tsx
@@ -8,7 +8,7 @@ import * as React from "react";
 import QuestionRendererForStories from "../../__testutils__/question-renderer-for-stories";
 
 import type {APIOptions} from "../../../types";
-import type {DropdownDefaultWidgetOptions} from "@khanacademy/perseus-core";
+import type {PerseusDropdownWidgetOptions} from "@khanacademy/perseus-core";
 import type {Decorator} from "@storybook/react-vite";
 
 export const dropdownRendererDecorator: Decorator = (
@@ -17,7 +17,7 @@ export const dropdownRendererDecorator: Decorator = (
         args,
         parameters,
     }: {
-        args: Partial<DropdownDefaultWidgetOptions>;
+        args: Partial<PerseusDropdownWidgetOptions>;
         parameters?: {
             apiOptions?: APIOptions;
             content?: string;

--- a/packages/perseus/src/widgets/explanation/__docs__/explanation-renderer-decorator.tsx
+++ b/packages/perseus/src/widgets/explanation/__docs__/explanation-renderer-decorator.tsx
@@ -9,7 +9,7 @@ import QuestionRendererForStories from "../../__testutils__/question-renderer-fo
 
 import type {APIOptions} from "../../../types";
 import type {
-    ExplanationDefaultWidgetOptions,
+    PerseusExplanationWidgetOptions,
     PerseusWidgetsMap,
 } from "@khanacademy/perseus-core";
 import type {Decorator} from "@storybook/react-vite";
@@ -20,7 +20,7 @@ export const explanationRendererDecorator: Decorator = (
         args,
         parameters,
     }: {
-        args: Partial<ExplanationDefaultWidgetOptions>;
+        args: Partial<PerseusExplanationWidgetOptions>;
         parameters?: {
             apiOptions?: APIOptions;
             content?: string;

--- a/packages/perseus/src/widgets/radio/__docs__/radio-renderer-decorator.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/radio-renderer-decorator.tsx
@@ -13,7 +13,7 @@ import {testDependenciesV2} from "../../../testing/test-dependencies";
 import type {APIOptions} from "../../../types";
 import type {
     PerseusImageDetail,
-    RadioDefaultWidgetOptions,
+    PerseusRadioWidgetOptions,
 } from "@khanacademy/perseus-core";
 import type {Decorator} from "@storybook/react-vite";
 
@@ -23,7 +23,7 @@ export const radioRendererDecorator: Decorator = (
         args,
         parameters,
     }: {
-        args: Partial<RadioDefaultWidgetOptions>;
+        args: Partial<PerseusRadioWidgetOptions>;
         parameters?: {
             apiOptions?: APIOptions;
             showSolutions?: "all" | "none" | "selected";
@@ -61,7 +61,7 @@ export const radioRendererDecoratorWithDebugUI: Decorator = (
         args,
         parameters,
     }: {
-        args: Partial<RadioDefaultWidgetOptions>;
+        args: Partial<PerseusRadioWidgetOptions>;
         parameters?: {
             apiOptions?: APIOptions;
             showSolutions?: "all" | "none" | "selected";


### PR DESCRIPTION
## Summary:

The only things we use `*DefaultWidgetOptions`:
1. Generator functions, which is somewhere we want a full widget (`Perseus*WidgetOptions`)
2. Initializing a widget in the editors, which I expect we also want a full widget

So I don't think we actually need it as a distinct type. For the most part the transition was smooth, but Image, NumberLine, and Orderer needed some additional defaults (which I think is a good thing).

Issue: LEMS-4477