### PR TITLE
Rewrite GradedGroupSet as a functional component

### DIFF
--- a/.changeset/four-points-shine.md
+++ b/.changeset/four-points-shine.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: the Graded Group Set widget is now a functional component.

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -1,23 +1,18 @@
 import Clickable from "@khanacademy/wonder-blocks-clickable";
-import {View} from "@khanacademy/wonder-blocks-core";
+import {useOnMountEffect, View} from "@khanacademy/wonder-blocks-core";
 import {border, font, semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet, css} from "aphrodite";
 import classNames from "classnames";
 import * as React from "react";
+import {forwardRef, useImperativeHandle, useRef, useState} from "react";
+import invariant from "tiny-invariant";
 
-import {withDependencies} from "../../components/with-dependencies";
-import {getDependencies} from "../../dependencies";
+import {getDependencies, useDependencies} from "../../dependencies";
 import {phoneMargin, negativePhoneMargin} from "../../styles/constants";
 import {getPromptJSON} from "../../widget-ai-utils/graded-group-set/graded-group-set-ai-utils";
 import {GradedGroup} from "../graded-group/graded-group";
 
-import type {
-    FocusPath,
-    PerseusDependenciesV2,
-    Widget,
-    WidgetExports,
-    WidgetProps,
-} from "../../types";
+import type {FocusPath, Widget, WidgetExports, WidgetProps} from "../../types";
 import type {GradedGroupSetPromptJSON} from "../../widget-ai-utils/graded-group-set/graded-group-set-ai-utils";
 import type {
     PerseusGradedGroupSetWidgetOptions,
@@ -83,71 +78,66 @@ function Indicators(props: IndicatorsProps) {
 
 type Props = WidgetProps<PerseusGradedGroupSetWidgetOptions> & {
     trackInteraction: () => void;
-    dependencies: PerseusDependenciesV2;
 };
 
-type State = {
-    currentGroup: number;
-};
+const GradedGroupSet = forwardRef<Widget, Props>(
+    function GradedGroupSet(props, ref) {
+        const dependencies = useDependencies();
+        const childGroup = useRef<GradedGroup>();
 
-class GradedGroupSet extends React.Component<Props, State> implements Widget {
-    // @ts-expect-error - TS2564 - Property '_childGroup' has no initializer and is not definitely assigned in the constructor.
-    _childGroup: GradedGroup;
+        const [currentGroupIndex, setCurrentGroupIndex] = useState(0);
 
-    state: State = {
-        currentGroup: 0,
-    };
-
-    componentDidMount(): void {
-        this.props.dependencies.analytics.onAnalyticsEvent({
-            type: "perseus:widget:rendered:ti",
-            payload: {
-                widgetType: "graded-group-set",
-                widgetSubType: "null",
-                widgetId: this.props.widgetId,
-            },
+        useOnMountEffect(() => {
+            dependencies.analytics.onAnalyticsEvent({
+                type: "perseus:widget:rendered:ti",
+                payload: {
+                    widgetType: "graded-group-set",
+                    widgetSubType: "null",
+                    widgetId: props.widgetId,
+                },
+            });
         });
-    }
 
-    // Mobile API
-    getInputPaths: () => ReadonlyArray<FocusPath> = () => {
-        return this._childGroup.getInputPaths();
-    };
+        useImperativeHandle(ref, () => ({
+            getInputPaths(): ReadonlyArray<FocusPath> {
+                return childGroup.current?.getInputPaths() ?? [];
+            },
 
-    getPromptJSON(): GradedGroupSetPromptJSON {
-        const activeGroupPromptJSON = this._childGroup.getPromptJSON();
+            getPromptJSON(): GradedGroupSetPromptJSON {
+                invariant(
+                    childGroup.current,
+                    "GradedGroupSet must have at least one group",
+                );
+                return getPromptJSON(props, childGroup.current.getPromptJSON());
+            },
 
-        return getPromptJSON(this.props, activeGroupPromptJSON);
-    }
+            focus(): boolean {
+                return childGroup.current?.focus() ?? false;
+            },
 
-    focus: () => boolean = () => {
-        return this._childGroup.focus();
-    };
+            focusInputPath(path: FocusPath) {
+                childGroup.current?.focusInputPath(path);
+            },
 
-    focusInputPath: (arg1: FocusPath) => void = (path) => {
-        this._childGroup.focusInputPath(path);
-    };
+            blurInputPath(path: FocusPath) {
+                childGroup.current?.blurInputPath(path);
+            },
+        }));
 
-    blurInputPath: (arg1: FocusPath) => void = (path) => {
-        this._childGroup.blurInputPath(path);
-    };
+        function handleNextQuestion() {
+            const numGroups = props.options.gradedGroups.length;
 
-    handleNextQuestion: () => void = () => {
-        const {currentGroup} = this.state;
-        const numGroups = this.props.options.gradedGroups.length;
-
-        if (currentGroup < numGroups - 1) {
-            this.setState({currentGroup: currentGroup + 1});
+            if (currentGroupIndex < numGroups - 1) {
+                setCurrentGroupIndex(currentGroupIndex + 1);
+            }
         }
-    };
 
-    render(): React.ReactNode {
         // When used in the context of TranslationEditor, render the
         // GradedGroup widget one below another instead of using an indicator
         // to click and switch between different graded groups. Translators
         // prefer to see all strings/labels on all GradedGroups readily visible
         // together instead of clicking on indicators to switch between them.
-        const {gradedGroups} = this.props.options;
+        const {gradedGroups} = props.options;
         const {JIPT} = getDependencies();
         if (JIPT.useJIPT && gradedGroups.length > 1) {
             return (
@@ -156,11 +146,12 @@ class GradedGroupSet extends React.Component<Props, State> implements Widget {
                         return (
                             <GradedGroup
                                 key={i}
-                                {...this.props}
-                                problemNum={(this.props.problemNum ?? 0) + i}
+                                {...props}
+                                problemNum={(props.problemNum ?? 0) + i}
                                 options={gradedGroup}
                                 inGradedGroupSet={false}
-                                linterContext={this.props.linterContext}
+                                linterContext={props.linterContext}
+                                dependencies={dependencies}
                             />
                         );
                     })}
@@ -168,18 +159,13 @@ class GradedGroupSet extends React.Component<Props, State> implements Widget {
             );
         }
 
-        const currentGroup = gradedGroups[this.state.currentGroup];
+        const currentGroup = gradedGroups[currentGroupIndex];
 
-        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-        if (!currentGroup) {
+        if (currentGroup == null) {
             return <span>No current group...</span>;
         }
 
         const numGroups = gradedGroups.length;
-        const handleNextQuestion =
-            this.state.currentGroup < numGroups - 1
-                ? this.handleNextQuestion
-                : undefined;
 
         return (
             <div className={css(styles.container)}>
@@ -189,21 +175,21 @@ class GradedGroupSet extends React.Component<Props, State> implements Widget {
                     </div>
                     <div className={css(styles.spacer)} />
                     <Indicators
-                        currentGroup={this.state.currentGroup}
+                        currentGroup={currentGroupIndex}
                         gradedGroups={gradedGroups}
-                        onChangeCurrentGroup={(currentGroup) =>
-                            this.setState({currentGroup})
+                        onChangeCurrentGroup={(currentGroupIndex) =>
+                            setCurrentGroupIndex(currentGroupIndex)
                         }
                     />
                 </div>
                 <GradedGroup
-                    key={this.state.currentGroup}
-                    ref={(comp) => (this._childGroup = comp)}
+                    key={currentGroupIndex}
+                    // @ts-expect-error - TS2322 - Type 'GradedGroup | null' is not assignable to type 'GradedGroup'.
+                    //  Type 'null' is not assignable to type 'GradedGroup'.
+                    ref={childGroup}
                     // We should pass in the set of props explicitly
-                    {...this.props}
-                    problemNum={
-                        (this.props.problemNum ?? 0) + this.state.currentGroup
-                    }
+                    {...props}
+                    problemNum={(props.problemNum ?? 0) + currentGroupIndex}
                     options={{
                         ...currentGroup,
                         // The set renders the group's title itself, above the
@@ -211,24 +197,27 @@ class GradedGroupSet extends React.Component<Props, State> implements Widget {
                         title: "",
                     }}
                     inGradedGroupSet={true}
-                    onNextQuestion={handleNextQuestion}
-                    linterContext={this.props.linterContext}
+                    onNextQuestion={
+                        currentGroupIndex < numGroups - 1
+                            ? handleNextQuestion
+                            : undefined
+                    }
+                    linterContext={props.linterContext}
+                    dependencies={dependencies}
                 />
             </div>
         );
-    }
-}
-
-const WrappedGradedGroupSet = withDependencies(GradedGroupSet);
+    },
+);
 
 export default {
     name: "graded-group-set",
     displayName: "Graded group set (articles only)",
-    widget: WrappedGradedGroupSet,
+    widget: GradedGroupSet,
     hidden: false,
     tracking: "all",
     isLintable: true,
-} satisfies WidgetExports<typeof WrappedGradedGroupSet>;
+} satisfies WidgetExports<typeof GradedGroupSet>;
 
 const styles = StyleSheet.create({
     top: {

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -14,6 +14,7 @@ import {GradedGroup} from "../graded-group/graded-group";
 
 import type {FocusPath, Widget, WidgetExports, WidgetProps} from "../../types";
 import type {GradedGroupSetPromptJSON} from "../../widget-ai-utils/graded-group-set/graded-group-set-ai-utils";
+import type {GradedGroupHandle} from "../graded-group/graded-group";
 import type {
     PerseusGradedGroupSetWidgetOptions,
     PerseusGradedGroupWidgetOptions,
@@ -83,7 +84,7 @@ type Props = WidgetProps<PerseusGradedGroupSetWidgetOptions> & {
 const GradedGroupSet = forwardRef<Widget, Props>(
     function GradedGroupSet(props, ref) {
         const dependencies = useDependencies();
-        const childGroup = useRef<GradedGroup | null>(null);
+        const childGroup = useRef<GradedGroupHandle | null>(null);
 
         const [currentGroupIndex, setCurrentGroupIndex] = useState(0);
 
@@ -100,7 +101,7 @@ const GradedGroupSet = forwardRef<Widget, Props>(
 
         useImperativeHandle(ref, () => ({
             getInputPaths(): ReadonlyArray<FocusPath> {
-                return childGroup.current?.getInputPaths() ?? [];
+                return childGroup.current?.getInputPaths?.() ?? [];
             },
 
             getPromptJSON(): GradedGroupSetPromptJSON {
@@ -143,7 +144,6 @@ const GradedGroupSet = forwardRef<Widget, Props>(
                                 options={gradedGroup}
                                 inGradedGroupSet={false}
                                 linterContext={props.linterContext}
-                                dependencies={dependencies}
                             />
                         );
                     })}
@@ -191,7 +191,6 @@ const GradedGroupSet = forwardRef<Widget, Props>(
                     inGradedGroupSet={true}
                     onNextQuestion={handleNextQuestion}
                     linterContext={props.linterContext}
-                    dependencies={dependencies}
                 />
             </div>
         );

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -83,7 +83,7 @@ type Props = WidgetProps<PerseusGradedGroupSetWidgetOptions> & {
 const GradedGroupSet = forwardRef<Widget, Props>(
     function GradedGroupSet(props, ref) {
         const dependencies = useDependencies();
-        const childGroup = useRef<GradedGroup>();
+        const childGroup = useRef<GradedGroup | null>(null);
 
         const [currentGroupIndex, setCurrentGroupIndex] = useState(0);
 
@@ -182,8 +182,6 @@ const GradedGroupSet = forwardRef<Widget, Props>(
                 </div>
                 <GradedGroup
                     key={currentGroupIndex}
-                    // @ts-expect-error - TS2322 - Type 'GradedGroup | null' is not assignable to type 'GradedGroup'.
-                    //  Type 'null' is not assignable to type 'GradedGroup'.
                     ref={childGroup}
                     // We should pass in the set of props explicitly
                     {...props}

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -124,14 +124,6 @@ const GradedGroupSet = forwardRef<Widget, Props>(
             },
         }));
 
-        function handleNextQuestion() {
-            const numGroups = props.options.gradedGroups.length;
-
-            if (currentGroupIndex < numGroups - 1) {
-                setCurrentGroupIndex(currentGroupIndex + 1);
-            }
-        }
-
         // When used in the context of TranslationEditor, render the
         // GradedGroup widget one below another instead of using an indicator
         // to click and switch between different graded groups. Translators
@@ -166,6 +158,10 @@ const GradedGroupSet = forwardRef<Widget, Props>(
         }
 
         const numGroups = gradedGroups.length;
+        const atEnd = currentGroupIndex >= numGroups - 1;
+        const handleNextQuestion = atEnd
+            ? undefined
+            : () => setCurrentGroupIndex(currentGroupIndex + 1);
 
         return (
             <div className={css(styles.container)}>
@@ -193,11 +189,7 @@ const GradedGroupSet = forwardRef<Widget, Props>(
                         title: "",
                     }}
                     inGradedGroupSet={true}
-                    onNextQuestion={
-                        currentGroupIndex < numGroups - 1
-                            ? handleNextQuestion
-                            : undefined
-                    }
+                    onNextQuestion={handleNextQuestion}
                     linterContext={props.linterContext}
                     dependencies={dependencies}
                 />

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -5,7 +5,6 @@ import {StyleSheet, css} from "aphrodite";
 import classNames from "classnames";
 import * as React from "react";
 
-import {PerseusI18nContext} from "../../components/i18n-context";
 import {withDependencies} from "../../components/with-dependencies";
 import {getDependencies} from "../../dependencies";
 import {phoneMargin, negativePhoneMargin} from "../../styles/constants";
@@ -31,63 +30,55 @@ type IndicatorsProps = {
     onChangeCurrentGroup: (groupNumber: number) => void;
 };
 
-class Indicators extends React.Component<IndicatorsProps> {
-    static contextType = PerseusI18nContext;
-    declare context: React.ContextType<typeof PerseusI18nContext>;
-
-    handleKeyDown = (e: React.KeyboardEvent, i: number) => {
+function Indicators(props: IndicatorsProps) {
+    function handleKeyDown(e: React.KeyboardEvent, i: number) {
         if (e.key === "Enter" || e.key === " ") {
-            this.props.onChangeCurrentGroup(i);
+            props.onChangeCurrentGroup(i);
         }
-    };
-
-    render(): React.ReactNode {
-        return (
-            // eslint-disable-next-line jsx-a11y/no-redundant-roles -- role="list" is intentional: Safari+VoiceOver strips list semantics from <ul> with list-style:none, so explicit role restores them
-            <ul
-                // reduntantly add class name for use in .css files--
-                //   the styles object key gets hashed
-                role="list"
-                className={classNames(
-                    css(styles.indicatorContainer),
-                    "indicatorContainer",
-                )}
-            >
-                {this.props.gradedGroups.map(({title}, i) => {
-                    const isCurrent = i === this.props.currentGroup;
-                    return (
-                        // Note: Use index as key — titles are user-authored and
-                        // not guaranteed unique. Groups are never reordered at
-                        // runtime, so index keys are stable.
-                        <li className={css(styles.indicator)} key={i}>
-                            <Clickable
-                                role="button"
-                                aria-label={title}
-                                aria-current={isCurrent}
-                                style={styles.indicatorButton}
-                                onClick={() =>
-                                    this.props.onChangeCurrentGroup(i)
-                                }
-                                onKeyDown={(e) => this.handleKeyDown(e, i)}
-                            >
-                                {({hovered, focused, pressed}) => (
-                                    <View
-                                        style={[
-                                            styles.indicatorDot,
-                                            isCurrent &&
-                                                styles.indicatorDotActive,
-                                            (hovered || focused || pressed) &&
-                                                styles.indicatorDotFocused,
-                                        ]}
-                                    />
-                                )}
-                            </Clickable>
-                        </li>
-                    );
-                })}
-            </ul>
-        );
     }
+
+    return (
+        // eslint-disable-next-line jsx-a11y/no-redundant-roles -- role="list" is intentional: Safari+VoiceOver strips list semantics from <ul> with list-style:none, so explicit role restores them
+        <ul
+            // reduntantly add class name for use in .css files--
+            //   the styles object key gets hashed
+            role="list"
+            className={classNames(
+                css(styles.indicatorContainer),
+                "indicatorContainer",
+            )}
+        >
+            {props.gradedGroups.map(({title}, i) => {
+                const isCurrent = i === props.currentGroup;
+                return (
+                    // Note: Use index as key — titles are user-authored and
+                    // not guaranteed unique. Groups are never reordered at
+                    // runtime, so index keys are stable.
+                    <li className={css(styles.indicator)} key={i}>
+                        <Clickable
+                            role="button"
+                            aria-label={title}
+                            aria-current={isCurrent}
+                            style={styles.indicatorButton}
+                            onClick={() => props.onChangeCurrentGroup(i)}
+                            onKeyDown={(e) => handleKeyDown(e, i)}
+                        >
+                            {({hovered, focused, pressed}) => (
+                                <View
+                                    style={[
+                                        styles.indicatorDot,
+                                        isCurrent && styles.indicatorDotActive,
+                                        (hovered || focused || pressed) &&
+                                            styles.indicatorDotFocused,
+                                    ]}
+                                />
+                            )}
+                        </Clickable>
+                    </li>
+                );
+            })}
+        </ul>
+    );
 }
 
 type Props = WidgetProps<PerseusGradedGroupSetWidgetOptions> & {

--- a/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
+++ b/packages/perseus/src/widgets/graded-group-set/graded-group-set.tsx
@@ -20,15 +20,15 @@ import type {
 } from "@khanacademy/perseus-core";
 
 type IndicatorsProps = {
-    currentGroup: number;
+    currentGroupIndex: number;
     gradedGroups: ReadonlyArray<PerseusGradedGroupWidgetOptions>;
-    onChangeCurrentGroup: (groupNumber: number) => void;
+    onChangeGroupIndex: (groupNumber: number) => void;
 };
 
 function Indicators(props: IndicatorsProps) {
     function handleKeyDown(e: React.KeyboardEvent, i: number) {
         if (e.key === "Enter" || e.key === " ") {
-            props.onChangeCurrentGroup(i);
+            props.onChangeGroupIndex(i);
         }
     }
 
@@ -44,7 +44,7 @@ function Indicators(props: IndicatorsProps) {
             )}
         >
             {props.gradedGroups.map(({title}, i) => {
-                const isCurrent = i === props.currentGroup;
+                const isCurrent = i === props.currentGroupIndex;
                 return (
                     // Note: Use index as key — titles are user-authored and
                     // not guaranteed unique. Groups are never reordered at
@@ -55,7 +55,7 @@ function Indicators(props: IndicatorsProps) {
                             aria-label={title}
                             aria-current={isCurrent}
                             style={styles.indicatorButton}
-                            onClick={() => props.onChangeCurrentGroup(i)}
+                            onClick={() => props.onChangeGroupIndex(i)}
                             onKeyDown={(e) => handleKeyDown(e, i)}
                         >
                             {({hovered, focused, pressed}) => (
@@ -175,11 +175,9 @@ const GradedGroupSet = forwardRef<Widget, Props>(
                     </div>
                     <div className={css(styles.spacer)} />
                     <Indicators
-                        currentGroup={currentGroupIndex}
+                        currentGroupIndex={currentGroupIndex}
                         gradedGroups={gradedGroups}
-                        onChangeCurrentGroup={(currentGroupIndex) =>
-                            setCurrentGroupIndex(currentGroupIndex)
-                        }
+                        onChangeGroupIndex={setCurrentGroupIndex}
                     />
                 </div>
                 <GradedGroup

--- a/packages/perseus/src/widgets/graded-group/graded-group.tsx
+++ b/packages/perseus/src/widgets/graded-group/graded-group.tsx
@@ -26,7 +26,6 @@ import type {ANSWER_BAR_STATES} from "./graded-group-answer-bar";
 import type {
     FocusPath,
     TrackingGradedGroupExtraArguments,
-    Widget,
     WidgetExports,
     WidgetProps,
 } from "../../types";
@@ -72,11 +71,22 @@ type Props = WidgetProps<
     onNextQuestion?: () => unknown; // Set by graded-group-set.jsx
 };
 
+/**
+ * Provides a more specific interface than Widget for GradedGroupSet to use.
+ */
+export interface GradedGroupHandle {
+    getInputPaths(): ReadonlyArray<FocusPath>;
+    getPromptJSON(): GradedGroupPromptJSON;
+    focus(): boolean;
+    focusInputPath(path: FocusPath): void;
+    blurInputPath(path: FocusPath): void;
+}
+
 // A Graded Group is more or less a Group widget that displays a check
 // answer button below the rendered content. When clicked, the widget grades
 // the stuff inside and displays feedback about whether the inputted answer was
 // correct or not.
-export const GradedGroup = forwardRef<Widget, Props>(
+export const GradedGroup = forwardRef<GradedGroupHandle, Props>(
     function GradedGroup(props, ref) {
         const {strings} = usePerseusI18n();
         const dependencies = useDependencies();
@@ -128,11 +138,11 @@ export const GradedGroup = forwardRef<Widget, Props>(
                 return !!rendererRef.current?.focus();
             },
 
-            focusInputPath(path: any): void {
+            focusInputPath(path: FocusPath): void {
                 rendererRef.current?.focusPath(path);
             },
 
-            blurInputPath(path: any): void {
+            blurInputPath(path: FocusPath): void {
                 rendererRef.current?.blurPath(path);
             },
         }));


### PR DESCRIPTION
## Summary:
This lets us get rid of a `withDependencies` HOC usage and clean up some other
legacy cruft.

Issue: none

## Test plan:

Review the Graded Group Set stories in Storybook.