### PR TITLE
Remove `Perseus*Rubric` and `Perseus*ValidationData` types

### DIFF
--- a/.changeset/better-wings-flow.md
+++ b/.changeset/better-wings-flow.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus-core": major
+"@khanacademy/perseus-score": patch
+"@khanacademy/perseus": patch
+---
+
+Remove Perseus*Rubric and Perseus*ValidationData types in favor of Perseus*WidgetOptions and *PublicWidgetOptions

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -424,6 +424,8 @@ export {
     generateSorterWidget,
     generateSorterOptions,
 } from "./utils/generators/sorter-widget-generator";
+/** @hidden */
+export {generateGrapherWidgetOptions} from "./utils/generators/grapher-widget-generator";
 
 export {
     getAnswersFromWidgets,

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -427,6 +427,8 @@ export {
     generateSorterOptions,
 } from "./utils/generators/sorter-widget-generator";
 /** @hidden */
+export {generateTableOptions} from "./utils/generators/table-widget-generator";
+/** @hidden */
 export {generateGrapherWidgetOptions} from "./utils/generators/grapher-widget-generator";
 
 export {

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -202,6 +202,8 @@ export type {GrapherPublicWidgetOptions} from "./widgets/grapher/grapher-util";
 /** @hidden */
 export {getGroupPublicWidgetOptions} from "./widgets/group/group-util";
 /** @hidden */
+export type {GroupPublicWidgetOptions} from "./widgets/group/group-util";
+/** @hidden */
 export {
     getInteractiveGraphPublicWidgetOptions,
     type InteractiveGraphPublicWidgetOptions,

--- a/packages/perseus-core/src/utils/generators/table-widget-generator.test.ts
+++ b/packages/perseus-core/src/utils/generators/table-widget-generator.test.ts
@@ -31,6 +31,9 @@ describe("generateTableOptions", () => {
         const options = generateTableOptions({
             answers: [["1", "2"]],
             rows: 5,
+            // `columns: 7` doesn't really make sense,
+            // but this test is testing that we prefer the provided `columns`
+            // over the calculated `columns`
             columns: 7,
             headers: ["a", "b"],
         });

--- a/packages/perseus-core/src/utils/generators/table-widget-generator.test.ts
+++ b/packages/perseus-core/src/utils/generators/table-widget-generator.test.ts
@@ -1,0 +1,43 @@
+import tableWidgetLogic from "../../widgets/table";
+
+import {generateTableOptions} from "./table-widget-generator";
+
+describe("generateTableOptions", () => {
+    it("returns the widget's default options when given no overrides", () => {
+        // Arrange, Act
+        const options = generateTableOptions();
+
+        // Assert
+        expect(options).toEqual(tableWidgetLogic.defaultWidgetOptions);
+    });
+
+    it("derives rows, columns and headers from the provided answers", () => {
+        // Arrange, Act
+        const options = generateTableOptions({
+            answers: [
+                ["1", "2", "3"],
+                ["4", "5", "6"],
+            ],
+        });
+
+        // Assert
+        expect(options.rows).toBe(2);
+        expect(options.columns).toBe(3);
+        expect(options.headers).toEqual(["", "", ""]);
+    });
+
+    it("uses the provided rows, columns and headers when they are given", () => {
+        // Arrange, Act
+        const options = generateTableOptions({
+            answers: [["1", "2"]],
+            rows: 5,
+            columns: 7,
+            headers: ["a", "b"],
+        });
+
+        // Assert
+        expect(options.rows).toBe(5);
+        expect(options.columns).toBe(7);
+        expect(options.headers).toEqual(["a", "b"]);
+    });
+});

--- a/packages/perseus-core/src/utils/generators/table-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/table-widget-generator.ts
@@ -1,0 +1,24 @@
+import tableWidgetLogic from "../../widgets/table";
+
+import type {PerseusTableWidgetOptions} from "../../data-schema";
+
+export function generateTableOptions(
+    options?: Partial<PerseusTableWidgetOptions>,
+): PerseusTableWidgetOptions {
+    const merged = {
+        ...tableWidgetLogic.defaultWidgetOptions,
+        ...options,
+    };
+
+    // `rows`, `columns` and `headers` all describe the shape of `answers`, so
+    // we derive them. That way a caller who overrides only `answers` still
+    // gets a coherent widget.
+    const columns = merged.answers[0]?.length ?? merged.columns;
+
+    return {
+        ...merged,
+        rows: options?.rows ?? merged.answers.length,
+        columns: options?.columns ?? columns,
+        headers: options?.headers ?? new Array(columns).fill(""),
+    };
+}

--- a/packages/perseus-core/src/utils/generators/table-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/table-widget-generator.ts
@@ -2,6 +2,11 @@ import tableWidgetLogic from "../../widgets/table";
 
 import type {PerseusTableWidgetOptions} from "../../data-schema";
 
+/**
+ * `rows`, `columns` and `headers` all describe the shape of `answers`, so
+ * we derive them. That way a caller who overrides only `answers` still
+ * gets a coherent widget.
+ */
 export function generateTableOptions(
     options?: Partial<PerseusTableWidgetOptions>,
 ): PerseusTableWidgetOptions {
@@ -10,9 +15,6 @@ export function generateTableOptions(
         ...options,
     };
 
-    // `rows`, `columns` and `headers` all describe the shape of `answers`, so
-    // we derive them. That way a caller who overrides only `answers` still
-    // gets a coherent widget.
     const columns = merged.answers[0]?.length ?? merged.columns;
 
     return {

--- a/packages/perseus-core/src/utils/generators/table-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/table-widget-generator.ts
@@ -6,6 +6,9 @@ import type {PerseusTableWidgetOptions} from "../../data-schema";
  * `rows`, `columns` and `headers` all describe the shape of `answers`, so
  * we derive them. That way a caller who overrides only `answers` still
  * gets a coherent widget.
+ *
+ * Each of the three resolves in the same order: the caller's value, then the
+ * shape of `answers`, then the widget default.
  */
 export function generateTableOptions(
     options?: Partial<PerseusTableWidgetOptions>,
@@ -15,12 +18,15 @@ export function generateTableOptions(
         ...options,
     };
 
-    const columns = merged.answers[0]?.length ?? merged.columns;
+    const columns =
+        options?.columns ??
+        merged.answers[0]?.length ??
+        tableWidgetLogic.defaultWidgetOptions.columns;
 
     return {
         ...merged,
         rows: options?.rows ?? merged.answers.length,
-        columns: options?.columns ?? columns,
+        columns,
         headers: options?.headers ?? new Array(columns).fill(""),
     };
 }

--- a/packages/perseus-core/src/validation.types.ts
+++ b/packages/perseus-core/src/validation.types.ts
@@ -32,25 +32,8 @@
 import type {
     GrapherAnswerTypes,
     MakeWidgetMap,
-    PerseusCategorizerWidgetOptions,
-    PerseusDropdownWidgetOptions,
-    PerseusExpressionWidgetOptions,
-    PerseusGradedGroupSetWidgetOptions,
-    PerseusGradedGroupWidgetOptions,
     PerseusGraphType,
-    PerseusGrapherWidgetOptions,
-    PerseusGroupWidgetOptions,
-    PerseusInteractiveGraphWidgetOptions,
-    PerseusLabelImageWidgetOptions,
-    PerseusMatcherWidgetOptions,
-    PerseusMatrixWidgetOptions,
-    PerseusNumberLineWidgetOptions,
-    PerseusNumericInputWidgetOptions,
-    PerseusOrdererWidgetOptions,
-    PerseusPlotterWidgetOptions,
-    PerseusRadioWidgetOptions,
-    PerseusSorterWidgetOptions,
-    PerseusTableWidgetOptions,
+    PerseusWidgetOptions,
 } from "./data-schema";
 import type {ErrorCode} from "./error-codes";
 import type {Relationship} from "./types";
@@ -92,7 +75,7 @@ export type WidgetScorerFunction = (
     userInput: UserInput | undefined,
 
     /** The scoring criteria containing the correct answer. */
-    rubric: Rubric,
+    rubric: PerseusWidgetOptions,
 
     /**
      * The locale for locale-sensitive scoring (eg. decimal separators).
@@ -344,35 +327,6 @@ export type PerseusSorterUserInput = {
  * entered by the learner, scored against the rubric's answers.
  */
 export type PerseusTableUserInput = string[][];
-
-/**
- * A registry mapping widget type names to their rubric types.
- */
-// NOTE: Extend this interface to add new widget rubric types.
-export interface RubricRegistry {
-    categorizer: PerseusCategorizerWidgetOptions;
-    dropdown: PerseusDropdownWidgetOptions;
-    expression: PerseusExpressionWidgetOptions;
-    "graded-group-set": PerseusGradedGroupSetWidgetOptions;
-    "graded-group": PerseusGradedGroupWidgetOptions;
-    grapher: PerseusGrapherWidgetOptions;
-    group: PerseusGroupWidgetOptions;
-    "input-number": PerseusNumericInputWidgetOptions;
-    "interactive-graph": PerseusInteractiveGraphWidgetOptions;
-    "label-image": PerseusLabelImageWidgetOptions;
-    matcher: PerseusMatcherWidgetOptions;
-    matrix: PerseusMatrixWidgetOptions;
-    "number-line": PerseusNumberLineWidgetOptions;
-    "numeric-input": PerseusNumericInputWidgetOptions;
-    orderer: PerseusOrdererWidgetOptions;
-    plotter: PerseusPlotterWidgetOptions;
-    radio: PerseusRadioWidgetOptions;
-    sorter: PerseusSorterWidgetOptions;
-    table: PerseusTableWidgetOptions;
-}
-
-/** A union of all widget rubric types. */
-export type Rubric = RubricRegistry[keyof RubricRegistry];
 
 /**
  * This is an interface so that it can be extended if a widget is created

--- a/packages/perseus-core/src/validation.types.ts
+++ b/packages/perseus-core/src/validation.types.ts
@@ -54,6 +54,9 @@ import type {
 } from "./data-schema";
 import type {ErrorCode} from "./error-codes";
 import type {Relationship} from "./types";
+import type {CategorizerPublicWidgetOptions} from "./widgets/categorizer/categorizer-util";
+import type {GroupPublicWidgetOptions} from "./widgets/group/group-util";
+import type {PlotterPublicWidgetOptions} from "./widgets/plotter/plotter-util";
 
 /**
  * The signature of a widget's client-side validation function. This function
@@ -415,9 +418,9 @@ export type UserInputMap = MakeWidgetMap<UserInputRegistry>;
  * validation data types.
  */
 export interface ValidationDataTypes {
-    categorizer: PerseusCategorizerWidgetOptions;
-    group: PerseusGroupWidgetOptions;
-    plotter: PerseusPlotterWidgetOptions;
+    categorizer: CategorizerPublicWidgetOptions;
+    group: GroupPublicWidgetOptions;
+    plotter: PlotterPublicWidgetOptions;
 }
 
 /**

--- a/packages/perseus-core/src/validation.types.ts
+++ b/packages/perseus-core/src/validation.types.ts
@@ -31,20 +31,26 @@
 
 import type {
     GrapherAnswerTypes,
-    PerseusDropdownChoice,
-    PerseusExpressionAnswerForm,
+    MakeWidgetMap,
+    PerseusCategorizerWidgetOptions,
+    PerseusDropdownWidgetOptions,
+    PerseusExpressionWidgetOptions,
     PerseusGradedGroupSetWidgetOptions,
     PerseusGradedGroupWidgetOptions,
     PerseusGraphType,
+    PerseusGrapherWidgetOptions,
     PerseusGroupWidgetOptions,
-    PerseusMatrixWidgetAnswers,
-    PerseusNumericInputAnswer,
+    PerseusInteractiveGraphWidgetOptions,
+    PerseusLabelImageWidgetOptions,
+    PerseusMatcherWidgetOptions,
+    PerseusMatrixWidgetOptions,
+    PerseusNumberLineWidgetOptions,
+    PerseusNumericInputWidgetOptions,
     PerseusOrdererWidgetOptions,
-    PerseusRadioChoice,
-    PerseusGraphCorrectType,
-    MakeWidgetMap,
-    PerseusFreeResponseWidgetScoringCriterion,
-    PerseusRenderer,
+    PerseusPlotterWidgetOptions,
+    PerseusRadioWidgetOptions,
+    PerseusSorterWidgetOptions,
+    PerseusTableWidgetOptions,
 } from "./data-schema";
 import type {ErrorCode} from "./error-codes";
 import type {Relationship} from "./types";
@@ -140,23 +146,6 @@ export type PerseusBlankUserInput = {
     selected: string | null;
 };
 
-export type PerseusBlankRubric = {
-    /**
-     * The ID of the correct answer tile
-     */
-    correctId: string;
-};
-
-/** Scoring rubric for the Categorizer widget. */
-export type PerseusCategorizerRubric = {
-    /**
-     * The correct category index for each item. The array index corresponds to
-     * the item; the value is the category index.
-     * e.g. [0, 1, 0, 1, 2]
-     */
-    values: number[];
-} & PerseusCategorizerValidationData;
-
 /**
  * User input for the Categorizer widget. Records which category
  * the user assigned to each item.
@@ -170,15 +159,6 @@ export type PerseusCategorizerUserInput = {
     values: Array<number | null | undefined>;
 };
 
-/** Validation data for the Categorizer widget. */
-export type PerseusCategorizerValidationData = {
-    /**
-     * Translatable text; items to categorize.
-     * e.g. ["banana", "yellow", "apple", "purple", "shirt"]
-     */
-    items: string[];
-};
-
 /** User input for the CS Program widget. */
 export type PerseusCSProgramUserInput = {
     /**
@@ -190,12 +170,6 @@ export type PerseusCSProgramUserInput = {
     message: string | null;
 };
 
-/** Scoring rubric for the Dropdown widget. */
-export type PerseusDropdownRubric = {
-    /** The list of choices; each has a `correct` flag used for scoring. */
-    choices: Array<PerseusDropdownChoice>;
-};
-
 /** User input for the Dropdown widget. */
 export type PerseusDropdownUserInput = {
     /**
@@ -205,21 +179,6 @@ export type PerseusDropdownUserInput = {
     value: number;
 };
 
-/** Scoring rubric for the Expression widget. */
-export type PerseusExpressionRubric = {
-    /**
-     * Ordered list of answer forms matched top-to-bottom; the first
-     * match determines the score.
-     */
-    answerForms: Array<PerseusExpressionAnswerForm>;
-    /**
-     * Variable names treated as functions (e.g. ["f", "g"]) during KAS
-     * parsing.
-     */
-    functions: string[];
-    extraKeys?: ReadonlyArray<string>;
-};
-
 /**
  * User input for the Expression widget: the raw math expression
  * string the learner typed, parsed by @khanacademy/kas for scoring.
@@ -227,34 +186,10 @@ export type PerseusExpressionRubric = {
 export type PerseusExpressionUserInput = string;
 
 /**
- * Scoring rubric for the Group widget: the full widget options including all
- * nested widgets and their rubrics.
- */
-export type PerseusGroupRubric = PerseusGroupWidgetOptions;
-
-/**
- * Validation data for the Group widget: the full renderer content used to
- * recursively validate nested widgets.
- */
-export type PerseusGroupValidationData = PerseusRenderer;
-
-/**
  * User input for the Group widget: a map of widget IDs to each widget's user
  * input. Scored by recursively scoring all contained widgets.
  */
 export type PerseusGroupUserInput = UserInputMap;
-
-/** Scoring rubric for the GradedGroup widget. */
-export type PerseusGradedGroupRubric = PerseusGradedGroupWidgetOptions;
-
-/** Scoring rubric for the GradedGroupSet widget. */
-export type PerseusGradedGroupSetRubric = PerseusGradedGroupSetWidgetOptions;
-
-/** Scoring rubric for the Grapher widget. */
-export type PerseusGrapherRubric = {
-    /** The expected function type and coordinates for a correct answer. */
-    correct: GrapherAnswerTypes;
-};
 
 /**
  * User input for the Grapher widget: the function type and
@@ -282,39 +217,11 @@ export type PerseusInputNumberUserInput = {
     currentValue: string;
 };
 
-/** Scoring rubric for the InteractiveGraph widget. */
-export type PerseusInteractiveGraphRubric = {
-    /**
-     * The expected graph state for a correct answer.
-     */
-    // TODO(LEMS-2344): make the type of `correct` more specific.
-    correct: PerseusGraphCorrectType;
-    /**
-     * The initial graph state; used to detect an unanswered/empty widget
-     * (input equals this when nothing has moved).
-     */
-    graph: PerseusGraphType;
-};
-
 /**
  * User input for the InteractiveGraph widget: the graph type and coordinates
  * the learner positioned.
  */
 export type PerseusInteractiveGraphUserInput = PerseusGraphType;
-
-/** Scoring rubric for the LabelImage widget. */
-export type PerseusLabelImageRubric = {
-    /**
-     * The expected answers for each labeled region in the image, parallel to
-     * the user input's markers.
-     */
-    markers: Array<{
-        /** The set of correct answer labels for this marker. */
-        answers: string[];
-        /** The label text identifying this marker in the image. */
-        label: string;
-    }>;
-};
 
 /** User input for a single image marker in the LabelImage widget. */
 export type PerseusLabelImageUserInputMarker = {
@@ -333,23 +240,6 @@ export type PerseusLabelImageUserInput = {
     markers: PerseusLabelImageUserInputMarker[];
 };
 
-/** Scoring rubric for the Matcher widget. */
-export type PerseusMatcherRubric = {
-    /**
-     * Static concepts for the left column. e.g. ["Fruit", "Color", "Clothes"]
-     *
-     * Translatable text.
-     */
-    left: string[];
-    /**
-     * the correct right-column values, ordered to match the left. e.g.
-     * ["Banana", "Red", "Shirt"]
-     *
-     * Translatable markup.
-     */
-    right: string[];
-};
-
 /** User input for the Matcher widget. */
 export type PerseusMatcherUserInput = {
     /** The left-column items in the learner's current arrangement. */
@@ -361,18 +251,6 @@ export type PerseusMatcherUserInput = {
     right: string[];
 };
 
-/** Scoring rubric for the Matrix widget. */
-export type PerseusMatrixRubric = {
-    /** The correct 2D matrix of answers. */
-    answers: PerseusMatrixWidgetAnswers;
-} & PerseusMatrixValidationData;
-
-/**
- * Validation data for the Matrix widget; currently empty — validation is
- * performed from user input alone.
- */
-export type PerseusMatrixValidationData = Empty;
-
 /** User input for the Matrix widget. */
 export type PerseusMatrixUserInput = {
     /**
@@ -380,27 +258,6 @@ export type PerseusMatrixUserInput = {
      * numeric expression.
      */
     answers: string[][];
-};
-
-/** Scoring rubric for the NumberLine widget. */
-export type PerseusNumberLineRubric = {
-    /**
-     * The correct inequality relation (e.g. "lt", "ge"), or null
-     * for an equality question.
-     */
-    correctRel: string | null | undefined;
-    /** The correct numeric position on the number line. */
-    correctX: number;
-    /** The [min, max] extent of the number line. */
-    range: number[];
-    /** The starting position of the point. Defaults to range[0] if null. */
-    initialX: number | null | undefined;
-    /** When true, the widget shows a shaded region and a relation selector. */
-    isInequality: boolean;
-    /** When true, the learner can adjust the number of tick-mark divisions. */
-    isTickCtrl?: boolean;
-    /** The [min, max] allowed number of divisions when isTickCtrl is true. */
-    divisionRange: number[];
 };
 
 /** User input for the NumberLine widget. */
@@ -424,26 +281,6 @@ export type PerseusNumberLineUserInput = {
     numDivisions: number;
 };
 
-/** Scoring rubric for the NumericInput widget. */
-export type PerseusNumericInputRubric = {
-    /**
-     * A list of correct and incorrect answers. Each answer can have a
-     * message explaining why it is correct/incorrect. There may be
-     * multiple correct answers if multiple formats are accepted. For
-     * example, some questions might accept either a fraction or a
-     * decimal as correct.
-     *
-     * The first answer that matches (correct or incorrect) is the scoring
-     * result (so order of answers is very important).
-     */
-    answers: PerseusNumericInputAnswer[];
-    /**
-     * When true, allows shorthand coefficient entry: `"-"` means `-1`
-     * and an empty string (`""`) means `1`.
-     */
-    coefficient: boolean;
-};
-
 /** User input for the NumericInput widget. */
 export type PerseusNumericInputUserInput = {
     /**
@@ -459,20 +296,6 @@ export type PerseusFreeResponseUserInput = {
     currentValue: string;
 };
 
-/** Scoring rubric for the FreeResponse widget. */
-export type PerseusFreeResponseRubric = {
-    /** The question text shown to the learner. */
-    question: string;
-    /** The criteria used for AI-assisted scoring of the learner's response. */
-    scoringCriteria: ReadonlyArray<PerseusFreeResponseWidgetScoringCriterion>;
-};
-
-/**
- * Scoring rubric for the Orderer widget: the full widget options
- * including the correct ordering.
- */
-export type PerseusOrdererRubric = PerseusOrdererWidgetOptions;
-
 /** User input for the Orderer widget. */
 export type PerseusOrdererUserInput = {
     /**
@@ -482,35 +305,11 @@ export type PerseusOrdererUserInput = {
     current: string[];
 };
 
-/** Scoring rubric for the Plotter widget. */
-export type PerseusPlotterRubric = {
-    /** The expected Y-axis values representing the correct answer. */
-    correct: number[];
-} & PerseusPlotterValidationData;
-
-/** Validation data for the Plotter widget. */
-export type PerseusPlotterValidationData = {
-    /** The initial Y-axis values the chart is pre-populated with. */
-    starting: number[];
-};
-
 /**
  * User input for the Plotter widget: an array of Y-axis values, one
  * per bar or data point, as set by the learner.
  */
 export type PerseusPlotterUserInput = number[];
-
-/** Scoring rubric for the Radio widget. */
-export type PerseusRadioRubric = {
-    /** The answer choices shown to the learner; each has a `correct` flag. */
-    choices: PerseusRadioChoice[];
-    /**
-     * When true, the learner must select exactly as many choices as there
-     * are correct answers before the answer is graded. Only has an effect
-     * when there are multiple correct answers.
-     */
-    countChoices?: boolean;
-};
 
 /** User input for the Radio widget. */
 export type PerseusRadioUserInput = {
@@ -521,15 +320,6 @@ export type PerseusRadioUserInput = {
      * the display order, which may be shuffled.
      */
     selectedChoiceIds: string[];
-};
-
-/** Scoring rubric for the Sorter widget. */
-export type PerseusSorterRubric = {
-    /**
-     * Translatable text; the correct ordering of the cards. The
-     * learner sees them in a randomized order.
-     */
-    correct: string[];
 };
 
 /** User input for the Sorter widget. */
@@ -546,12 +336,6 @@ export type PerseusSorterUserInput = {
     changed: boolean;
 };
 
-/** Scoring rubric for the Table widget. */
-export type PerseusTableRubric = {
-    /** Translatable text; the correct 2D array of cell values. */
-    answers: string[][];
-};
-
 /**
  * User input for the Table widget: a 2D array of cell values
  * entered by the learner, scored against the rubric's answers.
@@ -563,25 +347,25 @@ export type PerseusTableUserInput = string[][];
  */
 // NOTE: Extend this interface to add new widget rubric types.
 export interface RubricRegistry {
-    categorizer: PerseusCategorizerRubric;
-    dropdown: PerseusDropdownRubric;
-    expression: PerseusExpressionRubric;
-    "graded-group-set": PerseusGradedGroupSetRubric;
-    "graded-group": PerseusGradedGroupRubric;
-    grapher: PerseusGrapherRubric;
-    group: PerseusGroupRubric;
-    "input-number": PerseusNumericInputRubric;
-    "interactive-graph": PerseusInteractiveGraphRubric;
-    "label-image": PerseusLabelImageRubric;
-    matcher: PerseusMatcherRubric;
-    matrix: PerseusMatrixRubric;
-    "number-line": PerseusNumberLineRubric;
-    "numeric-input": PerseusNumericInputRubric;
-    orderer: PerseusOrdererRubric;
-    plotter: PerseusPlotterRubric;
-    radio: PerseusRadioRubric;
-    sorter: PerseusSorterRubric;
-    table: PerseusTableRubric;
+    categorizer: PerseusCategorizerWidgetOptions;
+    dropdown: PerseusDropdownWidgetOptions;
+    expression: PerseusExpressionWidgetOptions;
+    "graded-group-set": PerseusGradedGroupSetWidgetOptions;
+    "graded-group": PerseusGradedGroupWidgetOptions;
+    grapher: PerseusGrapherWidgetOptions;
+    group: PerseusGroupWidgetOptions;
+    "input-number": PerseusNumericInputWidgetOptions;
+    "interactive-graph": PerseusInteractiveGraphWidgetOptions;
+    "label-image": PerseusLabelImageWidgetOptions;
+    matcher: PerseusMatcherWidgetOptions;
+    matrix: PerseusMatrixWidgetOptions;
+    "number-line": PerseusNumberLineWidgetOptions;
+    "numeric-input": PerseusNumericInputWidgetOptions;
+    orderer: PerseusOrdererWidgetOptions;
+    plotter: PerseusPlotterWidgetOptions;
+    radio: PerseusRadioWidgetOptions;
+    sorter: PerseusSorterWidgetOptions;
+    table: PerseusTableWidgetOptions;
 }
 
 /** A union of all widget rubric types. */
@@ -631,9 +415,9 @@ export type UserInputMap = MakeWidgetMap<UserInputRegistry>;
  * validation data types.
  */
 export interface ValidationDataTypes {
-    categorizer: PerseusCategorizerValidationData;
-    group: PerseusGroupValidationData;
-    plotter: PerseusPlotterValidationData;
+    categorizer: PerseusCategorizerWidgetOptions;
+    group: PerseusGroupWidgetOptions;
+    plotter: PerseusPlotterWidgetOptions;
 }
 
 /**

--- a/packages/perseus-score/package.json
+++ b/packages/perseus-score/package.json
@@ -28,7 +28,8 @@
         "@khanacademy/kas": "workspace:*",
         "@khanacademy/kmath": "workspace:*",
         "@khanacademy/perseus-core": "workspace:*",
-        "@khanacademy/perseus-utils": "workspace:*"
+        "@khanacademy/perseus-utils": "workspace:*",
+        "tiny-invariant": "^1.3.3"
     },
     "devDependencies": {
         "perseus-build-settings": "workspace:*",

--- a/packages/perseus-score/src/index.ts
+++ b/packages/perseus-score/src/index.ts
@@ -41,7 +41,7 @@ export {default as hasEmptyDINERWidgets} from "./has-empty-diner-widgets";
 export {default as isWidgetScoreable} from "./util/is-widget-scoreable";
 
 export type {
-    PerseusMockWidgetRubric,
+    PerseusMockWidgetOptions,
     PerseusMockWidgetUserInput,
 } from "./widgets/mock-widget/mock-widget-validation.types";
 

--- a/packages/perseus-score/src/widgets/blank/score-blank.test.ts
+++ b/packages/perseus-score/src/widgets/blank/score-blank.test.ts
@@ -1,16 +1,15 @@
+import {generateBlankOptions} from "@khanacademy/perseus-core";
+
 import scoreBlank from "./score-blank";
 
-import type {
-    PerseusBlankRubric,
-    PerseusBlankUserInput,
-} from "@khanacademy/perseus-core";
+import type {PerseusBlankUserInput} from "@khanacademy/perseus-core";
 
 describe("scoreBlank", () => {
     it("returns a score of 'invalid' when the user input is undefined", () => {
         // Arrange
-        const rubric: PerseusBlankRubric = {
+        const rubric = generateBlankOptions({
             correctId: "answer-tile-1",
-        };
+        });
 
         const userInput = undefined;
 
@@ -23,9 +22,9 @@ describe("scoreBlank", () => {
 
     it("gives points when the selected tile matches the correct answer", () => {
         // Arrange
-        const rubric: PerseusBlankRubric = {
+        const rubric = generateBlankOptions({
             correctId: "answer-tile-1",
-        };
+        });
 
         const userInput: PerseusBlankUserInput = {
             selected: "answer-tile-1",
@@ -40,9 +39,9 @@ describe("scoreBlank", () => {
 
     it("does not give points when the selected tile does not match the correct answer", () => {
         // Arrange
-        const rubric: PerseusBlankRubric = {
+        const rubric = generateBlankOptions({
             correctId: "answer-tile-1",
-        };
+        });
 
         const userInput: PerseusBlankUserInput = {
             selected: "answer-tile-2",
@@ -57,9 +56,9 @@ describe("scoreBlank", () => {
 
     it("returns a score of 'invalid' when no tile has been selected", () => {
         // Arrange
-        const rubric: PerseusBlankRubric = {
+        const rubric = generateBlankOptions({
             correctId: "answer-tile-1",
-        };
+        });
 
         const userInput: PerseusBlankUserInput = {
             selected: null,

--- a/packages/perseus-score/src/widgets/blank/score-blank.ts
+++ b/packages/perseus-score/src/widgets/blank/score-blank.ts
@@ -1,7 +1,7 @@
 import validateBlank from "./validate-blank";
 
 import type {
-    PerseusBlankRubric,
+    PerseusBlankWidgetOptions,
     PerseusBlankUserInput,
     PerseusScore,
 } from "@khanacademy/perseus-core";
@@ -10,7 +10,7 @@ function scoreBlank(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusBlankUserInput | undefined,
-    rubric: PerseusBlankRubric,
+    rubric: PerseusBlankWidgetOptions,
 ): PerseusScore {
     const validationResult = validateBlank(userInput);
     if (validationResult != null) {

--- a/packages/perseus-score/src/widgets/categorizer/score-categorizer.test.ts
+++ b/packages/perseus-score/src/widgets/categorizer/score-categorizer.test.ts
@@ -1,13 +1,13 @@
-import scoreCategorizer from "./score-categorizer";
+import {generateCategorizerOptions} from "@khanacademy/perseus-core";
 
-import type {PerseusCategorizerRubric} from "@khanacademy/perseus-core";
+import scoreCategorizer from "./score-categorizer";
 
 describe("scoreCategorizer", () => {
     it("returns a score of 'invalid' when the user input is undefined", () => {
-        const rubric: PerseusCategorizerRubric = {
+        const rubric = generateCategorizerOptions({
             values: [1, 3],
             items: ["apples", "oranges"],
-        };
+        });
 
         const userInput = undefined;
 
@@ -17,10 +17,10 @@ describe("scoreCategorizer", () => {
     });
 
     it("gives points when the answer is correct", () => {
-        const rubric: PerseusCategorizerRubric = {
+        const rubric = generateCategorizerOptions({
             values: [1, 3],
             items: ["apples", "oranges"],
-        };
+        });
 
         const userInput = {
             values: [1, 3],
@@ -31,10 +31,10 @@ describe("scoreCategorizer", () => {
     });
 
     it("does not give points when incorrectly answered", () => {
-        const rubric: PerseusCategorizerRubric = {
+        const rubric = generateCategorizerOptions({
             values: [1, 3],
             items: ["apples", "oranges"],
-        };
+        });
 
         const userInput = {
             values: [2, 3],

--- a/packages/perseus-score/src/widgets/categorizer/score-categorizer.ts
+++ b/packages/perseus-score/src/widgets/categorizer/score-categorizer.ts
@@ -1,5 +1,5 @@
 import type {
-    PerseusCategorizerRubric,
+    PerseusCategorizerWidgetOptions,
     PerseusCategorizerUserInput,
     PerseusScore,
 } from "@khanacademy/perseus-core";
@@ -8,7 +8,7 @@ function scoreCategorizer(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusCategorizerUserInput | undefined,
-    rubric: PerseusCategorizerRubric,
+    rubric: PerseusCategorizerWidgetOptions,
 ): PerseusScore {
     if (userInput == null) {
         return {type: "invalid", message: null};

--- a/packages/perseus-score/src/widgets/categorizer/validate-categorizer.test.ts
+++ b/packages/perseus-score/src/widgets/categorizer/validate-categorizer.test.ts
@@ -1,12 +1,15 @@
-import {generateCategorizerOptions} from "@khanacademy/perseus-core";
+import {
+    generateCategorizerOptions,
+    getCategorizerPublicWidgetOptions,
+} from "@khanacademy/perseus-core";
 
 import validateCategorizer from "./validate-categorizer";
 
 describe("validateCategorizer", () => {
     it("returns a score of 'invalid' when the user input is undefined", () => {
-        const rubric = generateCategorizerOptions({
-            items: ["apples", "oranges"],
-        });
+        const rubric = getCategorizerPublicWidgetOptions(
+            generateCategorizerOptions({items: ["apples", "oranges"]}),
+        );
 
         const userInput = undefined;
 
@@ -16,9 +19,9 @@ describe("validateCategorizer", () => {
     });
 
     it("tells the learner its not complete if not selected", () => {
-        const validationData = generateCategorizerOptions({
-            items: ["apples", "oranges"],
-        });
+        const validationData = getCategorizerPublicWidgetOptions(
+            generateCategorizerOptions({items: ["apples", "oranges"]}),
+        );
 
         const userInput = {
             values: [2],
@@ -29,9 +32,9 @@ describe("validateCategorizer", () => {
     });
 
     it("returns null if the userInput is valid", () => {
-        const validationData = generateCategorizerOptions({
-            items: ["apples", "oranges"],
-        });
+        const validationData = getCategorizerPublicWidgetOptions(
+            generateCategorizerOptions({items: ["apples", "oranges"]}),
+        );
 
         const userInput = {
             values: [2, 4],

--- a/packages/perseus-score/src/widgets/categorizer/validate-categorizer.test.ts
+++ b/packages/perseus-score/src/widgets/categorizer/validate-categorizer.test.ts
@@ -1,12 +1,12 @@
-import validateCategorizer from "./validate-categorizer";
+import {generateCategorizerOptions} from "@khanacademy/perseus-core";
 
-import type {PerseusCategorizerValidationData} from "@khanacademy/perseus-core";
+import validateCategorizer from "./validate-categorizer";
 
 describe("validateCategorizer", () => {
     it("returns a score of 'invalid' when the user input is undefined", () => {
-        const rubric: PerseusCategorizerValidationData = {
+        const rubric = generateCategorizerOptions({
             items: ["apples", "oranges"],
-        };
+        });
 
         const userInput = undefined;
 
@@ -16,9 +16,9 @@ describe("validateCategorizer", () => {
     });
 
     it("tells the learner its not complete if not selected", () => {
-        const validationData: PerseusCategorizerValidationData = {
+        const validationData = generateCategorizerOptions({
             items: ["apples", "oranges"],
-        };
+        });
 
         const userInput = {
             values: [2],
@@ -29,9 +29,9 @@ describe("validateCategorizer", () => {
     });
 
     it("returns null if the userInput is valid", () => {
-        const validationData: PerseusCategorizerValidationData = {
+        const validationData = generateCategorizerOptions({
             items: ["apples", "oranges"],
-        };
+        });
 
         const userInput = {
             values: [2, 4],

--- a/packages/perseus-score/src/widgets/categorizer/validate-categorizer.ts
+++ b/packages/perseus-score/src/widgets/categorizer/validate-categorizer.ts
@@ -1,7 +1,7 @@
 import {
     ErrorCodes,
     type PerseusCategorizerUserInput,
-    type PerseusCategorizerValidationData,
+    type PerseusCategorizerWidgetOptions,
     type ValidationResult,
 } from "@khanacademy/perseus-core";
 
@@ -16,7 +16,7 @@ function validateCategorizer(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusCategorizerUserInput | undefined,
-    validationData: PerseusCategorizerValidationData,
+    validationData: PerseusCategorizerWidgetOptions,
 ): ValidationResult {
     if (userInput == null) {
         return {type: "invalid", message: null};

--- a/packages/perseus-score/src/widgets/categorizer/validate-categorizer.ts
+++ b/packages/perseus-score/src/widgets/categorizer/validate-categorizer.ts
@@ -1,7 +1,7 @@
 import {
     ErrorCodes,
     type PerseusCategorizerUserInput,
-    type PerseusCategorizerWidgetOptions,
+    type CategorizerPublicWidgetOptions,
     type ValidationResult,
 } from "@khanacademy/perseus-core";
 
@@ -16,7 +16,7 @@ function validateCategorizer(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusCategorizerUserInput | undefined,
-    validationData: PerseusCategorizerWidgetOptions,
+    validationData: CategorizerPublicWidgetOptions,
 ): ValidationResult {
     if (userInput == null) {
         return {type: "invalid", message: null};

--- a/packages/perseus-score/src/widgets/dropdown/score-dropdown.test.ts
+++ b/packages/perseus-score/src/widgets/dropdown/score-dropdown.test.ts
@@ -1,15 +1,14 @@
+import {generateDropdownOptions} from "@khanacademy/perseus-core";
+
 import scoreDropdown from "./score-dropdown";
 
-import type {
-    PerseusDropdownRubric,
-    PerseusDropdownUserInput,
-} from "@khanacademy/perseus-core";
+import type {PerseusDropdownUserInput} from "@khanacademy/perseus-core";
 
 describe("scoreDropdown", () => {
     it("returns a score of 'invalid' when the user input is undefined", () => {
         // Arrange
         const userInput = undefined;
-        const rubric: PerseusDropdownRubric = {choices: []};
+        const rubric = generateDropdownOptions({choices: []});
 
         // Act
         const score = scoreDropdown(userInput, rubric);
@@ -22,7 +21,7 @@ describe("scoreDropdown", () => {
         const userInput: PerseusDropdownUserInput = {
             value: 1,
         };
-        const rubric: PerseusDropdownRubric = {
+        const rubric = generateDropdownOptions({
             choices: [
                 {
                     content: "greater than or equal to",
@@ -33,7 +32,7 @@ describe("scoreDropdown", () => {
                     correct: true,
                 },
             ],
-        };
+        });
 
         // Act
         const score = scoreDropdown(userInput, rubric);
@@ -47,7 +46,7 @@ describe("scoreDropdown", () => {
         const userInput: PerseusDropdownUserInput = {
             value: 2,
         };
-        const rubric: PerseusDropdownRubric = {
+        const rubric = generateDropdownOptions({
             choices: [
                 {
                     content: "greater than or equal to",
@@ -58,7 +57,7 @@ describe("scoreDropdown", () => {
                     correct: true,
                 },
             ],
-        };
+        });
 
         // Act
         const score = scoreDropdown(userInput, rubric);

--- a/packages/perseus-score/src/widgets/dropdown/score-dropdown.ts
+++ b/packages/perseus-score/src/widgets/dropdown/score-dropdown.ts
@@ -1,5 +1,5 @@
 import type {
-    PerseusDropdownRubric,
+    PerseusDropdownWidgetOptions,
     PerseusDropdownUserInput,
     PerseusScore,
 } from "@khanacademy/perseus-core";
@@ -8,7 +8,7 @@ function scoreDropdown(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusDropdownUserInput | undefined,
-    rubric: PerseusDropdownRubric,
+    rubric: PerseusDropdownWidgetOptions,
 ): PerseusScore {
     if (userInput == null) {
         return {type: "invalid", message: null};

--- a/packages/perseus-score/src/widgets/expression/score-expression.test.ts
+++ b/packages/perseus-score/src/widgets/expression/score-expression.test.ts
@@ -1,12 +1,7 @@
-import {ErrorCodes} from "@khanacademy/perseus-core";
+import {ErrorCodes, generateExpressionOptions} from "@khanacademy/perseus-core";
 
 import scoreExpression from "./score-expression";
 import {expressionItem3Options} from "./score-expression.testdata";
-
-import type {
-    PerseusExpressionRubric,
-    PerseusExpressionWidgetOptions,
-} from "@khanacademy/perseus-core";
 
 describe("scoreExpression", () => {
     it("should score undefined user input as invalid", function () {
@@ -90,7 +85,7 @@ describe("scoreExpression", () => {
     });
 
     it("should handle TeX", () => {
-        const item: PerseusExpressionRubric = {
+        const item = generateExpressionOptions({
             answerForms: [
                 {
                     considered: "correct",
@@ -100,7 +95,7 @@ describe("scoreExpression", () => {
                 },
             ],
             functions: [],
-        };
+        });
 
         const result = scoreExpression("\\sqrt{42^{2}}", item, "en");
         expect(result).toHaveBeenAnsweredCorrectly();
@@ -110,7 +105,7 @@ describe("scoreExpression", () => {
         // The correct answer is 8. The content creator has predicted "8d" as a
         // wrong answer and added it accordingly. When the student enters "8d",
         // their answer should be marked incorrect instead of invalid.
-        const rubric: PerseusExpressionRubric = {
+        const rubric = generateExpressionOptions({
             answerForms: [
                 {
                     considered: "correct",
@@ -127,7 +122,7 @@ describe("scoreExpression", () => {
             ],
             functions: [],
             extraKeys: ["d"],
-        };
+        });
 
         const result = scoreExpression("8d", rubric, "en");
 
@@ -135,7 +130,7 @@ describe("scoreExpression", () => {
     });
 
     it("should return a WRONG_LETTER_ERROR when student uses an unexpected variable", function () {
-        const rubric: PerseusExpressionRubric = {
+        const rubric = generateExpressionOptions({
             answerForms: [
                 {
                     considered: "correct",
@@ -146,7 +141,7 @@ describe("scoreExpression", () => {
             ],
             functions: [],
             extraKeys: [],
-        };
+        });
 
         const result = scoreExpression("8d", rubric, "en");
 
@@ -155,7 +150,7 @@ describe("scoreExpression", () => {
     });
 
     it("should return a WRONG_CASE_ERROR when student uses wrong variable case", function () {
-        const rubric: PerseusExpressionRubric = {
+        const rubric = generateExpressionOptions({
             answerForms: [
                 {
                     considered: "correct",
@@ -166,7 +161,7 @@ describe("scoreExpression", () => {
             ],
             functions: [],
             extraKeys: ["x"],
-        };
+        });
 
         const result = scoreExpression("8X", rubric, "en");
 
@@ -179,7 +174,7 @@ describe("scoreExpression", () => {
         // "X" is a case-mismatch for "x", but "d" is entirely unexpected.
         // The letter error takes priority over the case error as it is more
         // applicable/universal to both situations.
-        const rubric: PerseusExpressionRubric = {
+        const rubric = generateExpressionOptions({
             answerForms: [
                 {
                     considered: "correct",
@@ -190,7 +185,7 @@ describe("scoreExpression", () => {
             ],
             functions: [],
             extraKeys: ["x"],
-        };
+        });
 
         const result = scoreExpression("8Xd", rubric, "en");
 
@@ -201,7 +196,7 @@ describe("scoreExpression", () => {
     it("should score as incorrect when the answer uses a variable the student omitted", function () {
         // The check is one-directional: student vars must appear in the answer,
         // but the answer may use variables the student didn't include.
-        const rubric: PerseusExpressionRubric = {
+        const rubric = generateExpressionOptions({
             answerForms: [
                 {
                     considered: "correct",
@@ -212,7 +207,7 @@ describe("scoreExpression", () => {
             ],
             functions: [],
             extraKeys: ["d"],
-        };
+        });
 
         const result = scoreExpression("8", rubric, "en");
 
@@ -220,7 +215,7 @@ describe("scoreExpression", () => {
     });
 
     it("should keep checking answer forms when earlier forms don't match", function () {
-        const rubric: PerseusExpressionRubric = {
+        const rubric = generateExpressionOptions({
             answerForms: [
                 {
                     considered: "correct",
@@ -237,7 +232,7 @@ describe("scoreExpression", () => {
             ],
             functions: [],
             extraKeys: ["x", "y"],
-        };
+        });
 
         const result = scoreExpression("y + 1", rubric, "en");
 
@@ -251,7 +246,7 @@ describe("scoreExpression", () => {
         const partialReversed = "f(2) = 4 + f(3)";
         const fullyReversed = "f(3) + 4 = f(2)";
 
-        const item: PerseusExpressionWidgetOptions = {
+        const item = generateExpressionOptions({
             answerForms: [
                 {
                     considered: "correct",
@@ -266,7 +261,7 @@ describe("scoreExpression", () => {
             buttonsVisible: "focused",
             visibleLabel: "Visible",
             ariaLabel: "Aria",
-        };
+        });
 
         // Act
         // Assert

--- a/packages/perseus-score/src/widgets/expression/score-expression.ts
+++ b/packages/perseus-score/src/widgets/expression/score-expression.ts
@@ -12,7 +12,7 @@ import KhanAnswerTypes from "../../util/answer-types";
 import type {Score} from "../../util/answer-types";
 import type {
     PerseusExpressionAnswerForm,
-    PerseusExpressionRubric,
+    PerseusExpressionWidgetOptions,
     PerseusExpressionUserInput,
     PerseusScore,
 } from "@khanacademy/perseus-core";
@@ -73,7 +73,7 @@ function scoreExpression(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusExpressionUserInput | undefined,
-    rubric: PerseusExpressionRubric,
+    rubric: PerseusExpressionWidgetOptions,
     locale: string,
 ): PerseusScore {
     if (userInput == null) {

--- a/packages/perseus-score/src/widgets/free-response/score-free-response.test.ts
+++ b/packages/perseus-score/src/widgets/free-response/score-free-response.test.ts
@@ -1,3 +1,5 @@
+import {generateFreeResponseOptions} from "@khanacademy/perseus-core";
+
 import scoreFreeResponse from "./score-free-response";
 
 describe("scoreFreeResponse", () => {
@@ -5,7 +7,7 @@ describe("scoreFreeResponse", () => {
         const userInput = {
             currentValue: "The answer is 42.",
         };
-        const rubric = {
+        const rubric = generateFreeResponseOptions({
             question:
                 "What is the answer to life, the universe, and everything?",
             scoringCriteria: [
@@ -13,7 +15,7 @@ describe("scoreFreeResponse", () => {
                     text: "Must contain 42",
                 },
             ],
-        };
+        });
 
         const score = scoreFreeResponse(userInput, rubric, "en");
         expect(score).toEqual({

--- a/packages/perseus-score/src/widgets/free-response/score-free-response.ts
+++ b/packages/perseus-score/src/widgets/free-response/score-free-response.ts
@@ -1,6 +1,6 @@
 import type {
     PerseusFreeResponseUserInput,
-    PerseusFreeResponseRubric,
+    PerseusFreeResponseWidgetOptions,
     PerseusScore,
 } from "@khanacademy/perseus-core";
 
@@ -8,7 +8,7 @@ function scoreFreeResponse(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusFreeResponseUserInput | undefined,
-    rubric: PerseusFreeResponseRubric,
+    rubric: PerseusFreeResponseWidgetOptions,
     locale: string,
 ): PerseusScore {
     // TODO(AX-961): Implement support for external scoring. Since the user's

--- a/packages/perseus-score/src/widgets/grapher/score-grapher.test.ts
+++ b/packages/perseus-score/src/widgets/grapher/score-grapher.test.ts
@@ -1,10 +1,8 @@
+import {generateGrapherWidgetOptions} from "@khanacademy/perseus-core";
+
 import scoreGrapher from "./score-grapher";
 
-import type {
-    PerseusGrapherRubric,
-    PerseusGrapherUserInput,
-    Coord,
-} from "@khanacademy/perseus-core";
+import type {PerseusGrapherUserInput, Coord} from "@khanacademy/perseus-core";
 
 describe("scoreGrapher", () => {
     it("is invalid when user input is undefined", () => {
@@ -18,13 +16,13 @@ describe("scoreGrapher", () => {
             [-10, -10],
             [10, 10],
         ];
-        const rubric: PerseusGrapherRubric = {
+        const rubric = generateGrapherWidgetOptions({
             correct: {
                 type: "logarithm",
                 asymptote,
                 coords,
             },
-        };
+        });
 
         // Act
         const result = scoreGrapher(userInput, rubric);
@@ -50,13 +48,13 @@ describe("scoreGrapher", () => {
             coords,
         };
 
-        const rubric: PerseusGrapherRubric = {
+        const rubric = generateGrapherWidgetOptions({
             correct: {
                 type: "logarithm",
                 asymptote,
                 coords,
             },
-        };
+        });
 
         // Act
         const result = scoreGrapher(userInput, rubric);
@@ -82,13 +80,13 @@ describe("scoreGrapher", () => {
             coords: null,
         };
 
-        const rubric: PerseusGrapherRubric = {
+        const rubric = generateGrapherWidgetOptions({
             correct: {
                 type: "exponential",
                 asymptote,
                 coords,
             },
-        };
+        });
 
         // Act
         const result = scoreGrapher(userInput, rubric);
@@ -112,12 +110,12 @@ describe("scoreGrapher", () => {
             coords,
         };
 
-        const rubric: PerseusGrapherRubric = {
+        const rubric = generateGrapherWidgetOptions({
             correct: {
                 type: "linear",
                 coords,
             },
-        };
+        });
 
         // Act
         const result = scoreGrapher(userInput, rubric);
@@ -143,12 +141,12 @@ describe("scoreGrapher", () => {
             ],
         };
 
-        const rubric: PerseusGrapherRubric = {
+        const rubric = generateGrapherWidgetOptions({
             correct: {
                 type: "linear",
                 coords: null,
             },
-        };
+        });
 
         // Act
         const result = scoreGrapher(userInput, rubric);
@@ -169,12 +167,12 @@ describe("scoreGrapher", () => {
             coords,
         };
 
-        const rubric: PerseusGrapherRubric = {
+        const rubric = generateGrapherWidgetOptions({
             correct: {
                 type: "linear",
                 coords,
             },
-        };
+        });
 
         // Act
         const result = scoreGrapher(userInput, rubric);
@@ -195,12 +193,12 @@ describe("scoreGrapher", () => {
             coords,
         };
 
-        const rubric: PerseusGrapherRubric = {
+        const rubric = generateGrapherWidgetOptions({
             correct: {
                 type: "tangent",
                 coords,
             },
-        };
+        });
 
         // Act
         const result = scoreGrapher(userInput, rubric);
@@ -224,12 +222,12 @@ describe("scoreGrapher", () => {
             coords,
         };
 
-        const rubric: PerseusGrapherRubric = {
+        const rubric = generateGrapherWidgetOptions({
             correct: {
                 type: "tangent",
                 coords,
             },
-        };
+        });
 
         // Act
         const result = scoreGrapher(userInput, rubric);
@@ -248,7 +246,7 @@ describe("scoreGrapher", () => {
             ],
         };
 
-        const rubric: PerseusGrapherRubric = {
+        const rubric = generateGrapherWidgetOptions({
             correct: {
                 type: "tangent",
                 coords: [
@@ -256,7 +254,7 @@ describe("scoreGrapher", () => {
                     [3, 3],
                 ],
             },
-        };
+        });
 
         // Act
         const result = scoreGrapher(userInput, rubric);
@@ -275,7 +273,7 @@ describe("scoreGrapher", () => {
             ],
         };
 
-        const rubric: PerseusGrapherRubric = {
+        const rubric = generateGrapherWidgetOptions({
             correct: {
                 type: "linear",
                 coords: [
@@ -283,7 +281,7 @@ describe("scoreGrapher", () => {
                     [10, 10],
                 ],
             },
-        };
+        });
 
         // Act
         const result = scoreGrapher(userInput, rubric);

--- a/packages/perseus-score/src/widgets/grapher/score-grapher.ts
+++ b/packages/perseus-score/src/widgets/grapher/score-grapher.ts
@@ -8,7 +8,7 @@ import {
 
 import type {TangentCoefficient} from "@khanacademy/kmath";
 import type {
-    PerseusGrapherRubric,
+    PerseusGrapherWidgetOptions,
     PerseusGrapherUserInput,
     PerseusScore,
     GrapherAnswerTypes,
@@ -46,7 +46,7 @@ function scoreGrapher(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusGrapherUserInput | undefined,
-    rubric: PerseusGrapherRubric,
+    rubric: PerseusGrapherWidgetOptions,
 ): PerseusScore {
     if (userInput == null) {
         return {
@@ -55,7 +55,7 @@ function scoreGrapher(
         };
     }
 
-    if (userInput.type !== rubric.correct.type) {
+    if (userInput.type !== rubric.correct!.type) {
         return {
             type: "points",
             earned: 0,
@@ -73,7 +73,7 @@ function scoreGrapher(
     }
 
     const guessCoeffs = getCoefficientsByType(userInput);
-    const correctCoeffs = getCoefficientsByType(rubric.correct);
+    const correctCoeffs = getCoefficientsByType(rubric.correct!);
 
     if (guessCoeffs == null || correctCoeffs == null) {
         return {

--- a/packages/perseus-score/src/widgets/grapher/score-grapher.ts
+++ b/packages/perseus-score/src/widgets/grapher/score-grapher.ts
@@ -5,6 +5,7 @@ import {
     PerseusError,
     GrapherUtil,
 } from "@khanacademy/perseus-core";
+import invariant from "tiny-invariant";
 
 import type {TangentCoefficient} from "@khanacademy/kmath";
 import type {
@@ -55,7 +56,11 @@ function scoreGrapher(
         };
     }
 
-    if (userInput.type !== rubric.correct!.type) {
+    invariant(
+        rubric.correct != null,
+        "correct is null or undefined in scoreGrapher",
+    );
+    if (userInput.type !== rubric.correct.type) {
         return {
             type: "points",
             earned: 0,

--- a/packages/perseus-score/src/widgets/group/score-group.test.ts
+++ b/packages/perseus-score/src/widgets/group/score-group.test.ts
@@ -1,12 +1,12 @@
 import scoreGroup from "./score-group";
 
-import type {PerseusGroupRubric} from "@khanacademy/perseus-core";
+import type {PerseusGroupWidgetOptions} from "@khanacademy/perseus-core";
 
 describe("scoreGroup", () => {
     it("returns a score of 'invalid' when the user input is undefined", () => {
         // Arrange:
         const userInput = undefined;
-        const rubric: PerseusGroupRubric = {
+        const rubric: PerseusGroupWidgetOptions = {
             content: "",
             images: {},
             widgets: {

--- a/packages/perseus-score/src/widgets/group/score-group.ts
+++ b/packages/perseus-score/src/widgets/group/score-group.ts
@@ -2,7 +2,7 @@ import {scoreWidgetsFunctional} from "../../score";
 import flattenScores from "../../util/flatten-scores";
 
 import type {
-    PerseusGroupRubric,
+    PerseusGroupWidgetOptions,
     PerseusGroupUserInput,
     PerseusScore,
 } from "@khanacademy/perseus-core";
@@ -11,7 +11,7 @@ import type {
 // it. As such, scoring a group means scoring all widgets it contains.
 function scoreGroup(
     userInput: PerseusGroupUserInput | undefined,
-    rubric: PerseusGroupRubric,
+    rubric: PerseusGroupWidgetOptions,
     locale: string,
 ): PerseusScore {
     if (userInput == null) {

--- a/packages/perseus-score/src/widgets/group/validate-group.test.ts
+++ b/packages/perseus-score/src/widgets/group/validate-group.test.ts
@@ -2,13 +2,13 @@ import {getTestDropdownWidget} from "../../util/test-helpers";
 
 import validateGroup from "./validate-group";
 
-import type {PerseusGroupValidationData} from "@khanacademy/perseus-core";
+import type {PerseusGroupWidgetOptions} from "@khanacademy/perseus-core";
 
 describe("validateGroup", () => {
     it("returns invalid when the user input is undefined", () => {
         // Arrange:
         const userInput = undefined;
-        const validationData: PerseusGroupValidationData = {
+        const validationData: PerseusGroupWidgetOptions = {
             content: "[[☃ dropdown 1]]",
             widgets: {
                 "dropdown 1": getTestDropdownWidget(),

--- a/packages/perseus-score/src/widgets/group/validate-group.test.ts
+++ b/packages/perseus-score/src/widgets/group/validate-group.test.ts
@@ -1,20 +1,23 @@
+import {getGroupPublicWidgetOptions} from "@khanacademy/perseus-core";
+
 import {getTestDropdownWidget} from "../../util/test-helpers";
 
 import validateGroup from "./validate-group";
 
-import type {PerseusGroupWidgetOptions} from "@khanacademy/perseus-core";
+import type {GroupPublicWidgetOptions} from "@khanacademy/perseus-core";
 
 describe("validateGroup", () => {
     it("returns invalid when the user input is undefined", () => {
         // Arrange:
         const userInput = undefined;
-        const validationData: PerseusGroupWidgetOptions = {
-            content: "[[☃ dropdown 1]]",
-            widgets: {
-                "dropdown 1": getTestDropdownWidget(),
-            },
-            images: {},
-        };
+        const validationData: GroupPublicWidgetOptions =
+            getGroupPublicWidgetOptions({
+                content: "[[☃ dropdown 1]]",
+                widgets: {
+                    "dropdown 1": getTestDropdownWidget(),
+                },
+                images: {},
+            });
 
         // Act:
         const result = validateGroup(userInput, validationData, "en");

--- a/packages/perseus-score/src/widgets/group/validate-group.test.ts
+++ b/packages/perseus-score/src/widgets/group/validate-group.test.ts
@@ -4,20 +4,17 @@ import {getTestDropdownWidget} from "../../util/test-helpers";
 
 import validateGroup from "./validate-group";
 
-import type {GroupPublicWidgetOptions} from "@khanacademy/perseus-core";
-
 describe("validateGroup", () => {
     it("returns invalid when the user input is undefined", () => {
         // Arrange:
         const userInput = undefined;
-        const validationData: GroupPublicWidgetOptions =
-            getGroupPublicWidgetOptions({
-                content: "[[☃ dropdown 1]]",
-                widgets: {
-                    "dropdown 1": getTestDropdownWidget(),
-                },
-                images: {},
-            });
+        const validationData = getGroupPublicWidgetOptions({
+            content: "[[☃ dropdown 1]]",
+            widgets: {
+                "dropdown 1": getTestDropdownWidget(),
+            },
+            images: {},
+        });
 
         // Act:
         const result = validateGroup(userInput, validationData, "en");

--- a/packages/perseus-score/src/widgets/group/validate-group.ts
+++ b/packages/perseus-score/src/widgets/group/validate-group.ts
@@ -4,13 +4,13 @@ import {emptyWidgetsFunctional} from "../../validate";
 
 import type {
     PerseusGroupUserInput,
-    PerseusGroupValidationData,
+    PerseusGroupWidgetOptions,
     ValidationResult,
 } from "@khanacademy/perseus-core";
 
 function validateGroup(
     userInput: PerseusGroupUserInput | undefined,
-    validationData: PerseusGroupValidationData,
+    validationData: PerseusGroupWidgetOptions,
     locale: string,
 ): ValidationResult {
     if (userInput == null) {

--- a/packages/perseus-score/src/widgets/group/validate-group.ts
+++ b/packages/perseus-score/src/widgets/group/validate-group.ts
@@ -4,13 +4,13 @@ import {emptyWidgetsFunctional} from "../../validate";
 
 import type {
     PerseusGroupUserInput,
-    PerseusGroupWidgetOptions,
+    GroupPublicWidgetOptions,
     ValidationResult,
 } from "@khanacademy/perseus-core";
 
 function validateGroup(
     userInput: PerseusGroupUserInput | undefined,
-    validationData: PerseusGroupWidgetOptions,
+    validationData: GroupPublicWidgetOptions,
     locale: string,
 ): ValidationResult {
     if (userInput == null) {

--- a/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.test.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.test.ts
@@ -1,21 +1,19 @@
+import {generateInteractiveGraphOptions} from "@khanacademy/perseus-core";
 import invariant from "tiny-invariant";
 import _ from "underscore";
 
 import scoreInteractiveGraph from "./score-interactive-graph";
 
-import type {
-    PerseusGraphType,
-    PerseusInteractiveGraphRubric,
-} from "@khanacademy/perseus-core";
+import type {PerseusGraphType} from "@khanacademy/perseus-core";
 
 describe("InteractiveGraph scoring on a 'none' question", () => {
     it("returns 0 earned / 0 total (ungraded) when both graphs are 'none'", () => {
         // Arrange
         const guess: PerseusGraphType = {type: "none"};
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "none"},
             correct: {type: "none"},
-        };
+        });
 
         // Act
         const result = scoreInteractiveGraph(guess, rubric);
@@ -33,7 +31,7 @@ describe("InteractiveGraph scoring on a 'none' question", () => {
 describe("InteractiveGraph scoring on a segment question", () => {
     it("marks the answer invalid if guess is undefined", () => {
         const guess = undefined;
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {
                 type: "segment",
             },
@@ -46,7 +44,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
                     ],
                 ],
             },
-        };
+        });
 
         const result = scoreInteractiveGraph(guess, rubric);
 
@@ -55,7 +53,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
 
     it("marks the answer invalid if guess.coords is missing", () => {
         const guess: PerseusGraphType = {type: "segment"};
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {
                 type: "segment",
             },
@@ -68,7 +66,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
                     ],
                 ],
             },
-        };
+        });
 
         const result = scoreInteractiveGraph(guess, rubric);
 
@@ -86,7 +84,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
             ],
         };
 
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "segment"},
             correct: {
                 type: "segment",
@@ -97,7 +95,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
                     ],
                 ],
             },
-        };
+        });
 
         const result = scoreInteractiveGraph(guess, rubric);
 
@@ -115,7 +113,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
             ],
         };
 
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "segment"},
             correct: {
                 type: "segment",
@@ -126,7 +124,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
                     ],
                 ],
             },
-        };
+        });
 
         const result = scoreInteractiveGraph(guess, rubric);
 
@@ -143,7 +141,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
                 ],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "segment"},
             correct: {
                 type: "segment",
@@ -154,7 +152,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
                     ],
                 ],
             },
-        };
+        });
 
         const result = scoreInteractiveGraph(guess, rubric);
 
@@ -172,7 +170,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
             ],
         };
 
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "segment"},
             correct: {
                 type: "segment",
@@ -183,7 +181,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
                     ],
                 ],
             },
-        };
+        });
 
         scoreInteractiveGraph(guess, rubric);
 
@@ -205,7 +203,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
                 ],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "segment"},
             correct: {
                 type: "segment",
@@ -216,7 +214,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
                     ],
                 ],
             },
-        };
+        });
 
         scoreInteractiveGraph(guess, rubric);
 
@@ -235,7 +233,7 @@ describe("InteractiveGraph scoring on a segment question", () => {
 describe("InteractiveGraph scoring on an angle question", () => {
     it("marks the answer invalid if guess.coords is missing", () => {
         const guess: PerseusGraphType = {type: "angle"};
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "angle"},
             correct: {
                 type: "angle",
@@ -247,7 +245,7 @@ describe("InteractiveGraph scoring on an angle question", () => {
                 allowReflexAngles: false,
                 match: "congruent",
             },
-        };
+        });
 
         const result = scoreInteractiveGraph(guess, rubric);
 
@@ -258,13 +256,13 @@ describe("InteractiveGraph scoring on an angle question", () => {
 describe("InteractiveGraph scoring on a point question", () => {
     it("marks the answer invalid if guess.coords is missing", () => {
         const guess: PerseusGraphType = {type: "point"};
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "point"},
             correct: {
                 type: "point",
                 coords: [[0, 0]],
             },
-        };
+        });
 
         const result = scoreInteractiveGraph(guess, rubric);
 
@@ -279,15 +277,14 @@ describe("InteractiveGraph scoring on a point question", () => {
             coords: [[0, 0]],
         };
 
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {
                 type: "point",
             },
-            // @ts-expect-error: Testing exception for invalid rubric
             correct: {
                 type: "point",
             },
-        };
+        });
 
         expect(() => scoreInteractiveGraph(guess, rubric)).toThrow();
     });
@@ -297,13 +294,13 @@ describe("InteractiveGraph scoring on a point question", () => {
             type: "point",
             coords: [[9, 9]],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "point"},
             correct: {
                 type: "point",
                 coords: [[0, 0]],
             },
-        };
+        });
 
         const result = scoreInteractiveGraph(guess, rubric);
 
@@ -315,13 +312,13 @@ describe("InteractiveGraph scoring on a point question", () => {
             type: "point",
             coords: [[7, 8]],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "point"},
             correct: {
                 type: "point",
                 coords: [[7, 8]],
             },
-        };
+        });
 
         const result = scoreInteractiveGraph(guess, rubric);
 
@@ -336,7 +333,7 @@ describe("InteractiveGraph scoring on a point question", () => {
                 [5, 6],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "point"},
             correct: {
                 type: "point",
@@ -345,7 +342,7 @@ describe("InteractiveGraph scoring on a point question", () => {
                     [7, 8],
                 ],
             },
-        };
+        });
 
         const result = scoreInteractiveGraph(guess, rubric);
 
@@ -360,7 +357,7 @@ describe("InteractiveGraph scoring on a point question", () => {
                 [5, 6],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "point"},
             correct: {
                 type: "point",
@@ -369,7 +366,7 @@ describe("InteractiveGraph scoring on a point question", () => {
                     [7, 8],
                 ],
             },
-        };
+        });
 
         const guessClone = _.clone(guess);
 
@@ -386,7 +383,7 @@ describe("InteractiveGraph scoring on a point question", () => {
                 [5, 6],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "point"},
             correct: {
                 type: "point",
@@ -395,7 +392,7 @@ describe("InteractiveGraph scoring on a point question", () => {
                     [7, 8],
                 ],
             },
-        };
+        });
 
         const rubricClone = _.clone(rubric);
 
@@ -409,7 +406,7 @@ describe("InteractiveGraph scoring on an angle question", () => {
     it("marks the answer invalid if guess.coords is missing", () => {
         // Arrange
         const guess: PerseusGraphType = {type: "angle"};
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {
                 type: "angle",
             },
@@ -422,7 +419,7 @@ describe("InteractiveGraph scoring on an angle question", () => {
                     [5, 5],
                 ],
             },
-        };
+        });
 
         // Act
         const result = scoreInteractiveGraph(guess, rubric);
@@ -441,7 +438,7 @@ describe("InteractiveGraph scoring on an angle question", () => {
                 [5, 5],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {
                 type: "angle",
             },
@@ -454,7 +451,7 @@ describe("InteractiveGraph scoring on an angle question", () => {
                     [-5, 0],
                 ],
             },
-        };
+        });
 
         // Act
         const result = scoreInteractiveGraph(guess, rubric);
@@ -473,7 +470,7 @@ describe("InteractiveGraph scoring on an angle question", () => {
                 [5, 5],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {
                 type: "angle",
             },
@@ -486,7 +483,7 @@ describe("InteractiveGraph scoring on an angle question", () => {
                     [5, 5],
                 ],
             },
-        };
+        });
 
         // Act
         const result = scoreInteractiveGraph(guess, rubric);
@@ -505,7 +502,7 @@ describe("InteractiveGraph scoring on an angle question", () => {
                 [-5, -5],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {
                 type: "angle",
                 coords: [
@@ -523,7 +520,7 @@ describe("InteractiveGraph scoring on an angle question", () => {
                     [-5, -5],
                 ],
             },
-        };
+        });
 
         // Act
         const result = scoreInteractiveGraph(guess, rubric);
@@ -544,7 +541,7 @@ describe("InteractiveGraph scoring on an angle question: defensive null-coords g
             center: [0, 0],
             radius: 5,
         } as unknown as PerseusGraphType;
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "angle"},
             correct: {
                 type: "angle",
@@ -555,7 +552,7 @@ describe("InteractiveGraph scoring on an angle question: defensive null-coords g
                     [0, 1],
                 ],
             },
-        };
+        });
 
         // Act
         const result = scoreInteractiveGraph(guess, rubric);
@@ -577,15 +574,14 @@ describe("InteractiveGraph scoring on an angle question: defensive null-coords g
                 [0, 1],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "angle"},
-            // @ts-expect-error: testing the defensive guard for missing correct.coords
             correct: {
                 type: "angle",
                 match: "congruent",
                 allowReflexAngles: false,
             },
-        };
+        });
 
         // Act
         const result = scoreInteractiveGraph(guess, rubric);
@@ -596,7 +592,7 @@ describe("InteractiveGraph scoring on an angle question: defensive null-coords g
 });
 
 // Test data: f(x) = 2·4^x + 3  →  f(0)=5, f(1)=11, asymptote y=3
-const exponentialRubric: PerseusInteractiveGraphRubric = {
+const exponentialRubric = generateInteractiveGraphOptions({
     graph: {type: "exponential"},
     correct: {
         type: "exponential",
@@ -606,7 +602,7 @@ const exponentialRubric: PerseusInteractiveGraphRubric = {
         ],
         asymptote: 3,
     },
-};
+});
 
 describe("InteractiveGraph scoring on an exponential question", () => {
     it("marks the answer invalid if guess is undefined", () => {
@@ -701,7 +697,7 @@ describe("InteractiveGraph scoring on an exponential question", () => {
     });
 });
 
-const logarithmRubric: PerseusInteractiveGraphRubric = {
+const logarithmRubric = generateInteractiveGraphOptions({
     graph: {type: "logarithm"},
     correct: {
         type: "logarithm",
@@ -711,7 +707,7 @@ const logarithmRubric: PerseusInteractiveGraphRubric = {
         ],
         asymptote: -6,
     },
-};
+});
 
 describe("InteractiveGraph scoring on a logarithm question", () => {
     it("marks the answer invalid if guess is undefined", () => {
@@ -789,7 +785,7 @@ describe("InteractiveGraph scoring on a logarithm question", () => {
 
     it("marks equivalent curves with different control points as correct", () => {
         // Arrange — y = ln(x): both sets of points produce a=1, b=1, c=0
-        const lnRubric: PerseusInteractiveGraphRubric = {
+        const lnRubric = generateInteractiveGraphOptions({
             graph: {type: "logarithm"},
             correct: {
                 type: "logarithm",
@@ -799,7 +795,7 @@ describe("InteractiveGraph scoring on a logarithm question", () => {
                 ],
                 asymptote: 0,
             },
-        };
+        });
         const guess: PerseusGraphType = {
             type: "logarithm",
             coords: [
@@ -821,7 +817,7 @@ describe("InteractiveGraph scoring on an absolute-value question", () => {
     it("marks the answer invalid if guess is undefined", () => {
         // Arrange
         const guess = undefined;
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "absolute-value"},
             correct: {
                 type: "absolute-value",
@@ -830,7 +826,7 @@ describe("InteractiveGraph scoring on an absolute-value question", () => {
                     [1, 1],
                 ],
             },
-        };
+        });
 
         // Act
         const result = scoreInteractiveGraph(guess, rubric);
@@ -842,7 +838,7 @@ describe("InteractiveGraph scoring on an absolute-value question", () => {
     it("marks the answer invalid if guess.coords is missing", () => {
         // Arrange
         const guess: PerseusGraphType = {type: "absolute-value"};
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "absolute-value"},
             correct: {
                 type: "absolute-value",
@@ -851,7 +847,7 @@ describe("InteractiveGraph scoring on an absolute-value question", () => {
                     [1, 1],
                 ],
             },
-        };
+        });
 
         // Act
         const result = scoreInteractiveGraph(guess, rubric);
@@ -869,7 +865,7 @@ describe("InteractiveGraph scoring on an absolute-value question", () => {
                 [1, 2],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "absolute-value"},
             correct: {
                 type: "absolute-value",
@@ -878,7 +874,7 @@ describe("InteractiveGraph scoring on an absolute-value question", () => {
                     [1, 1],
                 ],
             },
-        };
+        });
 
         // Act
         const result = scoreInteractiveGraph(guess, rubric);
@@ -896,7 +892,7 @@ describe("InteractiveGraph scoring on an absolute-value question", () => {
                 [1, 1],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "absolute-value"},
             correct: {
                 type: "absolute-value",
@@ -905,7 +901,7 @@ describe("InteractiveGraph scoring on an absolute-value question", () => {
                     [1, 1],
                 ],
             },
-        };
+        });
 
         // Act
         const result = scoreInteractiveGraph(guess, rubric);
@@ -923,7 +919,7 @@ describe("InteractiveGraph scoring on an absolute-value question", () => {
                 [-1, 1],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "absolute-value"},
             correct: {
                 type: "absolute-value",
@@ -932,7 +928,7 @@ describe("InteractiveGraph scoring on an absolute-value question", () => {
                     [1, 1],
                 ],
             },
-        };
+        });
 
         // Act
         const result = scoreInteractiveGraph(guess, rubric);
@@ -950,7 +946,7 @@ describe("InteractiveGraph scoring on an absolute-value question", () => {
                 [1, -1],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "absolute-value"},
             correct: {
                 type: "absolute-value",
@@ -959,7 +955,7 @@ describe("InteractiveGraph scoring on an absolute-value question", () => {
                     [1, 1],
                 ],
             },
-        };
+        });
 
         // Act
         const result = scoreInteractiveGraph(guess, rubric);
@@ -977,7 +973,7 @@ describe("InteractiveGraph scoring on an absolute-value question", () => {
                 [0, 2], // same x as vertex → infinite slope
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "absolute-value"},
             correct: {
                 type: "absolute-value",
@@ -986,7 +982,7 @@ describe("InteractiveGraph scoring on an absolute-value question", () => {
                     [1, 1],
                 ],
             },
-        };
+        });
 
         // Act
         const result = scoreInteractiveGraph(guess, rubric);
@@ -999,7 +995,7 @@ describe("InteractiveGraph scoring on an absolute-value question", () => {
 describe("InteractiveGraph scoring on a tangent question", () => {
     it("marks the answer invalid if guess is undefined", () => {
         const guess = undefined;
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "tangent"},
             correct: {
                 type: "tangent",
@@ -1008,7 +1004,7 @@ describe("InteractiveGraph scoring on a tangent question", () => {
                     [0.75, 0.75],
                 ],
             },
-        };
+        });
 
         const result = scoreInteractiveGraph(guess, rubric);
 
@@ -1017,7 +1013,7 @@ describe("InteractiveGraph scoring on a tangent question", () => {
 
     it("marks the answer invalid if guess has no coords", () => {
         const guess: PerseusGraphType = {type: "tangent"};
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "tangent"},
             correct: {
                 type: "tangent",
@@ -1026,7 +1022,7 @@ describe("InteractiveGraph scoring on a tangent question", () => {
                     [0.75, 0.75],
                 ],
             },
-        };
+        });
 
         const result = scoreInteractiveGraph(guess, rubric);
 
@@ -1041,7 +1037,7 @@ describe("InteractiveGraph scoring on a tangent question", () => {
                 [0.75, 0.75],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "tangent"},
             correct: {
                 type: "tangent",
@@ -1050,7 +1046,7 @@ describe("InteractiveGraph scoring on a tangent question", () => {
                     [0.75, 0.75],
                 ],
             },
-        };
+        });
 
         const result = scoreInteractiveGraph(guess, rubric);
 
@@ -1065,7 +1061,7 @@ describe("InteractiveGraph scoring on a tangent question", () => {
                 [2, 3],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "tangent"},
             correct: {
                 type: "tangent",
@@ -1074,7 +1070,7 @@ describe("InteractiveGraph scoring on a tangent question", () => {
                     [0.75, 0.75],
                 ],
             },
-        };
+        });
 
         const result = scoreInteractiveGraph(guess, rubric);
 
@@ -1091,7 +1087,7 @@ describe("InteractiveGraph scoring on a tangent question", () => {
                 [5, 1],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "tangent"},
             correct: {
                 type: "tangent",
@@ -1100,7 +1096,7 @@ describe("InteractiveGraph scoring on a tangent question", () => {
                     [1, 1],
                 ],
             },
-        };
+        });
 
         const result = scoreInteractiveGraph(guess, rubric);
 
@@ -1116,7 +1112,7 @@ describe("InteractiveGraph scoring on a tangent question", () => {
                 [1, -2],
             ],
         };
-        const rubric: PerseusInteractiveGraphRubric = {
+        const rubric = generateInteractiveGraphOptions({
             graph: {type: "tangent"},
             correct: {
                 type: "tangent",
@@ -1125,7 +1121,7 @@ describe("InteractiveGraph scoring on a tangent question", () => {
                     [1, -2],
                 ],
             },
-        };
+        });
 
         const result = scoreInteractiveGraph(guess, rubric);
 
@@ -1133,7 +1129,7 @@ describe("InteractiveGraph scoring on a tangent question", () => {
     });
 });
 
-const vectorRubric: PerseusInteractiveGraphRubric = {
+const vectorRubric = generateInteractiveGraphOptions({
     graph: {type: "vector"},
     correct: {
         type: "vector",
@@ -1142,7 +1138,7 @@ const vectorRubric: PerseusInteractiveGraphRubric = {
             [3, 4],
         ],
     },
-};
+});
 
 describe("InteractiveGraph scoring on a vector question", () => {
     it("marks the answer invalid if guess is undefined", () => {
@@ -1234,7 +1230,7 @@ describe("InteractiveGraph scoring on a vector question", () => {
     });
 });
 
-const vectorCongruentRubric: PerseusInteractiveGraphRubric = {
+const vectorCongruentRubric = generateInteractiveGraphOptions({
     graph: {type: "vector"},
     correct: {
         type: "vector",
@@ -1244,7 +1240,7 @@ const vectorCongruentRubric: PerseusInteractiveGraphRubric = {
         ],
         match: "congruent",
     },
-};
+});
 
 describe("InteractiveGraph scoring on a vector question with congruent matching", () => {
     it("marks a translated vector as correct when match is congruent", () => {

--- a/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.ts
+++ b/packages/perseus-score/src/widgets/interactive-graph/score-interactive-graph.ts
@@ -18,7 +18,7 @@ import {scoreVector} from "./sub-scorers/score-vector";
 
 import type {
     PerseusInteractiveGraphUserInput,
-    PerseusInteractiveGraphRubric,
+    PerseusInteractiveGraphWidgetOptions,
     PerseusScore,
 } from "@khanacademy/perseus-core";
 
@@ -26,7 +26,7 @@ function scoreInteractiveGraph(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusInteractiveGraphUserInput | undefined,
-    rubric: PerseusInteractiveGraphRubric,
+    rubric: PerseusInteractiveGraphWidgetOptions,
 ): PerseusScore {
     if (userInput == null) {
         return {type: "invalid", message: null};

--- a/packages/perseus-score/src/widgets/label-image/score-label-image.test.ts
+++ b/packages/perseus-score/src/widgets/label-image/score-label-image.test.ts
@@ -1,3 +1,5 @@
+import {generateLabelImageOptions} from "@khanacademy/perseus-core";
+
 import scoreLabelImage, {scoreLabelImageMarker} from "./score-label-image";
 
 describe("scoreLabelImageMarker", function () {
@@ -60,22 +62,28 @@ describe("scoreLabelImage", function () {
     it("should grade as invalid for undefined user input", function () {
         const userInput = undefined;
 
-        const rubric = {
+        const rubric = generateLabelImageOptions({
             markers: [
                 {
                     label: "England",
                     answers: [],
+                    x: 0,
+                    y: 0,
                 },
                 {
                     label: "Germany",
                     answers: [],
+                    x: 0,
+                    y: 0,
                 },
                 {
                     label: "Italy",
                     answers: [],
+                    x: 0,
+                    y: 0,
                 },
             ],
-        };
+        });
 
         const score = scoreLabelImage(userInput, rubric);
 
@@ -100,22 +108,28 @@ describe("scoreLabelImage", function () {
             ],
         };
 
-        const rubric = {
+        const rubric = generateLabelImageOptions({
             markers: [
                 {
                     label: "England",
                     answers: [],
+                    x: 0,
+                    y: 0,
                 },
                 {
                     label: "Germany",
                     answers: [],
+                    x: 0,
+                    y: 0,
                 },
                 {
                     label: "Italy",
                     answers: [],
+                    x: 0,
+                    y: 0,
                 },
             ],
-        };
+        });
 
         const score = scoreLabelImage(userInput, rubric);
 
@@ -140,22 +154,28 @@ describe("scoreLabelImage", function () {
             ],
         };
 
-        const rubric = {
+        const rubric = generateLabelImageOptions({
             markers: [
                 {
                     label: "England",
                     answers: ["Mini", "Morris Minor", "Reliant Robin"],
+                    x: 0,
+                    y: 0,
                 },
                 {
                     label: "Germany",
                     answers: ["BMW", "Volkswagen", "Porsche"],
+                    x: 0,
+                    y: 0,
                 },
                 {
                     label: "Italy",
                     answers: ["Lamborghini", "Fiat", "Ferrari"],
+                    x: 0,
+                    y: 0,
                 },
             ],
-        };
+        });
 
         const score = scoreLabelImage(userInput, rubric);
 
@@ -180,22 +200,28 @@ describe("scoreLabelImage", function () {
             ],
         };
 
-        const rubric = {
+        const rubric = generateLabelImageOptions({
             markers: [
                 {
                     label: "England",
                     answers: ["Mini", "Morris Minor", "Reliant Robin"],
+                    x: 0,
+                    y: 0,
                 },
                 {
                     label: "Germany",
                     answers: ["BMW", "Volkswagen", "Porsche"],
+                    x: 0,
+                    y: 0,
                 },
                 {
                     label: "Italy",
                     answers: ["Lamborghini", "Fiat", "Ferrari"],
+                    x: 0,
+                    y: 0,
                 },
             ],
-        };
+        });
 
         const score = scoreLabelImage(userInput, rubric);
 

--- a/packages/perseus-score/src/widgets/label-image/score-label-image.test.ts
+++ b/packages/perseus-score/src/widgets/label-image/score-label-image.test.ts
@@ -62,28 +62,7 @@ describe("scoreLabelImage", function () {
     it("should grade as invalid for undefined user input", function () {
         const userInput = undefined;
 
-        const rubric = generateLabelImageOptions({
-            markers: [
-                {
-                    label: "England",
-                    answers: [],
-                    x: 0,
-                    y: 0,
-                },
-                {
-                    label: "Germany",
-                    answers: [],
-                    x: 0,
-                    y: 0,
-                },
-                {
-                    label: "Italy",
-                    answers: [],
-                    x: 0,
-                    y: 0,
-                },
-            ],
-        });
+        const rubric = generateLabelImageOptions();
 
         const score = scoreLabelImage(userInput, rubric);
 

--- a/packages/perseus-score/src/widgets/label-image/score-label-image.ts
+++ b/packages/perseus-score/src/widgets/label-image/score-label-image.ts
@@ -1,6 +1,6 @@
 import type {
     PerseusLabelImageUserInput,
-    PerseusLabelImageRubric,
+    PerseusLabelImageWidgetOptions,
     PerseusScore,
 } from "@khanacademy/perseus-core";
 
@@ -14,7 +14,7 @@ export type InteractiveMarkerScore = {
 
 export function scoreLabelImageMarker(
     userInput: PerseusLabelImageUserInput["markers"][number]["selected"],
-    rubric: PerseusLabelImageRubric["markers"][number]["answers"],
+    rubric: PerseusLabelImageWidgetOptions["markers"][number]["answers"],
 ): InteractiveMarkerScore {
     const score = {
         hasAnswers: false,
@@ -44,7 +44,7 @@ function scoreLabelImage(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusLabelImageUserInput | undefined,
-    rubric: PerseusLabelImageRubric,
+    rubric: PerseusLabelImageWidgetOptions,
 ): PerseusScore {
     if (userInput == null) {
         return {type: "invalid", message: null};

--- a/packages/perseus-score/src/widgets/matcher/score-matcher.test.ts
+++ b/packages/perseus-score/src/widgets/matcher/score-matcher.test.ts
@@ -1,19 +1,18 @@
+import {generateMatcherOptions} from "@khanacademy/perseus-core";
+
 import scoreMatcher from "./score-matcher";
 
-import type {
-    PerseusMatcherRubric,
-    PerseusMatcherUserInput,
-} from "@khanacademy/perseus-core";
+import type {PerseusMatcherUserInput} from "@khanacademy/perseus-core";
 
 describe("scoreMatcher", () => {
     it("returns invalid for undefined user input", () => {
         // Arrange
         const userInput = undefined;
 
-        const rubric: PerseusMatcherRubric = {
+        const rubric = generateMatcherOptions({
             left: ["1", "0+1"],
             right: ["2", "0+2"],
-        };
+        });
 
         // Act
         const result = scoreMatcher(userInput, rubric);
@@ -29,10 +28,10 @@ describe("scoreMatcher", () => {
             right: ["cool", "beans"],
         };
 
-        const rubric: PerseusMatcherRubric = {
+        const rubric = generateMatcherOptions({
             left: ["1", "0+1"],
             right: ["2", "0+2"],
-        };
+        });
 
         // Act
         const result = scoreMatcher(userInput, rubric);
@@ -43,10 +42,10 @@ describe("scoreMatcher", () => {
 
     it("can be answered correctly", () => {
         // Arrange
-        const rubric: PerseusMatcherRubric = {
+        const rubric = generateMatcherOptions({
             left: ["1", "0+1"],
             right: ["2", "0+2"],
-        };
+        });
 
         const userInput: PerseusMatcherUserInput = {
             left: [...rubric.left],

--- a/packages/perseus-score/src/widgets/matcher/score-matcher.ts
+++ b/packages/perseus-score/src/widgets/matcher/score-matcher.ts
@@ -1,7 +1,7 @@
 import _ from "underscore";
 
 import type {
-    PerseusMatcherRubric,
+    PerseusMatcherWidgetOptions,
     PerseusMatcherUserInput,
     PerseusScore,
 } from "@khanacademy/perseus-core";
@@ -10,7 +10,7 @@ function scoreMatcher(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusMatcherUserInput | undefined,
-    rubric: PerseusMatcherRubric,
+    rubric: PerseusMatcherWidgetOptions,
 ): PerseusScore {
     if (userInput == null) {
         return {type: "invalid", message: null};

--- a/packages/perseus-score/src/widgets/matrix/score-matrix.test.ts
+++ b/packages/perseus-score/src/widgets/matrix/score-matrix.test.ts
@@ -1,20 +1,19 @@
+import {generateMatrixOptions} from "@khanacademy/perseus-core";
+
 import scoreMatrix from "./score-matrix";
 
-import type {
-    PerseusMatrixRubric,
-    PerseusMatrixUserInput,
-} from "@khanacademy/perseus-core";
+import type {PerseusMatrixUserInput} from "@khanacademy/perseus-core";
 
 describe("scoreMatrix", () => {
     it("returns invalid for undefined user input", () => {
         // Arrange
-        const rubric: PerseusMatrixRubric = {
+        const rubric = generateMatrixOptions({
             answers: [
                 [0, 1, 2],
                 [3, 4, 5],
                 [6, 7, 8],
             ],
-        };
+        });
 
         const userInput = undefined;
 
@@ -27,13 +26,13 @@ describe("scoreMatrix", () => {
 
     it("can be answered correctly", () => {
         // Arrange
-        const rubric: PerseusMatrixRubric = {
+        const rubric = generateMatrixOptions({
             answers: [
                 [0, 1, 2],
                 [3, 4, 5],
                 [6, 7, 8],
             ],
-        };
+        });
 
         const userInput: PerseusMatrixUserInput = {
             answers: rubric.answers.map((row) => row.map((num) => String(num))),
@@ -48,13 +47,13 @@ describe("scoreMatrix", () => {
 
     it("can be answered incorrectly", () => {
         // Arrange
-        const rubric: PerseusMatrixRubric = {
+        const rubric = generateMatrixOptions({
             answers: [
                 [0, 1, 2],
                 [3, 4, 5],
                 [6, 7, 8],
             ],
-        };
+        });
 
         const userInput: PerseusMatrixUserInput = {
             answers: [
@@ -73,13 +72,13 @@ describe("scoreMatrix", () => {
 
     it("is considered incorrect when the size is wrong", () => {
         // Arrange
-        const rubric: PerseusMatrixRubric = {
+        const rubric = generateMatrixOptions({
             answers: [
                 [0, 1, 2],
                 [3, 4, 5],
                 [6, 7, 8],
             ],
-        };
+        });
 
         const correctUserInput: PerseusMatrixUserInput = {
             answers: rubric.answers.map((row) => row.map((num) => String(num))),

--- a/packages/perseus-score/src/widgets/matrix/score-matrix.ts
+++ b/packages/perseus-score/src/widgets/matrix/score-matrix.ts
@@ -4,7 +4,7 @@ import _ from "underscore";
 import KhanAnswerTypes from "../../util/answer-types";
 
 import type {
-    PerseusMatrixRubric,
+    PerseusMatrixWidgetOptions,
     PerseusMatrixUserInput,
     PerseusScore,
 } from "@khanacademy/perseus-core";
@@ -13,7 +13,7 @@ function scoreMatrix(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusMatrixUserInput | undefined,
-    rubric: PerseusMatrixRubric,
+    rubric: PerseusMatrixWidgetOptions,
 ): PerseusScore {
     if (userInput == null) {
         return {type: "invalid", message: null};

--- a/packages/perseus-score/src/widgets/mock-widget/mock-widget-validation.types.ts
+++ b/packages/perseus-score/src/widgets/mock-widget/mock-widget-validation.types.ts
@@ -1,4 +1,4 @@
-export type PerseusMockWidgetRubric = {
+export type PerseusMockWidgetOptions = {
     value: string;
 };
 

--- a/packages/perseus-score/src/widgets/mock-widget/score-mock-widget.ts
+++ b/packages/perseus-score/src/widgets/mock-widget/score-mock-widget.ts
@@ -1,7 +1,7 @@
 import validateMockWidget from "./validate-mock-widget";
 
 import type {
-    PerseusMockWidgetRubric,
+    PerseusMockWidgetOptions,
     PerseusMockWidgetUserInput,
 } from "./mock-widget-validation.types";
 import type {PerseusScore} from "@khanacademy/perseus-core";
@@ -10,7 +10,7 @@ function scoreMockWidget(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusMockWidgetUserInput | undefined,
-    rubric: PerseusMockWidgetRubric,
+    rubric: PerseusMockWidgetOptions,
 ): PerseusScore {
     const validationResult = validateMockWidget(userInput);
     if (validationResult != null) {

--- a/packages/perseus-score/src/widgets/number-line/score-number-line.test.ts
+++ b/packages/perseus-score/src/widgets/number-line/score-number-line.test.ts
@@ -1,16 +1,15 @@
+import {generateNumberLineOptions} from "@khanacademy/perseus-core";
+
 import scoreNumberLine from "./score-number-line";
 
-import type {
-    PerseusNumberLineRubric,
-    PerseusNumberLineUserInput,
-} from "@khanacademy/perseus-core";
+import type {PerseusNumberLineUserInput} from "@khanacademy/perseus-core";
 
 describe("scoreNumberLine", () => {
     it("is invalid when user input is undefined", () => {
         // Arrange
         const userInput = undefined;
 
-        const rubric: PerseusNumberLineRubric = {
+        const rubric = generateNumberLineOptions({
             correctRel: "eq",
             correctX: -1.5,
             initialX: 0,
@@ -18,7 +17,7 @@ describe("scoreNumberLine", () => {
             isInequality: false,
             isTickCtrl: true,
             divisionRange: [-1, 1],
-        };
+        });
 
         // Act
         const validationError = scoreNumberLine(userInput, rubric);
@@ -35,7 +34,7 @@ describe("scoreNumberLine", () => {
             numLinePosition: 10,
         };
 
-        const rubric: PerseusNumberLineRubric = {
+        const rubric = generateNumberLineOptions({
             correctRel: "eq",
             correctX: -1.5,
             initialX: 0,
@@ -43,7 +42,7 @@ describe("scoreNumberLine", () => {
             isInequality: false,
             isTickCtrl: true,
             divisionRange: [-1, 1],
-        };
+        });
 
         // Act
         const validationError = scoreNumberLine(userInput, rubric);
@@ -62,7 +61,7 @@ describe("scoreNumberLine", () => {
             numLinePosition: 0,
         };
 
-        const rubric: PerseusNumberLineRubric = {
+        const rubric = generateNumberLineOptions({
             correctRel: "eq",
             correctX: -1.5,
             initialX: 0,
@@ -70,7 +69,7 @@ describe("scoreNumberLine", () => {
             isInequality: false,
             isTickCtrl: true,
             divisionRange: [-10, 10],
-        };
+        });
 
         // Act
         const score = scoreNumberLine(userInput, rubric);
@@ -87,7 +86,7 @@ describe("scoreNumberLine", () => {
             numLinePosition: -1.5,
         };
 
-        const rubric: PerseusNumberLineRubric = {
+        const rubric = generateNumberLineOptions({
             correctRel: "eq",
             correctX: -1.5,
             initialX: -1,
@@ -95,7 +94,7 @@ describe("scoreNumberLine", () => {
             isInequality: false,
             isTickCtrl: true,
             divisionRange: [-10, 10],
-        };
+        });
 
         // Act
         const score = scoreNumberLine(userInput, rubric);
@@ -112,7 +111,7 @@ describe("scoreNumberLine", () => {
             numLinePosition: 1.5,
         };
 
-        const rubric: PerseusNumberLineRubric = {
+        const rubric = generateNumberLineOptions({
             correctRel: "eq",
             correctX: -1.5,
             initialX: -1,
@@ -120,7 +119,7 @@ describe("scoreNumberLine", () => {
             isInequality: false,
             isTickCtrl: true,
             divisionRange: [-10, 10],
-        };
+        });
 
         // Act
         const score = scoreNumberLine(userInput, rubric);

--- a/packages/perseus-score/src/widgets/number-line/score-number-line.ts
+++ b/packages/perseus-score/src/widgets/number-line/score-number-line.ts
@@ -1,7 +1,7 @@
 import {number as knumber} from "@khanacademy/kmath";
 
 import type {
-    PerseusNumberLineRubric,
+    PerseusNumberLineWidgetOptions,
     PerseusNumberLineUserInput,
     PerseusScore,
 } from "@khanacademy/perseus-core";
@@ -10,7 +10,7 @@ function scoreNumberLine(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusNumberLineUserInput | undefined,
-    rubric: PerseusNumberLineRubric,
+    rubric: PerseusNumberLineWidgetOptions,
 ): PerseusScore {
     if (userInput == null) {
         return {type: "invalid", message: null};
@@ -34,7 +34,7 @@ function scoreNumberLine(
     const correctRel = rubric.correctRel || "eq";
     const correctPos = knumber.equal(
         userInput.numLinePosition,
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+
         rubric.correctX || 0,
     );
 

--- a/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
+++ b/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.test.ts
@@ -1,12 +1,13 @@
-import {generateNumericInputAnswer} from "@khanacademy/perseus-core";
+import {
+    generateNumericInputAnswer,
+    generateNumericInputOptions,
+} from "@khanacademy/perseus-core";
 
 import scoreNumericInput, {maybeParsePercentInput} from "./score-numeric-input";
 
-import type {PerseusNumericInputRubric} from "@khanacademy/perseus-core";
-
 describe("scoreNumericInput", () => {
     it("is invalid when input is undefined", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: 1,
@@ -18,7 +19,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: true,
-        };
+        });
 
         const userInput = undefined;
 
@@ -28,7 +29,7 @@ describe("scoreNumericInput", () => {
     });
 
     it("is correct when input is empty but answer is 1 and coefficient: true", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: 1,
@@ -40,7 +41,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: true,
-        };
+        });
 
         const userInput = {
             // Empty input being translated to "1" depends on coefficient being
@@ -54,10 +55,10 @@ describe("scoreNumericInput", () => {
     });
 
     it("scores a correct answer", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [generateNumericInputAnswer({value: 1})],
             coefficient: true,
-        };
+        });
 
         const userInput = {currentValue: "1"} as const;
 
@@ -67,10 +68,10 @@ describe("scoreNumericInput", () => {
     });
 
     it("scores an incorrect answer", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [generateNumericInputAnswer({value: 1})],
             coefficient: true,
-        };
+        });
 
         const userInput = {currentValue: "99"} as const;
 
@@ -80,7 +81,7 @@ describe("scoreNumericInput", () => {
     });
 
     it("should not consider commas as a decimal separator in the EN locale", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: 16,
@@ -92,7 +93,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: true,
-        };
+        });
 
         const userInput = {
             currentValue: "16,000",
@@ -104,7 +105,7 @@ describe("scoreNumericInput", () => {
     });
 
     it("should consider commas as the thousands separator in the EN locale", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: 16500,
@@ -116,7 +117,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: false,
-        };
+        });
 
         const userInput = {
             currentValue: "16,500.00",
@@ -130,7 +131,7 @@ describe("scoreNumericInput", () => {
     });
 
     it("should reject European decimal format if input is not a valid number in the EN locale", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: 16.5,
@@ -142,7 +143,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: false,
-        };
+        });
 
         const userInput = {
             currentValue: "16,5",
@@ -156,7 +157,7 @@ describe("scoreNumericInput", () => {
     });
 
     it("should consider commas as the decimal separator in the FR locale", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: 16.5,
@@ -168,7 +169,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: false,
-        };
+        });
 
         const userInput = {
             currentValue: "16,5",
@@ -181,7 +182,7 @@ describe("scoreNumericInput", () => {
     });
 
     it("should still accept periods as the thousands separator in FR locale", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: 16500,
@@ -193,7 +194,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: false,
-        };
+        });
 
         const userInput = {
             currentValue: "16.500,00",
@@ -207,7 +208,7 @@ describe("scoreNumericInput", () => {
     });
 
     it("with nonsense", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: 1,
@@ -219,7 +220,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: true,
-        };
+        });
 
         const userInput = {
             currentValue: "sadasdfas",
@@ -237,7 +238,7 @@ describe("scoreNumericInput", () => {
     // important to the test.
     // https://khanacademy.atlassian.net/browse/LC-691
     it("doesn't default to validating pi", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     maxError: null,
@@ -249,7 +250,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: false,
-        };
+        });
 
         const userInput = {
             // (pi / 12) * 173 = 45.291
@@ -271,7 +272,7 @@ describe("scoreNumericInput", () => {
     });
 
     it("still validates against pi if provided in answerForms", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     maxError: null,
@@ -284,7 +285,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: false,
-        };
+        });
 
         const userInput = {
             currentValue: "99 pi",
@@ -296,7 +297,7 @@ describe("scoreNumericInput", () => {
     });
 
     it("with a strict answer", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: 1,
@@ -308,7 +309,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: true,
-        };
+        });
 
         const userInput = {
             currentValue: "1.0",
@@ -320,7 +321,7 @@ describe("scoreNumericInput", () => {
     });
 
     it("with a strict answer and max error is outside range", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: 1,
@@ -332,7 +333,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: true,
-        };
+        });
 
         const userInput = {
             currentValue: "1.3",
@@ -344,7 +345,7 @@ describe("scoreNumericInput", () => {
     });
 
     it("with a strict answer and max error is inside range", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: 1,
@@ -356,7 +357,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: true,
-        };
+        });
 
         const userInput = {
             currentValue: "1.12",
@@ -368,7 +369,7 @@ describe("scoreNumericInput", () => {
     });
 
     it("rejects a strict improper with whole number answer", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: 3,
@@ -381,7 +382,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: true,
-        };
+        });
 
         const userInput = {
             currentValue: "3",
@@ -393,7 +394,7 @@ describe("scoreNumericInput", () => {
     });
 
     it("accepts a strict improper answer with tex answer", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: 3,
@@ -406,7 +407,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: true,
-        };
+        });
 
         const userInput = {
             currentValue: "\\frac{9}{3}",
@@ -418,7 +419,7 @@ describe("scoreNumericInput", () => {
     });
 
     it("accepts a strict improper answer with simple text answer", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: 3,
@@ -431,7 +432,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: true,
-        };
+        });
 
         const userInput = {
             currentValue: "9/3",
@@ -444,7 +445,7 @@ describe("scoreNumericInput", () => {
 
     it("respects the order of answer options when scoring", () => {
         // Arrange
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 // "4" is a wrong answer
                 {
@@ -466,7 +467,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: true,
-        };
+        });
 
         // Act - "wrong"
         const wrongInput = {
@@ -489,7 +490,7 @@ describe("scoreNumericInput", () => {
 
     it("defaults to 1 or -1 when user input is empty/incomplete", () => {
         // Arrange
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: 1,
@@ -509,7 +510,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: true,
-        };
+        });
 
         // Act - "empty"
         const emptyInput = {
@@ -535,7 +536,7 @@ describe("scoreNumericInput", () => {
         // behavior. Ideally, answers should always have a value field, but
         // some don't, so this test documents how we handle that.
         // TODO(benchristel): Fix the data so we can remove this test.
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     // This answer is missing its value field.
@@ -556,7 +557,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: true,
-        };
+        });
 
         const score = scoreNumericInput({currentValue: "50%"}, rubric);
 
@@ -568,7 +569,7 @@ describe("scoreNumericInput", () => {
         // behavior. Ideally, answers should always have a value field, but
         // some don't, so this test documents how we handle that.
         // TODO(benchristel): Fix the data so we can remove this test.
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: null,
@@ -589,7 +590,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: true,
-        };
+        });
 
         const score = scoreNumericInput({currentValue: "50%"}, rubric);
 
@@ -597,7 +598,7 @@ describe("scoreNumericInput", () => {
     });
 
     it("converts a percentage input value to a decimal", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: 0.2,
@@ -609,7 +610,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: true,
-        };
+        });
 
         const score = scoreNumericInput({currentValue: "20%"}, rubric);
 
@@ -620,7 +621,7 @@ describe("scoreNumericInput", () => {
         // NOTE(benchristel): This seems like incorrect behavior. I've added
         // this test to characterize the current behavior. Feel free to
         // delete/change it if it's in your way.
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: 1.2,
@@ -632,7 +633,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: true,
-        };
+        });
 
         const score = scoreNumericInput({currentValue: "120%"}, rubric);
 
@@ -643,7 +644,7 @@ describe("scoreNumericInput", () => {
         // NOTE(benchristel): This seems like incorrect behavior. I've added
         // this test to characterize the current behavior. Feel free to
         // delete/change it if it's in your way.
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: 1.1,
@@ -655,7 +656,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: true,
-        };
+        });
 
         const score = scoreNumericInput({currentValue: "1.1%"}, rubric);
 
@@ -663,7 +664,7 @@ describe("scoreNumericInput", () => {
     });
 
     it("rejects answers with an extra, incorrect percent sign if < 1", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     value: 0.9,
@@ -675,7 +676,7 @@ describe("scoreNumericInput", () => {
                 },
             ],
             coefficient: true,
-        };
+        });
 
         const score = scoreNumericInput({currentValue: "0.9%"}, rubric);
 
@@ -729,7 +730,7 @@ describe("scoreNumericInput", () => {
             const expected = answerMatchers[unsimplifiedFractionScore];
 
             // Arrange
-            const rubric: PerseusNumericInputRubric = {
+            const rubric = generateNumericInputOptions({
                 coefficient: false,
                 answers: [
                     {
@@ -741,7 +742,7 @@ describe("scoreNumericInput", () => {
                         message: "",
                     },
                 ],
-            };
+            });
 
             // Act
             const score = scoreNumericInput({currentValue: "2/4"}, rubric);
@@ -752,7 +753,7 @@ describe("scoreNumericInput", () => {
 
         it("marks a simplified fraction correct", () => {
             // Arrange
-            const rubric: PerseusNumericInputRubric = {
+            const rubric = generateNumericInputOptions({
                 coefficient: false,
                 answers: [
                     {
@@ -764,7 +765,7 @@ describe("scoreNumericInput", () => {
                         message: "",
                     },
                 ],
-            };
+            });
 
             // Act
             const score = scoreNumericInput({currentValue: "1/2"}, rubric);
@@ -775,7 +776,7 @@ describe("scoreNumericInput", () => {
 
         it("marks an incorrect fraction incorrect", () => {
             // Arrange
-            const rubric: PerseusNumericInputRubric = {
+            const rubric = generateNumericInputOptions({
                 coefficient: false,
                 answers: [
                     {
@@ -787,7 +788,7 @@ describe("scoreNumericInput", () => {
                         message: "",
                     },
                 ],
-            };
+            });
 
             // Act
             const score = scoreNumericInput({currentValue: "2/3"}, rubric);

--- a/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.ts
+++ b/packages/perseus-score/src/widgets/numeric-input/score-numeric-input.ts
@@ -5,7 +5,7 @@ import {parseTex} from "../../util/tex-wrangler";
 
 import type {Score} from "../../util/answer-types";
 import type {
-    PerseusNumericInputRubric,
+    PerseusNumericInputWidgetOptions,
     PerseusNumericInputUserInput,
     PerseusScore,
     MathFormat,
@@ -69,7 +69,7 @@ function scoreNumericInput(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusNumericInputUserInput | undefined,
-    rubric: PerseusNumericInputRubric,
+    rubric: PerseusNumericInputWidgetOptions,
     locale?: string,
 ): PerseusScore {
     if (userInput == null) {

--- a/packages/perseus-score/src/widgets/orderer/score-orderer.test.ts
+++ b/packages/perseus-score/src/widgets/orderer/score-orderer.test.ts
@@ -1,11 +1,11 @@
 import scoreOrderer from "./score-orderer";
 
 import type {
-    PerseusOrdererRubric,
+    PerseusOrdererWidgetOptions,
     PerseusOrdererUserInput,
 } from "@khanacademy/perseus-core";
 
-function generateOrdererRubric(): PerseusOrdererRubric {
+function generateOrdererRubric(): PerseusOrdererWidgetOptions {
     return {
         otherOptions: [],
         layout: "horizontal",
@@ -26,7 +26,7 @@ function generateOrdererRubric(): PerseusOrdererRubric {
 describe("scoreOrderer", () => {
     it("is invalid when the userInput is undefined", () => {
         // Arrange
-        const rubric: PerseusOrdererRubric = generateOrdererRubric();
+        const rubric: PerseusOrdererWidgetOptions = generateOrdererRubric();
         const userInput = undefined;
 
         // Act
@@ -38,7 +38,7 @@ describe("scoreOrderer", () => {
 
     it("is correct when the userInput is in the same order and is the same length as the rubric's correctOption content items", () => {
         // Arrange
-        const rubric: PerseusOrdererRubric = generateOrdererRubric();
+        const rubric: PerseusOrdererWidgetOptions = generateOrdererRubric();
 
         const userInput: PerseusOrdererUserInput = {
             current: rubric.correctOptions.map((e) => e.content),
@@ -53,7 +53,7 @@ describe("scoreOrderer", () => {
 
     it("is incorrect when the userInput is not in the same order as the rubric's correctOption content items", () => {
         // Arrange
-        const rubric: PerseusOrdererRubric = generateOrdererRubric();
+        const rubric: PerseusOrdererWidgetOptions = generateOrdererRubric();
 
         const userInput: PerseusOrdererUserInput = {
             current: rubric.options.map((e) => e.content),
@@ -68,7 +68,7 @@ describe("scoreOrderer", () => {
 
     it("is incorrect when the userInput is not the same length as the rubric's correctOption content items", () => {
         // Arrange
-        const rubric: PerseusOrdererRubric = generateOrdererRubric();
+        const rubric: PerseusOrdererWidgetOptions = generateOrdererRubric();
 
         const userInput: PerseusOrdererUserInput = {
             current: rubric.correctOptions.map((e) => e.content).slice(1),

--- a/packages/perseus-score/src/widgets/orderer/score-orderer.test.ts
+++ b/packages/perseus-score/src/widgets/orderer/score-orderer.test.ts
@@ -26,7 +26,7 @@ function generateOrdererRubric(): PerseusOrdererWidgetOptions {
 describe("scoreOrderer", () => {
     it("is invalid when the userInput is undefined", () => {
         // Arrange
-        const rubric: PerseusOrdererWidgetOptions = generateOrdererRubric();
+        const rubric = generateOrdererRubric();
         const userInput = undefined;
 
         // Act
@@ -38,7 +38,7 @@ describe("scoreOrderer", () => {
 
     it("is correct when the userInput is in the same order and is the same length as the rubric's correctOption content items", () => {
         // Arrange
-        const rubric: PerseusOrdererWidgetOptions = generateOrdererRubric();
+        const rubric = generateOrdererRubric();
 
         const userInput: PerseusOrdererUserInput = {
             current: rubric.correctOptions.map((e) => e.content),
@@ -53,7 +53,7 @@ describe("scoreOrderer", () => {
 
     it("is incorrect when the userInput is not in the same order as the rubric's correctOption content items", () => {
         // Arrange
-        const rubric: PerseusOrdererWidgetOptions = generateOrdererRubric();
+        const rubric = generateOrdererRubric();
 
         const userInput: PerseusOrdererUserInput = {
             current: rubric.options.map((e) => e.content),
@@ -68,7 +68,7 @@ describe("scoreOrderer", () => {
 
     it("is incorrect when the userInput is not the same length as the rubric's correctOption content items", () => {
         // Arrange
-        const rubric: PerseusOrdererWidgetOptions = generateOrdererRubric();
+        const rubric = generateOrdererRubric();
 
         const userInput: PerseusOrdererUserInput = {
             current: rubric.correctOptions.map((e) => e.content).slice(1),

--- a/packages/perseus-score/src/widgets/orderer/score-orderer.ts
+++ b/packages/perseus-score/src/widgets/orderer/score-orderer.ts
@@ -1,7 +1,7 @@
 import _ from "underscore";
 
 import type {
-    PerseusOrdererRubric,
+    PerseusOrdererWidgetOptions,
     PerseusOrdererUserInput,
     PerseusScore,
 } from "@khanacademy/perseus-core";
@@ -10,7 +10,7 @@ function scoreOrderer(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusOrdererUserInput | undefined,
-    rubric: PerseusOrdererRubric,
+    rubric: PerseusOrdererWidgetOptions,
 ): PerseusScore {
     if (userInput == null) {
         return {type: "invalid", message: null};

--- a/packages/perseus-score/src/widgets/plotter/score-plotter.test.ts
+++ b/packages/perseus-score/src/widgets/plotter/score-plotter.test.ts
@@ -1,9 +1,8 @@
+import {generatePlotterOptions} from "@khanacademy/perseus-core";
+
 import scorePlotter from "./score-plotter";
 
-import type {
-    PerseusPlotterRubric,
-    PerseusPlotterUserInput,
-} from "@khanacademy/perseus-core";
+import type {PerseusPlotterUserInput} from "@khanacademy/perseus-core";
 
 describe("scorePlotter", () => {
     it("returns incorrect when the user input is undefined", () => {
@@ -12,10 +11,10 @@ describe("scorePlotter", () => {
         // maybe `scorePlotter` should return invalid.
 
         // Arrange
-        const rubric: PerseusPlotterRubric = {
+        const rubric = generatePlotterOptions({
             correct: [15, 25, 5, 10, 10],
             starting: [0, 0, 0, 0, 0],
-        };
+        });
 
         const userInput = undefined;
 
@@ -28,10 +27,10 @@ describe("scorePlotter", () => {
 
     it("can be answered correctly", () => {
         // Arrange
-        const rubric: PerseusPlotterRubric = {
+        const rubric = generatePlotterOptions({
             correct: [15, 25, 5, 10, 10],
             starting: [0, 0, 0, 0, 0],
-        };
+        });
 
         const userInput: PerseusPlotterUserInput = rubric.correct;
 
@@ -44,10 +43,10 @@ describe("scorePlotter", () => {
 
     it("can be answered incorrectly", () => {
         // Arrange
-        const rubric: PerseusPlotterRubric = {
+        const rubric = generatePlotterOptions({
             correct: [15, 25, 5, 10, 10],
             starting: [0, 0, 0, 0, 0],
-        };
+        });
 
         const userInput: PerseusPlotterUserInput = [8, 6, 7, 5, 3, 0, 9];
 

--- a/packages/perseus-score/src/widgets/plotter/score-plotter.ts
+++ b/packages/perseus-score/src/widgets/plotter/score-plotter.ts
@@ -2,7 +2,7 @@ import {approximateDeepEqual} from "@khanacademy/perseus-core";
 
 import type {
     PerseusPlotterUserInput,
-    PerseusPlotterRubric,
+    PerseusPlotterWidgetOptions,
     PerseusScore,
 } from "@khanacademy/perseus-core";
 
@@ -10,7 +10,7 @@ function scorePlotter(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusPlotterUserInput | undefined,
-    rubric: PerseusPlotterRubric,
+    rubric: PerseusPlotterWidgetOptions,
 ): PerseusScore {
     return {
         type: "points",

--- a/packages/perseus-score/src/widgets/plotter/validate-plotter.test.ts
+++ b/packages/perseus-score/src/widgets/plotter/validate-plotter.test.ts
@@ -1,4 +1,7 @@
-import {generatePlotterOptions} from "@khanacademy/perseus-core";
+import {
+    generatePlotterOptions,
+    getPlotterPublicWidgetOptions,
+} from "@khanacademy/perseus-core";
 
 import validatePlotter from "./validate-plotter";
 
@@ -7,9 +10,9 @@ import type {PerseusPlotterUserInput} from "@khanacademy/perseus-core";
 describe("validatePlotter", () => {
     it("is invalid if the user input is undefined", () => {
         // Arrange
-        const validationData = generatePlotterOptions({
-            starting: [0, 0, 0, 0, 0],
-        });
+        const validationData = getPlotterPublicWidgetOptions(
+            generatePlotterOptions({starting: [0, 0, 0, 0, 0]}),
+        );
 
         const userInput = undefined;
 
@@ -22,9 +25,9 @@ describe("validatePlotter", () => {
 
     it("is invalid if the start and end are the same", () => {
         // Arrange
-        const validationData = generatePlotterOptions({
-            starting: [0, 0, 0, 0, 0],
-        });
+        const validationData = getPlotterPublicWidgetOptions(
+            generatePlotterOptions({starting: [0, 0, 0, 0, 0]}),
+        );
 
         const userInput: PerseusPlotterUserInput = validationData.starting;
 
@@ -37,9 +40,9 @@ describe("validatePlotter", () => {
 
     it("returns null if the start and end are not the same and the user has modified the graph", () => {
         // Arrange
-        const validationData = generatePlotterOptions({
-            starting: [0, 0, 0, 0, 0],
-        });
+        const validationData = getPlotterPublicWidgetOptions(
+            generatePlotterOptions({starting: [0, 0, 0, 0, 0]}),
+        );
 
         const userInput: PerseusPlotterUserInput = [0, 1, 2, 3, 4];
 

--- a/packages/perseus-score/src/widgets/plotter/validate-plotter.test.ts
+++ b/packages/perseus-score/src/widgets/plotter/validate-plotter.test.ts
@@ -1,16 +1,15 @@
+import {generatePlotterOptions} from "@khanacademy/perseus-core";
+
 import validatePlotter from "./validate-plotter";
 
-import type {
-    PerseusPlotterUserInput,
-    PerseusPlotterValidationData,
-} from "@khanacademy/perseus-core";
+import type {PerseusPlotterUserInput} from "@khanacademy/perseus-core";
 
 describe("validatePlotter", () => {
     it("is invalid if the user input is undefined", () => {
         // Arrange
-        const validationData: PerseusPlotterValidationData = {
+        const validationData = generatePlotterOptions({
             starting: [0, 0, 0, 0, 0],
-        };
+        });
 
         const userInput = undefined;
 
@@ -23,9 +22,9 @@ describe("validatePlotter", () => {
 
     it("is invalid if the start and end are the same", () => {
         // Arrange
-        const validationData: PerseusPlotterValidationData = {
+        const validationData = generatePlotterOptions({
             starting: [0, 0, 0, 0, 0],
-        };
+        });
 
         const userInput: PerseusPlotterUserInput = validationData.starting;
 
@@ -38,9 +37,9 @@ describe("validatePlotter", () => {
 
     it("returns null if the start and end are not the same and the user has modified the graph", () => {
         // Arrange
-        const validationData: PerseusPlotterValidationData = {
+        const validationData = generatePlotterOptions({
             starting: [0, 0, 0, 0, 0],
-        };
+        });
 
         const userInput: PerseusPlotterUserInput = [0, 1, 2, 3, 4];
 

--- a/packages/perseus-score/src/widgets/plotter/validate-plotter.ts
+++ b/packages/perseus-score/src/widgets/plotter/validate-plotter.ts
@@ -2,7 +2,7 @@ import {approximateDeepEqual} from "@khanacademy/perseus-core";
 
 import type {
     PerseusPlotterUserInput,
-    PerseusPlotterValidationData,
+    PerseusPlotterWidgetOptions,
     ValidationResult,
 } from "@khanacademy/perseus-core";
 
@@ -16,7 +16,7 @@ function validatePlotter(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusPlotterUserInput | undefined,
-    validationData: PerseusPlotterValidationData,
+    validationData: PerseusPlotterWidgetOptions,
 ): ValidationResult {
     if (
         userInput == null ||

--- a/packages/perseus-score/src/widgets/plotter/validate-plotter.ts
+++ b/packages/perseus-score/src/widgets/plotter/validate-plotter.ts
@@ -2,7 +2,7 @@ import {approximateDeepEqual} from "@khanacademy/perseus-core";
 
 import type {
     PerseusPlotterUserInput,
-    PerseusPlotterWidgetOptions,
+    PlotterPublicWidgetOptions,
     ValidationResult,
 } from "@khanacademy/perseus-core";
 
@@ -16,7 +16,7 @@ function validatePlotter(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: PerseusPlotterUserInput | undefined,
-    validationData: PerseusPlotterWidgetOptions,
+    validationData: PlotterPublicWidgetOptions,
 ): ValidationResult {
     if (
         userInput == null ||

--- a/packages/perseus-score/src/widgets/radio/score-radio.test.ts
+++ b/packages/perseus-score/src/widgets/radio/score-radio.test.ts
@@ -1,7 +1,7 @@
 import scoreRadio from "./score-radio";
 
 import type {
-    PerseusRadioRubric,
+    PerseusRadioWidgetOptions,
     PerseusRadioUserInput,
 } from "@khanacademy/perseus-core";
 
@@ -9,7 +9,7 @@ describe("scoreRadio", () => {
     it("is invalid when the user input is undefined", () => {
         const userInput = undefined;
 
-        const rubric: PerseusRadioRubric = {
+        const rubric: PerseusRadioWidgetOptions = {
             choices: [
                 {
                     id: "0-0-0-0-0",
@@ -44,7 +44,7 @@ describe("scoreRadio", () => {
             selectedChoiceIds: ["0-0-0-0-0"],
         };
 
-        const rubric: PerseusRadioRubric = {
+        const rubric: PerseusRadioWidgetOptions = {
             choices: [
                 {
                     id: "0-0-0-0-0",
@@ -80,7 +80,7 @@ describe("scoreRadio", () => {
             selectedChoiceIds: ["0-0-0-0-0"],
         };
 
-        const rubric: PerseusRadioRubric = {
+        const rubric: PerseusRadioWidgetOptions = {
             choices: [
                 {
                     id: "0-0-0-0-0",
@@ -116,7 +116,7 @@ describe("scoreRadio", () => {
             selectedChoiceIds: ["0-0-0-0-0", "4-4-4-4-4"],
         };
 
-        const rubric: PerseusRadioRubric = {
+        const rubric: PerseusRadioWidgetOptions = {
             choices: [
                 {
                     id: "0-0-0-0-0",
@@ -157,7 +157,7 @@ describe("scoreRadio", () => {
             selectedChoiceIds: ["0-0-0-0-0"],
         };
 
-        const rubric: PerseusRadioRubric = {
+        const rubric: PerseusRadioWidgetOptions = {
             choices: [
                 {
                     id: "0-0-0-0-0",
@@ -192,7 +192,7 @@ describe("scoreRadio", () => {
             selectedChoiceIds: ["3-3-3-3-3"],
         };
 
-        const rubric: PerseusRadioRubric = {
+        const rubric: PerseusRadioWidgetOptions = {
             choices: [
                 {
                     id: "0-0-0-0-0",
@@ -227,7 +227,7 @@ describe("scoreRadio", () => {
             selectedChoiceIds: ["0-0-0-0-0", "1-1-1-1-1"],
         };
 
-        const rubric: PerseusRadioRubric = {
+        const rubric: PerseusRadioWidgetOptions = {
             choices: [
                 {
                     id: "0-0-0-0-0",
@@ -262,7 +262,7 @@ describe("scoreRadio", () => {
             selectedChoiceIds: ["0-0-0-0-0", "3-3-3-3-3"],
         };
 
-        const rubric: PerseusRadioRubric = {
+        const rubric: PerseusRadioWidgetOptions = {
             choices: [
                 {
                     id: "0-0-0-0-0",
@@ -297,7 +297,7 @@ describe("scoreRadio", () => {
             selectedChoiceIds: ["4-4-4-4-4"],
         };
 
-        const rubric: PerseusRadioRubric = {
+        const rubric: PerseusRadioWidgetOptions = {
             choices: [
                 {
                     id: "0-0-0-0-0",
@@ -338,7 +338,7 @@ describe("scoreRadio", () => {
             selectedChoiceIds: ["4-4-4-4-4"],
         };
 
-        const rubric: PerseusRadioRubric = {
+        const rubric: PerseusRadioWidgetOptions = {
             choices: [
                 {
                     id: "0-0-0-0-0",

--- a/packages/perseus-score/src/widgets/radio/score-radio.ts
+++ b/packages/perseus-score/src/widgets/radio/score-radio.ts
@@ -1,7 +1,7 @@
 import {ErrorCodes} from "@khanacademy/perseus-core";
 
 import type {
-    PerseusRadioRubric,
+    PerseusRadioWidgetOptions,
     PerseusRadioUserInput,
     PerseusScore,
     RecursiveReadonly,
@@ -11,7 +11,7 @@ function scoreRadio(
     // NOTE(benchristel): userInput can be undefined if the widget has never
     // been interacted with.
     userInput: RecursiveReadonly<PerseusRadioUserInput> | undefined,
-    rubric: RecursiveReadonly<PerseusRadioRubric>,
+    rubric: RecursiveReadonly<PerseusRadioWidgetOptions>,
 ): PerseusScore {
     if (userInput == null) {
         return {type: "invalid", message: null};

--- a/packages/perseus-score/src/widgets/sorter/score-sorter.test.ts
+++ b/packages/perseus-score/src/widgets/sorter/score-sorter.test.ts
@@ -1,9 +1,8 @@
+import {generateSorterOptions} from "@khanacademy/perseus-core";
+
 import scoreSorter from "./score-sorter";
 
-import type {
-    PerseusSorterRubric,
-    PerseusSorterUserInput,
-} from "@khanacademy/perseus-core";
+import type {PerseusSorterUserInput} from "@khanacademy/perseus-core";
 
 describe("scoreSorter", () => {
     it("is correct when the user input values are in the order defined in the rubric", () => {
@@ -12,9 +11,9 @@ describe("scoreSorter", () => {
             options: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
             changed: true,
         };
-        const rubric: PerseusSorterRubric = {
+        const rubric = generateSorterOptions({
             correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
-        };
+        });
 
         // Act
         const result = scoreSorter(userInput, rubric);
@@ -29,9 +28,9 @@ describe("scoreSorter", () => {
             options: ["$15$ grams", "$55$ grams", "$0.005$ kilograms"],
             changed: true,
         };
-        const rubric: PerseusSorterRubric = {
+        const rubric = generateSorterOptions({
             correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
-        };
+        });
 
         // Act
         const result = scoreSorter(userInput, rubric);

--- a/packages/perseus-score/src/widgets/sorter/score-sorter.ts
+++ b/packages/perseus-score/src/widgets/sorter/score-sorter.ts
@@ -1,14 +1,14 @@
 import {approximateDeepEqual} from "@khanacademy/perseus-core";
 
 import type {
-    PerseusSorterRubric,
+    PerseusSorterWidgetOptions,
     PerseusSorterUserInput,
     PerseusScore,
 } from "@khanacademy/perseus-core";
 
 function scoreSorter(
     userInput: PerseusSorterUserInput,
-    rubric: PerseusSorterRubric,
+    rubric: PerseusSorterWidgetOptions,
 ): PerseusScore {
     const correct = approximateDeepEqual(userInput.options, rubric.correct);
     return {

--- a/packages/perseus-score/src/widgets/table/score-table.test.ts
+++ b/packages/perseus-score/src/widgets/table/score-table.test.ts
@@ -2,7 +2,7 @@ import scoreTable from "./score-table";
 import * as TableValidator from "./validate-table";
 
 import type {
-    PerseusTableRubric,
+    PerseusTableWidgetOptions,
     PerseusTableUserInput,
 } from "@khanacademy/perseus-core";
 
@@ -18,11 +18,14 @@ describe("scoreTable", () => {
             ["3", "4"],
         ];
 
-        const rubric: PerseusTableRubric = {
+        const rubric: PerseusTableWidgetOptions = {
             answers: [
                 ["1", "2"],
                 ["3", "4"],
             ],
+            headers: ["", ""],
+            rows: 2,
+            columns: 2,
         };
 
         // Act
@@ -44,11 +47,14 @@ describe("scoreTable", () => {
             ["3", "4"],
         ];
 
-        const rubric: PerseusTableRubric = {
+        const rubric: PerseusTableWidgetOptions = {
             answers: [
                 ["1", "2"],
                 ["3", "4"],
             ],
+            headers: ["", ""],
+            rows: 2,
+            columns: 2,
         };
 
         // Act
@@ -66,11 +72,14 @@ describe("scoreTable", () => {
             ["3", "4"],
         ];
 
-        const rubric: PerseusTableRubric = {
+        const rubric: PerseusTableWidgetOptions = {
             answers: [
                 ["1", "2"],
                 ["3", "4"],
             ],
+            headers: ["", ""],
+            rows: 2,
+            columns: 2,
         };
 
         // Act
@@ -88,11 +97,14 @@ describe("scoreTable", () => {
             ["5", "6"],
         ];
 
-        const rubric: PerseusTableRubric = {
+        const rubric: PerseusTableWidgetOptions = {
             answers: [
                 ["1", "2"],
                 ["3", "4"],
             ],
+            headers: ["", ""],
+            rows: 2,
+            columns: 2,
         };
 
         // Act
@@ -109,11 +121,14 @@ describe("scoreTable", () => {
             ["3", "5"],
         ];
 
-        const rubric: PerseusTableRubric = {
+        const rubric: PerseusTableWidgetOptions = {
             answers: [
                 ["1", "2"],
                 ["3", "4"],
             ],
+            headers: ["", ""],
+            rows: 2,
+            columns: 2,
         };
 
         // Act
@@ -130,11 +145,14 @@ describe("scoreTable", () => {
             ["3", "4"],
         ];
 
-        const rubric: PerseusTableRubric = {
+        const rubric: PerseusTableWidgetOptions = {
             answers: [
                 ["1", "2"],
                 ["3", "4"],
             ],
+            headers: ["", ""],
+            rows: 2,
+            columns: 2,
         };
 
         // Act
@@ -151,11 +169,14 @@ describe("scoreTable", () => {
             ["3.0", "4.0"],
         ];
 
-        const rubric: PerseusTableRubric = {
+        const rubric: PerseusTableWidgetOptions = {
             answers: [
                 ["1", "2"],
                 ["3", "4"],
             ],
+            headers: ["", ""],
+            rows: 2,
+            columns: 2,
         };
 
         // Act

--- a/packages/perseus-score/src/widgets/table/score-table.test.ts
+++ b/packages/perseus-score/src/widgets/table/score-table.test.ts
@@ -1,10 +1,9 @@
+import {generateTableOptions} from "@khanacademy/perseus-core";
+
 import scoreTable from "./score-table";
 import * as TableValidator from "./validate-table";
 
-import type {
-    PerseusTableWidgetOptions,
-    PerseusTableUserInput,
-} from "@khanacademy/perseus-core";
+import type {PerseusTableUserInput} from "@khanacademy/perseus-core";
 
 describe("scoreTable", () => {
     it("should be correctly answerable if validation passes", function () {
@@ -18,15 +17,12 @@ describe("scoreTable", () => {
             ["3", "4"],
         ];
 
-        const rubric: PerseusTableWidgetOptions = {
+        const rubric = generateTableOptions({
             answers: [
                 ["1", "2"],
                 ["3", "4"],
             ],
-            headers: ["", ""],
-            rows: 2,
-            columns: 2,
-        };
+        });
 
         // Act
         const score = scoreTable(userInput, rubric);
@@ -47,15 +43,12 @@ describe("scoreTable", () => {
             ["3", "4"],
         ];
 
-        const rubric: PerseusTableWidgetOptions = {
+        const rubric = generateTableOptions({
             answers: [
                 ["1", "2"],
                 ["3", "4"],
             ],
-            headers: ["", ""],
-            rows: 2,
-            columns: 2,
-        };
+        });
 
         // Act
         const score = scoreTable(userInput, rubric);
@@ -72,15 +65,12 @@ describe("scoreTable", () => {
             ["3", "4"],
         ];
 
-        const rubric: PerseusTableWidgetOptions = {
+        const rubric = generateTableOptions({
             answers: [
                 ["1", "2"],
                 ["3", "4"],
             ],
-            headers: ["", ""],
-            rows: 2,
-            columns: 2,
-        };
+        });
 
         // Act
         const result = scoreTable(userInput, rubric);
@@ -97,15 +87,12 @@ describe("scoreTable", () => {
             ["5", "6"],
         ];
 
-        const rubric: PerseusTableWidgetOptions = {
+        const rubric = generateTableOptions({
             answers: [
                 ["1", "2"],
                 ["3", "4"],
             ],
-            headers: ["", ""],
-            rows: 2,
-            columns: 2,
-        };
+        });
 
         // Act
         const result = scoreTable(userInput, rubric);
@@ -121,15 +108,12 @@ describe("scoreTable", () => {
             ["3", "5"],
         ];
 
-        const rubric: PerseusTableWidgetOptions = {
+        const rubric = generateTableOptions({
             answers: [
                 ["1", "2"],
                 ["3", "4"],
             ],
-            headers: ["", ""],
-            rows: 2,
-            columns: 2,
-        };
+        });
 
         // Act
         const result = scoreTable(userInput, rubric);
@@ -145,15 +129,12 @@ describe("scoreTable", () => {
             ["3", "4"],
         ];
 
-        const rubric: PerseusTableWidgetOptions = {
+        const rubric = generateTableOptions({
             answers: [
                 ["1", "2"],
                 ["3", "4"],
             ],
-            headers: ["", ""],
-            rows: 2,
-            columns: 2,
-        };
+        });
 
         // Act
         const result = scoreTable(userInput, rubric);
@@ -169,15 +150,12 @@ describe("scoreTable", () => {
             ["3.0", "4.0"],
         ];
 
-        const rubric: PerseusTableWidgetOptions = {
+        const rubric = generateTableOptions({
             answers: [
                 ["1", "2"],
                 ["3", "4"],
             ],
-            headers: ["", ""],
-            rows: 2,
-            columns: 2,
-        };
+        });
 
         // Act
         const result = scoreTable(userInput, rubric);

--- a/packages/perseus-score/src/widgets/table/score-table.ts
+++ b/packages/perseus-score/src/widgets/table/score-table.ts
@@ -4,14 +4,14 @@ import {filterNonEmpty} from "./utils";
 import validateTable from "./validate-table";
 
 import type {
-    PerseusTableRubric,
+    PerseusTableWidgetOptions,
     PerseusScore,
     PerseusTableUserInput,
 } from "@khanacademy/perseus-core";
 
 function scoreTable(
     userInput: PerseusTableUserInput,
-    rubric: PerseusTableRubric,
+    rubric: PerseusTableWidgetOptions,
 ): PerseusScore {
     const validationResult = validateTable(userInput);
     if (validationResult != null) {

--- a/packages/perseus/src/widgets/expression/expression.test.tsx
+++ b/packages/perseus/src/widgets/expression/expression.test.tsx
@@ -1,10 +1,10 @@
 import {it, describe, beforeEach} from "@jest/globals";
 import {
-    splitPerseusItem,
-    generateTestPerseusItem,
-    generateExpressionWidget,
     generateExpressionAnswerForm,
     generateExpressionOptions,
+    generateExpressionWidget,
+    generateTestPerseusItem,
+    splitPerseusItem,
 } from "@khanacademy/perseus-core";
 import {scorePerseusItem} from "@khanacademy/perseus-score";
 import {act, screen} from "@testing-library/react";
@@ -27,11 +27,7 @@ import {
     expressionItemWithLabels,
 } from "./expression.testdata";
 
-import type {
-    PerseusItem,
-    PerseusRenderer,
-    PerseusExpressionRubric,
-} from "@khanacademy/perseus-core";
+import type {PerseusItem, PerseusRenderer} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
 
 const renderAndAnswer = async (
@@ -361,10 +357,10 @@ describe("Expression Widget", function () {
 
         it("should return undefined if rubric.value is null/undefined", () => {
             // Arrange
-            const rubric: PerseusExpressionRubric = {
+            const rubric = generateExpressionOptions({
                 answerForms: [],
                 functions: [],
-            };
+            });
 
             // Act
             const result =
@@ -376,7 +372,7 @@ describe("Expression Widget", function () {
 
         it("returns a correct answer when there is one correct answer", () => {
             // Arrange
-            const rubric: PerseusExpressionRubric = {
+            const rubric = generateExpressionOptions({
                 answerForms: [
                     {
                         value: "123",
@@ -386,7 +382,7 @@ describe("Expression Widget", function () {
                     },
                 ],
                 functions: [],
-            };
+            });
 
             // Act
             const result =
@@ -398,7 +394,7 @@ describe("Expression Widget", function () {
 
         it("returns the first correct answer when there are multiple correct answers", () => {
             // Arrange
-            const rubric: PerseusExpressionRubric = {
+            const rubric = generateExpressionOptions({
                 answerForms: [
                     {
                         value: "123",
@@ -414,7 +410,7 @@ describe("Expression Widget", function () {
                     },
                 ],
                 functions: [],
-            };
+            });
 
             // Act
             const result =

--- a/packages/perseus/src/widgets/expression/expression.tsx
+++ b/packages/perseus/src/widgets/expression/expression.tsx
@@ -24,9 +24,8 @@ import type {ExpressionPromptJSON} from "../../widget-ai-utils/expression/expres
 import type {
     KeypadConfiguration,
     KeypadKey,
-    PerseusExpressionRubric,
-    PerseusExpressionUserInput,
     PerseusExpressionWidgetOptions,
+    PerseusExpressionUserInput,
 } from "@khanacademy/perseus-core";
 
 // Map of international operator names to their English equivalents
@@ -375,7 +374,7 @@ function getStartUserInput(): PerseusExpressionUserInput {
 }
 
 function getOneCorrectAnswerFromRubric(
-    rubric: PerseusExpressionRubric,
+    rubric: PerseusExpressionWidgetOptions,
 ): string | null | undefined {
     // TODO(LEMS-2656): remove TS suppression
     // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
@@ -32,11 +32,7 @@ import {
 } from "./numeric-input.testdata";
 import {findCommonFractions, findPrecision} from "./utils";
 
-import type {
-    PerseusItem,
-    PerseusNumericInputRubric,
-    PerseusRenderer,
-} from "@khanacademy/perseus-core";
+import type {PerseusItem, PerseusRenderer} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
 
 describe("numeric-input widget", () => {
@@ -289,10 +285,9 @@ describe("static function getOneCorrectAnswerFromRubric", () => {
             (widgetOptions && widgetOptions.answers) || [];
 
         const singleAnswer =
-            NumericInputWidgetExport.getOneCorrectAnswerFromRubric?.({
-                answers,
-                coefficient: false,
-            });
+            NumericInputWidgetExport.getOneCorrectAnswerFromRubric?.(
+                generateNumericInputOptions({answers, coefficient: false}),
+            );
         expect(singleAnswer).toBe("12.2");
     });
 
@@ -304,25 +299,23 @@ describe("static function getOneCorrectAnswerFromRubric", () => {
             // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
             (widgetOptions && widgetOptions.answers) || [];
         const singleAnswer =
-            NumericInputWidgetExport.getOneCorrectAnswerFromRubric?.({
-                answers,
-                coefficient: false,
-            });
+            NumericInputWidgetExport.getOneCorrectAnswerFromRubric?.(
+                generateNumericInputOptions({answers, coefficient: false}),
+            );
         expect(singleAnswer).toBe("1252");
     });
 
     it("can not get a correct answer from scoring data with no answer", () => {
         const answers: Array<never> = [];
         const singleAnswer =
-            NumericInputWidgetExport.getOneCorrectAnswerFromRubric?.({
-                answers,
-                coefficient: false,
-            });
+            NumericInputWidgetExport.getOneCorrectAnswerFromRubric?.(
+                generateNumericInputOptions({answers, coefficient: false}),
+            );
         expect(singleAnswer).toBeUndefined();
     });
 
     it("supports error bars", () => {
-        const rubric: PerseusNumericInputRubric = {
+        const rubric = generateNumericInputOptions({
             answers: [
                 {
                     status: "correct",
@@ -335,7 +328,7 @@ describe("static function getOneCorrectAnswerFromRubric", () => {
                 },
             ],
             coefficient: true,
-        };
+        });
         const singleAnswer =
             NumericInputWidgetExport.getOneCorrectAnswerFromRubric?.(rubric);
         expect(singleAnswer).toBe("1 ± 0.2");

--- a/packages/perseus/src/widgets/numeric-input/utils.ts
+++ b/packages/perseus/src/widgets/numeric-input/utils.ts
@@ -4,9 +4,8 @@ import type {PerseusStrings} from "../../strings";
 import type {
     MathFormat,
     PerseusNumericInputAnswerForm,
-    PerseusNumericInputRubric,
-    PerseusNumericInputUserInput,
     PerseusNumericInputWidgetOptions,
+    PerseusNumericInputUserInput,
 } from "@khanacademy/perseus-core";
 
 /**
@@ -240,7 +239,7 @@ export function getCorrectUserInput(
 }
 
 export function getOneCorrectAnswerFromRubric(
-    rubric: PerseusNumericInputRubric,
+    rubric: PerseusNumericInputWidgetOptions,
 ): string | null | undefined {
     const correctAnswers = rubric.answers.filter(
         (answer) => answer.status === "correct",

--- a/packages/perseus/src/widgets/radio/__tests__/radio-widget.test.tsx
+++ b/packages/perseus/src/widgets/radio/__tests__/radio-widget.test.tsx
@@ -16,7 +16,7 @@ import Radio from "../radio-widget";
 import type {WidgetProps} from "../../../types";
 import type {RadioChoiceWithMetadata, RadioProps} from "../radio-widget";
 import type {
-    PerseusRadioRubric,
+    PerseusRadioWidgetOptions,
     PerseusRadioUserInput,
 } from "@khanacademy/perseus-core";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
@@ -65,9 +65,17 @@ const getBaseOptions = (overrides?: Partial<RadioProps>): RadioProps => ({
 
 const getBaseProps = (
     overrides?: Partial<
-        WidgetProps<RadioProps, PerseusRadioUserInput, PerseusRadioRubric>
+        WidgetProps<
+            RadioProps,
+            PerseusRadioUserInput,
+            PerseusRadioWidgetOptions
+        >
     >,
-): WidgetProps<RadioProps, PerseusRadioUserInput, PerseusRadioRubric> => ({
+): WidgetProps<
+    RadioProps,
+    PerseusRadioUserInput,
+    PerseusRadioWidgetOptions
+> => ({
     options: getBaseOptions(),
     trackInteraction: jest.fn(),
     widgetId: "radio-1",

--- a/packages/perseus/src/widgets/radio/radio-widget.tsx
+++ b/packages/perseus/src/widgets/radio/radio-widget.tsx
@@ -17,7 +17,7 @@ import type {WidgetProps, ChoiceState, Widget} from "../../types";
 import type {RadioPromptJSON} from "../../widget-ai-utils/radio/radio-ai-utils";
 import type {
     PerseusRadioChoice,
-    PerseusRadioRubric,
+    PerseusRadioWidgetOptions,
     PerseusRadioUserInput,
 } from "@khanacademy/perseus-core";
 import type {LinterContextProps} from "@khanacademy/perseus-linter";
@@ -59,7 +59,11 @@ export interface RadioChoiceWithMetadata extends PerseusRadioChoice {
     correct?: boolean;
 }
 
-type Props = WidgetProps<RadioProps, PerseusRadioUserInput, PerseusRadioRubric>;
+type Props = WidgetProps<
+    RadioProps,
+    PerseusRadioUserInput,
+    PerseusRadioWidgetOptions
+>;
 
 /**
  * RadioWidget implements the Widget interface for multiple choice questions.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -922,6 +922,9 @@ importers:
       '@khanacademy/perseus-utils':
         specifier: workspace:*
         version: link:../perseus-utils
+      tiny-invariant:
+        specifier: ^1.3.3
+        version: 1.3.3
     devDependencies:
       perseus-build-settings:
         specifier: workspace:*


### PR DESCRIPTION
## Summary:
We had some cruft in our types.

1. `Perseus*Rubric` types aren't actually what get passed to the scoring functions, `Perseus*WidgetOptions` are
2. `Perseus*ValidationData` types aren't actually what get passed to the validation functions, `*PublicWidgetOptions` are

So I consolidated a little bit. The reason the PR is so big is because a lot of tests were hand-rolling `Perseus*Rubic` and `Perseus*ValidationData`, so the PR switches over to the generator functions to simplify things a bit.