### PR TITLE
Replace some uses of underscore with native alternatives

### DIFF
--- a/.changeset/blue-plums-find.md
+++ b/.changeset/blue-plums-find.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus-score": patch
+"@khanacademy/perseus": patch
+---
+
+Replace some uses of underscore with native alternatives

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -396,7 +396,7 @@ class Editor extends React.Component<Props, State> {
 
                 return {file: file, sentinel: sentinel};
             })
-            .reject(_.isNull)
+            .reject((fileAndSentinel) => fileAndSentinel === null)
             .tap(() => {
                 // See componentDidUpdate() for how this flag is used
                 this.lastUserValue = origContent;

--- a/packages/perseus-score/src/util/answer-types.ts
+++ b/packages/perseus-score/src/util/answer-types.ts
@@ -644,7 +644,7 @@ const KhanAnswerTypes = {
                     let interpretedGuess = false;
                     _.each(forms, function (form) {
                         const anyAreNaN = _.any(form(guess), function (t) {
-                            return t.value != null && !_.isNaN(t.value);
+                            return t.value != null && !Number.isNaN(t.value);
                         });
 
                         if (anyAreNaN) {

--- a/packages/perseus/src/components/graphie-classes.ts
+++ b/packages/perseus/src/components/graphie-classes.ts
@@ -58,7 +58,7 @@ const rewriteProps = function (props: any, childrenArray: any) {
     // childrenArray is always an array here because this is only called
     // from createClass, which initializes childrenArray as _.rest(arguments)
     return _.extend({}, props, {
-        children: _.filter(_.flatten(childrenArray), _.identity),
+        children: _.filter(_.flatten(childrenArray), (c) => c),
     });
 };
 

--- a/packages/perseus/src/interactive2/interactive-util.ts
+++ b/packages/perseus/src/interactive2/interactive-util.ts
@@ -110,7 +110,7 @@ const InteractiveUtil = {
             return [];
         }
         if (Array.isArray(funcOrArray)) {
-            return _.filter(_.flatten(funcOrArray), _.identity);
+            return _.filter(_.flatten(funcOrArray), (x) => x);
         }
         return [funcOrArray];
     },


### PR DESCRIPTION
## Summary:
This one focuses on `_.isNull`, `_.isNaN`, and `_.identity`, 