### PR TITLE
Replace `withDependencies` HOC with `useDependencies` where possible

### DIFF
--- a/.changeset/rich-candles-watch.md
+++ b/.changeset/rich-candles-watch.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Swap `withDependencies` HOC for `useDependencies` hook in several widgets.

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -8,32 +8,24 @@ import _ from "underscore";
 
 import {usePerseusI18n} from "../../components/i18n-context";
 import InlineIcon from "../../components/inline-icon";
-import {withDependencies} from "../../components/with-dependencies";
+import {useDependencies} from "../../dependencies";
 import {iconCircle, iconCircleThin} from "../../icon-paths";
 import Renderer from "../../renderer";
 import mediaQueries from "../../styles/media-queries";
 import sharedStyles from "../../styles/shared";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/categorizer/categorizer-ai-utils";
 
-import type {
-    PerseusDependenciesV2,
-    Widget,
-    WidgetExports,
-    WidgetProps,
-} from "../../types";
+import type {Widget, WidgetExports, WidgetProps} from "../../types";
 import type {CategorizerPromptJSON} from "../../widget-ai-utils/categorizer/categorizer-ai-utils";
 import type {
     PerseusCategorizerUserInput,
     PerseusCategorizerWidgetOptions,
 } from "@khanacademy/perseus-core";
 
-interface Props
-    extends WidgetProps<
-        PerseusCategorizerWidgetOptions,
-        PerseusCategorizerUserInput
-    > {
-    dependencies: PerseusDependenciesV2;
-}
+type Props = WidgetProps<
+    PerseusCategorizerWidgetOptions,
+    PerseusCategorizerUserInput
+>;
 
 const Categorizer = forwardRef<Widget, Props>(function Categorizer(props, ref) {
     const {items, categories, randomizeItems} = props.options;
@@ -44,8 +36,8 @@ const Categorizer = forwardRef<Widget, Props>(function Categorizer(props, ref) {
         linterContext,
         handleUserInput,
         trackInteraction,
-        dependencies,
     } = props;
+    const dependencies = useDependencies();
     const {strings} = usePerseusI18n();
     const idPrefix = useMemo(() => _.uniqueId("perseus_radio_"), []);
 
@@ -72,6 +64,9 @@ const Categorizer = forwardRef<Widget, Props>(function Categorizer(props, ref) {
             return {
                 ...options,
                 ...rest,
+                // `dependencies` probably shouldn't be included here, but this
+                // is for legacy compatibility.
+                dependencies,
                 values: userInput.values,
             };
         },
@@ -305,17 +300,12 @@ function getStartUserInput(): PerseusCategorizerUserInput {
     };
 }
 
-const WrappedCategorizer = withDependencies(Categorizer);
-
 export default {
     name: "categorizer",
     displayName: "Categorizer",
-    widget: WrappedCategorizer,
+    widget: Categorizer,
     getUserInputFromSerializedState,
     getCorrectUserInput,
     getStartUserInput,
     isLintable: true,
-} satisfies WidgetExports<
-    typeof WrappedCategorizer,
-    PerseusCategorizerUserInput
->;
+} satisfies WidgetExports<typeof Categorizer, PerseusCategorizerUserInput>;

--- a/packages/perseus/src/widgets/categorizer/categorizer.tsx
+++ b/packages/perseus/src/widgets/categorizer/categorizer.tsx
@@ -64,9 +64,6 @@ const Categorizer = forwardRef<Widget, Props>(function Categorizer(props, ref) {
             return {
                 ...options,
                 ...rest,
-                // `dependencies` probably shouldn't be included here, but this
-                // is for legacy compatibility.
-                dependencies,
                 values: userInput.values,
             };
         },

--- a/packages/perseus/src/widgets/categorizer/serialize-categorizer.test.ts
+++ b/packages/perseus/src/widgets/categorizer/serialize-categorizer.test.ts
@@ -7,10 +7,7 @@ import {userEvent as userEventLib} from "@testing-library/user-event";
 
 import {renderQuestion} from "../../__tests__/test-utils";
 import * as Dependencies from "../../dependencies";
-import {
-    testDependencies,
-    testDependenciesV2,
-} from "../../testing/test-dependencies";
+import {testDependencies} from "../../testing/test-dependencies";
 import {registerAllWidgetsForTesting} from "../../util/register-all-widgets-for-testing";
 
 import type {PerseusItem} from "@khanacademy/perseus-core";
@@ -99,7 +96,6 @@ describe("Categorizer serialization", () => {
                      * - value: represents which category is selected for that item
                      */
                     values: [undefined, 0],
-                    dependencies: testDependenciesV2,
                 },
             },
             hints: [],

--- a/packages/perseus/src/widgets/dropdown/dropdown.tsx
+++ b/packages/perseus/src/widgets/dropdown/dropdown.tsx
@@ -121,9 +121,6 @@ const Dropdown = forwardRef<Widget, Props>(function Dropdown(props, ref) {
             return {
                 ...otherOptions,
                 ...otherProps,
-                // `dependencies` probably shouldn't be included here, but this
-                // is for legacy compatibility.
-                dependencies,
                 choices: choices.map((choice) => choice.content),
                 selected: userInput.value,
             };

--- a/packages/perseus/src/widgets/dropdown/dropdown.tsx
+++ b/packages/perseus/src/widgets/dropdown/dropdown.tsx
@@ -11,17 +11,12 @@ import React, {
 } from "react";
 
 import {usePerseusI18n} from "../../components/i18n-context";
-import {withDependencies} from "../../components/with-dependencies";
+import {useDependencies} from "../../dependencies";
 import {ApiOptions} from "../../perseus-api";
 import Renderer from "../../renderer";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/dropdown/dropdown-ai-utils";
 
-import type {
-    PerseusDependenciesV2,
-    Widget,
-    WidgetExports,
-    WidgetProps,
-} from "../../types";
+import type {Widget, WidgetExports, WidgetProps} from "../../types";
 import type {DropdownPromptJSON} from "../../widget-ai-utils/dropdown/dropdown-ai-utils";
 import type {
     PerseusDropdownUserInput,
@@ -31,9 +26,7 @@ import type {
 type Props = WidgetProps<
     PerseusDropdownWidgetOptions,
     PerseusDropdownUserInput
-> & {
-    dependencies: PerseusDependenciesV2;
-};
+>;
 
 const Dropdown = forwardRef<Widget, Props>(function Dropdown(props, ref) {
     const {strings} = usePerseusI18n();
@@ -48,12 +41,12 @@ const Dropdown = forwardRef<Widget, Props>(function Dropdown(props, ref) {
     const {
         apiOptions = ApiOptions.defaults,
         userInput = {value: 0},
-        dependencies,
         widgetId,
         trackInteraction,
         handleUserInput,
     } = props;
     const isStatic = props.static ?? false;
+    const dependencies = useDependencies();
 
     // Fire analytics event on mount
     // We intentionally use an empty dependency array here because this analytics
@@ -128,6 +121,9 @@ const Dropdown = forwardRef<Widget, Props>(function Dropdown(props, ref) {
             return {
                 ...otherOptions,
                 ...otherProps,
+                // `dependencies` probably shouldn't be included here, but this
+                // is for legacy compatibility.
+                dependencies,
                 choices: choices.map((choice) => choice.content),
                 selected: userInput.value,
             };
@@ -233,13 +229,11 @@ function getCorrectUserInput(
     return {value: options.choices.findIndex((c) => c.correct) + 1};
 }
 
-const WrappedDropdown = withDependencies(Dropdown);
-
 export default {
     name: "dropdown",
     displayName: "Drop down",
-    widget: WrappedDropdown,
+    widget: Dropdown,
     getStartUserInput,
     getCorrectUserInput,
     getUserInputFromSerializedState,
-} satisfies WidgetExports<typeof WrappedDropdown>;
+} satisfies WidgetExports<typeof Dropdown>;

--- a/packages/perseus/src/widgets/dropdown/serialize-dropdown.test.ts
+++ b/packages/perseus/src/widgets/dropdown/serialize-dropdown.test.ts
@@ -7,10 +7,7 @@ import {userEvent as userEventLib} from "@testing-library/user-event";
 
 import {renderQuestion} from "../../__tests__/test-utils";
 import * as Dependencies from "../../dependencies";
-import {
-    testDependencies,
-    testDependenciesV2,
-} from "../../testing/test-dependencies";
+import {testDependencies} from "../../testing/test-dependencies";
 import {registerAllWidgetsForTesting} from "../../util/register-all-widgets-for-testing";
 
 import type {PerseusItem} from "@khanacademy/perseus-core";
@@ -93,7 +90,6 @@ describe("Dropdown serialization", () => {
                     alignment: "default",
                     static: false,
                     choices: ["Correct", "Incorrect"],
-                    dependencies: testDependenciesV2,
                     placeholder: "Choose",
                     // selected is added to Dropdown props and
                     // represents user input

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -77,9 +77,7 @@ function Indicators(props: IndicatorsProps) {
     );
 }
 
-type Props = WidgetProps<PerseusGradedGroupSetWidgetOptions> & {
-    trackInteraction: () => void;
-};
+type Props = WidgetProps<PerseusGradedGroupSetWidgetOptions>;
 
 const GradedGroupSet = forwardRef<Widget, Props>(
     function GradedGroupSet(props, ref) {

--- a/packages/perseus/src/widgets/matcher/matcher.tsx
+++ b/packages/perseus/src/widgets/matcher/matcher.tsx
@@ -8,18 +8,12 @@ import {forwardRef, useImperativeHandle, useRef, useState} from "react";
 
 import {usePerseusI18n} from "../../components/i18n-context";
 import Sortable from "../../components/sortable";
-import {withDependencies} from "../../components/with-dependencies";
-import {getDependencies} from "../../dependencies";
+import {getDependencies, useDependencies} from "../../dependencies";
 import Renderer from "../../renderer";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/matcher/matcher-ai-utils";
 
 import type {SortableOption} from "../../components/sortable";
-import type {
-    WidgetExports,
-    WidgetProps,
-    Widget,
-    PerseusDependenciesV2,
-} from "../../types";
+import type {WidgetExports, WidgetProps, Widget} from "../../types";
 import type {MatcherPromptJSON} from "../../widget-ai-utils/matcher/matcher-ai-utils";
 import type {
     PerseusMatcherWidgetOptions,
@@ -29,12 +23,7 @@ import type {
 
 const HACKY_CSS_CLASSNAME = "perseus-widget-matcher";
 
-type Props = WidgetProps<
-    PerseusMatcherWidgetOptions,
-    PerseusMatcherUserInput
-> & {
-    dependencies: PerseusDependenciesV2;
-};
+type Props = WidgetProps<PerseusMatcherWidgetOptions, PerseusMatcherUserInput>;
 
 /**
  * The imperative API the Matcher widget exposes to its parent renderer. On top
@@ -48,6 +37,7 @@ export interface MatcherHandle extends Widget {
 
 const Matcher = forwardRef<MatcherHandle, Props>(function Matcher(props, ref) {
     const {strings} = usePerseusI18n();
+    const dependencies = useDependencies();
 
     const leftSortable = useRef<Sortable>(null);
     const rightSortable = useRef<Sortable>(null);
@@ -57,7 +47,7 @@ const Matcher = forwardRef<MatcherHandle, Props>(function Matcher(props, ref) {
     const [texRendererLoaded, setTexRendererLoaded] = useState(false);
 
     useOnMountEffect(() => {
-        props.dependencies.analytics.onAnalyticsEvent({
+        dependencies.analytics.onAnalyticsEvent({
             type: "perseus:widget:rendered:ti",
             payload: {
                 widgetSubType: "null",
@@ -220,17 +210,15 @@ function getUserInputFromSerializedState(
     };
 }
 
-const WrappedMatcher = withDependencies(Matcher);
-
 export default {
     name: "matcher",
     displayName: "Matcher (two column)",
     hidden: true,
-    widget: WrappedMatcher,
+    widget: Matcher,
     isLintable: true,
     getStartUserInput,
     getUserInputFromSerializedState,
-} satisfies WidgetExports<typeof WrappedMatcher>;
+} satisfies WidgetExports<typeof Matcher>;
 
 const padding = 5;
 const border = `var(--wb-border-width-thin) solid var(--wb-semanticColor-core-border-neutral-strong)`;

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -15,16 +15,11 @@ import Graphie from "../../components/graphie";
 import {usePerseusI18n} from "../../components/i18n-context";
 import NumberInput from "../../components/number-input";
 import SimpleKeypadInput from "../../components/simple-keypad-input";
-import {withDependencies} from "../../components/with-dependencies";
+import {useDependencies} from "../../dependencies";
 import InteractiveUtil from "../../interactive2/interactive-util";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/number-line/number-line-ai-utils";
 
-import type {
-    PerseusDependenciesV2,
-    Widget,
-    WidgetExports,
-    WidgetProps,
-} from "../../types";
+import type {Widget, WidgetExports, WidgetProps} from "../../types";
 import type {NumberLinePromptJSON} from "../../widget-ai-utils/number-line/number-line-ai-utils";
 import type {
     NumberLinePublicWidgetOptions,
@@ -220,9 +215,7 @@ const TickMarks: any = (Graphie as any).createSimpleClass((graphie, props) => {
 type Props = WidgetProps<
     PerseusNumberLineWidgetOptions,
     PerseusNumberLineUserInput
-> & {
-    dependencies: PerseusDependenciesV2;
-};
+>;
 
 // Whether the widget's configuration makes a drawable number line. An invalid
 // configuration would send the drawing code into an infinite loop.
@@ -244,6 +237,7 @@ function isValid(props: Props): boolean {
 
 const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
     const {strings} = usePerseusI18n();
+    const dependencies = useDependencies();
     const propsRef = useLatestRef(props);
     const [numDivisionsEmpty, setNumDivisionsEmpty] = useState(false);
     const tickStep = getTickStep(
@@ -260,7 +254,7 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
     const tickCtrlRef = useRef<NumberInput | SimpleKeypadInput>(null);
 
     useOnMountEffect(() => {
-        props.dependencies.analytics.onAnalyticsEvent({
+        dependencies.analytics.onAnalyticsEvent({
             type: "perseus:widget:rendered:ti",
             payload: {
                 widgetSubType: "null",
@@ -769,13 +763,11 @@ function getStartUserInput(
     };
 }
 
-const WrappedNumberLine = withDependencies(NumberLine);
-
 export default {
     name: "number-line",
     displayName: "Number line",
-    widget: WrappedNumberLine,
+    widget: NumberLine,
     getCorrectUserInput,
     getStartUserInput,
     getUserInputFromSerializedState,
-} satisfies WidgetExports<typeof WrappedNumberLine>;
+} satisfies WidgetExports<typeof NumberLine>;

--- a/packages/perseus/src/widgets/python-program/python-program.tsx
+++ b/packages/perseus/src/widgets/python-program/python-program.tsx
@@ -6,15 +6,10 @@ import {StyleSheet} from "aphrodite";
 import React, {forwardRef, useImperativeHandle} from "react";
 
 import {usePerseusI18n} from "../../components/i18n-context";
-import {withDependencies} from "../../components/with-dependencies";
+import {useDependencies} from "../../dependencies";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/python-program/python-ai-utils";
 
-import type {
-    PerseusDependenciesV2,
-    Widget,
-    WidgetExports,
-    WidgetProps,
-} from "../../types";
+import type {Widget, WidgetExports, WidgetProps} from "../../types";
 import type {UnsupportedWidgetPromptJSON} from "../../widget-ai-utils/unsupported-widget";
 import type {PerseusPythonProgramWidgetOptions} from "@khanacademy/perseus-core";
 
@@ -22,9 +17,7 @@ function getUrlFromProgramID(programID: string) {
     return `/python-program/${programID}/embedded`;
 }
 
-type Props = WidgetProps<PerseusPythonProgramWidgetOptions> & {
-    dependencies: PerseusDependenciesV2;
-};
+type Props = WidgetProps<PerseusPythonProgramWidgetOptions>;
 
 // The Widget-interface methods this component exposes via its ref.
 type WidgetHandle = Pick<Widget, "getPromptJSON">;
@@ -35,8 +28,8 @@ type WidgetHandle = Pick<Widget, "getPromptJSON">;
 const PythonProgram = forwardRef<WidgetHandle, Props>(
     function PythonProgram(props, ref) {
         const {strings, locale} = usePerseusI18n();
+        const dependencies = useDependencies();
         const {programID, height} = props.options;
-        const {dependencies} = props;
 
         useImperativeHandle(ref, () => ({
             getPromptJSON: (): UnsupportedWidgetPromptJSON => {
@@ -87,10 +80,8 @@ const styles = StyleSheet.create({
     },
 });
 
-const WrappedPythonProgram = withDependencies(PythonProgram);
-
 export default {
     name: "python-program",
     displayName: "Python Program",
-    widget: WrappedPythonProgram,
-} satisfies WidgetExports<typeof WrappedPythonProgram>;
+    widget: PythonProgram,
+} satisfies WidgetExports<typeof PythonProgram>;


### PR DESCRIPTION
## Summary:
This lets us remove `dependencies` from the Props types.

Issue: LEMS-4426

## Test plan:

CI checks should pass.