### PR TITLE
Rename focus and blur to focusPerseus and blurPerseus

### DIFF
--- a/packages/perseus-core/src/keypad.ts
+++ b/packages/perseus-core/src/keypad.ts
@@ -123,5 +123,5 @@ export type KeypadConfiguration = {
 
 // Used by KeypadContext to pass around a renderer reference
 export interface KeypadContextRendererInterface {
-    blur(): void;
+    blurPerseus(): void;
 }

--- a/packages/perseus-core/src/types.ts
+++ b/packages/perseus-core/src/types.ts
@@ -4,15 +4,14 @@
 // Interfact currently only implemented by
 // ServerItemRenderer
 export interface RendererInterface {
+    blurPerseus(): void;
+    focusPerseus(): boolean | null | undefined;
+
     // TODO(LEMS-3185): remove serializedState
     /**
      * @deprecated - do not use in new code.
      */
     getSerializedState(): any;
-    // TODO(LEMS-3185): remove serializedState
-    blur(): void;
-    focus(): boolean | null | undefined;
-    props: any;
 }
 
 // Base marker, with the props that are set by the editor.

--- a/packages/perseus/src/__tests__/renderer.new.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.new.test.tsx
@@ -802,7 +802,7 @@ describe("renderer", () => {
             });
 
             // Act
-            const focusResult = renderer.focus();
+            const focusResult = renderer.focusPerseus();
 
             // Assert
             expect(focusResult).toBe(true);
@@ -840,7 +840,7 @@ describe("renderer", () => {
             );
 
             // Act
-            const focusResult = renderer.focus();
+            const focusResult = renderer.focusPerseus();
 
             // Assert
             expect(focusResult).toBeFalsy();
@@ -1030,7 +1030,7 @@ describe("renderer", () => {
             onFocusChange.mockClear();
 
             // Act
-            act(() => renderer.blur());
+            act(() => renderer.blurPerseus());
             act(() => jest.runOnlyPendingTimers()); // There's a _.defer() in this code path
 
             // Assert
@@ -1058,7 +1058,7 @@ describe("renderer", () => {
             );
 
             // Act
-            act(() => renderer.blur());
+            act(() => renderer.blurPerseus());
             act(() => jest.runOnlyPendingTimers()); // There's a _.defer() in this code path
 
             // Assert

--- a/packages/perseus/src/__tests__/renderer.test.tsx
+++ b/packages/perseus/src/__tests__/renderer.test.tsx
@@ -799,7 +799,7 @@ describe("renderer", () => {
             });
 
             // Act
-            const focusResult = renderer.focus();
+            const focusResult = renderer.focusPerseus();
 
             // Assert
             expect(focusResult).toBe(true);
@@ -837,7 +837,7 @@ describe("renderer", () => {
             );
 
             // Act
-            const focusResult = renderer.focus();
+            const focusResult = renderer.focusPerseus();
 
             // Assert
             expect(focusResult).toBeFalsy();
@@ -1027,7 +1027,7 @@ describe("renderer", () => {
             onFocusChange.mockClear();
 
             // Act
-            act(() => renderer.blur());
+            act(() => renderer.blurPerseus());
             act(() => jest.runOnlyPendingTimers()); // There's a _.defer() in this code path
 
             // Assert
@@ -1037,7 +1037,7 @@ describe("renderer", () => {
             );
         });
 
-        it("should do nothing when blur() called but no widget focused", () => {
+        it("should do nothing when blurPerseus() called but no widget focused", () => {
             // Arrange
             const onFocusChange = jest.fn();
             const {renderer} = renderQuestion(
@@ -1055,7 +1055,7 @@ describe("renderer", () => {
             );
 
             // Act
-            act(() => renderer.blur());
+            act(() => renderer.blurPerseus());
             act(() => jest.runOnlyPendingTimers()); // There's a _.defer() in this code path
 
             // Assert

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -467,7 +467,7 @@ describe("server item renderer", () => {
             });
 
             // Act
-            const gotFocus = await act(() => renderer.focus());
+            const gotFocus = await act(() => renderer.focusPerseus());
 
             // We have some async processes that need to be resolved here
             jest.runAllTimers();
@@ -512,7 +512,7 @@ describe("server item renderer", () => {
             );
 
             // Act
-            const gotFocus = await act(() => renderer.focus());
+            const gotFocus = await act(() => renderer.focusPerseus());
 
             // We have some async processes that need to be resolved here
             jest.runAllTimers();
@@ -534,10 +534,10 @@ describe("server item renderer", () => {
             const {renderer} = renderQuestion(itemWithMockWidget, {
                 onFocusChange,
             });
-            act(() => renderer.focus());
+            act(() => renderer.focusPerseus());
 
             // Act
-            act(() => renderer.blur());
+            act(() => renderer.blurPerseus());
 
             // We have some async processes that need to be resolved here
             jest.runAllTimers();
@@ -580,10 +580,10 @@ describe("server item renderer", () => {
                 {onFocusChange, isMobile: true},
                 {keypadElement},
             );
-            act(() => renderer.focus());
+            act(() => renderer.focusPerseus());
 
             // Act
-            act(() => renderer.blur());
+            act(() => renderer.blurPerseus());
 
             // We have some async processes that need to be resolved here
             jest.runAllTimers();

--- a/packages/perseus/src/article-renderer.tsx
+++ b/packages/perseus/src/article-renderer.tsx
@@ -153,7 +153,7 @@ class ArticleRenderer
         });
     };
 
-    blur: () => void = () => {
+    blurPerseus: () => void = () => {
         if (this._currentFocus) {
             const [sectionIndex, ...inputPath] = this._currentFocus;
             this.sectionRenderers[sectionIndex].blurPath(inputPath);

--- a/packages/perseus/src/renderer.new.tsx
+++ b/packages/perseus/src/renderer.new.tsx
@@ -77,6 +77,7 @@ import type {
     PerseusWidget,
     PerseusWidgetOptions,
     PerseusWidgetsMap,
+    RendererInterface,
     ShowSolutions,
     UserInput,
     UserInputMap,
@@ -237,7 +238,7 @@ function isDifferentQuestion(
 
 class Renderer
     extends React.Component<Props, State>
-    implements GetPromptJSONInterface
+    implements RendererInterface, GetPromptJSONInterface
 {
     static contextType = PerseusI18nContext;
     declare context: React.ContextType<typeof PerseusI18nContext>;
@@ -1277,7 +1278,7 @@ class Renderer
         }
     };
 
-    focus: () => boolean | null | undefined = () => {
+    focusPerseus: () => boolean | null | undefined = () => {
         let id;
         let focusResult;
         for (let i = 0; i < this.widgetIds.length; i++) {
@@ -1413,7 +1414,7 @@ class Renderer
         }
     };
 
-    blur: () => void = () => {
+    blurPerseus: () => void = () => {
         if (this._currentFocus) {
             this.blurPath(this._currentFocus);
         }

--- a/packages/perseus/src/renderer.old.tsx
+++ b/packages/perseus/src/renderer.old.tsx
@@ -77,6 +77,7 @@ import type {
     PerseusWidget,
     PerseusWidgetOptions,
     PerseusWidgetsMap,
+    RendererInterface,
     ShowSolutions,
     UserInput,
     UserInputMap,
@@ -229,7 +230,7 @@ export function isDifferentQuestion(
 
 class Renderer
     extends React.Component<Props, State>
-    implements GetPromptJSONInterface
+    implements RendererInterface, GetPromptJSONInterface
 {
     static contextType = PerseusI18nContext;
     declare context: React.ContextType<typeof PerseusI18nContext>;
@@ -1270,7 +1271,7 @@ class Renderer
         }
     };
 
-    focus: () => boolean | null | undefined = () => {
+    focusPerseus: () => boolean | null | undefined = () => {
         let id;
         let focusResult;
         for (let i = 0; i < this.widgetIds.length; i++) {
@@ -1406,7 +1407,7 @@ class Renderer
         }
     };
 
-    blur: () => void = () => {
+    blurPerseus: () => void = () => {
         if (this._currentFocus) {
             this.blurPath(this._currentFocus);
         }

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -262,11 +262,11 @@ export class ServerItemRenderer
         return questionAreaInputPaths;
     }
 
-    focus(): boolean | null | undefined {
-        return this.questionRenderer.focus();
+    focusPerseus(): boolean | null | undefined {
+        return this.questionRenderer.focusPerseus();
     }
 
-    blur(): void {
+    blurPerseus(): void {
         if (this._currentFocus) {
             this.blurPath(this._currentFocus);
         }

--- a/packages/perseus/src/widgets/dropdown/dropdown.test.ts
+++ b/packages/perseus/src/widgets/dropdown/dropdown.test.ts
@@ -141,12 +141,12 @@ describe("Dropdown widget", () => {
         });
     });
 
-    it("should return true when focus() called and focus the dropdown button", async () => {
+    it("should return true when focusPerseus() called and focus the dropdown button", async () => {
         // Arrange
         const {renderer} = renderQuestion(basicDropdown);
 
         // Act
-        const focused = renderer.focus();
+        const focused = renderer.focusPerseus();
 
         // Assert
         expect(focused).toBe(true);
@@ -167,7 +167,7 @@ describe("Dropdown widget", () => {
         const {renderer} = renderQuestion(basicDropdown, {readOnly: true});
 
         // Act
-        const focused = renderer.focus();
+        const focused = renderer.focusPerseus();
 
         // Assert
         expect(focused).toBeFalsy();
@@ -195,7 +195,7 @@ describe("Dropdown widget", () => {
         const {renderer} = renderQuestion(staticDropdown);
 
         // Act
-        const focused = renderer.focus();
+        const focused = renderer.focusPerseus();
 
         // Assert
         expect(focused).toBeFalsy();
@@ -210,7 +210,7 @@ describe("Dropdown widget", () => {
         button.setAttribute("aria-disabled", "true");
 
         // Act
-        const focused = renderer.focus();
+        const focused = renderer.focusPerseus();
 
         // Assert
         expect(focused).toBeFalsy();

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.test.ts
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.test.ts
@@ -222,7 +222,7 @@ describe("graded group set widget", () => {
 
         // Act
         // The first "focusable" widget receives focus...
-        act(() => renderer.focus());
+        act(() => renderer.focusPerseus());
 
         // Assert
         expect(screen.getByRole("textbox")).toHaveFocus();

--- a/packages/perseus/src/widgets/graded-group/graded-group.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.tsx
@@ -185,7 +185,7 @@ export class GradedGroup
     }
 
     focus: () => boolean = () => {
-        return !!this.rendererRef.current?.focus();
+        return !!this.rendererRef.current?.focusPerseus();
     };
 
     focusInputPath: (arg1: any) => void = (path) => {

--- a/packages/perseus/src/widgets/group/group.test.tsx
+++ b/packages/perseus/src/widgets/group/group.test.tsx
@@ -54,7 +54,7 @@ describe("group widget", () => {
             });
 
             // Act
-            act(() => renderer.focus());
+            act(() => renderer.focusPerseus());
 
             // Assert
             expect(onFocusChange).toHaveBeenCalledWith(
@@ -81,7 +81,7 @@ describe("group widget", () => {
             onFocusChange.mockClear();
 
             // Act
-            act(() => renderer.blur());
+            act(() => renderer.blurPerseus());
 
             // Assert
             await waitFor(() =>

--- a/packages/perseus/src/widgets/group/group.tsx
+++ b/packages/perseus/src/widgets/group/group.tsx
@@ -66,7 +66,7 @@ class Group extends React.Component<Props> implements Widget {
     }
 
     focus() {
-        return this.rendererRef?.focus() ?? false;
+        return this.rendererRef?.focusPerseus() ?? false;
     }
 
     focusInputPath: (arg1: FocusPath) => void = (path) => {

--- a/packages/perseus/src/widgets/input-number/input-number.test.ts
+++ b/packages/perseus/src/widgets/input-number/input-number.test.ts
@@ -427,7 +427,7 @@ describe("input-number", () => {
         const {renderer} = renderQuestion(question);
 
         // Act
-        const gotFocus = await act(() => renderer.focus());
+        const gotFocus = await act(() => renderer.focusPerseus());
 
         // Assert
         expect(screen.getByRole("textbox")).toHaveFocus();
@@ -437,11 +437,11 @@ describe("input-number", () => {
     it("supports blurring", async () => {
         // Arrange
         const {renderer} = renderQuestion(question);
-        await act(() => renderer.focus());
+        await act(() => renderer.focusPerseus());
         expect(screen.getByRole("textbox")).toHaveFocus();
 
         // Act
-        await act(() => renderer.blur());
+        await act(() => renderer.blurPerseus());
 
         // Assert
         await waitFor(() => {
@@ -559,7 +559,7 @@ describe("focus state", () => {
         const {renderer} = renderQuestion(question);
 
         // Act
-        const gotFocus = await act(() => renderer.focus());
+        const gotFocus = await act(() => renderer.focusPerseus());
 
         // Assert
         expect(screen.getByRole("textbox")).toHaveFocus();
@@ -569,11 +569,11 @@ describe("focus state", () => {
     it("supports blurring", async () => {
         //  Arrange
         const {renderer} = renderQuestion(question);
-        await act(() => renderer.focus());
+        await act(() => renderer.focusPerseus());
         expect(screen.getByRole("textbox")).toHaveFocus();
 
         // Act
-        await act(() => renderer.blur());
+        await act(() => renderer.blurPerseus());
 
         // Assert
         await waitFor(() => {

--- a/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
+++ b/packages/perseus/src/widgets/numeric-input/numeric-input.test.ts
@@ -463,7 +463,7 @@ describe("Numeric input widget", () => {
         const {renderer} = renderQuestion(question1);
 
         // Act
-        const gotFocus = await act(() => renderer.focus());
+        const gotFocus = await act(() => renderer.focusPerseus());
 
         // Assert
         expect(gotFocus).toBe(true);
@@ -476,7 +476,7 @@ describe("Numeric input widget", () => {
         // Act
         const input = screen.getByRole("textbox", {hidden: true});
         act(() => input.focus());
-        act(() => renderer.blur());
+        act(() => renderer.blurPerseus());
 
         // Assert
         // eslint-disable-next-line testing-library/no-node-access


### PR DESCRIPTION
## Summary:

This is just to get a vibe check.

Focus management in Perseus is a little complicated (maybe too complicated). One of the things that make it complicated is our use of class components, imperative APIs, and generic naming.

For example, ServerItemRenderer is a class component with a bunch of methods on it that could be called imperatively: `focusPath`, `blurPath`, `getDOMNodeForPath`, `getInputPaths`, `focus`, `blur`, etc. Of those, only `focus` and `blur` seem to be used externally but then there's another problem: it's kind of tricky to see _where_ they're used because `focus` and `blur` are very common names.

So this is a simple PR that mostly just renames `focus` and `blur` to `focusPerseus` and `blurPerseus` to make it easier to discover their uses.