### PR TITLE
[Color][Graded Group] Make correct/incorrect bar color match the marker color in Graded Group

### DIFF
--- a/.changeset/long-birds-see.md
+++ b/.changeset/long-birds-see.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Make the correctness indicator bar colors match their correctness indicator symbol color in Graded Group

--- a/packages/perseus/src/styles/widgets/graded-group.css
+++ b/packages/perseus/src/styles/widgets/graded-group.css
@@ -4,7 +4,6 @@
     margin-left: 3px;
     padding-left: 5px;
 }
-
 .framework-perseus .perseus-graded-group.answer-correct {
     /* Foreground token used to match the icon color.
     This border is meant to impart correctness meaning, so foreground

--- a/packages/perseus/src/styles/widgets/graded-group.css
+++ b/packages/perseus/src/styles/widgets/graded-group.css
@@ -4,14 +4,21 @@
     margin-left: 3px;
     padding-left: 5px;
 }
+
 .framework-perseus .perseus-graded-group.answer-correct {
+    /* Foreground token used to match the icon color.
+    This border is meant to impart correctness meaning, so foreground
+    seems appropriate */
     border-left: var(--wb-border-width-thick) solid
-        var(--wb-semanticColor-core-border-success-default);
+        var(--wb-semanticColor-core-foreground-success-default);
     margin-left: 0;
 }
 .framework-perseus .perseus-graded-group.answer-incorrect {
+    /* Foreground token used to match the icon color.
+    This border is meant to impart correctness meaning, so foreground
+    seems appropriate */
     border-left: var(--wb-border-width-thick) solid
-        var(--wb-semanticColor-core-border-critical-default);
+        var(--wb-semanticColor-core-foreground-critical-default);
     margin-left: 0;
 }
 .framework-perseus .perseus-graded-group .group-icon {

--- a/packages/perseus/src/widgets/graded-group/graded-group.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.tsx
@@ -289,13 +289,6 @@ export class GradedGroup
                             userInput={userInput}
                             handleUserInput={handleUserInput}
                             problemNum={0}
-                            // userInput={this.props.userInput}
-                            // handleUserInput={(widgetId, userInput) => {
-                            //     this.props.handleUserInput({
-                            //         ...this.props.userInput,
-                            //         [widgetId]: userInput,
-                            //     });
-                            // }}
                             ref={this.rendererRef}
                             keypadElement={this.props.keypadElement}
                             apiOptions={{...apiOptions, readOnly}}


### PR DESCRIPTION
## Summary:
Two colors displayed for showing correctness in Graded Group. This aligns the green bar with the green checkmark and the red "x" with the red bar. The bars were previously border tokens. Since these bars are meant to convey meaning other than just being a border for this section, the border colors were changed to match the foreground token used with the markers.

**Correct and Incorrect Before:**

https://github.com/user-attachments/assets/601ca5dc-91b1-4113-9c97-0fec14f23a73


**Correct and incorrect Now:**

https://github.com/user-attachments/assets/11bd10ce-ca93-47e8-92d8-44828598e6fe


Issue: LEMS-4479

## Test plan:
- Confirm the correct bar matches the correct marker and the incorrect bar matches the incorrect marker
- Confirm visual regression stories are as expected
- All checks pass