### PR TITLE
[Color][Expression] Improve contrast of hovering on Expression's button to open the keypad in Dark Mode

### DIFF
--- a/.changeset/chilly-horses-lose.md
+++ b/.changeset/chilly-horses-lose.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus": patch
 ---
 
-Fix contrast of Expression's open keypad buttonin Dark Mode
+Fix contrast of Expression's open keypad button in Dark Mode

--- a/.changeset/chilly-horses-lose.md
+++ b/.changeset/chilly-horses-lose.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix contrast of Expression's open keypad buttonin Dark Mode

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -482,8 +482,7 @@ const MathInputIcon = ({hovered, focused, active}) => {
                 semanticColor.action.primary.progressive.default.foreground;
             break;
         case hovered:
-            fillColor =
-                semanticColor.action.primary.progressive.hover.background;
+            fillColor = semanticColor.core.foreground.instructive.default;
             break;
         default:
             fillColor = semanticColor.core.foreground.neutral.strong;

--- a/packages/perseus/src/components/math-input.tsx
+++ b/packages/perseus/src/components/math-input.tsx
@@ -482,7 +482,7 @@ const MathInputIcon = ({hovered, focused, active}) => {
                 semanticColor.action.primary.progressive.default.foreground;
             break;
         case hovered:
-            fillColor = semanticColor.core.foreground.instructive.default;
+            fillColor = semanticColor.core.foreground.instructive.strong;
             break;
         default:
             fillColor = semanticColor.core.foreground.neutral.strong;


### PR DESCRIPTION
## Summary:
The previous font color of the math symbols on the button to open the keypad in expression were below required contrast. This improves contrast so it passes in all modes.

| Default | SYL | Dark |
|------|------|------|
| <img width="77" height="74" alt="image" src="https://github.com/user-attachments/assets/f140db31-cfce-4101-bd7b-6d744cb0ae00" /> | <img width="69" height="76" alt="image" src="https://github.com/user-attachments/assets/32c03ee2-001c-48ec-8b69-677e4030af8e" /> | <img width="74" height="80" alt="image" src="https://github.com/user-attachments/assets/755a8948-0009-4f03-b5a4-b7188f776bd0" /> |
|6.3:1|8.54:1|7.1:1|

Issue: LEMS-4446

## Test plan:
- Confirm chromatic snapshot changes are as expected
- Confirm contrast is higher with this change than without