### PR TITLE
Remove redundant `shouldComponentUpdate` methods

### DIFF
--- a/.changeset/cuddly-turkeys-cough.md
+++ b/.changeset/cuddly-turkeys-cough.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: remove `shouldComponentUpdate` methods that just check shallow equality of props and state

--- a/packages/perseus/src/article-renderer.tsx
+++ b/packages/perseus/src/article-renderer.tsx
@@ -59,10 +59,6 @@ class ArticleRenderer
         this._currentFocus = null;
     }
 
-    shouldComponentUpdate(nextProps: Props): boolean {
-        return nextProps !== this.props;
-    }
-
     _handleFocusChange: (arg1: any, arg2: any) => void = (
         newFocusPath,
         oldFocusPath,

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -119,10 +119,6 @@ class GradedGroupSet extends React.Component<Props, State> implements Widget {
         });
     }
 
-    shouldComponentUpdate(nextProps: Props, nextState: State): boolean {
-        return nextProps !== this.props || nextState !== this.state;
-    }
-
     // Mobile API
     getInputPaths: () => ReadonlyArray<FocusPath> = () => {
         return this._childGroup.getInputPaths();

--- a/packages/perseus/src/widgets/graded-group/graded-group.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.tsx
@@ -111,10 +111,6 @@ export class GradedGroup
         });
     }
 
-    shouldComponentUpdate(nextProps: Props, nextState: State): boolean {
-        return nextProps !== this.props || nextState !== this.state;
-    }
-
     _handleUserInput(_userInput: UserInputMap, widgetsEmpty: boolean): void {
         // Reset grading display when user changes answer
         this.setState({


### PR DESCRIPTION
## Summary:
This PR removes an obstacle to converting Graded Group and Graded Group Set
to functional components.

`shouldComponentUpdate` is supposed to be for optimization. Class components
can implement it to return false when React does not need to render the
component.

These `shouldComponentUpdate` methods just checked shallow equality of props
and state.  This is redundant, since the only reason a component would normally
rerender is if props or state changed.
 
Issue: none

## Test plan:

CI checks should pass.