### PR TITLE
Remove `wb-themed-math` CSS class

### DIFF
--- a/.changeset/nine-ravens-battle.md
+++ b/.changeset/nine-ravens-battle.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-editor": major
+"@khanacademy/perseus": major
+---
+
+The temporary `wb-themed-math` class has been removed. Clients must now use `@khanacademy/mathjax-renderer` 3.2.0 or later with Perseus.

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -54,7 +54,7 @@ const withPerseusDecorator: Decorator = (Story) => {
                     Include box-sizing-border-box-reset to reflect the global styles
                     from prod.
                 */}
-                <div className="framework-perseus wb-themed-math box-sizing-border-box-reset">
+                <div className="framework-perseus box-sizing-border-box-reset">
                     <Story />
                 </div>
             </DependenciesContext.Provider>

--- a/packages/perseus-editor/src/__docs__/editor.stories.tsx
+++ b/packages/perseus-editor/src/__docs__/editor.stories.tsx
@@ -52,8 +52,7 @@ export const DemoInteractiveGraph = (): React.ReactElement => {
         // Many of the editor components use scoped CSS that requires this
         // class to be above it.
         // TODO: Refactor to aphrodite styles instead of scoped CSS in Less.
-        // TODO(LEMS-4492): remove wb-themed-math
-        <div className="framework-perseus wb-themed-math">
+        <div className="framework-perseus">
             <SplitView
                 rendererTitle="Editor"
                 renderer={

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ArticleEditor should match snapshot for editing disabled for all widgets 1`] = `
 <div>
   <div
-    class="framework-perseus wb-themed-math perseus-article-editor"
+    class="framework-perseus perseus-article-editor"
   >
     <div
       class="perseus-editor-table"

--- a/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`EditorPage should match snapshot for editing disabled for all widgets 1`] = `
 <div>
   <div
-    class="framework-perseus wb-themed-math"
+    class="framework-perseus"
     id="perseus"
   >
     <div

--- a/packages/perseus-editor/src/article-editor.tsx
+++ b/packages/perseus-editor/src/article-editor.tsx
@@ -486,8 +486,7 @@ export default class ArticleEditor extends React.Component<Props, State> {
             <Dependencies.DependenciesContext.Provider
                 value={this.props.dependencies}
             >
-                {/* TODO(LEMS-4492): remove wb-themed-math*/}
-                <div className="framework-perseus wb-themed-math perseus-article-editor">
+                <div className="framework-perseus perseus-article-editor">
                     {this.props.mode === "edit" && this._renderEditor()}
 
                     {this.props.mode === "preview" && this._renderPreviewMode()}

--- a/packages/perseus-editor/src/components/__docs__/text-list-editor.stories.tsx
+++ b/packages/perseus-editor/src/components/__docs__/text-list-editor.stories.tsx
@@ -14,8 +14,7 @@ const meta: Meta = {
     },
     decorators: [
         (Story) => (
-            // TODO(LEMS-4492): remove wb-themed-math
-            <div className={"framework-perseus wb-themed-math orderer"}>
+            <div className={"framework-perseus orderer"}>
                 <Story />
             </div>
         ),

--- a/packages/perseus-editor/src/content-preview.tsx
+++ b/packages/perseus-editor/src/content-preview.tsx
@@ -69,8 +69,7 @@ function ContentPreview({
 
     return (
         <View
-            // TODO(LEMS-4492): remove wb-themed-math
-            className={`framework-perseus wb-themed-math ${className}`}
+            className={`framework-perseus ${className}`}
             style={[styles.container, !seamless ? styles.gutter : undefined]}
         >
             <StatefulKeypadContextProvider>

--- a/packages/perseus-editor/src/diffs/__tests__/__snapshots__/article-diff.test.tsx.snap
+++ b/packages/perseus-editor/src/diffs/__tests__/__snapshots__/article-diff.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ArticleDiff renders an article in the diff view 1`] = `
 <div>
   <div
-    class="framework-perseus wb-themed-math"
+    class="framework-perseus"
   >
     <div>
       <div>

--- a/packages/perseus-editor/src/diffs/__tests__/__snapshots__/item-diff.test.tsx.snap
+++ b/packages/perseus-editor/src/diffs/__tests__/__snapshots__/item-diff.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ItemDiff renders a diff view 1`] = `
 <div>
   <div
-    class="framework-perseus wb-themed-math"
+    class="framework-perseus"
   >
     <div>
       <div>

--- a/packages/perseus-editor/src/diffs/article-diff.tsx
+++ b/packages/perseus-editor/src/diffs/article-diff.tsx
@@ -58,8 +58,7 @@ class ArticleDiff extends React.Component<Props, ArticleDiffState> {
             <Dependencies.DependenciesContext.Provider
                 value={this.props.dependencies}
             >
-                {/* TODO(LEMS-4492): remove wb-themed-math */}
-                <div className="framework-perseus wb-themed-math">
+                <div className="framework-perseus">
                     {sections}
                 </div>
             </Dependencies.DependenciesContext.Provider>

--- a/packages/perseus-editor/src/diffs/article-diff.tsx
+++ b/packages/perseus-editor/src/diffs/article-diff.tsx
@@ -58,9 +58,7 @@ class ArticleDiff extends React.Component<Props, ArticleDiffState> {
             <Dependencies.DependenciesContext.Provider
                 value={this.props.dependencies}
             >
-                <div className="framework-perseus">
-                    {sections}
-                </div>
+                <div className="framework-perseus">{sections}</div>
             </Dependencies.DependenciesContext.Provider>
         );
     }

--- a/packages/perseus-editor/src/diffs/item-diff.tsx
+++ b/packages/perseus-editor/src/diffs/item-diff.tsx
@@ -61,8 +61,7 @@ class ItemDiff extends React.Component<Props> {
             <Dependencies.DependenciesContext.Provider
                 value={this.props.dependencies}
             >
-                {/* TODO(LEMS-4492): remove wb-themed-math */}
-                <div className="framework-perseus wb-themed-math">
+                <div className="framework-perseus">
                     {question}
                     {extras}
                     {hints.length > 0 && <div className="diff-separator" />}

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -282,8 +282,7 @@ class EditorPage extends React.Component<Props, State> {
     };
 
     render(): React.ReactNode {
-        // TODO(LEMS-4492): remove wb-themed-math
-        let className = "framework-perseus wb-themed-math";
+        let className = "framework-perseus";
         const editingDisabled = this.props.apiOptions?.editingDisabled ?? false;
 
         const touch =

--- a/packages/perseus-editor/src/testing/preview/preview-renderer.tsx
+++ b/packages/perseus-editor/src/testing/preview/preview-renderer.tsx
@@ -91,8 +91,7 @@ function PreviewKeypadConnection({
 
     return (
         <View
-            // TODO(LEMS-4492): remove wb-themed-math
-            className={`framework-perseus wb-themed-math ${className}`}
+            className={`framework-perseus ${className}`}
             style={containerStyle}
         >
             {children({...keypadCtx, isMobile})}

--- a/packages/perseus-editor/src/testing/split-view.tsx
+++ b/packages/perseus-editor/src/testing/split-view.tsx
@@ -23,8 +23,7 @@ const SplitView = ({
 }: Props): React.ReactElement => {
     return (
         <View style={styles.sideBySide}>
-            {/* TODO(LEMS-4492): remove wb-themed-math */}
-            <View className="framework-perseus wb-themed-math">
+            <View className="framework-perseus">
                 <Heading size="large">{rendererTitle}</Heading>
                 {renderer}
             </View>

--- a/packages/perseus/src/article-renderer.tsx
+++ b/packages/perseus/src/article-renderer.tsx
@@ -195,8 +195,6 @@ class ArticleRenderer
         const classes = classNames({
             "framework-perseus": true,
             "perseus-article": true,
-            // TODO(LEMS-4492): remove wb-themed-math
-            "wb-themed-math": true,
             // NOTE(charlie): For exercises, this is applied outside of Perseus
             // (in khan/frontend).
             [ApiClassNames.MOBILE]: apiOptions.isMobile,

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -365,43 +365,7 @@
 /*****************************
  * GLOBAL DARK MODE SETTINGS *
  *****************************/
-[data-wb-theme$="-dark"] .framework-perseus:not(.wb-themed-math) {
-    /* TODO(benchristel): this set of file extensions is duplicated in
-     * image.css and dark-mode-toggle.tsx. Replace these selectors with a
-     * class that gets added to images that should be inverted, so the set of
-     * extensions can have a single representation in TypeScript code.
-     */
-    img[src$=".png"],
-    img[src$=".svg"],
-    .graphie:not(.perseus-widget-plotter),
-    .mathjax-wrapper:not(.graphie:not(.perseus-widget-plotter) *) {
-        /* This filter is applied to PNG/SVG images, Graphie (excluding the
-           Plotter, which is themed), and MathJax. MathJax inside inverted
-           Graphies is excluded so it doesn't get double-inverted. JPEGs & GIFs
-           are untouched.
-         */
-        filter: invert(1) hue-rotate(180deg) brightness(1.5);
-    }
-
-    .mathjax-wrapper > mjx-container {
-        /* Since we invert all MathJax colors (above), we need to force the
-           default foreground color to dark so it will be light when inverted.
-           If we don't do this, then math will inherit the theme's foreground
-           color and invert it, resulting in dark-on-dark text.
-
-           The precise color used here is unimportant; off-black colors get
-           washed out by the brightness filter, so they end up as #fff anyway.
-         */
-        color: black;
-    }
-}
-
-/* TODO(LEMS-4492): remove the .wb-themed-math class once math uses WB
-   tokens everywhere. In the future, the styles below should become the only
-   dark mode styles. We can also remove the !important from the .graphie-label
-   styles, and set the label foreground color directly in graphie.ts.
- */
-[data-wb-theme$="-dark"] .framework-perseus.wb-themed-math {
+[data-wb-theme$="-dark"] .framework-perseus {
     /* TODO(benchristel): this set of file extensions is duplicated in
      * image.css and dark-mode-toggle.tsx. Replace these selectors with a
      * class that gets added to images that should be inverted, so the set of

--- a/packages/perseus/src/testing/render-question-with-cypress.tsx
+++ b/packages/perseus/src/testing/render-question-with-cypress.tsx
@@ -49,7 +49,7 @@ const renderQuestion = (
     // they are fully rendered (like KaTeX, for example).
     // onRender is also used to signal that rendering has completed.
     mount(
-        <div className="framework-perseus wb-themed-math">
+        <div className="framework-perseus">
             <AssetContext.Provider value={{assetStatuses, setAssetStatus}}>
                 <RenderStateRoot>
                     <DependenciesContext.Provider value={cypressDependenciesV2}>

--- a/packages/perseus/src/testing/split-view.tsx
+++ b/packages/perseus/src/testing/split-view.tsx
@@ -23,7 +23,7 @@ const SplitView = ({
 }: Props): React.ReactElement => {
     return (
         <View style={styles.sideBySide}>
-            <View className="framework-perseus wb-themed-math">
+            <View className="framework-perseus">
                 <Heading size="large">{rendererTitle}</Heading>
                 {renderer}
             </View>

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -26,6 +26,7 @@ import type {MouseHandler} from "./interactive";
 import type {Interval} from "./interval";
 import type {Coord} from "../interactive2/types";
 import type {GraphieLabelElement} from "../types";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 
 const {processMath} = Tex;
 

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -26,7 +26,6 @@ import type {MouseHandler} from "./interactive";
 import type {Interval} from "./interval";
 import type {Coord} from "../interactive2/types";
 import type {GraphieLabelElement} from "../types";
-import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 
 const {processMath} = Tex;
 

--- a/packages/perseus/src/widgets/__testutils__/story-decorators.tsx
+++ b/packages/perseus/src/widgets/__testutils__/story-decorators.tsx
@@ -4,21 +4,21 @@ import type {Decorator} from "@storybook/react-vite";
 
 export const mobileDecorator: Decorator = (Story) => (
     // TODO(LEMS-4492): remove wb-themed-math
-    <div className="framework-perseus wb-themed-math perseus-mobile">
+    <div className="framework-perseus perseus-mobile">
         <Story />
     </div>
 );
 
 export const articleDecorator: Decorator = (Story) => (
     // TODO(LEMS-4492): remove wb-themed-math
-    <div className="framework-perseus wb-themed-math perseus-article">
+    <div className="framework-perseus perseus-article">
         <Story />
     </div>
 );
 
 export const mobileArticleDecorator: Decorator = (Story) => (
     // TODO(LEMS-4492): remove wb-themed-math
-    <div className="framework-perseus wb-themed-math perseus-mobile perseus-article">
+    <div className="framework-perseus perseus-mobile perseus-article">
         <Story />
     </div>
 );
@@ -60,8 +60,7 @@ const articleContent3 =
     "The nucleolus (a structure inside the nucleus where ribosomes are made) disappears during prophase. The mitotic spindle begins to form during prophase, starting at regions called centrosomes. These regions contain the material needed for building the spindle, and also function to regulate the spindle throughout mitosis.";
 
 export const mobileArticleFloatLeftDecorator: Decorator = (Story) => (
-    // TODO(LEMS-4492): remove wb-themed-math
-    <div className="framework-perseus wb-themed-math perseus-mobile perseus-article">
+    <div className="framework-perseus perseus-mobile perseus-article">
         <div className="paragraph">
             <div className="perseus-widget-container widget-nohighlight widget-wrap-left">
                 <Story />
@@ -74,8 +73,7 @@ export const mobileArticleFloatLeftDecorator: Decorator = (Story) => (
 );
 
 export const mobileArticleFloatRightDecorator: Decorator = (Story) => (
-    // TODO(LEMS-4492): remove wb-themed-math
-    <div className="framework-perseus wb-themed-math perseus-mobile perseus-article">
+    <div className="framework-perseus perseus-mobile perseus-article">
         <div className="paragraph">
             <div className="perseus-widget-container widget-nohighlight widget-wrap-right">
                 <Story />
@@ -88,8 +86,7 @@ export const mobileArticleFloatRightDecorator: Decorator = (Story) => (
 );
 
 export const articleFloatLeftDecorator: Decorator = (Story) => (
-    // TODO(LEMS-4492): remove wb-themed-math
-    <div className="framework-perseus wb-themed-math perseus-article">
+    <div className="framework-perseus perseus-article">
         <div className="paragraph">
             <div className="perseus-widget-container widget-nohighlight widget-wrap-left">
                 <Story />
@@ -102,8 +99,7 @@ export const articleFloatLeftDecorator: Decorator = (Story) => (
 );
 
 export const articleFloatRightDecorator: Decorator = (Story) => (
-    // TODO(LEMS-4492): remove wb-themed-math
-    <div className="framework-perseus wb-themed-math perseus-article">
+    <div className="framework-perseus perseus-article">
         <div className="paragraph">
             <div className="perseus-widget-container widget-nohighlight widget-wrap-right">
                 <Story />

--- a/packages/perseus/src/widgets/image/__docs__/image-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/image/__docs__/image-initial-state-regression.stories.tsx
@@ -503,8 +503,7 @@ export const MarkdownTableWithMarkdownImages: Story = {
 export const AllAlignmentsInSameArticle: Story = {
     render: function Render() {
         return (
-            // TODO(LEMS-4492): remove wb-themed-math
-            <div className="framework-perseus wb-themed-math perseus-article">
+            <div className="framework-perseus perseus-article">
                 <QuestionRendererForStories
                     question={generateTestPerseusRenderer({
                         content: `${bioContent1}\n\n[[☃ image 1]]\n\n${bioContent2}\n\n[[☃ image 2]]\n\n${bioContent3}\n\nBlock image\n\n[[☃ image 3]]\n\nFull-width image\n\n[[☃ image 4]]`,
@@ -556,8 +555,7 @@ export const AllAlignmentsInSameArticle: Story = {
 export const AllAlignmentsInSameArticleMobile: Story = {
     render: function Render() {
         return (
-            // TODO(LEMS-4492): remove wb-themed-math
-            <div className="framework-perseus wb-themed-math perseus-mobile perseus-article">
+            <div className="framework-perseus perseus-mobile perseus-article">
                 <QuestionRendererForStories
                     question={generateTestPerseusRenderer({
                         content: `${bioContent1}\n\n[[☃ image 1]]\n\n${bioContent2}\n\n[[☃ image 2]]\n\n${bioContent3}\n\nBlock image\n\n[[☃ image 3]]\n\nFull-width image\n\n[[☃ image 4]]`,

--- a/packages/perseus/src/widgets/image/components/explore-image-modal.tsx
+++ b/packages/perseus/src/widgets/image/components/explore-image-modal.tsx
@@ -56,8 +56,7 @@ export const ExploreImageModal = (props: CommonImageProps) => {
             // We need to manually add the `framework-perseus` class so that
             // the modal can have the correct styling, even when the portal
             // makes it render outside the normal `framework-perseus` container.
-            // TODO(LEMS-4492): remove wb-themed-math
-            className={`framework-perseus wb-themed-math ${styles.modalContainer}`}
+            className={`framework-perseus ${styles.modalContainer}`}
         >
             <FlexibleDialog
                 title={title}

--- a/packages/perseus/src/widgets/numeric-input/__docs__/numeric-input-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/numeric-input/__docs__/numeric-input-interactions-regression.stories.tsx
@@ -276,8 +276,7 @@ function MobileKeypadItemRenderer({question}: {question: PerseusRenderer}) {
 export const MobilePhoneBasicKeypadOpen: Story = {
     render: () => (
         <div
-            // TODO(LEMS-4492): remove wb-themed-math
-            className="framework-perseus wb-themed-math perseus-mobile"
+            className="framework-perseus perseus-mobile"
             style={{
                 transform: "translateZ(0)",
                 position: "relative",
@@ -305,8 +304,7 @@ export const MobilePhoneBasicKeypadOpen: Story = {
 export const MobileTabletExpandedKeypadOpen: Story = {
     render: () => (
         <div
-            // TODO(LEMS-4492): remove wb-themed-math
-            className="framework-perseus wb-themed-math perseus-mobile"
+            className="framework-perseus perseus-mobile"
             style={{
                 transform: "translateZ(0)",
                 position: "relative",

--- a/packages/perseus/src/widgets/video/__docs__/video-demo.stories.tsx
+++ b/packages/perseus/src/widgets/video/__docs__/video-demo.stories.tsx
@@ -23,8 +23,7 @@ type Story = StoryObj<typeof meta>;
 export const AllAlignmentsInSameArticle: Story = {
     render: function Render() {
         return (
-            // TODO(LEMS-4492): remove wb-themed-math
-            <div className="framework-perseus wb-themed-math perseus-article">
+            <div className="framework-perseus perseus-article">
                 <QuestionRendererForStories
                     question={generateTestPerseusRenderer({
                         content: `Block video\n\n[[☃ video 1]]\n\nFull-width video\n\n[[☃ video 2]]`,
@@ -57,8 +56,7 @@ export const AllAlignmentsInSameArticle: Story = {
 export const AllAlignmentsInSameArticleMobile: Story = {
     render: function Render() {
         return (
-            // TODO(LEMS-4492): remove wb-themed-math
-            <div className="framework-perseus wb-themed-math perseus-mobile perseus-article">
+            <div className="framework-perseus perseus-mobile perseus-article">
                 <QuestionRendererForStories
                     question={generateTestPerseusRenderer({
                         content: `Block video\n\n[[☃ video 1]]\n\nFull-width video\n\n[[☃ video 2]]`,


### PR DESCRIPTION
## Summary:
This CSS class was temporary scaffolding that we used to safely change
how we colorize math notation. The change has happened and now we can
remove the class and de-duplicate the CSS.

Issue: LEMS-4492

## Test plan:

Review Chromatic snapshots - there should be no changes to math colors.