### PR TITLE
Fix editor crash when a locked vector with a label is edited to have length 0

### DIFF
--- a/.changeset/goofy-kids-study.md
+++ b/.changeset/goofy-kids-study.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Internal: Refactor editor components to remove unnecessary state and de-duplicate validation.

--- a/.changeset/pretty-rooms-peel.md
+++ b/.changeset/pretty-rooms-peel.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Internal: Temporarily replace Mafs' `vec.midpoint()` with our own `line.midpoint()` to guard against a bug. Mafs' implementation of `midpoint()` returns `[NaN, NaN]` given two equal points.

--- a/packages/perseus-editor/src/components/__docs__/scrollless-number-text-field.stories.tsx
+++ b/packages/perseus-editor/src/components/__docs__/scrollless-number-text-field.stories.tsx
@@ -36,7 +36,7 @@ Default.args = defaultProps;
  */
 export const Controlled: StoryComponentType = {
     render: function Render() {
-        const [value, setValue] = React.useState("");
+        const [value, setValue] = React.useState(0);
 
         return <ScrolllessNumberTextField value={value} onChange={setValue} />;
     },
@@ -57,7 +57,7 @@ Controlled.parameters = {
  */
 export const LongPageScroll: StoryComponentType = {
     render: function Render() {
-        const [value, setValue] = React.useState("");
+        const [value, setValue] = React.useState(0);
 
         return (
             <>

--- a/packages/perseus-editor/src/components/__tests__/scrollless-number-text-field.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/scrollless-number-text-field.test.tsx
@@ -54,6 +54,9 @@ describe("ScrolllessNumberTextField", () => {
         expect(onChange).not.toHaveBeenCalled();
     });
 
+    // TODO-NEXT: add tests showing that the displayed input value is empty
+    //  ("") when `value={NaN}` or `value={Infinity}`.
+
     test("calls onFocus on focus", async () => {
         // Arrange
         const onFocus = jest.fn();

--- a/packages/perseus-editor/src/components/__tests__/scrollless-number-text-field.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/scrollless-number-text-field.test.tsx
@@ -54,8 +54,40 @@ describe("ScrolllessNumberTextField", () => {
         expect(onChange).not.toHaveBeenCalled();
     });
 
-    // TODO-NEXT: add tests showing that the displayed input value is empty
-    //  ("") when `value={NaN}` or `value={Infinity}`.
+    test("Should not call the onChange callback when the field is cleared", async () => {
+        // Arrange
+        const onChange = jest.fn();
+        render(<ScrolllessNumberTextField value={42} onChange={onChange} />);
+        const input = screen.getByRole("spinbutton");
+
+        // Act
+        await userEvent.clear(input);
+
+        // Assert
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    test("displays an empty input value when value is NaN", () => {
+        // Arrange, Act
+        render(<ScrolllessNumberTextField value={NaN} onChange={() => {}} />);
+
+        const input = screen.getByRole("spinbutton");
+
+        // Assert
+        expect(input).toHaveValue(null);
+    });
+
+    test("displays an empty input value when value is Infinity", () => {
+        // Arrange, Act
+        render(
+            <ScrolllessNumberTextField value={Infinity} onChange={() => {}} />,
+        );
+
+        const input = screen.getByRole("spinbutton");
+
+        // Assert
+        expect(input).toHaveValue(null);
+    });
 
     test("calls onFocus on focus", async () => {
         // Arrange

--- a/packages/perseus-editor/src/components/__tests__/scrollless-number-text-field.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/scrollless-number-text-field.test.tsx
@@ -67,6 +67,34 @@ describe("ScrolllessNumberTextField", () => {
         expect(onChange).not.toHaveBeenCalled();
     });
 
+    test("Should parse exponential notation", async () => {
+        // Arrange
+        const onChange = jest.fn();
+        render(<ScrolllessNumberTextField value={42} onChange={onChange} />);
+        const input = screen.getByRole("spinbutton");
+
+        // Act
+        await userEvent.clear(input);
+        await userEvent.paste("1e42");
+
+        // Assert
+        expect(onChange).toHaveBeenLastCalledWith(1e42);
+    });
+
+    test("Should not call the onChange callback when the number is outside the representable range", async () => {
+        // Arrange
+        const onChange = jest.fn();
+        render(<ScrolllessNumberTextField value={42} onChange={onChange} />);
+        const input = screen.getByRole("spinbutton");
+
+        // Act
+        await userEvent.clear(input);
+        await userEvent.paste("1e999");
+
+        // Assert
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
     test("displays an empty input value when value is NaN", () => {
         // Arrange, Act
         render(<ScrolllessNumberTextField value={NaN} onChange={() => {}} />);

--- a/packages/perseus-editor/src/components/__tests__/scrollless-number-text-field.test.tsx
+++ b/packages/perseus-editor/src/components/__tests__/scrollless-number-text-field.test.tsx
@@ -19,7 +19,7 @@ describe("ScrolllessNumberTextField", () => {
         const onChange = jest.fn();
 
         // Act
-        render(<ScrolllessNumberTextField value="42" onChange={onChange} />);
+        render(<ScrolllessNumberTextField value={42} onChange={onChange} />);
 
         const input = screen.getByRole("spinbutton");
 
@@ -31,20 +31,20 @@ describe("ScrolllessNumberTextField", () => {
     test("Should call the onChange callback when the value changes", async () => {
         // Arrange
         const onChange = jest.fn();
-        render(<ScrolllessNumberTextField value="" onChange={onChange} />);
+        render(<ScrolllessNumberTextField value={0} onChange={onChange} />);
         const input = screen.getByRole("spinbutton");
 
         // Act
         await userEvent.type(input, "2");
 
         // Assert
-        expect(onChange).toHaveBeenLastCalledWith("2");
+        expect(onChange).toHaveBeenLastCalledWith(2);
     });
 
     test("Should not call the onChange callback when the value is not a number", async () => {
         // Arrange
         const onChange = jest.fn();
-        render(<ScrolllessNumberTextField value="42" onChange={onChange} />);
+        render(<ScrolllessNumberTextField value={42} onChange={onChange} />);
         const input = screen.getByRole("spinbutton");
 
         // Act
@@ -59,7 +59,7 @@ describe("ScrolllessNumberTextField", () => {
         const onFocus = jest.fn();
         render(
             <ScrolllessNumberTextField
-                value="42"
+                value={42}
                 onChange={() => {}}
                 onFocus={onFocus}
             />,
@@ -78,7 +78,7 @@ describe("ScrolllessNumberTextField", () => {
         const onBlur = jest.fn();
         render(
             <ScrolllessNumberTextField
-                value="42"
+                value={42}
                 onChange={() => {}}
                 onBlur={onBlur}
             />,

--- a/packages/perseus-editor/src/components/angle-input.tsx
+++ b/packages/perseus-editor/src/components/angle-input.tsx
@@ -17,13 +17,7 @@ type Props = {
 const AngleInput = (props: Props) => {
     const {angle, onChange} = props;
 
-    function handleAngleChange(newValue) {
-        // If the new value is not a number, don't update the props.
-        // If it's empty, keep the props the same value instead of setting to 0.
-        if (isNaN(+newValue) || newValue === "") {
-            return;
-        }
-
+    function handleAngleChange(newValue: number) {
         // Update the graph.
         onChange(convertDegreesToRadians(newValue));
     }
@@ -33,7 +27,7 @@ const AngleInput = (props: Props) => {
             angle (degrees)
             <Strut size={spacing.xxSmall_6} />
             <ScrolllessNumberTextField
-                value={String(convertRadiansToDegrees(angle))}
+                value={convertRadiansToDegrees(angle)}
                 onChange={handleAngleChange}
                 style={styles.textField}
             />

--- a/packages/perseus-editor/src/components/angle-input.tsx
+++ b/packages/perseus-editor/src/components/angle-input.tsx
@@ -17,14 +17,7 @@ type Props = {
 const AngleInput = (props: Props) => {
     const {angle, onChange} = props;
 
-    const [angleInput, setAngleInput] = React.useState(
-        convertRadiansToDegrees(angle).toString(),
-    );
-
     function handleAngleChange(newValue) {
-        // Update the local state (update the input field value).
-        setAngleInput(newValue);
-
         // If the new value is not a number, don't update the props.
         // If it's empty, keep the props the same value instead of setting to 0.
         if (isNaN(+newValue) || newValue === "") {
@@ -40,7 +33,7 @@ const AngleInput = (props: Props) => {
             angle (degrees)
             <Strut size={spacing.xxSmall_6} />
             <ScrolllessNumberTextField
-                value={angleInput}
+                value={String(convertRadiansToDegrees(angle))}
                 onChange={handleAngleChange}
                 style={styles.textField}
             />

--- a/packages/perseus-editor/src/components/coordinate-pair-input.tsx
+++ b/packages/perseus-editor/src/components/coordinate-pair-input.tsx
@@ -41,13 +41,7 @@ const CoordinatePairInput = (props: Props) => {
     const xLabel = labels ? labels[0] : "x coord";
     const yLabel = labels ? labels[1] : "y coord";
 
-    function handleCoordChange(newValue: string, coordIndex: number) {
-        // If the new value is not a number, don't update the props.
-        // If it's empty, keep the props the same value instead of setting to 0.
-        if (isNaN(+newValue) || newValue === "") {
-            return;
-        }
-
+    function handleCoordChange(newValue: number, coordIndex: number) {
         // Update the props (update the graph).
         const newCoords: Coord = [...coord];
         newCoords[coordIndex] = +newValue;
@@ -60,7 +54,7 @@ const CoordinatePairInput = (props: Props) => {
                 <span className={labelClassName}>{xLabel}</span>
 
                 <ScrolllessNumberTextField
-                    value={String(coord[0])}
+                    value={coord[0]}
                     disabled={disabled}
                     onChange={(newValue) => handleCoordChange(newValue, 0)}
                     style={[
@@ -74,7 +68,7 @@ const CoordinatePairInput = (props: Props) => {
                 <span className={labelClassName}>{yLabel}</span>
 
                 <ScrolllessNumberTextField
-                    value={String(coord[1])}
+                    value={coord[1]}
                     disabled={disabled}
                     onChange={(newValue) => handleCoordChange(newValue, 1)}
                     style={[

--- a/packages/perseus-editor/src/components/coordinate-pair-input.tsx
+++ b/packages/perseus-editor/src/components/coordinate-pair-input.tsx
@@ -44,7 +44,7 @@ const CoordinatePairInput = (props: Props) => {
     function handleCoordChange(newValue: number, coordIndex: number) {
         // Update the props (update the graph).
         const newCoords: Coord = [...coord];
-        newCoords[coordIndex] = +newValue;
+        newCoords[coordIndex] = newValue;
         onChange(newCoords);
     }
 

--- a/packages/perseus-editor/src/components/coordinate-pair-input.tsx
+++ b/packages/perseus-editor/src/components/coordinate-pair-input.tsx
@@ -41,26 +41,7 @@ const CoordinatePairInput = (props: Props) => {
     const xLabel = labels ? labels[0] : "x coord";
     const yLabel = labels ? labels[1] : "y coord";
 
-    // Keep track of the coordinates via state as the user is editing them,
-    // before they are updated in the props as a valid number.
-    const [coordState, setCoordState] = React.useState([
-        // Using strings to make it easier to work with the text fields.
-        coord[0].toString(),
-        coord[1].toString(),
-    ]);
-
-    // Update the local state when the props change. (Such as when the graph
-    // type is changed, and the coordinates are reset.)
-    React.useEffect(() => {
-        setCoordState([coord[0].toString(), coord[1].toString()]);
-    }, [coord]);
-
-    function handleCoordChange(newValue, coordIndex) {
-        // Update the local state (update the input field value).
-        const newCoordState = [...coordState];
-        newCoordState[coordIndex] = newValue;
-        setCoordState(newCoordState);
-
+    function handleCoordChange(newValue: string, coordIndex: number) {
         // If the new value is not a number, don't update the props.
         // If it's empty, keep the props the same value instead of setting to 0.
         if (isNaN(+newValue) || newValue === "") {
@@ -68,7 +49,7 @@ const CoordinatePairInput = (props: Props) => {
         }
 
         // Update the props (update the graph).
-        const newCoords = [...coord] satisfies [number, number];
+        const newCoords: Coord = [...coord];
         newCoords[coordIndex] = +newValue;
         onChange(newCoords);
     }
@@ -79,7 +60,7 @@ const CoordinatePairInput = (props: Props) => {
                 <span className={labelClassName}>{xLabel}</span>
 
                 <ScrolllessNumberTextField
-                    value={coordState[0]}
+                    value={String(coord[0])}
                     disabled={disabled}
                     onChange={(newValue) => handleCoordChange(newValue, 0)}
                     style={[
@@ -93,7 +74,7 @@ const CoordinatePairInput = (props: Props) => {
                 <span className={labelClassName}>{yLabel}</span>
 
                 <ScrolllessNumberTextField
-                    value={coordState[1]}
+                    value={String(coord[1])}
                     disabled={disabled}
                     onChange={(newValue) => handleCoordChange(newValue, 1)}
                     style={[

--- a/packages/perseus-editor/src/components/scrollless-number-text-field.tsx
+++ b/packages/perseus-editor/src/components/scrollless-number-text-field.tsx
@@ -1,7 +1,7 @@
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import * as React from "react";
 
-import type {StyleType} from "@khanacademy/wonder-blocks-core/dist/util/types";
+import type {StyleType} from "@khanacademy/wonder-blocks-core";
 
 interface Props {
     value: number;

--- a/packages/perseus-editor/src/components/scrollless-number-text-field.tsx
+++ b/packages/perseus-editor/src/components/scrollless-number-text-field.tsx
@@ -1,7 +1,18 @@
 import {TextField} from "@khanacademy/wonder-blocks-form";
 import * as React from "react";
 
-import type {PropsFor} from "@khanacademy/wonder-blocks-core";
+import type {StyleType} from "@khanacademy/wonder-blocks-core/dist/util/types";
+
+interface Props {
+    value: number;
+    onChange: (value: number) => void;
+    min?: number;
+    max?: number;
+    disabled?: boolean;
+    onFocus?: (e: React.FocusEvent<HTMLInputElement>) => void;
+    onBlur?: (e: React.FocusEvent<HTMLInputElement>) => void;
+    style?: StyleType;
+}
 
 /**
  * This is a custom text field of type="number" for use in Perseus Editors.
@@ -14,6 +25,8 @@ import type {PropsFor} from "@khanacademy/wonder-blocks-core";
  *    events. This is useful to make sure that input behavior
  *    remains predictable, rather than possibly having the cursor
  *    jump around uenxpectedly.
+ * 3. only valid, finite numbers are passed to `onChange`. NaN and +/-Infinity
+ *    are never emitted.
  *
  * NOTE 1: Native HTML number inputs do not update the number value on scroll,
  * they only scroll the page. Inputs in React do NOT work this way (explanation
@@ -25,7 +38,7 @@ import type {PropsFor} from "@khanacademy/wonder-blocks-core";
  * NOTE 2: Firefox seems to have a custom override for input scroll. Even
  * with this stopPropogation, Firefox matches the native HTML behavior.
  */
-const ScrolllessNumberTextField = (props: PropsFor<typeof TextField>) => {
+const ScrolllessNumberTextField = (props: Props) => {
     const {value, onChange, ...restOfProps} = props;
     const [focused, setFocused] = React.useState(false);
     const [wipValue, setWipValue] = React.useState("");
@@ -53,13 +66,15 @@ const ScrolllessNumberTextField = (props: PropsFor<typeof TextField>) => {
         <TextField
             {...restOfProps}
             type="number"
-            value={focused ? wipValue : value}
+            value={focused ? wipValue : String(value)}
             onChange={(newValue) => {
                 setWipValue(newValue);
-                onChange(newValue);
+                if (isFiniteNumeric(newValue)) {
+                    onChange(+newValue);
+                }
             }}
             onFocus={(e) => {
-                setWipValue(value);
+                setWipValue(String(value));
                 setFocused(true);
 
                 props.onFocus?.(e);
@@ -73,5 +88,9 @@ const ScrolllessNumberTextField = (props: PropsFor<typeof TextField>) => {
         />
     );
 };
+
+function isFiniteNumeric(value: string): boolean {
+    return value.trim() !== "" && Number.isFinite(+value);
+}
 
 export default ScrolllessNumberTextField;

--- a/packages/perseus-editor/src/util/midpoint.test.ts
+++ b/packages/perseus-editor/src/util/midpoint.test.ts
@@ -1,0 +1,17 @@
+import {describe, expect, it} from "@jest/globals";
+
+import {midpoint} from "./midpoint";
+
+describe("midpoint", () => {
+    it("returns point P given (P, P)", () => {
+        expect(midpoint([0, 0], [0, 0])).toEqual([0, 0]);
+    });
+
+    it("returns a point halfway between two points", () => {
+        expect(midpoint([0, 1], [2, 5])).toEqual([1, 3]);
+    });
+
+    it("handles negatives", () => {
+        expect(midpoint([0, -1], [-2, 5])).toEqual([-1, 2]);
+    });
+});

--- a/packages/perseus-editor/src/util/midpoint.ts
+++ b/packages/perseus-editor/src/util/midpoint.ts
@@ -1,0 +1,10 @@
+import {vec} from "mafs";
+
+import type {Coord} from "@khanacademy/perseus-core";
+
+// TODO(LEMS-4567): this is a temporary workaround for a bug in mafs'
+//  vec.midpoint() function. Remove this implementation of midpoint and use
+//  vec.midpoint once we have the fix in https://github.com/stevenpetryk/mafs/pull/188.
+export function midpoint(p1: Coord, p2: Coord): Coord {
+    return vec.scale(vec.add(p1, p2), 0.5);
+}

--- a/packages/perseus-editor/src/widgets/image-editor/components/image-scale-input.tsx
+++ b/packages/perseus-editor/src/widgets/image-editor/components/image-scale-input.tsx
@@ -36,24 +36,20 @@ export default function ImageScaleInput({
     const hasInvalidDimensions =
         isInvalidDimension(width) || isInvalidDimension(height);
 
-    function handleScaleChange(newScale: string) {
-        const scaleNum = Number(newScale);
-
+    function handleScaleChange(newScale: number) {
         // Scale needs to be a positive number.
-        if (isNaN(scaleNum) || scaleNum <= 0) {
+        if (newScale <= 0) {
             return;
         }
 
         onChange({
-            scale: scaleNum,
+            scale: newScale,
         });
     }
 
-    function handleScaledWidthChange(newScaledWidth: string) {
-        const newScaledWidthNum = Number(newScaledWidth);
-
+    function handleScaledWidthChange(newScaledWidth: number) {
         // Width needs to be a positive number.
-        if (isNaN(newScaledWidthNum) || newScaledWidthNum <= 0) {
+        if (newScaledWidth <= 0) {
             return;
         }
 
@@ -62,18 +58,14 @@ export default function ImageScaleInput({
             return;
         }
 
-        const newScale = newScaledWidthNum / width;
-
         onChange({
-            scale: newScale,
+            scale: newScaledWidth / width,
         });
     }
 
-    function handleScaledHeightChange(newScaledHeight: string) {
-        const newScaledHeightNum = Number(newScaledHeight);
-
+    function handleScaledHeightChange(newScaledHeight: number) {
         // Height needs to be a positive number.
-        if (isNaN(newScaledHeightNum) || newScaledHeightNum <= 0) {
+        if (newScaledHeight <= 0) {
             return;
         }
 
@@ -82,10 +74,8 @@ export default function ImageScaleInput({
             return;
         }
 
-        const newScale = newScaledHeightNum / height;
-
         onChange({
-            scale: newScale,
+            scale: newScaledHeight / height,
         });
     }
 
@@ -154,7 +144,7 @@ export default function ImageScaleInput({
                 description="Use 1 to display image at original size."
                 field={
                     <ScrolllessNumberTextField
-                        value={scale.toString()}
+                        value={scale}
                         min={0}
                         onChange={handleScaleChange}
                         disabled={hasInvalidDimensions || editingDisabled}
@@ -167,7 +157,7 @@ export default function ImageScaleInput({
                     label="Scaled Width"
                     field={
                         <ScrolllessNumberTextField
-                            value={(width * scale).toString()}
+                            value={width * scale}
                             min={0}
                             onChange={handleScaledWidthChange}
                             disabled={hasInvalidDimensions || editingDisabled}
@@ -180,7 +170,7 @@ export default function ImageScaleInput({
                     label="Scaled Height"
                     field={
                         <ScrolllessNumberTextField
-                            value={(height * scale).toString()}
+                            value={height * scale}
                             min={0}
                             onChange={handleScaledHeightChange}
                             disabled={hasInvalidDimensions || editingDisabled}

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-line-settings.tsx
@@ -17,6 +17,7 @@ import * as React from "react";
 
 import PerseusEditorAccordion from "../../../components/perseus-editor-accordion";
 import {TypedSingleSelect} from "../../../components/typed-single-select";
+import {midpoint} from "../../../util/midpoint";
 
 import ColorSelect from "./color-select";
 import LineStrokeSelect, {lineStrokeStyleOptions} from "./line-stroke-select";
@@ -149,11 +150,8 @@ const LockedLineSettings = (props: Props) => {
 
         // Update labels to be centered between the two points,
         // retaining existing offset.
-        const oldMidpoint = vec.midpoint(points[0].coord, points[1].coord);
-        const newMidpoint = vec.midpoint(
-            newPoints[0].coord,
-            newPoints[1].coord,
-        );
+        const oldMidpoint = midpoint(points[0].coord, points[1].coord);
+        const newMidpoint = midpoint(newPoints[0].coord, newPoints[1].coord);
         const offset: Coord = [
             newMidpoint[0] - oldMidpoint[0],
             newMidpoint[1] - oldMidpoint[1],
@@ -351,7 +349,7 @@ const LockedLineSettings = (props: Props) => {
                     const offsetPerLabel: vec.Vector2 = [0, -1];
                     const labelLocation = vec.add(
                         vec.scale(offsetPerLabel, labels.length),
-                        vec.midpoint(points[0].coord, points[1].coord),
+                        midpoint(points[0].coord, points[1].coord),
                     );
 
                     const newLabel = {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-point-settings.test.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-point-settings.test.tsx
@@ -103,49 +103,46 @@ describe("LockedPointSettings", () => {
         expect(yCoordField).toHaveValue(null);
     });
 
-    // While you may expect the value of the field to reflect the input value,
-    // (and it does, visually), the actual value on the HTML element is null
-    // unless the input is a valid number. This is because the input has
-    // type="number".
-    describe.each`
-        Coordinate
-        ${"x"}
-        ${"y"}
-    `("Coordinate $Coordinate", ({Coordinate}) => {
-        test.each`
-            inputValue | expectedValue
-            ${"-"}     | ${null}
-            ${"."}     | ${null}
-            ${"0"}     | ${0}
-            ${"1"}     | ${1}
-            ${"1.2"}   | ${1.2}
-            ${".2"}    | ${0.2}
-            ${"0.2"}   | ${0.2}
-            ${"-1"}    | ${-1}
-            ${"-1.2"}  | ${-1.2}
-            ${"-.2"}   | ${-0.2}
-        `(
-            "Typing in the coord field should update the numeric field value ($inputValue)",
-            async ({inputValue, expectedValue}) => {
-                // Arrange
-                render(
-                    <LockedPointSettings
-                        {...defaultProps}
-                        onChangeProps={() => {}}
-                    />,
-                    {wrapper: RenderStateRoot},
-                );
-
-                // Act
-                const coordField = screen.getByLabelText(`${Coordinate} coord`);
-                await userEvent.clear(coordField);
-                await userEvent.type(coordField, inputValue);
-                await userEvent.tab();
-
-                // Assert
-                expect(coordField).toHaveValue(expectedValue);
-            },
+    it("does not call onChangeProps when you enter an invalid x coordinate", async () => {
+        // Arrange
+        const onChangeSpy = jest.fn();
+        render(
+            <LockedPointSettings
+                {...defaultProps}
+                onChangeProps={onChangeSpy}
+            />,
+            {wrapper: RenderStateRoot},
         );
+
+        // Act
+        const coordField = screen.getByLabelText(`x coord`);
+        await userEvent.clear(coordField);
+        await userEvent.type(coordField, "invalid");
+        await userEvent.tab();
+
+        // Assert
+        expect(onChangeSpy).not.toHaveBeenCalled();
+    });
+
+    it("does not call onChangeProps when you enter an invalid y coordinate", async () => {
+        // Arrange
+        const onChangeSpy = jest.fn();
+        render(
+            <LockedPointSettings
+                {...defaultProps}
+                onChangeProps={onChangeSpy}
+            />,
+            {wrapper: RenderStateRoot},
+        );
+
+        // Act
+        const coordField = screen.getByLabelText(`y coord`);
+        await userEvent.clear(coordField);
+        await userEvent.type(coordField, "invalid");
+        await userEvent.tab();
+
+        // Assert
+        expect(onChangeSpy).not.toHaveBeenCalled();
     });
 
     test("Calls onToggle when header is clicked", async () => {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/locked-figures/locked-vector-settings.tsx
@@ -16,6 +16,7 @@ import * as React from "react";
 
 import CoordinatePairInput from "../../../components/coordinate-pair-input";
 import PerseusEditorAccordion from "../../../components/perseus-editor-accordion";
+import {midpoint} from "../../../util/midpoint";
 
 import ColorSelect from "./color-select";
 import LineSwatch from "./line-swatch";
@@ -117,8 +118,8 @@ const LockedVectorSettings = (props: Props) => {
             newPoints[index] = [...newCoord];
 
             // Update labels to match the new points
-            const oldMidpoint = vec.midpoint(tail, tip);
-            const newMidpoint = vec.midpoint(newPoints[0], newPoints[1]);
+            const oldMidpoint = midpoint(tail, tip);
+            const newMidpoint = midpoint(newPoints[0], newPoints[1]);
             const offset = vec.sub(newMidpoint, oldMidpoint);
             const newLabels = labels.map((label) => ({
                 ...label,
@@ -292,7 +293,7 @@ const LockedVectorSettings = (props: Props) => {
                     const offsetPerLabel: vec.Vector2 = [0, -1];
                     const labelLocation = vec.add(
                         vec.scale(offsetPerLabel, labels.length),
-                        vec.midpoint(tail, tip),
+                        midpoint(tail, tip),
                     );
 
                     const newLabel = {

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/asymptote-input.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/asymptote-input.tsx
@@ -15,24 +15,13 @@ interface AsymptoteInputProps {
 const AsymptoteInput = (props: AsymptoteInputProps) => {
     const {axis, value, onChange} = props;
 
-    // Local state so the user can type freely without the field resetting
-    // mid-keystroke. Pattern from StartCoordsCircle.
-    const [textState, setTextState] = React.useState(value.toString());
-
-    // Sync local state when props change (e.g. "Use default start coordinates").
-    React.useEffect(() => {
-        setTextState(value.toString());
-    }, [value]);
-
     function handleChange(newValue: string) {
-        setTextState(newValue);
-
         // Assume the user is still typing. Don't propagate until a valid number.
         if (isNaN(+newValue) || newValue === "") {
             return;
         }
 
-        onChange(parseFloat(newValue));
+        onChange(+newValue);
     }
 
     return (
@@ -40,7 +29,7 @@ const AsymptoteInput = (props: AsymptoteInputProps) => {
             {`Asymptote ${axis} =`}
             <View className={styles["text-field-wrapper"]}>
                 <ScrolllessNumberTextField
-                    value={textState}
+                    value={String(value)}
                     onChange={handleChange}
                 />
             </View>

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/asymptote-input.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/asymptote-input.tsx
@@ -15,13 +15,8 @@ interface AsymptoteInputProps {
 const AsymptoteInput = (props: AsymptoteInputProps) => {
     const {axis, value, onChange} = props;
 
-    function handleChange(newValue: string) {
-        // Assume the user is still typing. Don't propagate until a valid number.
-        if (isNaN(+newValue) || newValue === "") {
-            return;
-        }
-
-        onChange(+newValue);
+    function handleChange(newValue: number) {
+        onChange(newValue);
     }
 
     return (
@@ -29,7 +24,7 @@ const AsymptoteInput = (props: AsymptoteInputProps) => {
             {`Asymptote ${axis} =`}
             <View className={styles["text-field-wrapper"]}>
                 <ScrolllessNumberTextField
-                    value={String(value)}
+                    value={value}
                     onChange={handleChange}
                 />
             </View>

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-circle.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-circle.tsx
@@ -26,20 +26,7 @@ interface StartCoordsCircleProps {
 const StartCoordsCircle = (props: StartCoordsCircleProps) => {
     const {startCoords, onChange, pointLabels, onChangePointLabels} = props;
 
-    const [radiusState, setRadiusState] = React.useState(
-        startCoords.radius.toString(),
-    );
-
-    // Update the local state when the props change. (Specifically, when
-    // the radius is reset from the "Use default start coordinates" button.)
-    React.useEffect(() => {
-        setRadiusState(startCoords.radius.toString());
-    }, [startCoords.radius]);
-
     function handleRadiusChange(newValue: string) {
-        // Update the local state to update the input field.
-        setRadiusState(newValue);
-
         // Assume the user is in the middle of typing. Don't update
         // the props until they've finished typing a valid number.
         if (isNaN(+newValue) || newValue === "" || +newValue === 0) {
@@ -81,7 +68,7 @@ const StartCoordsCircle = (props: StartCoordsCircleProps) => {
                 Radius:
                 <Strut size={spacing.small_12} />
                 <ScrolllessNumberTextField
-                    value={radiusState}
+                    value={String(startCoords.radius)}
                     onChange={handleRadiusChange}
                     style={styles.textField}
                 />

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-circle.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-circle.tsx
@@ -36,7 +36,7 @@ const StartCoordsCircle = (props: StartCoordsCircleProps) => {
         setRadiusState(startCoords.radius.toString());
     }, [startCoords.radius]);
 
-    function handleRadiuschange(newValue: string) {
+    function handleRadiusChange(newValue: string) {
         // Update the local state to update the input field.
         setRadiusState(newValue);
 
@@ -82,7 +82,7 @@ const StartCoordsCircle = (props: StartCoordsCircleProps) => {
                 <Strut size={spacing.small_12} />
                 <ScrolllessNumberTextField
                     value={radiusState}
-                    onChange={handleRadiuschange}
+                    onChange={handleRadiusChange}
                     style={styles.textField}
                 />
             </BodyText>

--- a/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-circle.tsx
+++ b/packages/perseus-editor/src/widgets/interactive-graph-editor/start-coords/start-coords-circle.tsx
@@ -26,17 +26,17 @@ interface StartCoordsCircleProps {
 const StartCoordsCircle = (props: StartCoordsCircleProps) => {
     const {startCoords, onChange, pointLabels, onChangePointLabels} = props;
 
-    function handleRadiusChange(newValue: string) {
+    function handleRadiusChange(newValue: number) {
         // Assume the user is in the middle of typing. Don't update
         // the props until they've finished typing a valid number.
-        if (isNaN(+newValue) || newValue === "" || +newValue === 0) {
+        if (newValue === 0) {
             return;
         }
 
         // Update the props (update the graph).
         onChange({
             center: startCoords.center,
-            radius: parseFloat(newValue),
+            radius: newValue,
         });
     }
 
@@ -68,7 +68,7 @@ const StartCoordsCircle = (props: StartCoordsCircleProps) => {
                 Radius:
                 <Strut size={spacing.small_12} />
                 <ScrolllessNumberTextField
-                    value={String(startCoords.radius)}
+                    value={startCoords.radius}
                     onChange={handleRadiusChange}
                     style={styles.textField}
                 />

--- a/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/graphs/polygon.tsx
@@ -1,4 +1,4 @@
-import {angles, geometry} from "@khanacademy/kmath";
+import {angles, geometry, line} from "@khanacademy/kmath";
 import {useTimeout} from "@khanacademy/wonder-blocks-timing";
 import {UnreachableCaseError} from "@khanacademy/wonder-stuff-core";
 import {Polygon, Polyline, vec} from "mafs";
@@ -285,7 +285,9 @@ const LimitedPolygonGraph = (statefulProps: StatefulProps) => {
             {showSides &&
                 lines.map(([start, end], i) => {
                     // Use x and y to find the position of the label
-                    const [x, y] = vec.midpoint(start, end);
+                    // TODO(LEMS-4567): use vec.midpoint from Mafs here; it has
+                    //  better types.
+                    const [x, y] = line.midpoint([start, end]);
                     const length = vec.dist(start, end);
                     // Check if the length needs to indicate
                     // that it's an approximation.


### PR DESCRIPTION
## Summary:
The content editor was crashing when a locked vector's tail and tip were
updated to be the same point, AND the vector had a label.
Slack thread: https://khanacademy.slack.com/archives/C04EA1QAKN0/p1788437550399459

The chain of events was:
- The vector coordinates were updated (e.g. to `[1, 2], [1, 2]`)
- The new label position was computed relative to the vector's midpoint.
- **Bug:** the midpoint calculation returned `[NaN, NaN]`.
- The label coordinates were set to `[NaN, NaN]` and emitted via a callback
  to the frontend code.
- The frontend exercise editor code serialized the data as JSON, converting
  NaN values to null. 
- The exercise editor parsed the JSON again and passed the data, containing
  unexpected `null` values, back to the Perseus editors.
- Perseus called `.toString()` on the null values in preparation for passing
  them to a text input component. **This caused the crash**.

This PR fixes both the immediate bug (the bad midpoint calculation) and our
handling of number inputs in the editor more generally.

To fix the midpoint issue, I replaced all usages of `vec.midpoint` with a
temporary patched version. I've pull-requested a fix to Mafs:
https://github.com/stevenpetryk/mafs/pull/188

`ScrolllessNumberTextField` now takes a number `value` and emits a finite
`number` via `onChange`.  It never emits `NaN`, `Infinity`, or `-Infinity`.
This allows clients to do less validation and type conversion. Crucially, it
allows us to avoid calling `toString()`, which is what caused the crash.

This PR also removes unnecessary state from several components, and removes
redundant tests. The unnecessary state was also involved in the `toString()`
call.

Issue: LEMS-4564

## Test plan:

The affected editor components should work in Storybook, and
reject invalid input:

In the Interactive Graph editor:

- The angle input of a locked ellipse
- The coordinates of a locked vector
- The center and radius of a circle graph
- The asymptote of logarithm and exponential graphs

In the Image editor:

- Scale (should reject zero and negative input)