### PR TITLE
[ColorSync] Finish #4109 tooltip shadow + tokenize interactive-graph drop shadows and remaining one-off colors

### DIFF
--- a/.changeset/lucky-shadows-sync.md
+++ b/.changeset/lucky-shadows-sync.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Replace remaining hardcoded colors with Wonder Blocks semantic tokens: the movable-point tooltip shadow, the three interactive-graph drop shadows (now theme-aware in dark mode), the error-boundary icon fill, and the plotter scale-box border

--- a/packages/perseus/src/error-boundary.tsx
+++ b/packages/perseus/src/error-boundary.tsx
@@ -1,4 +1,5 @@
 import {Errors} from "@khanacademy/perseus-core";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import * as React from "react";
 
 import {Log} from "./logging/log";
@@ -53,7 +54,7 @@ class ErrorBoundary extends React.Component<Props, State> {
                     <title>Rendering Error!</title>
                     <path
                         d="m8 16c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8zm0-3c0.55 0 1-0.45 1-1s-0.45-1-1-1-1 0.45-1 1 0.45 1 1 1zm0-9c-0.55 0-1 0.45-1 1v4c0 0.55.45 1 1 1s1-0.45 1-1v-4c0-0.55-0.45-1-1-1z"
-                        fill="#d92916"
+                        fill={semanticColor.core.foreground.critical.default}
                         fillRule="evenodd"
                     />
                 </svg>

--- a/packages/perseus/src/interactive2/movable-point.tsx
+++ b/packages/perseus/src/interactive2/movable-point.tsx
@@ -306,8 +306,7 @@ export class MovablePoint {
                                 svgElem.getElementsByClassName(
                                     "tooltip-content",
                                 )[0];
-                            const filter =
-                                "drop-shadow(0px 0px 5px rgba(0, 0, 0, 0.5))";
+                            const filter = wrappedEllipseShadow;
 
                             content.style.filter = filter;
                         }

--- a/packages/perseus/src/styles/widgets/plotter.css
+++ b/packages/perseus/src/styles/widgets/plotter.css
@@ -6,7 +6,7 @@
     transform: rotate(-90deg);
 }
 .set-from-scale-box {
-    border: 2px solid #eeeeee;
+    border: 2px solid var(--wb-semanticColor-core-border-neutral-subtle);
     border-radius: 3px;
     padding: 3px;
 }

--- a/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
+++ b/packages/perseus/src/widgets/interactive-graphs/mafs-styles.css
@@ -142,9 +142,9 @@
     r: var(--movable-point-halo-radius);
     fill: var(--movable-point-color);
     opacity: 0.25;
-    /* Not using a semantic token here because there's no equivalent that
-     * would work for the drop shadow filter. */
-    filter: drop-shadow(0 5px 5px #0008);
+    filter: drop-shadow(
+        0 5px 5px var(--wb-semanticColor-core-shadow-transparent-low)
+    );
 }
 
 .MafsView .movable-point-ring {
@@ -188,7 +188,8 @@
     .movable-point:is(:hover, .movable-point--hover)
     .movable-point-focus-outline {
     r: calc(
-        var(--movable-point-hover-expansion) + var(--movable-point-halo-radius) +
+        var(--movable-point-hover-expansion) +
+            var(--movable-point-halo-radius) +
             var(--movable-point-focus-ring-offset)
     );
 }
@@ -295,9 +296,9 @@
     vector-effect: non-scaling-stroke;
     transform-box: fill-box;
     transform-origin: 100% 50%;
-    /* Not using a semantic token here because there's no equivalent that
-     * would work for the drop shadow filter. */
-    filter: drop-shadow(0 1px 4px rgba(33, 36, 44, 0.16));
+    filter: drop-shadow(
+        0 1px 4px var(--wb-semanticColor-core-shadow-transparent-low)
+    );
 }
 
 .MafsView .movable-arrowhead-halo {
@@ -356,9 +357,9 @@
 
 .MafsView .movable-pill-handle-halo {
     opacity: 0.25;
-    /* Not using a semantic token here because there's no equivalent that
-     * would work for the drop shadow filter. */
-    filter: drop-shadow(0 5px 5px #0008);
+    filter: drop-shadow(
+        0 5px 5px var(--wb-semanticColor-core-shadow-transparent-low)
+    );
 }
 
 .MafsView .movable-pill-handle-ring {


### PR DESCRIPTION
## Summary

Four small conversions left over from the 2026-08-24 color token audit ([LEMS-4543](https://khanacademy.atlassian.net/browse/LEMS-4543)):

1. **`interactive2/movable-point.tsx`** — the tooltip shadow missed by #4109: replaced the hardcoded `drop-shadow(0px 0px 5px rgba(0, 0, 0, 0.5))` with the already-imported `wrappedEllipseShadow`, matching the sibling `if (state.shadow)` block.
2. **`widgets/interactive-graphs/mafs-styles.css`** — the three hardcoded drop-shadows (movable-point halo, arrowhead ring, pill-handle halo) now use `var(--wb-semanticColor-core-shadow-transparent-low)`, and the stale "no equivalent token" comments are gone. This also fixes these shadows not adapting in dark mode.
3. **`error-boundary.tsx`** — error icon `fill="#d92916"` → `semanticColor.core.foreground.critical.default` (same value in the default theme).
4. **`styles/widgets/plotter.css`** — scale-box border `#eeeeee` → `var(--wb-semanticColor-core-border-neutral-subtle)` (closest semantic match; renders `rgba(33,36,44,0.16)` ≈ `#e4e5e7` over white).

**Shadow-intensity note for design eyes:** Figma has no shadow design for the movable-point/pill-handle halos, so all three shadows start at `-low` per prior art — the arrowhead ring value is an exact light-theme match for `-low`, while the two `#0008` halos will render lighter than before (the halos carry `opacity: 0.25`, so `-low` renders at ~4% vs. ~13% today). If the Chromatic diff shows the halos washing out, the plan is to bump those two to `-mid`.

## Test plan

- `pnpm tsc` — clean
- Lint (eslint 8 + prettier) — clean
- Jest `--findRelatedTests` on the changed files: 188 suites, 2945 tests passed
- Review Chromatic diffs in default + thunderblocks themes. Expected diffs: shadow intensity on the two halos in light mode, all three interactive-graph shadows in dark mode, possibly nothing for the arrowhead ring in light mode.

Changeset: patch for `@khanacademy/perseus`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BN2QQY7YyKEn7UnXwdzxmJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01BN2QQY7YyKEn7UnXwdzxmJ)_

[LEMS-4543]: https://khanacademy.atlassian.net/browse/LEMS-4543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ