### PR TITLE
Add `seed` to ArticleRenderer

### DIFF
--- a/.changeset/tall-clouds-relax.md
+++ b/.changeset/tall-clouds-relax.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus": major
+"@khanacademy/perseus-editor": patch
+---
+
+Add a required `seed` prop to ArticleRenderer to make sure things shuffle correctly.

--- a/packages/perseus-editor/src/testing/preview/preview-renderer.tsx
+++ b/packages/perseus-editor/src/testing/preview/preview-renderer.tsx
@@ -205,6 +205,7 @@ export function PreviewRenderer({content, isMobile, hasLintGutter}: Props) {
                 {({keypadElement, isMobile}) => (
                     <ArticleRenderer
                         json={article}
+                        seed={0}
                         apiOptions={{...apiOptions, isMobile}}
                         keypadElement={keypadElement}
                         legacyPerseusLint={legacyPerseusLint}
@@ -230,6 +231,7 @@ export function PreviewRenderer({content, isMobile, hasLintGutter}: Props) {
                 {({keypadElement, isMobile}) => (
                     <ArticleRenderer
                         json={[...article]}
+                        seed={0}
                         apiOptions={{...apiOptions, isMobile}}
                         keypadElement={keypadElement}
                         dependencies={storybookDependenciesV2}

--- a/packages/perseus/src/__docs__/renderer-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/__docs__/renderer-initial-state-regression.stories.tsx
@@ -56,6 +56,7 @@ const RenderArticleContent = (
         return (
             <ArticleRenderer
                 json={json}
+                seed={0}
                 dependencies={storybookDependenciesV2}
                 apiOptions={apiOptions}
             />

--- a/packages/perseus/src/__tests__/article-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/article-renderer.test.tsx
@@ -37,6 +37,7 @@ import type {APIOptions} from "../types";
 import type {
     PerseusGradedGroupWidgetOptions,
     PerseusArticle,
+    PerseusRenderer,
     RadioWidget,
 } from "@khanacademy/perseus-core";
 
@@ -244,6 +245,22 @@ describe("article renderer", () => {
                 widgets: {"radio 1": randomizedRadioWidget()},
             });
 
+        const sectionWithRandomizedRadio = (): PerseusRenderer =>
+            generateTestPerseusRenderer({
+                content: "[[☃ graded-group 1]]",
+                widgets: {
+                    "graded-group 1": generateGradedGroupWidget({
+                        options: gradedGroupWithRandomizedRadio("Group"),
+                    }),
+                },
+            });
+
+        const apiOptions = {
+            ...ApiOptions.defaults,
+            isMobile: false,
+            customKeypad: false,
+        };
+
         /**
          * The rendered choice order of every radio widget on the page, in DOM
          * order. Two entries that are equal mean those two radio widgets were
@@ -259,28 +276,26 @@ describe("article renderer", () => {
                 );
 
         it("shuffles the same radio widget differently in each article section", () => {
-            // Arrange
-            const section = () =>
-                generateTestPerseusRenderer({
-                    content: "[[☃ graded-group 1]]",
-                    widgets: {
-                        "graded-group 1": generateGradedGroupWidget({
-                            options: gradedGroupWithRandomizedRadio("Group"),
-                        }),
-                    },
-                });
-
-            // Act
-            renderArticle([section(), section()], {
-                ...ApiOptions.defaults,
-                isMobile: false,
-                customKeypad: false,
-            });
+            // Arrange, Act
+            renderArticle(
+                [sectionWithRandomizedRadio(), sectionWithRandomizedRadio()],
+                apiOptions,
+            );
 
             // Assert
             const [firstSectionOrder, secondSectionOrder] =
                 getRenderedChoiceOrders();
             expect(firstSectionOrder).not.toEqual(secondSectionOrder);
+        });
+
+        it("shuffles the same article differently for different seeds", () => {
+            // Arrange, Act
+            renderArticle(sectionWithRandomizedRadio(), apiOptions, 0);
+            renderArticle(sectionWithRandomizedRadio(), apiOptions, 1);
+
+            // Assert
+            const [firstSeedOrder, secondSeedOrder] = getRenderedChoiceOrders();
+            expect(firstSeedOrder).not.toEqual(secondSeedOrder);
         });
 
         it("shuffles the same radio widget differently in each group of a graded group set", async () => {
@@ -302,11 +317,7 @@ describe("article renderer", () => {
                         }),
                     },
                 }),
-                {
-                    ...ApiOptions.defaults,
-                    isMobile: false,
-                    customKeypad: false,
-                },
+                apiOptions,
             );
 
             // A graded group set only renders the current group, so we have to

--- a/packages/perseus/src/__tests__/article-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/article-renderer.test.tsx
@@ -3,8 +3,25 @@ import {
     KeypadContext,
 } from "@khanacademy/keypad-context";
 import {MobileKeypad} from "@khanacademy/math-input";
+import {
+    generateGradedGroupOptions,
+    generateGradedGroupSetWidget,
+    generateGradedGroupWidget,
+    generateRadioChoice,
+    generateRadioOptions,
+    generateRadioWidget,
+    generateTestPerseusRenderer,
+} from "@khanacademy/perseus-core";
 import {RenderStateRoot} from "@khanacademy/wonder-blocks-core";
-import {screen, render, fireEvent, waitFor, act} from "@testing-library/react";
+import {
+    screen,
+    render,
+    fireEvent,
+    waitFor,
+    act,
+    within,
+} from "@testing-library/react";
+import {userEvent} from "@testing-library/user-event";
 import * as React from "react";
 
 import {articleSectionWithExpression} from "../__testdata__/article-renderer.testdata";
@@ -17,7 +34,11 @@ import {
 } from "../testing/test-dependencies";
 
 import type {APIOptions} from "../types";
-import type {PerseusArticle} from "@khanacademy/perseus-core";
+import type {
+    PerseusGradedGroupWidgetOptions,
+    PerseusArticle,
+    RadioWidget,
+} from "@khanacademy/perseus-core";
 
 function KeypadWithContext() {
     return (
@@ -184,6 +205,116 @@ describe("article renderer", () => {
         // We also need to wait for the onFocusChange callback to be called
         await waitFor(() => {
             expect(answerableCallback).toHaveBeenCalled();
+        });
+    });
+
+    describe("Randomization", () => {
+        const choiceContents = [
+            "Choice A",
+            "Choice B",
+            "Choice C",
+            "Choice D",
+            "Choice E",
+        ];
+
+        // Every copy of this widget is identical (ids included), so any
+        // difference in the rendered choice order has to come from Perseus
+        // giving each copy a different shuffle.
+        const randomizedRadioWidget = (): RadioWidget =>
+            generateRadioWidget({
+                options: generateRadioOptions({
+                    randomize: true,
+                    choices: choiceContents.map((content, index) =>
+                        generateRadioChoice(content, {
+                            id: `choice-${index}`,
+                            correct: index === 0,
+                        }),
+                    ),
+                }),
+            });
+
+        const gradedGroupWithRandomizedRadio = (
+            title: string,
+        ): PerseusGradedGroupWidgetOptions =>
+            generateGradedGroupOptions({
+                title,
+                content: "[[☃ radio 1]]",
+                widgets: {"radio 1": randomizedRadioWidget()},
+            });
+
+        /**
+         * The rendered choice order of every radio widget on the page, in DOM
+         * order. Two entries that are equal mean those two radio widgets were
+         * shuffled the same way.
+         */
+        const getRenderedChoiceOrders = (): string[][] =>
+            screen.getAllByRole("group").map((radioWidget) =>
+                within(radioWidget)
+                    .getAllByRole("listitem")
+                    .map((choice) => choice.textContent ?? ""),
+            );
+
+        it("shuffles the same radio widget differently in each article section", () => {
+            // Arrange
+            const section = () =>
+                generateTestPerseusRenderer({
+                    content: "[[☃ graded-group 1]]",
+                    widgets: {
+                        "graded-group 1": generateGradedGroupWidget({
+                            options: gradedGroupWithRandomizedRadio("Group"),
+                        }),
+                    },
+                });
+
+            // Act
+            renderArticle([section(), section()], {
+                ...ApiOptions.defaults,
+                isMobile: false,
+                customKeypad: false,
+            });
+
+            // Assert
+            const [firstSectionOrder, secondSectionOrder] =
+                getRenderedChoiceOrders();
+            expect(firstSectionOrder).not.toEqual(secondSectionOrder);
+        });
+
+        it("shuffles the same radio widget differently in each group of a graded group set", async () => {
+            // Arrange
+            const user = userEvent.setup({
+                advanceTimers: jest.advanceTimersByTime,
+            });
+            renderArticle(
+                generateTestPerseusRenderer({
+                    content: "[[☃ graded-group-set 1]]",
+                    widgets: {
+                        "graded-group-set 1": generateGradedGroupSetWidget({
+                            options: {
+                                gradedGroups: [
+                                    gradedGroupWithRandomizedRadio("Group 1"),
+                                    gradedGroupWithRandomizedRadio("Group 2"),
+                                ],
+                            },
+                        }),
+                    },
+                }),
+                {
+                    ...ApiOptions.defaults,
+                    isMobile: false,
+                    customKeypad: false,
+                },
+            );
+
+            // A graded group set only renders the current group, so we have to
+            // read the first group's order before switching to the second.
+            const [firstGroupOrder] = getRenderedChoiceOrders();
+
+            // Act
+            await user.click(screen.getByRole("button", {name: "Group 2"}));
+
+            // Assert
+            const [secondGroupOrder] = getRenderedChoiceOrders();
+            expect(firstGroupOrder).not.toEqual(secondGroupOrder);
         });
     });
 });

--- a/packages/perseus/src/__tests__/article-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/article-renderer.test.tsx
@@ -96,6 +96,12 @@ export const renderArticle = (
     return {container, renderer};
 };
 
+const apiOptions = {
+    ...ApiOptions.defaults,
+    isMobile: false,
+    customKeypad: false,
+};
+
 describe("article renderer", () => {
     beforeEach(() => {
         // Mock ResizeObserver used by the mobile keypad
@@ -120,11 +126,7 @@ describe("article renderer", () => {
 
     it("should render the content for a section", () => {
         // Arrange and Act
-        renderArticle(articleSectionWithExpression, {
-            ...ApiOptions.defaults,
-            isMobile: false,
-            customKeypad: false,
-        });
+        renderArticle(articleSectionWithExpression, apiOptions);
 
         // Assert
         expect(screen.getByRole("textbox")).toBeInTheDocument();
@@ -132,11 +134,7 @@ describe("article renderer", () => {
 
     it("should render the content for a section as list", () => {
         // Arrange and Act
-        renderArticle([articleSectionWithExpression], {
-            ...ApiOptions.defaults,
-            isMobile: false,
-            customKeypad: false,
-        });
+        renderArticle([articleSectionWithExpression], apiOptions);
 
         // Assert
         expect(screen.getByRole("textbox")).toBeInTheDocument();
@@ -152,11 +150,7 @@ describe("article renderer", () => {
         });
 
         // Act
-        renderArticle(articleSectionWithExpression, {
-            ...ApiOptions.defaults,
-            isMobile: false,
-            customKeypad: false,
-        });
+        renderArticle(articleSectionWithExpression, apiOptions);
 
         // Assert
         expect(screen.getByRole("textbox")).toBeInTheDocument();
@@ -172,11 +166,7 @@ describe("article renderer", () => {
         });
 
         // Act
-        renderArticle([articleSectionWithExpression], {
-            ...ApiOptions.defaults,
-            isMobile: false,
-            customKeypad: false,
-        });
+        renderArticle([articleSectionWithExpression], apiOptions);
 
         // Assert
         expect(screen.getByRole("textbox")).toBeInTheDocument();
@@ -223,8 +213,8 @@ describe("article renderer", () => {
         // Every copy of this widget is identical (ids included), so any
         // difference in the rendered choice order has to come from Perseus
         // giving each copy a different shuffle.
-        const randomizedRadioWidget = (): RadioWidget =>
-            generateRadioWidget({
+        function randomizedRadioWidget(): RadioWidget {
+            return generateRadioWidget({
                 options: generateRadioOptions({
                     randomize: true,
                     choices: choiceContents.map((content, index) =>
@@ -235,18 +225,20 @@ describe("article renderer", () => {
                     ),
                 }),
             });
+        }
 
-        const gradedGroupWithRandomizedRadio = (
+        function gradedGroupWithRandomizedRadio(
             title: string,
-        ): PerseusGradedGroupWidgetOptions =>
-            generateGradedGroupOptions({
+        ): PerseusGradedGroupWidgetOptions {
+            return generateGradedGroupOptions({
                 title,
                 content: "[[☃ radio 1]]",
                 widgets: {"radio 1": randomizedRadioWidget()},
             });
+        }
 
-        const sectionWithRandomizedRadio = (): PerseusRenderer =>
-            generateTestPerseusRenderer({
+        function sectionWithRandomizedRadio(): PerseusRenderer {
+            return generateTestPerseusRenderer({
                 content: "[[☃ graded-group 1]]",
                 widgets: {
                     "graded-group 1": generateGradedGroupWidget({
@@ -254,26 +246,22 @@ describe("article renderer", () => {
                     }),
                 },
             });
-
-        const apiOptions = {
-            ...ApiOptions.defaults,
-            isMobile: false,
-            customKeypad: false,
-        };
+        }
 
         /**
          * The rendered choice order of every radio widget on the page, in DOM
          * order. Two entries that are equal mean those two radio widgets were
          * shuffled the same way.
          */
-        const getRenderedChoiceOrders = (): string[][] =>
-            screen
+        function getRenderedChoiceOrders(): string[][] {
+            return screen
                 .getAllByRole("list", {name: "Choose 1 answer:"})
                 .map((choiceList) =>
                     within(choiceList)
                         .getAllByRole("listitem")
                         .map((choice) => choice.textContent ?? ""),
                 );
+        }
 
         it("shuffles the same radio widget differently in each article section", () => {
             // Arrange, Act

--- a/packages/perseus/src/__tests__/article-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/article-renderer.test.tsx
@@ -60,6 +60,7 @@ function KeypadWithContext() {
 export const renderArticle = (
     json: PerseusArticle = articleSectionWithExpression,
     apiOptions: APIOptions = Object.freeze({}),
+    seed = 0,
 ): {
     container: HTMLElement;
     renderer: ArticleRenderer;
@@ -76,6 +77,7 @@ export const renderArticle = (
                                 setRenderer(node);
                             }}
                             json={json}
+                            seed={seed}
                             dependencies={testDependenciesV2}
                             apiOptions={{...apiOptions}}
                             keypadElement={keypadElement}
@@ -248,11 +250,13 @@ describe("article renderer", () => {
          * shuffled the same way.
          */
         const getRenderedChoiceOrders = (): string[][] =>
-            screen.getAllByRole("group").map((radioWidget) =>
-                within(radioWidget)
-                    .getAllByRole("listitem")
-                    .map((choice) => choice.textContent ?? ""),
-            );
+            screen
+                .getAllByRole("list", {name: "Choose 1 answer:"})
+                .map((choiceList) =>
+                    within(choiceList)
+                        .getAllByRole("listitem")
+                        .map((choice) => choice.textContent ?? ""),
+                );
 
         it("shuffles the same radio widget differently in each article section", () => {
             // Arrange

--- a/packages/perseus/src/article-renderer.tsx
+++ b/packages/perseus/src/article-renderer.tsx
@@ -29,6 +29,7 @@ type Props = Partial<React.ContextType<typeof DependenciesContext>> &
         legacyPerseusLint?: ReadonlyArray<string>;
         keypadElement?: KeypadAPI | null | undefined;
         dependencies: PerseusDependenciesV2;
+        // the seed for deterministic shuffling
         seed: number;
     };
 

--- a/packages/perseus/src/article-renderer.tsx
+++ b/packages/perseus/src/article-renderer.tsx
@@ -29,7 +29,7 @@ type Props = Partial<React.ContextType<typeof DependenciesContext>> &
         legacyPerseusLint?: ReadonlyArray<string>;
         keypadElement?: KeypadAPI | null | undefined;
         dependencies: PerseusDependenciesV2;
-        // the seed for deterministic shuffling
+        // the seed for deterministic shuffling (randomization)
         seed: number;
     };
 

--- a/packages/perseus/src/article-renderer.tsx
+++ b/packages/perseus/src/article-renderer.tsx
@@ -29,6 +29,7 @@ type Props = Partial<React.ContextType<typeof DependenciesContext>> &
         legacyPerseusLint?: ReadonlyArray<string>;
         keypadElement?: KeypadAPI | null | undefined;
         dependencies: PerseusDependenciesV2;
+        seed: number;
     };
 
 type DefaultProps = {
@@ -210,9 +211,14 @@ class ArticleRenderer
         // identifier for each section. This should be fine as we never remove
         // or reorder sections.
         const sections = this._sections().map((section, sectionIndex) => {
+            const sectionSeed = this.props.seed + sectionIndex;
+
             return (
                 <div key={sectionIndex} className="clearfix">
-                    <UserInputManager widgets={section.widgets} problemNum={0}>
+                    <UserInputManager
+                        widgets={section.widgets}
+                        problemNum={sectionSeed}
+                    >
                         {({
                             userInput,
                             handleUserInput,
@@ -220,6 +226,7 @@ class ArticleRenderer
                         }) => (
                             <Renderer
                                 {...section}
+                                problemNum={sectionSeed}
                                 userInput={userInput}
                                 handleUserInput={handleUserInput}
                                 initializeUserInput={initializeUserInput}

--- a/packages/perseus/src/testing/article-renderer-with-debug-ui.tsx
+++ b/packages/perseus/src/testing/article-renderer-with-debug-ui.tsx
@@ -23,6 +23,7 @@ type Props = {
      * `json`, but it is the article. Trust me.
      */
     json: PerseusArticle;
+    seed?: number;
     apiOptions?: APIOptions;
     linterContext?: LinterContextProps;
 };
@@ -30,6 +31,7 @@ type Props = {
 export const ArticleRendererWithDebugUI = ({
     title = "📜 Article",
     json,
+    seed = 0,
     apiOptions = Object.freeze({}),
     linterContext,
 }: Props): React.ReactElement => {
@@ -83,6 +85,7 @@ export const ArticleRendererWithDebugUI = ({
                                             ref={ref}
                                             apiOptions={options}
                                             json={json}
+                                            seed={seed}
                                             dependencies={
                                                 storybookDependenciesV2
                                             }

--- a/packages/perseus/src/widgets/__docs__/nested-widgets-renderer-decorator.tsx
+++ b/packages/perseus/src/widgets/__docs__/nested-widgets-renderer-decorator.tsx
@@ -13,6 +13,7 @@ export const articleRendererDecorator: Decorator = (
     return (
         <ArticleRenderer
             json={parameters.question!}
+            seed={0}
             dependencies={storybookDependenciesV2}
         />
     );

--- a/packages/perseus/src/widgets/definition/__docs__/definition-initial-state-regression.stories.tsx
+++ b/packages/perseus/src/widgets/definition/__docs__/definition-initial-state-regression.stories.tsx
@@ -65,6 +65,7 @@ export const Article = (): React.ReactNode => {
     return (
         <ArticleRenderer
             json={article}
+            seed={0}
             dependencies={storybookDependenciesV2}
             apiOptions={apiOptions}
         />

--- a/packages/perseus/src/widgets/definition/__docs__/definition.stories.tsx
+++ b/packages/perseus/src/widgets/definition/__docs__/definition.stories.tsx
@@ -37,6 +37,7 @@ export const Article = (): React.ReactNode => {
     return (
         <ArticleRenderer
             json={article}
+            seed={0}
             dependencies={storybookDependenciesV2}
         />
     );

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -171,6 +171,7 @@ class GradedGroupSet extends React.Component<Props, State> implements Widget {
                             <GradedGroup
                                 key={i}
                                 {...this.props}
+                                problemNum={(this.props.problemNum ?? 0) + i}
                                 options={gradedGroup}
                                 inGradedGroupSet={false}
                                 linterContext={this.props.linterContext}
@@ -216,6 +217,9 @@ class GradedGroupSet extends React.Component<Props, State> implements Widget {
                     ref={(comp) => (this._childGroup = comp)}
                     // We should pass in the set of props explicitly
                     {...this.props}
+                    problemNum={
+                        (this.props.problemNum ?? 0) + this.state.currentGroup
+                    }
                     options={{
                         ...currentGroup,
                         // The set renders the group's title itself, above the

--- a/packages/perseus/src/widgets/graded-group/graded-group.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.tsx
@@ -279,7 +279,7 @@ export class GradedGroup
                         userInput: UserInputMap,
                         widgetsEmpty: boolean,
                     ) => this._handleUserInput(userInput, widgetsEmpty)}
-                    problemNum={0}
+                    problemNum={this.props.problemNum ?? 0}
                 >
                     {({userInput, handleUserInput}) => (
                         <Renderer
@@ -288,7 +288,7 @@ export class GradedGroup
                             images={this.props.options.images}
                             userInput={userInput}
                             handleUserInput={handleUserInput}
-                            problemNum={0}
+                            problemNum={this.props.problemNum ?? 0}
                             ref={this.rendererRef}
                             keypadElement={this.props.keypadElement}
                             apiOptions={{...apiOptions, readOnly}}
@@ -371,7 +371,7 @@ export class GradedGroup
 
                             <UserInputManager
                                 widgets={this.props.options.hint.widgets}
-                                problemNum={0}
+                                problemNum={this.props.problemNum ?? 0}
                             >
                                 {({
                                     userInput,

--- a/packages/perseus/src/widgets/radio/__docs__/multiple-choice-interactions-regression.stories.tsx
+++ b/packages/perseus/src/widgets/radio/__docs__/multiple-choice-interactions-regression.stories.tsx
@@ -220,6 +220,7 @@ export const ChoiceTextColorInArticle = {
     render: function Render() {
         return (
             <ArticleRenderer
+                seed={0}
                 json={generateTestPerseusRenderer({
                     content:
                         "Exceeding reaction chamber thermal limit. We have begun power-supply calibration. Force fields have been established on all turbo lifts and crawlways. Computer, run a level-two diagnostic on warp-drive systems. Antimatter containment positive. Warp drive within normal parameters. I read an ion trail characteristic of a freighter escape pod. The bomb had a molecular-decay detonator. Detecting some unusual fluctuations in subspace frequencies.\n\n" +


### PR DESCRIPTION
## Summary:
`ServerItemRenderer` accepted `problemNum` which isn't really a problem number - it's a shuffle seed. Unfortunately we didn't do this for ArticleRenderer, so everything was getting shuffled the same. This PR adds `seed` to `ArticleRenderer` along with some tests to assert that the seed works as expected. Now Frontend need to pass a unique seed (likely a hash of KAID and article ID).

Issue: LEMS-4542

## Test plan:
- Added unit tests