### PR TITLE
[FITB] Add the new Fill in the Blank widget's schema and logic to perseus-core

### DIFF
--- a/.changeset/some-cloths-grow.md
+++ b/.changeset/some-cloths-grow.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-core": minor
+"@khanacademy/perseus": minor
+---
+
+Add the new Fill in the Blank widget's schema and logic to perseus-core

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -150,6 +150,7 @@ export interface PerseusWidgetTypes {
     dropdown: DropdownWidget;
     explanation: ExplanationWidget;
     expression: ExpressionWidget;
+    "fill-in-the-blank": FillInTheBlankWidget;
     "free-response": FreeResponseWidget;
     grapher: GrapherWidget;
     "graded-group-set": GradedGroupSetWidget;
@@ -465,6 +466,8 @@ export type ExplanationWidget = WidgetOptions<'explanation', PerseusExplanationW
 // prettier-ignore
 export type ExpressionWidget = WidgetOptions<'expression', PerseusExpressionWidgetOptions>;
 // prettier-ignore
+export type FillInTheBlankWidget = WidgetOptions<'fill-in-the-blank', PerseusFillInTheBlankWidgetOptions>;
+// prettier-ignore
 export type FreeResponseWidget = WidgetOptions<'free-response', PerseusFreeResponseWidgetOptions>;
 // prettier-ignore
 export type GradedGroupSetWidget = WidgetOptions<'graded-group-set', PerseusGradedGroupSetWidgetOptions>;
@@ -552,6 +555,60 @@ export type PerseusBlankWidgetOptions = {
     displayType: "normal" | "superscript" | "subscript";
     /** ID for the correct answer tile for the blank */
     correctId: string;
+};
+
+/**
+ * How many times each tile in a choice bank may be used. "single" removes a
+ * tile from the bank once placed; "multi" leaves it, capped by
+ * `maxUsesPerTile`. Applies to the whole bank — the two cannot be mixed.
+ */
+export type PerseusAnswerTileUsage = "single" | "multi";
+
+/**
+ * A draggable tile in a "Drag And Drop" widget's choice bank, shared across
+ * the widget family.
+ *
+ * Presentation only: each widget expresses correctness differently, so one
+ * needing extra data should intersect this type locally rather than widen it.
+ * Any field added here must be optional.
+ */
+export type PerseusAnswerTile = {
+    /** Identifies the tile. */
+    id: string;
+    /**
+     * Translatable Markdown; what this tile displays. Blank renders an empty
+     * tile, which is announced using `label`.
+     */
+    content: string;
+    /** Translatable text; the tile's value as plain text, for screen readers */
+    label: string;
+    /** Display height in px for an image tile. The editor offers 24, 36,
+     *  48, 60, 72, 84 and 96 */
+    imageHeight?: number;
+};
+
+/**
+ * Options for the fill-in-the-blank widget. Presents content with inline
+ * blanks above a choice bank of answer tiles.
+ */
+export type PerseusFillInTheBlankWidgetOptions = {
+    /** Translatable Markdown; the content. Translators may move the
+     *  `[[☃ blank n]]` markers within it */
+    content: string;
+    /** The widgets embedded in `content`, keyed by marker id. Blanks today */
+    widgets: PerseusWidgetsMap;
+    // No `images` map, unlike group and graded-group: tile images are
+    // markdown sized by `imageHeight`, not by the renderer's image map.
+    /** The choice bank the learner draws answer tiles from */
+    tiles: PerseusAnswerTile[];
+    /** See PerseusAnswerTileUsage */
+    tileUsage: PerseusAnswerTileUsage;
+    /** Caps uses of each tile when multi-use; omitted means unlimited */
+    maxUsesPerTile?: number;
+    /**
+     * Randomize the order of the answer tiles or keep them as defined.
+     */
+    randomize: boolean;
 };
 
 /** Options for the categorizer widget. Presents items to sort into groups. */
@@ -2277,6 +2334,7 @@ export type PerseusWidgetOptions =
     | PerseusDropdownWidgetOptions
     | PerseusExplanationWidgetOptions
     | PerseusExpressionWidgetOptions
+    | PerseusFillInTheBlankWidgetOptions
     | PerseusFreeResponseWidgetOptions
     | PerseusGradedGroupSetWidgetOptions
     | PerseusGradedGroupWidgetOptions

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -558,13 +558,6 @@ export type PerseusBlankWidgetOptions = {
 };
 
 /**
- * How many times each tile in a choice bank may be used. "single" removes a
- * tile from the bank once placed; "multi" leaves it, capped by
- * `maxUsesPerTile`. Applies to the whole bank — the two cannot be mixed.
- */
-export type PerseusAnswerTileUsage = "single" | "multi";
-
-/**
  * A draggable tile in a "Drag And Drop" widget's choice bank, shared across
  * the widget family.
  *
@@ -573,7 +566,11 @@ export type PerseusAnswerTileUsage = "single" | "multi";
  * Any field added here must be optional.
  */
 export type PerseusAnswerTile = {
-    /** Identifies the tile. */
+    /**
+     * Identifies the tile within its own widget's choice bank: a blank's
+     * `correctId` and the learner's placements both name a tile this way.
+     * Uniqueness is scoped to the one widget.
+     */
     id: string;
     /**
      * Translatable Markdown; what this tile displays. Blank renders an empty
@@ -582,8 +579,7 @@ export type PerseusAnswerTile = {
     content: string;
     /** Translatable text; the tile's value as plain text, for screen readers */
     label: string;
-    /** Display height in px for an image tile. The editor offers 24, 36,
-     *  48, 60, 72, 84 and 96 */
+    /** Display height in px for an image tile. */
     imageHeight?: number;
 };
 
@@ -593,18 +589,16 @@ export type PerseusAnswerTile = {
  */
 export type PerseusFillInTheBlankWidgetOptions = {
     /** Translatable Markdown; the content. Translators may move the
-     *  `[[☃ blank n]]` markers within it */
+     *  `[[☃ blank n]]` widget placeholders within it */
     content: string;
-    /** The widgets embedded in `content`, keyed by marker id. Blanks today */
+    /** The widgets embedded in `content`, keyed by widget id. */
     widgets: PerseusWidgetsMap;
-    // No `images` map, unlike group and graded-group: tile images are
-    // markdown sized by `imageHeight`, not by the renderer's image map.
     /** The choice bank the learner draws answer tiles from */
     tiles: PerseusAnswerTile[];
-    /** See PerseusAnswerTileUsage */
-    tileUsage: PerseusAnswerTileUsage;
-    /** Caps uses of each tile when multi-use; omitted means unlimited */
-    maxUsesPerTile?: number;
+    /**
+     * How many times each tile may be placed, for the whole choice bank.
+     */
+    maxUsesPerTile: number | "unlimited";
     /**
      * Randomize the order of the answer tiles or keep them as defined.
      */

--- a/packages/perseus-core/src/index.ts
+++ b/packages/perseus-core/src/index.ts
@@ -97,6 +97,8 @@ export {default as expressionLogic} from "./widgets/expression";
 /** @hidden */
 export {default as deriveExtraKeys} from "./widgets/expression/derive-extra-keys";
 /** @hidden */
+export {default as fillInTheBlankLogic} from "./widgets/fill-in-the-blank";
+/** @hidden */
 export {default as gradedGroupLogic} from "./widgets/graded-group";
 /** @hidden */
 export {default as freeResponseLogic} from "./widgets/free-response";
@@ -304,6 +306,12 @@ export {
     generateExpressionAnswerForm,
     generateExpressionWidget,
 } from "./utils/generators/expression-widget-generator";
+/** @hidden */
+export {
+    generateAnswerTile,
+    generateFillInTheBlankOptions,
+    generateFillInTheBlankWidget,
+} from "./utils/generators/fill-in-the-blank-widget-generator";
 /** @hidden */
 export {
     generateFreeResponseOptions,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/answer-tile.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/answer-tile.ts
@@ -1,0 +1,16 @@
+import {number, object, optional, string} from "../general-purpose-parsers";
+
+const answerTileSchema = {
+    id: string,
+    content: string,
+    label: string,
+    imageHeight: optional(number),
+};
+
+/**
+ * Parses one tile in a Drag And Drop widget's choice bank.
+ *
+ * Shared, like `PerseusAnswerTile`. A widget that adds a field of its own
+ * should export the schema above and spread it, rather than restate these.
+ */
+export const parseAnswerTile = object(answerTileSchema);

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/answer-tile.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/answer-tile.ts
@@ -1,5 +1,7 @@
 import {number, object, optional, string} from "../general-purpose-parsers";
 
+// NOTE: A widget whose tiles carry a field of their own should export
+// this schema and spread it, rather than restate these fields.
 const answerTileSchema = {
     id: string,
     content: string,
@@ -8,9 +10,7 @@ const answerTileSchema = {
 };
 
 /**
- * Parses one tile in a Drag And Drop widget's choice bank.
- *
- * Shared, like `PerseusAnswerTile`. A widget that adds a field of its own
- * should export the schema above and spread it, rather than restate these.
+ * Parses one tile in a Drag And Drop widget's choice bank. Shared across the
+ * widget family, like `PerseusAnswerTile`.
  */
 export const parseAnswerTile = object(answerTileSchema);

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/fill-in-the-blank-widget.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/fill-in-the-blank-widget.test.ts
@@ -1,0 +1,170 @@
+// `import/no-restricted-paths` keeps the parsers self-contained: they may not
+// import from the rest of perseus-core. Tests can override that restriction,
+// while main files cannot — hence the disables on the imports below.
+import {
+    generateAnswerTile,
+    generateFillInTheBlankOptions,
+    generateFillInTheBlankWidget,
+    // eslint-disable-next-line import/no-restricted-paths
+} from "../../utils/generators/fill-in-the-blank-widget-generator";
+// eslint-disable-next-line import/no-restricted-paths
+import fillInTheBlankWidgetLogic from "../../widgets/fill-in-the-blank";
+import {parse} from "../parse";
+import {failure, success} from "../result";
+
+import {parseFillInTheBlankWidget} from "./fill-in-the-blank-widget";
+
+describe("fillInTheBlankWidget", () => {
+    it("accepts a fill-in-the-blank widget with valid data", () => {
+        const widget = generateFillInTheBlankWidget({
+            options: generateFillInTheBlankOptions({
+                content: "The [[☃ blank 1]] drum is a tall drum.",
+                widgets: {
+                    "blank 1": {
+                        type: "blank",
+                        version: {major: 0, minor: 0},
+                        options: {
+                            displayType: "normal",
+                            correctId: "tile-1",
+                        },
+                    },
+                },
+                tiles: [
+                    generateAnswerTile({
+                        id: "tile-1",
+                        content: "djembe",
+                        label: "djembe",
+                    }),
+                    generateAnswerTile({
+                        id: "tile-2",
+                        content: "bongo",
+                        label: "bongo",
+                    }),
+                ],
+                maxUsesPerTile: 1,
+                randomize: false,
+            }),
+        });
+
+        expect(parse(widget, parseFillInTheBlankWidget)).toEqual(
+            success(widget),
+        );
+    });
+
+    it("accepts the widget's own default options", () => {
+        const widget = generateFillInTheBlankWidget({
+            options: fillInTheBlankWidgetLogic.defaultWidgetOptions,
+        });
+
+        expect(parse(widget, parseFillInTheBlankWidget)).toEqual(
+            success(widget),
+        );
+    });
+
+    it("accepts a multi-use choice bank with a per-tile cap", () => {
+        const widget = generateFillInTheBlankWidget({
+            options: generateFillInTheBlankOptions({maxUsesPerTile: 3}),
+        });
+
+        expect(parse(widget, parseFillInTheBlankWidget)).toEqual(
+            success(widget),
+        );
+    });
+
+    it("accepts an uncapped multi-use choice bank", () => {
+        const widget = generateFillInTheBlankWidget({
+            options: generateFillInTheBlankOptions({
+                maxUsesPerTile: "unlimited",
+            }),
+        });
+
+        expect(parse(widget, parseFillInTheBlankWidget)).toEqual(
+            success(widget),
+        );
+    });
+
+    it("accepts a tile with an image height", () => {
+        const widget = generateFillInTheBlankWidget({
+            options: generateFillInTheBlankOptions({
+                tiles: [generateAnswerTile({imageHeight: 72})],
+            }),
+        });
+
+        expect(parse(widget, parseFillInTheBlankWidget)).toEqual(
+            success(widget),
+        );
+    });
+
+    // Every field is required, with no `defaulted` fallback: this widget is
+    // new enough to have no legacy content, and a field lost in a bad write
+    // should fail loudly rather than parse to a silently valid item.
+    it.each([
+        ["content", "expected string"],
+        ["widgets", "expected PerseusWidgetsMap"],
+        ["tiles", "expected array"],
+        ["maxUsesPerTile", 'expected a positive number, or "unlimited"'],
+        ["randomize", "expected boolean"],
+    ])("rejects a widget with no %s", (field: string, expected: string) => {
+        const widget = generateFillInTheBlankWidget({
+            options: generateFillInTheBlankOptions({[field]: undefined}),
+        });
+
+        expect(parse(widget, parseFillInTheBlankWidget)).toEqual(
+            failure(
+                expect.stringContaining(
+                    `At (root).options.${field} -- ${expected}, but got undefined`,
+                ),
+            ),
+        );
+    });
+
+    it("rejects a tile with no label", () => {
+        const widget = generateFillInTheBlankWidget({
+            options: generateFillInTheBlankOptions({
+                tiles: [generateAnswerTile({label: undefined})],
+            }),
+        });
+
+        expect(parse(widget, parseFillInTheBlankWidget)).toEqual(
+            failure(
+                expect.stringContaining(
+                    "At (root).options.tiles[0].label -- expected string, but got undefined",
+                ),
+            ),
+        );
+    });
+
+    it.each([0, -3, 1.5])(
+        "rejects maxUsesPerTile of %p",
+        (maxUsesPerTile: number) => {
+            const widget = generateFillInTheBlankWidget({
+                options: generateFillInTheBlankOptions({maxUsesPerTile}),
+            });
+
+            expect(parse(widget, parseFillInTheBlankWidget)).toEqual(
+                failure(
+                    expect.stringContaining(
+                        `At (root).options.maxUsesPerTile -- expected a positive number, or "unlimited"`,
+                    ),
+                ),
+            );
+        },
+    );
+
+    it("rejects an unrecognized maxUsesPerTile sigil", () => {
+        const widget = generateFillInTheBlankWidget({
+            options: generateFillInTheBlankOptions({
+                // @ts-expect-error: the point of the test is the invalid value
+                maxUsesPerTile: "infinite",
+            }),
+        });
+
+        expect(parse(widget, parseFillInTheBlankWidget)).toEqual(
+            failure(
+                expect.stringContaining(
+                    `At (root).options.maxUsesPerTile -- expected a positive number, or "unlimited"`,
+                ),
+            ),
+        );
+    });
+});

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/fill-in-the-blank-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/fill-in-the-blank-widget.ts
@@ -1,0 +1,36 @@
+import {
+    array,
+    boolean,
+    constant,
+    defaulted,
+    enumeration,
+    number,
+    object,
+    optional,
+    string,
+} from "../general-purpose-parsers";
+
+import {parseAnswerTile} from "./answer-tile";
+import {parseWidget} from "./widget";
+import {parseWidgetsMap} from "./widgets-map";
+
+export const parseFillInTheBlankWidget = parseWidget(
+    constant("fill-in-the-blank"),
+    // Not parsePerseusRenderer: these options add the choice bank, and
+    // `object` drops whatever its schema omits.
+    object({
+        content: defaulted(string, () => ""),
+        // Import cycle with parseWidgetsMap; the wrapper defers reading it.
+        widgets: defaulted(
+            (rawVal, ctx) => parseWidgetsMap(rawVal, ctx),
+            () => ({}),
+        ),
+        tiles: defaulted(array(parseAnswerTile), () => []),
+        tileUsage: defaulted(
+            enumeration("single", "multi"),
+            () => "single" as const,
+        ),
+        maxUsesPerTile: optional(number),
+        randomize: defaulted(boolean, () => false),
+    }),
+);

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/fill-in-the-blank-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/fill-in-the-blank-widget.ts
@@ -2,11 +2,7 @@ import {
     array,
     boolean,
     constant,
-    defaulted,
-    enumeration,
-    number,
     object,
-    optional,
     string,
 } from "../general-purpose-parsers";
 
@@ -14,23 +10,32 @@ import {parseAnswerTile} from "./answer-tile";
 import {parseWidget} from "./widget";
 import {parseWidgetsMap} from "./widgets-map";
 
+import type {Parser} from "../parser-types";
+
+/**
+ * How many blanks one tile may fill: a positive number, or "unlimited".
+ */
+const usesPerTile: Parser<number | "unlimited"> = (rawValue, ctx) => {
+    if (rawValue === "unlimited") {
+        return ctx.success(rawValue);
+    }
+    if (
+        typeof rawValue === "number" &&
+        Number.isInteger(rawValue) &&
+        rawValue >= 1
+    ) {
+        return ctx.success(rawValue);
+    }
+    return ctx.failure('a positive number, or "unlimited"', rawValue);
+};
+
 export const parseFillInTheBlankWidget = parseWidget(
     constant("fill-in-the-blank"),
-    // Not parsePerseusRenderer: these options add the choice bank, and
-    // `object` drops whatever its schema omits.
     object({
-        content: defaulted(string, () => ""),
-        // Import cycle with parseWidgetsMap; the wrapper defers reading it.
-        widgets: defaulted(
-            (rawVal, ctx) => parseWidgetsMap(rawVal, ctx),
-            () => ({}),
-        ),
-        tiles: defaulted(array(parseAnswerTile), () => []),
-        tileUsage: defaulted(
-            enumeration("single", "multi"),
-            () => "single" as const,
-        ),
-        maxUsesPerTile: optional(number),
-        randomize: defaulted(boolean, () => false),
+        content: string,
+        widgets: (rawVal, ctx) => parseWidgetsMap(rawVal, ctx),
+        tiles: array(parseAnswerTile),
+        maxUsesPerTile: usesPerTile,
+        randomize: boolean,
     }),
 );

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/fill-in-the-blank-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/fill-in-the-blank-widget.typetest.ts
@@ -1,0 +1,16 @@
+import {describe, it, expect} from "tstyche";
+
+import {ctx} from "../general-purpose-parsers/test-helpers";
+
+import {parseFillInTheBlankWidget} from "./fill-in-the-blank-widget";
+
+import type {FillInTheBlankWidget} from "../../data-schema";
+import type {ParseResult} from "../parser-types";
+
+describe("the FillInTheBlankWidget parser", () => {
+    it("should return the widget type defined in data-schema.ts", () => {
+        expect(parseFillInTheBlankWidget({}, ctx())).type.toBe<
+            ParseResult<FillInTheBlankWidget>
+        >();
+    });
+});

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -7,6 +7,9 @@ import {
 // Tests are fine to import, main files aren't
 // eslint-disable-next-line import/no-restricted-paths
 import {generateVideoWidget} from "../../utils/generators/video-widget-generator";
+// Tests are fine to import, main files aren't
+// eslint-disable-next-line import/no-restricted-paths
+import fillInTheBlankWidgetLogic from "../../widgets/fill-in-the-blank";
 import {anyFailure} from "../general-purpose-parsers/test-helpers";
 import {parse} from "../parse";
 import {failure, success} from "../result";
@@ -103,6 +106,110 @@ describe("parseWidgetsMap", () => {
         const result = parse(widgetsMap, parseWidgetsMap);
 
         expect(result).toEqual(success(widgetsMap));
+    });
+
+    it("accepts a fill-in-the-blank widget", () => {
+        const widgetsMap: unknown = {
+            "fill-in-the-blank 1": {
+                type: "fill-in-the-blank",
+                version: {major: 0, minor: 0},
+                options: {
+                    content: "The [[☃ blank 1]] drum is a tall drum.",
+                    widgets: {
+                        "blank 1": {
+                            type: "blank",
+                            version: {major: 0, minor: 0},
+                            options: {
+                                displayType: "normal",
+                                correctId: "tile-1",
+                            },
+                        },
+                    },
+                    tiles: [
+                        {id: "tile-1", content: "djembe", label: "djembe"},
+                        {id: "tile-2", content: "bongo", label: "bongo"},
+                    ],
+                    tileUsage: "single",
+                    randomize: false,
+                },
+            },
+        };
+
+        const result = parse(widgetsMap, parseWidgetsMap);
+
+        expect(result).toEqual(success(widgetsMap));
+    });
+
+    it("defaults the fill-in-the-blank fields that older content lacks", () => {
+        const widgetsMap: unknown = {
+            "fill-in-the-blank 1": {
+                type: "fill-in-the-blank",
+                version: {major: 0, minor: 0},
+                options: {content: "Nothing to fill in yet."},
+            },
+        };
+
+        const result = parse(widgetsMap, parseWidgetsMap);
+
+        expect(result).toEqual(
+            success({
+                "fill-in-the-blank 1": {
+                    type: "fill-in-the-blank",
+                    version: {major: 0, minor: 0},
+                    options: {
+                        content: "Nothing to fill in yet.",
+                        widgets: {},
+                        tiles: [],
+                        tileUsage: "single",
+                        randomize: false,
+                    },
+                },
+            }),
+        );
+    });
+
+    it("parses empty fill-in-the-blank options to the widget's own defaults", () => {
+        // Pins the parser's `defaulted` fallbacks to defaultWidgetOptions.
+        // They are two independent copies of the same values, and nothing
+        // else would fail if one of them changed.
+        const widgetsMap: unknown = {
+            "fill-in-the-blank 1": {
+                type: "fill-in-the-blank",
+                version: {major: 0, minor: 0},
+                options: {},
+            },
+        };
+
+        const result = parse(widgetsMap, parseWidgetsMap);
+
+        expect(result).toEqual(
+            success({
+                "fill-in-the-blank 1": {
+                    type: "fill-in-the-blank",
+                    version: {major: 0, minor: 0},
+                    options: fillInTheBlankWidgetLogic.defaultWidgetOptions,
+                },
+            }),
+        );
+    });
+
+    it("rejects a fill-in-the-blank tile with no label", () => {
+        // Proves the widget reaches its own parser rather than the fallback
+        // that accepts any options for an unrecognized widget type.
+        const widgetsMap: unknown = {
+            "fill-in-the-blank 1": {
+                type: "fill-in-the-blank",
+                version: {major: 0, minor: 0},
+                options: {
+                    content: "",
+                    tiles: [{id: "tile-1", content: "djembe"}],
+                },
+            },
+        };
+
+        const result = parse(widgetsMap, parseWidgetsMap);
+
+        expect(result).toEqual(anyFailure);
     });
 
     it("accepts a categorizer widget", () => {

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -1,22 +1,19 @@
+// `import/no-restricted-paths` keeps the parsers self-contained: they may not
+// import from the rest of perseus-core. Tests can override that restriction,
+// while main files cannot — hence the disables on the imports below.
 import {
     generateDefinitionOptions,
     generateDefinitionWidget,
-    // Tests are fine to import, main files aren't
     // eslint-disable-next-line import/no-restricted-paths
 } from "../../utils/generators/definition-widget-generator";
-// Tests are fine to import, main files aren't
 // eslint-disable-next-line import/no-restricted-paths
 import {generateVideoWidget} from "../../utils/generators/video-widget-generator";
-// Tests are fine to import, main files aren't
-// eslint-disable-next-line import/no-restricted-paths
-import fillInTheBlankWidgetLogic from "../../widgets/fill-in-the-blank";
 import {anyFailure} from "../general-purpose-parsers/test-helpers";
 import {parse} from "../parse";
 import {failure, success} from "../result";
 
 import {parseWidgetsMap} from "./widgets-map";
 
-// Tests are fine to import, main files aren't
 // eslint-disable-next-line import/no-restricted-paths
 import type {PerseusWidgetsMap} from "../../data-schema";
 
@@ -125,11 +122,8 @@ describe("parseWidgetsMap", () => {
                             },
                         },
                     },
-                    tiles: [
-                        {id: "tile-1", content: "djembe", label: "djembe"},
-                        {id: "tile-2", content: "bongo", label: "bongo"},
-                    ],
-                    tileUsage: "single",
+                    tiles: [{id: "tile-1", content: "djembe", label: "djembe"}],
+                    maxUsesPerTile: 1,
                     randomize: false,
                 },
             },
@@ -140,69 +134,18 @@ describe("parseWidgetsMap", () => {
         expect(result).toEqual(success(widgetsMap));
     });
 
-    it("defaults the fill-in-the-blank fields that older content lacks", () => {
-        const widgetsMap: unknown = {
-            "fill-in-the-blank 1": {
-                type: "fill-in-the-blank",
-                version: {major: 0, minor: 0},
-                options: {content: "Nothing to fill in yet."},
-            },
-        };
-
-        const result = parse(widgetsMap, parseWidgetsMap);
-
-        expect(result).toEqual(
-            success({
-                "fill-in-the-blank 1": {
-                    type: "fill-in-the-blank",
-                    version: {major: 0, minor: 0},
-                    options: {
-                        content: "Nothing to fill in yet.",
-                        widgets: {},
-                        tiles: [],
-                        tileUsage: "single",
-                        randomize: false,
-                    },
-                },
-            }),
-        );
-    });
-
-    it("parses empty fill-in-the-blank options to the widget's own defaults", () => {
-        // Pins the parser's `defaulted` fallbacks to defaultWidgetOptions.
-        // They are two independent copies of the same values, and nothing
-        // else would fail if one of them changed.
-        const widgetsMap: unknown = {
-            "fill-in-the-blank 1": {
-                type: "fill-in-the-blank",
-                version: {major: 0, minor: 0},
-                options: {},
-            },
-        };
-
-        const result = parse(widgetsMap, parseWidgetsMap);
-
-        expect(result).toEqual(
-            success({
-                "fill-in-the-blank 1": {
-                    type: "fill-in-the-blank",
-                    version: {major: 0, minor: 0},
-                    options: fillInTheBlankWidgetLogic.defaultWidgetOptions,
-                },
-            }),
-        );
-    });
-
-    it("rejects a fill-in-the-blank tile with no label", () => {
-        // Proves the widget reaches its own parser rather than the fallback
-        // that accepts any options for an unrecognized widget type.
+    it("routes a fill-in-the-blank widget to its own parser", () => {
         const widgetsMap: unknown = {
             "fill-in-the-blank 1": {
                 type: "fill-in-the-blank",
                 version: {major: 0, minor: 0},
                 options: {
-                    content: "",
+                    content: "The [[☃ blank 1]] drum is a tall drum.",
+                    widgets: {},
+                    // The missing `label` is the only defect.
                     tiles: [{id: "tile-1", content: "djembe"}],
+                    maxUsesPerTile: 1,
+                    randomize: false,
                 },
             },
         };

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widgets-map.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widgets-map.ts
@@ -13,6 +13,7 @@ import {parseDefinitionWidget} from "./definition-widget";
 import {parseDropdownWidget} from "./dropdown-widget";
 import {parseExplanationWidget} from "./explanation-widget";
 import {parseExpressionWidget} from "./expression-widget";
+import {parseFillInTheBlankWidget} from "./fill-in-the-blank-widget";
 import {parseFreeResponseWidget} from "./free-response-widget";
 import {parseGradedGroupSetWidget} from "./graded-group-set-widget";
 import {parseGradedGroupWidget} from "./graded-group-widget";
@@ -112,6 +113,11 @@ const parseWidgetsMapEntry: (
             return parseAndAssign(`explanation ${n}`, parseExplanationWidget);
         case "expression":
             return parseAndAssign(`expression ${n}`, parseExpressionWidget);
+        case "fill-in-the-blank":
+            return parseAndAssign(
+                `fill-in-the-blank ${n}`,
+                parseFillInTheBlankWidget,
+            );
         case "free-response":
             return parseAndAssign(
                 `free-response ${n}`,

--- a/packages/perseus-core/src/traversal.test.ts
+++ b/packages/perseus-core/src/traversal.test.ts
@@ -1,4 +1,10 @@
 import {traverse} from "./traversal";
+import {generateBlankWidget} from "./utils/generators/blank-widget-generator";
+import {
+    generateAnswerTile,
+    generateFillInTheBlankOptions,
+    generateFillInTheBlankWidget,
+} from "./utils/generators/fill-in-the-blank-widget-generator";
 import {registerCoreWidgets} from "./widgets/core-widget-registry";
 
 import type {PerseusRenderer} from "./data-schema";
@@ -119,11 +125,42 @@ const sampleGroup: PerseusRenderer = {
 
 const clonedSampleGroup = JSON.parse(JSON.stringify(sampleGroup));
 
+const sampleFillInTheBlank: PerseusRenderer = {
+    content: "[[☃ fill-in-the-blank 1]]\n\n",
+    images: {},
+    widgets: {
+        "fill-in-the-blank 1": generateFillInTheBlankWidget({
+            options: generateFillInTheBlankOptions({
+                content: "The [[☃ blank 1]] drum is a tall drum.",
+                widgets: {
+                    "blank 1": generateBlankWidget({
+                        options: {displayType: "normal", correctId: "tile-1"},
+                    }),
+                },
+                tiles: [
+                    generateAnswerTile({
+                        id: "tile-1",
+                        content: "djembe",
+                        label: "djembe",
+                    }),
+                ],
+                maxUsesPerTile: 3,
+                randomize: true,
+            }),
+        }),
+    },
+};
+
+const clonedSampleFillInTheBlank = JSON.parse(
+    JSON.stringify(sampleFillInTheBlank),
+);
+
 const assertNonMutative = () => {
     expect(missingOptions).toEqual(clonedMissingOptions);
     expect(sampleOptions).toEqual(clonedSampleOptions);
     expect(sampleOptions2).toEqual(clonedSampleOptions2);
     expect(sampleGroup).toEqual(clonedSampleGroup);
+    expect(sampleFillInTheBlank).toEqual(clonedSampleFillInTheBlank);
 };
 
 describe("Traversal", () => {
@@ -204,6 +241,44 @@ describe("Traversal", () => {
             group: 1,
             radio: 1,
         });
+        assertNonMutative();
+    });
+
+    it("visits the blank widgets nested inside a fill-in-the-blank", () => {
+        const widgetMap: Record<string, any> = {};
+
+        traverse(sampleFillInTheBlank, null, (widgetInfo) => {
+            widgetMap[widgetInfo.type] = (widgetMap[widgetInfo.type] || 0) + 1;
+        });
+
+        expect(widgetMap).toEqual({
+            "fill-in-the-blank": 1,
+            blank: 1,
+        });
+        assertNonMutative();
+    });
+
+    it("modifies the content inside a fill-in-the-blank", () => {
+        const newOptions = traverse(sampleFillInTheBlank, (content) =>
+            content.replace("tall", "short"),
+        );
+
+        expect(newOptions.widgets["fill-in-the-blank 1"].options.content).toBe(
+            "The [[☃ blank 1]] drum is a short drum.",
+        );
+        assertNonMutative();
+    });
+
+    it("preserves a fill-in-the-blank's non-renderer options", () => {
+        const newOptions = traverse(sampleFillInTheBlank, (content) => content);
+
+        expect(newOptions.widgets["fill-in-the-blank 1"].options).toMatchObject(
+            {
+                tiles: [{id: "tile-1", content: "djembe", label: "djembe"}],
+                maxUsesPerTile: 3,
+                randomize: true,
+            },
+        );
         assertNonMutative();
     });
 

--- a/packages/perseus-core/src/utils/generators/fill-in-the-blank-widget-generator.test.ts
+++ b/packages/perseus-core/src/utils/generators/fill-in-the-blank-widget-generator.test.ts
@@ -1,0 +1,134 @@
+import {generateBlankWidget} from "./blank-widget-generator";
+import {
+    generateAnswerTile,
+    generateFillInTheBlankOptions,
+    generateFillInTheBlankWidget,
+} from "./fill-in-the-blank-widget-generator";
+
+describe("generateAnswerTile", () => {
+    it("builds a default answer tile", () => {
+        // Arrange, Act
+        const tile = generateAnswerTile();
+
+        // Assert
+        expect(tile).toEqual({
+            id: "answer-tile-1",
+            content: "answer",
+            label: "answer",
+        });
+    });
+
+    it("builds an answer tile with all props", () => {
+        // Arrange, Act
+        const tile = generateAnswerTile({
+            id: "tile-2",
+            content: "![a pile of coins](https://example.com/coins.png)",
+            label: "a pile of coins",
+            imageHeight: 48,
+        });
+
+        // Assert
+        expect(tile).toEqual({
+            id: "tile-2",
+            content: "![a pile of coins](https://example.com/coins.png)",
+            label: "a pile of coins",
+            imageHeight: 48,
+        });
+    });
+
+    it("omits imageHeight when it is not given", () => {
+        // Arrange, Act
+        const tile = generateAnswerTile({id: "tile-3"});
+
+        // Assert
+        expect(tile).not.toHaveProperty("imageHeight");
+    });
+});
+
+describe("generateFillInTheBlankOptions", () => {
+    it("builds a default fill-in-the-blank options object", () => {
+        // Arrange, Act
+        const options = generateFillInTheBlankOptions();
+
+        // Assert
+        expect(options).toEqual({
+            content: "",
+            widgets: {},
+            tiles: [],
+            tileUsage: "single",
+            randomize: false,
+        });
+    });
+
+    it("builds a fill-in-the-blank options object with all props", () => {
+        // Arrange, Act
+        const options = generateFillInTheBlankOptions({
+            content: "The [[☃ blank 1]] drum is a tall drum.",
+            widgets: {"blank 1": generateBlankWidget()},
+            tiles: [generateAnswerTile({id: "tile-1", content: "djembe"})],
+            tileUsage: "multi",
+            maxUsesPerTile: 3,
+            randomize: true,
+        });
+
+        // Assert
+        expect(options.content).toBe("The [[☃ blank 1]] drum is a tall drum.");
+        expect(options.widgets).toHaveProperty("blank 1");
+        expect(options.tiles).toHaveLength(1);
+        expect(options.tileUsage).toBe("multi");
+        expect(options.maxUsesPerTile).toBe(3);
+        expect(options.randomize).toBe(true);
+    });
+});
+
+describe("generateFillInTheBlankWidget", () => {
+    it("builds a default fill-in-the-blank widget", () => {
+        // Arrange, Act
+        const widget = generateFillInTheBlankWidget();
+
+        // Assert
+        expect(widget.type).toBe("fill-in-the-blank");
+        expect(widget.graded).toBe(true);
+        expect(widget.static).toBe(false);
+        expect(widget.version).toEqual({major: 0, minor: 0});
+        expect(widget.alignment).toBe("default");
+        expect(widget.options).toEqual({
+            content: "",
+            widgets: {},
+            tiles: [],
+            tileUsage: "single",
+            randomize: false,
+        });
+    });
+
+    it("builds a fill-in-the-blank widget with all props", () => {
+        // Arrange, Act
+        const widget = generateFillInTheBlankWidget({
+            graded: false,
+            version: {major: 1, minor: 0},
+            static: true,
+            alignment: "block",
+            options: generateFillInTheBlankOptions({
+                tiles: [
+                    generateAnswerTile({
+                        id: "tile-1",
+                        content: "djembe",
+                        label: "djembe",
+                    }),
+                ],
+                tileUsage: "multi",
+            }),
+        });
+
+        // Assert
+        expect(widget.type).toBe("fill-in-the-blank");
+        expect(widget.graded).toBe(false);
+        expect(widget.version).toEqual({major: 1, minor: 0});
+        expect(widget.static).toBe(true);
+        expect(widget.alignment).toBe("block");
+        expect(widget.options.tiles).toEqual([
+            {id: "tile-1", content: "djembe", label: "djembe"},
+        ]);
+        expect(widget.options.tileUsage).toBe("multi");
+    });
+});

--- a/packages/perseus-core/src/utils/generators/fill-in-the-blank-widget-generator.test.ts
+++ b/packages/perseus-core/src/utils/generators/fill-in-the-blank-widget-generator.test.ts
@@ -55,7 +55,7 @@ describe("generateFillInTheBlankOptions", () => {
             content: "",
             widgets: {},
             tiles: [],
-            tileUsage: "single",
+            maxUsesPerTile: 1,
             randomize: false,
         });
     });
@@ -66,7 +66,6 @@ describe("generateFillInTheBlankOptions", () => {
             content: "The [[☃ blank 1]] drum is a tall drum.",
             widgets: {"blank 1": generateBlankWidget()},
             tiles: [generateAnswerTile({id: "tile-1", content: "djembe"})],
-            tileUsage: "multi",
             maxUsesPerTile: 3,
             randomize: true,
         });
@@ -75,7 +74,6 @@ describe("generateFillInTheBlankOptions", () => {
         expect(options.content).toBe("The [[☃ blank 1]] drum is a tall drum.");
         expect(options.widgets).toHaveProperty("blank 1");
         expect(options.tiles).toHaveLength(1);
-        expect(options.tileUsage).toBe("multi");
         expect(options.maxUsesPerTile).toBe(3);
         expect(options.randomize).toBe(true);
     });
@@ -96,7 +94,7 @@ describe("generateFillInTheBlankWidget", () => {
             content: "",
             widgets: {},
             tiles: [],
-            tileUsage: "single",
+            maxUsesPerTile: 1,
             randomize: false,
         });
     });
@@ -116,7 +114,7 @@ describe("generateFillInTheBlankWidget", () => {
                         label: "djembe",
                     }),
                 ],
-                tileUsage: "multi",
+                maxUsesPerTile: "unlimited",
             }),
         });
 
@@ -129,6 +127,6 @@ describe("generateFillInTheBlankWidget", () => {
         expect(widget.options.tiles).toEqual([
             {id: "tile-1", content: "djembe", label: "djembe"},
         ]);
-        expect(widget.options.tileUsage).toBe("multi");
+        expect(widget.options.maxUsesPerTile).toBe("unlimited");
     });
 });

--- a/packages/perseus-core/src/utils/generators/fill-in-the-blank-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/fill-in-the-blank-widget-generator.ts
@@ -1,0 +1,51 @@
+import fillInTheBlankWidgetLogic from "../../widgets/fill-in-the-blank";
+
+import type {
+    FillInTheBlankWidget,
+    PerseusAnswerTile,
+    PerseusFillInTheBlankWidgetOptions,
+} from "../../data-schema";
+
+export function generateAnswerTile(
+    tile?: Partial<PerseusAnswerTile>,
+): PerseusAnswerTile {
+    const defaultAnswerTile: PerseusAnswerTile = {
+        // Matches generateBlankOptions' default correctId, so composing the
+        // two generators yields a blank that points at a tile that exists.
+        id: "answer-tile-1",
+        content: "answer",
+        label: "answer",
+    };
+
+    return {
+        ...defaultAnswerTile,
+        ...tile,
+    };
+}
+
+export function generateFillInTheBlankOptions(
+    options?: Partial<PerseusFillInTheBlankWidgetOptions>,
+): PerseusFillInTheBlankWidgetOptions {
+    return {
+        ...fillInTheBlankWidgetLogic.defaultWidgetOptions,
+        ...options,
+    };
+}
+
+export function generateFillInTheBlankWidget(
+    fillInTheBlankWidgetProperties?: Partial<
+        Omit<FillInTheBlankWidget, "type">
+    >,
+): FillInTheBlankWidget {
+    return {
+        type: "fill-in-the-blank",
+        graded: true,
+        version: {major: 0, minor: 0},
+        static: false,
+        alignment: "default",
+        ...fillInTheBlankWidgetProperties,
+        options: generateFillInTheBlankOptions({
+            ...fillInTheBlankWidgetProperties?.options,
+        }),
+    };
+}

--- a/packages/perseus-core/src/utils/generators/fill-in-the-blank-widget-generator.ts
+++ b/packages/perseus-core/src/utils/generators/fill-in-the-blank-widget-generator.ts
@@ -10,8 +10,6 @@ export function generateAnswerTile(
     tile?: Partial<PerseusAnswerTile>,
 ): PerseusAnswerTile {
     const defaultAnswerTile: PerseusAnswerTile = {
-        // Matches generateBlankOptions' default correctId, so composing the
-        // two generators yields a blank that points at a tile that exists.
         id: "answer-tile-1",
         content: "answer",
         label: "answer",
@@ -44,8 +42,8 @@ export function generateFillInTheBlankWidget(
         static: false,
         alignment: "default",
         ...fillInTheBlankWidgetProperties,
-        options: generateFillInTheBlankOptions({
-            ...fillInTheBlankWidgetProperties?.options,
-        }),
+        options: generateFillInTheBlankOptions(
+            fillInTheBlankWidgetProperties?.options,
+        ),
     };
 }

--- a/packages/perseus-core/src/utils/split-perseus-renderer.test.ts
+++ b/packages/perseus-core/src/utils/split-perseus-renderer.test.ts
@@ -1,10 +1,16 @@
 import {applyDefaultsToWidgets} from "../widgets/apply-defaults";
 import {registerCoreWidgets} from "../widgets/core-widget-registry";
 
+import {generateBlankWidget} from "./generators/blank-widget-generator";
 import {
     generateExplanationOptions,
     generateExplanationWidget,
 } from "./generators/explanation-widget-generator";
+import {
+    generateAnswerTile,
+    generateFillInTheBlankOptions,
+    generateFillInTheBlankWidget,
+} from "./generators/fill-in-the-blank-widget-generator";
 import splitPerseusRenderer from "./split-perseus-renderer";
 
 import type {PerseusRenderer, RadioWidget} from "../data-schema";
@@ -357,6 +363,51 @@ describe("splitPerseusRenderer", () => {
 
         // Assert
         expect(rv).toEqual(expected);
+    });
+
+    it("strips the blanks nested in a FillInTheBlank widget", () => {
+        // Fill in the Blank keeps its answers one level down, on the blanks
+        // embedded in its content. splitPerseusRenderer does not recurse on
+        // its own, so this only passes while the widget registers a
+        // getPublicWidgetOptions of its own.
+        // Arrange
+        const question: PerseusRenderer = {
+            content: "[[\u2603 fill-in-the-blank 1]]",
+            images: {},
+            widgets: {
+                "fill-in-the-blank 1": generateFillInTheBlankWidget({
+                    options: generateFillInTheBlankOptions({
+                        content: "The [[\u2603 blank 1]] drum is a tall drum.",
+                        widgets: {
+                            "blank 1": generateBlankWidget({
+                                options: {
+                                    displayType: "normal",
+                                    correctId: "tile-1",
+                                },
+                            }),
+                        },
+                        tiles: [
+                            generateAnswerTile({
+                                id: "tile-1",
+                                content: "djembe",
+                                label: "djembe",
+                            }),
+                        ],
+                    }),
+                }),
+            },
+        };
+
+        // Act
+        const rv = splitPerseusRenderer(question);
+
+        // Assert
+        const blank =
+            rv.widgets["fill-in-the-blank 1"].options.widgets["blank 1"];
+        expect(blank.options).toEqual({displayType: "normal"});
+        expect(rv.widgets["fill-in-the-blank 1"].options.tiles).toEqual([
+            {id: "tile-1", content: "djembe", label: "djembe"},
+        ]);
     });
 
     it("handles multiple widgets", () => {

--- a/packages/perseus-core/src/utils/split-perseus-renderer.test.ts
+++ b/packages/perseus-core/src/utils/split-perseus-renderer.test.ts
@@ -366,10 +366,6 @@ describe("splitPerseusRenderer", () => {
     });
 
     it("strips the blanks nested in a FillInTheBlank widget", () => {
-        // Fill in the Blank keeps its answers one level down, on the blanks
-        // embedded in its content. splitPerseusRenderer does not recurse on
-        // its own, so this only passes while the widget registers a
-        // getPublicWidgetOptions of its own.
         // Arrange
         const question: PerseusRenderer = {
             content: "[[\u2603 fill-in-the-blank 1]]",

--- a/packages/perseus-core/src/utils/split-perseus-renderer.ts
+++ b/packages/perseus-core/src/utils/split-perseus-renderer.ts
@@ -3,7 +3,7 @@ import {getPublicWidgetOptionsFunction} from "../widgets/core-widget-registry";
 
 import deepClone from "./deep-clone";
 
-import type {PerseusRenderer} from "../data-schema";
+import type {PerseusRenderer, PerseusWidgetsMap} from "../data-schema";
 
 /**
  * Return a copy of a PerseusRenderer with rubric data removed (ie answers)
@@ -13,10 +13,17 @@ import type {PerseusRenderer} from "../data-schema";
 export default function splitPerseusRenderer(
     original: PerseusRenderer,
 ): PerseusRenderer {
-    const clone = deepClone(original);
-    const originalWidgets = clone.widgets ?? {};
+    return {...original, widgets: splitWidgetsMap(original.widgets)};
+}
 
-    const upgradedWidgets = applyDefaultsToWidgets(originalWidgets);
+/**
+ * Return a copy of a widgets map with rubric data removed (ie answers).
+ *
+ * Does not recurse: a widget whose options nest more widgets has to call this
+ * from its own getPublicWidgetOptions.
+ */
+export function splitWidgetsMap(widgets: PerseusWidgetsMap): PerseusWidgetsMap {
+    const upgradedWidgets = applyDefaultsToWidgets(deepClone(widgets ?? {}));
     const splitWidgets = {};
 
     for (const [id, widget] of Object.entries(upgradedWidgets)) {
@@ -41,8 +48,6 @@ export default function splitPerseusRenderer(
         }
     }
 
-    return {
-        ...original,
-        widgets: splitWidgets,
-    };
+    // eslint-disable-next-line no-restricted-syntax
+    return splitWidgets as PerseusWidgetsMap;
 }

--- a/packages/perseus-core/src/utils/split-perseus-renderer.ts
+++ b/packages/perseus-core/src/utils/split-perseus-renderer.ts
@@ -18,9 +18,6 @@ export default function splitPerseusRenderer(
 
 /**
  * Return a copy of a widgets map with rubric data removed (ie answers).
- *
- * Does not recurse: a widget whose options nest more widgets has to call this
- * from its own getPublicWidgetOptions.
  */
 export function splitWidgetsMap(widgets: PerseusWidgetsMap): PerseusWidgetsMap {
     const upgradedWidgets = applyDefaultsToWidgets(deepClone(widgets ?? {}));

--- a/packages/perseus-core/src/widgets/core-widget-registry.ts
+++ b/packages/perseus-core/src/widgets/core-widget-registry.ts
@@ -10,6 +10,7 @@ import deprecatedStandinWidgetLogic from "./deprecated-standin";
 import dropdownWidgetLogic from "./dropdown";
 import explanationWidgetLogic from "./explanation";
 import expressionWidgetLogic from "./expression";
+import fillInTheBlankWidgetLogic from "./fill-in-the-blank";
 import gradedGroupWidgetLogic from "./graded-group";
 import gradedGroupSetWidgetLogic from "./graded-group-set";
 import grapherWidgetLogic from "./grapher";
@@ -200,6 +201,7 @@ export function registerCoreWidgets() {
         dropdownWidgetLogic,
         explanationWidgetLogic,
         expressionWidgetLogic,
+        fillInTheBlankWidgetLogic,
         gradedGroupWidgetLogic,
         gradedGroupSetWidgetLogic,
         grapherWidgetLogic,

--- a/packages/perseus-core/src/widgets/fill-in-the-blank/fill-in-the-blank-util.test.ts
+++ b/packages/perseus-core/src/widgets/fill-in-the-blank/fill-in-the-blank-util.test.ts
@@ -1,0 +1,103 @@
+import {generateBlankWidget} from "../../utils/generators/blank-widget-generator";
+import {
+    generateAnswerTile,
+    generateFillInTheBlankOptions,
+} from "../../utils/generators/fill-in-the-blank-widget-generator";
+import {registerCoreWidgets} from "../core-widget-registry";
+
+import {getFillInTheBlankPublicWidgetOptions} from "./fill-in-the-blank-util";
+
+import type {PerseusFillInTheBlankWidgetOptions} from "../../data-schema";
+
+// The split walks the nested widgets through the core registry, so the blank
+// widget's own logic has to be registered for its options to be stripped.
+beforeAll(() => {
+    registerCoreWidgets();
+});
+
+function optionsWithTwoBlanks(): PerseusFillInTheBlankWidgetOptions {
+    return generateFillInTheBlankOptions({
+        content:
+            "The [[\u2603 blank 1]] drum is played with your [[\u2603 blank 2]].",
+        widgets: {
+            "blank 1": generateBlankWidget({
+                options: {displayType: "normal", correctId: "tile-1"},
+            }),
+            "blank 2": generateBlankWidget({
+                options: {displayType: "normal", correctId: "tile-3"},
+            }),
+        },
+        tiles: [
+            generateAnswerTile({
+                id: "tile-1",
+                content: "djembe",
+                label: "djembe",
+            }),
+            generateAnswerTile({
+                id: "tile-3",
+                content: "hands",
+                label: "hands",
+            }),
+        ],
+    });
+}
+
+describe("getFillInTheBlankPublicWidgetOptions", () => {
+    it("strips the correctId from every nested blank", () => {
+        // Arrange, Act
+        const publicOptions = getFillInTheBlankPublicWidgetOptions(
+            optionsWithTwoBlanks(),
+        );
+
+        // Assert
+        expect(publicOptions.widgets["blank 1"].options).not.toHaveProperty(
+            "correctId",
+        );
+        expect(publicOptions.widgets["blank 2"].options).not.toHaveProperty(
+            "correctId",
+        );
+    });
+
+    it("keeps the display type of every nested blank", () => {
+        // Arrange, Act
+        const publicOptions = getFillInTheBlankPublicWidgetOptions(
+            optionsWithTwoBlanks(),
+        );
+
+        // Assert
+        expect(publicOptions.widgets["blank 1"].options).toEqual({
+            displayType: "normal",
+        });
+    });
+
+    it("keeps the choice bank, which the learner has to see", () => {
+        // Arrange, Act
+        const publicOptions = getFillInTheBlankPublicWidgetOptions(
+            optionsWithTwoBlanks(),
+        );
+
+        // Assert
+        expect(publicOptions.tiles).toEqual([
+            {id: "tile-1", content: "djembe", label: "djembe"},
+            {id: "tile-3", content: "hands", label: "hands"},
+        ]);
+        expect(publicOptions.content).toBe(
+            "The [[☃ blank 1]] drum is played with your [[☃ blank 2]].",
+        );
+        expect(publicOptions.tileUsage).toBe("single");
+    });
+
+    it("does not mutate the options it was given", () => {
+        // Arrange
+        const options = optionsWithTwoBlanks();
+
+        // Act
+        getFillInTheBlankPublicWidgetOptions(options);
+
+        // Assert
+        expect(options.widgets["blank 1"].options).toHaveProperty(
+            "correctId",
+            "tile-1",
+        );
+    });
+});

--- a/packages/perseus-core/src/widgets/fill-in-the-blank/fill-in-the-blank-util.test.ts
+++ b/packages/perseus-core/src/widgets/fill-in-the-blank/fill-in-the-blank-util.test.ts
@@ -84,7 +84,7 @@ describe("getFillInTheBlankPublicWidgetOptions", () => {
         expect(publicOptions.content).toBe(
             "The [[☃ blank 1]] drum is played with your [[☃ blank 2]].",
         );
-        expect(publicOptions.tileUsage).toBe("single");
+        expect(publicOptions.maxUsesPerTile).toBe(1);
     });
 
     it("does not mutate the options it was given", () => {

--- a/packages/perseus-core/src/widgets/fill-in-the-blank/fill-in-the-blank-util.ts
+++ b/packages/perseus-core/src/widgets/fill-in-the-blank/fill-in-the-blank-util.ts
@@ -1,0 +1,16 @@
+import {splitWidgetsMap} from "../../utils/split-perseus-renderer";
+
+import type {PerseusFillInTheBlankWidgetOptions} from "../../data-schema";
+
+export type FillInTheBlankPublicWidgetOptions =
+    PerseusFillInTheBlankWidgetOptions;
+
+/**
+ * Given a PerseusFillInTheBlankWidgetOptions object, return a new object with
+ * only the public options that should be exposed to the client.
+ */
+export function getFillInTheBlankPublicWidgetOptions(
+    options: PerseusFillInTheBlankWidgetOptions,
+): FillInTheBlankPublicWidgetOptions {
+    return {...options, widgets: splitWidgetsMap(options.widgets)};
+}

--- a/packages/perseus-core/src/widgets/fill-in-the-blank/index.ts
+++ b/packages/perseus-core/src/widgets/fill-in-the-blank/index.ts
@@ -1,0 +1,33 @@
+import {getFillInTheBlankPublicWidgetOptions} from "./fill-in-the-blank-util";
+
+import type {FillInTheBlankPublicWidgetOptions} from "./fill-in-the-blank-util";
+import type {PerseusFillInTheBlankWidgetOptions} from "../../data-schema";
+import type {WidgetLogic} from "../logic-export.types";
+
+const currentVersion = {major: 0, minor: 0};
+
+const defaultWidgetOptions: PerseusFillInTheBlankWidgetOptions = {
+    content: "",
+    widgets: {},
+    tiles: [],
+    tileUsage: "single",
+    randomize: false,
+};
+
+const fillInTheBlankWidgetLogic: WidgetLogic<
+    PerseusFillInTheBlankWidgetOptions,
+    FillInTheBlankPublicWidgetOptions
+> = {
+    name: "fill-in-the-blank",
+    version: currentVersion,
+    defaultAlignment: "block",
+    defaultWidgetOptions,
+    accessible: true,
+    getPublicWidgetOptions: getFillInTheBlankPublicWidgetOptions,
+    traverseChildWidgets: (props, traverseRenderer) => ({
+        ...props,
+        ...traverseRenderer(props),
+    }),
+};
+
+export default fillInTheBlankWidgetLogic;

--- a/packages/perseus-core/src/widgets/fill-in-the-blank/index.ts
+++ b/packages/perseus-core/src/widgets/fill-in-the-blank/index.ts
@@ -4,13 +4,11 @@ import type {FillInTheBlankPublicWidgetOptions} from "./fill-in-the-blank-util";
 import type {PerseusFillInTheBlankWidgetOptions} from "../../data-schema";
 import type {WidgetLogic} from "../logic-export.types";
 
-const currentVersion = {major: 0, minor: 0};
-
 const defaultWidgetOptions: PerseusFillInTheBlankWidgetOptions = {
     content: "",
     widgets: {},
     tiles: [],
-    tileUsage: "single",
+    maxUsesPerTile: 1,
     randomize: false,
 };
 
@@ -19,7 +17,7 @@ const fillInTheBlankWidgetLogic: WidgetLogic<
     FillInTheBlankPublicWidgetOptions
 > = {
     name: "fill-in-the-blank",
-    version: currentVersion,
+    version: {major: 0, minor: 0},
     defaultAlignment: "block",
     defaultWidgetOptions,
     accessible: true,

--- a/packages/perseus-core/src/widgets/logic-export.types.ts
+++ b/packages/perseus-core/src/widgets/logic-export.types.ts
@@ -2,6 +2,7 @@ import type {getCategorizerPublicWidgetOptions} from "./categorizer/categorizer-
 import type {getCSProgramPublicWidgetOptions} from "./cs-program/cs-program-util";
 import type {getDropdownPublicWidgetOptions} from "./dropdown/dropdown-util";
 import type {getExpressionPublicWidgetOptions} from "./expression/expression-util";
+import type {getFillInTheBlankPublicWidgetOptions} from "./fill-in-the-blank/fill-in-the-blank-util";
 import type {getFreeResponsePublicWidgetOptions} from "./free-response/free-response-util";
 import type {getGrapherPublicWidgetOptions} from "./grapher/grapher-util";
 import type {getGroupPublicWidgetOptions} from "./group/group-util";
@@ -36,6 +37,7 @@ export type PublicWidgetOptionsFunction =
     | typeof getCSProgramPublicWidgetOptions
     | typeof getDropdownPublicWidgetOptions
     | typeof getExpressionPublicWidgetOptions
+    | typeof getFillInTheBlankPublicWidgetOptions
     | typeof getFreeResponsePublicWidgetOptions
     | typeof getGrapherPublicWidgetOptions
     | typeof getGroupPublicWidgetOptions

--- a/packages/perseus/src/widgets/fill-in-the-blank/notes/fill-in-the-blank.md
+++ b/packages/perseus/src/widgets/fill-in-the-blank/notes/fill-in-the-blank.md
@@ -91,6 +91,18 @@ entire answer-zone contents as one string.
   `packages/perseus/src/widgets/CLAUDE.md` (component, tests, `index.ts`,
   `__docs__/` stories, registration in `extra-widgets.ts`, scoring in
   perseus-score, editor in perseus-editor, schema in perseus-core, linter rule).
+- **FITB schema (landed):** `PerseusFillInTheBlankWidgetOptions` in
+  perseus-core's `src/data-schema.ts`, with the widget logic, JSON parser and
+  test-data generators alongside it
+  ([LEMS-4321](https://khanacademy.atlassian.net/browse/LEMS-4321)). The tile
+  type is **`PerseusAnswerTile`** — named for the Drag-and-Drop family's shared
+  element rather than for FITB, since Sorter, Categorizer and Composer render
+  the same tile. It carries presentation only (`id`, `content`, `label`,
+  `imageHeight?`); each widget expresses correctness its own way, so one
+  needing more should intersect the type locally rather than widen it.
+  Scaffolding only: no render component, no scoring
+  ([LEMS-4370](https://khanacademy.atlassian.net/browse/LEMS-4370)) and no
+  editor ([LEMS-4371](https://khanacademy.atlassian.net/browse/LEMS-4371)) yet.
 - **`blank` widget stub:** `packages/perseus/src/widgets/blank/` — the dropzone
   primitive FITB builds on. Built during the shared prework
   ([LEMS-4364](https://khanacademy.atlassian.net/browse/LEMS-4364)) and likely to


### PR DESCRIPTION
## Summary:
This PR is the base code for Fill in the Blank widget and this adds the schema and logic to perseus-core.

Related Webapp PR: https://github.com/Khan/webapp/pull/42130

Issue: LEMS-4321

## Test plan: