### PR TITLE
Switch from state to ref for keypad context

### DIFF
--- a/.changeset/wicked-memes-pull.md
+++ b/.changeset/wicked-memes-pull.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/keypad-context": major
+"@khanacademy/math-input": major
+"@khanacademy/perseus": patch
+---
+
+Change KeypadContext API so that rather than exposing a raw `renderer` we abstract functionality behind `blurRenderer`

--- a/packages/keypad-context/src/keypad-context.test.tsx
+++ b/packages/keypad-context/src/keypad-context.test.tsx
@@ -1,0 +1,126 @@
+import {render} from "@testing-library/react";
+import * as React from "react";
+
+import {KeypadContext, StatefulKeypadContextProvider} from "./keypad-context";
+
+import type {KeypadContextType} from "./types";
+
+describe("StatefulKeypadContextProvider", () => {
+    /**
+     * Renders a consumer under the provider and hands back the context value it
+     * saw, plus how many times it rendered.
+     */
+    function renderConsumer() {
+        const contexts: KeypadContextType[] = [];
+
+        function Consumer() {
+            contexts.push(React.useContext(KeypadContext));
+            return null;
+        }
+
+        const view = render(
+            <StatefulKeypadContextProvider>
+                <Consumer />
+            </StatefulKeypadContextProvider>,
+        );
+
+        return {
+            ...view,
+            contexts,
+            latest: () => contexts[contexts.length - 1],
+            renderConsumerAgain: () =>
+                view.rerender(
+                    <StatefulKeypadContextProvider>
+                        <Consumer />
+                    </StatefulKeypadContextProvider>,
+                ),
+        };
+    }
+
+    it("blurs the renderer that was attached with setRenderer", () => {
+        // Arrange
+        const renderer = {blur: jest.fn()};
+        const {latest} = renderConsumer();
+
+        // Act
+        // No act() needed: attaching writes to a ref, so nothing re-renders.
+        latest().setRenderer(renderer);
+        latest().blurRenderer();
+
+        // Assert
+        expect(renderer.blur).toHaveBeenCalledTimes(1);
+    });
+
+    it("blurs only the most recently attached renderer", () => {
+        // Arrange
+        const oldRenderer = {blur: jest.fn()};
+        const newRenderer = {blur: jest.fn()};
+        const {latest} = renderConsumer();
+
+        // Act
+        latest().setRenderer(oldRenderer);
+        latest().setRenderer(newRenderer);
+        latest().blurRenderer();
+
+        // Assert
+        expect(oldRenderer.blur).not.toHaveBeenCalled();
+        expect(newRenderer.blur).toHaveBeenCalledTimes(1);
+    });
+
+    it("does nothing when blurring with no renderer attached", () => {
+        // Arrange
+        const {latest} = renderConsumer();
+
+        // Act, Assert
+        expect(() => latest().blurRenderer()).not.toThrow();
+    });
+
+    it("does not re-render consumers when a renderer is attached", () => {
+        // Arrange
+        // Callers attach the renderer from an inline callback ref, which React
+        // re-invokes on every commit with a fresh handle. Attaching therefore
+        // has to stay out of state: if it re-rendered consumers, each render
+        // would attach again and the tree would never settle. The cap keeps a
+        // regression failing this assertion rather than hanging the suite.
+        const renderLimit = 10;
+        let renderCount = 0;
+
+        function Consumer() {
+            const {setRenderer} = React.useContext(KeypadContext);
+            renderCount++;
+
+            React.useEffect(() => {
+                if (renderCount < renderLimit) {
+                    setRenderer({blur: jest.fn()});
+                }
+            });
+
+            return null;
+        }
+
+        // Act
+        render(
+            <StatefulKeypadContextProvider>
+                <Consumer />
+            </StatefulKeypadContextProvider>,
+        );
+
+        // Assert
+        expect(renderCount).toBe(1);
+    });
+
+    it("returns the same setRenderer and blurRenderer across renders", () => {
+        // Arrange
+        const {contexts, renderConsumerAgain} = renderConsumer();
+
+        // Act
+        renderConsumerAgain();
+
+        // Assert
+        // Both are documented as safe for dependency arrays, so their identity
+        // has to survive a re-render.
+        expect(contexts.length).toBe(2);
+        expect(contexts[1].setRenderer).toBe(contexts[0].setRenderer);
+        expect(contexts[1].blurRenderer).toBe(contexts[0].blurRenderer);
+    });
+});

--- a/packages/keypad-context/src/keypad-context.tsx
+++ b/packages/keypad-context/src/keypad-context.tsx
@@ -37,6 +37,7 @@ export function StatefulKeypadContextProvider(props: Props) {
 
     const rendererRef = useRef<KeypadContextRendererInterface | null>(null);
 
+    // useCallback is to keep useMemo stable
     const setRenderer = useCallback<KeypadContextType["setRenderer"]>(
         (renderer) => {
             rendererRef.current = renderer ?? null;
@@ -44,12 +45,14 @@ export function StatefulKeypadContextProvider(props: Props) {
         [],
     );
 
-    // Exposed instead of the renderer itself so consumers can't reach past
-    // blurring into the renderer's internals.
+    // useCallback is to keep useMemo stable
     const blurRenderer = useCallback(() => {
         rendererRef.current?.blur();
     }, []);
 
+    // the context is wrapped around most of Khan Academy frontend code
+    // without memoization, we were rerendering the entire application
+    // which affected redirects negatively.
     const memoizedValue = useMemo(
         () => ({
             keypadActive,
@@ -63,13 +66,10 @@ export function StatefulKeypadContextProvider(props: Props) {
         }),
         [
             keypadActive,
-            setKeypadActive,
             keypadElement,
-            setKeypadElement,
             setRenderer,
             blurRenderer,
             scrollableElement,
-            setScrollableElement,
         ],
     );
 

--- a/packages/keypad-context/src/keypad-context.tsx
+++ b/packages/keypad-context/src/keypad-context.tsx
@@ -8,20 +8,19 @@
  * - Perseus Renderers (Server/Item/Article)
  */
 import * as React from "react";
-import {useState, useMemo} from "react";
+import {useCallback, useRef, useState, useMemo} from "react";
 
 import type {KeypadContextType} from "./types";
 import type {KeypadContextRendererInterface} from "@khanacademy/perseus-core";
 
-// @ts-expect-error - TS2322 - Type 'Context<{ setKeypadElement: (keypadElement: HTMLElement | null | undefined) => void; keypadElement: null; setRenderer: (renderer: RendererInterface | null | undefined) => void; renderer: null; setScrollableElement: (scrollableElement: HTMLElement | ... 1 more ... | undefined) => void; scrollableElement: null; }>' is not assignable to type 'Context<KeypadContext>'.
 export const KeypadContext: React.Context<KeypadContextType> =
-    React.createContext({
+    React.createContext<KeypadContextType>({
         setKeypadActive: (keypadActive) => {},
         keypadActive: false,
         setKeypadElement: (keypadElement) => {},
         keypadElement: null,
         setRenderer: (renderer) => {},
-        renderer: null,
+        blurRenderer: () => {},
         setScrollableElement: (scrollableElement) => {},
         scrollableElement: null,
     });
@@ -33,11 +32,23 @@ export function StatefulKeypadContextProvider(props: Props) {
     const [keypadActive, setKeypadActive] = useState<boolean>(false);
     // used to communicate between the keypad and the Renderer
     const [keypadElement, setKeypadElement] = useState<any>();
-    // this is a KeypadContextRendererInterface from Perseus
-    const [renderer, setRenderer] =
-        useState<KeypadContextRendererInterface | null>();
     const [scrollableElement, setScrollableElement] =
         useState<HTMLElement | null>();
+
+    const rendererRef = useRef<KeypadContextRendererInterface | null>(null);
+
+    const setRenderer = useCallback<KeypadContextType["setRenderer"]>(
+        (renderer) => {
+            rendererRef.current = renderer ?? null;
+        },
+        [],
+    );
+
+    // Exposed instead of the renderer itself so consumers can't reach past
+    // blurring into the renderer's internals.
+    const blurRenderer = useCallback(() => {
+        rendererRef.current?.blur();
+    }, []);
 
     const memoizedValue = useMemo(
         () => ({
@@ -45,8 +56,8 @@ export function StatefulKeypadContextProvider(props: Props) {
             setKeypadActive,
             keypadElement,
             setKeypadElement,
-            renderer,
             setRenderer,
+            blurRenderer,
             scrollableElement,
             setScrollableElement,
         }),
@@ -55,8 +66,8 @@ export function StatefulKeypadContextProvider(props: Props) {
             setKeypadActive,
             keypadElement,
             setKeypadElement,
-            renderer,
             setRenderer,
+            blurRenderer,
             scrollableElement,
             setScrollableElement,
         ],

--- a/packages/keypad-context/src/types.ts
+++ b/packages/keypad-context/src/types.ts
@@ -6,15 +6,13 @@ export type KeypadContextType = {
     setKeypadElement: (keypadElement?: any) => void;
     keypadElement: any;
     /**
-     * Attaches the renderer the keypad should act on. Safe to call from a ref
-     * callback: it writes to a ref, so it never triggers a render.
+     * Attaches the renderer the keypad should act on
      */
     setRenderer: (
         renderer?: KeypadContextRendererInterface | null | undefined,
     ) => void;
     /**
-     * Blurs the currently attached renderer, if there is one. Stable across
-     * renders, so it's safe to use in dependency arrays.
+     * Blurs the currently attached renderer, if there is one
      */
     blurRenderer: () => void;
     setScrollableElement: (

--- a/packages/keypad-context/src/types.ts
+++ b/packages/keypad-context/src/types.ts
@@ -1,10 +1,22 @@
+import type {KeypadContextRendererInterface} from "@khanacademy/perseus-core";
+
 export type KeypadContextType = {
     setKeypadActive: (keypadActive: boolean) => void;
     keypadActive: boolean;
     setKeypadElement: (keypadElement?: any) => void;
     keypadElement: any;
-    setRenderer: (renderer?: any) => void;
-    renderer: any;
+    /**
+     * Attaches the renderer the keypad should act on. Safe to call from a ref
+     * callback: it writes to a ref, so it never triggers a render.
+     */
+    setRenderer: (
+        renderer?: KeypadContextRendererInterface | null | undefined,
+    ) => void;
+    /**
+     * Blurs the currently attached renderer, if there is one. Stable across
+     * renders, so it's safe to use in dependency arrays.
+     */
+    blurRenderer: () => void;
     setScrollableElement: (
         scrollableElement?: HTMLElement | null | undefined,
     ) => void;

--- a/packages/math-input/src/types.ts
+++ b/packages/math-input/src/types.ts
@@ -61,7 +61,7 @@ export type KeypadContextType = {
     setRenderer: (
         renderer?: KeypadContextRendererInterface | null | undefined,
     ) => void;
-    renderer: KeypadContextRendererInterface | null | undefined;
+    blurRenderer: () => void;
     setScrollableElement: (
         scrollableElement?: HTMLElement | null | undefined,
     ) => void;

--- a/packages/perseus/src/testing/test-keypad-context-wrapper.tsx
+++ b/packages/perseus/src/testing/test-keypad-context-wrapper.tsx
@@ -28,10 +28,10 @@ const Footer = ({
     return (
         <View style={styles.keypadContainer}>
             <KeypadContext.Consumer>
-                {({setKeypadElement, renderer}) => (
+                {({setKeypadElement, blurRenderer}) => (
                     <MobileKeypad
                         onElementMounted={setKeypadElement}
-                        onDismiss={() => renderer?.blur()}
+                        onDismiss={blurRenderer}
                         style={keypadStyle}
                         onAnalyticsEvent={async (e) => {
                             action("onAnalyticsEvent")(e);


### PR DESCRIPTION
## Summary:
When I tried to ship https://github.com/Khan/perseus/pull/4126, I ended up with an infinite rerender loop because class component identity is stable and functional component identity is not. Switching to component meant that setRenderer kept getting called which kept rerendering, which created a new component instance, which triggered a setRenderer...etc.

This PR fixes some of those issues:
- Use `useRef` (which doesn't cause rerenders) rather than `useState` (which does)
- Abstract away direct `Renderer` access away behind `blurRenderer`