### PR TITLE
[Radio Widget] Fix randomized choices always rendering in the same order in articles

### DIFF
--- a/.changeset/forty-buttons-grow.md
+++ b/.changeset/forty-buttons-grow.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus": patch
+---
+
+Fix randomized choices always rendering in the same order in articles for Radio widget inside a graded group

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -259,7 +259,12 @@ export {
 /** @hidden */
 export type {MatcherPublicWidgetOptions} from "./widgets/matcher/matcher-util";
 /** @hidden */
-export {shuffle, seededRNG, random} from "./utils/random-util";
+export {
+    shuffle,
+    seededRNG,
+    random,
+    hashStringToSeed,
+} from "./utils/random-util";
 export {default as PerseusFeatureFlags} from "./feature-flags";
 /** @hidden */
 export {isFeatureOn} from "./feature-flags";

--- a/packages/perseus-core/src/utils/random-util.test.ts
+++ b/packages/perseus-core/src/utils/random-util.test.ts
@@ -2,11 +2,36 @@ import {describe, it, expect} from "@jest/globals";
 
 import {
     constrainedShuffle,
+    hashStringToSeed,
     randomIntInRange,
     seededRNG,
     shuffle,
 } from "./random-util";
 import {range} from "./range";
+
+describe("hashStringToSeed", () => {
+    it.each([
+        ["", 2166136261],
+        ["a", 3826002220],
+        ["foobar", 3214735720],
+    ])("returns the published FNV-1a hash of %p", (input, expected) => {
+        expect(hashStringToSeed(input)).toBe(expected);
+    });
+
+    it("returns different seeds for strings that differ only in order", () => {
+        expect(hashStringToSeed("ab")).not.toEqual(hashStringToSeed("ba"));
+    });
+
+    it("returns a non-negative 32-bit integer", () => {
+        const seeds = range(0, 200).map((i) => hashStringToSeed(`choice-${i}`));
+
+        seeds.forEach((seed) => {
+            expect(Number.isInteger(seed)).toBe(true);
+            expect(seed).toBeGreaterThanOrEqual(0);
+            expect(seed).toBeLessThanOrEqual(0xffffffff);
+        });
+    });
+});
 
 describe("shuffle", () => {
     it("does nothing to an empty array", () => {

--- a/packages/perseus-core/src/utils/random-util.ts
+++ b/packages/perseus-core/src/utils/random-util.ts
@@ -27,6 +27,30 @@ export const seededRNG: (seed: number) => RNG = function (seed: number): RNG {
 };
 
 /**
+ * Hash a string into a 32-bit unsigned integer, for seeding
+ * `seededRNG`/`shuffle` from content rather than from a position.
+ *
+ * FNV-1a: fast and well-spread for short strings, but not cryptographic.
+ */
+export function hashStringToSeed(str: string): number {
+    let hash = 0x811c9dc5; // FNV offset basis
+    for (let i = 0; i < str.length; i++) {
+        hash ^= str.charCodeAt(i);
+        // Multiply by the FNV prime (16777619) via shifts. `hash * 16777619`
+        // would exceed exact float integer range and lose the low bits.
+        hash =
+            (hash +
+                ((hash << 1) +
+                    (hash << 4) +
+                    (hash << 7) +
+                    (hash << 8) +
+                    (hash << 24))) >>>
+            0;
+    }
+    return hash;
+}
+
+/**
  * Shuffle an array using a given random seed or function.
  * If `ensurePermuted` is true, the input and output are guaranteed to be
  * distinct permutations.

--- a/packages/perseus/src/widgets/radio/__docs__/multiple-choice-randomization.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/multiple-choice-randomization.stories.tsx
@@ -1,0 +1,185 @@
+import {
+    generateGradedGroupOptions,
+    generateGradedGroupWidget,
+    generateRadioChoice,
+    generateRadioOptions,
+    generateRadioWidget,
+    generateTestPerseusRenderer,
+} from "@khanacademy/perseus-core";
+
+import {ArticleRendererWithDebugUI} from "../../../testing/article-renderer-with-debug-ui";
+
+import type {
+    PerseusArticle,
+    PerseusRadioChoice,
+    PerseusWidgetsMap,
+} from "@khanacademy/perseus-core";
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+const meta = {
+    title: "Widgets/Radio/Randomization",
+    component: ArticleRendererWithDebugUI,
+    tags: ["!manifest", "!autodocs"],
+} satisfies Meta<typeof ArticleRendererWithDebugUI>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// Renders as Mitochondria, Nucleus, Vacuole, Ribosome — only the last two move.
+const ORGANELLES = ["Mitochondria", "Nucleus", "Ribosome", "Vacuole"];
+const ORGANELLE_PROMPT =
+    "Which organelle produces most of a cell's energy? (Mitochondria is authored first)";
+
+function radioChoices(contents: string[]): PerseusRadioChoice[] {
+    return contents.map((content, index) =>
+        generateRadioChoice(content, {
+            // Ids are set explicitly because the seed hashes them and
+            // `generateRadioChoice` randomises them.
+            id: `radio-choice-${index}`,
+            correct: index === 0,
+        }),
+    );
+}
+
+function gradedGroupWithRadio(
+    title: string,
+    prompt: string,
+    contents: string[],
+    randomize: boolean,
+) {
+    return generateGradedGroupWidget({
+        options: generateGradedGroupOptions({
+            title,
+            content: `**${prompt}**\n\n[[☃ radio 1]]`,
+            widgets: {
+                "radio 1": generateRadioWidget({
+                    options: generateRadioOptions({
+                        choices: radioChoices(contents),
+                        randomize,
+                        numCorrect: 1,
+                    }),
+                }),
+            },
+        }),
+    });
+}
+
+function article(
+    intro: string,
+    groups: Array<{
+        title: string;
+        prompt: string;
+        contents: string[];
+        randomize?: boolean;
+    }>,
+): PerseusArticle {
+    const widgets: PerseusWidgetsMap = {};
+    groups.forEach((group, index) => {
+        widgets[`graded-group ${index + 1}`] = gradedGroupWithRadio(
+            group.title,
+            group.prompt,
+            group.contents,
+            group.randomize ?? true,
+        );
+    });
+
+    const body = groups
+        .map((_, index) => `[[☃ graded-group ${index + 1}]]`)
+        .join("\n\n");
+
+    return generateTestPerseusRenderer({
+        content: `${intro}\n\n${body}`,
+        widgets,
+    });
+}
+
+export const SingleQuestionLooksBarelyShuffled: Story = {
+    args: {
+        title: "📜 One question — order is fixed, and that's expected",
+        json: article(
+            [
+                "## A single question looks barely shuffled",
+                "",
+                "Authored as Mitochondria, Nucleus, Ribosome, Vacuole — it renders **Mitochondria, Nucleus, Vacuole, Ribosome**, so only the last two appear to have moved.",
+                "",
+                "That is one of the 24 permutations, not a failure to randomize. Reloading will not change it; the order is a pure function of the question's content. About 1 question in 12 leaves the first two choices in place.",
+                "",
+                'Note the **letters are position labels** and always read A, B, C, D top to bottom — only the content moves. Naming choices after the letters ("Choice A", "Choice B", …) makes a shuffled question look untouched, so avoid it when smoke testing.',
+            ].join("\n"),
+            [
+                {
+                    title: "CHECK FOR UNDERSTANDING:",
+                    prompt: ORGANELLE_PROMPT,
+                    contents: ORGANELLES,
+                },
+            ],
+        ),
+    },
+};
+
+export const SingleQuestionWithoutRandomization: Story = {
+    args: {
+        title: "📜 One question — randomize off",
+        json: article(
+            "## Randomize order: off\n\nThe same question unshuffled, for side-by-side comparison with the story above. Only the last two choices differ between them.",
+            [
+                {
+                    title: "CHECK FOR UNDERSTANDING:",
+                    prompt: ORGANELLE_PROMPT,
+                    contents: ORGANELLES,
+                    randomize: false,
+                },
+            ],
+        ),
+    },
+};
+
+export const CorrectAnswerMovesBetweenQuestions: Story = {
+    args: {
+        title: "📜 Five questions — the correct answer moves",
+        json: article(
+            [
+                "## Randomization is visible across questions, not within one",
+                "",
+                "Every question below authors the correct answer **first**, and all five render at the same position seed — articles supply no `problemNum`, and each graded group restarts the widget index at 0.",
+                "",
+                "Before the fix all five shuffled identically, with the correct answer pinned to C. Now it lands at **A, B, C, D**.",
+                "",
+                "Question 5 is included deliberately: its permutation is the identity, so it renders in the authored order and looks entirely unshuffled. That happens to 1 in 24 four-choice questions, and is why one question is never evidence either way.",
+            ].join("\n"),
+            [
+                {
+                    title: "QUESTION 1 — correct answer renders at A:",
+                    prompt: "Which city is the capital of France? (Paris is authored first)",
+                    contents: ["Paris", "London", "Rome", "Madrid"],
+                },
+                {
+                    title: "QUESTION 2 — correct answer renders at B:",
+                    prompt: "Which planet is closest to the Sun? (Mercury is authored first)",
+                    contents: ["Mercury", "Venus", "Earth", "Mars"],
+                },
+                {
+                    title: "QUESTION 3 — correct answer renders at C:",
+                    prompt: "Which process turns liquid water into vapour? (Evaporation is authored first)",
+                    contents: [
+                        "Evaporation",
+                        "Condensation",
+                        "Precipitation",
+                        "Collection",
+                    ],
+                },
+                {
+                    title: "QUESTION 4 — correct answer renders at D:",
+                    prompt: "Which gas do we breathe in to survive? (Oxygen is authored first)",
+                    contents: ["Oxygen", "Carbon", "Helium", "Nitrogen"],
+                },
+                {
+                    title: "QUESTION 5 — renders in the authored order:",
+                    prompt: "Which word type names a person or thing? (Noun is authored first)",
+                    contents: ["Noun", "Verb", "Adjective", "Adverb"],
+                },
+            ],
+        ),
+    },
+};

--- a/packages/perseus/src/widgets/radio/__tests__/randomization.test.tsx
+++ b/packages/perseus/src/widgets/radio/__tests__/randomization.test.tsx
@@ -1,0 +1,161 @@
+import {
+    StatefulKeypadContextProvider,
+    KeypadContext,
+} from "@khanacademy/keypad-context";
+import {
+    generateGradedGroupOptions,
+    generateGradedGroupWidget,
+    generateRadioChoice,
+    generateRadioOptions,
+    generateRadioWidget,
+    generateTestPerseusRenderer,
+} from "@khanacademy/perseus-core";
+import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
+import {screen, render, within} from "@testing-library/react";
+import * as React from "react";
+
+import ArticleRenderer from "../../../article-renderer";
+import * as Dependencies from "../../../dependencies";
+import {
+    testDependencies,
+    testDependenciesV2,
+} from "../../../testing/test-dependencies";
+import {registerAllWidgetsForTesting} from "../../../util/register-all-widgets-for-testing";
+
+import type {
+    PerseusArticle,
+    PerseusWidgetsMap,
+} from "@khanacademy/perseus-core";
+
+const CAPITALS = ["Paris", "London", "Rome", "Madrid"];
+const PLANETS = ["Mercury", "Venus", "Earth", "Mars"];
+const AUTHORED_ORDER = [0, 1, 2, 3];
+const CORRECT_ANSWER_INDEX = 0;
+
+function renderArticle(json: PerseusArticle): void {
+    render(
+        <RenderStateRoot>
+            <StatefulKeypadContextProvider>
+                <KeypadContext.Consumer>
+                    {({keypadElement}) => (
+                        <ArticleRenderer
+                            json={json}
+                            dependencies={testDependenciesV2}
+                            apiOptions={{}}
+                            keypadElement={keypadElement}
+                        />
+                    )}
+                </KeypadContext.Consumer>
+            </StatefulKeypadContextProvider>
+        </RenderStateRoot>,
+    );
+}
+
+function buildArticle(
+    questions: ReadonlyArray<{choices: string[]; randomize?: boolean}>,
+): PerseusArticle {
+    const widgets: PerseusWidgetsMap = {};
+
+    questions.forEach(({choices, randomize = true}, index) => {
+        widgets[`graded-group ${index + 1}`] = generateGradedGroupWidget({
+            options: generateGradedGroupOptions({
+                title: `Question ${index + 1}`,
+                content: "[[☃ radio 1]]",
+                widgets: {
+                    "radio 1": generateRadioWidget({
+                        options: generateRadioOptions({
+                            numCorrect: 1,
+                            randomize,
+                            // Ids are set explicitly because the seed hashes
+                            // them and `generateRadioChoice` randomises them.
+                            choices: choices.map((content, choiceIndex) =>
+                                generateRadioChoice(content, {
+                                    id: `radio-choice-${choiceIndex}`,
+                                    correct:
+                                        choiceIndex === CORRECT_ANSWER_INDEX,
+                                }),
+                            ),
+                        }),
+                    }),
+                },
+            }),
+        });
+    });
+
+    return generateTestPerseusRenderer({
+        content: questions
+            .map((_, index) => `[[☃ graded-group ${index + 1}]]`)
+            .join("\n\n"),
+        widgets,
+    });
+}
+
+function renderedOrdersByAuthoredIndex(
+    questions: ReadonlyArray<{choices: string[]}>,
+): number[][] {
+    // Choices are a role="list" per question; their buttons hold only the letter.
+    const lists = screen.getAllByRole("list");
+
+    return questions.map(({choices}, questionIndex) =>
+        within(lists[questionIndex])
+            .getAllByRole("listitem")
+            .map((item) =>
+                choices.findIndex((content) =>
+                    item.textContent?.includes(content),
+                ),
+            ),
+    );
+}
+
+describe("radio randomization in an article", () => {
+    beforeAll(() => {
+        registerAllWidgetsForTesting();
+    });
+
+    beforeEach(() => {
+        jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+            testDependencies,
+        );
+    });
+
+    it("renders the authored order when randomize is off", () => {
+        const questions = [{choices: CAPITALS, randomize: false}];
+
+        renderArticle(buildArticle(questions));
+
+        expect(renderedOrdersByAuthoredIndex(questions)).toEqual([
+            AUTHORED_ORDER,
+        ]);
+    });
+
+    it("shuffles the choices when randomize is on", () => {
+        const questions = [{choices: CAPITALS}];
+
+        renderArticle(buildArticle(questions));
+
+        expect(renderedOrdersByAuthoredIndex(questions)).not.toEqual([
+            AUTHORED_ORDER,
+        ]);
+    });
+
+    it("gives two questions in the same article different orders", () => {
+        const questions = [{choices: CAPITALS}, {choices: PLANETS}];
+
+        renderArticle(buildArticle(questions));
+
+        const [firstOrder, secondOrder] =
+            renderedOrdersByAuthoredIndex(questions);
+        expect(firstOrder).not.toEqual(secondOrder);
+    });
+
+    it("does not put the correct answer in the same position in every question", () => {
+        const questions = [{choices: CAPITALS}, {choices: PLANETS}];
+
+        renderArticle(buildArticle(questions));
+
+        const correctAnswerPositions = renderedOrdersByAuthoredIndex(
+            questions,
+        ).map((order) => order.indexOf(CORRECT_ANSWER_INDEX));
+        expect(new Set(correctAnswerPositions).size).toBeGreaterThan(1);
+    });
+});

--- a/packages/perseus/src/widgets/radio/radio-widget.tsx
+++ b/packages/perseus/src/widgets/radio/radio-widget.tsx
@@ -10,7 +10,7 @@ import Renderer from "../../renderer";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/radio/radio-ai-utils";
 
 import RadioComponent from "./radio-component";
-import {choiceTransform} from "./util";
+import {choiceTransform, getShuffleSeed} from "./util";
 import {getChoiceStates} from "./utils/general-utils";
 
 import type {WidgetProps, ChoiceState, Widget} from "../../types";
@@ -94,17 +94,23 @@ const RadioWidget = forwardRef<RadioWidgetHandle, Props>(
         const {strings} = usePerseusI18n();
         const {analytics} = useDependencies();
 
-        const randomSeed = (props.problemNum ?? 0) + (props.widgetIndex ?? 0);
+        const positionSeed = (props.problemNum ?? 0) + (props.widgetIndex ?? 0);
         const choices = useMemo(() => {
             return [
                 ...choiceTransform(
                     options.choices,
                     options.randomize,
                     strings,
-                    randomSeed,
+                    getShuffleSeed(widgetId, options.choices, positionSeed),
                 ),
             ];
-        }, [options.choices, options.randomize, strings, randomSeed]);
+        }, [
+            options.choices,
+            options.randomize,
+            strings,
+            widgetId,
+            positionSeed,
+        ]);
 
         useOnMountEffect(() => {
             analytics.onAnalyticsEvent({

--- a/packages/perseus/src/widgets/radio/serialize-radio.test.ts
+++ b/packages/perseus/src/widgets/radio/serialize-radio.test.ts
@@ -17,30 +17,33 @@ const expectedSerializedRadio = {
     alignment: "default",
     numCorrect: 1,
     hasNoneOfTheAbove: false,
+    // The shuffle `getShuffleSeed` produces from the choice ids and content
+    // below at position seed 0 (what `renderQuestion` gives us). Editing that
+    // content changes the order and this fixture with it.
     choices: [
         {
-            id: "5-5-5-5-5",
-            content: "Content 4",
-            correct: false,
-            originalIndex: 3, // <= note we stash original index
-        },
-        {
-            id: "3-3-3-3-3",
+            id: "radio-choice-1",
             content: "Content 2",
             correct: false,
-            originalIndex: 1,
+            originalIndex: 1, // <= note we stash original index
         },
         {
-            id: "0-0-0-0-0",
-            content: "Content 1",
-            correct: true,
-            originalIndex: 0,
+            id: "radio-choice-3",
+            content: "Content 4",
+            correct: false,
+            originalIndex: 3,
         },
         {
-            id: "4-4-4-4-4",
+            id: "radio-choice-2",
             content: "Content 3",
             correct: false,
             originalIndex: 2,
+        },
+        {
+            id: "radio-choice-0",
+            content: "Content 1",
+            correct: true,
+            originalIndex: 0,
         },
     ],
     choiceStates: [
@@ -111,22 +114,22 @@ describe("Radio widget serialization", () => {
                         randomize: true, // <= important
                         choices: [
                             {
-                                id: "0-0-0-0-0",
+                                id: "radio-choice-0",
                                 content: "Content 1",
                                 correct: true,
                             },
                             {
-                                id: "3-3-3-3-3",
+                                id: "radio-choice-1",
                                 content: "Content 2",
                                 correct: false,
                             },
                             {
-                                id: "4-4-4-4-4",
+                                id: "radio-choice-2",
                                 content: "Content 3",
                                 correct: false,
                             },
                             {
-                                id: "5-5-5-5-5",
+                                id: "radio-choice-3",
                                 content: "Content 4",
                                 correct: false,
                             },

--- a/packages/perseus/src/widgets/radio/util.test.ts
+++ b/packages/perseus/src/widgets/radio/util.test.ts
@@ -4,6 +4,7 @@ import {
     choiceTransform,
     enforceOrdering,
     getChoiceLetter,
+    getShuffleSeed,
     moveNoneOfTheAboveToEnd,
 } from "./util";
 
@@ -215,6 +216,94 @@ describe("enforceOrdering", () => {
 
         expect(rv[0].content).toBe("Hello");
         expect(rv[1].content).toBe("World");
+    });
+});
+
+describe("getShuffleSeed", () => {
+    function generateChoices(contents: string[]): PerseusRadioChoice[] {
+        return contents.map((content, i) => ({
+            content,
+            id: `radio-choice-${i}`,
+        }));
+    }
+
+    // A change here silently reorders every randomized radio question shipped.
+    it("returns a stable seed for a known widget, choices, and position", () => {
+        const choices = generateChoices(["Paris", "London", "Rome", "Madrid"]);
+
+        expect(getShuffleSeed("radio 1", choices, 0)).toBe(3883733930);
+    });
+
+    it("returns different seeds for different widget ids", () => {
+        const choices = generateChoices(["Choice 1", "Choice 2"]);
+
+        expect(getShuffleSeed("radio 1", choices, 0)).not.toEqual(
+            getShuffleSeed("radio 2", choices, 0),
+        );
+    });
+
+    // `problemNum` varies across a session, so re-encountered items reshuffle.
+    it("returns different seeds for the same question at different positions", () => {
+        const choices = generateChoices(["Choice 1", "Choice 2", "Choice 3"]);
+
+        expect(getShuffleSeed("radio 1", choices, 0)).not.toEqual(
+            getShuffleSeed("radio 1", choices, 1),
+        );
+    });
+
+    // These two collide under `${id}:${content}` joined on `|` — Markdown
+    // content contains both characters.
+    it("returns different seeds for choice sets that differ only in delimiter placement", () => {
+        const oneChoice: PerseusRadioChoice[] = [
+            {id: "radio-choice-0", content: "Yes|radio-choice-1:No"},
+        ];
+        const twoChoices: PerseusRadioChoice[] = [
+            {id: "radio-choice-0", content: "Yes"},
+            {id: "radio-choice-1", content: "No"},
+        ];
+
+        expect(getShuffleSeed("radio 1", oneChoice, 0)).not.toEqual(
+            getShuffleSeed("radio 1", twoChoices, 0),
+        );
+    });
+
+    it("spreads the correct answer across all positions when questions share a position seed", () => {
+        const questionCount = 200;
+        const choiceCount = 4;
+
+        const correctPositions = Array.from(
+            {length: questionCount},
+            (_, questionIndex) => {
+                const choices: PerseusRadioChoice[] = Array.from(
+                    {length: choiceCount},
+                    (_, choiceIndex) => ({
+                        id: `radio-choice-${choiceIndex}`,
+                        content: `Question ${questionIndex} choice ${choiceIndex}`,
+                        // Correct answer first — the shape that caused the bug.
+                        correct: choiceIndex === 0,
+                    }),
+                );
+                const shuffled = choiceTransform(
+                    choices,
+                    true,
+                    mockStrings,
+                    getShuffleSeed("radio 1", choices, 0),
+                );
+                return shuffled.findIndex((choice) => choice.correct);
+            },
+        );
+
+        const counts = Array.from(
+            {length: choiceCount},
+            (_, position) =>
+                correctPositions.filter((p) => p === position).length,
+        );
+
+        // Even spread is 25% each; these bounds catch a collapsed or skewed seed.
+        counts.forEach((count) => {
+            expect(count).toBeGreaterThan(questionCount * 0.1);
+            expect(count).toBeLessThan(questionCount * 0.4);
+        });
     });
 });
 

--- a/packages/perseus/src/widgets/radio/util.ts
+++ b/packages/perseus/src/widgets/radio/util.ts
@@ -1,4 +1,5 @@
 import {
+    hashStringToSeed,
     shuffle,
     type PerseusRadioUserInput,
     type PerseusRadioWidgetOptions,
@@ -107,6 +108,38 @@ export function enforceOrdering(
         return [choices[1], choices[0]];
     }
     return choices;
+}
+
+/**
+ * Derive the seed used to shuffle a radio widget's choices, mixing the widget's
+ * position (`problemNum + widgetIndex`) with its id and choice content.
+ *
+ * Both inputs are needed. Position alone collapses to 0 in articles and in every
+ * nested renderer (graded-group, group, explanation), which pinned the correct
+ * answer to the same letter — the bug this fixes. Content alone collapses for
+ * questions that share option text ("Increases"/"Decreases"/"Stays the same"),
+ * since choice ids are positional and carry no entropy. Position also keeps an
+ * item reshuffling when a learner re-encounters it, as `problemNum` varies.
+ *
+ * Only *public* options may be used: `getRadioPublicWidgetOptions` strips
+ * `rationale` and `correct`, so seeding on those would shuffle a question
+ * differently before and after scoring. Content is translated, so orders differ
+ * per locale — fine, since order need only be stable within one.
+ */
+export function getShuffleSeed(
+    widgetId: string,
+    choices: PerseusRadioWidgetOptions["choices"],
+    positionSeed: number,
+): number {
+    // JSON rather than a delimiter: Markdown content contains `|` and `:`, so
+    // different choice sets could serialize to the same string.
+    const identity = JSON.stringify([
+        positionSeed,
+        widgetId,
+        choices.map((choice) => [choice.id, choice.content]),
+    ]);
+
+    return hashStringToSeed(identity);
 }
 
 // Transforms the choices for display.


### PR DESCRIPTION
## Summary:
This PR fixes the randomization choices issue rendering in the same order in articles' graded group. The seed now includes the question's own content (the widget id and the choice text), not just its position on the page. Position can be 0, but the content is different for every question, so two questions no longer get the same seed. Position stays in the mix so exercises still reshuffle when a learner sees the same item again.

The Radio choice order is shuffled deterministically from a seed of `problemNum + widgetIndex`. Articles never set `problemNum`, and every nested renderer (graded group, group, explanation) restarts `widgetIndex` at 0 — so the seed collapsed to `0`. For a 4-choice question that always yields the permutation `[3, 1, 0, 2]`, putting the first-authored choice at position 2, which is why the correct answer was always **C**. The exercises were unaffected, since `ServerItemRenderer` supplies a real `problemNum`.

Issue: LEMS-4542

## Test plan: