### PR TITLE
Encapsulate ServerItemRenderer to limit its external API

### DIFF
--- a/.changeset/gentle-nails-greet.md
+++ b/.changeset/gentle-nails-greet.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": major
+"@khanacademy/perseus-core": patch
+---
+
+Encapsulate ServerItemRenderer to only allow explicitly declared imperative APIS

--- a/packages/perseus-core/src/types.ts
+++ b/packages/perseus-core/src/types.ts
@@ -12,7 +12,6 @@ export interface RendererInterface {
     // TODO(LEMS-3185): remove serializedState
     blur(): void;
     focus(): boolean | null | undefined;
-    props: any;
 }
 
 // Base marker, with the props that are set by the editor.

--- a/packages/perseus/src/__docs__/server-item-renderer.stories.tsx
+++ b/packages/perseus/src/__docs__/server-item-renderer.stories.tsx
@@ -11,7 +11,7 @@ import {
     itemWithMultipleNumericInputs,
     itemWithRadioAndExpressionWidgets,
 } from "../__testdata__/server-item-renderer.testdata";
-import {ServerItemRenderer} from "../server-item-renderer";
+import ServerItemRenderer from "../server-item-renderer";
 import {ServerItemRendererWithDebugUI} from "../testing/server-item-renderer-with-debug-ui";
 import {storybookDependenciesV2} from "../testing/test-dependencies";
 

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -21,7 +21,8 @@ import {
 } from "../__testdata__/server-item-renderer.testdata";
 import {ENTRANCE_TRANSITION_DURATION_MS} from "../components/zoomable";
 import * as Dependencies from "../dependencies";
-import {ServerItemRenderer} from "../server-item-renderer";
+import LoadingContext from "../loading-context";
+import ServerItemRenderer from "../server-item-renderer";
 import {
     testDependencies,
     testDependenciesV2,
@@ -34,6 +35,7 @@ import MockAssetLoadingWidgetExport, {
 
 import {renderQuestion} from "./test-utils";
 
+import type {ServerItemRendererHandle} from "../server-item-renderer";
 import type {MockAssetLoadingWidget} from "../widgets/mock-widgets/mock-asset-loading-widget";
 import type {KeypadAPI} from "@khanacademy/math-input";
 import type {UserEvent} from "@testing-library/user-event";
@@ -173,18 +175,19 @@ describe("server item renderer", () => {
         );
 
         const onRendered = jest.fn();
-        let renderer: ServerItemRenderer | null | undefined;
+        let renderer: ServerItemRendererHandle | null | undefined;
         const {rerender} = render(
-            <RenderStateRoot>
-                <ServerItemRenderer
-                    ref={(component) => (renderer = component)}
-                    item={mockedAssetItem}
-                    problemNum={0}
-                    reviewMode={false}
-                    onRendered={onRendered}
-                    dependencies={testDependenciesV2}
-                />
-            </RenderStateRoot>,
+            <LoadingContext.Provider value={{onRendered}}>
+                <RenderStateRoot>
+                    <ServerItemRenderer
+                        ref={(component) => (renderer = component)}
+                        item={mockedAssetItem}
+                        problemNum={0}
+                        reviewMode={false}
+                        dependencies={testDependenciesV2}
+                    />
+                </RenderStateRoot>
+            </LoadingContext.Provider>,
         );
         if (renderer == null) {
             throw new Error("Renderer failed to render.");
@@ -198,15 +201,16 @@ describe("server item renderer", () => {
         }
 
         rerender(
-            <RenderStateRoot>
-                <ServerItemRenderer
-                    item={mockedAssetItem}
-                    problemNum={1}
-                    reviewMode={false}
-                    onRendered={onRendered}
-                    dependencies={testDependenciesV2}
-                />
-            </RenderStateRoot>,
+            <LoadingContext.Provider value={{onRendered}}>
+                <RenderStateRoot>
+                    <ServerItemRenderer
+                        item={mockedAssetItem}
+                        problemNum={1}
+                        reviewMode={false}
+                        dependencies={testDependenciesV2}
+                    />
+                </RenderStateRoot>
+            </LoadingContext.Provider>,
         );
 
         // Act
@@ -235,15 +239,16 @@ describe("server item renderer", () => {
 
         // Act
         render(
-            <RenderStateRoot>
-                <ServerItemRenderer
-                    item={itemWithMath}
-                    problemNum={0}
-                    reviewMode={false}
-                    dependencies={testDependenciesV2}
-                    onRendered={onRendered}
-                />
-            </RenderStateRoot>,
+            <LoadingContext.Provider value={{onRendered}}>
+                <RenderStateRoot>
+                    <ServerItemRenderer
+                        item={itemWithMath}
+                        problemNum={0}
+                        reviewMode={false}
+                        dependencies={testDependenciesV2}
+                    />
+                </RenderStateRoot>
+            </LoadingContext.Provider>,
         );
 
         // Assert
@@ -275,15 +280,16 @@ describe("server item renderer", () => {
 
         // Act
         render(
-            <RenderStateRoot>
-                <ServerItemRenderer
-                    item={itemWithMath}
-                    problemNum={0}
-                    reviewMode={false}
-                    dependencies={testDependenciesV2}
-                    onRendered={onRendered}
-                />
-            </RenderStateRoot>,
+            <LoadingContext.Provider value={{onRendered}}>
+                <RenderStateRoot>
+                    <ServerItemRenderer
+                        item={itemWithMath}
+                        problemNum={0}
+                        reviewMode={false}
+                        dependencies={testDependenciesV2}
+                    />
+                </RenderStateRoot>
+            </LoadingContext.Provider>,
         );
 
         // Assert
@@ -313,16 +319,17 @@ describe("server item renderer", () => {
 
         // Act
         render(
-            <RenderStateRoot>
-                <ServerItemRenderer
-                    item={itemWithMath}
-                    problemNum={0}
-                    reviewMode={false}
-                    apiOptions={{isMobile: true}}
-                    dependencies={testDependenciesV2}
-                    onRendered={onRendered}
-                />
-            </RenderStateRoot>,
+            <LoadingContext.Provider value={{onRendered}}>
+                <RenderStateRoot>
+                    <ServerItemRenderer
+                        item={itemWithMath}
+                        problemNum={0}
+                        reviewMode={false}
+                        apiOptions={{isMobile: true}}
+                        dependencies={testDependenciesV2}
+                    />
+                </RenderStateRoot>
+            </LoadingContext.Provider>,
         );
 
         // Assert
@@ -343,16 +350,17 @@ describe("server item renderer", () => {
 
         // Act
         render(
-            <RenderStateRoot>
-                <ServerItemRenderer
-                    item={itemWithTable}
-                    problemNum={0}
-                    reviewMode={false}
-                    apiOptions={{isMobile: true}}
-                    dependencies={testDependenciesV2}
-                    onRendered={onRendered}
-                />
-            </RenderStateRoot>,
+            <LoadingContext.Provider value={{onRendered}}>
+                <RenderStateRoot>
+                    <ServerItemRenderer
+                        item={itemWithTable}
+                        problemNum={0}
+                        reviewMode={false}
+                        apiOptions={{isMobile: true}}
+                        dependencies={testDependenciesV2}
+                    />
+                </RenderStateRoot>
+            </LoadingContext.Provider>,
         );
 
         // Assert
@@ -401,15 +409,16 @@ describe("server item renderer", () => {
 
         // Act
         render(
-            <RenderStateRoot>
-                <ServerItemRenderer
-                    item={content}
-                    problemNum={0}
-                    reviewMode={false}
-                    dependencies={testDependenciesV2}
-                    onRendered={onRendered}
-                />
-            </RenderStateRoot>,
+            <LoadingContext.Provider value={{onRendered}}>
+                <RenderStateRoot>
+                    <ServerItemRenderer
+                        item={content}
+                        problemNum={0}
+                        reviewMode={false}
+                        dependencies={testDependenciesV2}
+                    />
+                </RenderStateRoot>
+            </LoadingContext.Provider>,
         );
 
         // Assert

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -437,6 +437,84 @@ describe("server item renderer", () => {
         expect(Object.keys(json.widgets)).toEqual(widgetKeys);
     });
 
+    describe("imperative handle", () => {
+        // Callers commonly attach an inline arrow function as the ref, which
+        // React detaches and reattaches on every commit because its identity
+        // changes each render. React also folds `ref` into the dependency list
+        // it uses for useImperativeHandle, so the handle has to be built once
+        // and reused rather than recreated whenever the ref changes.
+        it("returns the same handle after a re-render with a new ref callback", () => {
+            // Arrange
+            const handles: Array<ServerItemRendererHandle | null> = [];
+            const renderWithRef = (
+                refCallback: (handle: ServerItemRendererHandle | null) => void,
+            ) => (
+                <RenderStateRoot>
+                    <ServerItemRenderer
+                        ref={refCallback}
+                        item={itemWithMockWidget}
+                        problemNum={0}
+                        reviewMode={false}
+                        dependencies={testDependenciesV2}
+                    />
+                </RenderStateRoot>
+            );
+            const {rerender} = render(
+                renderWithRef((node) => handles.push(node)),
+            );
+
+            // Act
+            rerender(renderWithRef((node) => handles.push(node)));
+
+            // Assert
+            // Compared as a boolean rather than with toBe(): a failure message
+            // would serialize the handle, and its questionRenderer getter drags
+            // in the whole renderer instance.
+            const attached = handles.filter(Boolean);
+            expect(attached.length).toBe(2);
+            expect(attached[0] === attached[1]).toBe(true);
+        });
+
+        it("does not re-render forever when a caller stores the handle in state", () => {
+            // Arrange
+            // A new handle per render would make setRenderer see a new value
+            // every time, re-rendering the caller forever. The cap keeps a
+            // regression failing this assertion rather than hanging the suite.
+            const renderLimit = 20;
+            let renderCount = 0;
+
+            function Harness() {
+                const [, setRenderer] =
+                    React.useState<ServerItemRendererHandle | null>(null);
+                renderCount++;
+
+                return (
+                    <ServerItemRenderer
+                        ref={(node) => {
+                            if (renderCount < renderLimit) {
+                                setRenderer(node);
+                            }
+                        }}
+                        item={itemWithMockWidget}
+                        problemNum={0}
+                        reviewMode={false}
+                        dependencies={testDependenciesV2}
+                    />
+                );
+            }
+
+            // Act
+            render(
+                <RenderStateRoot>
+                    <Harness />
+                </RenderStateRoot>,
+            );
+
+            // Assert
+            expect(renderCount).toBeLessThan(renderLimit);
+        });
+    });
+
     describe("focus management", () => {
         it("calls onFocusChange when focusing the renderer", async () => {
             // Arranged

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -6,7 +6,7 @@ import {
 } from "@khanacademy/perseus-core";
 import {scorePerseusItem} from "@khanacademy/perseus-score";
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
-import {within, render, screen, act, waitFor} from "@testing-library/react";
+import {render, screen, act, waitFor} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
 
@@ -120,36 +120,6 @@ describe("server item renderer", () => {
             "mock-widget 1": {currentValue: "1"},
             "mock-widget 2": {currentValue: "2"},
         });
-    });
-
-    it("should return the DOM node for the requested focus path", async () => {
-        // Arrange
-        const {renderer} = renderQuestion(itemWithMockWidget);
-
-        // Act
-        const node = renderer.getDOMNodeForPath(["mock-widget 1"]);
-
-        // Assert
-        // @ts-expect-error - TS2345 - Argument of type 'Element | Text | null | undefined' is not assignable to parameter of type 'HTMLElement'.
-        expect(await within(node).findAllByRole("textbox")).toHaveLength(1);
-    });
-
-    it("should return the number of hints available", () => {
-        // Arrange
-        const {renderer} = renderQuestion({
-            ...itemWithMockWidget,
-            hints: [
-                {content: "Hint #1", images: {}, widgets: {}},
-                {content: "Hint #2", images: {}, widgets: {}},
-                {content: "Hint #3", images: {}, widgets: {}},
-            ],
-        });
-
-        // Act
-        const numHints = renderer.getNumHints();
-
-        // Assert
-        expect(numHints).toBe(3);
     });
 
     it("should return all widget ids", () => {
@@ -596,28 +566,6 @@ describe("server item renderer", () => {
                 ["numeric-input 1"],
                 0,
                 null,
-            );
-        });
-
-        it("should focus the widget requested in focusPath()", () => {
-            // Arrange
-            const onFocusChange = jest.fn();
-            const {renderer} = renderQuestion(itemWithMockWidget, {
-                onFocusChange,
-            });
-
-            // Act
-            act(() => renderer.focusPath(["mock-widget 1"]));
-
-            // We have some async processes that need to be resolved here
-            jest.runAllTimers();
-
-            // Assert
-            expect(onFocusChange).toHaveBeenCalledWith(
-                ["mock-widget 1"],
-                null,
-                0,
-                expect.any(Object),
             );
         });
     });

--- a/packages/perseus/src/__tests__/test-utils.tsx
+++ b/packages/perseus/src/__tests__/test-utils.tsx
@@ -39,6 +39,7 @@ export const renderQuestion = (
             />
         </RenderStateRoot>,
     );
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!renderer) {
         throw new Error(`Failed to render!`);
     }

--- a/packages/perseus/src/__tests__/test-utils.tsx
+++ b/packages/perseus/src/__tests__/test-utils.tsx
@@ -6,7 +6,7 @@ import * as React from "react";
 import WrappedServerItemRenderer from "../server-item-renderer";
 import {testDependenciesV2} from "../testing/test-dependencies";
 
-import type {ServerItemRenderer} from "../server-item-renderer";
+import type {ServerItemRendererHandle} from "../server-item-renderer";
 import type {APIOptions} from "../types";
 import type {PerseusItem} from "@khanacademy/perseus-core";
 import type {PropsFor} from "@khanacademy/wonder-blocks-core";
@@ -21,10 +21,10 @@ export const renderQuestion = (
     > = Object.freeze({}),
 ): {
     container: HTMLElement;
-    renderer: ServerItemRenderer;
+    renderer: ServerItemRendererHandle;
     rerender: any;
 } => {
-    let renderer: ServerItemRenderer | null = null;
+    let renderer: ServerItemRendererHandle | null = null;
 
     const {container, rerender} = render(
         <RenderStateRoot>
@@ -39,7 +39,6 @@ export const renderQuestion = (
             />
         </RenderStateRoot>,
     );
-    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
     if (!renderer) {
         throw new Error(`Failed to render!`);
     }

--- a/packages/perseus/src/index.ts
+++ b/packages/perseus/src/index.ts
@@ -175,7 +175,10 @@ export {extractWidgetIds} from "./util/extract-widget-ids";
  * Types
  */
 export type {ILogger, LogErrorOptions} from "./logging/log";
-export type {ServerItemRenderer as ServerItemRendererComponent} from "./server-item-renderer";
+export type {
+    ServerItemRendererHandle,
+    ServerItemRendererHandle as ServerItemRendererComponent,
+} from "./server-item-renderer";
 export type {
     APIOptions,
     /** @hidden */

--- a/packages/perseus/src/renderer.new.tsx
+++ b/packages/perseus/src/renderer.new.tsx
@@ -77,6 +77,7 @@ import type {
     PerseusWidget,
     PerseusWidgetOptions,
     PerseusWidgetsMap,
+    RendererInterface,
     ShowSolutions,
     UserInput,
     UserInputMap,
@@ -237,7 +238,7 @@ function isDifferentQuestion(
 
 class Renderer
     extends React.Component<Props, State>
-    implements GetPromptJSONInterface
+    implements RendererInterface, GetPromptJSONInterface
 {
     static contextType = PerseusI18nContext;
     declare context: React.ContextType<typeof PerseusI18nContext>;

--- a/packages/perseus/src/renderer.old.tsx
+++ b/packages/perseus/src/renderer.old.tsx
@@ -77,6 +77,7 @@ import type {
     PerseusWidget,
     PerseusWidgetOptions,
     PerseusWidgetsMap,
+    RendererInterface,
     ShowSolutions,
     UserInput,
     UserInputMap,
@@ -229,7 +230,7 @@ export function isDifferentQuestion(
 
 class Renderer
     extends React.Component<Props, State>
-    implements GetPromptJSONInterface
+    implements RendererInterface, GetPromptJSONInterface
 {
     static contextType = PerseusI18nContext;
     declare context: React.ContextType<typeof PerseusI18nContext>;

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -421,6 +421,10 @@ const styles = StyleSheet.create({
     },
 });
 
+// By wrapping ServerItemRenderer in a
+// functional component with a handle, it allows
+// us to scope our external API to only the functionality
+// that we want consumers to be using
 export interface ServerItemRendererHandle
     extends RendererInterface,
         KeypadContextRendererInterface,
@@ -447,6 +451,7 @@ export default React.forwardRef<
 >(function ServerItemRendererWithRef(props, ref) {
     const innerRef = React.useRef<ServerItemRenderer>(null);
 
+    // external imperative API for ServerItemRenderer
     React.useImperativeHandle(
         ref,
         () => {

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -65,7 +65,7 @@ type DefaultProps = Required<
  * @deprecated and likely a very broken API
  * [LEMS-3185] do not trust serializedState
  */
-export type SerializedState = {
+type SerializedState = {
     question: any;
     hints: any;
 };

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -70,7 +70,7 @@ export type SerializedState = {
     hints: any;
 };
 
-export class ServerItemRenderer
+class ServerItemRenderer
     extends React.Component<Props>
     implements
         RendererInterface,

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -451,33 +451,42 @@ export default React.forwardRef<
 >(function ServerItemRendererWithRef(props, ref) {
     const innerRef = React.useRef<ServerItemRenderer>(null);
 
-    // external imperative API for ServerItemRenderer
-    React.useImperativeHandle(
-        ref,
-        () => {
-            const instance = (): ServerItemRenderer => {
-                const current = innerRef.current;
-                invariant(
-                    current,
-                    "ServerItemRenderer: ref was used before mount or after unmount",
-                );
-                return current;
-            };
+    // external imperative API for ServerItemRenderer.
+    //
+    // The handle is built exactly once and stored in a ref so that its identity
+    // never changes for the lifetime of this component. That stability matters:
+    // React appends `ref` to the dependency list it uses internally for
+    // `useImperativeHandle`, so a caller passing an inline callback ref (whose
+    // identity changes every render) makes the create function re-run on every
+    // render. If that produced a new handle each time, callers that store the
+    // handle in state would loop forever ("Maximum update depth exceeded").
+    // Every method reads through `innerRef`, so nothing here needs to change
+    // across renders.
+    const handleRef = React.useRef<ServerItemRendererHandle | null>(null);
+    if (handleRef.current === null) {
+        const instance = (): ServerItemRenderer => {
+            const current = innerRef.current;
+            invariant(
+                current,
+                "ServerItemRenderer: ref was used before mount or after unmount",
+            );
+            return current;
+        };
 
-            return {
-                focus: () => instance().focus(),
-                blur: () => instance().blur(),
-                getPromptJSON: () => instance().getPromptJSON(),
-                getUserInput: () => instance().getUserInput(),
-                getWidgetIds: () => instance().getWidgetIds(),
-                getSerializedState: () => instance().getSerializedState(),
-                get questionRenderer() {
-                    return instance().questionRenderer;
-                },
-            };
-        },
-        [],
-    );
+        handleRef.current = {
+            focus: () => instance().focus(),
+            blur: () => instance().blur(),
+            getPromptJSON: () => instance().getPromptJSON(),
+            getUserInput: () => instance().getUserInput(),
+            getWidgetIds: () => instance().getWidgetIds(),
+            getSerializedState: () => instance().getSerializedState(),
+            get questionRenderer() {
+                return instance().questionRenderer;
+            },
+        };
+    }
+
+    React.useImperativeHandle(ref, () => handleRef.current!, []);
 
     return (
         <LoadingContext.Consumer>

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -273,10 +273,6 @@ class ServerItemRenderer
         }
     }
 
-    getNumHints(): number {
-        return this.props.item.hints.length;
-    }
-
     getPromptJSON(): RendererPromptJSON {
         return this.questionRenderer.getPromptJSON();
     }

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -473,9 +473,6 @@ export default React.forwardRef<
                 get questionRenderer() {
                     return instance().questionRenderer;
                 },
-                get props() {
-                    return instance().props;
-                },
             };
         },
         [],

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -430,13 +430,18 @@ export interface ServerItemRendererHandle
         KeypadContextRendererInterface,
         GetPromptJSONInterface {
     getUserInput(): UserInputMap;
-    getNumHints(): number;
     getWidgetIds(): ReadonlyArray<string>;
-    getDOMNodeForPath(path: FocusPath): Element | Text | null | undefined;
-    focusPath(path: FocusPath): void;
-    blurPath(path: FocusPath): void;
-    getInputPaths(): ReadonlyArray<FocusPath>;
+
+    /**
+     * @deprecated and likely very broken API
+     * [LEMS-3185] do not trust serializedState
+     */
     getSerializedState(): SerializedState;
+
+    /**
+     * @deprecated do not reach into inner
+     * class component properties
+     */
     readonly questionRenderer: Renderer;
 }
 
@@ -461,11 +466,6 @@ export default React.forwardRef<
             return {
                 focus: () => instance().focus(),
                 blur: () => instance().blur(),
-                focusPath: (path) => instance().focusPath(path),
-                blurPath: (path) => instance().blurPath(path),
-                getDOMNodeForPath: (path) => instance().getDOMNodeForPath(path),
-                getInputPaths: () => instance().getInputPaths(),
-                getNumHints: () => instance().getNumHints(),
                 getPromptJSON: () => instance().getPromptJSON(),
                 getUserInput: () => instance().getUserInput(),
                 getWidgetIds: () => instance().getWidgetIds(),

--- a/packages/perseus/src/server-item-renderer.tsx
+++ b/packages/perseus/src/server-item-renderer.tsx
@@ -9,6 +9,7 @@ import {StyleSheet, css} from "aphrodite";
  * This component is compatible with server-rendering of a perseus exercise.
  */
 import * as React from "react";
+import invariant from "tiny-invariant";
 import _ from "underscore";
 
 import AssetContext from "./asset-context";
@@ -64,7 +65,7 @@ type DefaultProps = Required<
  * @deprecated and likely a very broken API
  * [LEMS-3185] do not trust serializedState
  */
-type SerializedState = {
+export type SerializedState = {
     question: any;
     hints: any;
 };
@@ -424,17 +425,69 @@ const styles = StyleSheet.create({
     },
 });
 
+export interface ServerItemRendererHandle
+    extends RendererInterface,
+        KeypadContextRendererInterface,
+        GetPromptJSONInterface {
+    getUserInput(): UserInputMap;
+    getNumHints(): number;
+    getWidgetIds(): ReadonlyArray<string>;
+    getDOMNodeForPath(path: FocusPath): Element | Text | null | undefined;
+    focusPath(path: FocusPath): void;
+    blurPath(path: FocusPath): void;
+    getInputPaths(): ReadonlyArray<FocusPath>;
+    getSerializedState(): SerializedState;
+    readonly questionRenderer: Renderer;
+}
+
 export default React.forwardRef<
-    ServerItemRenderer,
+    ServerItemRendererHandle,
     Omit<PropsFor<typeof ServerItemRenderer>, "onRendered">
 >(function ServerItemRendererWithRef(props, ref) {
+    const innerRef = React.useRef<ServerItemRenderer>(null);
+
+    React.useImperativeHandle(
+        ref,
+        () => {
+            const instance = (): ServerItemRenderer => {
+                const current = innerRef.current;
+                invariant(
+                    current,
+                    "ServerItemRenderer: ref was used before mount or after unmount",
+                );
+                return current;
+            };
+
+            return {
+                focus: () => instance().focus(),
+                blur: () => instance().blur(),
+                focusPath: (path) => instance().focusPath(path),
+                blurPath: (path) => instance().blurPath(path),
+                getDOMNodeForPath: (path) => instance().getDOMNodeForPath(path),
+                getInputPaths: () => instance().getInputPaths(),
+                getNumHints: () => instance().getNumHints(),
+                getPromptJSON: () => instance().getPromptJSON(),
+                getUserInput: () => instance().getUserInput(),
+                getWidgetIds: () => instance().getWidgetIds(),
+                getSerializedState: () => instance().getSerializedState(),
+                get questionRenderer() {
+                    return instance().questionRenderer;
+                },
+                get props() {
+                    return instance().props;
+                },
+            };
+        },
+        [],
+    );
+
     return (
         <LoadingContext.Consumer>
             {({onRendered}) => (
                 <ServerItemRenderer
                     {...props}
                     onRendered={onRendered}
-                    ref={ref}
+                    ref={innerRef}
                 />
             )}
         </LoadingContext.Consumer>

--- a/packages/perseus/src/testing/item-renderer-hooks.tsx
+++ b/packages/perseus/src/testing/item-renderer-hooks.tsx
@@ -6,7 +6,7 @@ import invariant from "tiny-invariant";
 
 import {createInitialState, itemRendererReducer} from "./item-renderer-reducer";
 
-import type {ServerItemRenderer} from "../server-item-renderer";
+import type {ServerItemRendererHandle} from "../server-item-renderer";
 import type {APIOptions} from "../types";
 import type {
     PerseusItem,
@@ -24,7 +24,7 @@ export const useItemRenderer = (
     reviewMode: boolean = false,
     showSolutions?: ShowSolutions,
 ) => {
-    const ref = useRef<ServerItemRenderer>(null);
+    const ref = useRef<ServerItemRendererHandle>(null);
     const [state, dispatch] = useReducer(
         itemRendererReducer,
         createInitialState(

--- a/packages/perseus/src/testing/server-item-renderer-with-debug-ui.tsx
+++ b/packages/perseus/src/testing/server-item-renderer-with-debug-ui.tsx
@@ -2,7 +2,7 @@ import {KeypadContext} from "@khanacademy/keypad-context";
 import {View} from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
 
-import {ServerItemRenderer} from "../server-item-renderer";
+import ServerItemRenderer from "../server-item-renderer";
 import {isCorrect} from "../util/scoring";
 
 import {DebugAccordionUI} from "./debug-accordion-ui";

--- a/packages/perseus/src/widgets/graded-group/__docs__/graded-group-renderer-decorator.tsx
+++ b/packages/perseus/src/widgets/graded-group/__docs__/graded-group-renderer-decorator.tsx
@@ -6,7 +6,7 @@ import {
 } from "@khanacademy/perseus-core";
 import * as React from "react";
 
-import {ServerItemRenderer} from "../../../server-item-renderer";
+import ServerItemRenderer from "../../../server-item-renderer";
 import {testDependenciesV2} from "../../../testing/test-dependencies";
 
 import type {APIOptions} from "../../../types";

--- a/packages/perseus/src/widgets/radio/__docs__/multiple-choice-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/multiple-choice-initial-state-regression.stories.tsx
@@ -5,7 +5,7 @@ import {
 import * as React from "react";
 
 import {themeModes} from "../../../../../../.storybook/modes";
-import {ServerItemRenderer} from "../../../server-item-renderer";
+import ServerItemRenderer from "../../../server-item-renderer";
 import {testDependenciesV2} from "../../../testing/test-dependencies";
 import {
     mobileDecorator,

--- a/packages/perseus/src/widgets/radio/__docs__/radio-renderer-decorator.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/radio-renderer-decorator.tsx
@@ -6,7 +6,7 @@ import {
 } from "@khanacademy/perseus-core";
 import * as React from "react";
 
-import {ServerItemRenderer} from "../../../server-item-renderer";
+import ServerItemRenderer from "../../../server-item-renderer";
 import {ServerItemRendererWithDebugUI} from "../../../testing/server-item-renderer-with-debug-ui";
 import {testDependenciesV2} from "../../../testing/test-dependencies";
 


### PR DESCRIPTION
## Summary:

I had a random idea this morning: what if we just wrap ServerItemRenderer (SIR) in a `forwardRef` and use `useImperativeHandle` to explicitly declare its external API? Turns out we were already wrapping SIR in a `forwardRef` so all I had to do was (1) stop exporting the inner SIR and (2) explicitly declare the API based on what we're actually using externally.

Before the external API was something like (not including the methods starting with `_` like `_setCurrentFocus`):

```
// methods
focus
blur
focusPath
blurPath
getDOMNodeForPath
getInputPaths
getNumHints
getPromptJSON
getUserInput
getWidgetIds
getSerializedState

// properties
questionRenderer
props
```

Now it's:

```
// methods
focus
blur
getPromptJSON
getUserInput
getWidgetIds
getSerializedState

// properties
questionRenderer
```

And the methods starting with `_` are not accessible at all.