### PR TITLE
Mark Sorter's `padding` as deprecated

### DIFF
--- a/.changeset/icy-houses-guess.md
+++ b/.changeset/icy-houses-guess.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+Mark Sorter's `padding` as deprecated

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -1893,15 +1893,19 @@ export type PerseusSorterWidgetOptions = {
      */
     correct: string[];
     /**
-     * Adds padding to the options. Padding is good for text but not needed
-     * for images
-     */
-    padding: boolean;
-    /**
      * Use the "horizontal" layout for short text and small images. The
      * "vertical" layout is best for longer text and larger images.
      */
     layout: "horizontal" | "vertical";
+    /**
+     * Adds padding to the options. Padding is good for text but not needed
+     * for images
+     *
+     * @deprecated
+     *
+     * TODO(LEMS-4538): remove padding from Sorter
+     */
+    padding: boolean;
 };
 
 /** Options for the table widget. A grid of input cells with column headers. */

--- a/packages/perseus-core/src/widgets/sorter/sorter-util.ts
+++ b/packages/perseus-core/src/widgets/sorter/sorter-util.ts
@@ -7,11 +7,20 @@ import type {PerseusSorterWidgetOptions} from "../../data-schema";
  * PerseusSorterWidgetOptions type
  */
 export type SorterPublicWidgetOptions = {
-    // TODO(benchristel): rename to `cards`; the whole point of public widget
-    // options is that this isn't the correct order!
-    correct: PerseusSorterWidgetOptions["correct"];
-    padding: PerseusSorterWidgetOptions["padding"];
     layout: PerseusSorterWidgetOptions["layout"];
+    /**
+     * `correct` is the wrong term, because it's not
+     * in the correct order when in SorterPublicWidgetOptions
+     *
+     * TODO(LEMS-4535): rename this
+     */
+    correct: PerseusSorterWidgetOptions["correct"];
+    /**
+     * @deprecated
+     *
+     * TODO(LEMS-4538): remove padding from Sorter
+     */
+    padding: PerseusSorterWidgetOptions["padding"];
 };
 
 /**


### PR DESCRIPTION
## Summary:
See [this Slack thread](https://khanacademy.slack.com/archives/C0B7GPHP6H0/p1787853062739429?thread_ts=1787852902.505989&cid=C0B7GPHP6H0)

Issue: LEMS-4536