### PR TITLE
Update catalog hashes

### DIFF
--- a/.changeset/full-eggs-mate.md
+++ b/.changeset/full-eggs-mate.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-editor": patch
+"@khanacademy/math-input": patch
+---
+
+Internal: Update catalog hashes

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -82,6 +82,6 @@
     },
     "keywords": [],
     "khan": {
-        "catalogHash": "b6ee32d91be9a77e"
+        "catalogHash": "5cd7f0b55b2e97bf"
     }
 }

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -111,6 +111,6 @@
     },
     "keywords": [],
     "khan": {
-        "catalogHash": "7f07796630cee0b3"
+        "catalogHash": "a12a1605e2325e3e"
     }
 }


### PR DESCRIPTION
## Summary:
This unblocks the release. See thread for context:
https://khanacademy.slack.com/archives/C01AZ9H8TTQ/p1787930389307059

The cause of the catalog hashes being out of date was that I updated
the `@khanacademy/mathjax-renderer` peer dependency in this PR:
https://github.com/Khan/perseus/pull/4131

Issue: none

## Test plan:

- Land this PR
- Land the Version Packages PR
- A release should be published to NPM.