### PR TITLE
Fix bugs related to dark mode

### DIFF
--- a/.changeset/frank-ducks-wave.md
+++ b/.changeset/frank-ducks-wave.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+The editor preview for the Image widget now displays the correct colors for Graphie labels when the dark mode preview is toggled on.

--- a/.changeset/silent-candies-cough.md
+++ b/.changeset/silent-candies-cough.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Bugfix: Graphie labels with no `style` property no longer crash the Renderer.

--- a/packages/perseus/src/__testdata__/graphie.testdata.ts
+++ b/packages/perseus/src/__testdata__/graphie.testdata.ts
@@ -58,3 +58,47 @@ export const itemWithLabeledAngle: PerseusItem = generateTestPerseusItem({
         },
     },
 });
+
+export const itemWithImageLabelWithNoStyle: PerseusItem =
+    generateTestPerseusItem({
+        question: {
+            content: "[[☃ image 1]]",
+            images: {},
+            widgets: {
+                "image 1": {
+                    type: "image",
+                    static: false,
+                    graded: true,
+                    alignment: "block",
+                    options: generateImageOptions({
+                        backgroundImage: {
+                            url: "https://ka-perseus-images.s3.amazonaws.com/0ba867e121eb4a2dfc2a854e22f571469a8d8793.svg",
+                            width: 264,
+                            height: 203,
+                        },
+                        labels: [
+                            {
+                                content: "7\\text{ cm}",
+                                alignment: "left",
+                                coordinates: [3.5, 3.5],
+                            },
+                            {
+                                content: "\\text{width}",
+                                alignment: "center",
+                                coordinates: [6.9, 9],
+                            },
+                        ],
+                        range: [
+                            [0, 10],
+                            [0, 10],
+                        ],
+                        box: [264, 203],
+                    }),
+                    version: {
+                        major: 0,
+                        minor: 0,
+                    },
+                },
+            },
+        },
+    });

--- a/packages/perseus/src/components/__docs__/graphie-regression.stories.tsx
+++ b/packages/perseus/src/components/__docs__/graphie-regression.stories.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+import {itemWithImageLabelWithNoStyle} from "../../__testdata__/graphie.testdata";
+import {ServerItemRendererWithDebugUI} from "../../testing/server-item-renderer-with-debug-ui";
+import Graphie from "../graphie";
+
+import type {StoryObj, Meta} from "@storybook/react-vite";
+
+type Story = StoryObj<typeof Graphie>;
+
+const meta: Meta = {
+    title: "Components/Graphie/Visual Regression Tests",
+    component: Graphie,
+    parameters: {
+        chromatic: {disableSnapshot: false},
+    },
+};
+export default meta;
+
+export const LabelsWithNoStyleProperty: Story = {
+    render: () => (
+        <ServerItemRendererWithDebugUI item={itemWithImageLabelWithNoStyle} />
+    ),
+};

--- a/packages/perseus/src/components/svg-image.tsx
+++ b/packages/perseus/src/components/svg-image.tsx
@@ -377,7 +377,7 @@ class SvgImage extends React.Component<Props, State> {
                 // closest semantic color from Wonder Blocks. This ensures that
                 // labels follow the dark mode / light mode theme and remain
                 // readable.
-                if (labelData.style.color) {
+                if (labelData.style?.color) {
                     label.css(
                         "color",
                         toClosestMathColor(labelData.style.color),

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -368,9 +368,9 @@
 [data-wb-theme$="-dark"] .framework-perseus,
 .perseus-image-preview-container[data-wb-theme$="-dark"] {
     /* TODO(benchristel): this set of file extensions is duplicated in
-     * image.css and dark-mode-toggle.tsx. Replace these selectors with a
-     * class that gets added to images that should be inverted, so the set of
-     * extensions can have a single representation in TypeScript code.
+     * dark-mode-toggle.tsx. Replace these selectors with a class that gets
+     * added to images that should be inverted, so the set of extensions can
+     * have a single representation in TypeScript code.
      */
     img[src$=".png"],
     img[src$=".svg"],

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -365,7 +365,8 @@
 /*****************************
  * GLOBAL DARK MODE SETTINGS *
  *****************************/
-[data-wb-theme$="-dark"] .framework-perseus {
+[data-wb-theme$="-dark"] .framework-perseus,
+.perseus-image-preview-container[data-wb-theme$="-dark"] {
     /* TODO(benchristel): this set of file extensions is duplicated in
      * image.css and dark-mode-toggle.tsx. Replace these selectors with a
      * class that gets added to images that should be inverted, so the set of

--- a/packages/perseus/src/styles/widgets/image.css
+++ b/packages/perseus/src/styles/widgets/image.css
@@ -46,15 +46,6 @@
     background-color: var(--wb-semanticColor-core-background-base-default);
 }
 
-.perseus-image-preview-container[data-wb-theme$="-dark"] {
-    img[src$=".png"],
-    img[src$=".svg"],
-    .graphie,
-    .perseus-block-math .mathjax-wrapper {
-        filter: invert(1) hue-rotate(180deg) brightness(1.5);
-    }
-}
-
 /* This prevents the image from overflowing its container in editor previews */
 .perseus-image-preview-container .image-loader-img {
     overflow: hidden;


### PR DESCRIPTION
## Summary:
There were two bugs related to dark mode rendering of images that are fixed in this PR.

- In the editor, the Image widget preview did not display the correct colors
  for graphie labels when the dark mode preview was toggled on.
- In production, graphie images that use the deprecated `labels` option on the
  Image widget caused the widget to crash, because those labels do not have a
  `style` property.

Issue: none

## Test plan:

- Review the new story in Chromatic
- Test the dark mode preview in the Image editor. Use this image:
  `web+graphie://ka-perseus-graphie.s3.amazonaws.com/4559c8e0bd022d37bc3291ef5e600ae917046ab2`

Before:

<img width="335" height="254" alt="Screenshot 2026-09-02 at 10 06 39 AM" src="https://github.com/user-attachments/assets/46e9faaf-ce7e-44ce-a9f6-03280053e897" />

After:

<img width="336" height="258" alt="Screenshot 2026-09-02 at 10 06 55 AM" src="https://github.com/user-attachments/assets/9c808be4-858d-4067-b437-8694e774fe74" />
