### PR TITLE
Modernize SorterEditor

### DIFF
--- a/.changeset/gentle-paws-notice.md
+++ b/.changeset/gentle-paws-notice.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus-linter": minor
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus-core": patch
+---
+
+Modernize Sorter editor and add some lint rules to make sure content is reasonable

--- a/packages/perseus-core/src/widgets/sorter/sorter-util.test.ts
+++ b/packages/perseus-core/src/widgets/sorter/sorter-util.test.ts
@@ -27,6 +27,23 @@ describe("getSorterPublicWidgetOptions", () => {
             padding: true,
         });
     });
+
+    // An author can delete every card, and a phantom `undefined` card would
+    // reach the client as an empty draggable.
+    it("returns no cards when the correct answer is empty", () => {
+        // Arrange
+        const options: PerseusSorterWidgetOptions = {
+            correct: [],
+            layout: "horizontal",
+            padding: true,
+        };
+
+        // Act
+        const publicWidgetOptions = getSorterPublicWidgetOptions(options);
+
+        // Assert
+        expect(publicWidgetOptions.correct).toEqual([]);
+    });
 });
 
 describe("shuffleSorter", () => {

--- a/packages/perseus-core/src/widgets/sorter/sorter-util.test.ts
+++ b/packages/perseus-core/src/widgets/sorter/sorter-util.test.ts
@@ -28,8 +28,6 @@ describe("getSorterPublicWidgetOptions", () => {
         });
     });
 
-    // An author can delete every card, and a phantom `undefined` card would
-    // reach the client as an empty draggable.
     it("returns no cards when the correct answer is empty", () => {
         // Arrange
         const options: PerseusSorterWidgetOptions = {

--- a/packages/perseus-core/src/widgets/sorter/sorter-util.ts
+++ b/packages/perseus-core/src/widgets/sorter/sorter-util.ts
@@ -51,7 +51,14 @@ export function shuffleSorter(
     return shuffleDisplacingFirst(correct, rng);
 }
 
-function sortAllButFirst([first, ...rest]: readonly string[]): string[] {
+function sortAllButFirst(cards: readonly string[]): string[] {
+    // An author can delete every card, so `correct` can be empty. Destructuring
+    // a first card off an empty array would hand the client `[undefined]` — a
+    // phantom card — instead of no cards at all.
+    if (cards.length === 0) {
+        return [];
+    }
+    const [first, ...rest] = cards;
     return [first, ...rest.sort()];
 }
 

--- a/packages/perseus-core/src/widgets/sorter/sorter-util.ts
+++ b/packages/perseus-core/src/widgets/sorter/sorter-util.ts
@@ -52,9 +52,6 @@ export function shuffleSorter(
 }
 
 function sortAllButFirst(cards: readonly string[]): string[] {
-    // An author can delete every card, so `correct` can be empty. Destructuring
-    // a first card off an empty array would hand the client `[undefined]` — a
-    // phantom card — instead of no cards at all.
     if (cards.length === 0) {
         return [];
     }

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -15502,74 +15502,239 @@ table: [[☃ table 1]]
                           class="default_7zhre1-o_O-cards_b4wskx"
                         >
                           <li
-                            class="default_7zhre1"
+                            class="default_7zhre1-o_O-card_tlw8lk"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 1"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
                               id=":r6c:"
                               type="text"
                               value="1"
                             />
+                            <button
+                              aria-disabled="true"
+                              aria-label="Move card 1 up"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1-o_O-disabled_1y1yrlc"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_1w2ke9h"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="false"
+                              aria-label="Move card 1 down"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_514u8y"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="false"
+                              aria-label="Delete card 1"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1ugjna4"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_q5oi6w"
+                              />
+                            </button>
                           </li>
                           <li
-                            class="default_7zhre1"
+                            class="default_7zhre1-o_O-card_tlw8lk"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 2"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
                               id=":r6d:"
                               type="text"
                               value="2"
                             />
+                            <button
+                              aria-disabled="false"
+                              aria-label="Move card 2 up"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_1w2ke9h"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="false"
+                              aria-label="Move card 2 down"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_514u8y"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="false"
+                              aria-label="Delete card 2"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1ugjna4"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_q5oi6w"
+                              />
+                            </button>
                           </li>
                           <li
-                            class="default_7zhre1"
+                            class="default_7zhre1-o_O-card_tlw8lk"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 3"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
                               id=":r6e:"
                               type="text"
                               value="3"
                             />
+                            <button
+                              aria-disabled="false"
+                              aria-label="Move card 3 up"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_1w2ke9h"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="false"
+                              aria-label="Move card 3 down"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_514u8y"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="false"
+                              aria-label="Delete card 3"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1ugjna4"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_q5oi6w"
+                              />
+                            </button>
                           </li>
                           <li
-                            class="default_7zhre1"
+                            class="default_7zhre1-o_O-card_tlw8lk"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 4"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
                               id=":r6f:"
                               type="text"
                               value="4"
                             />
+                            <button
+                              aria-disabled="false"
+                              aria-label="Move card 4 up"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_1w2ke9h"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="false"
+                              aria-label="Move card 4 down"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_514u8y"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="false"
+                              aria-label="Delete card 4"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1ugjna4"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_q5oi6w"
+                              />
+                            </button>
                           </li>
                           <li
-                            class="default_7zhre1"
+                            class="default_7zhre1-o_O-card_tlw8lk"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 5"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
                               id=":r6g:"
                               type="text"
                               value="5"
                             />
+                            <button
+                              aria-disabled="false"
+                              aria-label="Move card 5 up"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_1w2ke9h"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="true"
+                              aria-label="Move card 5 down"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1-o_O-disabled_1y1yrlc"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_514u8y"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="false"
+                              aria-label="Delete card 5"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1ugjna4"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_q5oi6w"
+                              />
+                            </button>
                           </li>
                         </ol>
                         <button

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -15571,21 +15571,26 @@ table: [[☃ table 1]]
                               value="5"
                             />
                           </li>
-                          <li
-                            class="default_7zhre1"
-                          >
-                            <input
-                              aria-disabled="false"
-                              aria-invalid="false"
-                              aria-label="Add a card"
-                              aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                              id=":r6h:"
-                              type="text"
-                              value=""
-                            />
-                          </li>
                         </ol>
+                        <button
+                          aria-disabled="false"
+                          class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1xfocwy-o_O-addCard_1bfjkya"
+                          data-kind="tertiary"
+                          type="button"
+                        >
+                          <div
+                            class="default_7zhre1-o_O-iconWrapper_bqwm7d"
+                          >
+                            <span
+                              class="svg_1q6jc65-o_O-medium_12bui46-o_O-startIcon_1ll1fk7-o_O-tertiaryStartIcon_121powu-o_O-inlineStyles_1gy2kn5"
+                            />
+                          </div>
+                          <span
+                            class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-text_1kowsup"
+                          >
+                            Add a card
+                          </span>
+                        </button>
                       </div>
                       <div
                         class="default_7zhre1"
@@ -15598,8 +15603,8 @@ table: [[☃ table 1]]
                           >
                             <label
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_qt7cw0-o_O-labelWithNoDescription_i032sc"
-                              for=":r6i:-labeled-field-field"
-                              id=":r6i:-labeled-field-label"
+                              for=":r6h:-labeled-field-field"
+                              id=":r6h:-labeled-field-label"
                             >
                               Layout
                             </label>
@@ -15608,14 +15613,14 @@ table: [[☃ table 1]]
                             class="default_7zhre1-o_O-menuWrapper_1rs652y"
                           >
                             <button
-                              aria-controls=":r6j:"
+                              aria-controls=":r6i:"
                               aria-describedby=""
                               aria-expanded="false"
                               aria-haspopup="listbox"
                               aria-invalid="false"
                               aria-required="false"
                               class="button_vr44p2-o_O-shared_1hhaz1q-o_O-default_znuyo8"
-                              id=":r6i:-labeled-field-field"
+                              id=":r6h:-labeled-field-field"
                               role="combobox"
                               type="button"
                             >
@@ -15634,7 +15639,7 @@ table: [[☃ table 1]]
                             aria-atomic="true"
                             aria-live="assertive"
                             class="default_7zhre1-o_O-helperTextWithIcon_1hmzxfl"
-                            id=":r6i:-labeled-field-error"
+                            id=":r6h:-labeled-field-error"
                           />
                         </div>
                         <span
@@ -15662,7 +15667,7 @@ table: [[☃ table 1]]
                                   aria-invalid="false"
                                   checked=""
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1ywap6u"
-                                  id=":r6l:"
+                                  id=":r6k:"
                                   type="checkbox"
                                 />
                                 <span
@@ -15674,7 +15679,7 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                             >
                               <label
-                                for=":r6l:"
+                                for=":r6k:"
                               >
                                 Padding
                               </label>

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -15484,122 +15484,159 @@ table: [[☃ table 1]]
                   <div
                     class="perseus-widget-editor-content enter"
                   >
-                    <div>
-                      <div>
-                         
-                        Correct answer:
-                         
-                        <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-spacingLeft_wn7g7u-o_O-inlineStyles_zmizzn"
-                          tabindex="0"
-                        />
-                      </div>
-                      <ol
-                        class="default_7zhre1-o_O-cards_18gwzo2"
+                    <div
+                      class="default_7zhre1-o_O-editor_qvunv6"
+                    >
+                      <div
+                        class="default_7zhre1-o_O-section_1d3v9jw"
                       >
-                        <li
-                          class="default_7zhre1"
-                        >
-                          <input
-                            aria-disabled="false"
-                            aria-invalid="false"
-                            aria-label="Card 1"
-                            aria-required="false"
-                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                            id=":r6c:"
-                            type="text"
-                            value="1"
-                          />
-                        </li>
-                        <li
-                          class="default_7zhre1"
-                        >
-                          <input
-                            aria-disabled="false"
-                            aria-invalid="false"
-                            aria-label="Card 2"
-                            aria-required="false"
-                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                            id=":r6d:"
-                            type="text"
-                            value="2"
-                          />
-                        </li>
-                        <li
-                          class="default_7zhre1"
-                        >
-                          <input
-                            aria-disabled="false"
-                            aria-invalid="false"
-                            aria-label="Card 3"
-                            aria-required="false"
-                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                            id=":r6e:"
-                            type="text"
-                            value="3"
-                          />
-                        </li>
-                        <li
-                          class="default_7zhre1"
-                        >
-                          <input
-                            aria-disabled="false"
-                            aria-invalid="false"
-                            aria-label="Card 4"
-                            aria-required="false"
-                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                            id=":r6f:"
-                            type="text"
-                            value="4"
-                          />
-                        </li>
-                        <li
-                          class="default_7zhre1"
-                        >
-                          <input
-                            aria-disabled="false"
-                            aria-invalid="false"
-                            aria-label="Card 5"
-                            aria-required="false"
-                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                            id=":r6g:"
-                            type="text"
-                            value="5"
-                          />
-                        </li>
-                        <li
-                          class="default_7zhre1"
-                        >
-                          <input
-                            aria-disabled="false"
-                            aria-invalid="false"
-                            aria-label="Add a card"
-                            aria-required="false"
-                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                            id=":r6h:"
-                            type="text"
-                            value=""
-                          />
-                        </li>
-                      </ol>
-                      <div>
-                        <label>
+                        <div>
+                          Correct answer
                            
-                          Layout:
-                           
-                          <select>
-                            <option
-                              value="horizontal"
+                          <span
+                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-spacingLeft_wn7g7u-o_O-inlineStyles_zmizzn"
+                            tabindex="0"
+                          />
+                        </div>
+                        <ol
+                          class="default_7zhre1-o_O-cards_b4wskx"
+                        >
+                          <li
+                            class="default_7zhre1"
+                          >
+                            <input
+                              aria-disabled="false"
+                              aria-invalid="false"
+                              aria-label="Card 1"
+                              aria-required="false"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              id=":r6c:"
+                              type="text"
+                              value="1"
+                            />
+                          </li>
+                          <li
+                            class="default_7zhre1"
+                          >
+                            <input
+                              aria-disabled="false"
+                              aria-invalid="false"
+                              aria-label="Card 2"
+                              aria-required="false"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              id=":r6d:"
+                              type="text"
+                              value="2"
+                            />
+                          </li>
+                          <li
+                            class="default_7zhre1"
+                          >
+                            <input
+                              aria-disabled="false"
+                              aria-invalid="false"
+                              aria-label="Card 3"
+                              aria-required="false"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              id=":r6e:"
+                              type="text"
+                              value="3"
+                            />
+                          </li>
+                          <li
+                            class="default_7zhre1"
+                          >
+                            <input
+                              aria-disabled="false"
+                              aria-invalid="false"
+                              aria-label="Card 4"
+                              aria-required="false"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              id=":r6f:"
+                              type="text"
+                              value="4"
+                            />
+                          </li>
+                          <li
+                            class="default_7zhre1"
+                          >
+                            <input
+                              aria-disabled="false"
+                              aria-invalid="false"
+                              aria-label="Card 5"
+                              aria-required="false"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              id=":r6g:"
+                              type="text"
+                              value="5"
+                            />
+                          </li>
+                          <li
+                            class="default_7zhre1"
+                          >
+                            <input
+                              aria-disabled="false"
+                              aria-invalid="false"
+                              aria-label="Add a card"
+                              aria-required="false"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              id=":r6h:"
+                              type="text"
+                              value=""
+                            />
+                          </li>
+                        </ol>
+                      </div>
+                      <div
+                        class="default_7zhre1"
+                      >
+                        <div
+                          class="default_7zhre1"
+                        >
+                          <div
+                            class="default_7zhre1-o_O-labelContainer_1qlbwdv"
+                          >
+                            <label
+                              class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_qt7cw0-o_O-labelWithNoDescription_i032sc"
+                              for=":r6i:-labeled-field-field"
+                              id=":r6i:-labeled-field-label"
                             >
-                              Horizontal
-                            </option>
-                            <option
-                              value="vertical"
+                              Layout
+                            </label>
+                          </div>
+                          <div
+                            class="default_7zhre1-o_O-menuWrapper_1rs652y"
+                          >
+                            <button
+                              aria-controls=":r6j:"
+                              aria-describedby=""
+                              aria-expanded="false"
+                              aria-haspopup="listbox"
+                              aria-invalid="false"
+                              aria-required="false"
+                              class="button_vr44p2-o_O-shared_1hhaz1q-o_O-default_znuyo8"
+                              id=":r6i:-labeled-field-field"
+                              role="combobox"
+                              type="button"
                             >
-                              Vertical
-                            </option>
-                          </select>
-                        </label>
+                              <span
+                                class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-text_awxjrp"
+                              >
+                                Horizontal
+                              </span>
+                              <span
+                                aria-hidden="true"
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-caret_1e21hpf-o_O-inlineStyles_efsbsa"
+                              />
+                            </button>
+                          </div>
+                          <div
+                            aria-atomic="true"
+                            aria-live="assertive"
+                            class="default_7zhre1-o_O-helperTextWithIcon_1hmzxfl"
+                            id=":r6i:-labeled-field-error"
+                          />
+                        </div>
                         <span
                           class="svg_1q6jc65-o_O-small_6q1hy-o_O-spacingLeft_wn7g7u-o_O-inlineStyles_zmizzn"
                           tabindex="0"
@@ -15625,7 +15662,7 @@ table: [[☃ table 1]]
                                   aria-invalid="false"
                                   checked=""
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1ywap6u"
-                                  id=":r6i:"
+                                  id=":r6l:"
                                   type="checkbox"
                                 />
                                 <span
@@ -15637,9 +15674,9 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                             >
                               <label
-                                for=":r6i:"
+                                for=":r6l:"
                               >
-                                Padding:
+                                Padding
                               </label>
                             </div>
                           </div>

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -15485,10 +15485,10 @@ table: [[☃ table 1]]
                     class="perseus-widget-editor-content enter"
                   >
                     <div
-                      class="default_7zhre1-o_O-editor_qvunv6"
+                      class="default_7zhre1 editor"
                     >
                       <div
-                        class="default_7zhre1-o_O-section_1d3v9jw"
+                        class="default_7zhre1 section"
                       >
                         <div>
                           Correct answer
@@ -15499,17 +15499,17 @@ table: [[☃ table 1]]
                           />
                         </div>
                         <ol
-                          class="default_7zhre1-o_O-cards_b4wskx"
+                          class="default_7zhre1 cards"
                         >
                           <li
-                            class="default_7zhre1-o_O-card_tlw8lk"
+                            class="default_7zhre1 card"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 1"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-inlineStyles_t0tx82"
                               id=":r6c:"
                               type="text"
                               value="1"
@@ -15549,14 +15549,14 @@ table: [[☃ table 1]]
                             </button>
                           </li>
                           <li
-                            class="default_7zhre1-o_O-card_tlw8lk"
+                            class="default_7zhre1 card"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 2"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-inlineStyles_t0tx82"
                               id=":r6d:"
                               type="text"
                               value="2"
@@ -15596,14 +15596,14 @@ table: [[☃ table 1]]
                             </button>
                           </li>
                           <li
-                            class="default_7zhre1-o_O-card_tlw8lk"
+                            class="default_7zhre1 card"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 3"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-inlineStyles_t0tx82"
                               id=":r6e:"
                               type="text"
                               value="3"
@@ -15643,14 +15643,14 @@ table: [[☃ table 1]]
                             </button>
                           </li>
                           <li
-                            class="default_7zhre1-o_O-card_tlw8lk"
+                            class="default_7zhre1 card"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 4"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-inlineStyles_t0tx82"
                               id=":r6f:"
                               type="text"
                               value="4"
@@ -15690,14 +15690,14 @@ table: [[☃ table 1]]
                             </button>
                           </li>
                           <li
-                            class="default_7zhre1-o_O-card_tlw8lk"
+                            class="default_7zhre1 card"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 5"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-inlineStyles_t0tx82"
                               id=":r6g:"
                               type="text"
                               value="5"
@@ -15739,7 +15739,7 @@ table: [[☃ table 1]]
                         </ol>
                         <button
                           aria-disabled="false"
-                          class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1xfocwy-o_O-addCard_1bfjkya"
+                          class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1xfocwy add-card"
                           data-kind="tertiary"
                           type="button"
                         >

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -15494,52 +15494,94 @@ table: [[☃ table 1]]
                           tabindex="0"
                         />
                       </div>
-                      <ul
-                        class="perseus-text-list-editor perseus-clearfix layout-horizontal"
+                      <ol
+                        class="default_7zhre1-o_O-cards_18gwzo2"
                       >
-                        <li>
+                        <li
+                          class="default_7zhre1"
+                        >
                           <input
-                            style="width: 5px;"
+                            aria-disabled="false"
+                            aria-invalid="false"
+                            aria-label="Card 1"
+                            aria-required="false"
+                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                            id=":r6c:"
                             type="text"
                             value="1"
                           />
                         </li>
-                        <li>
+                        <li
+                          class="default_7zhre1"
+                        >
                           <input
-                            style="width: 5px;"
+                            aria-disabled="false"
+                            aria-invalid="false"
+                            aria-label="Card 2"
+                            aria-required="false"
+                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                            id=":r6d:"
                             type="text"
                             value="2"
                           />
                         </li>
-                        <li>
+                        <li
+                          class="default_7zhre1"
+                        >
                           <input
-                            style="width: 5px;"
+                            aria-disabled="false"
+                            aria-invalid="false"
+                            aria-label="Card 3"
+                            aria-required="false"
+                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                            id=":r6e:"
                             type="text"
                             value="3"
                           />
                         </li>
-                        <li>
+                        <li
+                          class="default_7zhre1"
+                        >
                           <input
-                            style="width: 5px;"
+                            aria-disabled="false"
+                            aria-invalid="false"
+                            aria-label="Card 4"
+                            aria-required="false"
+                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                            id=":r6f:"
                             type="text"
                             value="4"
                           />
                         </li>
-                        <li>
+                        <li
+                          class="default_7zhre1"
+                        >
                           <input
-                            style="width: 5px;"
+                            aria-disabled="false"
+                            aria-invalid="false"
+                            aria-label="Card 5"
+                            aria-required="false"
+                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                            id=":r6g:"
                             type="text"
                             value="5"
                           />
                         </li>
-                        <li>
+                        <li
+                          class="default_7zhre1"
+                        >
                           <input
-                            style="width: 5px;"
+                            aria-disabled="false"
+                            aria-invalid="false"
+                            aria-label="Add a card"
+                            aria-required="false"
+                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                            id=":r6h:"
                             type="text"
                             value=""
                           />
                         </li>
-                      </ul>
+                      </ol>
                       <div>
                         <label>
                            
@@ -15583,7 +15625,7 @@ table: [[☃ table 1]]
                                   aria-invalid="false"
                                   checked=""
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1ywap6u"
-                                  id=":r6c:"
+                                  id=":r6i:"
                                   type="checkbox"
                                 />
                                 <span
@@ -15595,7 +15637,7 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                             >
                               <label
-                                for=":r6c:"
+                                for=":r6i:"
                               >
                                 Padding:
                               </label>

--- a/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
@@ -15552,10 +15552,10 @@ table: [[☃ table 1]]
                     class="perseus-widget-editor-content enter"
                   >
                     <div
-                      class="default_7zhre1-o_O-editor_qvunv6"
+                      class="default_7zhre1 editor"
                     >
                       <div
-                        class="default_7zhre1-o_O-section_1d3v9jw"
+                        class="default_7zhre1 section"
                       >
                         <div>
                           Correct answer
@@ -15566,17 +15566,17 @@ table: [[☃ table 1]]
                           />
                         </div>
                         <ol
-                          class="default_7zhre1-o_O-cards_b4wskx"
+                          class="default_7zhre1 cards"
                         >
                           <li
-                            class="default_7zhre1-o_O-card_tlw8lk"
+                            class="default_7zhre1 card"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 1"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-inlineStyles_t0tx82"
                               id=":r64:"
                               type="text"
                               value="1"
@@ -15616,14 +15616,14 @@ table: [[☃ table 1]]
                             </button>
                           </li>
                           <li
-                            class="default_7zhre1-o_O-card_tlw8lk"
+                            class="default_7zhre1 card"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 2"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-inlineStyles_t0tx82"
                               id=":r65:"
                               type="text"
                               value="2"
@@ -15663,14 +15663,14 @@ table: [[☃ table 1]]
                             </button>
                           </li>
                           <li
-                            class="default_7zhre1-o_O-card_tlw8lk"
+                            class="default_7zhre1 card"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 3"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-inlineStyles_t0tx82"
                               id=":r66:"
                               type="text"
                               value="3"
@@ -15710,14 +15710,14 @@ table: [[☃ table 1]]
                             </button>
                           </li>
                           <li
-                            class="default_7zhre1-o_O-card_tlw8lk"
+                            class="default_7zhre1 card"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 4"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-inlineStyles_t0tx82"
                               id=":r67:"
                               type="text"
                               value="4"
@@ -15757,14 +15757,14 @@ table: [[☃ table 1]]
                             </button>
                           </li>
                           <li
-                            class="default_7zhre1-o_O-card_tlw8lk"
+                            class="default_7zhre1 card"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 5"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-inlineStyles_t0tx82"
                               id=":r68:"
                               type="text"
                               value="5"
@@ -15806,7 +15806,7 @@ table: [[☃ table 1]]
                         </ol>
                         <button
                           aria-disabled="false"
-                          class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1xfocwy-o_O-addCard_1bfjkya"
+                          class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1xfocwy add-card"
                           data-kind="tertiary"
                           type="button"
                         >

--- a/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
@@ -15638,21 +15638,26 @@ table: [[☃ table 1]]
                               value="5"
                             />
                           </li>
-                          <li
-                            class="default_7zhre1"
-                          >
-                            <input
-                              aria-disabled="false"
-                              aria-invalid="false"
-                              aria-label="Add a card"
-                              aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                              id=":r69:"
-                              type="text"
-                              value=""
-                            />
-                          </li>
                         </ol>
+                        <button
+                          aria-disabled="false"
+                          class="button_vr44p2-o_O-reset_1ck4g21-o_O-shared_1jpsfmg-o_O-default_1xfocwy-o_O-addCard_1bfjkya"
+                          data-kind="tertiary"
+                          type="button"
+                        >
+                          <div
+                            class="default_7zhre1-o_O-iconWrapper_bqwm7d"
+                          >
+                            <span
+                              class="svg_1q6jc65-o_O-medium_12bui46-o_O-startIcon_1ll1fk7-o_O-tertiaryStartIcon_121powu-o_O-inlineStyles_1gy2kn5"
+                            />
+                          </div>
+                          <span
+                            class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-text_1kowsup"
+                          >
+                            Add a card
+                          </span>
+                        </button>
                       </div>
                       <div
                         class="default_7zhre1"
@@ -15665,8 +15670,8 @@ table: [[☃ table 1]]
                           >
                             <label
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_qt7cw0-o_O-labelWithNoDescription_i032sc"
-                              for=":r6a:-labeled-field-field"
-                              id=":r6a:-labeled-field-label"
+                              for=":r69:-labeled-field-field"
+                              id=":r69:-labeled-field-label"
                             >
                               Layout
                             </label>
@@ -15675,14 +15680,14 @@ table: [[☃ table 1]]
                             class="default_7zhre1-o_O-menuWrapper_1rs652y"
                           >
                             <button
-                              aria-controls=":r6b:"
+                              aria-controls=":r6a:"
                               aria-describedby=""
                               aria-expanded="false"
                               aria-haspopup="listbox"
                               aria-invalid="false"
                               aria-required="false"
                               class="button_vr44p2-o_O-shared_1hhaz1q-o_O-default_znuyo8"
-                              id=":r6a:-labeled-field-field"
+                              id=":r69:-labeled-field-field"
                               role="combobox"
                               type="button"
                             >
@@ -15701,7 +15706,7 @@ table: [[☃ table 1]]
                             aria-atomic="true"
                             aria-live="assertive"
                             class="default_7zhre1-o_O-helperTextWithIcon_1hmzxfl"
-                            id=":r6a:-labeled-field-error"
+                            id=":r69:-labeled-field-error"
                           />
                         </div>
                         <span
@@ -15729,7 +15734,7 @@ table: [[☃ table 1]]
                                   aria-invalid="false"
                                   checked=""
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1ywap6u"
-                                  id=":r6d:"
+                                  id=":r6c:"
                                   type="checkbox"
                                 />
                                 <span
@@ -15741,7 +15746,7 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                             >
                               <label
-                                for=":r6d:"
+                                for=":r6c:"
                               >
                                 Padding
                               </label>
@@ -16016,6 +16021,54 @@ table: [[☃ table 1]]
                           aria-invalid="false"
                           class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_vfcxos"
                           disabled=""
+                          id=":r6d:"
+                          type="checkbox"
+                        />
+                      </div>
+                    </div>
+                    <div
+                      class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy-o_O-disabledLabel_1d65n8m"
+                    >
+                      <label
+                        for=":r6d:"
+                      >
+                        <div
+                          class="default_7zhre1-o_O-inlineStyles_qb00m9"
+                        >
+                          Show calculator
+                           
+                          <span
+                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-spacingLeft_wn7g7u-o_O-inlineStyles_zmizzn"
+                            tabindex="0"
+                          />
+                        </div>
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="default_7zhre1"
+              >
+                <div
+                  class="default_7zhre1"
+                >
+                  <div
+                    class="default_7zhre1-o_O-wrapper_119rz02"
+                    tabindex="-1"
+                  >
+                    <div
+                      class="default_7zhre1-o_O-choiceWrapper_s2wtqp"
+                    >
+                      <div
+                        class="default_7zhre1-o_O-inputWrapper_w6nz04-o_O-inputWrapper_1k6ggkh"
+                        data-testid="wb-checkbox-wrapper"
+                      >
+                        <input
+                          aria-checked="false"
+                          aria-invalid="false"
+                          class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_vfcxos"
+                          disabled=""
                           id=":r6e:"
                           type="checkbox"
                         />
@@ -16030,7 +16083,7 @@ table: [[☃ table 1]]
                         <div
                           class="default_7zhre1-o_O-inlineStyles_qb00m9"
                         >
-                          Show calculator
+                          Show financial calculator
                            
                           <span
                             class="svg_1q6jc65-o_O-small_6q1hy-o_O-spacingLeft_wn7g7u-o_O-inlineStyles_zmizzn"
@@ -16074,54 +16127,6 @@ table: [[☃ table 1]]
                     >
                       <label
                         for=":r6f:"
-                      >
-                        <div
-                          class="default_7zhre1-o_O-inlineStyles_qb00m9"
-                        >
-                          Show financial calculator
-                           
-                          <span
-                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-spacingLeft_wn7g7u-o_O-inlineStyles_zmizzn"
-                            tabindex="0"
-                          />
-                        </div>
-                      </label>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="default_7zhre1"
-              >
-                <div
-                  class="default_7zhre1"
-                >
-                  <div
-                    class="default_7zhre1-o_O-wrapper_119rz02"
-                    tabindex="-1"
-                  >
-                    <div
-                      class="default_7zhre1-o_O-choiceWrapper_s2wtqp"
-                    >
-                      <div
-                        class="default_7zhre1-o_O-inputWrapper_w6nz04-o_O-inputWrapper_1k6ggkh"
-                        data-testid="wb-checkbox-wrapper"
-                      >
-                        <input
-                          aria-checked="false"
-                          aria-invalid="false"
-                          class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_vfcxos"
-                          disabled=""
-                          id=":r6g:"
-                          type="checkbox"
-                        />
-                      </div>
-                    </div>
-                    <div
-                      class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy-o_O-disabledLabel_1d65n8m"
-                    >
-                      <label
-                        for=":r6g:"
                       >
                         <div
                           class="default_7zhre1-o_O-inlineStyles_qb00m9"

--- a/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
@@ -15561,52 +15561,94 @@ table: [[☃ table 1]]
                           tabindex="0"
                         />
                       </div>
-                      <ul
-                        class="perseus-text-list-editor perseus-clearfix layout-horizontal"
+                      <ol
+                        class="default_7zhre1-o_O-cards_18gwzo2"
                       >
-                        <li>
+                        <li
+                          class="default_7zhre1"
+                        >
                           <input
-                            style="width: 5px;"
+                            aria-disabled="false"
+                            aria-invalid="false"
+                            aria-label="Card 1"
+                            aria-required="false"
+                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                            id=":r64:"
                             type="text"
                             value="1"
                           />
                         </li>
-                        <li>
+                        <li
+                          class="default_7zhre1"
+                        >
                           <input
-                            style="width: 5px;"
+                            aria-disabled="false"
+                            aria-invalid="false"
+                            aria-label="Card 2"
+                            aria-required="false"
+                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                            id=":r65:"
                             type="text"
                             value="2"
                           />
                         </li>
-                        <li>
+                        <li
+                          class="default_7zhre1"
+                        >
                           <input
-                            style="width: 5px;"
+                            aria-disabled="false"
+                            aria-invalid="false"
+                            aria-label="Card 3"
+                            aria-required="false"
+                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                            id=":r66:"
                             type="text"
                             value="3"
                           />
                         </li>
-                        <li>
+                        <li
+                          class="default_7zhre1"
+                        >
                           <input
-                            style="width: 5px;"
+                            aria-disabled="false"
+                            aria-invalid="false"
+                            aria-label="Card 4"
+                            aria-required="false"
+                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                            id=":r67:"
                             type="text"
                             value="4"
                           />
                         </li>
-                        <li>
+                        <li
+                          class="default_7zhre1"
+                        >
                           <input
-                            style="width: 5px;"
+                            aria-disabled="false"
+                            aria-invalid="false"
+                            aria-label="Card 5"
+                            aria-required="false"
+                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                            id=":r68:"
                             type="text"
                             value="5"
                           />
                         </li>
-                        <li>
+                        <li
+                          class="default_7zhre1"
+                        >
                           <input
-                            style="width: 5px;"
+                            aria-disabled="false"
+                            aria-invalid="false"
+                            aria-label="Add a card"
+                            aria-required="false"
+                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                            id=":r69:"
                             type="text"
                             value=""
                           />
                         </li>
-                      </ul>
+                      </ol>
                       <div>
                         <label>
                            
@@ -15650,7 +15692,7 @@ table: [[☃ table 1]]
                                   aria-invalid="false"
                                   checked=""
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1ywap6u"
-                                  id=":r64:"
+                                  id=":r6a:"
                                   type="checkbox"
                                 />
                                 <span
@@ -15662,7 +15704,7 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                             >
                               <label
-                                for=":r64:"
+                                for=":r6a:"
                               >
                                 Padding:
                               </label>
@@ -15937,7 +15979,7 @@ table: [[☃ table 1]]
                           aria-invalid="false"
                           class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_vfcxos"
                           disabled=""
-                          id=":r65:"
+                          id=":r6b:"
                           type="checkbox"
                         />
                       </div>
@@ -15946,7 +15988,7 @@ table: [[☃ table 1]]
                       class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy-o_O-disabledLabel_1d65n8m"
                     >
                       <label
-                        for=":r65:"
+                        for=":r6b:"
                       >
                         <div
                           class="default_7zhre1-o_O-inlineStyles_qb00m9"
@@ -15985,7 +16027,7 @@ table: [[☃ table 1]]
                           aria-invalid="false"
                           class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_vfcxos"
                           disabled=""
-                          id=":r66:"
+                          id=":r6c:"
                           type="checkbox"
                         />
                       </div>
@@ -15994,7 +16036,7 @@ table: [[☃ table 1]]
                       class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy-o_O-disabledLabel_1d65n8m"
                     >
                       <label
-                        for=":r66:"
+                        for=":r6c:"
                       >
                         <div
                           class="default_7zhre1-o_O-inlineStyles_qb00m9"
@@ -16033,7 +16075,7 @@ table: [[☃ table 1]]
                           aria-invalid="false"
                           class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_vfcxos"
                           disabled=""
-                          id=":r67:"
+                          id=":r6d:"
                           type="checkbox"
                         />
                       </div>
@@ -16042,7 +16084,7 @@ table: [[☃ table 1]]
                       class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy-o_O-disabledLabel_1d65n8m"
                     >
                       <label
-                        for=":r67:"
+                        for=":r6d:"
                       >
                         <div
                           class="default_7zhre1-o_O-inlineStyles_qb00m9"

--- a/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
@@ -15551,122 +15551,159 @@ table: [[☃ table 1]]
                   <div
                     class="perseus-widget-editor-content enter"
                   >
-                    <div>
-                      <div>
-                         
-                        Correct answer:
-                         
-                        <span
-                          class="svg_1q6jc65-o_O-small_6q1hy-o_O-spacingLeft_wn7g7u-o_O-inlineStyles_zmizzn"
-                          tabindex="0"
-                        />
-                      </div>
-                      <ol
-                        class="default_7zhre1-o_O-cards_18gwzo2"
+                    <div
+                      class="default_7zhre1-o_O-editor_qvunv6"
+                    >
+                      <div
+                        class="default_7zhre1-o_O-section_1d3v9jw"
                       >
-                        <li
-                          class="default_7zhre1"
-                        >
-                          <input
-                            aria-disabled="false"
-                            aria-invalid="false"
-                            aria-label="Card 1"
-                            aria-required="false"
-                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                            id=":r64:"
-                            type="text"
-                            value="1"
-                          />
-                        </li>
-                        <li
-                          class="default_7zhre1"
-                        >
-                          <input
-                            aria-disabled="false"
-                            aria-invalid="false"
-                            aria-label="Card 2"
-                            aria-required="false"
-                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                            id=":r65:"
-                            type="text"
-                            value="2"
-                          />
-                        </li>
-                        <li
-                          class="default_7zhre1"
-                        >
-                          <input
-                            aria-disabled="false"
-                            aria-invalid="false"
-                            aria-label="Card 3"
-                            aria-required="false"
-                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                            id=":r66:"
-                            type="text"
-                            value="3"
-                          />
-                        </li>
-                        <li
-                          class="default_7zhre1"
-                        >
-                          <input
-                            aria-disabled="false"
-                            aria-invalid="false"
-                            aria-label="Card 4"
-                            aria-required="false"
-                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                            id=":r67:"
-                            type="text"
-                            value="4"
-                          />
-                        </li>
-                        <li
-                          class="default_7zhre1"
-                        >
-                          <input
-                            aria-disabled="false"
-                            aria-invalid="false"
-                            aria-label="Card 5"
-                            aria-required="false"
-                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                            id=":r68:"
-                            type="text"
-                            value="5"
-                          />
-                        </li>
-                        <li
-                          class="default_7zhre1"
-                        >
-                          <input
-                            aria-disabled="false"
-                            aria-invalid="false"
-                            aria-label="Add a card"
-                            aria-required="false"
-                            class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
-                            id=":r69:"
-                            type="text"
-                            value=""
-                          />
-                        </li>
-                      </ol>
-                      <div>
-                        <label>
+                        <div>
+                          Correct answer
                            
-                          Layout:
-                           
-                          <select>
-                            <option
-                              value="horizontal"
+                          <span
+                            class="svg_1q6jc65-o_O-small_6q1hy-o_O-spacingLeft_wn7g7u-o_O-inlineStyles_zmizzn"
+                            tabindex="0"
+                          />
+                        </div>
+                        <ol
+                          class="default_7zhre1-o_O-cards_b4wskx"
+                        >
+                          <li
+                            class="default_7zhre1"
+                          >
+                            <input
+                              aria-disabled="false"
+                              aria-invalid="false"
+                              aria-label="Card 1"
+                              aria-required="false"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              id=":r64:"
+                              type="text"
+                              value="1"
+                            />
+                          </li>
+                          <li
+                            class="default_7zhre1"
+                          >
+                            <input
+                              aria-disabled="false"
+                              aria-invalid="false"
+                              aria-label="Card 2"
+                              aria-required="false"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              id=":r65:"
+                              type="text"
+                              value="2"
+                            />
+                          </li>
+                          <li
+                            class="default_7zhre1"
+                          >
+                            <input
+                              aria-disabled="false"
+                              aria-invalid="false"
+                              aria-label="Card 3"
+                              aria-required="false"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              id=":r66:"
+                              type="text"
+                              value="3"
+                            />
+                          </li>
+                          <li
+                            class="default_7zhre1"
+                          >
+                            <input
+                              aria-disabled="false"
+                              aria-invalid="false"
+                              aria-label="Card 4"
+                              aria-required="false"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              id=":r67:"
+                              type="text"
+                              value="4"
+                            />
+                          </li>
+                          <li
+                            class="default_7zhre1"
+                          >
+                            <input
+                              aria-disabled="false"
+                              aria-invalid="false"
+                              aria-label="Card 5"
+                              aria-required="false"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              id=":r68:"
+                              type="text"
+                              value="5"
+                            />
+                          </li>
+                          <li
+                            class="default_7zhre1"
+                          >
+                            <input
+                              aria-disabled="false"
+                              aria-invalid="false"
+                              aria-label="Add a card"
+                              aria-required="false"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              id=":r69:"
+                              type="text"
+                              value=""
+                            />
+                          </li>
+                        </ol>
+                      </div>
+                      <div
+                        class="default_7zhre1"
+                      >
+                        <div
+                          class="default_7zhre1"
+                        >
+                          <div
+                            class="default_7zhre1-o_O-labelContainer_1qlbwdv"
+                          >
+                            <label
+                              class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_qt7cw0-o_O-labelWithNoDescription_i032sc"
+                              for=":r6a:-labeled-field-field"
+                              id=":r6a:-labeled-field-label"
                             >
-                              Horizontal
-                            </option>
-                            <option
-                              value="vertical"
+                              Layout
+                            </label>
+                          </div>
+                          <div
+                            class="default_7zhre1-o_O-menuWrapper_1rs652y"
+                          >
+                            <button
+                              aria-controls=":r6b:"
+                              aria-describedby=""
+                              aria-expanded="false"
+                              aria-haspopup="listbox"
+                              aria-invalid="false"
+                              aria-required="false"
+                              class="button_vr44p2-o_O-shared_1hhaz1q-o_O-default_znuyo8"
+                              id=":r6a:-labeled-field-field"
+                              role="combobox"
+                              type="button"
                             >
-                              Vertical
-                            </option>
-                          </select>
-                        </label>
+                              <span
+                                class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-text_awxjrp"
+                              >
+                                Horizontal
+                              </span>
+                              <span
+                                aria-hidden="true"
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-caret_1e21hpf-o_O-inlineStyles_efsbsa"
+                              />
+                            </button>
+                          </div>
+                          <div
+                            aria-atomic="true"
+                            aria-live="assertive"
+                            class="default_7zhre1-o_O-helperTextWithIcon_1hmzxfl"
+                            id=":r6a:-labeled-field-error"
+                          />
+                        </div>
                         <span
                           class="svg_1q6jc65-o_O-small_6q1hy-o_O-spacingLeft_wn7g7u-o_O-inlineStyles_zmizzn"
                           tabindex="0"
@@ -15692,7 +15729,7 @@ table: [[☃ table 1]]
                                   aria-invalid="false"
                                   checked=""
                                   class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_1ywap6u"
-                                  id=":r6a:"
+                                  id=":r6d:"
                                   type="checkbox"
                                 />
                                 <span
@@ -15704,9 +15741,9 @@ table: [[☃ table 1]]
                               class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy"
                             >
                               <label
-                                for=":r6a:"
+                                for=":r6d:"
                               >
-                                Padding:
+                                Padding
                               </label>
                             </div>
                           </div>
@@ -15979,7 +16016,7 @@ table: [[☃ table 1]]
                           aria-invalid="false"
                           class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_vfcxos"
                           disabled=""
-                          id=":r6b:"
+                          id=":r6e:"
                           type="checkbox"
                         />
                       </div>
@@ -15988,7 +16025,7 @@ table: [[☃ table 1]]
                       class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy-o_O-disabledLabel_1d65n8m"
                     >
                       <label
-                        for=":r6b:"
+                        for=":r6e:"
                       >
                         <div
                           class="default_7zhre1-o_O-inlineStyles_qb00m9"
@@ -16027,7 +16064,7 @@ table: [[☃ table 1]]
                           aria-invalid="false"
                           class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_vfcxos"
                           disabled=""
-                          id=":r6c:"
+                          id=":r6f:"
                           type="checkbox"
                         />
                       </div>
@@ -16036,7 +16073,7 @@ table: [[☃ table 1]]
                       class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy-o_O-disabledLabel_1d65n8m"
                     >
                       <label
-                        for=":r6c:"
+                        for=":r6f:"
                       >
                         <div
                           class="default_7zhre1-o_O-inlineStyles_qb00m9"
@@ -16075,7 +16112,7 @@ table: [[☃ table 1]]
                           aria-invalid="false"
                           class="inputReset_1wxa7bn-o_O-default_xseuv1-o_O-default_vfcxos"
                           disabled=""
-                          id=":r6d:"
+                          id=":r6g:"
                           type="checkbox"
                         />
                       </div>
@@ -16084,7 +16121,7 @@ table: [[☃ table 1]]
                       class="text_f1191h-o_O-BodyText_1xtvlx3-o_O-BodyTextMediumSemiWeight_w58hss-o_O-label_18akocy-o_O-disabledLabel_1d65n8m"
                     >
                       <label
-                        for=":r6d:"
+                        for=":r6g:"
                       >
                         <div
                           class="default_7zhre1-o_O-inlineStyles_qb00m9"

--- a/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
@@ -15569,74 +15569,239 @@ table: [[☃ table 1]]
                           class="default_7zhre1-o_O-cards_b4wskx"
                         >
                           <li
-                            class="default_7zhre1"
+                            class="default_7zhre1-o_O-card_tlw8lk"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 1"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
                               id=":r64:"
                               type="text"
                               value="1"
                             />
+                            <button
+                              aria-disabled="true"
+                              aria-label="Move card 1 up"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1-o_O-disabled_1y1yrlc"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_1w2ke9h"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="false"
+                              aria-label="Move card 1 down"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_514u8y"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="false"
+                              aria-label="Delete card 1"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1ugjna4"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_q5oi6w"
+                              />
+                            </button>
                           </li>
                           <li
-                            class="default_7zhre1"
+                            class="default_7zhre1-o_O-card_tlw8lk"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 2"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
                               id=":r65:"
                               type="text"
                               value="2"
                             />
+                            <button
+                              aria-disabled="false"
+                              aria-label="Move card 2 up"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_1w2ke9h"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="false"
+                              aria-label="Move card 2 down"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_514u8y"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="false"
+                              aria-label="Delete card 2"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1ugjna4"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_q5oi6w"
+                              />
+                            </button>
                           </li>
                           <li
-                            class="default_7zhre1"
+                            class="default_7zhre1-o_O-card_tlw8lk"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 3"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
                               id=":r66:"
                               type="text"
                               value="3"
                             />
+                            <button
+                              aria-disabled="false"
+                              aria-label="Move card 3 up"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_1w2ke9h"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="false"
+                              aria-label="Move card 3 down"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_514u8y"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="false"
+                              aria-label="Delete card 3"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1ugjna4"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_q5oi6w"
+                              />
+                            </button>
                           </li>
                           <li
-                            class="default_7zhre1"
+                            class="default_7zhre1-o_O-card_tlw8lk"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 4"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
                               id=":r67:"
                               type="text"
                               value="4"
                             />
+                            <button
+                              aria-disabled="false"
+                              aria-label="Move card 4 up"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_1w2ke9h"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="false"
+                              aria-label="Move card 4 down"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_514u8y"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="false"
+                              aria-label="Delete card 4"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1ugjna4"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_q5oi6w"
+                              />
+                            </button>
                           </li>
                           <li
-                            class="default_7zhre1"
+                            class="default_7zhre1-o_O-card_tlw8lk"
                           >
                             <input
                               aria-disabled="false"
                               aria-invalid="false"
                               aria-label="Card 5"
                               aria-required="false"
-                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b"
+                              class="input_ttwki7-o_O-BodyTextMediumMediumWeight_ijclyr-o_O-default_j8cf2b-o_O-cardInput_t0tx82"
                               id=":r68:"
                               type="text"
                               value="5"
                             />
+                            <button
+                              aria-disabled="false"
+                              aria-label="Move card 5 up"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_1w2ke9h"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="true"
+                              aria-label="Move card 5 down"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1lwuax1-o_O-disabled_1y1yrlc"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_514u8y"
+                              />
+                            </button>
+                            <button
+                              aria-disabled="false"
+                              aria-label="Delete card 5"
+                              class="button_vr44p2-o_O-shared_3mvh93-o_O-default_1ugjna4"
+                              data-kind="tertiary"
+                              type="button"
+                            >
+                              <span
+                                class="svg_1q6jc65-o_O-small_6q1hy-o_O-inlineStyles_q5oi6w"
+                              />
+                            </button>
                           </li>
                         </ol>
                         <button

--- a/packages/perseus-editor/src/widgets/sorter-editor/card-editor.module.css
+++ b/packages/perseus-editor/src/widgets/sorter-editor/card-editor.module.css
@@ -1,0 +1,9 @@
+/* TODO(LEMS-3686): Remove the !important once Wonder Blocks is in the shared layer. */
+
+/* A card's text sits on one line with the controls that reorder and remove it,
+   so the controls stay next to the card they act on. */
+.card {
+    flex-direction: row !important;
+    align-items: center !important;
+    gap: var(--wb-sizing-size_040) !important;
+}

--- a/packages/perseus-editor/src/widgets/sorter-editor/card-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/card-editor.test.tsx
@@ -1,0 +1,154 @@
+import {render, screen} from "@testing-library/react";
+import {userEvent as userEventLib} from "@testing-library/user-event";
+import * as React from "react";
+
+import CardEditor from "./card-editor";
+
+import type {UserEvent} from "@testing-library/user-event";
+
+type Props = React.ComponentProps<typeof CardEditor>;
+
+/**
+ * Renders a card inside a list, since the card is a list item. Anything a test
+ * asserts on should be passed in explicitly rather than left to these
+ * placeholder values.
+ */
+function renderCard(props: Partial<Props> = {}) {
+    render(
+        <ol>
+            <CardEditor
+                index={0}
+                value="Cat"
+                isFirst={false}
+                isLast={false}
+                onChange={() => {}}
+                onMoveUp={() => {}}
+                onMoveDown={() => {}}
+                onDelete={() => {}}
+                {...props}
+            />
+        </ol>,
+    );
+}
+
+describe("card-editor", () => {
+    let userEvent: UserEvent;
+    beforeEach(() => {
+        userEvent = userEventLib.setup({
+            advanceTimers: jest.advanceTimersByTime,
+        });
+    });
+
+    it("renders the card's text", () => {
+        // Arrange, Act
+        renderCard({value: "Cat"});
+
+        // Assert
+        expect(screen.getByRole("textbox")).toHaveValue("Cat");
+    });
+
+    it("names the input and its controls after the card's position", () => {
+        // Arrange, Act
+        renderCard({index: 1});
+
+        // Assert: the index is zero-based, but authors count from one.
+        expect(screen.getByRole("textbox")).toHaveAccessibleName("Card 2");
+        expect(
+            screen.getByRole("button", {name: "Move card 2 up"}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Move card 2 down"}),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", {name: "Delete card 2"}),
+        ).toBeInTheDocument();
+    });
+
+    it("calls onChange with the edited text", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        renderCard({value: "Cat", onChange: onChangeMock});
+
+        // Act
+        await userEvent.type(screen.getByRole("textbox"), "s");
+
+        // Assert
+        expect(onChangeMock).toHaveBeenCalledWith("Cats");
+    });
+
+    it("calls onMoveUp when move up is clicked", async () => {
+        // Arrange
+        const onMoveUpMock = jest.fn();
+        renderCard({index: 1, onMoveUp: onMoveUpMock});
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("button", {name: "Move card 2 up"}),
+        );
+
+        // Assert
+        expect(onMoveUpMock).toHaveBeenCalled();
+    });
+
+    it("calls onMoveDown when move down is clicked", async () => {
+        // Arrange
+        const onMoveDownMock = jest.fn();
+        renderCard({index: 1, onMoveDown: onMoveDownMock});
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("button", {name: "Move card 2 down"}),
+        );
+
+        // Assert
+        expect(onMoveDownMock).toHaveBeenCalled();
+    });
+
+    it("calls onDelete when delete is clicked", async () => {
+        // Arrange
+        const onDeleteMock = jest.fn();
+        renderCard({index: 1, onDelete: onDeleteMock});
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("button", {name: "Delete card 2"}),
+        );
+
+        // Assert
+        expect(onDeleteMock).toHaveBeenCalled();
+    });
+
+    it("disables move up for the first card", () => {
+        // Arrange, Act
+        renderCard({index: 0, isFirst: true});
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Move card 1 up"}),
+        ).toHaveAttribute("aria-disabled", "true");
+    });
+
+    it("disables move down for the last card", () => {
+        // Arrange, Act
+        renderCard({index: 0, isLast: true});
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Move card 1 down"}),
+        ).toHaveAttribute("aria-disabled", "true");
+    });
+
+    it("does not call onMoveUp when the first card's move up is clicked", async () => {
+        // Arrange
+        const onMoveUpMock = jest.fn();
+        renderCard({index: 0, isFirst: true, onMoveUp: onMoveUpMock});
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("button", {name: "Move card 1 up"}),
+        );
+
+        // Assert
+        expect(onMoveUpMock).not.toHaveBeenCalled();
+    });
+});

--- a/packages/perseus-editor/src/widgets/sorter-editor/card-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/card-editor.test.tsx
@@ -137,18 +137,4 @@ describe("card-editor", () => {
             screen.getByRole("button", {name: "Move card 1 down"}),
         ).toHaveAttribute("aria-disabled", "true");
     });
-
-    it("does not call onMoveUp when the first card's move up is clicked", async () => {
-        // Arrange
-        const onMoveUpMock = jest.fn();
-        renderCard({index: 0, isFirst: true, onMoveUp: onMoveUpMock});
-
-        // Act
-        await userEvent.click(
-            screen.getByRole("button", {name: "Move card 1 up"}),
-        );
-
-        // Assert
-        expect(onMoveUpMock).not.toHaveBeenCalled();
-    });
 });

--- a/packages/perseus-editor/src/widgets/sorter-editor/card-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/card-editor.tsx
@@ -49,12 +49,6 @@ function CardEditor({
 
     return (
         <View tag="li" className={styles.card}>
-            {/*
-             * The cards have no visible label, but screen reader users still
-             * need each input to have a distinguishable name, hence the
-             * aria-label. The card's controls are named the same way so it's
-             * clear which card each one acts on.
-             */}
             <TextField
                 aria-label={`Card ${cardNumber}`}
                 value={value}

--- a/packages/perseus-editor/src/widgets/sorter-editor/card-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/card-editor.tsx
@@ -11,13 +11,10 @@ import styles from "./card-editor.module.css";
 import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 // Passed to TextField's `style` prop, which is typed as Wonder Blocks
-// `StyleType` and does not accept a CSS-module className. Lets the text take
-// the space the controls don't need.
+// `StyleType` and does not accept a CSS-module className.
 const cardInputStyle: StyleType = {flexGrow: 1};
 
 type Props = {
-    // Zero-based, but the cards are numbered from one in their labels so the
-    // numbering matches what the author sees.
     index: number;
     value: string;
     isFirst: boolean;
@@ -29,8 +26,7 @@ type Props = {
 };
 
 /**
- * An editor for a single sorter card: its text, plus the controls that move it
- * within the answer or remove it.
+ * An editor for a single sorter card
  *
  * Renders as a list item, so it belongs inside the sorter editor's list of
  * cards.

--- a/packages/perseus-editor/src/widgets/sorter-editor/card-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/card-editor.tsx
@@ -1,0 +1,101 @@
+import {View} from "@khanacademy/wonder-blocks-core";
+import {TextField} from "@khanacademy/wonder-blocks-form";
+import IconButton from "@khanacademy/wonder-blocks-icon-button";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import arrowDown from "@phosphor-icons/core/regular/arrow-down.svg";
+import arrowUp from "@phosphor-icons/core/regular/arrow-up.svg";
+import trash from "@phosphor-icons/core/regular/trash.svg";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+
+type Props = {
+    // Zero-based, but the cards are numbered from one in their labels so the
+    // numbering matches what the author sees.
+    index: number;
+    value: string;
+    isFirst: boolean;
+    isLast: boolean;
+    onChange: (value: string) => void;
+    onMoveUp: () => void;
+    onMoveDown: () => void;
+    onDelete: () => void;
+};
+
+/**
+ * An editor for a single sorter card: its text, plus the controls that move it
+ * within the answer or remove it.
+ *
+ * Renders as a list item, so it belongs inside the sorter editor's list of
+ * cards.
+ */
+function CardEditor({
+    index,
+    value,
+    isFirst,
+    isLast,
+    onChange,
+    onMoveUp,
+    onMoveDown,
+    onDelete,
+}: Props) {
+    const cardNumber = index + 1;
+
+    return (
+        <View tag="li" style={styles.card}>
+            {/*
+             * The cards have no visible label, but screen reader users still
+             * need each input to have a distinguishable name, hence the
+             * aria-label. The card's controls are named the same way so it's
+             * clear which card each one acts on.
+             */}
+            <TextField
+                aria-label={`Card ${cardNumber}`}
+                value={value}
+                onChange={onChange}
+                style={styles.cardInput}
+            />
+            <IconButton
+                aria-label={`Move card ${cardNumber} up`}
+                icon={arrowUp}
+                kind="tertiary"
+                actionType="neutral"
+                size="small"
+                disabled={isFirst}
+                onClick={onMoveUp}
+            />
+            <IconButton
+                aria-label={`Move card ${cardNumber} down`}
+                icon={arrowDown}
+                kind="tertiary"
+                actionType="neutral"
+                size="small"
+                disabled={isLast}
+                onClick={onMoveDown}
+            />
+            <IconButton
+                aria-label={`Delete card ${cardNumber}`}
+                icon={trash}
+                kind="tertiary"
+                actionType="destructive"
+                size="small"
+                onClick={onDelete}
+            />
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    // A card's text sits on one line with the controls that reorder and remove
+    // it, so the controls stay next to the card they act on.
+    card: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: sizing.size_040,
+    },
+    // Let the text take the space the controls don't need.
+    cardInput: {
+        flexGrow: 1,
+    },
+});
+
+export default CardEditor;

--- a/packages/perseus-editor/src/widgets/sorter-editor/card-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/card-editor.tsx
@@ -1,12 +1,19 @@
 import {View} from "@khanacademy/wonder-blocks-core";
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import arrowDown from "@phosphor-icons/core/regular/arrow-down.svg";
 import arrowUp from "@phosphor-icons/core/regular/arrow-up.svg";
 import trash from "@phosphor-icons/core/regular/trash.svg";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
+
+import styles from "./card-editor.module.css";
+
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
+
+// Passed to TextField's `style` prop, which is typed as Wonder Blocks
+// `StyleType` and does not accept a CSS-module className. Lets the text take
+// the space the controls don't need.
+const cardInputStyle: StyleType = {flexGrow: 1};
 
 type Props = {
     // Zero-based, but the cards are numbered from one in their labels so the
@@ -41,7 +48,7 @@ function CardEditor({
     const cardNumber = index + 1;
 
     return (
-        <View tag="li" style={styles.card}>
+        <View tag="li" className={styles.card}>
             {/*
              * The cards have no visible label, but screen reader users still
              * need each input to have a distinguishable name, hence the
@@ -52,7 +59,7 @@ function CardEditor({
                 aria-label={`Card ${cardNumber}`}
                 value={value}
                 onChange={onChange}
-                style={styles.cardInput}
+                style={cardInputStyle}
             />
             <IconButton
                 aria-label={`Move card ${cardNumber} up`}
@@ -83,19 +90,5 @@ function CardEditor({
         </View>
     );
 }
-
-const styles = StyleSheet.create({
-    // A card's text sits on one line with the controls that reorder and remove
-    // it, so the controls stay next to the card they act on.
-    card: {
-        flexDirection: "row",
-        alignItems: "center",
-        gap: sizing.size_040,
-    },
-    // Let the text take the space the controls don't need.
-    cardInput: {
-        flexGrow: 1,
-    },
-});
 
 export default CardEditor;

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.module.css
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.module.css
@@ -1,0 +1,29 @@
+/* TODO(LEMS-3686): Remove the !important once Wonder Blocks is in the shared layer. */
+
+/* Separates the three sections (cards, layout, padding) from each other. */
+.editor {
+    gap: var(--wb-sizing-size_240) !important;
+}
+
+/* Separates a section's label from the control it describes. Smaller than the
+   gap between sections so each label groups with its own control. */
+.section {
+    gap: var(--wb-sizing-size_080) !important;
+}
+
+/* The cards always stack in the editor, regardless of the `layout` option,
+   which only controls how the widget renders for students. */
+.cards {
+    list-style: none !important;
+    padding-inline-start: 0 !important;
+    /* Drop the browser's default list margins; `section` and `editor` above
+       own the spacing around the list. */
+    margin-block: 0 !important;
+    gap: var(--wb-sizing-size_120) !important;
+}
+
+/* Keep the button hugging its label rather than stretching to the width of the
+   cards above it. */
+.add-card {
+    align-self: flex-start !important;
+}

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.stories.tsx
@@ -1,7 +1,10 @@
+import {sorterLogic} from "@khanacademy/perseus-core";
+import * as React from "react";
 import {action} from "storybook/actions";
 
 import SorterEditor from "./sorter-editor";
 
+import type {PerseusSorterWidgetOptions} from "@khanacademy/perseus-core";
 import type {Meta, StoryObj} from "@storybook/react-vite";
 
 const meta: Meta = {
@@ -11,9 +14,28 @@ const meta: Meta = {
 } satisfies Meta<typeof SorterEditor>;
 export default meta;
 
+/**
+ * Holds the widget options in state so the editor behaves the way it does in
+ * the real content editor, where edits are round-tripped back in as props.
+ */
+const InteractiveSorterEditor = () => {
+    const [options, setOptions] = React.useState<PerseusSorterWidgetOptions>(
+        sorterLogic.defaultWidgetOptions,
+    );
+
+    const onChange = (
+        newOptions: Partial<PerseusSorterWidgetOptions>,
+        callback?: () => void,
+    ) => {
+        action("onChange")(newOptions);
+        setOptions((prevOptions) => ({...prevOptions, ...newOptions}));
+        callback?.();
+    };
+
+    return <SorterEditor {...options} onChange={onChange} />;
+};
+
 type Story = StoryObj<typeof meta>;
 export const Default: Story = {
-    args: {
-        onChange: action("onChange"),
-    },
+    render: () => <InteractiveSorterEditor />,
 };

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.stories.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.stories.tsx
@@ -14,22 +14,14 @@ const meta: Meta = {
 } satisfies Meta<typeof SorterEditor>;
 export default meta;
 
-/**
- * Holds the widget options in state so the editor behaves the way it does in
- * the real content editor, where edits are round-tripped back in as props.
- */
 const InteractiveSorterEditor = () => {
     const [options, setOptions] = React.useState<PerseusSorterWidgetOptions>(
         sorterLogic.defaultWidgetOptions,
     );
 
-    const onChange = (
-        newOptions: Partial<PerseusSorterWidgetOptions>,
-        callback?: () => void,
-    ) => {
+    const onChange = (newOptions: Partial<PerseusSorterWidgetOptions>) => {
         action("onChange")(newOptions);
         setOptions((prevOptions) => ({...prevOptions, ...newOptions}));
-        callback?.();
     };
 
     return <SorterEditor {...options} onChange={onChange} />;

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
@@ -8,7 +8,34 @@ import {testDependencies} from "../../testing/test-dependencies";
 
 import SorterEditor from "./sorter-editor";
 
+import type {PerseusSorterWidgetOptions} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
+
+/**
+ * Renders the editor the way the content editor does: every change is fed back
+ * in as props. Tests that make more than one edit, or that depend on the editor
+ * re-rendering, need this rather than a bare `render`.
+ */
+function renderControlled(
+    options: PerseusSorterWidgetOptions,
+    onChange?: (newOptions: Partial<PerseusSorterWidgetOptions>) => void,
+) {
+    function Controlled() {
+        const [currentOptions, setCurrentOptions] = React.useState(options);
+
+        return (
+            <SorterEditor
+                {...currentOptions}
+                onChange={(newOptions) => {
+                    onChange?.(newOptions);
+                    setCurrentOptions((prev) => ({...prev, ...newOptions}));
+                }}
+            />
+        );
+    }
+
+    return render(<Controlled />);
+}
 
 describe("sorter-editor", () => {
     let userEvent: UserEvent;
@@ -92,11 +119,9 @@ describe("sorter-editor", () => {
     it("calls onChange with the updated correct answer when a card is edited", async () => {
         // Arrange
         const onChangeMock = jest.fn();
-        render(
-            <SorterEditor
-                onChange={onChangeMock}
-                {...generateSorterOptions({correct: ["Cat", "Dog"]})}
-            />,
+        renderControlled(
+            generateSorterOptions({correct: ["Cat", "Dog"]}),
+            onChangeMock,
         );
 
         // Act
@@ -108,6 +133,49 @@ describe("sorter-editor", () => {
         expect(onChangeMock).toHaveBeenLastCalledWith({
             correct: ["Cat", "Emu"],
         });
+    });
+
+    it("calls onChange with an empty card appended when the add button is clicked", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <SorterEditor
+                onChange={onChangeMock}
+                {...generateSorterOptions({correct: ["Cat", "Dog"]})}
+            />,
+        );
+
+        // Act
+        await userEvent.click(screen.getByRole("button", {name: "Add a card"}));
+
+        // Assert
+        expect(onChangeMock).toHaveBeenCalledWith({
+            correct: ["Cat", "Dog", ""],
+        });
+    });
+
+    it("focuses the new card's input after a card is added", async () => {
+        // Arrange
+        renderControlled(generateSorterOptions({correct: ["Cat", "Dog"]}));
+
+        // Act
+        await userEvent.click(screen.getByRole("button", {name: "Add a card"}));
+
+        // Assert
+        expect(screen.getByRole("textbox", {name: "Card 3"})).toHaveFocus();
+    });
+
+    it("does not render an empty card until one is added", () => {
+        // Arrange, Act
+        render(
+            <SorterEditor
+                onChange={() => {}}
+                {...generateSorterOptions({correct: ["Cat", "Dog"]})}
+            />,
+        );
+
+        // Assert
+        expect(screen.getAllByRole("textbox")).toHaveLength(2);
     });
 
     it("serializes the correct answer, layout, and padding", () => {

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
@@ -536,4 +536,94 @@ describe("sorter-editor", () => {
         expect(screen.getByDisplayValue("$y$")).toBeInTheDocument();
         expect(screen.getByDisplayValue("$z$")).toBeInTheDocument();
     });
+
+    describe("getSaveWarnings", () => {
+        function renderForWarnings(correct: string[]) {
+            const editorRef = React.createRef<SorterEditorHandle>();
+            renderControlled(
+                generateSorterOptions({correct}),
+                undefined,
+                editorRef,
+            );
+            return editorRef;
+        }
+
+        it("returns no warnings when every card has text", () => {
+            // Arrange, Act
+            const editorRef = renderForWarnings(["Cat", "Dog"]);
+
+            // Assert
+            expect(editorRef.current?.getSaveWarnings()).toEqual([]);
+        });
+
+        it("warns when a card is blank", () => {
+            // Arrange, Act
+            const editorRef = renderForWarnings(["Cat", ""]);
+
+            // Assert
+            expect(editorRef.current?.getSaveWarnings()).toEqual([
+                "Sorter cards cannot be blank.",
+            ]);
+        });
+
+        it("warns when a card holds only whitespace", () => {
+            // Arrange, Act
+            const editorRef = renderForWarnings(["Cat", "   "]);
+
+            // Assert
+            expect(editorRef.current?.getSaveWarnings()).toEqual([
+                "Sorter cards cannot be blank.",
+            ]);
+        });
+
+        it("warns when there are fewer than two cards", () => {
+            // Arrange, Act
+            const editorRef = renderForWarnings(["Cat"]);
+
+            // Assert
+            expect(editorRef.current?.getSaveWarnings()).toEqual([
+                "Sorter requires at least 2 cards.",
+            ]);
+        });
+
+        it("warns when every card has been deleted", () => {
+            // Arrange, Act
+            const editorRef = renderForWarnings([]);
+
+            // Assert
+            expect(editorRef.current?.getSaveWarnings()).toEqual([
+                "Sorter requires at least 2 cards.",
+            ]);
+        });
+
+        // The warnings have to reflect the edit in progress, the same way
+        // `serialize` does — WidgetEditor asks for both mid-edit.
+        it("warns about a card the author has just cleared", async () => {
+            // Arrange
+            const editorRef = renderForWarnings(["Cat", "Dog"]);
+
+            // Act
+            await userEvent.clear(screen.getByDisplayValue("Dog"));
+
+            // Assert
+            expect(editorRef.current?.getSaveWarnings()).toEqual([
+                "Sorter cards cannot be blank.",
+            ]);
+        });
+
+        it("warns about a newly added card before it has text", async () => {
+            // Arrange
+            const editorRef = renderForWarnings(["Cat", "Dog"]);
+
+            // Act
+            await userEvent.click(
+                screen.getByRole("button", {name: "Add a card"}),
+            );
+
+            // Assert
+            expect(editorRef.current?.getSaveWarnings()).toEqual([
+                "Sorter cards cannot be blank.",
+            ]);
+        });
+    });
 });

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
@@ -178,6 +178,157 @@ describe("sorter-editor", () => {
         expect(screen.getAllByRole("textbox")).toHaveLength(2);
     });
 
+    it("swaps a card with the one above it when move up is clicked", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <SorterEditor
+                onChange={onChangeMock}
+                {...generateSorterOptions({correct: ["Cat", "Dog", "Emu"]})}
+            />,
+        );
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("button", {name: "Move card 3 up"}),
+        );
+
+        // Assert
+        expect(onChangeMock).toHaveBeenCalledWith({
+            correct: ["Cat", "Emu", "Dog"],
+        });
+    });
+
+    it("swaps a card with the one below it when move down is clicked", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <SorterEditor
+                onChange={onChangeMock}
+                {...generateSorterOptions({correct: ["Cat", "Dog", "Emu"]})}
+            />,
+        );
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("button", {name: "Move card 1 down"}),
+        );
+
+        // Assert
+        expect(onChangeMock).toHaveBeenCalledWith({
+            correct: ["Dog", "Cat", "Emu"],
+        });
+    });
+
+    it("disables move up on the first card and move down on the last card", () => {
+        // Arrange, Act
+        render(
+            <SorterEditor
+                onChange={() => {}}
+                {...generateSorterOptions({correct: ["Cat", "Dog", "Emu"]})}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Move card 1 up"}),
+        ).toHaveAttribute("aria-disabled", "true");
+        expect(
+            screen.getByRole("button", {name: "Move card 3 down"}),
+        ).toHaveAttribute("aria-disabled", "true");
+        expect(
+            screen.getByRole("button", {name: "Move card 1 down"}),
+        ).toHaveAttribute("aria-disabled", "false");
+        expect(
+            screen.getByRole("button", {name: "Move card 3 up"}),
+        ).toHaveAttribute("aria-disabled", "false");
+    });
+
+    it("keeps focus on the moved card so it can be moved again", async () => {
+        // Arrange
+        renderControlled(
+            generateSorterOptions({correct: ["Cat", "Dog", "Emu"]}),
+        );
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("button", {name: "Move card 3 up"}),
+        );
+
+        // Assert: "Emu" is now the second card, so its own move up button is
+        // the one that should have focus.
+        expect(screen.getByDisplayValue("Emu")).toHaveAccessibleName("Card 2");
+        expect(
+            screen.getByRole("button", {name: "Move card 2 up"}),
+        ).toHaveFocus();
+    });
+
+    it("removes a card when its delete button is clicked", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <SorterEditor
+                onChange={onChangeMock}
+                {...generateSorterOptions({correct: ["Cat", "Dog", "Emu"]})}
+            />,
+        );
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("button", {name: "Delete card 2"}),
+        );
+
+        // Assert
+        expect(onChangeMock).toHaveBeenCalledWith({correct: ["Cat", "Emu"]});
+    });
+
+    it("focuses the card that takes the deleted card's place", async () => {
+        // Arrange
+        renderControlled(
+            generateSorterOptions({correct: ["Cat", "Dog", "Emu"]}),
+        );
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("button", {name: "Delete card 2"}),
+        );
+
+        // Assert: "Emu" moved up into the deleted card's slot.
+        expect(screen.getByDisplayValue("Emu")).toHaveAccessibleName("Card 2");
+        expect(
+            screen.getByRole("button", {name: "Delete card 2"}),
+        ).toHaveFocus();
+    });
+
+    it("focuses the last remaining card when the last card is deleted", async () => {
+        // Arrange
+        renderControlled(generateSorterOptions({correct: ["Cat", "Dog"]}));
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("button", {name: "Delete card 2"}),
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Delete card 1"}),
+        ).toHaveFocus();
+    });
+
+    it("focuses the add button when the only card is deleted", async () => {
+        // Arrange
+        renderControlled(generateSorterOptions({correct: ["Cat"]}));
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("button", {name: "Delete card 1"}),
+        );
+
+        // Assert
+        expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+        expect(screen.getByRole("button", {name: "Add a card"})).toHaveFocus();
+    });
+
     it("serializes the correct answer, layout, and padding", () => {
         // Arrange
         const editorRef = React.createRef<SorterEditor>();

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
@@ -314,19 +314,6 @@ describe("sorter-editor", () => {
         });
     });
 
-    it("does not render an empty card until one is added", () => {
-        // Arrange, Act
-        render(
-            <SorterEditor
-                onChange={() => {}}
-                {...generateSorterOptions({correct: ["Cat", "Dog"]})}
-            />,
-        );
-
-        // Assert
-        expect(screen.getAllByRole("textbox")).toHaveLength(2);
-    });
-
     it("swaps a card with the one above it when move up is clicked", async () => {
         // Arrange
         const onChangeMock = jest.fn();

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
@@ -1,5 +1,5 @@
 import {Dependencies} from "@khanacademy/perseus";
-import {generateSorterOptions} from "@khanacademy/perseus-core";
+import {generateSorterOptions, sorterLogic} from "@khanacademy/perseus-core";
 import {render, screen} from "@testing-library/react";
 import {userEvent as userEventLib} from "@testing-library/user-event";
 import * as React from "react";
@@ -12,6 +12,14 @@ import type {PerseusSorterWidgetOptions} from "@khanacademy/perseus-core";
 import type {UserEvent} from "@testing-library/user-event";
 
 /**
+ * WidgetEditor holds the editor by ref and calls `serialize()` on it, so that
+ * handle is part of the editor's contract with the rest of the system. Deriving
+ * the type from the component keeps these tests tied to the contract rather than
+ * to how the component happens to be written.
+ */
+type SorterEditorHandle = React.ElementRef<typeof SorterEditor>;
+
+/**
  * Renders the editor the way the content editor does: every change is fed back
  * in as props. Tests that make more than one edit, or that depend on the editor
  * re-rendering, need this rather than a bare `render`.
@@ -19,12 +27,14 @@ import type {UserEvent} from "@testing-library/user-event";
 function renderControlled(
     options: PerseusSorterWidgetOptions,
     onChange?: (newOptions: Partial<PerseusSorterWidgetOptions>) => void,
+    ref?: React.Ref<SorterEditorHandle>,
 ) {
     function Controlled() {
         const [currentOptions, setCurrentOptions] = React.useState(options);
 
         return (
             <SorterEditor
+                ref={ref}
                 {...currentOptions}
                 onChange={(newOptions) => {
                     onChange?.(newOptions);
@@ -272,7 +282,7 @@ describe("sorter-editor", () => {
 
         it("serializes all of the cards, including the ones past the limit", () => {
             // Arrange
-            const editorRef = React.createRef<SorterEditor>();
+            const editorRef = React.createRef<SorterEditorHandle>();
             render(
                 <SorterEditor
                     ref={editorRef}
@@ -432,7 +442,7 @@ describe("sorter-editor", () => {
 
     it("serializes the correct answer, layout, and padding", () => {
         // Arrange
-        const editorRef = React.createRef<SorterEditor>();
+        const editorRef = React.createRef<SorterEditorHandle>();
         render(
             <SorterEditor
                 ref={editorRef}
@@ -454,5 +464,76 @@ describe("sorter-editor", () => {
             layout: "vertical",
             padding: false,
         });
+    });
+
+    // WidgetEditor serializes the editor *during* an edit, to fold the editor's
+    // current options into the change it's about to publish. A handle that
+    // captured the props it was created with would serialize pre-edit options
+    // and quietly revert the author's work, so serializing has to see the props
+    // from the latest render, not the first one.
+    it("serializes card edits made after the first render", async () => {
+        // Arrange
+        const editorRef = React.createRef<SorterEditorHandle>();
+        renderControlled(
+            generateSorterOptions({correct: ["Cat", "Dog"]}),
+            undefined,
+            editorRef,
+        );
+
+        // Act
+        const card = screen.getByDisplayValue("Dog");
+        await userEvent.clear(card);
+        await userEvent.type(card, "Emu");
+
+        // Assert
+        expect(editorRef.current?.serialize()).toMatchObject({
+            correct: ["Cat", "Emu"],
+        });
+    });
+
+    it("serializes layout changes made after the first render", async () => {
+        // Arrange
+        const editorRef = React.createRef<SorterEditorHandle>();
+        renderControlled(
+            generateSorterOptions({layout: "horizontal"}),
+            undefined,
+            editorRef,
+        );
+
+        // Act
+        await userEvent.click(screen.getByRole("combobox", {name: "Layout"}));
+        await userEvent.click(screen.getByRole("option", {name: "Vertical"}));
+
+        // Assert
+        expect(editorRef.current?.serialize()).toMatchObject({
+            layout: "vertical",
+        });
+    });
+
+    // The editor is registered by its widget name (Widgets.registerEditors
+    // throws without one) and the editor page reads its default options to seed
+    // a newly inserted sorter. Both are read off the component itself, so
+    // they're part of its public surface, not implementation detail.
+    it("exposes the widget name it is registered under", () => {
+        // Arrange, Act, Assert
+        expect(SorterEditor.widgetName).toBe("sorter");
+    });
+
+    it("exposes the default widget options a new sorter starts with", () => {
+        // Arrange, Act, Assert
+        expect(SorterEditor.defaultProps).toEqual(
+            sorterLogic.defaultWidgetOptions,
+        );
+    });
+
+    it("renders the default cards when no options are given", () => {
+        // Arrange, Act
+        render(<SorterEditor onChange={() => {}} />);
+
+        // Assert
+        expect(screen.getAllByRole("textbox")).toHaveLength(3);
+        expect(screen.getByDisplayValue("$x$")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("$y$")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("$z$")).toBeInTheDocument();
     });
 });

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
@@ -154,17 +154,6 @@ describe("sorter-editor", () => {
         });
     });
 
-    it("focuses the new card's input after a card is added", async () => {
-        // Arrange
-        renderControlled(generateSorterOptions({correct: ["Cat", "Dog"]}));
-
-        // Act
-        await userEvent.click(screen.getByRole("button", {name: "Add a card"}));
-
-        // Assert
-        expect(screen.getByRole("textbox", {name: "Card 3"})).toHaveFocus();
-    });
-
     it("does not render an empty card until one is added", () => {
         // Arrange, Act
         render(
@@ -244,25 +233,6 @@ describe("sorter-editor", () => {
         ).toHaveAttribute("aria-disabled", "false");
     });
 
-    it("keeps focus on the moved card so it can be moved again", async () => {
-        // Arrange
-        renderControlled(
-            generateSorterOptions({correct: ["Cat", "Dog", "Emu"]}),
-        );
-
-        // Act
-        await userEvent.click(
-            screen.getByRole("button", {name: "Move card 3 up"}),
-        );
-
-        // Assert: "Emu" is now the second card, so its own move up button is
-        // the one that should have focus.
-        expect(screen.getByDisplayValue("Emu")).toHaveAccessibleName("Card 2");
-        expect(
-            screen.getByRole("button", {name: "Move card 2 up"}),
-        ).toHaveFocus();
-    });
-
     it("removes a card when its delete button is clicked", async () => {
         // Arrange
         const onChangeMock = jest.fn();
@@ -282,7 +252,20 @@ describe("sorter-editor", () => {
         expect(onChangeMock).toHaveBeenCalledWith({correct: ["Cat", "Emu"]});
     });
 
-    it("focuses the card that takes the deleted card's place", async () => {
+    it("renders no cards once the last one is deleted", async () => {
+        // Arrange
+        renderControlled(generateSorterOptions({correct: ["Cat"]}));
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("button", {name: "Delete card 1"}),
+        );
+
+        // Assert
+        expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    });
+
+    it("renumbers the remaining cards after one is deleted", async () => {
         // Arrange
         renderControlled(
             generateSorterOptions({correct: ["Cat", "Dog", "Emu"]}),
@@ -295,38 +278,6 @@ describe("sorter-editor", () => {
 
         // Assert: "Emu" moved up into the deleted card's slot.
         expect(screen.getByDisplayValue("Emu")).toHaveAccessibleName("Card 2");
-        expect(
-            screen.getByRole("button", {name: "Delete card 2"}),
-        ).toHaveFocus();
-    });
-
-    it("focuses the last remaining card when the last card is deleted", async () => {
-        // Arrange
-        renderControlled(generateSorterOptions({correct: ["Cat", "Dog"]}));
-
-        // Act
-        await userEvent.click(
-            screen.getByRole("button", {name: "Delete card 2"}),
-        );
-
-        // Assert
-        expect(
-            screen.getByRole("button", {name: "Delete card 1"}),
-        ).toHaveFocus();
-    });
-
-    it("focuses the add button when the only card is deleted", async () => {
-        // Arrange
-        renderControlled(generateSorterOptions({correct: ["Cat"]}));
-
-        // Act
-        await userEvent.click(
-            screen.getByRole("button", {name: "Delete card 1"}),
-        );
-
-        // Assert
-        expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
-        expect(screen.getByRole("button", {name: "Add a card"})).toHaveFocus();
     });
 
     it("serializes the correct answer, layout, and padding", () => {

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
@@ -154,6 +154,59 @@ describe("sorter-editor", () => {
         });
     });
 
+    it("disables the add button once there are ten cards", () => {
+        // Arrange, Act
+        render(
+            <SorterEditor
+                onChange={() => {}}
+                {...generateSorterOptions({
+                    correct: Array.from({length: 10}, (_, i) => `Card ${i}`),
+                })}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Add a card"}),
+        ).toHaveAttribute("aria-disabled", "true");
+    });
+
+    it("does not add an eleventh card when the add button is clicked", async () => {
+        // Arrange
+        const onChangeMock = jest.fn();
+        render(
+            <SorterEditor
+                onChange={onChangeMock}
+                {...generateSorterOptions({
+                    correct: Array.from({length: 10}, (_, i) => `Card ${i}`),
+                })}
+            />,
+        );
+
+        // Act
+        await userEvent.click(screen.getByRole("button", {name: "Add a card"}));
+
+        // Assert
+        expect(onChangeMock).not.toHaveBeenCalled();
+    });
+
+    it("keeps the add button enabled below ten cards", () => {
+        // Arrange, Act
+        render(
+            <SorterEditor
+                onChange={() => {}}
+                {...generateSorterOptions({
+                    correct: Array.from({length: 9}, (_, i) => `Card ${i}`),
+                })}
+            />,
+        );
+
+        // Assert
+        expect(
+            screen.getByRole("button", {name: "Add a card"}),
+        ).toHaveAttribute("aria-disabled", "false");
+    });
+
     it("does not render an empty card until one is added", () => {
         // Arrange, Act
         render(

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
@@ -207,6 +207,103 @@ describe("sorter-editor", () => {
         ).toHaveAttribute("aria-disabled", "false");
     });
 
+    // Content authored before the ten-card cap can have more cards than the
+    // editor now lets you add. The cap only blocks growth: those cards must
+    // still be visible and editable, and the extras must not be dropped.
+    describe("existing content over the ten-card limit", () => {
+        const fifteenCards = Array.from(
+            {length: 15},
+            (_, i) => `Item ${i + 1}`,
+        );
+
+        it("renders an input for every card", () => {
+            // Arrange, Act
+            render(
+                <SorterEditor
+                    onChange={() => {}}
+                    {...generateSorterOptions({correct: fifteenCards})}
+                />,
+            );
+
+            // Assert
+            expect(screen.getAllByRole("textbox")).toHaveLength(15);
+            expect(screen.getByDisplayValue("Item 15")).toBeInTheDocument();
+        });
+
+        it("calls onChange with the updated correct answer when a card past the limit is edited", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+            renderControlled(
+                generateSorterOptions({correct: fifteenCards}),
+                onChangeMock,
+            );
+
+            // Act
+            const card = screen.getByDisplayValue("Item 15");
+            await userEvent.clear(card);
+            await userEvent.type(card, "Emu");
+
+            // Assert
+            expect(onChangeMock).toHaveBeenLastCalledWith({
+                correct: [...fifteenCards.slice(0, 14), "Emu"],
+            });
+        });
+
+        it("removes a card past the limit when its delete button is clicked", async () => {
+            // Arrange
+            const onChangeMock = jest.fn();
+            render(
+                <SorterEditor
+                    onChange={onChangeMock}
+                    {...generateSorterOptions({correct: fifteenCards})}
+                />,
+            );
+
+            // Act
+            await userEvent.click(
+                screen.getByRole("button", {name: "Delete card 15"}),
+            );
+
+            // Assert
+            expect(onChangeMock).toHaveBeenCalledWith({
+                correct: fifteenCards.slice(0, 14),
+            });
+        });
+
+        it("serializes all of the cards, including the ones past the limit", () => {
+            // Arrange
+            const editorRef = React.createRef<SorterEditor>();
+            render(
+                <SorterEditor
+                    ref={editorRef}
+                    onChange={() => {}}
+                    {...generateSorterOptions({correct: fifteenCards})}
+                />,
+            );
+
+            // Act
+            const serialized = editorRef.current?.serialize();
+
+            // Assert
+            expect(serialized?.correct).toEqual(fifteenCards);
+        });
+
+        it("disables the add button", () => {
+            // Arrange, Act
+            render(
+                <SorterEditor
+                    onChange={() => {}}
+                    {...generateSorterOptions({correct: fifteenCards})}
+                />,
+            );
+
+            // Assert
+            expect(
+                screen.getByRole("button", {name: "Add a card"}),
+            ).toHaveAttribute("aria-disabled", "true");
+        });
+    });
+
     it("does not render an empty card until one is added", () => {
         // Arrange, Act
         render(

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.test.tsx
@@ -25,28 +25,42 @@ describe("sorter-editor", () => {
     it("renders", async () => {
         render(<SorterEditor onChange={() => {}} />);
 
-        expect(screen.getByText("Correct answer:")).toBeInTheDocument();
+        expect(screen.getByText("Correct answer")).toBeInTheDocument();
     });
 
     it("should be possible to change layout to vertical", async () => {
+        // Arrange
         const onChangeMock = jest.fn();
+        render(
+            <SorterEditor
+                onChange={onChangeMock}
+                {...generateSorterOptions({layout: "horizontal"})}
+            />,
+        );
 
-        render(<SorterEditor onChange={onChangeMock} />);
+        // Act
+        await userEvent.click(screen.getByRole("combobox", {name: "Layout"}));
+        await userEvent.click(screen.getByRole("option", {name: "Vertical"}));
 
-        const select = screen.getByRole("combobox", {name: "Layout:"});
-        await userEvent.selectOptions(select, "vertical");
-
+        // Assert
         expect(onChangeMock).toHaveBeenCalledWith({layout: "vertical"});
     });
 
     it("should be possible to change layout to horizontal", async () => {
+        // Arrange
         const onChangeMock = jest.fn();
+        render(
+            <SorterEditor
+                onChange={onChangeMock}
+                {...generateSorterOptions({layout: "vertical"})}
+            />,
+        );
 
-        render(<SorterEditor onChange={onChangeMock} />);
+        // Act
+        await userEvent.click(screen.getByRole("combobox", {name: "Layout"}));
+        await userEvent.click(screen.getByRole("option", {name: "Horizontal"}));
 
-        const select = screen.getByRole("combobox", {name: "Layout:"});
-        await userEvent.selectOptions(select, "horizontal");
-
+        // Assert
         expect(onChangeMock).toHaveBeenCalledWith({layout: "horizontal"});
     });
 
@@ -55,7 +69,7 @@ describe("sorter-editor", () => {
 
         render(<SorterEditor onChange={onChangeMock} />);
 
-        await userEvent.click(screen.getByRole("checkbox", {name: "Padding:"}));
+        await userEvent.click(screen.getByRole("checkbox", {name: "Padding"}));
 
         expect(onChangeMock).toHaveBeenCalledWith({padding: false});
     });

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -4,14 +4,18 @@ import {
 } from "@khanacademy/perseus-core";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Checkbox, TextField} from "@khanacademy/wonder-blocks-form";
+import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import InfoTip from "../../components/info-tip";
+import {TypedSingleSelect} from "../../components/typed-single-select";
 
-const HORIZONTAL = "horizontal";
-const VERTICAL = "vertical";
+const layoutOptions = {
+    horizontal: "Horizontal",
+    vertical: "Vertical",
+} as const satisfies Record<PerseusSorterWidgetOptions["layout"], string>;
 
 type Props = PerseusSorterWidgetOptions & {
     onChange: (
@@ -78,18 +82,6 @@ class SorterEditor extends React.Component<Props, State> {
         this.props.onChange({correct: cards.filter(Boolean)});
     };
 
-    onLayoutChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-        const layout = e.target.value;
-        switch (layout) {
-            case HORIZONTAL:
-            case VERTICAL:
-                this.props.onChange({layout});
-                break;
-            default:
-                throw new Error(`${layout} is not an available layout option`);
-        }
-    };
-
     serialize = (): PerseusSorterWidgetOptions => {
         return {
             correct: this.props.correct,
@@ -100,48 +92,50 @@ class SorterEditor extends React.Component<Props, State> {
 
     render(): React.ReactNode {
         return (
-            <div>
-                <div>
-                    {" "}
-                    Correct answer:{" "}
-                    <InfoTip>
-                        <p>
-                            Enter the correct answer (in the correct order)
-                            here. The preview on the right will have the cards
-                            in a randomized order, which is how the student will
-                            see them.
-                        </p>
-                    </InfoTip>
-                </div>
-                <View tag="ol" style={styles.cards}>
-                    {this.state.cards.map((card, i) => (
-                        <View tag="li" key={i}>
-                            <CardEditor
-                                ariaLabel={
-                                    i === this.state.cards.length - 1
-                                        ? "Add a card"
-                                        : `Card ${i + 1}`
-                                }
-                                value={card}
-                                onChange={(value) =>
-                                    this.onCardChange(i, value)
+            <View style={styles.editor}>
+                <View style={styles.section}>
+                    <div>
+                        Correct answer{" "}
+                        <InfoTip>
+                            <p>
+                                Enter the correct answer (in the correct order)
+                                here. The preview on the right will have the
+                                cards in a randomized order, which is how the
+                                student will see them.
+                            </p>
+                        </InfoTip>
+                    </div>
+                    <View tag="ol" style={styles.cards}>
+                        {this.state.cards.map((card, i) => (
+                            <View tag="li" key={i}>
+                                <CardEditor
+                                    ariaLabel={
+                                        i === this.state.cards.length - 1
+                                            ? "Add a card"
+                                            : `Card ${i + 1}`
+                                    }
+                                    value={card}
+                                    onChange={(value) =>
+                                        this.onCardChange(i, value)
+                                    }
+                                />
+                            </View>
+                        ))}
+                    </View>
+                </View>
+                <View>
+                    <LabeledField
+                        label="Layout"
+                        field={
+                            <TypedSingleSelect
+                                options={layoutOptions}
+                                selectedValue={this.props.layout}
+                                onChange={(layout) =>
+                                    this.props.onChange({layout})
                                 }
                             />
-                        </View>
-                    ))}
-                </View>
-                <div>
-                    <label>
-                        {" "}
-                        Layout:{" "}
-                        <select
-                            value={this.props.layout}
-                            onChange={this.onLayoutChange}
-                        >
-                            <option value={HORIZONTAL}>Horizontal</option>
-                            <option value={VERTICAL}>Vertical</option>
-                        </select>
-                    </label>
+                        }
+                    />
                     <InfoTip>
                         <p>
                             Use the horizontal layout for short text and small
@@ -149,10 +143,10 @@ class SorterEditor extends React.Component<Props, State> {
                             and larger images.
                         </p>
                     </InfoTip>
-                </div>
+                </View>
                 <div>
                     <Checkbox
-                        label="Padding:"
+                        label="Padding"
                         checked={this.props.padding}
                         onChange={(value) => {
                             this.props.onChange({padding: value});
@@ -164,18 +158,29 @@ class SorterEditor extends React.Component<Props, State> {
                         </p>
                     </InfoTip>
                 </div>
-            </div>
+            </View>
         );
     }
 }
 
 const styles = StyleSheet.create({
+    // Separates the three sections (cards, layout, padding) from each other.
+    editor: {
+        gap: sizing.size_240,
+    },
+    // Separates a section's label from the control it describes. Smaller than
+    // the gap between sections so each label groups with its own control.
+    section: {
+        gap: sizing.size_080,
+    },
     // The cards always stack in the editor, regardless of the `layout` option,
     // which only controls how the widget renders for students.
     cards: {
         listStyle: "none",
         paddingInlineStart: 0,
-        marginBlock: sizing.size_080,
+        // Drop the browser's default list margins; `section` and `editor`
+        // above own the spacing around the list.
+        marginBlock: 0,
         gap: sizing.size_120,
     },
 });

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -2,10 +2,12 @@ import {
     sorterLogic,
     type PerseusSorterWidgetOptions,
 } from "@khanacademy/perseus-core";
+import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Checkbox, TextField} from "@khanacademy/wonder-blocks-form";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import plusCircle from "@phosphor-icons/core/regular/plus-circle.svg";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
@@ -24,28 +26,26 @@ type Props = PerseusSorterWidgetOptions & {
     ) => void;
 };
 
-type State = {
-    // The cards being edited, always with a trailing empty card that authors
-    // type into to add another. Kept in local state (rather than read straight
-    // off `props.correct`) so that a card can be cleared and retyped without
-    // its input disappearing mid-edit.
-    cards: string[];
-};
-
 type CardEditorProps = {
     // The cards have no visible label, but screen reader users still need each
     // input to have a distinguishable name, hence the aria-label.
     ariaLabel: string;
     value: string;
     onChange: (value: string) => void;
+    inputRef: React.Ref<HTMLInputElement>;
 };
 
 /**
  * An editor for a single sorter card.
  */
-function CardEditor({ariaLabel, value, onChange}: CardEditorProps) {
+function CardEditor({ariaLabel, value, onChange, inputRef}: CardEditorProps) {
     return (
-        <TextField aria-label={ariaLabel} value={value} onChange={onChange} />
+        <TextField
+            aria-label={ariaLabel}
+            value={value}
+            onChange={onChange}
+            ref={inputRef}
+        />
     );
 }
 
@@ -53,33 +53,38 @@ function CardEditor({ariaLabel, value, onChange}: CardEditorProps) {
 /**
  * An editor for adding a sorter widget that allows users to arrange items in a specific order.
  */
-class SorterEditor extends React.Component<Props, State> {
+class SorterEditor extends React.Component<Props> {
     static widgetName = "sorter" as const;
 
     static defaultProps: PerseusSorterWidgetOptions =
         sorterLogic.defaultWidgetOptions;
 
-    state: State = {cards: [...this.props.correct, ""]};
+    // The card inputs, by index, so a newly added card can be focused.
+    cardInputs: (HTMLInputElement | null)[] = [];
 
-    componentDidUpdate(prevProps: Props) {
-        if (prevProps.correct !== this.props.correct) {
-            this.setState({cards: [...this.props.correct, ""]});
+    // Set when the author adds a card, then consumed once the new input has
+    // rendered — focus can't move to an input that doesn't exist yet.
+    pendingFocusIndex: number | null = null;
+
+    componentDidUpdate() {
+        const index = this.pendingFocusIndex;
+        if (index != null) {
+            this.pendingFocusIndex = null;
+            this.cardInputs[index]?.focus();
         }
     }
 
     onCardChange = (index: number, value: string) => {
-        const cards = [...this.state.cards];
-        cards[index] = value;
+        const correct = [...this.props.correct];
+        correct[index] = value;
+        this.props.onChange({correct});
+    };
 
-        // Typing in the trailing card turns it into a real one, so grow the
-        // list to keep an empty card available for the next one.
-        if (index === cards.length - 1) {
-            cards.push("");
-        }
-
-        this.setState({cards});
-        // Empty cards are editing scaffolding, not answers.
-        this.props.onChange({correct: cards.filter(Boolean)});
+    onAddCard = () => {
+        // Focus the card that's about to render so the author can type into it
+        // right away instead of tabbing back from the button.
+        this.pendingFocusIndex = this.props.correct.length;
+        this.props.onChange({correct: [...this.props.correct, ""]});
     };
 
     serialize = (): PerseusSorterWidgetOptions => {
@@ -103,25 +108,37 @@ class SorterEditor extends React.Component<Props, State> {
                                 cards in a randomized order, which is how the
                                 student will see them.
                             </p>
+                            <p>
+                                For horizontal orientation, the top input
+                                represents the leftmost card and the bottom
+                                input represents the rightmost card.
+                            </p>
                         </InfoTip>
                     </div>
                     <View tag="ol" style={styles.cards}>
-                        {this.state.cards.map((card, i) => (
+                        {this.props.correct.map((card, i) => (
                             <View tag="li" key={i}>
                                 <CardEditor
-                                    ariaLabel={
-                                        i === this.state.cards.length - 1
-                                            ? "Add a card"
-                                            : `Card ${i + 1}`
-                                    }
+                                    ariaLabel={`Card ${i + 1}`}
                                     value={card}
                                     onChange={(value) =>
                                         this.onCardChange(i, value)
                                     }
+                                    inputRef={(node) => {
+                                        this.cardInputs[i] = node;
+                                    }}
                                 />
                             </View>
                         ))}
                     </View>
+                    <Button
+                        kind="tertiary"
+                        startIcon={plusCircle}
+                        style={styles.addCard}
+                        onClick={this.onAddCard}
+                    >
+                        Add a card
+                    </Button>
                 </View>
                 <View>
                     <LabeledField
@@ -182,6 +199,11 @@ const styles = StyleSheet.create({
         // above own the spacing around the list.
         marginBlock: 0,
         gap: sizing.size_120,
+    },
+    // Keep the button hugging its label rather than stretching to the width of
+    // the card inputs above it.
+    addCard: {
+        alignSelf: "flex-start",
     },
 });
 

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -15,6 +15,10 @@ import {TypedSingleSelect} from "../../components/typed-single-select";
 import CardEditor from "./card-editor";
 import styles from "./sorter-editor.module.css";
 
+// Ideally Content Creators would keep it <=7
+// but 10 is our hard limit
+const maxCards = 10;
+
 const layoutOptions = {
     horizontal: "Horizontal",
     vertical: "Vertical",
@@ -44,6 +48,9 @@ class SorterEditor extends React.Component<Props> {
     };
 
     onAddCard = () => {
+        if (this.props.correct.length >= maxCards) {
+            return;
+        }
         this.props.onChange({correct: [...this.props.correct, ""]});
     };
 
@@ -112,6 +119,7 @@ class SorterEditor extends React.Component<Props> {
                         kind="tertiary"
                         startIcon={plusCircle}
                         className={styles.addCard}
+                        disabled={this.props.correct.length >= maxCards}
                         onClick={this.onAddCard}
                     >
                         Add a card

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -5,9 +5,13 @@ import {
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Checkbox, TextField} from "@khanacademy/wonder-blocks-form";
+import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import arrowDown from "@phosphor-icons/core/regular/arrow-down.svg";
+import arrowUp from "@phosphor-icons/core/regular/arrow-up.svg";
 import plusCircle from "@phosphor-icons/core/regular/plus-circle.svg";
+import trash from "@phosphor-icons/core/regular/trash.svg";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
@@ -26,26 +30,98 @@ type Props = PerseusSorterWidgetOptions & {
     ) => void;
 };
 
+// The controls in a card's row. Reordering and deleting shuffle the rows
+// around, so the editor needs to name a specific one when moving focus.
+type CardControl = "input" | "moveUp" | "moveDown" | "delete";
+
+const controlKey = (index: number, control: CardControl) =>
+    `${index}:${control}`;
+
 type CardEditorProps = {
-    // The cards have no visible label, but screen reader users still need each
-    // input to have a distinguishable name, hence the aria-label.
-    ariaLabel: string;
+    // Zero-based, but the cards are numbered from one in their labels so the
+    // numbering matches what the author sees.
+    index: number;
     value: string;
+    isFirst: boolean;
+    isLast: boolean;
     onChange: (value: string) => void;
-    inputRef: React.Ref<HTMLInputElement>;
+    onMoveUp: () => void;
+    onMoveDown: () => void;
+    onDelete: () => void;
+    // Hands each control's DOM node to the editor, which moves focus once a
+    // card has been added, moved, or deleted.
+    registerControl: (control: CardControl, node: HTMLElement | null) => void;
 };
 
 /**
- * An editor for a single sorter card.
+ * An editor for a single sorter card: its text, plus the controls that move it
+ * within the answer or remove it.
  */
-function CardEditor({ariaLabel, value, onChange, inputRef}: CardEditorProps) {
+function CardEditor({
+    index,
+    value,
+    isFirst,
+    isLast,
+    onChange,
+    onMoveUp,
+    onMoveDown,
+    onDelete,
+    registerControl,
+}: CardEditorProps) {
+    const cardNumber = index + 1;
+
+    // IconButton's ref can also be a react-router Link, which has nothing to
+    // focus, so only DOM nodes are worth keeping.
+    const registerButton =
+        (control: CardControl) =>
+        (node: React.ComponentRef<typeof IconButton> | null) =>
+            registerControl(control, node instanceof HTMLElement ? node : null);
+
     return (
-        <TextField
-            aria-label={ariaLabel}
-            value={value}
-            onChange={onChange}
-            ref={inputRef}
-        />
+        <View tag="li" style={styles.card}>
+            {/*
+             * The cards have no visible label, but screen reader users still
+             * need each input to have a distinguishable name, hence the
+             * aria-label. The card's controls are named the same way so it's
+             * clear which card each one acts on.
+             */}
+            <TextField
+                aria-label={`Card ${cardNumber}`}
+                value={value}
+                onChange={onChange}
+                style={styles.cardInput}
+                ref={(node) => registerControl("input", node)}
+            />
+            <IconButton
+                aria-label={`Move card ${cardNumber} up`}
+                icon={arrowUp}
+                kind="tertiary"
+                actionType="neutral"
+                size="small"
+                disabled={isFirst}
+                onClick={onMoveUp}
+                ref={registerButton("moveUp")}
+            />
+            <IconButton
+                aria-label={`Move card ${cardNumber} down`}
+                icon={arrowDown}
+                kind="tertiary"
+                actionType="neutral"
+                size="small"
+                disabled={isLast}
+                onClick={onMoveDown}
+                ref={registerButton("moveDown")}
+            />
+            <IconButton
+                aria-label={`Delete card ${cardNumber}`}
+                icon={trash}
+                kind="tertiary"
+                actionType="destructive"
+                size="small"
+                onClick={onDelete}
+                ref={registerButton("delete")}
+            />
+        </View>
     );
 }
 
@@ -59,20 +135,41 @@ class SorterEditor extends React.Component<Props> {
     static defaultProps: PerseusSorterWidgetOptions =
         sorterLogic.defaultWidgetOptions;
 
-    // The card inputs, by index, so a newly added card can be focused.
-    cardInputs: (HTMLInputElement | null)[] = [];
+    // Every card control currently rendered, keyed by card index and control.
+    cardControls = new Map<string, HTMLElement>();
 
-    // Set when the author adds a card, then consumed once the new input has
-    // rendered — focus can't move to an input that doesn't exist yet.
-    pendingFocusIndex: number | null = null;
+    addCardButton = React.createRef<HTMLButtonElement>();
+
+    // What to focus once the changed list of cards has rendered. Focus has to
+    // wait: the control the author clicked may not exist yet (a card that's
+    // being added), may be gone (a card that's being deleted), or may now
+    // belong to a different card (the cards on either side of a move).
+    pendingFocus: (() => void) | null = null;
 
     componentDidUpdate() {
-        const index = this.pendingFocusIndex;
-        if (index != null) {
-            this.pendingFocusIndex = null;
-            this.cardInputs[index]?.focus();
+        const focus = this.pendingFocus;
+        if (focus) {
+            this.pendingFocus = null;
+            focus();
         }
     }
+
+    registerCardControl = (
+        index: number,
+        control: CardControl,
+        node: HTMLElement | null,
+    ) => {
+        const key = controlKey(index, control);
+        if (node) {
+            this.cardControls.set(key, node);
+        } else {
+            this.cardControls.delete(key);
+        }
+    };
+
+    focusCardControl = (index: number, control: CardControl) => {
+        this.cardControls.get(controlKey(index, control))?.focus();
+    };
 
     onCardChange = (index: number, value: string) => {
         const correct = [...this.props.correct];
@@ -83,8 +180,45 @@ class SorterEditor extends React.Component<Props> {
     onAddCard = () => {
         // Focus the card that's about to render so the author can type into it
         // right away instead of tabbing back from the button.
-        this.pendingFocusIndex = this.props.correct.length;
+        const index = this.props.correct.length;
+        this.pendingFocus = () => this.focusCardControl(index, "input");
         this.props.onChange({correct: [...this.props.correct, ""]});
+    };
+
+    onMoveCard = (index: number, offset: -1 | 1) => {
+        const correct = [...this.props.correct];
+        const newIndex = index + offset;
+        [correct[index], correct[newIndex]] = [
+            correct[newIndex],
+            correct[index],
+        ];
+
+        // Follow the card to its new position, so pressing the same button
+        // again keeps moving the same card in the same direction.
+        this.pendingFocus = () =>
+            this.focusCardControl(
+                newIndex,
+                offset === -1 ? "moveUp" : "moveDown",
+            );
+        this.props.onChange({correct});
+    };
+
+    onDeleteCard = (index: number) => {
+        const correct = this.props.correct.filter((card, i) => i !== index);
+
+        // Stay on the delete button, which now belongs to the card that moved
+        // up into this slot (or to the new last card, if this was the last
+        // one). With no cards left there is nothing to delete, so fall back to
+        // the button that adds one.
+        this.pendingFocus =
+            correct.length === 0
+                ? () => this.addCardButton.current?.focus()
+                : () =>
+                      this.focusCardControl(
+                          Math.min(index, correct.length - 1),
+                          "delete",
+                      );
+        this.props.onChange({correct});
     };
 
     serialize = (): PerseusSorterWidgetOptions => {
@@ -117,18 +251,22 @@ class SorterEditor extends React.Component<Props> {
                     </div>
                     <View tag="ol" style={styles.cards}>
                         {this.props.correct.map((card, i) => (
-                            <View tag="li" key={i}>
-                                <CardEditor
-                                    ariaLabel={`Card ${i + 1}`}
-                                    value={card}
-                                    onChange={(value) =>
-                                        this.onCardChange(i, value)
-                                    }
-                                    inputRef={(node) => {
-                                        this.cardInputs[i] = node;
-                                    }}
-                                />
-                            </View>
+                            <CardEditor
+                                key={i}
+                                index={i}
+                                value={card}
+                                isFirst={i === 0}
+                                isLast={i === this.props.correct.length - 1}
+                                onChange={(value) =>
+                                    this.onCardChange(i, value)
+                                }
+                                onMoveUp={() => this.onMoveCard(i, -1)}
+                                onMoveDown={() => this.onMoveCard(i, 1)}
+                                onDelete={() => this.onDeleteCard(i)}
+                                registerControl={(control, node) =>
+                                    this.registerCardControl(i, control, node)
+                                }
+                            />
                         ))}
                     </View>
                     <Button
@@ -136,6 +274,7 @@ class SorterEditor extends React.Component<Props> {
                         startIcon={plusCircle}
                         style={styles.addCard}
                         onClick={this.onAddCard}
+                        ref={this.addCardButton}
                     >
                         Add a card
                     </Button>
@@ -200,8 +339,19 @@ const styles = StyleSheet.create({
         marginBlock: 0,
         gap: sizing.size_120,
     },
+    // A card's text sits on one line with the controls that reorder and remove
+    // it, so the controls stay next to the card they act on.
+    card: {
+        flexDirection: "row",
+        alignItems: "center",
+        gap: sizing.size_040,
+    },
+    // Let the text take the space the controls don't need.
+    cardInput: {
+        flexGrow: 1,
+    },
     // Keep the button hugging its label rather than stretching to the width of
-    // the card inputs above it.
+    // the cards above it.
     addCard: {
         alignSelf: "flex-start",
     },

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -6,15 +6,14 @@ import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import plusCircle from "@phosphor-icons/core/regular/plus-circle.svg";
-import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import InfoTip from "../../components/info-tip";
 import {TypedSingleSelect} from "../../components/typed-single-select";
 
 import CardEditor from "./card-editor";
+import styles from "./sorter-editor.module.css";
 
 const layoutOptions = {
     horizontal: "Horizontal",
@@ -74,8 +73,8 @@ class SorterEditor extends React.Component<Props> {
 
     render(): React.ReactNode {
         return (
-            <View style={styles.editor}>
-                <View style={styles.section}>
+            <View className={styles.editor}>
+                <View className={styles.section}>
                     <div>
                         Correct answer{" "}
                         <InfoTip>
@@ -92,7 +91,7 @@ class SorterEditor extends React.Component<Props> {
                             </p>
                         </InfoTip>
                     </div>
-                    <View tag="ol" style={styles.cards}>
+                    <View tag="ol" className={styles.cards}>
                         {this.props.correct.map((card, i) => (
                             <CardEditor
                                 key={i}
@@ -112,7 +111,7 @@ class SorterEditor extends React.Component<Props> {
                     <Button
                         kind="tertiary"
                         startIcon={plusCircle}
-                        style={styles.addCard}
+                        className={styles.addCard}
                         onClick={this.onAddCard}
                     >
                         Add a card
@@ -157,32 +156,5 @@ class SorterEditor extends React.Component<Props> {
         );
     }
 }
-
-const styles = StyleSheet.create({
-    // Separates the three sections (cards, layout, padding) from each other.
-    editor: {
-        gap: sizing.size_240,
-    },
-    // Separates a section's label from the control it describes. Smaller than
-    // the gap between sections so each label groups with its own control.
-    section: {
-        gap: sizing.size_080,
-    },
-    // The cards always stack in the editor, regardless of the `layout` option,
-    // which only controls how the widget renders for students.
-    cards: {
-        listStyle: "none",
-        paddingInlineStart: 0,
-        // Drop the browser's default list margins; `section` and `editor`
-        // above own the spacing around the list.
-        marginBlock: 0,
-        gap: sizing.size_120,
-    },
-    // Keep the button hugging its label rather than stretching to the width of
-    // the cards above it.
-    addCard: {
-        alignSelf: "flex-start",
-    },
-});
 
 export default SorterEditor;

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -19,6 +19,9 @@ import styles from "./sorter-editor.module.css";
 // but 10 is our hard limit
 const maxCards = 10;
 
+// There's nothing to sort with fewer than two cards.
+const minCards = 2;
+
 // Annotated because WidgetLogic types `defaultWidgetOptions` as `any`. Without
 // this, the `any` spreads: a destructured prop whose default is `any` is itself
 // `any`, which would silently untype every option below.
@@ -48,6 +51,7 @@ type Props = Partial<PerseusSorterWidgetOptions> & {
  */
 type SorterEditorHandle = {
     serialize: () => PerseusSorterWidgetOptions;
+    getSaveWarnings: () => string[];
 };
 
 // JSDoc will be shown in Storybook widget editor description
@@ -68,6 +72,25 @@ const SorterEditor = React.forwardRef<SorterEditorHandle, Props>(
             ref,
             () => ({
                 serialize: () => ({correct, layout, padding}),
+
+                // Adding a card puts an empty string into `correct`, and
+                // clearing a card's text leaves one behind, so an author can
+                // save cards that students would see as blank.
+                //
+                // TODO(LEMS-3643): Remove `getSaveWarnings` once the frontend
+                // uses the new linter rules for save warnings.
+                getSaveWarnings: () => {
+                    const warnings: string[] = [];
+                    if (correct.length < minCards) {
+                        warnings.push(
+                            `Sorter requires at least ${minCards} cards.`,
+                        );
+                    }
+                    if (correct.some((card) => card.trim() === "")) {
+                        warnings.push("Sorter cards cannot be blank.");
+                    }
+                    return warnings;
+                },
             }),
             [correct, layout, padding],
         );

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -19,7 +19,11 @@ import styles from "./sorter-editor.module.css";
 // but 10 is our hard limit
 const maxCards = 10;
 
-const defaultOptions = sorterLogic.defaultWidgetOptions;
+// Annotated because WidgetLogic types `defaultWidgetOptions` as `any`. Without
+// this, the `any` spreads: a destructured prop whose default is `any` is itself
+// `any`, which would silently untype every option below.
+const defaultOptions: PerseusSorterWidgetOptions =
+    sorterLogic.defaultWidgetOptions;
 
 const layoutOptions = {
     horizontal: "Horizontal",

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -33,10 +33,7 @@ const layoutOptions = {
     vertical: "Vertical",
 } as const satisfies Record<PerseusSorterWidgetOptions["layout"], string>;
 
-// The widget options are optional because WidgetEditor renders this editor with
-// whatever options the content has, and content predating an option won't carry
-// it. The defaults below fill in the gaps.
-type Props = Partial<PerseusSorterWidgetOptions> & {
+type Props = PerseusSorterWidgetOptions & {
     onChange: (
         newOptions: Partial<PerseusSorterWidgetOptions>,
         callback?: () => void,
@@ -44,10 +41,7 @@ type Props = Partial<PerseusSorterWidgetOptions> & {
 };
 
 /**
- * What WidgetEditor can call on this editor through its ref. It serializes the
- * editor mid-edit, to fold the editor's current options into the change it's
- * about to publish, so `serialize` has to report the options this editor was
- * last rendered with.
+ * Imperative API that WidgetEditor calls
  */
 type SorterEditorHandle = {
     serialize: () => PerseusSorterWidgetOptions;
@@ -71,21 +65,21 @@ const SorterEditor = React.forwardRef<SorterEditorHandle, Props>(
         React.useImperativeHandle(
             ref,
             () => ({
-                serialize: () => ({correct, layout, padding}),
+                serialize: () => {
+                    return {correct, layout, padding};
+                },
 
-                // Adding a card puts an empty string into `correct`, and
-                // clearing a card's text leaves one behind, so an author can
-                // save cards that students would see as blank.
-                //
                 // TODO(LEMS-3643): Remove `getSaveWarnings` once the frontend
                 // uses the new linter rules for save warnings.
                 getSaveWarnings: () => {
                     const warnings: string[] = [];
+                    // don't allow too few cards
                     if (correct.length < minCards) {
                         warnings.push(
                             `Sorter requires at least ${minCards} cards.`,
                         );
                     }
+                    // don't allow blanks
                     if (correct.some((card) => card.trim() === "")) {
                         warnings.push("Sorter cards cannot be blank.");
                     }
@@ -214,8 +208,6 @@ export default Object.assign(SorterEditor, {
     widgetName: "sorter" as const,
 
     // Read directly by the editor page to seed the options of a newly inserted
-    // sorter. It's deliberately not how this component gets its own defaults —
-    // React only applies defaultProps to a component's props up to React 18,
-    // so the defaults live in the destructuring above instead.
+    // sorter.
     defaultProps: defaultOptions,
 });

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -19,66 +19,84 @@ import styles from "./sorter-editor.module.css";
 // but 10 is our hard limit
 const maxCards = 10;
 
+const defaultOptions = sorterLogic.defaultWidgetOptions;
+
 const layoutOptions = {
     horizontal: "Horizontal",
     vertical: "Vertical",
 } as const satisfies Record<PerseusSorterWidgetOptions["layout"], string>;
 
-type Props = PerseusSorterWidgetOptions & {
+// The widget options are optional because WidgetEditor renders this editor with
+// whatever options the content has, and content predating an option won't carry
+// it. The defaults below fill in the gaps.
+type Props = Partial<PerseusSorterWidgetOptions> & {
     onChange: (
         newOptions: Partial<PerseusSorterWidgetOptions>,
         callback?: () => void,
     ) => void;
 };
 
+/**
+ * What WidgetEditor can call on this editor through its ref. It serializes the
+ * editor mid-edit, to fold the editor's current options into the change it's
+ * about to publish, so `serialize` has to report the options this editor was
+ * last rendered with.
+ */
+type SorterEditorHandle = {
+    serialize: () => PerseusSorterWidgetOptions;
+};
+
 // JSDoc will be shown in Storybook widget editor description
 /**
  * An editor for adding a sorter widget that allows users to arrange items in a specific order.
  */
-class SorterEditor extends React.Component<Props> {
-    static widgetName = "sorter" as const;
+const SorterEditor = React.forwardRef<SorterEditorHandle, Props>(
+    function SorterEditor(
+        {
+            correct = defaultOptions.correct,
+            layout = defaultOptions.layout,
+            padding = defaultOptions.padding,
+            onChange,
+        },
+        ref,
+    ) {
+        React.useImperativeHandle(
+            ref,
+            () => ({
+                serialize: () => ({correct, layout, padding}),
+            }),
+            [correct, layout, padding],
+        );
 
-    static defaultProps: PerseusSorterWidgetOptions =
-        sorterLogic.defaultWidgetOptions;
-
-    onCardChange = (index: number, value: string) => {
-        const correct = [...this.props.correct];
-        correct[index] = value;
-        this.props.onChange({correct});
-    };
-
-    onAddCard = () => {
-        if (this.props.correct.length >= maxCards) {
-            return;
-        }
-        this.props.onChange({correct: [...this.props.correct, ""]});
-    };
-
-    onMoveCard = (index: number, offset: -1 | 1) => {
-        const correct = [...this.props.correct];
-        const newIndex = index + offset;
-        [correct[index], correct[newIndex]] = [
-            correct[newIndex],
-            correct[index],
-        ];
-        this.props.onChange({correct});
-    };
-
-    onDeleteCard = (index: number) => {
-        this.props.onChange({
-            correct: this.props.correct.filter((card, i) => i !== index),
-        });
-    };
-
-    serialize = (): PerseusSorterWidgetOptions => {
-        return {
-            correct: this.props.correct,
-            layout: this.props.layout,
-            padding: this.props.padding,
+        const onCardChange = (index: number, value: string) => {
+            const newCorrect = [...correct];
+            newCorrect[index] = value;
+            onChange({correct: newCorrect});
         };
-    };
 
-    render(): React.ReactNode {
+        const onAddCard = () => {
+            if (correct.length >= maxCards) {
+                return;
+            }
+            onChange({correct: [...correct, ""]});
+        };
+
+        const onMoveCard = (index: number, offset: -1 | 1) => {
+            const newCorrect = [...correct];
+            const newIndex = index + offset;
+            [newCorrect[index], newCorrect[newIndex]] = [
+                newCorrect[newIndex],
+                newCorrect[index],
+            ];
+            onChange({correct: newCorrect});
+        };
+
+        const onDeleteCard = (index: number) => {
+            onChange({
+                correct: correct.filter((card, i) => i !== index),
+            });
+        };
+
         return (
             <View className={styles.editor}>
                 <View className={styles.section}>
@@ -99,19 +117,17 @@ class SorterEditor extends React.Component<Props> {
                         </InfoTip>
                     </div>
                     <View tag="ol" className={styles.cards}>
-                        {this.props.correct.map((card, i) => (
+                        {correct.map((card, i) => (
                             <CardEditor
                                 key={i}
                                 index={i}
                                 value={card}
                                 isFirst={i === 0}
-                                isLast={i === this.props.correct.length - 1}
-                                onChange={(value) =>
-                                    this.onCardChange(i, value)
-                                }
-                                onMoveUp={() => this.onMoveCard(i, -1)}
-                                onMoveDown={() => this.onMoveCard(i, 1)}
-                                onDelete={() => this.onDeleteCard(i)}
+                                isLast={i === correct.length - 1}
+                                onChange={(value) => onCardChange(i, value)}
+                                onMoveUp={() => onMoveCard(i, -1)}
+                                onMoveDown={() => onMoveCard(i, 1)}
+                                onDelete={() => onDeleteCard(i)}
                             />
                         ))}
                     </View>
@@ -119,8 +135,8 @@ class SorterEditor extends React.Component<Props> {
                         kind="tertiary"
                         startIcon={plusCircle}
                         className={styles.addCard}
-                        disabled={this.props.correct.length >= maxCards}
-                        onClick={this.onAddCard}
+                        disabled={correct.length >= maxCards}
+                        onClick={onAddCard}
                     >
                         Add a card
                     </Button>
@@ -131,9 +147,9 @@ class SorterEditor extends React.Component<Props> {
                         field={
                             <TypedSingleSelect
                                 options={layoutOptions}
-                                selectedValue={this.props.layout}
-                                onChange={(layout) =>
-                                    this.props.onChange({layout})
+                                selectedValue={layout}
+                                onChange={(newLayout) =>
+                                    onChange({layout: newLayout})
                                 }
                             />
                         }
@@ -149,9 +165,9 @@ class SorterEditor extends React.Component<Props> {
                 <div>
                     <Checkbox
                         label="Padding"
-                        checked={this.props.padding}
+                        checked={padding}
                         onChange={(value) => {
-                            this.props.onChange({padding: value});
+                            onChange({padding: value});
                         }}
                     />
                     <InfoTip>
@@ -162,7 +178,17 @@ class SorterEditor extends React.Component<Props> {
                 </div>
             </View>
         );
-    }
-}
+    },
+);
 
-export default SorterEditor;
+export default Object.assign(SorterEditor, {
+    // Widgets.registerEditors registers the editor under this name, and throws
+    // without it.
+    widgetName: "sorter" as const,
+
+    // Read directly by the editor page to seed the options of a newly inserted
+    // sorter. It's deliberately not how this component gets its own defaults —
+    // React only applies defaultProps to a component's props up to React 18,
+    // so the defaults live in the destructuring above instead.
+    defaultProps: defaultOptions,
+});

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -2,11 +2,13 @@ import {
     sorterLogic,
     type PerseusSorterWidgetOptions,
 } from "@khanacademy/perseus-core";
-import {Checkbox} from "@khanacademy/wonder-blocks-form";
+import {View} from "@khanacademy/wonder-blocks-core";
+import {Checkbox, TextField} from "@khanacademy/wonder-blocks-form";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
+import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import InfoTip from "../../components/info-tip";
-import TextListEditor from "../../components/text-list-editor";
 
 const HORIZONTAL = "horizontal";
 const VERTICAL = "vertical";
@@ -18,15 +20,63 @@ type Props = PerseusSorterWidgetOptions & {
     ) => void;
 };
 
+type State = {
+    // The cards being edited, always with a trailing empty card that authors
+    // type into to add another. Kept in local state (rather than read straight
+    // off `props.correct`) so that a card can be cleared and retyped without
+    // its input disappearing mid-edit.
+    cards: string[];
+};
+
+type CardEditorProps = {
+    // The cards have no visible label, but screen reader users still need each
+    // input to have a distinguishable name, hence the aria-label.
+    ariaLabel: string;
+    value: string;
+    onChange: (value: string) => void;
+};
+
+/**
+ * An editor for a single sorter card.
+ */
+function CardEditor({ariaLabel, value, onChange}: CardEditorProps) {
+    return (
+        <TextField aria-label={ariaLabel} value={value} onChange={onChange} />
+    );
+}
+
 // JSDoc will be shown in Storybook widget editor description
 /**
  * An editor for adding a sorter widget that allows users to arrange items in a specific order.
  */
-class SorterEditor extends React.Component<Props> {
+class SorterEditor extends React.Component<Props, State> {
     static widgetName = "sorter" as const;
 
     static defaultProps: PerseusSorterWidgetOptions =
         sorterLogic.defaultWidgetOptions;
+
+    state: State = {cards: [...this.props.correct, ""]};
+
+    componentDidUpdate(prevProps: Props) {
+        if (prevProps.correct !== this.props.correct) {
+            this.setState({cards: [...this.props.correct, ""]});
+        }
+    }
+
+    onCardChange = (index: number, value: string) => {
+        const cards = [...this.state.cards];
+        cards[index] = value;
+
+        // Typing in the trailing card turns it into a real one, so grow the
+        // list to keep an empty card available for the next one.
+        if (index === cards.length - 1) {
+            cards.push("");
+        }
+
+        this.setState({cards});
+        // Empty cards are editing scaffolding, not answers.
+        this.props.onChange({correct: cards.filter(Boolean)});
+    };
 
     onLayoutChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
         const layout = e.target.value;
@@ -63,13 +113,23 @@ class SorterEditor extends React.Component<Props> {
                         </p>
                     </InfoTip>
                 </div>
-                <TextListEditor
-                    options={this.props.correct}
-                    onChange={(options) => {
-                        this.props.onChange({correct: options});
-                    }}
-                    layout={this.props.layout}
-                />
+                <View tag="ol" style={styles.cards}>
+                    {this.state.cards.map((card, i) => (
+                        <View tag="li" key={i}>
+                            <CardEditor
+                                ariaLabel={
+                                    i === this.state.cards.length - 1
+                                        ? "Add a card"
+                                        : `Card ${i + 1}`
+                                }
+                                value={card}
+                                onChange={(value) =>
+                                    this.onCardChange(i, value)
+                                }
+                            />
+                        </View>
+                    ))}
+                </View>
                 <div>
                     <label>
                         {" "}
@@ -108,5 +168,16 @@ class SorterEditor extends React.Component<Props> {
         );
     }
 }
+
+const styles = StyleSheet.create({
+    // The cards always stack in the editor, regardless of the `layout` option,
+    // which only controls how the widget renders for students.
+    cards: {
+        listStyle: "none",
+        paddingInlineStart: 0,
+        marginBlock: sizing.size_080,
+        gap: sizing.size_120,
+    },
+});
 
 export default SorterEditor;

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -4,19 +4,17 @@ import {
 } from "@khanacademy/perseus-core";
 import Button from "@khanacademy/wonder-blocks-button";
 import {View} from "@khanacademy/wonder-blocks-core";
-import {Checkbox, TextField} from "@khanacademy/wonder-blocks-form";
-import IconButton from "@khanacademy/wonder-blocks-icon-button";
+import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import {LabeledField} from "@khanacademy/wonder-blocks-labeled-field";
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
-import arrowDown from "@phosphor-icons/core/regular/arrow-down.svg";
-import arrowUp from "@phosphor-icons/core/regular/arrow-up.svg";
 import plusCircle from "@phosphor-icons/core/regular/plus-circle.svg";
-import trash from "@phosphor-icons/core/regular/trash.svg";
 import {StyleSheet} from "aphrodite";
 import * as React from "react";
 
 import InfoTip from "../../components/info-tip";
 import {TypedSingleSelect} from "../../components/typed-single-select";
+
+import CardEditor from "./card-editor";
 
 const layoutOptions = {
     horizontal: "Horizontal",
@@ -29,79 +27,6 @@ type Props = PerseusSorterWidgetOptions & {
         callback?: () => void,
     ) => void;
 };
-
-type CardEditorProps = {
-    // Zero-based, but the cards are numbered from one in their labels so the
-    // numbering matches what the author sees.
-    index: number;
-    value: string;
-    isFirst: boolean;
-    isLast: boolean;
-    onChange: (value: string) => void;
-    onMoveUp: () => void;
-    onMoveDown: () => void;
-    onDelete: () => void;
-};
-
-/**
- * An editor for a single sorter card: its text, plus the controls that move it
- * within the answer or remove it.
- */
-function CardEditor({
-    index,
-    value,
-    isFirst,
-    isLast,
-    onChange,
-    onMoveUp,
-    onMoveDown,
-    onDelete,
-}: CardEditorProps) {
-    const cardNumber = index + 1;
-
-    return (
-        <View tag="li" style={styles.card}>
-            {/*
-             * The cards have no visible label, but screen reader users still
-             * need each input to have a distinguishable name, hence the
-             * aria-label. The card's controls are named the same way so it's
-             * clear which card each one acts on.
-             */}
-            <TextField
-                aria-label={`Card ${cardNumber}`}
-                value={value}
-                onChange={onChange}
-                style={styles.cardInput}
-            />
-            <IconButton
-                aria-label={`Move card ${cardNumber} up`}
-                icon={arrowUp}
-                kind="tertiary"
-                actionType="neutral"
-                size="small"
-                disabled={isFirst}
-                onClick={onMoveUp}
-            />
-            <IconButton
-                aria-label={`Move card ${cardNumber} down`}
-                icon={arrowDown}
-                kind="tertiary"
-                actionType="neutral"
-                size="small"
-                disabled={isLast}
-                onClick={onMoveDown}
-            />
-            <IconButton
-                aria-label={`Delete card ${cardNumber}`}
-                icon={trash}
-                kind="tertiary"
-                actionType="destructive"
-                size="small"
-                onClick={onDelete}
-            />
-        </View>
-    );
-}
 
 // JSDoc will be shown in Storybook widget editor description
 /**
@@ -252,17 +177,6 @@ const styles = StyleSheet.create({
         // above own the spacing around the list.
         marginBlock: 0,
         gap: sizing.size_120,
-    },
-    // A card's text sits on one line with the controls that reorder and remove
-    // it, so the controls stay next to the card they act on.
-    card: {
-        flexDirection: "row",
-        alignItems: "center",
-        gap: sizing.size_040,
-    },
-    // Let the text take the space the controls don't need.
-    cardInput: {
-        flexGrow: 1,
     },
     // Keep the button hugging its label rather than stretching to the width of
     // the cards above it.

--- a/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
+++ b/packages/perseus-editor/src/widgets/sorter-editor/sorter-editor.tsx
@@ -30,13 +30,6 @@ type Props = PerseusSorterWidgetOptions & {
     ) => void;
 };
 
-// The controls in a card's row. Reordering and deleting shuffle the rows
-// around, so the editor needs to name a specific one when moving focus.
-type CardControl = "input" | "moveUp" | "moveDown" | "delete";
-
-const controlKey = (index: number, control: CardControl) =>
-    `${index}:${control}`;
-
 type CardEditorProps = {
     // Zero-based, but the cards are numbered from one in their labels so the
     // numbering matches what the author sees.
@@ -48,9 +41,6 @@ type CardEditorProps = {
     onMoveUp: () => void;
     onMoveDown: () => void;
     onDelete: () => void;
-    // Hands each control's DOM node to the editor, which moves focus once a
-    // card has been added, moved, or deleted.
-    registerControl: (control: CardControl, node: HTMLElement | null) => void;
 };
 
 /**
@@ -66,16 +56,8 @@ function CardEditor({
     onMoveUp,
     onMoveDown,
     onDelete,
-    registerControl,
 }: CardEditorProps) {
     const cardNumber = index + 1;
-
-    // IconButton's ref can also be a react-router Link, which has nothing to
-    // focus, so only DOM nodes are worth keeping.
-    const registerButton =
-        (control: CardControl) =>
-        (node: React.ComponentRef<typeof IconButton> | null) =>
-            registerControl(control, node instanceof HTMLElement ? node : null);
 
     return (
         <View tag="li" style={styles.card}>
@@ -90,7 +72,6 @@ function CardEditor({
                 value={value}
                 onChange={onChange}
                 style={styles.cardInput}
-                ref={(node) => registerControl("input", node)}
             />
             <IconButton
                 aria-label={`Move card ${cardNumber} up`}
@@ -100,7 +81,6 @@ function CardEditor({
                 size="small"
                 disabled={isFirst}
                 onClick={onMoveUp}
-                ref={registerButton("moveUp")}
             />
             <IconButton
                 aria-label={`Move card ${cardNumber} down`}
@@ -110,7 +90,6 @@ function CardEditor({
                 size="small"
                 disabled={isLast}
                 onClick={onMoveDown}
-                ref={registerButton("moveDown")}
             />
             <IconButton
                 aria-label={`Delete card ${cardNumber}`}
@@ -119,7 +98,6 @@ function CardEditor({
                 actionType="destructive"
                 size="small"
                 onClick={onDelete}
-                ref={registerButton("delete")}
             />
         </View>
     );
@@ -135,42 +113,6 @@ class SorterEditor extends React.Component<Props> {
     static defaultProps: PerseusSorterWidgetOptions =
         sorterLogic.defaultWidgetOptions;
 
-    // Every card control currently rendered, keyed by card index and control.
-    cardControls = new Map<string, HTMLElement>();
-
-    addCardButton = React.createRef<HTMLButtonElement>();
-
-    // What to focus once the changed list of cards has rendered. Focus has to
-    // wait: the control the author clicked may not exist yet (a card that's
-    // being added), may be gone (a card that's being deleted), or may now
-    // belong to a different card (the cards on either side of a move).
-    pendingFocus: (() => void) | null = null;
-
-    componentDidUpdate() {
-        const focus = this.pendingFocus;
-        if (focus) {
-            this.pendingFocus = null;
-            focus();
-        }
-    }
-
-    registerCardControl = (
-        index: number,
-        control: CardControl,
-        node: HTMLElement | null,
-    ) => {
-        const key = controlKey(index, control);
-        if (node) {
-            this.cardControls.set(key, node);
-        } else {
-            this.cardControls.delete(key);
-        }
-    };
-
-    focusCardControl = (index: number, control: CardControl) => {
-        this.cardControls.get(controlKey(index, control))?.focus();
-    };
-
     onCardChange = (index: number, value: string) => {
         const correct = [...this.props.correct];
         correct[index] = value;
@@ -178,10 +120,6 @@ class SorterEditor extends React.Component<Props> {
     };
 
     onAddCard = () => {
-        // Focus the card that's about to render so the author can type into it
-        // right away instead of tabbing back from the button.
-        const index = this.props.correct.length;
-        this.pendingFocus = () => this.focusCardControl(index, "input");
         this.props.onChange({correct: [...this.props.correct, ""]});
     };
 
@@ -192,33 +130,13 @@ class SorterEditor extends React.Component<Props> {
             correct[newIndex],
             correct[index],
         ];
-
-        // Follow the card to its new position, so pressing the same button
-        // again keeps moving the same card in the same direction.
-        this.pendingFocus = () =>
-            this.focusCardControl(
-                newIndex,
-                offset === -1 ? "moveUp" : "moveDown",
-            );
         this.props.onChange({correct});
     };
 
     onDeleteCard = (index: number) => {
-        const correct = this.props.correct.filter((card, i) => i !== index);
-
-        // Stay on the delete button, which now belongs to the card that moved
-        // up into this slot (or to the new last card, if this was the last
-        // one). With no cards left there is nothing to delete, so fall back to
-        // the button that adds one.
-        this.pendingFocus =
-            correct.length === 0
-                ? () => this.addCardButton.current?.focus()
-                : () =>
-                      this.focusCardControl(
-                          Math.min(index, correct.length - 1),
-                          "delete",
-                      );
-        this.props.onChange({correct});
+        this.props.onChange({
+            correct: this.props.correct.filter((card, i) => i !== index),
+        });
     };
 
     serialize = (): PerseusSorterWidgetOptions => {
@@ -263,9 +181,6 @@ class SorterEditor extends React.Component<Props> {
                                 onMoveUp={() => this.onMoveCard(i, -1)}
                                 onMoveDown={() => this.onMoveCard(i, 1)}
                                 onDelete={() => this.onDeleteCard(i)}
-                                registerControl={(control, node) =>
-                                    this.registerCardControl(i, control, node)
-                                }
                             />
                         ))}
                     </View>
@@ -274,7 +189,6 @@ class SorterEditor extends React.Component<Props> {
                         startIcon={plusCircle}
                         style={styles.addCard}
                         onClick={this.onAddCard}
-                        ref={this.addCardButton}
                     >
                         Add a card
                     </Button>

--- a/packages/perseus-linter/src/rules/all-rules.ts
+++ b/packages/perseus-linter/src/rules/all-rules.ts
@@ -37,6 +37,7 @@ import NumericInputWidgetError from "./numeric-input-widget-error";
 import PhetSimulationWidgetError from "./phet-simulation-widget-error";
 import PythonProgramWidgetError from "./python-program-widget-error";
 import RadioWidgetError from "./radio-widget-error";
+import SorterWidgetError from "./sorter-widget-error";
 import StaticWidgetInQuestionStem from "./static-widget-in-question-stem";
 import TableMissingCells from "./table-missing-cells";
 import UnbalancedCodeDelimiters from "./unbalanced-code-delimiters";
@@ -88,4 +89,5 @@ export default [
     PythonProgramWidgetError,
     LabelImageWidgetError,
     InteractiveGraphWidgetError,
+    SorterWidgetError,
 ];

--- a/packages/perseus-linter/src/rules/sorter-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/sorter-widget-error.test.ts
@@ -1,0 +1,103 @@
+import {expectPass, expectWarning} from "../__tests__/test-utils";
+
+import sorterWidgetErrorRule from "./sorter-widget-error";
+
+describe("sorter-widget-error", () => {
+    it("warns for a sorter widget with a blank card", () => {
+        expectWarning(
+            sorterWidgetErrorRule,
+            "[[☃ sorter 1]]",
+            {
+                widgets: {
+                    "sorter 1": {
+                        options: {correct: ["Cat", ""]},
+                    },
+                },
+            },
+            {message: "Sorter cards cannot be blank."},
+        );
+    });
+
+    it("warns for a sorter widget with a whitespace-only card", () => {
+        expectWarning(
+            sorterWidgetErrorRule,
+            "[[☃ sorter 1]]",
+            {
+                widgets: {
+                    "sorter 1": {
+                        options: {correct: ["Cat", "   "]},
+                    },
+                },
+            },
+            {message: "Sorter cards cannot be blank."},
+        );
+    });
+
+    it("warns for a sorter widget with only one card", () => {
+        expectWarning(
+            sorterWidgetErrorRule,
+            "[[☃ sorter 1]]",
+            {
+                widgets: {
+                    "sorter 1": {
+                        options: {correct: ["Cat"]},
+                    },
+                },
+            },
+            {message: "Sorter requires at least 2 cards."},
+        );
+    });
+
+    it("warns for a sorter widget with no cards", () => {
+        expectWarning(
+            sorterWidgetErrorRule,
+            "[[☃ sorter 1]]",
+            {
+                widgets: {
+                    "sorter 1": {
+                        options: {correct: []},
+                    },
+                },
+            },
+            {message: "Sorter requires at least 2 cards."},
+        );
+    });
+
+    it("reports both problems when a sorter has a single blank card", () => {
+        expectWarning(
+            sorterWidgetErrorRule,
+            "[[☃ sorter 1]]",
+            {
+                widgets: {
+                    "sorter 1": {
+                        options: {correct: [""]},
+                    },
+                },
+            },
+            {
+                message:
+                    "Sorter requires at least 2 cards.\n\nSorter cards cannot be blank.",
+            },
+        );
+    });
+
+    it("passes for a sorter widget whose cards all have text", () => {
+        expectPass(sorterWidgetErrorRule, "[[☃ sorter 1]]", {
+            widgets: {
+                "sorter 1": {
+                    options: {correct: ["Cat", "Dog", "Emu"]},
+                },
+            },
+        });
+    });
+
+    it("passes for a widget of another type", () => {
+        expectPass(sorterWidgetErrorRule, "[[☃ matcher 1]]", {
+            widgets: {
+                "matcher 1": {
+                    options: {left: [], right: []},
+                },
+            },
+        });
+    });
+});

--- a/packages/perseus-linter/src/rules/sorter-widget-error.ts
+++ b/packages/perseus-linter/src/rules/sorter-widget-error.ts
@@ -1,0 +1,44 @@
+import Rule from "../rule";
+
+// There's nothing to sort with fewer than two cards.
+const minCards = 2;
+
+// eslint-disable-next-line no-restricted-syntax
+export default Rule.makeRule({
+    name: "sorter-widget-error",
+    severity: Rule.Severity.ERROR,
+    selector: "widget",
+    lint: function (state, content, nodes, match, context) {
+        // This rule only looks at sorter widgets
+        if (state.currentNode().widgetType !== "sorter") {
+            return;
+        }
+
+        const nodeId = state.currentNode().id;
+        if (!nodeId) {
+            return;
+        }
+
+        // If it can't find a definition for the widget it does nothing
+        const widget = context?.widgets?.[nodeId];
+        if (!widget) {
+            return;
+        }
+
+        const warnings: string[] = [];
+        const correct: string[] = widget.options.correct ?? [];
+
+        if (correct.length < minCards) {
+            warnings.push(`Sorter requires at least ${minCards} cards.`);
+        }
+
+        // The editor adds a card as an empty string, and clearing a card's text
+        // leaves one behind, so a blank card reaches the learner as an empty
+        // draggable.
+        if (correct.some((card) => card.trim() === "")) {
+            warnings.push("Sorter cards cannot be blank.");
+        }
+
+        return warnings.join("\n\n");
+    },
+}) as Rule;

--- a/packages/perseus-linter/src/rules/sorter-widget-error.ts
+++ b/packages/perseus-linter/src/rules/sorter-widget-error.ts
@@ -32,9 +32,6 @@ export default Rule.makeRule({
             warnings.push(`Sorter requires at least ${minCards} cards.`);
         }
 
-        // The editor adds a card as an empty string, and clearing a card's text
-        // leaves one behind, so a blank card reaches the learner as an empty
-        // draggable.
         if (correct.some((card) => card.trim() === "")) {
             warnings.push("Sorter cards cannot be blank.");
         }


### PR DESCRIPTION
(Don't let the +/- numbers scare you: over 600 lines of changes are snapshots and over 300 lines are tests)

## Summary:

The goal of the PR is to modernize the SorterEditor component. Things I did:

- Convert to a functional component
- Switch UI to use Wonder-Blocks (no longer using TextListEditor)
- Added some niceties to help with the UX (hopefully)
- Cap the number of cards Content Creators can add (10)
    - Still supports _editing_ higher than 10
- A _lot_ of this is test coverage or test related
- Switch to CSS Modules
- Make the editor story interactive
- Add some lint safety nets around empty cards and <2 cards

---

**BEFORE**

<img width="361" height="240" alt="Screenshot 2026-08-27 at 3 57 06 PM" src="https://github.com/user-attachments/assets/d6fbece8-2462-4cd1-9ca9-be5743e43f57" />

**AFTER**

<img width="356" height="424" alt="Screenshot 2026-08-27 at 3 56 48 PM" src="https://github.com/user-attachments/assets/ac88d663-5ff4-4945-b3f8-9730354a07a0" />

---

Issue: LEMS-4497

## Test plan:
- Added a bunch of unit tests
- Made the editor story interactive to make testing behavior easier