### PR TITLE
Update editor styles to be less confusing

### DIFF
--- a/.changeset/full-groups-build.md
+++ b/.changeset/full-groups-build.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Update editor styles to be less confusing

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -15,42 +15,42 @@ exports[`ArticleEditor should match snapshot for editing disabled for all widget
           class="perseus-editor-left-cell"
         >
           <div
-            class="perseus-widget-editor perseus-issues-panel"
+            class="perseus-editor-sticky-header"
           >
             <div
-              class="perseus-widget-editor-title"
+              class="perseus-widget-editor perseus-issues-panel"
             >
               <div
-                class="perseus-widget-editor-title-id"
+                class="perseus-widget-editor-title"
               >
                 <div
-                  class="default_7zhre1-o_O-inlineStyles_d7xzml"
+                  class="perseus-widget-editor-title-id"
                 >
-                  <span
-                    class="svg_1q6jc65-o_O-small_6q1hy-o_O-collapsed_zgg88f-o_O-inlineStyles_u4fgyh"
-                  />
-                  <span>
-                    Issues
-                  </span>
+                  <div
+                    class="default_7zhre1-o_O-inlineStyles_d7xzml"
+                  >
+                    <span
+                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-collapsed_zgg88f-o_O-inlineStyles_u4fgyh"
+                    />
+                    <span>
+                      Issues
+                    </span>
+                  </div>
                 </div>
+                <span
+                  class="svg_1q6jc65-o_O-medium_12bui46-o_O-inlineStyles_1bholod"
+                  data-testid="issues-icon-warning-octagon-fill.svg"
+                />
+                16 issues
               </div>
-              <span
-                class="svg_1q6jc65-o_O-medium_12bui46-o_O-inlineStyles_1bholod"
-                data-testid="issues-icon-warning-octagon-fill.svg"
-              />
-              16 issues
             </div>
-          </div>
-          <fieldset
-            disabled=""
-          >
             <div
               class="pod-title"
             >
               Section 
               1
-              <div
-                style="display: inline-block; float: inline-end;"
+              <fieldset
+                disabled=""
               >
                 <span />
                 <button
@@ -75,8 +75,12 @@ exports[`ArticleEditor should match snapshot for editing disabled for all widget
                     class="svg_1q6jc65-o_O-medium_12bui46-o_O-inlineStyles_13u9hv4"
                   />
                 </button>
-              </div>
+              </fieldset>
             </div>
+          </div>
+          <fieldset
+            disabled=""
+          >
             <div
               class="perseus-single-editor  perseus-editor-disabled"
               data-testid="perseus-single-editor"

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -14,36 +14,36 @@ exports[`ArticleEditor should match snapshot for editing disabled for all widget
         <div
           class="perseus-editor-left-cell"
         >
+          <div
+            class="perseus-widget-editor perseus-issues-panel"
+          >
+            <div
+              class="perseus-widget-editor-title"
+            >
+              <div
+                class="perseus-widget-editor-title-id"
+              >
+                <div
+                  class="default_7zhre1-o_O-inlineStyles_d7xzml"
+                >
+                  <span
+                    class="svg_1q6jc65-o_O-small_6q1hy-o_O-collapsed_zgg88f-o_O-inlineStyles_u4fgyh"
+                  />
+                  <span>
+                    Issues
+                  </span>
+                </div>
+              </div>
+              <span
+                class="svg_1q6jc65-o_O-medium_12bui46-o_O-inlineStyles_1bholod"
+                data-testid="issues-icon-warning-octagon-fill.svg"
+              />
+              16 issues
+            </div>
+          </div>
           <fieldset
             disabled=""
           >
-            <div
-              class="perseus-widget-editor"
-            >
-              <div
-                class="perseus-widget-editor-title"
-              >
-                <div
-                  class="perseus-widget-editor-title-id"
-                >
-                  <div
-                    class="default_7zhre1-o_O-inlineStyles_d7xzml"
-                  >
-                    <span
-                      class="svg_1q6jc65-o_O-small_6q1hy-o_O-collapsed_zgg88f-o_O-inlineStyles_u4fgyh"
-                    />
-                    <span>
-                      Issues
-                    </span>
-                  </div>
-                </div>
-                <span
-                  class="svg_1q6jc65-o_O-medium_12bui46-o_O-inlineStyles_1bholod"
-                  data-testid="issues-icon-warning-octagon-fill.svg"
-                />
-                16 issues
-              </div>
-            </div>
             <div
               class="pod-title"
             >

--- a/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
@@ -141,7 +141,7 @@ exports[`EditorPage should match snapshot for editing disabled for all widgets 1
           class="perseus-editor-left-cell"
         >
           <div
-            class="perseus-widget-editor"
+            class="perseus-widget-editor perseus-issues-panel"
           >
             <div
               class="perseus-widget-editor-title"
@@ -16615,9 +16615,6 @@ table: [[☃ table 1]]
             </div>
           </div>
         </div>
-        <div
-          class="perseus-editor-right-cell"
-        />
       </div>
       <div
         class="perseus-editor-row"

--- a/packages/perseus-editor/src/article-editor.tsx
+++ b/packages/perseus-editor/src/article-editor.tsx
@@ -187,10 +187,13 @@ export default class ArticleEditor extends React.Component<Props, State> {
                     return [
                         <div className="perseus-editor-row" key={i}>
                             <div className="perseus-editor-left-cell">
+                                {/* The issues panel lives outside the
+                                 * fieldset so that it stays usable when
+                                 * editing is disabled, and so that its
+                                 * containing block is the scrolling left
+                                 * cell (which is what lets it stick). */}
+                                <IssuesPanel issues={this.state.issues[i]} />
                                 <fieldset disabled={editingDisabled}>
-                                    <IssuesPanel
-                                        issues={this.state.issues[i]}
-                                    />
                                     <div className="pod-title">
                                         Section {i + 1}
                                         <div

--- a/packages/perseus-editor/src/article-editor.tsx
+++ b/packages/perseus-editor/src/article-editor.tsx
@@ -187,21 +187,16 @@ export default class ArticleEditor extends React.Component<Props, State> {
                     return [
                         <div className="perseus-editor-row" key={i}>
                             <div className="perseus-editor-left-cell">
-                                {/* The issues panel lives outside the
-                                 * fieldset so that it stays usable when
-                                 * editing is disabled, and so that its
-                                 * containing block is the scrolling left
-                                 * cell (which is what lets it stick). */}
-                                <IssuesPanel issues={this.state.issues[i]} />
-                                <fieldset disabled={editingDisabled}>
+                                {/* The issues panel and section title are
+                                 * pinned to the top of the left cell as a
+                                 * single sticky unit. */}
+                                <div className="perseus-editor-sticky-header">
+                                    <IssuesPanel
+                                        issues={this.state.issues[i]}
+                                    />
                                     <div className="pod-title">
                                         Section {i + 1}
-                                        <div
-                                            style={{
-                                                display: "inline-block",
-                                                float: "inline-end",
-                                            }}
-                                        >
+                                        <fieldset disabled={editingDisabled}>
                                             {sectionImageUploadGenerator(i)}
                                             <SectionControlButton
                                                 icon={plusIcon}
@@ -256,8 +251,10 @@ export default class ArticleEditor extends React.Component<Props, State> {
                                                 }}
                                                 title="Delete this section"
                                             />
-                                        </div>
+                                        </fieldset>
                                     </div>
+                                </div>
+                                <fieldset disabled={editingDisabled}>
                                     <Editor
                                         {...section}
                                         apiOptions={apiOptions}

--- a/packages/perseus-editor/src/combined-hints-editor.tsx
+++ b/packages/perseus-editor/src/combined-hints-editor.tsx
@@ -7,6 +7,7 @@ import {ApiOptions} from "@khanacademy/perseus";
 import Button from "@khanacademy/wonder-blocks-button";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
+import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import arrowCircleDownIcon from "@phosphor-icons/core/bold/arrow-circle-down-bold.svg";
 import arrowCircleUpIcon from "@phosphor-icons/core/bold/arrow-circle-up-bold.svg";
@@ -127,61 +128,64 @@ class HintEditor extends React.Component<HintEditorProps> {
                     widgetIsOpen={this.props.widgetIsOpen}
                 />
 
-                {this.props.isLast && (
-                    <BodyText size="xsmall">
-                        The last hint is automatically bolded.
-                    </BodyText>
-                )}
-
-                {/* Row that includes movement buttons and the "Replace previous hint" checkbox */}
-                <div
-                    style={{
-                        display: "flex",
-                        justifyContent: "space-between",
-                        alignItems: "center",
-                    }}
-                >
-                    {this.props.showMoveButtons && (
-                        <div className="reorder-hints">
-                            <IconButton
-                                icon={arrowCircleDownIcon}
-                                size="small"
-                                kind="tertiary"
-                                onClick={_.partial(this.props.onMove, 1)}
-                                disabled={this.props.isLast}
-                            />
-                            <IconButton
-                                icon={arrowCircleUpIcon}
-                                size="small"
-                                kind="tertiary"
-                                onClick={_.partial(this.props.onMove, -1)}
-                                disabled={this.props.isFirst}
-                            />
-                        </div>
+                {/* All buttons under the editor */}
+                <div className="perseus-hint-editor-actions">
+                    {this.props.isLast && (
+                        <BodyText size="xsmall">
+                            The last hint is automatically bolded.
+                        </BodyText>
                     )}
-                    <Checkbox
-                        checked={this.props.replace}
-                        onChange={(newCheckedState) => {
-                            this.props.onChange({replace: newCheckedState});
-                        }}
-                        label="Replace previous hint"
-                        style={{display: "inline-block"}}
-                    />
-                </div>
 
-                {this.props.showRemoveButton && (
-                    <Button
-                        startIcon={trashIcon}
-                        size="small"
-                        kind="tertiary"
-                        disabled={this.props.apiOptions?.editingDisabled}
-                        onClick={this.props.onRemove}
-                        // Have the "Remove" button align to the right.
-                        style={{marginInlineStart: "auto", display: "flex"}}
+                    {/* Row that includes movement buttons and the "Replace previous hint" checkbox */}
+                    <div
+                        style={{
+                            display: "flex",
+                            justifyContent: "space-between",
+                            alignItems: "center",
+                        }}
                     >
-                        Remove this hint
-                    </Button>
-                )}
+                        {this.props.showMoveButtons && (
+                            <>
+                                <IconButton
+                                    icon={arrowCircleDownIcon}
+                                    size="small"
+                                    kind="tertiary"
+                                    onClick={_.partial(this.props.onMove, 1)}
+                                    disabled={this.props.isLast}
+                                />
+                                <IconButton
+                                    icon={arrowCircleUpIcon}
+                                    size="small"
+                                    kind="tertiary"
+                                    onClick={_.partial(this.props.onMove, -1)}
+                                    disabled={this.props.isFirst}
+                                />
+                            </>
+                        )}
+                        <Checkbox
+                            checked={this.props.replace}
+                            onChange={(newCheckedState) => {
+                                this.props.onChange({replace: newCheckedState});
+                            }}
+                            label="Replace previous hint"
+                            style={{display: "inline-block"}}
+                        />
+                    </div>
+
+                    {this.props.showRemoveButton && (
+                        <Button
+                            startIcon={trashIcon}
+                            size="small"
+                            kind="tertiary"
+                            disabled={this.props.apiOptions?.editingDisabled}
+                            onClick={this.props.onRemove}
+                            // Have the "Remove" button align to the right.
+                            style={{marginInlineStart: "auto", display: "flex"}}
+                        >
+                            Remove this hint
+                        </Button>
+                    )}
+                </div>
             </div>
         );
     }

--- a/packages/perseus-editor/src/combined-hints-editor.tsx
+++ b/packages/perseus-editor/src/combined-hints-editor.tsx
@@ -7,7 +7,6 @@ import {ApiOptions} from "@khanacademy/perseus";
 import Button from "@khanacademy/wonder-blocks-button";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import IconButton from "@khanacademy/wonder-blocks-icon-button";
-import {sizing} from "@khanacademy/wonder-blocks-tokens";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import arrowCircleDownIcon from "@phosphor-icons/core/bold/arrow-circle-down-bold.svg";
 import arrowCircleUpIcon from "@phosphor-icons/core/bold/arrow-circle-up-bold.svg";

--- a/packages/perseus-editor/src/components/issues-panel.tsx
+++ b/packages/perseus-editor/src/components/issues-panel.tsx
@@ -100,7 +100,7 @@ const IssuesPanel = (props: IssuesPanelProps) => {
     });
 
     return (
-        <div className="perseus-widget-editor">
+        <div className="perseus-widget-editor perseus-issues-panel">
             <div className="perseus-widget-editor-title">
                 <div className="perseus-widget-editor-title-id">
                     <View

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -193,8 +193,6 @@ class ItemEditor extends React.Component<Props> {
                             {...this.props.answerArea}
                         />
                     </div>
-
-                    <div className="perseus-editor-right-cell" />
                 </div>
 
                 <CombinedHintsEditor

--- a/packages/perseus-editor/src/styles/perseus-editor.css
+++ b/packages/perseus-editor/src/styles/perseus-editor.css
@@ -113,6 +113,8 @@ code {
 .perseus-widget-editor {
     border: 1px solid #ddd;
     border-radius: 3px;
+}
+.perseus-widget-editor:not(:first-child) {
     margin-top: 10px;
 }
 .perseus-widget-editor .perseus-widget-editor-title {

--- a/packages/perseus-editor/src/styles/perseus-editor.css
+++ b/packages/perseus-editor/src/styles/perseus-editor.css
@@ -266,6 +266,7 @@ code {
 .perseus-editor-row {
     display: flex;
     flex-direction: row;
+    margin-block-end: 32px;
 }
 .perseus-editor-left-cell {
     display: flex;
@@ -284,6 +285,10 @@ code {
     /* Keep the left cell scroll area within the viewport. (244px to account
      * for the header.) */
     max-height: calc(95vh - 244px);
+
+    /* Border and gutter to make it more obvious how big the left cell is. */
+    border: 1px solid var(--wb-semanticColor-core-border-neutral-default);
+    margin-inline-end: 32px;
 }
 .perseus-editor-right-cell {
     box-sizing: border-box;
@@ -300,6 +305,8 @@ code {
     /* Don't shrink below the preview's intrinsic width. We need this to
      * preserve the Tablet and Desktop preview widths. */
     flex-shrink: 0;
+    /* Border to make it more obvious how big the left cell is. */
+    border: 1px solid var(--wb-semanticColor-core-border-neutral-default);
 }
 .perseus-hint-editor {
     padding-bottom: 20px;
@@ -338,6 +345,32 @@ code {
 .perseus-article-editor .perseus-editor-left-cell {
     min-width: 360px;
 }
+/* Pin the issues panel to the top of the section's scroll area so it stays
+ * visible while the author scrolls through that section's content. The left
+ * cell is the scroll container, and the panel is one of its direct children,
+ * so `inset-block-start: 0` sticks it to the top of that scrollport. */
+.perseus-article-editor .perseus-editor-left-cell > .perseus-issues-panel {
+    position: sticky;
+    inset-block-start: 0;
+    /* Draw above the section content that scrolls underneath it. Nothing else
+     * inside the left cell sets a z-index, so 1 is enough. */
+    z-index: 1;
+    /* Sticky elements don't get a background for free; without one the section
+     * content would show through the panel as it scrolls past. */
+    background-color: var(--wb-semanticColor-core-background-base-default);
+    /* A flex item won't shrink below its content by default, but it also
+     * shouldn't stretch to fill the cell when the section is short. */
+    flex-shrink: 0;
+}
+/* An expanded panel with many issues could otherwise cover the whole scroll
+ * area, leaving nothing to scroll. Cap it and let the list scroll instead. */
+.perseus-article-editor
+    .perseus-editor-left-cell
+    > .perseus-issues-panel
+    .perseus-widget-editor-panel {
+    max-height: 40vh;
+    overflow-y: auto;
+}
 .perseus-article-editor .mobile-preview,
 .perseus-article-editor .desktop-preview,
 .perseus-article-editor .editor-preview,
@@ -353,6 +386,9 @@ code {
 .perseus-article-editor .desktop-preview {
     border: 1px solid transparent;
     padding: 32px 20px;
+}
+.perseus-article-editor .editor-preview {
+    border: 1px solid var(--wb-semanticColor-core-border-neutral-default);
 }
 .perseus-article-editor .editor-preview {
     /* Make the preview scrollable. */

--- a/packages/perseus-editor/src/styles/perseus-editor.css
+++ b/packages/perseus-editor/src/styles/perseus-editor.css
@@ -341,9 +341,6 @@ code {
     margin-bottom: 20px;
     margin-top: 20px;
 }
-.perseus-article-editor .perseus-single-editor {
-    margin-bottom: 10px;
-}
 .perseus-article-editor .section-control-button,
 .perseus-article-editor .step-control-button {
     font-size: 13px;

--- a/packages/perseus-editor/src/styles/perseus-editor.css
+++ b/packages/perseus-editor/src/styles/perseus-editor.css
@@ -9,6 +9,15 @@ code {
     padding: 4px 10px;
     border-radius: 3px 3px 0 0;
 }
+/* Pin the "Question", "Question extras", and "Hint" titles to the top of their
+ * left cell, which is the scroll container. */
+.perseus-editor-left-cell > .pod-title,
+.perseus-editor-left-cell > .perseus-hint-editor > .pod-title {
+    position: sticky;
+    inset-block-start: 0;
+    /* Draw above the editor content that scrolls underneath. */
+    z-index: 1;
+}
 .pod-title.closed {
     border-radius: 3px;
 }
@@ -345,18 +354,18 @@ code {
 .perseus-article-editor .perseus-editor-left-cell {
     min-width: 360px;
 }
-/* Pin the issues panel to the top of the section's scroll area so it stays
- * visible while the author scrolls through that section's content. The left
- * cell is the scroll container, and the panel is one of its direct children,
- * so `inset-block-start: 0` sticks it to the top of that scrollport. */
-.perseus-article-editor .perseus-editor-left-cell > .perseus-issues-panel {
+/* Pin the issues panel and section title to the top of the section's scroll
+ * area so they stay visible while the author scrolls through that section's
+ * content. */
+.perseus-article-editor
+    .perseus-editor-left-cell
+    > .perseus-editor-sticky-header {
     position: sticky;
     inset-block-start: 0;
-    /* Draw above the section content that scrolls underneath it. Nothing else
-     * inside the left cell sets a z-index, so 1 is enough. */
+    /* Draw above the section content that scrolls underneath it. */
     z-index: 1;
-    /* Sticky elements don't get a background for free; without one the section
-     * content would show through the panel as it scrolls past. */
+    /* Make the sticky element background opaque so text doesn't overlap
+     * while scrolling. */
     background-color: var(--wb-semanticColor-core-background-base-default);
     /* A flex item won't shrink below its content by default, but it also
      * shouldn't stretch to fill the cell when the section is short. */
@@ -365,8 +374,7 @@ code {
 /* An expanded panel with many issues could otherwise cover the whole scroll
  * area, leaving nothing to scroll. Cap it and let the list scroll instead. */
 .perseus-article-editor
-    .perseus-editor-left-cell
-    > .perseus-issues-panel
+    .perseus-editor-sticky-header
     .perseus-widget-editor-panel {
     max-height: 40vh;
     overflow-y: auto;
@@ -432,8 +440,11 @@ code {
 .perseus-article-editor .framework-perseus.perseus-article * {
     box-sizing: inherit;
 }
-.perseus-article-editor .perseus-editor-left-cell > .pod-title {
+.perseus-article-editor .perseus-editor-sticky-header > .pod-title {
     padding: 4px 9px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
 }
 .perseus-widget-dropdown input[type="text"] {
     border: 1px solid #ccc;

--- a/packages/perseus-editor/src/styles/perseus-editor.css
+++ b/packages/perseus-editor/src/styles/perseus-editor.css
@@ -319,15 +319,8 @@ code {
     /* Border to make it more obvious how big the left cell is. */
     border: 1px solid var(--wb-semanticColor-core-border-neutral-default);
 }
-.perseus-hint-editor {
-    padding-bottom: 20px;
-}
 .perseus-hint-editor .perseus-single-editor {
     margin-bottom: 5px;
-}
-.perseus-hint-editor .reorder-hints {
-    display: flex;
-    align-items: center;
 }
 .perseus-hint-editor .remove-hint {
     float: right;
@@ -339,6 +332,10 @@ code {
 }
 .perseus-hint-editor + div .perseus-hint-renderer div.paragraph {
     margin: 0px 0px 22px 0px;
+}
+.perseus-hint-editor-actions {
+    margin: 8px;
+    margin-block-start: 0;
 }
 .perseus-article-editor {
     margin-bottom: 20px;


### PR DESCRIPTION
## Summary:
Ever since we updated the exercise and article editors to have scroll containers,
it's been difficult to tell where each section begins or ends.

Updating the styles to include outlines here so it's clearer where each section is,
and adding gutters to add visual separation and another place to allow scrolling
the whole page. Outlines and gutters were requested by the content team.

Also made the headers sticky so that folks can tell what section they're editing
even after scrolling down.

Issue: https://khanacademy.atlassian.net/browse/LEMS-4432

## Test plan:
Storybook
- `/?path=/story/editors-editorpage--with-all-widgets`
- `/?path=/story/editors-articleeditor--demo`

Use this PR to create a snapshot to test in the frontend environment.

[ZND for testing](https://prod-znd-260901-15667-7481c4a.khanacademy.org/)

## Screenshots

### Exercise editor before
<img width="1727" height="877" alt="Screenshot 2026-09-01 at 12 10 38 PM" src="https://github.com/user-attachments/assets/47107726-c458-4b0b-acd2-7dc01052a12d" />

### Exercise editor after
<img width="1726" height="874" alt="Screenshot 2026-09-01 at 12 10 44 PM" src="https://github.com/user-attachments/assets/f98e4ff4-eea7-4fc7-800e-30a668775598" />

### Article editor before
<img width="1728" height="876" alt="Screenshot 2026-09-01 at 12 10 55 PM" src="https://github.com/user-attachments/assets/f1e799ba-1db2-4d83-a270-463fc52734de" />

### Article editor after 
<img width="1724" height="876" alt="Screenshot 2026-09-01 at 12 11 02 PM" src="https://github.com/user-attachments/assets/d75e53ad-8cc2-46cd-aeee-06720cda729f" />
