### PR TITLE
Add a .wb-themed-math CSS class so clients can opt-in to new math colors

### DIFF
--- a/.changeset/ripe-lemons-glow.md
+++ b/.changeset/ripe-lemons-glow.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-editor": minor
+"@khanacademy/perseus": minor
+---
+
+Clients can now set a `wb-themed-math` CSS class on the `framework-perseus` element to opt into Wonder Blocks math styling. Clients should upgrade to `@khanacademy/mathjax-renderer` 3.2.0 at the same time, and should not use 3.2.0 without enabling `wb-themed-math`.

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -54,7 +54,7 @@ const withPerseusDecorator: Decorator = (Story) => {
                     Include box-sizing-border-box-reset to reflect the global styles
                     from prod.
                 */}
-                <div className="framework-perseus box-sizing-border-box-reset">
+                <div className="framework-perseus wb-themed-math box-sizing-border-box-reset">
                     <Story />
                 </div>
             </DependenciesContext.Provider>

--- a/packages/perseus-editor/src/__docs__/editor.stories.tsx
+++ b/packages/perseus-editor/src/__docs__/editor.stories.tsx
@@ -52,7 +52,8 @@ export const DemoInteractiveGraph = (): React.ReactElement => {
         // Many of the editor components use scoped CSS that requires this
         // class to be above it.
         // TODO: Refactor to aphrodite styles instead of scoped CSS in Less.
-        <div className="framework-perseus">
+        // TODO(LEMS-4492): remove wb-themed-math
+        <div className="framework-perseus wb-themed-math">
             <SplitView
                 rendererTitle="Editor"
                 renderer={

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ArticleEditor should match snapshot for editing disabled for all widgets 1`] = `
 <div>
   <div
-    class="framework-perseus perseus-article-editor"
+    class="framework-perseus wb-themed-math perseus-article-editor"
   >
     <div
       class="perseus-editor-table"

--- a/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EditorPage should match snapshot for editing disabled for all widgets 1`] = `
 <div>
   <div
-    class="framework-perseus"
+    class="framework-perseus wb-themed-math"
     id="perseus"
   >
     <div

--- a/packages/perseus-editor/src/article-editor.tsx
+++ b/packages/perseus-editor/src/article-editor.tsx
@@ -486,7 +486,8 @@ export default class ArticleEditor extends React.Component<Props, State> {
             <Dependencies.DependenciesContext.Provider
                 value={this.props.dependencies}
             >
-                <div className="framework-perseus perseus-article-editor">
+                {/* TODO(LEMS-4492): remove wb-themed-math*/}
+                <div className="framework-perseus wb-themed-math perseus-article-editor">
                     {this.props.mode === "edit" && this._renderEditor()}
 
                     {this.props.mode === "preview" && this._renderPreviewMode()}

--- a/packages/perseus-editor/src/components/__docs__/text-list-editor.stories.tsx
+++ b/packages/perseus-editor/src/components/__docs__/text-list-editor.stories.tsx
@@ -14,7 +14,8 @@ const meta: Meta = {
     },
     decorators: [
         (Story) => (
-            <div className={"framework-perseus orderer"}>
+            // TODO(LEMS-4492): remove wb-themed-math
+            <div className={"framework-perseus wb-themed-math orderer"}>
                 <Story />
             </div>
         ),

--- a/packages/perseus-editor/src/content-preview.tsx
+++ b/packages/perseus-editor/src/content-preview.tsx
@@ -69,7 +69,8 @@ function ContentPreview({
 
     return (
         <View
-            className={`framework-perseus ${className}`}
+            // TODO(LEMS-4492): remove wb-themed-math
+            className={`framework-perseus wb-themed-math ${className}`}
             style={[styles.container, !seamless ? styles.gutter : undefined]}
         >
             <StatefulKeypadContextProvider>

--- a/packages/perseus-editor/src/diffs/__tests__/__snapshots__/article-diff.test.tsx.snap
+++ b/packages/perseus-editor/src/diffs/__tests__/__snapshots__/article-diff.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ArticleDiff renders an article in the diff view 1`] = `
 <div>
   <div
-    class="framework-perseus"
+    class="framework-perseus wb-themed-math"
   >
     <div>
       <div>

--- a/packages/perseus-editor/src/diffs/__tests__/__snapshots__/item-diff.test.tsx.snap
+++ b/packages/perseus-editor/src/diffs/__tests__/__snapshots__/item-diff.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ItemDiff renders a diff view 1`] = `
 <div>
   <div
-    class="framework-perseus"
+    class="framework-perseus wb-themed-math"
   >
     <div>
       <div>

--- a/packages/perseus-editor/src/diffs/article-diff.tsx
+++ b/packages/perseus-editor/src/diffs/article-diff.tsx
@@ -58,7 +58,10 @@ class ArticleDiff extends React.Component<Props, ArticleDiffState> {
             <Dependencies.DependenciesContext.Provider
                 value={this.props.dependencies}
             >
-                <div className="framework-perseus">{sections}</div>
+                {/* TODO(LEMS-4492): remove wb-themed-math */}
+                <div className="framework-perseus wb-themed-math">
+                    {sections}
+                </div>
             </Dependencies.DependenciesContext.Provider>
         );
     }

--- a/packages/perseus-editor/src/diffs/item-diff.tsx
+++ b/packages/perseus-editor/src/diffs/item-diff.tsx
@@ -61,7 +61,8 @@ class ItemDiff extends React.Component<Props> {
             <Dependencies.DependenciesContext.Provider
                 value={this.props.dependencies}
             >
-                <div className="framework-perseus">
+                {/* TODO(LEMS-4492): remove wb-themed-math */}
+                <div className="framework-perseus wb-themed-math">
                     {question}
                     {extras}
                     {hints.length > 0 && <div className="diff-separator" />}

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -282,7 +282,8 @@ class EditorPage extends React.Component<Props, State> {
     };
 
     render(): React.ReactNode {
-        let className = "framework-perseus";
+        // TODO(LEMS-4492): remove wb-themed-math
+        let className = "framework-perseus wb-themed-math";
         const editingDisabled = this.props.apiOptions?.editingDisabled ?? false;
 
         const touch =

--- a/packages/perseus-editor/src/testing/preview/preview-renderer.tsx
+++ b/packages/perseus-editor/src/testing/preview/preview-renderer.tsx
@@ -91,7 +91,8 @@ function PreviewKeypadConnection({
 
     return (
         <View
-            className={`framework-perseus ${className}`}
+            // TODO(LEMS-4492): remove wb-themed-math
+            className={`framework-perseus wb-themed-math ${className}`}
             style={containerStyle}
         >
             {children({...keypadCtx, isMobile})}

--- a/packages/perseus-editor/src/testing/split-view.tsx
+++ b/packages/perseus-editor/src/testing/split-view.tsx
@@ -23,7 +23,8 @@ const SplitView = ({
 }: Props): React.ReactElement => {
     return (
         <View style={styles.sideBySide}>
-            <View className="framework-perseus">
+            {/* TODO(LEMS-4492): remove wb-themed-math */}
+            <View className="framework-perseus wb-themed-math">
                 <Heading size="large">{rendererTitle}</Heading>
                 {renderer}
             </View>

--- a/packages/perseus/src/article-renderer.tsx
+++ b/packages/perseus/src/article-renderer.tsx
@@ -199,6 +199,8 @@ class ArticleRenderer
         const classes = classNames({
             "framework-perseus": true,
             "perseus-article": true,
+            // TODO(LEMS-4492): remove wb-themed-math
+            "wb-themed-math": true,
             // NOTE(charlie): For exercises, this is applied outside of Perseus
             // (in khan/frontend).
             [ApiClassNames.MOBILE]: apiOptions.isMobile,

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -365,7 +365,7 @@
 /*****************************
  * GLOBAL DARK MODE SETTINGS *
  *****************************/
-[data-wb-theme$="-dark"] .framework-perseus {
+[data-wb-theme$="-dark"] .framework-perseus:not(.wb-themed-math) {
     /* TODO(benchristel): this set of file extensions is duplicated in
      * image.css and dark-mode-toggle.tsx. Replace these selectors with a
      * class that gets added to images that should be inverted, so the set of
@@ -393,5 +393,34 @@
            washed out by the brightness filter, so they end up as #fff anyway.
          */
         color: black;
+    }
+}
+
+/* TODO(LEMS-4492): remove the .wb-themed-math class once math uses WB
+   tokens everywhere. In the future, the styles below should become the only
+   dark mode styles.
+ */
+[data-wb-theme$="-dark"] .framework-perseus.wb-themed-math {
+    /* TODO(benchristel): this set of file extensions is duplicated in
+     * image.css and dark-mode-toggle.tsx. Replace these selectors with a
+     * class that gets added to images that should be inverted, so the set of
+     * extensions can have a single representation in TypeScript code.
+     */
+    img[src$=".png"],
+    img[src$=".svg"],
+    .graphie:not(.perseus-widget-plotter) > svg {
+        /* Invert the colors of PNG/SVG images and Graphie SVGs (excluding the
+           Plotter, which is themed).
+         */
+        filter: invert(1) hue-rotate(180deg) brightness(1.5);
+    }
+
+    .graphie-label {
+        /* Graphie hardcodes `color: black` on its label elements, so we have
+           to override that with `!important`.
+         */
+        color: var(
+            --wb-semanticColor-core-foreground-neutral-default
+        ) !important;
     }
 }

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -398,7 +398,8 @@
 
 /* TODO(LEMS-4492): remove the .wb-themed-math class once math uses WB
    tokens everywhere. In the future, the styles below should become the only
-   dark mode styles.
+   dark mode styles. We can also remove the !important from the .graphie-label
+   styles, and set the label foreground color directly in graphie.ts.
  */
 [data-wb-theme$="-dark"] .framework-perseus.wb-themed-math {
     /* TODO(benchristel): this set of file extensions is duplicated in
@@ -420,7 +421,7 @@
            to override that with `!important`.
          */
         color: var(
-            --wb-semanticColor-core-foreground-neutral-default
+            --wb-semanticColor-core-foreground-neutral-strong
         ) !important;
     }
 }

--- a/packages/perseus/src/testing/render-question-with-cypress.tsx
+++ b/packages/perseus/src/testing/render-question-with-cypress.tsx
@@ -49,7 +49,7 @@ const renderQuestion = (
     // they are fully rendered (like KaTeX, for example).
     // onRender is also used to signal that rendering has completed.
     mount(
-        <div className="framework-perseus">
+        <div className="framework-perseus wb-themed-math">
             <AssetContext.Provider value={{assetStatuses, setAssetStatus}}>
                 <RenderStateRoot>
                     <DependenciesContext.Provider value={cypressDependenciesV2}>

--- a/packages/perseus/src/testing/split-view.tsx
+++ b/packages/perseus/src/testing/split-view.tsx
@@ -23,7 +23,7 @@ const SplitView = ({
 }: Props): React.ReactElement => {
     return (
         <View style={styles.sideBySide}>
-            <View className="framework-perseus">
+            <View className="framework-perseus wb-themed-math">
                 <Heading size="large">{rendererTitle}</Heading>
                 {renderer}
             </View>

--- a/packages/perseus/src/widgets/__testutils__/story-decorators.tsx
+++ b/packages/perseus/src/widgets/__testutils__/story-decorators.tsx
@@ -3,19 +3,22 @@ import * as React from "react";
 import type {Decorator} from "@storybook/react-vite";
 
 export const mobileDecorator: Decorator = (Story) => (
-    <div className="framework-perseus perseus-mobile">
+    // TODO(LEMS-4492): remove wb-themed-math
+    <div className="framework-perseus wb-themed-math perseus-mobile">
         <Story />
     </div>
 );
 
 export const articleDecorator: Decorator = (Story) => (
-    <div className="framework-perseus perseus-article">
+    // TODO(LEMS-4492): remove wb-themed-math
+    <div className="framework-perseus wb-themed-math perseus-article">
         <Story />
     </div>
 );
 
 export const mobileArticleDecorator: Decorator = (Story) => (
-    <div className="framework-perseus perseus-mobile perseus-article">
+    // TODO(LEMS-4492): remove wb-themed-math
+    <div className="framework-perseus wb-themed-math perseus-mobile perseus-article">
         <Story />
     </div>
 );
@@ -57,7 +60,8 @@ const articleContent3 =
     "The nucleolus (a structure inside the nucleus where ribosomes are made) disappears during prophase. The mitotic spindle begins to form during prophase, starting at regions called centrosomes. These regions contain the material needed for building the spindle, and also function to regulate the spindle throughout mitosis.";
 
 export const mobileArticleFloatLeftDecorator: Decorator = (Story) => (
-    <div className="framework-perseus perseus-mobile perseus-article">
+    // TODO(LEMS-4492): remove wb-themed-math
+    <div className="framework-perseus wb-themed-math perseus-mobile perseus-article">
         <div className="paragraph">
             <div className="perseus-widget-container widget-nohighlight widget-wrap-left">
                 <Story />
@@ -70,7 +74,8 @@ export const mobileArticleFloatLeftDecorator: Decorator = (Story) => (
 );
 
 export const mobileArticleFloatRightDecorator: Decorator = (Story) => (
-    <div className="framework-perseus perseus-mobile perseus-article">
+    // TODO(LEMS-4492): remove wb-themed-math
+    <div className="framework-perseus wb-themed-math perseus-mobile perseus-article">
         <div className="paragraph">
             <div className="perseus-widget-container widget-nohighlight widget-wrap-right">
                 <Story />
@@ -83,7 +88,8 @@ export const mobileArticleFloatRightDecorator: Decorator = (Story) => (
 );
 
 export const articleFloatLeftDecorator: Decorator = (Story) => (
-    <div className="framework-perseus perseus-article">
+    // TODO(LEMS-4492): remove wb-themed-math
+    <div className="framework-perseus wb-themed-math perseus-article">
         <div className="paragraph">
             <div className="perseus-widget-container widget-nohighlight widget-wrap-left">
                 <Story />
@@ -96,7 +102,8 @@ export const articleFloatLeftDecorator: Decorator = (Story) => (
 );
 
 export const articleFloatRightDecorator: Decorator = (Story) => (
-    <div className="framework-perseus perseus-article">
+    // TODO(LEMS-4492): remove wb-themed-math
+    <div className="framework-perseus wb-themed-math perseus-article">
         <div className="paragraph">
             <div className="perseus-widget-container widget-nohighlight widget-wrap-right">
                 <Story />

--- a/packages/perseus/src/widgets/image/__docs__/image-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/image/__docs__/image-initial-state-regression.stories.tsx
@@ -503,7 +503,8 @@ export const MarkdownTableWithMarkdownImages: Story = {
 export const AllAlignmentsInSameArticle: Story = {
     render: function Render() {
         return (
-            <div className="framework-perseus perseus-article">
+            // TODO(LEMS-4492): remove wb-themed-math
+            <div className="framework-perseus wb-themed-math perseus-article">
                 <QuestionRendererForStories
                     question={generateTestPerseusRenderer({
                         content: `${bioContent1}\n\n[[☃ image 1]]\n\n${bioContent2}\n\n[[☃ image 2]]\n\n${bioContent3}\n\nBlock image\n\n[[☃ image 3]]\n\nFull-width image\n\n[[☃ image 4]]`,
@@ -555,7 +556,8 @@ export const AllAlignmentsInSameArticle: Story = {
 export const AllAlignmentsInSameArticleMobile: Story = {
     render: function Render() {
         return (
-            <div className="framework-perseus perseus-mobile perseus-article">
+            // TODO(LEMS-4492): remove wb-themed-math
+            <div className="framework-perseus wb-themed-math perseus-mobile perseus-article">
                 <QuestionRendererForStories
                     question={generateTestPerseusRenderer({
                         content: `${bioContent1}\n\n[[☃ image 1]]\n\n${bioContent2}\n\n[[☃ image 2]]\n\n${bioContent3}\n\nBlock image\n\n[[☃ image 3]]\n\nFull-width image\n\n[[☃ image 4]]`,

--- a/packages/perseus/src/widgets/image/components/explore-image-modal.tsx
+++ b/packages/perseus/src/widgets/image/components/explore-image-modal.tsx
@@ -56,7 +56,8 @@ export const ExploreImageModal = (props: CommonImageProps) => {
             // We need to manually add the `framework-perseus` class so that
             // the modal can have the correct styling, even when the portal
             // makes it render outside the normal `framework-perseus` container.
-            className={`framework-perseus ${styles.modalContainer}`}
+            // TODO(LEMS-4492): remove wb-themed-math
+            className={`framework-perseus wb-themed-math ${styles.modalContainer}`}
         >
             <FlexibleDialog
                 title={title}

--- a/packages/perseus/src/widgets/numeric-input/__docs__/numeric-input-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/numeric-input/__docs__/numeric-input-interactions-regression.stories.tsx
@@ -276,7 +276,8 @@ function MobileKeypadItemRenderer({question}: {question: PerseusRenderer}) {
 export const MobilePhoneBasicKeypadOpen: Story = {
     render: () => (
         <div
-            className="framework-perseus perseus-mobile"
+            // TODO(LEMS-4492): remove wb-themed-math
+            className="framework-perseus wb-themed-math perseus-mobile"
             style={{
                 transform: "translateZ(0)",
                 position: "relative",
@@ -304,7 +305,8 @@ export const MobilePhoneBasicKeypadOpen: Story = {
 export const MobileTabletExpandedKeypadOpen: Story = {
     render: () => (
         <div
-            className="framework-perseus perseus-mobile"
+            // TODO(LEMS-4492): remove wb-themed-math
+            className="framework-perseus wb-themed-math perseus-mobile"
             style={{
                 transform: "translateZ(0)",
                 position: "relative",

--- a/packages/perseus/src/widgets/video/__docs__/video-demo.stories.tsx
+++ b/packages/perseus/src/widgets/video/__docs__/video-demo.stories.tsx
@@ -23,7 +23,8 @@ type Story = StoryObj<typeof meta>;
 export const AllAlignmentsInSameArticle: Story = {
     render: function Render() {
         return (
-            <div className="framework-perseus perseus-article">
+            // TODO(LEMS-4492): remove wb-themed-math
+            <div className="framework-perseus wb-themed-math perseus-article">
                 <QuestionRendererForStories
                     question={generateTestPerseusRenderer({
                         content: `Block video\n\n[[☃ video 1]]\n\nFull-width video\n\n[[☃ video 2]]`,
@@ -56,7 +57,8 @@ export const AllAlignmentsInSameArticle: Story = {
 export const AllAlignmentsInSameArticleMobile: Story = {
     render: function Render() {
         return (
-            <div className="framework-perseus perseus-mobile perseus-article">
+            // TODO(LEMS-4492): remove wb-themed-math
+            <div className="framework-perseus wb-themed-math perseus-mobile perseus-article">
                 <QuestionRendererForStories
                     question={generateTestPerseusRenderer({
                         content: `Block video\n\n[[☃ video 1]]\n\nFull-width video\n\n[[☃ video 2]]`,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   devDeps:
     '@khanacademy/mathjax-renderer':
-      specifier: 3.1.4
-      version: 3.1.4
+      specifier: 3.2.0
+      version: 3.2.0
     '@khanacademy/wonder-blocks-accordion':
       specifier: 3.1.69
       version: 3.1.69
@@ -179,7 +179,7 @@ importers:
         version: 1.0.0(eslint@8.57.1)(typescript@5.9.3)
       '@khanacademy/mathjax-renderer':
         specifier: catalog:devDeps
-        version: 3.1.4
+        version: 3.2.0
       '@khanacademy/wonder-blocks-accordion':
         specifier: catalog:devDeps
         version: 3.1.69(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -524,7 +524,7 @@ importers:
     devDependencies:
       '@khanacademy/mathjax-renderer':
         specifier: catalog:devDeps
-        version: 3.1.4
+        version: 3.2.0
       '@khanacademy/wonder-blocks-clickable':
         specifier: catalog:devDeps
         version: 8.2.9(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -797,7 +797,7 @@ importers:
     devDependencies:
       '@khanacademy/mathjax-renderer':
         specifier: catalog:devDeps
-        version: 3.1.4
+        version: 3.2.0
       '@khanacademy/wonder-blocks-accordion':
         specifier: catalog:devDeps
         version: 3.1.69(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -2408,8 +2408,8 @@ packages:
   '@khanacademy/eslint-plugin@3.1.2':
     resolution: {integrity: sha512-+9ohgHE6R0ox98rcfh28D4Hmue4acL3fUh8wZ7JwVBXE9JWBRWaehWRwYyKi71rUI9g2ierY4Gu5qbPx2LhOpQ==}
 
-  '@khanacademy/mathjax-renderer@3.1.4':
-    resolution: {integrity: sha512-27COKZ01wo0rb8xNrVnT3Q8tk70tS9pKb7fMET+vjvAD3ZuhgfHDqaou6RRqf7T9wQb7K1l3b56wqulaGTR94w==}
+  '@khanacademy/mathjax-renderer@3.2.0':
+    resolution: {integrity: sha512-9njJGqo8RBE8OK2e6bwRa8dwwqklY0D1jRVmyYjKUJGhIlEql0YRRR5LxmuTTSitGSkLuYPpDeHeQIdLLsiKMg==}
     engines: {node: '>=24.18 <25'}
 
   '@khanacademy/wonder-blocks-accordion@3.1.69':
@@ -11443,7 +11443,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@khanacademy/mathjax-renderer@3.1.4':
+  '@khanacademy/mathjax-renderer@3.2.0':
     dependencies:
       mathjax-full: 3.2.2
       mu-lambda: 0.0.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,7 +61,7 @@ catalogs:
         underscore: ^1.4.4
         "@phosphor-icons/core": ^2.0.2
         "@popperjs/core": ^2.10.2
-        "@khanacademy/mathjax-renderer": ^3.1.4
+        "@khanacademy/mathjax-renderer": ^3.2.0
         "@khanacademy/wonder-blocks-accordion": ^3.1.69
         "@khanacademy/wonder-blocks-announcer": ^1.1.1
         "@khanacademy/wonder-blocks-badge": ^1.1.21
@@ -102,7 +102,7 @@ catalogs:
         vite: 5.4.0
         "@phosphor-icons/core": 2.0.2
         "@popperjs/core": 2.10.2
-        "@khanacademy/mathjax-renderer": 3.1.4
+        "@khanacademy/mathjax-renderer": 3.2.0
         "@khanacademy/wonder-blocks-accordion": 3.1.69
         "@khanacademy/wonder-blocks-announcer": 1.1.1
         "@khanacademy/wonder-blocks-badge": 1.1.21


### PR DESCRIPTION
## Summary:
Context: for back-to-school 2026, we shipped Dark Mode on a tight timeline. One
of the shortcuts we took to get dark mode out quickly was to hack around the
lack of support for Wonder Blocks' semantic colors in the
`@khanacademy/mathjax-renderer` library. What we did was to invert the colors
of all math elements in dark mode. This worked okay, but the colors were a
little washed out. It also created a bug where selecting a math element
resulted in a too-bright highlight color, which made the math unreadable.

As of version 3.2.0, mathjax-renderer will use WB semantic colors if the CSS
variables are defined. We can upgrade to version 3.2.0 and stop inverting the
math colors in Perseus.  This is a bit tricky, though, because Perseus does
not directly control the version of mathjax-renderer used in the KA frontend.
Instead, Perseus requires mathjax-renderer as a peer dependency, and also
accepts an injected TeX component via `setDependencies()`. So Perseus itself
has no way to know if it needs to invert the math colors or not!

What this means is that frontend must simultaneously opt-in to both the
new mathjax-renderer version and the Wonder Blocks math theming in Perseus, to
ensure that math doesn't get color-inverted when it shouldn't be.

In this PR, we make Perseus aware of a new, temporary CSS class,
`wb-themed-math`, which will trigger the new math styles if set on the
`.framework-perseus` element. The plan is for frontend to set this class and,
at the same time, upgrade to mathjax-renderer 3.2.0, which supports WB styles.
The frontend PR to do that is here: https://github.com/Khan/frontend/pull/15463

Issue: LEMS-4492

## Test plan:

Review the visual regression tests in Chromatic. Expect changes to colorized
math in dark mode (we've changed from inverted colors to proper WB tokens).