### PR TITLE
Widen the peer dep version range for `@khanacademy/mathjax-renderer`.

### DIFF
--- a/.changeset/old-parts-carry.md
+++ b/.changeset/old-parts-carry.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-editor": patch
+"@khanacademy/math-input": patch
+---
+
+Widen the peer dep version range for `@khanacademy/mathjax-renderer`. We support 3.1.4 as well as 3.2.0.

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -82,6 +82,6 @@
     },
     "keywords": [],
     "khan": {
-        "catalogHash": "5cd7f0b55b2e97bf"
+        "catalogHash": "b6ee32d91be9a77e"
     }
 }

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -111,6 +111,6 @@
     },
     "keywords": [],
     "khan": {
-        "catalogHash": "a12a1605e2325e3e"
+        "catalogHash": "7f07796630cee0b3"
     }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,7 +61,7 @@ catalogs:
         underscore: ^1.4.4
         "@phosphor-icons/core": ^2.0.2
         "@popperjs/core": ^2.10.2
-        "@khanacademy/mathjax-renderer": ^3.2.0
+        "@khanacademy/mathjax-renderer": ^3.1.4
         "@khanacademy/wonder-blocks-accordion": ^3.1.69
         "@khanacademy/wonder-blocks-announcer": ^1.1.1
         "@khanacademy/wonder-blocks-badge": ^1.1.21


### PR DESCRIPTION
## Summary:
We support 3.1.4 as well as 3.2.0.

This is causing CI failures in frontend because the perseus bump script is
failing on the "out-of-date" peer dep.

Issue: none

## Test plan:

Release. CI should pass on frontend PRs.