### PR TITLE
[ColorSync] Convert graphie grid/axis strokes and movable line segment colors to semantic tokens

### DIFF
--- a/.changeset/colorsync-graphie-grid-axis-tokens.md
+++ b/.changeset/colorsync-graphie-grid-axis-tokens.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus": patch
 ---
 
-Updates the grid, axis, tick, and label colors of legacy graphie graphs and the colors of draggable line segments (used by the plotter widget) to Wonder Blocks semantic color tokens, so these graphs pick up the correct colors in every theme and match the modern interactive graphs.
+Updates the grid and axis colors of grapher graphs and the colors of the draggable line segments used by the plotter widget to Wonder Blocks semantic color tokens. Grapher and number-line graphs are now themed directly in dark mode instead of having their colors approximated by a filter, which also fixes slightly-off line colors in dark-mode number lines.

--- a/.changeset/colorsync-graphie-grid-axis-tokens.md
+++ b/.changeset/colorsync-graphie-grid-axis-tokens.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Updates the grid, axis, tick, and label colors of legacy graphie graphs and the colors of draggable line segments (used by the plotter widget) to Wonder Blocks semantic color tokens, so these graphs pick up the correct colors in every theme and match the modern interactive graphs.

--- a/.changeset/colorsync-graphie-grid-axis-tokens.md
+++ b/.changeset/colorsync-graphie-grid-axis-tokens.md
@@ -2,4 +2,4 @@
 "@khanacademy/perseus": patch
 ---
 
-Updates the grid and axis colors of grapher graphs and the colors of the draggable line segments used by the plotter widget to Wonder Blocks semantic color tokens. Grapher and number-line graphs are now themed directly in dark mode instead of having their colors approximated by a filter, which also fixes slightly-off line colors in dark-mode number lines.
+Updates grapher, number line, and plotter graph colors to semantic color tokens, so they render correctly in every theme, including dark mode.

--- a/packages/perseus/src/components/graphie.tsx
+++ b/packages/perseus/src/components/graphie.tsx
@@ -22,6 +22,9 @@ const {assert} = InteractiveUtil;
 
 type Props = {
     addMouseLayer?: boolean;
+    // Extra class for the .graphie div. Used to exclude themed widgets'
+    // graphies from the dark-mode invert filter in styles.css.
+    className?: string;
     box: Size;
     range: [Coord, Coord];
     ranges?: [Range, Range];
@@ -387,7 +390,14 @@ class Graphie extends React.Component<Props> {
     render(): React.ReactNode {
         return (
             <div className="graphie-container">
-                <div className="graphie" ref={this.graphieDivRef} />
+                <div
+                    className={
+                        this.props.className
+                            ? `graphie ${this.props.className}`
+                            : "graphie"
+                    }
+                    ref={this.graphieDivRef}
+                />
             </div>
         );
     }

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -373,9 +373,14 @@
      */
     img[src$=".png"],
     img[src$=".svg"],
-    .graphie:not(.perseus-widget-plotter) > svg {
-        /* Invert the colors of PNG/SVG images and Graphie SVGs (excluding the
-           Plotter, which is themed).
+    .graphie:not(.perseus-widget-plotter):not(.perseus-widget-grapher):not(
+            .perseus-widget-number-line
+        )
+        > svg {
+        /* Invert the colors of PNG/SVG images and Graphie SVGs, excluding
+           widgets that draw with semantic tokens and are themed directly
+           (the :not() list). A themed graphie must be excluded, or its
+           dark-theme colors get inverted a second time by this filter.
          */
         filter: invert(1) hue-rotate(180deg) brightness(1.5);
     }

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -6,7 +6,7 @@ import {
     KhanMath,
 } from "@khanacademy/kmath";
 import {Errors, PerseusError} from "@khanacademy/perseus-core";
-import {semanticColor, tokenValue} from "@khanacademy/wonder-blocks-tokens";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {entries} from "@khanacademy/wonder-stuff-core";
 import $ from "jquery";
 import Raphael from "raphael";
@@ -17,6 +17,7 @@ import Raphael from "raphael";
 
 import {Log} from "../logging/log";
 
+import KhanColors from "./colors";
 import {DrawingTransform} from "./drawing-transform";
 import {GraphBounds} from "./graph-bounds";
 import Tex from "./tex";
@@ -211,6 +212,10 @@ export class Graphie {
         xLabelFormat?: (x: number) => string;
         unityLabels?: boolean | [boolean, boolean];
         isMobile?: boolean;
+        // Raw CSS colors for the grid and axis/tick/label strokes. See the
+        // note above the defaults in the function body.
+        gridStroke?: string;
+        axisStroke?: string;
     }) {
         // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
         options = options || {};
@@ -304,18 +309,19 @@ export class Graphie {
             isMobile: options.isMobile,
         });
 
-        // tokenValue resolves the semantic tokens to raw hex; graphie only
-        // accepts raw CSS colors, not CSS variables.
-        const gridStroke = tokenValue(
-            options.isMobile
-                ? semanticColor.core.border.neutral.subtle
-                : semanticColor.core.foreground.neutral.strong,
-        );
-        const axisStroke = tokenValue(
-            options.isMobile
-                ? semanticColor.core.foreground.neutral.default
-                : semanticColor.core.foreground.neutral.strong,
-        );
+        // The default strokes are raw light-theme colors, not semantic
+        // tokens, because in dark themes graphie SVGs are recolored by the
+        // invert filter in styles.css ("GLOBAL DARK MODE SETTINGS"); a token
+        // would resolve to the dark theme's value at draw time and get
+        // double-inverted (LEMS-4547). Callers whose graphie is excluded
+        // from that filter should pass gridStroke/axisStroke themselves,
+        // resolved from semantic tokens via tokenValue().
+        const gridStroke =
+            options.gridStroke ??
+            (options.isMobile ? KhanColors.GRAY_C : "#000000");
+        const axisStroke =
+            options.axisStroke ??
+            (options.isMobile ? KhanColors.GRAY_G : "#000000");
 
         // draw grid
         if (grid) {
@@ -369,11 +375,7 @@ export class Graphie {
                 const thisGraphie = this;
                 this.style(
                     {
-                        // Unlike the other axis styles, this one does not
-                        // lighten on mobile.
-                        stroke: tokenValue(
-                            semanticColor.core.foreground.neutral.strong,
-                        ),
+                        stroke: options.axisStroke ?? "#000000",
                         opacity: axisOpacity,
                         strokeWidth: 2,
                         arrows: axisArrows,

--- a/packages/perseus/src/util/graphie.ts
+++ b/packages/perseus/src/util/graphie.ts
@@ -6,6 +6,7 @@ import {
     KhanMath,
 } from "@khanacademy/kmath";
 import {Errors, PerseusError} from "@khanacademy/perseus-core";
+import {semanticColor, tokenValue} from "@khanacademy/wonder-blocks-tokens";
 import {entries} from "@khanacademy/wonder-stuff-core";
 import $ from "jquery";
 import Raphael from "raphael";
@@ -16,7 +17,6 @@ import Raphael from "raphael";
 
 import {Log} from "../logging/log";
 
-import KhanColors from "./colors";
 import {DrawingTransform} from "./drawing-transform";
 import {GraphBounds} from "./graph-bounds";
 import Tex from "./tex";
@@ -304,10 +304,23 @@ export class Graphie {
             isMobile: options.isMobile,
         });
 
+        // tokenValue resolves the semantic tokens to raw hex; graphie only
+        // accepts raw CSS colors, not CSS variables.
+        const gridStroke = tokenValue(
+            options.isMobile
+                ? semanticColor.core.border.neutral.subtle
+                : semanticColor.core.foreground.neutral.strong,
+        );
+        const axisStroke = tokenValue(
+            options.isMobile
+                ? semanticColor.core.foreground.neutral.default
+                : semanticColor.core.foreground.neutral.strong,
+        );
+
         // draw grid
         if (grid) {
             this.grid(gridRange[0], gridRange[1], {
-                stroke: options.isMobile ? KhanColors.GRAY_C : "#000000",
+                stroke: gridStroke,
                 opacity: options.isMobile ? 1 : gridOpacity,
                 step: gridStep,
                 strokeWidth: options.isMobile ? 1 : 2,
@@ -321,9 +334,7 @@ export class Graphie {
                 const thisGraphie = this;
                 this.style(
                     {
-                        stroke: options.isMobile
-                            ? KhanColors.GRAY_G
-                            : "#000000",
+                        stroke: axisStroke,
                         opacity: options.isMobile ? 1 : axisOpacity,
                         strokeWidth: options.isMobile ? 1 : 2,
                         arrows: "->",
@@ -358,7 +369,11 @@ export class Graphie {
                 const thisGraphie = this;
                 this.style(
                     {
-                        stroke: "#000000",
+                        // Unlike the other axis styles, this one does not
+                        // lighten on mobile.
+                        stroke: tokenValue(
+                            semanticColor.core.foreground.neutral.strong,
+                        ),
                         opacity: axisOpacity,
                         strokeWidth: 2,
                         arrows: axisArrows,
@@ -397,7 +412,7 @@ export class Graphie {
             const thisGraphie = this;
             this.style(
                 {
-                    stroke: options.isMobile ? KhanColors.GRAY_G : "#000000",
+                    stroke: axisStroke,
                     opacity: options.isMobile ? 1 : tickOpacity,
                     strokeWidth: 1,
                 },
@@ -503,7 +518,7 @@ export class Graphie {
             const thisGraphie = this;
             this.style(
                 {
-                    stroke: options.isMobile ? KhanColors.GRAY_G : "#000000",
+                    stroke: axisStroke,
                     opacity: options.isMobile ? 1 : labelOpacity,
                 },
                 function () {

--- a/packages/perseus/src/util/interactive.ts
+++ b/packages/perseus/src/util/interactive.ts
@@ -999,8 +999,12 @@ _.extend(GraphUtils.Graphie.prototype, {
                     "stroke-width": 6,
                 },
                 labelStyle: {
-                    stroke: KhanColors.INTERACTIVE,
-                    color: KhanColors.INTERACTIVE,
+                    stroke: tokenValue(
+                        semanticColor.core.foreground.instructive.default,
+                    ),
+                    color: tokenValue(
+                        semanticColor.core.foreground.instructive.default,
+                    ),
                 },
                 highlight: false,
                 dragging: false,
@@ -1021,9 +1025,13 @@ _.extend(GraphUtils.Graphie.prototype, {
             options,
         );
 
-        const normalColor = lineSegment.fixed
-            ? KhanColors.DYNAMIC
-            : KhanColors.INTERACTIVE;
+        // tokenValue resolves the semantic tokens to raw hex; graphie only
+        // accepts raw CSS colors, not CSS variables.
+        const normalColor = tokenValue(
+            lineSegment.fixed
+                ? semanticColor.core.foreground.disabled.strong
+                : semanticColor.core.foreground.instructive.default,
+        );
         lineSegment.normalStyle = {
             "stroke-width": 2,
             stroke: normalColor,

--- a/packages/perseus/src/util/interactive.ts
+++ b/packages/perseus/src/util/interactive.ts
@@ -1028,9 +1028,7 @@ _.extend(GraphUtils.Graphie.prototype, {
         // tokenValue resolves the semantic tokens to raw hex; graphie only
         // accepts raw CSS colors, not CSS variables.
         const normalColor = tokenValue(
-            lineSegment.fixed
-                ? semanticColor.core.foreground.disabled.strong
-                : semanticColor.core.foreground.instructive.default,
+            semanticColor.core.foreground.instructive.default,
         );
         lineSegment.normalStyle = {
             "stroke-width": 2,

--- a/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
+++ b/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
@@ -1531,7 +1531,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,400L0,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1539,7 +1539,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M20,400L20,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1547,7 +1547,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M40,400L40,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1555,7 +1555,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M60,400L60,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1563,7 +1563,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M80,400L80,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1571,7 +1571,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M100,400L100,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1579,7 +1579,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M120,400L120,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1587,7 +1587,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M140,400L140,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1595,7 +1595,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M160,400L160,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1603,7 +1603,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M180,400L180,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1611,7 +1611,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M200,400L200,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1619,7 +1619,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M220,400L220,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1627,7 +1627,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M240,400L240,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1635,7 +1635,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M260,400L260,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1643,7 +1643,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M280,400L280,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1651,7 +1651,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M300,400L300,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1659,7 +1659,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M320,400L320,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1667,7 +1667,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M340,400L340,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1675,7 +1675,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M360,400L360,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1683,7 +1683,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M380,400L380,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1691,7 +1691,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M400,400L400,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1699,7 +1699,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,400L400,400"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1707,7 +1707,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,380L400,380"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1715,7 +1715,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,360L400,360"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1723,7 +1723,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,340L400,340"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1731,7 +1731,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,320L400,320"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1739,7 +1739,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,300L400,300"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1747,7 +1747,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,280L400,280"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1755,7 +1755,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,260L400,260"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1763,7 +1763,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,240L400,240"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1771,7 +1771,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,220L400,220"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1779,7 +1779,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,200L400,200"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1787,7 +1787,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,180L400,180"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1795,7 +1795,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,160L400,160"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1803,7 +1803,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,140L400,140"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1811,7 +1811,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,120L400,120"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1819,7 +1819,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,100L400,100"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1827,7 +1827,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,80L400,80"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1835,7 +1835,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,60L400,60"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1843,7 +1843,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,40L400,40"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1851,7 +1851,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,20L400,20"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1859,7 +1859,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,0L400,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1867,7 +1867,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M-3.4499999999999886,205.6C-3.0999999999999885,203.5,0.7500000000000115,200.35,1.8000000000000114,200C0.7500000000000113,199.65,-3.099999999999989,196.5,-3.4499999999999886,194.4"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-linecap="round"
                         stroke-linejoin="round"
                         stroke-width="2"
@@ -1878,7 +1878,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M200,200C200,200,200,200,1.0500000000000114,200"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
                       />
@@ -1886,7 +1886,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M394.45,205.6C394.8,203.5,398.65,200.35,399.7,200C398.65,199.65,394.8,196.5,394.45,194.4"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-linecap="round"
                         stroke-linejoin="round"
                         stroke-width="2"
@@ -1897,7 +1897,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M200,200C200,200,200,200,398.95,200"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
                       />
@@ -1905,7 +1905,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195.5,404.55C195.85,402.45,199.7,399.3,200.75,398.95C199.7,398.59999999999997,195.85,395.45,195.5,393.34999999999997"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-linecap="round"
                         stroke-linejoin="round"
                         stroke-width="2"
@@ -1916,7 +1916,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M200,200C200,200,200,200,200,398.95"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
                       />
@@ -1924,7 +1924,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195.5,6.650000000000011C195.85,4.550000000000011,199.7,1.400000000000011,200.75,1.0500000000000114C199.7,0.7000000000000114,195.85,-2.4499999999999886,195.5,-4.549999999999988"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-linecap="round"
                         stroke-linejoin="round"
                         stroke-width="2"
@@ -1935,7 +1935,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M200,200C200,200,200,200,200,1.0500000000000114"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
                       />
@@ -1943,7 +1943,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M220,205L220,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -1951,7 +1951,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M240,205L240,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -1959,7 +1959,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M260,205L260,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -1967,7 +1967,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M280,205L280,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -1975,7 +1975,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M300,205L300,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -1983,7 +1983,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M320,205L320,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -1991,7 +1991,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M340,205L340,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -1999,7 +1999,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M360,205L360,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2007,7 +2007,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M380,205L380,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2015,7 +2015,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M180,205L180,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2023,7 +2023,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M160,205L160,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2031,7 +2031,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M140,205L140,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2039,7 +2039,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M120,205L120,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2047,7 +2047,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M100,205L100,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2055,7 +2055,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M80,205L80,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2063,7 +2063,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M60,205L60,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2071,7 +2071,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M40,205L40,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2079,7 +2079,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M20,205L20,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2087,7 +2087,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,180L205,180"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2095,7 +2095,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,160L205,160"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2103,7 +2103,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,140L205,140"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2111,7 +2111,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,120L205,120"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2119,7 +2119,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,100L205,100"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2127,7 +2127,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,80L205,80"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2135,7 +2135,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,60L205,60"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2143,7 +2143,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,40L205,40"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2151,7 +2151,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,20L205,20"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2159,7 +2159,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,220L205,220"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2167,7 +2167,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,240L205,240"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2175,7 +2175,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,260L205,260"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2183,7 +2183,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,280L205,280"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2191,7 +2191,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,300L205,300"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2199,7 +2199,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,320L205,320"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2207,7 +2207,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,340L205,340"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2215,7 +2215,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,360L205,360"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2223,7 +2223,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,380L205,380"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2422,7 +2422,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{1}"
-                      style="position: absolute; padding: 7px; color: black; left: 220px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 220px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2431,7 +2431,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{2}"
-                      style="position: absolute; padding: 7px; color: black; left: 240px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 240px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2440,7 +2440,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{3}"
-                      style="position: absolute; padding: 7px; color: black; left: 260px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 260px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2449,7 +2449,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{4}"
-                      style="position: absolute; padding: 7px; color: black; left: 280px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 280px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2458,7 +2458,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{5}"
-                      style="position: absolute; padding: 7px; color: black; left: 300px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 300px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2467,7 +2467,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{6}"
-                      style="position: absolute; padding: 7px; color: black; left: 320px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 320px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2476,7 +2476,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{7}"
-                      style="position: absolute; padding: 7px; color: black; left: 340px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 340px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2485,7 +2485,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{8}"
-                      style="position: absolute; padding: 7px; color: black; left: 360px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 360px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2494,7 +2494,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{9}"
-                      style="position: absolute; padding: 7px; color: black; left: 380px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 380px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2503,7 +2503,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}2}"
-                      style="position: absolute; padding: 7px; color: black; left: 160px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 160px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2512,7 +2512,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}3}"
-                      style="position: absolute; padding: 7px; color: black; left: 140px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 140px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2521,7 +2521,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}4}"
-                      style="position: absolute; padding: 7px; color: black; left: 120px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 120px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2530,7 +2530,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}5}"
-                      style="position: absolute; padding: 7px; color: black; left: 100px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 100px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2539,7 +2539,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}6}"
-                      style="position: absolute; padding: 7px; color: black; left: 80px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 80px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2548,7 +2548,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}7}"
-                      style="position: absolute; padding: 7px; color: black; left: 60px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 60px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2557,7 +2557,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}8}"
-                      style="position: absolute; padding: 7px; color: black; left: 40px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 40px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2566,7 +2566,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}9}"
-                      style="position: absolute; padding: 7px; color: black; left: 20px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 20px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2575,7 +2575,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{1}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 180px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 180px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2584,7 +2584,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{2}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 160px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 160px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2593,7 +2593,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{3}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 140px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 140px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2602,7 +2602,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{4}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 120px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 120px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2611,7 +2611,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{5}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 100px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 100px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2620,7 +2620,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{6}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 80px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 80px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2629,7 +2629,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{7}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 60px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 60px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2638,7 +2638,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{8}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 40px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 40px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2647,7 +2647,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{9}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 20px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 20px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2656,7 +2656,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}2}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 240px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 240px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2665,7 +2665,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}3}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 260px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 260px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2674,7 +2674,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}4}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 280px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 280px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2683,7 +2683,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}5}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 300px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 300px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2692,7 +2692,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}6}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 320px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 320px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2701,7 +2701,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}7}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 340px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 340px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2710,7 +2710,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}8}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 360px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 360px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2719,7 +2719,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}9}"
-                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 380px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; color: black; left: 200px; top: 380px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"

--- a/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
+++ b/packages/perseus/src/widgets/grapher/__snapshots__/grapher.test.ts.snap
@@ -1493,7 +1493,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                 >
                   <div
                     aria-hidden="true"
-                    class="graphie"
+                    class="graphie perseus-widget-grapher"
                     style="position: relative; width: 400px; height: 400px;"
                   >
                     <svg
@@ -1531,7 +1531,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,400L0,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1539,7 +1539,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M20,400L20,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1547,7 +1547,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M40,400L40,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1555,7 +1555,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M60,400L60,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1563,7 +1563,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M80,400L80,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1571,7 +1571,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M100,400L100,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1579,7 +1579,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M120,400L120,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1587,7 +1587,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M140,400L140,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1595,7 +1595,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M160,400L160,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1603,7 +1603,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M180,400L180,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1611,7 +1611,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M200,400L200,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1619,7 +1619,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M220,400L220,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1627,7 +1627,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M240,400L240,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1635,7 +1635,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M260,400L260,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1643,7 +1643,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M280,400L280,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1651,7 +1651,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M300,400L300,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1659,7 +1659,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M320,400L320,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1667,7 +1667,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M340,400L340,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1675,7 +1675,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M360,400L360,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1683,7 +1683,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M380,400L380,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1691,7 +1691,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M400,400L400,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1699,7 +1699,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,400L400,400"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1707,7 +1707,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,380L400,380"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1715,7 +1715,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,360L400,360"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1723,7 +1723,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,340L400,340"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1731,7 +1731,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,320L400,320"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1739,7 +1739,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,300L400,300"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1747,7 +1747,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,280L400,280"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1755,7 +1755,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,260L400,260"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1763,7 +1763,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,240L400,240"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1771,7 +1771,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,220L400,220"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1779,7 +1779,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,200L400,200"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1787,7 +1787,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,180L400,180"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1795,7 +1795,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,160L400,160"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1803,7 +1803,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,140L400,140"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1811,7 +1811,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,120L400,120"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1819,7 +1819,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,100L400,100"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1827,7 +1827,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,80L400,80"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1835,7 +1835,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,60L400,60"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1843,7 +1843,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,40L400,40"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1851,7 +1851,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,20L400,20"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1859,7 +1859,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M0,0L400,0"
                         fill="none"
                         opacity="0.1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                       />
@@ -1867,7 +1867,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M-3.4499999999999886,205.6C-3.0999999999999885,203.5,0.7500000000000115,200.35,1.8000000000000114,200C0.7500000000000113,199.65,-3.099999999999989,196.5,-3.4499999999999886,194.4"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-linecap="round"
                         stroke-linejoin="round"
                         stroke-width="2"
@@ -1878,7 +1878,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M200,200C200,200,200,200,1.0500000000000114,200"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
                       />
@@ -1886,7 +1886,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M394.45,205.6C394.8,203.5,398.65,200.35,399.7,200C398.65,199.65,394.8,196.5,394.45,194.4"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-linecap="round"
                         stroke-linejoin="round"
                         stroke-width="2"
@@ -1897,7 +1897,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M200,200C200,200,200,200,398.95,200"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
                       />
@@ -1905,7 +1905,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195.5,404.55C195.85,402.45,199.7,399.3,200.75,398.95C199.7,398.59999999999997,195.85,395.45,195.5,393.34999999999997"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-linecap="round"
                         stroke-linejoin="round"
                         stroke-width="2"
@@ -1916,7 +1916,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M200,200C200,200,200,200,200,398.95"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
                       />
@@ -1924,7 +1924,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195.5,6.650000000000011C195.85,4.550000000000011,199.7,1.400000000000011,200.75,1.0500000000000114C199.7,0.7000000000000114,195.85,-2.4499999999999886,195.5,-4.549999999999988"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-linecap="round"
                         stroke-linejoin="round"
                         stroke-width="2"
@@ -1935,7 +1935,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M200,200C200,200,200,200,200,1.0500000000000114"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="2"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
                       />
@@ -1943,7 +1943,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M220,205L220,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -1951,7 +1951,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M240,205L240,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -1959,7 +1959,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M260,205L260,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -1967,7 +1967,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M280,205L280,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -1975,7 +1975,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M300,205L300,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -1983,7 +1983,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M320,205L320,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -1991,7 +1991,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M340,205L340,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -1999,7 +1999,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M360,205L360,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2007,7 +2007,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M380,205L380,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2015,7 +2015,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M180,205L180,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2023,7 +2023,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M160,205L160,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2031,7 +2031,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M140,205L140,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2039,7 +2039,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M120,205L120,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2047,7 +2047,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M100,205L100,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2055,7 +2055,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M80,205L80,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2063,7 +2063,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M60,205L60,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2071,7 +2071,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M40,205L40,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2079,7 +2079,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M20,205L20,195"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2087,7 +2087,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,180L205,180"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2095,7 +2095,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,160L205,160"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2103,7 +2103,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,140L205,140"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2111,7 +2111,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,120L205,120"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2119,7 +2119,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,100L205,100"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2127,7 +2127,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,80L205,80"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2135,7 +2135,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,60L205,60"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2143,7 +2143,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,40L205,40"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2151,7 +2151,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,20L205,20"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2159,7 +2159,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,220L205,220"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2167,7 +2167,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,240L205,240"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2175,7 +2175,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,260L205,260"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2183,7 +2183,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,280L205,280"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2191,7 +2191,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,300L205,300"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2199,7 +2199,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,320L205,320"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2207,7 +2207,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,340L205,340"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2215,7 +2215,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,360L205,360"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2223,7 +2223,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                         d="M195,380L205,380"
                         fill="none"
                         opacity="1"
-                        stroke="#000000"
+                        stroke="none"
                         stroke-width="1"
                         style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                       />
@@ -2422,7 +2422,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{1}"
-                      style="position: absolute; padding: 7px; left: 220px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 220px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2431,7 +2431,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{2}"
-                      style="position: absolute; padding: 7px; left: 240px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 240px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2440,7 +2440,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{3}"
-                      style="position: absolute; padding: 7px; left: 260px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 260px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2449,7 +2449,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{4}"
-                      style="position: absolute; padding: 7px; left: 280px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 280px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2458,7 +2458,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{5}"
-                      style="position: absolute; padding: 7px; left: 300px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 300px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2467,7 +2467,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{6}"
-                      style="position: absolute; padding: 7px; left: 320px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 320px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2476,7 +2476,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{7}"
-                      style="position: absolute; padding: 7px; left: 340px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 340px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2485,7 +2485,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{8}"
-                      style="position: absolute; padding: 7px; left: 360px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 360px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2494,7 +2494,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{9}"
-                      style="position: absolute; padding: 7px; left: 380px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 380px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2503,7 +2503,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}2}"
-                      style="position: absolute; padding: 7px; left: 160px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 160px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2512,7 +2512,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}3}"
-                      style="position: absolute; padding: 7px; left: 140px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 140px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2521,7 +2521,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}4}"
-                      style="position: absolute; padding: 7px; left: 120px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 120px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2530,7 +2530,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}5}"
-                      style="position: absolute; padding: 7px; left: 100px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 100px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2539,7 +2539,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}6}"
-                      style="position: absolute; padding: 7px; left: 80px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 80px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2548,7 +2548,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}7}"
-                      style="position: absolute; padding: 7px; left: 60px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 60px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2557,7 +2557,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}8}"
-                      style="position: absolute; padding: 7px; left: 40px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 40px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2566,7 +2566,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}9}"
-                      style="position: absolute; padding: 7px; left: 20px; top: 200px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 20px; top: 200px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2575,7 +2575,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{1}"
-                      style="position: absolute; padding: 7px; left: 200px; top: 180px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 180px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2584,7 +2584,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{2}"
-                      style="position: absolute; padding: 7px; left: 200px; top: 160px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 160px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2593,7 +2593,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{3}"
-                      style="position: absolute; padding: 7px; left: 200px; top: 140px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 140px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2602,7 +2602,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{4}"
-                      style="position: absolute; padding: 7px; left: 200px; top: 120px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 120px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2611,7 +2611,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{5}"
-                      style="position: absolute; padding: 7px; left: 200px; top: 100px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 100px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2620,7 +2620,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{6}"
-                      style="position: absolute; padding: 7px; left: 200px; top: 80px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 80px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2629,7 +2629,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{7}"
-                      style="position: absolute; padding: 7px; left: 200px; top: 60px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 60px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2638,7 +2638,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{8}"
-                      style="position: absolute; padding: 7px; left: 200px; top: 40px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 40px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2647,7 +2647,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{9}"
-                      style="position: absolute; padding: 7px; left: 200px; top: 20px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 20px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2656,7 +2656,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}2}"
-                      style="position: absolute; padding: 7px; left: 200px; top: 240px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 240px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2665,7 +2665,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}3}"
-                      style="position: absolute; padding: 7px; left: 200px; top: 260px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 260px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2674,7 +2674,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}4}"
-                      style="position: absolute; padding: 7px; left: 200px; top: 280px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 280px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2683,7 +2683,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}5}"
-                      style="position: absolute; padding: 7px; left: 200px; top: 300px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 300px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2692,7 +2692,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}6}"
-                      style="position: absolute; padding: 7px; left: 200px; top: 320px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 320px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2701,7 +2701,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}7}"
-                      style="position: absolute; padding: 7px; left: 200px; top: 340px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 340px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2710,7 +2710,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}8}"
-                      style="position: absolute; padding: 7px; left: 200px; top: 360px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 360px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"
@@ -2719,7 +2719,7 @@ exports[`grapher widget should snapshot question with multiple graph types: init
                     <span
                       class="graphie-label"
                       data-math-formula="\\small{\\llap{-}9}"
-                      style="position: absolute; padding: 7px; left: 200px; top: 380px; fill: none; stroke: #000000; opacity: 1;"
+                      style="position: absolute; padding: 7px; left: 200px; top: 380px; fill: none; opacity: 1;"
                     >
                       <span
                         class="tex-holder"

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -346,7 +346,13 @@ class FunctionGrapher extends React.Component<FunctionGrapherProps> {
                     }}
                 >
                     {image}
-                    <Graphie {...this.props.graph}>
+                    <Graphie
+                        {...this.props.graph}
+                        // Excludes this graphie from the dark-mode invert
+                        // filter in styles.css; its colors are semantic
+                        // tokens, so it is themed directly.
+                        className="perseus-widget-grapher"
+                    >
                         {this.props.model && this.renderPlot()}
                         {this.props.model && this.renderAsymptote()}
                         {this.props.model && points}
@@ -427,8 +433,26 @@ class Grapher extends React.Component<Props> implements Widget {
     _setupGraphie: (arg1: any, arg2: any) => void = (graphie, options) => {
         const isMobile = this.props.apiOptions.isMobile;
 
+        // This graphie is excluded from the dark-mode invert filter (see
+        // the className on <Graphie>), so it draws with semantic tokens,
+        // resolved to raw values because graphie/Raphael sets SVG
+        // attributes, where var() references don't resolve. The token
+        // choices mirror the Mafs graphs (mafs-styles.css).
+        const gridStroke = tokenValue(
+            isMobile
+                ? semanticColor.core.border.neutral.subtle
+                : semanticColor.core.foreground.neutral.strong,
+        );
+        const axisStroke = tokenValue(
+            isMobile
+                ? semanticColor.core.foreground.neutral.default
+                : semanticColor.core.foreground.neutral.strong,
+        );
+
         if (options.markings === "graph") {
             graphie.graphInit({
+                gridStroke,
+                axisStroke,
                 range: options.range,
                 scale: options.gridConfig.map((e) => e.scale),
                 axisArrows: "<->",
@@ -460,6 +484,8 @@ class Grapher extends React.Component<Props> implements Widget {
             );
         } else if (options.markings === "grid") {
             graphie.graphInit({
+                gridStroke,
+                axisStroke,
                 range: options.range,
                 scale: options.gridConfig.map((e) => e.scale),
                 gridStep: options.gridStep,

--- a/packages/perseus/src/widgets/grapher/grapher.tsx
+++ b/packages/perseus/src/widgets/grapher/grapher.tsx
@@ -348,9 +348,6 @@ class FunctionGrapher extends React.Component<FunctionGrapherProps> {
                     {image}
                     <Graphie
                         {...this.props.graph}
-                        // Excludes this graphie from the dark-mode invert
-                        // filter in styles.css; its colors are semantic
-                        // tokens, so it is themed directly.
                         className="perseus-widget-grapher"
                     >
                         {this.props.model && this.renderPlot()}

--- a/packages/perseus/src/widgets/interaction/__snapshots__/interaction.test.ts.snap
+++ b/packages/perseus/src/widgets/interaction/__snapshots__/interaction.test.ts.snap
@@ -58,7 +58,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M7.2727272727272725,400L7.2727272727272725,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -66,7 +66,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M21.818181818181817,400L21.818181818181817,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -74,7 +74,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M36.36363636363636,400L36.36363636363636,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -82,7 +82,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M50.90909090909091,400L50.90909090909091,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -90,7 +90,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M65.45454545454545,400L65.45454545454545,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -98,7 +98,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M80,400L80,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -106,7 +106,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M94.54545454545455,400L94.54545454545455,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -114,7 +114,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M109.0909090909091,400L109.0909090909091,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -122,7 +122,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M123.63636363636363,400L123.63636363636363,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -130,7 +130,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M138.1818181818182,400L138.1818181818182,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -138,7 +138,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M152.72727272727272,400L152.72727272727272,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -146,7 +146,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M167.27272727272728,400L167.27272727272728,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -154,7 +154,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M181.8181818181818,400L181.8181818181818,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -162,7 +162,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M196.36363636363635,400L196.36363636363635,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -170,7 +170,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M210.9090909090909,400L210.9090909090909,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -178,7 +178,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M225.45454545454544,400L225.45454545454544,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -186,7 +186,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M240,400L240,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -194,7 +194,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M254.54545454545453,400L254.54545454545453,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -202,7 +202,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M269.09090909090907,400L269.09090909090907,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -210,7 +210,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M283.6363636363636,400L283.6363636363636,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -218,7 +218,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M298.1818181818182,400L298.1818181818182,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -226,7 +226,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M312.7272727272727,400L312.7272727272727,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -234,7 +234,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M327.27272727272725,400L327.27272727272725,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -242,7 +242,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M341.8181818181818,400L341.8181818181818,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -250,7 +250,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M356.3636363636364,400L356.3636363636364,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -258,7 +258,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M370.9090909090909,400L370.9090909090909,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -266,7 +266,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M385.45454545454544,400L385.45454545454544,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -274,7 +274,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M400,400L400,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -282,7 +282,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,392.7272727272727L400,392.7272727272727"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -290,7 +290,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,378.1818181818182L400,378.1818181818182"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -298,7 +298,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,363.6363636363636L400,363.6363636363636"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -306,7 +306,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,349.09090909090907L400,349.09090909090907"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -314,7 +314,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,334.54545454545456L400,334.54545454545456"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -322,7 +322,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,320L400,320"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -330,7 +330,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,305.45454545454544L400,305.45454545454544"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -338,7 +338,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,290.9090909090909L400,290.9090909090909"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -346,7 +346,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,276.3636363636364L400,276.3636363636364"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -354,7 +354,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,261.8181818181818L400,261.8181818181818"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -362,7 +362,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,247.27272727272725L400,247.27272727272725"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -370,7 +370,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,232.72727272727272L400,232.72727272727272"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -378,7 +378,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,218.1818181818182L400,218.1818181818182"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -386,7 +386,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,203.63636363636363L400,203.63636363636363"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -394,7 +394,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,189.0909090909091L400,189.0909090909091"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -402,7 +402,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,174.54545454545453L400,174.54545454545453"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -410,7 +410,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,160L400,160"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -418,7 +418,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,145.45454545454544L400,145.45454545454544"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -426,7 +426,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,130.9090909090909L400,130.9090909090909"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -434,7 +434,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,116.36363636363636L400,116.36363636363636"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -442,7 +442,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,101.81818181818181L400,101.81818181818181"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -450,7 +450,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,87.27272727272727L400,87.27272727272727"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -458,7 +458,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,72.72727272727272L400,72.72727272727272"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -466,7 +466,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,58.18181818181818L400,58.18181818181818"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -474,7 +474,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,43.63636363636363L400,43.63636363636363"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -482,7 +482,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,29.09090909090909L400,29.09090909090909"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -490,7 +490,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,14.545454545454545L400,14.545454545454545"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -498,7 +498,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M0,0L400,0"
                   fill="none"
                   opacity="0.1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 0.1;"
                 />
@@ -506,7 +506,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M-3.450000000000003,369.23636363636365C-3.1000000000000028,367.1363636363636,0.7499999999999973,363.98636363636365,1.7999999999999972,363.6363636363636C0.7499999999999971,363.2863636363636,-3.100000000000003,360.1363636363636,-3.450000000000003,358.0363636363636"
                   fill="none"
                   opacity="1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   stroke-width="2"
@@ -517,7 +517,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M36.36363636363636,363.6363636363636C36.36363636363636,363.6363636363636,36.36363636363636,363.6363636363636,1.0499999999999972,363.6363636363636"
                   fill="none"
                   opacity="1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
                 />
@@ -525,7 +525,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M394.45,369.23636363636365C394.8,367.1363636363636,398.65,363.98636363636365,399.7,363.6363636363636C398.65,363.2863636363636,394.8,360.1363636363636,394.45,358.0363636363636"
                   fill="none"
                   opacity="1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   stroke-width="2"
@@ -536,7 +536,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M36.36363636363636,363.6363636363636C36.36363636363636,363.6363636363636,36.36363636363636,363.6363636363636,398.95,363.6363636363636"
                   fill="none"
                   opacity="1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
                 />
@@ -544,7 +544,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M31.86363636363636,404.55C32.21363636363636,402.45,36.06363636363636,399.3,37.11363636363636,398.95C36.06363636363636,398.59999999999997,32.21363636363636,395.45,31.86363636363636,393.34999999999997"
                   fill="none"
                   opacity="1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   stroke-width="2"
@@ -555,7 +555,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M36.36363636363636,363.6363636363636C36.36363636363636,363.6363636363636,36.36363636363636,363.6363636363636,36.36363636363636,398.95"
                   fill="none"
                   opacity="1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
                 />
@@ -563,7 +563,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M31.86363636363636,6.650000000000011C32.21363636363636,4.550000000000011,36.06363636363636,1.400000000000011,37.11363636363636,1.0500000000000114C36.06363636363636,0.7000000000000114,32.21363636363636,-2.4499999999999886,31.86363636363636,-4.549999999999988"
                   fill="none"
                   opacity="1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-linecap="round"
                   stroke-linejoin="round"
                   stroke-width="2"
@@ -574,7 +574,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M36.36363636363636,363.6363636363636C36.36363636363636,363.6363636363636,36.36363636363636,363.6363636363636,36.36363636363636,1.0500000000000114"
                   fill="none"
                   opacity="1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="2"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 2; opacity: 1;"
                 />
@@ -582,7 +582,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M109.0909090909091,368.6363636363636L109.0909090909091,358.6363636363636"
                   fill="none"
                   opacity="1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="1"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                 />
@@ -590,7 +590,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M181.8181818181818,368.6363636363636L181.8181818181818,358.6363636363636"
                   fill="none"
                   opacity="1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="1"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                 />
@@ -598,7 +598,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M254.54545454545453,368.6363636363636L254.54545454545453,358.6363636363636"
                   fill="none"
                   opacity="1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="1"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                 />
@@ -606,7 +606,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M327.27272727272725,368.6363636363636L327.27272727272725,358.6363636363636"
                   fill="none"
                   opacity="1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="1"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                 />
@@ -614,7 +614,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M31.363636363636363,290.9090909090909L41.36363636363636,290.9090909090909"
                   fill="none"
                   opacity="1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="1"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                 />
@@ -622,7 +622,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M31.363636363636363,218.1818181818182L41.36363636363636,218.1818181818182"
                   fill="none"
                   opacity="1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="1"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                 />
@@ -630,7 +630,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M31.363636363636363,145.45454545454544L41.36363636363636,145.45454545454544"
                   fill="none"
                   opacity="1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="1"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                 />
@@ -638,7 +638,7 @@ exports[`interaction widget renders movable point elements with blank constraint
                   d="M31.363636363636363,72.72727272727272L41.36363636363636,72.72727272727272"
                   fill="none"
                   opacity="1"
-                  stroke="#000000"
+                  stroke="none"
                   stroke-width="1"
                   style="-webkit-tap-highlight-color: rgba(0, 0, 0, 0); stroke-width: 1; opacity: 1;"
                 />
@@ -716,7 +716,7 @@ exports[`interaction widget renders movable point elements with blank constraint
               <span
                 class="graphie-label"
                 data-math-formula="\\small{10}"
-                style="position: absolute; padding: 7px; color: black; left: 109.0909090909091px; top: 363.6363636363636px; fill: none; stroke: #000000; opacity: 1;"
+                style="position: absolute; padding: 7px; color: black; left: 109.0909090909091px; top: 363.6363636363636px; fill: none; opacity: 1;"
               >
                 <span
                   class="tex-holder"
@@ -725,7 +725,7 @@ exports[`interaction widget renders movable point elements with blank constraint
               <span
                 class="graphie-label"
                 data-math-formula="\\small{20}"
-                style="position: absolute; padding: 7px; color: black; left: 181.8181818181818px; top: 363.6363636363636px; fill: none; stroke: #000000; opacity: 1;"
+                style="position: absolute; padding: 7px; color: black; left: 181.8181818181818px; top: 363.6363636363636px; fill: none; opacity: 1;"
               >
                 <span
                   class="tex-holder"
@@ -734,7 +734,7 @@ exports[`interaction widget renders movable point elements with blank constraint
               <span
                 class="graphie-label"
                 data-math-formula="\\small{30}"
-                style="position: absolute; padding: 7px; color: black; left: 254.54545454545453px; top: 363.6363636363636px; fill: none; stroke: #000000; opacity: 1;"
+                style="position: absolute; padding: 7px; color: black; left: 254.54545454545453px; top: 363.6363636363636px; fill: none; opacity: 1;"
               >
                 <span
                   class="tex-holder"
@@ -743,7 +743,7 @@ exports[`interaction widget renders movable point elements with blank constraint
               <span
                 class="graphie-label"
                 data-math-formula="\\small{40}"
-                style="position: absolute; padding: 7px; color: black; left: 327.27272727272725px; top: 363.6363636363636px; fill: none; stroke: #000000; opacity: 1;"
+                style="position: absolute; padding: 7px; color: black; left: 327.27272727272725px; top: 363.6363636363636px; fill: none; opacity: 1;"
               >
                 <span
                   class="tex-holder"
@@ -752,7 +752,7 @@ exports[`interaction widget renders movable point elements with blank constraint
               <span
                 class="graphie-label"
                 data-math-formula="\\small{10}"
-                style="position: absolute; padding: 7px; color: black; left: 36.36363636363636px; top: 290.9090909090909px; fill: none; stroke: #000000; opacity: 1;"
+                style="position: absolute; padding: 7px; color: black; left: 36.36363636363636px; top: 290.9090909090909px; fill: none; opacity: 1;"
               >
                 <span
                   class="tex-holder"
@@ -761,7 +761,7 @@ exports[`interaction widget renders movable point elements with blank constraint
               <span
                 class="graphie-label"
                 data-math-formula="\\small{20}"
-                style="position: absolute; padding: 7px; color: black; left: 36.36363636363636px; top: 218.1818181818182px; fill: none; stroke: #000000; opacity: 1;"
+                style="position: absolute; padding: 7px; color: black; left: 36.36363636363636px; top: 218.1818181818182px; fill: none; opacity: 1;"
               >
                 <span
                   class="tex-holder"
@@ -770,7 +770,7 @@ exports[`interaction widget renders movable point elements with blank constraint
               <span
                 class="graphie-label"
                 data-math-formula="\\small{30}"
-                style="position: absolute; padding: 7px; color: black; left: 36.36363636363636px; top: 145.45454545454544px; fill: none; stroke: #000000; opacity: 1;"
+                style="position: absolute; padding: 7px; color: black; left: 36.36363636363636px; top: 145.45454545454544px; fill: none; opacity: 1;"
               >
                 <span
                   class="tex-holder"
@@ -779,7 +779,7 @@ exports[`interaction widget renders movable point elements with blank constraint
               <span
                 class="graphie-label"
                 data-math-formula="\\small{40}"
-                style="position: absolute; padding: 7px; color: black; left: 36.36363636363636px; top: 72.72727272727272px; fill: none; stroke: #000000; opacity: 1;"
+                style="position: absolute; padding: 7px; color: black; left: 36.36363636363636px; top: 72.72727272727272px; fill: none; opacity: 1;"
               >
                 <span
                   class="tex-holder"

--- a/packages/perseus/src/widgets/number-line/__snapshots__/number-line.test.ts.snap
+++ b/packages/perseus/src/widgets/number-line/__snapshots__/number-line.test.ts.snap
@@ -66,7 +66,7 @@ exports[`number-line widget snapshots can handle fractions: show fractions 1`] =
             >
               <div
                 aria-hidden="true"
-                class="graphie"
+                class="graphie perseus-widget-number-line"
                 style="position: relative; width: 459.99999999999994px; height: 100px;"
               >
                 <svg
@@ -423,7 +423,7 @@ exports[`number-line widget snapshots default: first render 1`] = `
             >
               <div
                 aria-hidden="true"
-                class="graphie"
+                class="graphie perseus-widget-number-line"
                 style="position: relative; width: 459.99999999999994px; height: 80px;"
               >
                 <svg
@@ -796,7 +796,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
             >
               <div
                 aria-hidden="true"
-                class="graphie"
+                class="graphie perseus-widget-number-line"
                 style="position: relative; width: 460px; height: 80px;"
               >
                 <svg
@@ -1361,7 +1361,7 @@ exports[`number-line widget snapshots endpoints are highlighted when labels are 
             >
               <div
                 aria-hidden="true"
-                class="graphie"
+                class="graphie perseus-widget-number-line"
                 style="position: relative; width: 460px; height: 80px;"
               >
                 <svg
@@ -1926,7 +1926,7 @@ exports[`number-line widget snapshots labels are highlighted when part of the ti
             >
               <div
                 aria-hidden="true"
-                class="graphie"
+                class="graphie perseus-widget-number-line"
                 style="position: relative; width: 460px; height: 80px;"
               >
                 <svg
@@ -2331,7 +2331,7 @@ exports[`number-line widget snapshots labels are inserted when NOT part of the t
             >
               <div
                 aria-hidden="true"
-                class="graphie"
+                class="graphie perseus-widget-number-line"
                 style="position: relative; width: 460px; height: 80px;"
               >
                 <svg
@@ -2773,7 +2773,7 @@ exports[`number-line widget snapshots mobile: first mobile render 1`] = `
             >
               <div
                 aria-hidden="true"
-                class="graphie"
+                class="graphie perseus-widget-number-line"
                 style="position: relative; width: 288px; height: 80px;"
               >
                 <svg
@@ -3146,7 +3146,7 @@ exports[`number-line widget snapshots only endpoints/labels show when "Show labe
             >
               <div
                 aria-hidden="true"
-                class="graphie"
+                class="graphie perseus-widget-number-line"
                 style="position: relative; width: 460px; height: 80px;"
               >
                 <svg
@@ -3540,7 +3540,7 @@ exports[`number-line widget snapshots only endpoints/labels show when "Show labe
             >
               <div
                 aria-hidden="true"
-                class="graphie"
+                class="graphie perseus-widget-number-line"
                 style="position: relative; width: 460px; height: 80px;"
               >
                 <svg

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -579,9 +579,6 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
         return (
             <Graphie
                 ref={graphieRef}
-                // Excludes this graphie from the dark-mode invert filter in
-                // styles.css; its colors are semantic tokens, so it is
-                // themed directly.
                 className="perseus-widget-number-line"
                 // HACK(emily): We key this graphie on the label style because
                 // when the label style changes we want to resize the graphie,

--- a/packages/perseus/src/widgets/number-line/number-line.tsx
+++ b/packages/perseus/src/widgets/number-line/number-line.tsx
@@ -579,6 +579,10 @@ const NumberLine = forwardRef<Widget, Props>(function NumberLine(props, ref) {
         return (
             <Graphie
                 ref={graphieRef}
+                // Excludes this graphie from the dark-mode invert filter in
+                // styles.css; its colors are semantic tokens, so it is
+                // themed directly.
+                className="perseus-widget-number-line"
                 // HACK(emily): We key this graphie on the label style because
                 // when the label style changes we want to resize the graphie,
                 // which isn't doable without throwing away the graphie and


### PR DESCRIPTION
## Summary

Updates the last legacy hardcoded colors in the old graph-drawing system to semantic color tokens: the grid and axis colors of grapher graphs, the number line's strokes, and the colors of the draggable line segments used by the plotter widget. Grapher and number-line graphs are now themed directly in dark mode instead of having their colors approximated by an inversion filter — which also fixes a subtle existing dark-mode bug where a number line's line color didn't quite match its movable point.

<details><summary>Details</summary>

**Why not just convert the strokes in place:** in dark themes, `styles.css` recolors graphie SVGs with `filter: invert(1) hue-rotate(180deg) brightness(1.5)`, on the assumption that they're drawn in light-theme colors. A semantic token resolved at draw time yields the *dark* theme's value, which the filter then inverts a second time (the first push here did exactly that; the syl-dark Chromatic stories showed near-black axes on a dark background). So this PR follows the plotter's precedent instead: theme the whole widget and exclude its graphie from the filter.

- **`util/graphie.ts` (`graphInit`)** — takes optional `gridStroke`/`axisStroke` colors. The defaults remain the raw light-theme colors (`GRAY_C`/`GRAY_G`/`#000000`) with a comment explaining why they must stay raw: callers still under the invert filter (interaction, measurer-adjacent paths) are unchanged. The previously-hardcoded `#000000` in the `"->"` axis branch also respects `axisStroke`.
- **`widgets/grapher/grapher.tsx`** — passes token strokes to both `graphInit` calls, resolved via `tokenValue()` at draw time (Raphael sets SVG presentation attributes, where `var()` doesn't resolve — same mechanism as #4109/#4116). Mapping mirrors the Mafs graphs (`mafs-styles.css`): grid = `border.neutral.subtle` (mobile) / `foreground.neutral.strong` (desktop); axes/ticks/labels = `foreground.neutral.default` (mobile) / `foreground.neutral.strong` (desktop). The mobile GRAY_C/GRAY_G values are near-identical to their tokens in the default theme.
- **`styles.css`** — grapher and number-line join the plotter in the invert-filter exclusion list (`:not()` chain).
- **`components/graphie.tsx`** — the `Graphie` component takes an optional `className` so widgets can tag their `.graphie` div for the exclusion.
- **`widgets/number-line/number-line.tsx`** — tagged for exclusion, and its own drawing is now fully tokenized: the line body, arrowheads, and non-highlighted ticks previously drew with Raphael's default black and relied on the invert filter to become visible in dark mode (verified black-on-black in the Storybook publish before the fix); they now use `core.foreground.neutral.strong`. The movable elements were already tokenized — and the filter was distorting them: the line/ray render in graphie's main SVG (a direct child of `.graphie`, matched by the filter) while the movable point renders in nested wrapper divs the `.graphie > svg` selector never matched, so in dark mode the line's purple subtly mismatched the point's. Exclusion makes them match.
- **`util/interactive.ts` (`addMovableLineSegment`)** — the four live `KhanColors.INTERACTIVE`/`DYNAMIC` sites map to `core.foreground.instructive.default`. `DYNAMIC` (`color.blue`) is value-identical to that token in the default theme, and the old `fixed ? DYNAMIC : INTERACTIVE` ternary collapses since both sides resolve to the same token — the only caller (plotter, already filter-excluded) never sets `fixed` anyway. The plotter also overrides the segment stroke with the instructive token already, so the visible plotter change is limited to the arrow/label color unification (was `color.green`).
- **Snapshot updates** (`grapher`, `number-line`, `interaction`): `tokenValue()` reads CSS custom properties, which jsdom doesn't populate, so token strokes serialize as `"none"`; plus the new classNames.
- Deliberately untouched: interaction's authored element colors and measurer's protractor PNG keep those widgets under the invert filter (their `graphInit`/draw colors stay raw), and the opacity-0 fills are LEMS-4548.

</details>

Issue: [LEMS-4547](https://khanacademy.atlassian.net/browse/LEMS-4547)

## Test Plan

- Checks pass (`pnpm tesc`, `pnpm tsc`, `pnpm fixc`)

**Expected Chromatic diffs — where to look**

These stories snapshot in the `default` and `thunderblocks` theme modes; the grapher Dark Mode regression stories pin `syl-dark`.

| Change | Story to check | default | thunderblocks |
| --- | --- | --- | --- |
| Grapher grid/axis/tick/label strokes | Grapher → Visual Regression Tests → Initial State (desktop + `isMobile` variants) and Interactions | Subtle: black → `foreground.neutral.strong` (near-black); mobile grays near-identical | Strokes recolored to thunderblocks neutrals |
| Grapher dark mode (filter → direct theming) | Grapher → Visual Regression Tests → Dark Mode | — | — (syl-dark mode: grid/axes now use the dark theme's actual token values instead of filter-inverted black; should look close to the old inverted rendering, not black-on-black) |
| Number-line strokes | Number line → Visual Regression Tests | Subtle: line/arrows/plain ticks black → `foreground.neutral.strong` (near-black) | Recolored to thunderblocks neutrals |
| Movable line segment (plotter bars) | Plotter → Visual Regression Tests → Initial State (bar-type stories) | Little to no segment diff (stroke already overridden with the instructive token); arrow/label color unifies green→blue | Recolored to the thunderblocks instructive token |

Manual Storybook checks:
- [ ] Grapher in syl-dark: grid/axes/labels legible and matching the Mafs interactive-graph look.
- [ ] Number-line in syl-dark: line, arrows, and ticks light-on-dark; line, ray, and movable point the same purple. (Verified black-on-black before the stroke fix; re-check on the new build.)
- [ ] Interaction widget in syl-dark: unchanged (still inverted, axes still white).
- [ ] Drag a plotter bar to confirm the movable segment highlight/drag behavior is unchanged.

[LEMS-4547]: https://khanacademy.atlassian.net/browse/LEMS-4547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ