### PR TITLE
Convert authored graphie label colors to semantic tokens

### DIFF
--- a/.changeset/tough-seals-double.md
+++ b/.changeset/tough-seals-double.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Graphie labels now render in colors from the Wonder Blocks theme. We use the WB learning.math.foreground color that best matches the authored color.

--- a/packages/perseus/src/__docs__/colors.stories.tsx
+++ b/packages/perseus/src/__docs__/colors.stories.tsx
@@ -1,0 +1,65 @@
+import * as React from "react";
+
+import {resolveColor} from "../util/colors";
+
+import type {Meta, StoryObj} from "@storybook/react-vite";
+
+type Story = StoryObj;
+
+const meta: Meta = {
+    title: "Utilities/resolveColor",
+    tags: ["!manifest"],
+    parameters: {
+        docs: {
+            description: {
+                component:
+                    "Converts any CSS color (e.g. #fff or " +
+                    '"white") to its red, green, and blue ' +
+                    "components as numbers from 0 to 255.",
+            },
+        },
+    },
+};
+export default meta;
+
+const COLORS = [
+    "black",
+    "white",
+    "red",
+    "aliceblue",
+    "blanchedalmond",
+    "burlywood",
+    "cadetblue",
+    "honeydew",
+    "hotpink",
+    "#0f0",
+    "rgb(127, 127, 127)",
+];
+
+export const ResolveColor: Story = {
+    render: () => (
+        <ul>
+            {COLORS.map((color) => {
+                const {r, g, b} = resolveColor(color);
+                const rgbCode = `rgb(${r}, ${g}, ${b})`;
+
+                return (
+                    <li
+                        key={color}
+                        style={{display: "flex", alignItems: "center", gap: 8}}
+                    >
+                        <span
+                            style={{
+                                display: "inline-block",
+                                width: 72,
+                                height: 72,
+                                backgroundColor: rgbCode,
+                            }}
+                        />
+                        {color}: {rgbCode}
+                    </li>
+                );
+            })}
+        </ul>
+    ),
+};

--- a/packages/perseus/src/__docs__/colors.stories.tsx
+++ b/packages/perseus/src/__docs__/colors.stories.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 
+import {themeModes} from "../../../../.storybook/modes";
 import {resolveColor} from "../util/colors";
 
 import type {Meta, StoryObj} from "@storybook/react-vite";
-import {themeModes} from "../../../../.storybook/modes";
 
 type Story = StoryObj;
 

--- a/packages/perseus/src/__docs__/colors.stories.tsx
+++ b/packages/perseus/src/__docs__/colors.stories.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 import {resolveColor} from "../util/colors";
 
 import type {Meta, StoryObj} from "@storybook/react-vite";
+import {themeModes} from "../../../../.storybook/modes";
 
 type Story = StoryObj;
 
@@ -18,6 +19,7 @@ const meta: Meta = {
                     "components as numbers from 0 to 255.",
             },
         },
+        chromatic: {disableSnapshot: false, modes: themeModes},
     },
 };
 export default meta;

--- a/packages/perseus/src/__testdata__/graphie.testdata.ts
+++ b/packages/perseus/src/__testdata__/graphie.testdata.ts
@@ -1,5 +1,7 @@
 import {
     generateImageOptions,
+    generateImageWidget,
+    generateTestPerseusItem,
     getDefaultAnswerArea,
     type PerseusItem,
 } from "@khanacademy/perseus-core";
@@ -40,3 +42,19 @@ export const itemWithPieChart: PerseusItem = {
         },
     },
 };
+
+export const itemWithLabeledAngle: PerseusItem = generateTestPerseusItem({
+    question: {
+        content: "[[☃ image 1]]",
+        images: {},
+        widgets: {
+            "image 1": generateImageWidget({
+                options: generateImageOptions({
+                    backgroundImage: {
+                        url: "web+graphie://ka-perseus-graphie.s3.amazonaws.com/cc939c7b30d59b952f579a17e410c8e86055e84a",
+                    },
+                }),
+            }),
+        },
+    },
+});

--- a/packages/perseus/src/components/__docs__/graphie.stories.tsx
+++ b/packages/perseus/src/components/__docs__/graphie.stories.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 
-import {itemWithPieChart} from "../../__testdata__/graphie.testdata";
+import {
+    itemWithLabeledAngle,
+    itemWithPieChart,
+} from "../../__testdata__/graphie.testdata";
 import {ServerItemRendererWithDebugUI} from "../../testing/server-item-renderer-with-debug-ui";
 import Graphie from "../graphie";
 
@@ -28,11 +31,11 @@ export default meta;
  * with overlaid labels and an image caption below.
  */
 export const PieChartGraphieLabels: Story = {
-    args: {
-        box: [size, size],
-        setup: () => {},
-    },
-    render: (args) => <ServerItemRendererWithDebugUI item={itemWithPieChart} />,
+    render: () => <ServerItemRendererWithDebugUI item={itemWithPieChart} />,
+};
+
+export const AngleWithColoredGraphieLabels: Story = {
+    render: () => <ServerItemRendererWithDebugUI item={itemWithLabeledAngle} />,
 };
 
 export const SquareBoxSizeAndOtherwiseEmpty: Story = {

--- a/packages/perseus/src/components/svg-image.tsx
+++ b/packages/perseus/src/components/svg-image.tsx
@@ -19,6 +19,7 @@ import type {Coord} from "../interactive2/types";
 import type {APIOptions} from "../types";
 import type {Alignment, Size} from "@khanacademy/perseus-core";
 import type {ParsedFrame} from "gifuct-js";
+import {toClosestMathColor} from "../util/colors";
 
 function isImageProbablyPhotograph(imageUrl) {
     return /\.(jpg|jpeg)$/i.test(imageUrl);
@@ -371,6 +372,14 @@ class SvgImage extends React.Component<Props, State> {
                 _.each(labelData.style, (styleValue, styleName) => {
                     label.css(styleName, styleValue);
                 });
+
+                // Override the color authored in `style` with the perceptually
+                // closest semantic color from Wonder Blocks. This ensures that
+                // labels follow the dark mode / light mode theme and remain
+                // readable.
+                if (labelData.style.color) {
+                    label.css("color", toClosestMathColor(labelData.style.color));
+                }
             }
             newLabelsRendered[labelData.content] = true;
         });

--- a/packages/perseus/src/components/svg-image.tsx
+++ b/packages/perseus/src/components/svg-image.tsx
@@ -5,6 +5,7 @@ import _ from "underscore";
 
 import {getDependencies} from "../dependencies";
 import Util from "../util";
+import {toClosestMathColor} from "../util/colors";
 import {loadGraphie} from "../util/graphie-utils";
 
 import FixedToResponsive from "./fixed-to-responsive";
@@ -19,7 +20,6 @@ import type {Coord} from "../interactive2/types";
 import type {APIOptions} from "../types";
 import type {Alignment, Size} from "@khanacademy/perseus-core";
 import type {ParsedFrame} from "gifuct-js";
-import {toClosestMathColor} from "../util/colors";
 
 function isImageProbablyPhotograph(imageUrl) {
     return /\.(jpg|jpeg)$/i.test(imageUrl);
@@ -378,7 +378,10 @@ class SvgImage extends React.Component<Props, State> {
                 // labels follow the dark mode / light mode theme and remain
                 // readable.
                 if (labelData.style.color) {
-                    label.css("color", toClosestMathColor(labelData.style.color));
+                    label.css(
+                        "color",
+                        toClosestMathColor(labelData.style.color),
+                    );
                 }
             }
             newLabelsRendered[labelData.content] = true;

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -415,13 +415,4 @@
          */
         filter: invert(1) hue-rotate(180deg) brightness(1.5);
     }
-
-    .graphie-label {
-        /* Graphie hardcodes `color: black` on its label elements, so we have
-           to override that with `!important`.
-         */
-        color: var(
-            --wb-semanticColor-core-foreground-neutral-strong
-        ) !important;
-    }
 }

--- a/packages/perseus/src/util/colors.test.ts
+++ b/packages/perseus/src/util/colors.test.ts
@@ -1,4 +1,9 @@
-import {diffColors, getBackgroundColor, parseHexColor, toClosestMathColor} from "./colors";
+import {
+    diffColors,
+    getBackgroundColor,
+    parseHexColor,
+    toClosestMathColor,
+} from "./colors";
 
 describe("Color Utilities", () => {
     describe("getBackgroundColor", () => {
@@ -115,38 +120,48 @@ describe("Color Utilities", () => {
 
     describe("toClosestMathColor", () => {
         it("says pure red is closest to learning.math.foreground.red", () => {
-            expect(toClosestMathColor("#ff0000")).toBe("var(--wb-semanticColor-learning-math-foreground-red)");
+            expect(toClosestMathColor("#ff0000")).toBe(
+                "var(--wb-semanticColor-learning-math-foreground-red)",
+            );
         });
 
         it("says bright orange is closest to learning.math.foreground.gold", () => {
-            expect(toClosestMathColor("#ee7700")).toBe("var(--wb-semanticColor-learning-math-foreground-gold)");
+            expect(toClosestMathColor("#ee7700")).toBe(
+                "var(--wb-semanticColor-learning-math-foreground-gold)",
+            );
         });
 
         it("says teal is closest to learning.math.foreground.blue", () => {
-            expect(toClosestMathColor("#007777")).toBe("var(--wb-semanticColor-learning-math-foreground-blue)");
+            expect(toClosestMathColor("#007777")).toBe(
+                "var(--wb-semanticColor-learning-math-foreground-blue)",
+            );
         });
 
         it("says gray is closest to learning.math.foreground.gray", () => {
-            expect(toClosestMathColor("#777777")).toBe("var(--wb-semanticColor-learning-math-foreground-gray)");
+            expect(toClosestMathColor("#777777")).toBe(
+                "var(--wb-semanticColor-learning-math-foreground-gray)",
+            );
         });
 
         it("says black is closest to core.foreground.neutral.strong", () => {
-            expect(toClosestMathColor("#000000")).toBe("var(--wb-semanticColor-core-foreground-neutral-strong)");
+            expect(toClosestMathColor("#000000")).toBe(
+                "var(--wb-semanticColor-core-foreground-neutral-strong)",
+            );
         });
-    })
+    });
 
     describe("parseHexColor", () => {
         it("parses #f00 as red", () => {
             expect(parseHexColor("#f00")).toEqual({r: 255, g: 0, b: 0});
-        })
+        });
 
         it("parses #0f0 as green", () => {
             expect(parseHexColor("#0f0")).toEqual({r: 0, g: 255, b: 0});
-        })
+        });
 
         it("parses #00f as blue", () => {
             expect(parseHexColor("#00f")).toEqual({r: 0, g: 0, b: 255});
-        })
+        });
 
         it("parses #f009 as red, discarding the alpha channel", () => {
             expect(parseHexColor("#f009")).toEqual({r: 255, g: 0, b: 0});
@@ -154,18 +169,18 @@ describe("Color Utilities", () => {
 
         it("parses #ff0000 as red", () => {
             expect(parseHexColor("#ff0000")).toEqual({r: 255, g: 0, b: 0});
-        })
+        });
 
         it("parses #00ff00 as green", () => {
             expect(parseHexColor("#00ff00")).toEqual({r: 0, g: 255, b: 0});
-        })
+        });
 
         it("parses #0000ff as blue", () => {
             expect(parseHexColor("#0000ff")).toEqual({r: 0, g: 0, b: 255});
-        })
+        });
 
         it("parses #ff000099 as red, discarding the alpha channel", () => {
             expect(parseHexColor("#ff000099")).toEqual({r: 255, g: 0, b: 0});
-        })
-    })
+        });
+    });
 });

--- a/packages/perseus/src/util/colors.test.ts
+++ b/packages/perseus/src/util/colors.test.ts
@@ -1,4 +1,4 @@
-import {getBackgroundColor} from "./colors";
+import {diffColors, getBackgroundColor} from "./colors";
 
 describe("Color Utilities", () => {
     describe("getBackgroundColor", () => {
@@ -59,6 +59,57 @@ describe("Color Utilities", () => {
             parentElement.appendChild(testElement);
             const result = getBackgroundColor(testElement);
             expect(result).toBe("green");
+        });
+    });
+
+    describe("diffColors", () => {
+        it("says white is the same as itself", () => {
+            const white = {r: 255, g: 255, b: 255};
+            expect(diffColors(white, white)).toBe(0);
+        });
+
+        it("says black is the same as itself", () => {
+            const black = {r: 0, g: 0, b: 0};
+            expect(diffColors(black, black)).toBe(0);
+        });
+
+        it("says red is the same as itself", () => {
+            const red = {r: 255, g: 0, b: 0};
+            expect(diffColors(red, red)).toBe(0);
+        });
+
+        it("says green is the same as itself", () => {
+            const green = {r: 0, g: 255, b: 0};
+            expect(diffColors(green, green)).toBe(0);
+        });
+
+        it("says blue is the same as itself", () => {
+            const blue = {r: 0, g: 0, b: 255};
+            expect(diffColors(blue, blue)).toBe(0);
+        });
+
+        it("says orange is closer to red than gray", () => {
+            const orange = {r: 255, g: 127, b: 0};
+            const red = {r: 255, g: 0, b: 0};
+            const gray = {r: 127, g: 127, b: 127};
+            expect(diffColors(orange, red)).toBeLessThan(
+                diffColors(orange, gray),
+            );
+        });
+
+        it("says very dark red is closer to black than red", () => {
+            const darkRed = {r: 10, g: 0, b: 0};
+            const red = {r: 255, g: 0, b: 0};
+            const black = {r: 0, g: 0, b: 0};
+            expect(diffColors(darkRed, black)).toBeLessThan(
+                diffColors(darkRed, red),
+            );
+        });
+
+        it("is commutative", () => {
+            const a = {r: 111, g: 222, b: 55};
+            const b = {r: 255, g: 30, b: 100};
+            expect(diffColors(a, b)).toBe(diffColors(b, a));
         });
     });
 });

--- a/packages/perseus/src/util/colors.test.ts
+++ b/packages/perseus/src/util/colors.test.ts
@@ -1,4 +1,4 @@
-import {diffColors, getBackgroundColor} from "./colors";
+import {diffColors, getBackgroundColor, parseHexColor, toClosestMathColor} from "./colors";
 
 describe("Color Utilities", () => {
     describe("getBackgroundColor", () => {
@@ -112,4 +112,60 @@ describe("Color Utilities", () => {
             expect(diffColors(a, b)).toBe(diffColors(b, a));
         });
     });
+
+    describe("toClosestMathColor", () => {
+        it("says pure red is closest to learning.math.foreground.red", () => {
+            expect(toClosestMathColor("#ff0000")).toBe("var(--wb-semanticColor-learning-math-foreground-red)");
+        });
+
+        it("says bright orange is closest to learning.math.foreground.gold", () => {
+            expect(toClosestMathColor("#ee7700")).toBe("var(--wb-semanticColor-learning-math-foreground-gold)");
+        });
+
+        it("says teal is closest to learning.math.foreground.blue", () => {
+            expect(toClosestMathColor("#007777")).toBe("var(--wb-semanticColor-learning-math-foreground-blue)");
+        });
+
+        it("says gray is closest to learning.math.foreground.gray", () => {
+            expect(toClosestMathColor("#777777")).toBe("var(--wb-semanticColor-learning-math-foreground-gray)");
+        });
+
+        it("says black is closest to core.foreground.neutral.strong", () => {
+            expect(toClosestMathColor("#000000")).toBe("var(--wb-semanticColor-core-foreground-neutral-strong)");
+        });
+    })
+
+    describe("parseHexColor", () => {
+        it("parses #f00 as red", () => {
+            expect(parseHexColor("#f00")).toEqual({r: 255, g: 0, b: 0});
+        })
+
+        it("parses #0f0 as green", () => {
+            expect(parseHexColor("#0f0")).toEqual({r: 0, g: 255, b: 0});
+        })
+
+        it("parses #00f as blue", () => {
+            expect(parseHexColor("#00f")).toEqual({r: 0, g: 0, b: 255});
+        })
+
+        it("parses #f009 as red, discarding the alpha channel", () => {
+            expect(parseHexColor("#f009")).toEqual({r: 255, g: 0, b: 0});
+        });
+
+        it("parses #ff0000 as red", () => {
+            expect(parseHexColor("#ff0000")).toEqual({r: 255, g: 0, b: 0});
+        })
+
+        it("parses #00ff00 as green", () => {
+            expect(parseHexColor("#00ff00")).toEqual({r: 0, g: 255, b: 0});
+        })
+
+        it("parses #0000ff as blue", () => {
+            expect(parseHexColor("#0000ff")).toEqual({r: 0, g: 0, b: 255});
+        })
+
+        it("parses #ff000099 as red, discarding the alpha channel", () => {
+            expect(parseHexColor("#ff000099")).toEqual({r: 255, g: 0, b: 0});
+        })
+    })
 });

--- a/packages/perseus/src/util/colors.ts
+++ b/packages/perseus/src/util/colors.ts
@@ -120,4 +120,24 @@ export const getBackgroundColor = (elementToInspect: HTMLElement): string => {
     return getBackgroundColor(parentElement);
 };
 
+interface RGB {
+    r: number;
+    g: number;
+    b: number;
+}
+
+// TODO-NEXT: write Storybook stories in packages/perseus/src/docs testing this
+//  function for a few colors (e.g. "white", "black", "red").
+export function hexForColorName(name: string): RGB {
+    const canvas = document.createElement("canvas");
+    const ctx = canvas.getContext("2d");
+    if (!ctx) {
+        return {r: 0, g: 0, b: 0};
+    }
+    ctx.fillStyle = name;
+    ctx.fillRect(0, 0, 1, 1);
+    const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
+    return {r, g, b};
+}
+
 export default KhanColors;

--- a/packages/perseus/src/util/colors.ts
+++ b/packages/perseus/src/util/colors.ts
@@ -126,15 +126,18 @@ interface RGB {
     b: number;
 }
 
-// TODO-NEXT: write Storybook stories in packages/perseus/src/docs testing this
-//  function for a few colors (e.g. "white", "black", "red").
-export function hexForColorName(name: string): RGB {
+// Tested via Storybook, since JSDOM doesn't implement the canvas API.
+/**
+ * Resolves a CSS color into its red, green, and blue components.
+ * @param color - can be hex, a name like `"black"`, or e.g. `rgb(0, 0, 0)`.
+ */
+export function resolveColor(color: string): RGB {
     const canvas = document.createElement("canvas");
     const ctx = canvas.getContext("2d");
     if (!ctx) {
         return {r: 0, g: 0, b: 0};
     }
-    ctx.fillStyle = name;
+    ctx.fillStyle = color;
     ctx.fillRect(0, 0, 1, 1);
     const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
     return {r, g, b};

--- a/packages/perseus/src/util/colors.ts
+++ b/packages/perseus/src/util/colors.ts
@@ -7,7 +7,7 @@
  * provided on KhanUtil.
  */
 // eslint-disable-next-line no-restricted-imports -- Replace with semanticColor
-import {color} from "@khanacademy/wonder-blocks-tokens";
+import {color, semanticColor, tokenValue} from "@khanacademy/wonder-blocks-tokens";
 
 // TODO(WB-2160): Update these to use the new semanticColor tokens, and use the
 // new tokenValue() function to get the raw value of the token. This is
@@ -132,6 +132,9 @@ interface RGB {
  * @param color - can be hex, a name like `"black"`, or e.g. `rgb(0, 0, 0)`.
  */
 export function resolveColor(color: string): RGB {
+    if (color[0] === "#") {
+        return parseHexColor(color);
+    }
     const canvas = document.createElement("canvas");
     const ctx = canvas.getContext("2d");
     if (!ctx) {
@@ -141,6 +144,58 @@ export function resolveColor(color: string): RGB {
     ctx.fillRect(0, 0, 1, 1);
     const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
     return {r, g, b};
+}
+
+const lightModeHexForMathColor = {
+    [semanticColor.learning.math.foreground.blue]: "#3D7586",
+    [semanticColor.learning.math.foreground.gold]: "#946700",
+    [semanticColor.learning.math.foreground.green]: "#447A53",
+    [semanticColor.learning.math.foreground.gray]: "#5D5F66",
+    [semanticColor.learning.math.foreground.grayH]: "#3B3D45",
+    [semanticColor.learning.math.foreground.grayI]: "#21242C",
+    [semanticColor.learning.math.foreground.purple]: "#594094",
+    [semanticColor.learning.math.foreground.purpleD]: "#8351E8",
+    [semanticColor.learning.math.foreground.pink]: "#B25071",
+    [semanticColor.learning.math.foreground.red]: "#D92916",
+}
+
+export function toClosestMathColor(target: string): string {
+    const targetRGB = resolveColor(target);
+    let closestRGB = {r: 0, g: 0, b: 0};
+    let closestCSSVar = semanticColor.core.foreground.neutral.strong;
+    for (const [cssVar, hex] of Object.entries(lightModeHexForMathColor)) {
+        const candidate = resolveColor(hex);
+        if (diffColors(targetRGB, candidate) < diffColors(targetRGB, closestRGB)) {
+            closestRGB = candidate;
+            closestCSSVar = cssVar;
+        }
+    }
+    return closestCSSVar;
+}
+
+export function parseHexColor(hex: string): RGB {
+    // This case also parses four-digit hex like #1234, but discards the alpha
+    // channel.
+    const threeDigitMatch = hex.match(/^#([0-9A-Fa-f])([0-9A-Fa-f])([0-9A-Fa-f])([0-9A-Fa-f])?$/);
+    if (threeDigitMatch) {
+        return {
+            r: parseInt(threeDigitMatch[1], 16) * 17,
+            g: parseInt(threeDigitMatch[2], 16) * 17,
+            b: parseInt(threeDigitMatch[3], 16) * 17,
+        }
+    }
+
+    // This case also parses eight-digit hex like #11223344, but discards the
+    // alpha channel.
+    const sixDigitMatch = hex.match(/^#([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})?$/);
+    if (sixDigitMatch) {
+        return {
+            r: parseInt(sixDigitMatch[1], 16),
+            g: parseInt(sixDigitMatch[2], 16),
+            b: parseInt(sixDigitMatch[3], 16),
+        }
+    }
+    return {r: 0, g: 0, b: 0};
 }
 
 /**

--- a/packages/perseus/src/util/colors.ts
+++ b/packages/perseus/src/util/colors.ts
@@ -127,12 +127,18 @@ interface RGB {
     b: number;
 }
 
+const resolveColorCache = new Map<string, RGB | undefined>();
+
 // Tested via Storybook, since JSDOM doesn't implement the canvas API.
 /**
  * Resolves a CSS color into its red, green, and blue components.
  * @param color - can be hex, a name like `"black"`, or e.g. `rgb(0, 0, 0)`.
  */
 export function resolveColor(color: string): RGB {
+    const cached = resolveColorCache.get(color);
+    if (cached != null) {
+        return cached;
+    }
     if (color[0] === "#") {
         return parseHexColor(color);
     }
@@ -144,7 +150,9 @@ export function resolveColor(color: string): RGB {
     ctx.fillStyle = color;
     ctx.fillRect(0, 0, 1, 1);
     const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
-    return {r, g, b};
+    const resolved = {r, g, b};
+    resolveColorCache.set(color, resolved);
+    return resolved;
 }
 
 const lightModeHexForMathColor = {

--- a/packages/perseus/src/util/colors.ts
+++ b/packages/perseus/src/util/colors.ts
@@ -143,4 +143,21 @@ export function resolveColor(color: string): RGB {
     return {r, g, b};
 }
 
+/**
+ * Uses a variant of the "redmean" algorithm to determine how similar two
+ * colors are. In contrast to redmean, we skip taking the square root of the
+ * result, which means this function gives you a relative difference, not an
+ * absolute difference.
+ */
+export function diffColors(a: RGB, b: RGB): number {
+    const redMean = (a.r + b.r) / 2;
+    const redWeight = 2 + redMean / 256;
+    const blueWeight = 2 + (255 - redMean) / 256;
+    const greenWeight = 4;
+    const dr = a.r - b.r;
+    const dg = a.g - b.g;
+    const db = a.b - b.b;
+    return redWeight * dr * dr + greenWeight * dg * dg + blueWeight * db * db;
+}
+
 export default KhanColors;

--- a/packages/perseus/src/util/colors.ts
+++ b/packages/perseus/src/util/colors.ts
@@ -210,6 +210,7 @@ export function parseHexColor(hex: string): RGB {
  * colors are. In contrast to redmean, we skip taking the square root of the
  * result, which means this function gives you a relative difference, not an
  * absolute difference.
+ * See: https://en.wikipedia.org/wiki/Color_difference
  */
 export function diffColors(a: RGB, b: RGB): number {
     const redMean = (a.r + b.r) / 2;

--- a/packages/perseus/src/util/colors.ts
+++ b/packages/perseus/src/util/colors.ts
@@ -6,8 +6,9 @@
  * khan-exercises submodule, as graphie-to-png still relies on the palette
  * provided on KhanUtil.
  */
-// eslint-disable-next-line no-restricted-imports -- Replace with semanticColor
-import {color, semanticColor, tokenValue} from "@khanacademy/wonder-blocks-tokens";
+
+// eslint-disable-next-line no-restricted-imports -- Replace color with semanticColor
+import {color, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 
 // TODO(WB-2160): Update these to use the new semanticColor tokens, and use the
 // new tokenValue() function to get the raw value of the token. This is
@@ -157,7 +158,7 @@ const lightModeHexForMathColor = {
     [semanticColor.learning.math.foreground.purpleD]: "#8351E8",
     [semanticColor.learning.math.foreground.pink]: "#B25071",
     [semanticColor.learning.math.foreground.red]: "#D92916",
-}
+};
 
 export function toClosestMathColor(target: string): string {
     const targetRGB = resolveColor(target);
@@ -165,7 +166,9 @@ export function toClosestMathColor(target: string): string {
     let closestCSSVar = semanticColor.core.foreground.neutral.strong;
     for (const [cssVar, hex] of Object.entries(lightModeHexForMathColor)) {
         const candidate = resolveColor(hex);
-        if (diffColors(targetRGB, candidate) < diffColors(targetRGB, closestRGB)) {
+        if (
+            diffColors(targetRGB, candidate) < diffColors(targetRGB, closestRGB)
+        ) {
             closestRGB = candidate;
             closestCSSVar = cssVar;
         }
@@ -176,24 +179,28 @@ export function toClosestMathColor(target: string): string {
 export function parseHexColor(hex: string): RGB {
     // This case also parses four-digit hex like #1234, but discards the alpha
     // channel.
-    const threeDigitMatch = hex.match(/^#([0-9A-Fa-f])([0-9A-Fa-f])([0-9A-Fa-f])([0-9A-Fa-f])?$/);
+    const threeDigitMatch = hex.match(
+        /^#([0-9A-Fa-f])([0-9A-Fa-f])([0-9A-Fa-f])([0-9A-Fa-f])?$/,
+    );
     if (threeDigitMatch) {
         return {
             r: parseInt(threeDigitMatch[1], 16) * 17,
             g: parseInt(threeDigitMatch[2], 16) * 17,
             b: parseInt(threeDigitMatch[3], 16) * 17,
-        }
+        };
     }
 
     // This case also parses eight-digit hex like #11223344, but discards the
     // alpha channel.
-    const sixDigitMatch = hex.match(/^#([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})?$/);
+    const sixDigitMatch = hex.match(
+        /^#([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})?$/,
+    );
     if (sixDigitMatch) {
         return {
             r: parseInt(sixDigitMatch[1], 16),
             g: parseInt(sixDigitMatch[2], 16),
             b: parseInt(sixDigitMatch[3], 16),
-        }
+        };
     }
     return {r: 0, g: 0, b: 0};
 }

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -6,6 +6,7 @@ import {
     KhanMath,
 } from "@khanacademy/kmath";
 import {Errors, PerseusError} from "@khanacademy/perseus-core";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {entries} from "@khanacademy/wonder-stuff-core";
 import $ from "jquery";
 import Raphael from "raphael";
@@ -990,8 +991,7 @@ export class Graphie {
                 .css({
                     position: "absolute",
                     padding: (pad != null ? pad : 7) + "px",
-                    // Note: Theme aware as is; breaks if converted to a token
-                    color: "black",
+                    color: semanticColor.core.foreground.neutral.strong,
                 })
                 .data("labelDirection", direction)
                 .appendTo(this.el);

--- a/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
+++ b/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
@@ -2422,7 +2422,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{1}"
-                      style="position: absolute; padding: 7px; color: black; left: 220px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 220px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2431,7 +2431,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{2}"
-                      style="position: absolute; padding: 7px; color: black; left: 240px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 240px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2440,7 +2440,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{3}"
-                      style="position: absolute; padding: 7px; color: black; left: 260px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 260px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2449,7 +2449,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{4}"
-                      style="position: absolute; padding: 7px; color: black; left: 280px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 280px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2458,7 +2458,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{5}"
-                      style="position: absolute; padding: 7px; color: black; left: 300px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 300px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2467,7 +2467,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{6}"
-                      style="position: absolute; padding: 7px; color: black; left: 320px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 320px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2476,7 +2476,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{7}"
-                      style="position: absolute; padding: 7px; color: black; left: 340px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 340px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2485,7 +2485,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{8}"
-                      style="position: absolute; padding: 7px; color: black; left: 360px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 360px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2494,7 +2494,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{9}"
-                      style="position: absolute; padding: 7px; color: black; left: 380px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 380px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2503,7 +2503,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}2}"
-                      style="position: absolute; padding: 7px; color: black; left: 160px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 160px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2512,7 +2512,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}3}"
-                      style="position: absolute; padding: 7px; color: black; left: 140px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 140px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2521,7 +2521,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}4}"
-                      style="position: absolute; padding: 7px; color: black; left: 120px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 120px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2530,7 +2530,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}5}"
-                      style="position: absolute; padding: 7px; color: black; left: 100px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 100px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2539,7 +2539,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}6}"
-                      style="position: absolute; padding: 7px; color: black; left: 80px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 80px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2548,7 +2548,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}7}"
-                      style="position: absolute; padding: 7px; color: black; left: 60px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 60px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2557,7 +2557,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}8}"
-                      style="position: absolute; padding: 7px; color: black; left: 40px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 40px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2566,7 +2566,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}9}"
-                      style="position: absolute; padding: 7px; color: black; left: 20px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 20px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2575,7 +2575,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{1}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 180px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 180px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2584,7 +2584,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{2}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 160px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 160px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2593,7 +2593,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{3}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 140px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 140px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2602,7 +2602,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{4}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 120px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 120px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2611,7 +2611,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{5}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 100px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 100px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2620,7 +2620,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{6}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 80px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 80px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2629,7 +2629,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{7}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 60px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 60px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2638,7 +2638,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{8}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 40px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 40px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2647,7 +2647,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{9}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 20px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 20px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2656,7 +2656,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}2}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 240px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 240px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2665,7 +2665,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}3}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 260px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 260px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2674,7 +2674,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}4}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 280px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 280px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2683,7 +2683,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}5}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 300px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 300px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2692,7 +2692,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}6}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 320px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 320px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2701,7 +2701,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}7}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 340px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 340px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2710,7 +2710,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}8}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 360px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 360px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2719,7 +2719,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}9}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 380px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 380px; fill: none; stroke: #000000; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2728,7 +2728,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="y"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 0px; fill: none;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 0px; fill: none;"
                     >
                       <span
                         class="tex-holder"
@@ -2737,7 +2737,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="x"
-                      style="position: absolute; padding: 7px; color: black; left: 400px; top: 200px; fill: none;"
+                      style="position: absolute; padding: 7px; left: 400px; top: 200px; fill: none;"
                     >
                       <span
                         class="tex-holder"

--- a/packages/perseus/src/widgets/interaction/__snapshots__/interaction.test.ts.snap
+++ b/packages/perseus/src/widgets/interaction/__snapshots__/interaction.test.ts.snap
@@ -716,7 +716,7 @@ exports[`interaction widget renders movable point elements with blank constraint
               <span
                 class="graphie-label"
                 data-math-formula="\\small{10}"
-                style="position: absolute; padding: 7px; color: black; left: 109.0909090909091px; top: 363.6363636363636px; fill: none; stroke: #000000; opacity: 1;"
+                style="position: absolute; padding: 7px; left: 109.0909090909091px; top: 363.6363636363636px; fill: none; stroke: #000000; opacity: 1;"
               >
                 <span
                   class="tex-holder"
@@ -725,7 +725,7 @@ exports[`interaction widget renders movable point elements with blank constraint
               <span
                 class="graphie-label"
                 data-math-formula="\\small{20}"
-                style="position: absolute; padding: 7px; color: black; left: 181.8181818181818px; top: 363.6363636363636px; fill: none; stroke: #000000; opacity: 1;"
+                style="position: absolute; padding: 7px; left: 181.8181818181818px; top: 363.6363636363636px; fill: none; stroke: #000000; opacity: 1;"
               >
                 <span
                   class="tex-holder"
@@ -734,7 +734,7 @@ exports[`interaction widget renders movable point elements with blank constraint
               <span
                 class="graphie-label"
                 data-math-formula="\\small{30}"
-                style="position: absolute; padding: 7px; color: black; left: 254.54545454545453px; top: 363.6363636363636px; fill: none; stroke: #000000; opacity: 1;"
+                style="position: absolute; padding: 7px; left: 254.54545454545453px; top: 363.6363636363636px; fill: none; stroke: #000000; opacity: 1;"
               >
                 <span
                   class="tex-holder"
@@ -743,7 +743,7 @@ exports[`interaction widget renders movable point elements with blank constraint
               <span
                 class="graphie-label"
                 data-math-formula="\\small{40}"
-                style="position: absolute; padding: 7px; color: black; left: 327.27272727272725px; top: 363.6363636363636px; fill: none; stroke: #000000; opacity: 1;"
+                style="position: absolute; padding: 7px; left: 327.27272727272725px; top: 363.6363636363636px; fill: none; stroke: #000000; opacity: 1;"
               >
                 <span
                   class="tex-holder"
@@ -752,7 +752,7 @@ exports[`interaction widget renders movable point elements with blank constraint
               <span
                 class="graphie-label"
                 data-math-formula="\\small{10}"
-                style="position: absolute; padding: 7px; color: black; left: 36.36363636363636px; top: 290.9090909090909px; fill: none; stroke: #000000; opacity: 1;"
+                style="position: absolute; padding: 7px; left: 36.36363636363636px; top: 290.9090909090909px; fill: none; stroke: #000000; opacity: 1;"
               >
                 <span
                   class="tex-holder"
@@ -761,7 +761,7 @@ exports[`interaction widget renders movable point elements with blank constraint
               <span
                 class="graphie-label"
                 data-math-formula="\\small{20}"
-                style="position: absolute; padding: 7px; color: black; left: 36.36363636363636px; top: 218.1818181818182px; fill: none; stroke: #000000; opacity: 1;"
+                style="position: absolute; padding: 7px; left: 36.36363636363636px; top: 218.1818181818182px; fill: none; stroke: #000000; opacity: 1;"
               >
                 <span
                   class="tex-holder"
@@ -770,7 +770,7 @@ exports[`interaction widget renders movable point elements with blank constraint
               <span
                 class="graphie-label"
                 data-math-formula="\\small{30}"
-                style="position: absolute; padding: 7px; color: black; left: 36.36363636363636px; top: 145.45454545454544px; fill: none; stroke: #000000; opacity: 1;"
+                style="position: absolute; padding: 7px; left: 36.36363636363636px; top: 145.45454545454544px; fill: none; stroke: #000000; opacity: 1;"
               >
                 <span
                   class="tex-holder"
@@ -779,7 +779,7 @@ exports[`interaction widget renders movable point elements with blank constraint
               <span
                 class="graphie-label"
                 data-math-formula="\\small{40}"
-                style="position: absolute; padding: 7px; color: black; left: 36.36363636363636px; top: 72.72727272727272px; fill: none; stroke: #000000; opacity: 1;"
+                style="position: absolute; padding: 7px; left: 36.36363636363636px; top: 72.72727272727272px; fill: none; stroke: #000000; opacity: 1;"
               >
                 <span
                   class="tex-holder"
@@ -788,7 +788,7 @@ exports[`interaction widget renders movable point elements with blank constraint
               <span
                 class="graphie-label"
                 data-math-formula="y"
-                style="position: absolute; padding: 7px; color: black; left: 36.36363636363636px; top: 0px; fill: none;"
+                style="position: absolute; padding: 7px; left: 36.36363636363636px; top: 0px; fill: none;"
               >
                 <span
                   class="tex-holder"
@@ -797,7 +797,7 @@ exports[`interaction widget renders movable point elements with blank constraint
               <span
                 class="graphie-label"
                 data-math-formula="x"
-                style="position: absolute; padding: 7px; color: black; left: 400px; top: 363.6363636363636px; fill: none;"
+                style="position: absolute; padding: 7px; left: 400px; top: 363.6363636363636px; fill: none;"
               >
                 <span
                   class="tex-holder"
@@ -1040,7 +1040,7 @@ exports[`interaction widget should render 1`] = `
               <span
                 class="graphie-label"
                 data-math-formula="\\Huge 2"
-                style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 116.59637038983988px; top: 88.69565217391305px; fill: none;"
+                style="position: absolute; padding: 7px; left: 116.59637038983988px; top: 88.69565217391305px; fill: none; color: rgb(100, 149, 237);"
               >
                 <span
                   class="tex-holder"
@@ -1049,7 +1049,7 @@ exports[`interaction widget should render 1`] = `
               <span
                 class="graphie-label"
                 data-math-formula="\\Huge 5"
-                style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 181.46123525470475px; top: 88.69565217391305px; fill: none;"
+                style="position: absolute; padding: 7px; left: 181.46123525470475px; top: 88.69565217391305px; fill: none; color: rgb(100, 149, 237);"
               >
                 <span
                   class="tex-holder"
@@ -1058,7 +1058,7 @@ exports[`interaction widget should render 1`] = `
               <span
                 class="graphie-label"
                 data-math-formula="\\Huge 9"
-                style="position: absolute; padding: 7px; color: rgb(100, 149, 237); left: 246.3261001195696px; top: 88.69565217391305px; fill: none;"
+                style="position: absolute; padding: 7px; left: 246.3261001195696px; top: 88.69565217391305px; fill: none; color: rgb(100, 149, 237);"
               >
                 <span
                   class="tex-holder"
@@ -1067,7 +1067,7 @@ exports[`interaction widget should render 1`] = `
               <span
                 class="graphie-label"
                 data-math-formula="\\small 259"
-                style="position: absolute; padding: 7px; color: gray; left: 19.459459459459445px; top: 26.08695652173914px; fill: none;"
+                style="position: absolute; padding: 7px; left: 19.459459459459445px; top: 26.08695652173914px; fill: none; color: gray;"
               >
                 <span
                   class="tex-holder"
@@ -1076,7 +1076,7 @@ exports[`interaction widget should render 1`] = `
               <span
                 class="graphie-label"
                 data-math-formula="\\small 259 \\times 10"
-                style="position: absolute; padding: 7px; color: gray; left: 149.18918918918916px; top: 26.08695652173914px; fill: none;"
+                style="position: absolute; padding: 7px; left: 149.18918918918916px; top: 26.08695652173914px; fill: none; color: gray;"
               >
                 <span
                   class="tex-holder"

--- a/packages/perseus/src/widgets/number-line/__snapshots__/number-line.test.ts.snap
+++ b/packages/perseus/src/widgets/number-line/__snapshots__/number-line.test.ts.snap
@@ -296,7 +296,7 @@ exports[`number-line widget snapshots can handle fractions: show fractions 1`] =
                 <span
                   class="graphie-label"
                   data-math-formula="\\dfrac{1}{3}"
-                  style="position: absolute; padding: 7px; color: black; left: 144.28571428571428px; top: 46.8px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 144.28571428571428px; top: 46.8px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -305,7 +305,7 @@ exports[`number-line widget snapshots can handle fractions: show fractions 1`] =
                 <span
                   class="graphie-label"
                   data-math-formula="\\dfrac{1}{2}"
-                  style="position: absolute; padding: 7px; color: black; left: 201.42857142857142px; top: 46.8px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 201.42857142857142px; top: 46.8px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -314,7 +314,7 @@ exports[`number-line widget snapshots can handle fractions: show fractions 1`] =
                 <span
                   class="graphie-label"
                   data-math-formula="\\dfrac{2}{3}"
-                  style="position: absolute; padding: 7px; color: black; left: 258.57142857142856px; top: 46.8px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 258.57142857142856px; top: 46.8px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -323,7 +323,7 @@ exports[`number-line widget snapshots can handle fractions: show fractions 1`] =
                 <span
                   class="graphie-label"
                   data-math-formula="\\dfrac{5}{6}"
-                  style="position: absolute; padding: 7px; color: black; left: 315.71428571428567px; top: 46.8px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 315.71428571428567px; top: 46.8px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -332,7 +332,7 @@ exports[`number-line widget snapshots can handle fractions: show fractions 1`] =
                 <span
                   class="graphie-label"
                   data-math-formula="1"
-                  style="position: absolute; padding: 7px; color: black; left: 372.8571428571428px; top: 46.8px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 372.8571428571428px; top: 46.8px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -341,7 +341,7 @@ exports[`number-line widget snapshots can handle fractions: show fractions 1`] =
                 <span
                   class="graphie-label"
                   data-math-formula="\\dfrac{7}{6}"
-                  style="position: absolute; padding: 7px; color: black; left: 429.99999999999994px; top: 46.8px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 429.99999999999994px; top: 46.8px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -651,7 +651,7 @@ exports[`number-line widget snapshots default: first render 1`] = `
                 <span
                   class="graphie-label"
                   data-math-formula="-3"
-                  style="position: absolute; padding: 7px; color: black; left: 79.99999999999999px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 79.99999999999999px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -660,7 +660,7 @@ exports[`number-line widget snapshots default: first render 1`] = `
                 <span
                   class="graphie-label"
                   data-math-formula="-2"
-                  style="position: absolute; padding: 7px; color: black; left: 129.99999999999997px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 129.99999999999997px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -669,7 +669,7 @@ exports[`number-line widget snapshots default: first render 1`] = `
                 <span
                   class="graphie-label"
                   data-math-formula="-1"
-                  style="position: absolute; padding: 7px; color: black; left: 179.99999999999997px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 179.99999999999997px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -678,7 +678,7 @@ exports[`number-line widget snapshots default: first render 1`] = `
                 <span
                   class="graphie-label"
                   data-math-formula="0"
-                  style="position: absolute; padding: 7px; color: black; left: 229.99999999999997px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 229.99999999999997px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -687,7 +687,7 @@ exports[`number-line widget snapshots default: first render 1`] = `
                 <span
                   class="graphie-label"
                   data-math-formula="1"
-                  style="position: absolute; padding: 7px; color: black; left: 280px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 280px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -696,7 +696,7 @@ exports[`number-line widget snapshots default: first render 1`] = `
                 <span
                   class="graphie-label"
                   data-math-formula="2"
-                  style="position: absolute; padding: 7px; color: black; left: 330px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 330px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -705,7 +705,7 @@ exports[`number-line widget snapshots default: first render 1`] = `
                 <span
                   class="graphie-label"
                   data-math-formula="3"
-                  style="position: absolute; padding: 7px; color: black; left: 380px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 380px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1108,7 +1108,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="-9"
-                  style="position: absolute; padding: 7px; color: black; left: 50px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 50px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1117,7 +1117,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="-8"
-                  style="position: absolute; padding: 7px; color: black; left: 70px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 70px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1126,7 +1126,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="-7"
-                  style="position: absolute; padding: 7px; color: black; left: 90px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 90px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1135,7 +1135,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="-6"
-                  style="position: absolute; padding: 7px; color: black; left: 110px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 110px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1144,7 +1144,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="-5"
-                  style="position: absolute; padding: 7px; color: black; left: 130px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 130px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1153,7 +1153,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="-4"
-                  style="position: absolute; padding: 7px; color: black; left: 150px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 150px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1162,7 +1162,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="-3"
-                  style="position: absolute; padding: 7px; color: black; left: 170px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 170px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1171,7 +1171,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="-2"
-                  style="position: absolute; padding: 7px; color: black; left: 190px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 190px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1180,7 +1180,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="-1"
-                  style="position: absolute; padding: 7px; color: black; left: 210px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 210px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1189,7 +1189,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="0"
-                  style="position: absolute; padding: 7px; color: black; left: 230px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 230px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1198,7 +1198,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="1"
-                  style="position: absolute; padding: 7px; color: black; left: 250px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 250px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1207,7 +1207,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="2"
-                  style="position: absolute; padding: 7px; color: black; left: 270px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 270px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1216,7 +1216,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="3"
-                  style="position: absolute; padding: 7px; color: black; left: 290px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 290px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1225,7 +1225,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="4"
-                  style="position: absolute; padding: 7px; color: black; left: 310px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 310px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1243,7 +1243,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="6"
-                  style="position: absolute; padding: 7px; color: black; left: 350px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 350px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1252,7 +1252,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="7"
-                  style="position: absolute; padding: 7px; color: black; left: 370px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 370px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1261,7 +1261,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="8"
-                  style="position: absolute; padding: 7px; color: black; left: 390px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 390px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1270,7 +1270,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="9"
-                  style="position: absolute; padding: 7px; color: black; left: 410px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 410px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1279,7 +1279,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="10"
-                  style="position: absolute; padding: 7px; color: black; left: 430px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 430px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1664,7 +1664,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="-10"
-                  style="position: absolute; padding: 7px; color: black; left: 30px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 30px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1673,7 +1673,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="-9"
-                  style="position: absolute; padding: 7px; color: black; left: 50px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 50px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1682,7 +1682,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="-8"
-                  style="position: absolute; padding: 7px; color: black; left: 70px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 70px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1691,7 +1691,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="-7"
-                  style="position: absolute; padding: 7px; color: black; left: 90px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 90px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1700,7 +1700,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="-6"
-                  style="position: absolute; padding: 7px; color: black; left: 110px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 110px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1718,7 +1718,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="-4"
-                  style="position: absolute; padding: 7px; color: black; left: 150px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 150px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1727,7 +1727,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="-3"
-                  style="position: absolute; padding: 7px; color: black; left: 170px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 170px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1736,7 +1736,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="-2"
-                  style="position: absolute; padding: 7px; color: black; left: 190px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 190px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1745,7 +1745,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="-1"
-                  style="position: absolute; padding: 7px; color: black; left: 210px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 210px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1754,7 +1754,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="0"
-                  style="position: absolute; padding: 7px; color: black; left: 230px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 230px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1763,7 +1763,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="1"
-                  style="position: absolute; padding: 7px; color: black; left: 250px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 250px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1772,7 +1772,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="2"
-                  style="position: absolute; padding: 7px; color: black; left: 270px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 270px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1781,7 +1781,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="3"
-                  style="position: absolute; padding: 7px; color: black; left: 290px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 290px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1790,7 +1790,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="4"
-                  style="position: absolute; padding: 7px; color: black; left: 310px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 310px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1799,7 +1799,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="5"
-                  style="position: absolute; padding: 7px; color: black; left: 330px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 330px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1808,7 +1808,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="6"
-                  style="position: absolute; padding: 7px; color: black; left: 350px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 350px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1817,7 +1817,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="7"
-                  style="position: absolute; padding: 7px; color: black; left: 370px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 370px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1826,7 +1826,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="8"
-                  style="position: absolute; padding: 7px; color: black; left: 390px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 390px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -1835,7 +1835,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
                 <span
                   class="graphie-label"
                   data-math-formula="9"
-                  style="position: absolute; padding: 7px; color: black; left: 410px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 410px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2159,7 +2159,7 @@ exports[`number-line widget snapshots labels are highlighted when part of the ti
                 <span
                   class="graphie-label"
                   data-math-formula="-10"
-                  style="position: absolute; padding: 7px; color: black; left: 30px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 30px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2168,7 +2168,7 @@ exports[`number-line widget snapshots labels are highlighted when part of the ti
                 <span
                   class="graphie-label"
                   data-math-formula="-8"
-                  style="position: absolute; padding: 7px; color: black; left: 70px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 70px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2186,7 +2186,7 @@ exports[`number-line widget snapshots labels are highlighted when part of the ti
                 <span
                   class="graphie-label"
                   data-math-formula="-4"
-                  style="position: absolute; padding: 7px; color: black; left: 150px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 150px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2195,7 +2195,7 @@ exports[`number-line widget snapshots labels are highlighted when part of the ti
                 <span
                   class="graphie-label"
                   data-math-formula="-2"
-                  style="position: absolute; padding: 7px; color: black; left: 190px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 190px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2204,7 +2204,7 @@ exports[`number-line widget snapshots labels are highlighted when part of the ti
                 <span
                   class="graphie-label"
                   data-math-formula="0"
-                  style="position: absolute; padding: 7px; color: black; left: 230px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 230px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2213,7 +2213,7 @@ exports[`number-line widget snapshots labels are highlighted when part of the ti
                 <span
                   class="graphie-label"
                   data-math-formula="2"
-                  style="position: absolute; padding: 7px; color: black; left: 270px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 270px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2222,7 +2222,7 @@ exports[`number-line widget snapshots labels are highlighted when part of the ti
                 <span
                   class="graphie-label"
                   data-math-formula="4"
-                  style="position: absolute; padding: 7px; color: black; left: 310px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 310px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2240,7 +2240,7 @@ exports[`number-line widget snapshots labels are highlighted when part of the ti
                 <span
                   class="graphie-label"
                   data-math-formula="8"
-                  style="position: absolute; padding: 7px; color: black; left: 390px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 390px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2249,7 +2249,7 @@ exports[`number-line widget snapshots labels are highlighted when part of the ti
                 <span
                   class="graphie-label"
                   data-math-formula="10"
-                  style="position: absolute; padding: 7px; color: black; left: 430px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 430px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2578,7 +2578,7 @@ exports[`number-line widget snapshots labels are inserted when NOT part of the t
                 <span
                   class="graphie-label"
                   data-math-formula="-10"
-                  style="position: absolute; padding: 7px; color: black; left: 30px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 30px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2587,7 +2587,7 @@ exports[`number-line widget snapshots labels are inserted when NOT part of the t
                 <span
                   class="graphie-label"
                   data-math-formula="-8"
-                  style="position: absolute; padding: 7px; color: black; left: 70px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 70px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2596,7 +2596,7 @@ exports[`number-line widget snapshots labels are inserted when NOT part of the t
                 <span
                   class="graphie-label"
                   data-math-formula="-6"
-                  style="position: absolute; padding: 7px; color: black; left: 110px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 110px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2614,7 +2614,7 @@ exports[`number-line widget snapshots labels are inserted when NOT part of the t
                 <span
                   class="graphie-label"
                   data-math-formula="-4"
-                  style="position: absolute; padding: 7px; color: black; left: 150px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 150px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2623,7 +2623,7 @@ exports[`number-line widget snapshots labels are inserted when NOT part of the t
                 <span
                   class="graphie-label"
                   data-math-formula="-2"
-                  style="position: absolute; padding: 7px; color: black; left: 190px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 190px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2632,7 +2632,7 @@ exports[`number-line widget snapshots labels are inserted when NOT part of the t
                 <span
                   class="graphie-label"
                   data-math-formula="0"
-                  style="position: absolute; padding: 7px; color: black; left: 230px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 230px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2641,7 +2641,7 @@ exports[`number-line widget snapshots labels are inserted when NOT part of the t
                 <span
                   class="graphie-label"
                   data-math-formula="2"
-                  style="position: absolute; padding: 7px; color: black; left: 270px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 270px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2650,7 +2650,7 @@ exports[`number-line widget snapshots labels are inserted when NOT part of the t
                 <span
                   class="graphie-label"
                   data-math-formula="4"
-                  style="position: absolute; padding: 7px; color: black; left: 310px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 310px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2668,7 +2668,7 @@ exports[`number-line widget snapshots labels are inserted when NOT part of the t
                 <span
                   class="graphie-label"
                   data-math-formula="6"
-                  style="position: absolute; padding: 7px; color: black; left: 350px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 350px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2677,7 +2677,7 @@ exports[`number-line widget snapshots labels are inserted when NOT part of the t
                 <span
                   class="graphie-label"
                   data-math-formula="8"
-                  style="position: absolute; padding: 7px; color: black; left: 390px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 390px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -2686,7 +2686,7 @@ exports[`number-line widget snapshots labels are inserted when NOT part of the t
                 <span
                   class="graphie-label"
                   data-math-formula="10"
-                  style="position: absolute; padding: 7px; color: black; left: 430px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 430px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -3001,7 +3001,7 @@ exports[`number-line widget snapshots mobile: first mobile render 1`] = `
                 <span
                   class="graphie-label"
                   data-math-formula="-3"
-                  style="position: absolute; padding: 7px; color: black; left: 58.49999999999999px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 58.49999999999999px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -3010,7 +3010,7 @@ exports[`number-line widget snapshots mobile: first mobile render 1`] = `
                 <span
                   class="graphie-label"
                   data-math-formula="-2"
-                  style="position: absolute; padding: 7px; color: black; left: 86.99999999999999px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 86.99999999999999px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -3019,7 +3019,7 @@ exports[`number-line widget snapshots mobile: first mobile render 1`] = `
                 <span
                   class="graphie-label"
                   data-math-formula="-1"
-                  style="position: absolute; padding: 7px; color: black; left: 115.49999999999999px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 115.49999999999999px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -3028,7 +3028,7 @@ exports[`number-line widget snapshots mobile: first mobile render 1`] = `
                 <span
                   class="graphie-label"
                   data-math-formula="0"
-                  style="position: absolute; padding: 7px; color: black; left: 144px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 144px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -3037,7 +3037,7 @@ exports[`number-line widget snapshots mobile: first mobile render 1`] = `
                 <span
                   class="graphie-label"
                   data-math-formula="1"
-                  style="position: absolute; padding: 7px; color: black; left: 172.5px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 172.5px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -3046,7 +3046,7 @@ exports[`number-line widget snapshots mobile: first mobile render 1`] = `
                 <span
                   class="graphie-label"
                   data-math-formula="2"
-                  style="position: absolute; padding: 7px; color: black; left: 201px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 201px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"
@@ -3055,7 +3055,7 @@ exports[`number-line widget snapshots mobile: first mobile render 1`] = `
                 <span
                   class="graphie-label"
                   data-math-formula="3"
-                  style="position: absolute; padding: 7px; color: black; left: 229.5px; top: 61.2px; fill: none;"
+                  style="position: absolute; padding: 7px; left: 229.5px; top: 61.2px; fill: none;"
                 >
                   <span
                     class="tex-holder"


### PR DESCRIPTION
## Summary:
Some labels in Graphie images weren't being styled correctly, due to the
multiple mechanisms content creators use to author colors in Graphies.  The
foreground text color of the improperly-styled labels defaulted to
`semanticColor.core.foreground.neutral.strong`.

- Mechanism 1: TeX macros like `\red`. These are working properly.
- Mechanism 2: colors specified via `label` and related functions in the graphie
  JavaScript API. For example:
  ```js
  drawAngleLabel({
    points: [b, a, c],
    label: "2x",
    distance: 4,
    color: MAROON_C // Note: this is an rgb(...) string.
  });
  ```
  These colors were not working, because they got overridden by a CSS rule
  that selected `.graphie-label` and styled `color` with `!important`.

The problem is, we can't just use the label `color` as authored, because it
wouldn't be legible in dark mode. Nor do we want to invert the authored color
with a CSS filter in dark mode; that washes out the colors too much, and
creates usability problems (see LEMS-4492).

The solution in this PR is to map the authored colors to the nearest semantic
color.

Issue: LEMS-4550

## Test plan:

- `pnpm storybook`
- visit:
  http://localhost:6006/?path=/story/widgets-image-widget-demo--graphie-image&globals=theme:syl-dark
- You should see the labels display in the correct foreground color. The CSS
  should not override the color with `!important`, and the labels should be
  styled using a WB token.