### PR TITLE
Editor tooltip and spacing improvements

### DIFF
--- a/.changeset/fresh-months-repair.md
+++ b/.changeset/fresh-months-repair.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-editor": patch
+"@khanacademy/perseus": patch
+---
+
+Editor tooltip and spacing improvements

--- a/packages/perseus-editor/src/styles/perseus-editor.css
+++ b/packages/perseus-editor/src/styles/perseus-editor.css
@@ -249,10 +249,6 @@ code {
 #perseus #problemarea #workarea .perseus-image-caption {
     top: 0px !important;
 }
-#perseus .perseus-question-container > div,
-#perseus .perseus-answer-container > div {
-    padding-bottom: 25px;
-}
 #perseus .add-choice-container {
     display: flex;
     flex-direction: row;

--- a/packages/perseus/src/__tests__/server-item-renderer.test.tsx
+++ b/packages/perseus/src/__tests__/server-item-renderer.test.tsx
@@ -654,35 +654,51 @@ describe("server item renderer", () => {
     });
 
     describe("content editing", () => {
-        it("shouldn't show linting errors when highlightLint is false", () => {
-            // Arrange and Act
+        const renderQuestionWithLint = (highlightLint: boolean) =>
             renderQuestion(itemWithLintingError, undefined, {
                 linterContext: {
                     contentType: "exercise",
-                    highlightLint: false,
+                    highlightLint,
                     stack: [],
                 },
             });
 
+        // The lint indicator is a link to the rule's documentation, labelled
+        // with the severity and rule name.
+        const lintIndicatorName = "Warning: heading-level-1";
+
+        it("doesn't render a lint indicator when highlightLint is false", () => {
+            // Arrange, Act
+            renderQuestionWithLint(false);
+
             expect(
-                screen.queryByText("Don't use level-1 headings", {
-                    exact: false,
-                }),
+                screen.queryByRole("link", {name: lintIndicatorName}),
             ).not.toBeInTheDocument();
         });
 
-        it("should show linting errors when highlightLint is true", () => {
-            // Arrange and Act
-            renderQuestion(itemWithLintingError, undefined, {
-                linterContext: {
-                    contentType: "exercise",
-                    highlightLint: true,
-                    stack: [],
-                },
-            });
+        it("renders a lint indicator when highlightLint is true", () => {
+            // Arrange, Act
+            renderQuestionWithLint(true);
 
             expect(
-                screen.getByText("Don't use level-1 headings", {exact: false}),
+                screen.getByRole("link", {name: lintIndicatorName}),
+            ).toBeInTheDocument();
+        });
+
+        it("shows the lint message when the indicator is hovered", async () => {
+            // Arrange
+            renderQuestionWithLint(true);
+
+            // Act
+            await userEvent.hover(
+                screen.getByRole("link", {name: lintIndicatorName}),
+            );
+
+            // The tooltip opens after a short delay, so we have to wait for it.
+            expect(
+                await screen.findByText("Don't use level-1 headings", {
+                    exact: false,
+                }),
             ).toBeInTheDocument();
         });
     });

--- a/packages/perseus/src/components/__docs__/lint.stories.tsx
+++ b/packages/perseus/src/components/__docs__/lint.stories.tsx
@@ -50,8 +50,6 @@ export const DefaultLintContainerAndMessage: Story = {};
 
 export const LintSeverity1Error: Story = {args: {severity: 1}};
 export const LintSeverity2Warning: Story = {args: {severity: 2}};
-export const LintSeverity3Recommendation: Story = {args: {severity: 3}};
-export const LintSeverity4OfflineReportingOnly: Story = {args: {severity: 4}};
 export const InlineLintContainerAndMessage: Story = {
     args: {
         inline: true,

--- a/packages/perseus/src/components/lint.tsx
+++ b/packages/perseus/src/components/lint.tsx
@@ -1,20 +1,11 @@
-import IconButton from "@khanacademy/wonder-blocks-icon-button";
-import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
-import Tooltip, {TooltipContent} from "@khanacademy/wonder-blocks-tooltip";
-import {BodyText} from "@khanacademy/wonder-blocks-typography";
-import dotOutlineIcon from "@phosphor-icons/core/fill/dot-outline-fill.svg";
-import warningCircleIcon from "@phosphor-icons/core/fill/warning-circle-fill.svg";
+import {semanticColor} from "@khanacademy/wonder-blocks-tokens";
 import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
 
-import type {CSSProperties} from "aphrodite";
+import LinterLink from "./linter-link";
 
-enum Severity {
-    Error = 1,
-    Warning = 2,
-    Recommendation = 3,
-    OfflineReportingOnly = 4,
-}
+import type {Severity} from "./linter-link";
+import type {CSSProperties} from "aphrodite";
 
 type Props = {
     /** The children are the linty content we're highlighting */
@@ -44,22 +35,19 @@ type Props = {
  * are inserted into the tree by the Perseus linter (see
  * perseus-linter/src/index).
  *
- * This component serves multiple purposes
+ * 1) This component renders a small circle IconButton in the right margin
+ * to indicate that there is lint on (or near) that line.
  *
- * 1) It renders a small circle in the right margin to indicate that there
- * is lint on (or near) that line.
+ * 2) When the mouse moves over the circle IconButton, the linty content
+ * is highlighted and a tooltip is displayed that explains what the problem is.
  *
- * 2) The area around the circle is hoverable: when the mouse moves over it
- * the linty content is highlighted and a Wonder Blocks tooltip is displayed
- * that explains what the problem is.
- *
- * 3) The hoverable area is also an HTML <a> tag. Clicking on it opens
- * a new tab and links to additional details about the specific lint rule.
+ * 3) Clicking on the IconButton opens a new tab and links to additional
+ * details about the specific lint rule.
  *
  * The CSS required to position the circles in the right margin is tricky
  * and it does not always work perfectly. When lint occurs on a block element
  * that has a right margin (like anything blockquoted) the circle will appear
- * to the left of where it belongs.  And if there is more
+ * to the left of where it belongs.
  **/
 function Lint({
     children,
@@ -70,62 +58,7 @@ function Lint({
     blockHighlight,
     severity,
 }: Props): React.ReactElement {
-    // Render the <a> element that holds the indicator icon, wrapped in the
-    // tooltip that describes the lint. We pass different styles for the
-    // inline and block cases.
-    const renderLink = (style: CSSProperties): React.ReactElement => {
-        let severityLabel;
-        let severityLabelStyle;
-        if (severity === Severity.Error) {
-            severityLabel = "Error";
-            severityLabelStyle = styles.publishBlockingError;
-        } else if (severity === Severity.Warning) {
-            severityLabel = "Warning";
-            severityLabelStyle = styles.warning;
-        } else {
-            severityLabel = "Recommendation";
-            severityLabelStyle = styles.warning;
-        }
-
-        return (
-            <Tooltip
-                // The anchor is an <a href>, which is already keyboard
-                // focusable, so the tooltip doesn't need to add a tabindex.
-                forceAnchorFocusivity={false}
-                variant="strong"
-                content={
-                    <TooltipContent
-                        title={
-                            <BodyText weight="bold" style={severityLabelStyle}>
-                                {severityLabel}
-                            </BodyText>
-                        }
-                    >
-                        {message.split("\n\n").map((paragraph, i) => (
-                            <BodyText key={i} style={styles.tooltipParagraph}>
-                                {paragraph}
-                            </BodyText>
-                        ))}
-                    </TooltipContent>
-                }
-            >
-                <IconButton
-                    size="small"
-                    kind="tertiary"
-                    actionType="destructive"
-                    aria-label={`${severityLabel}: ${ruleName}`}
-                    href={`https://khanacademy.org/r/linter-rules#${ruleName}`}
-                    icon={
-                        severity === Severity.Error
-                            ? warningCircleIcon
-                            : dotOutlineIcon
-                    }
-                    style={style}
-                />
-            </Tooltip>
-        );
-    };
-
+    const linterLinkProps = {message, ruleName, severity} as const;
     if (insideTable) {
         // If we're inside a table, then linty nodes just get
         // a simple wrapper that allows them to be highlighted
@@ -139,7 +72,10 @@ function Lint({
             <span
                 className={css(styles.lintContainer, styles.lintContainerBlock)}
             >
-                {renderLink(styles.radioWidgetHoverTarget)}
+                <LinterLink
+                    {...linterLinkProps}
+                    style={styles.radioWidgetHoverTarget}
+                />
                 <span>{children}</span>
             </span>
         );
@@ -147,14 +83,17 @@ function Lint({
     if (inline) {
         return (
             <span className={css(styles.lintContainer)}>
-                {renderLink(styles.inlineHoverTarget)}
+                <LinterLink
+                    {...linterLinkProps}
+                    style={styles.inlineHoverTarget}
+                />
                 <span>{children}</span>
             </span>
         );
     }
     return (
         <div className={css(styles.lintContainer)}>
-            {renderLink(styles.hoverTarget)}
+            <LinterLink {...linterLinkProps} style={styles.hoverTarget} />
             <div>{children}</div>
         </div>
     );
@@ -251,24 +190,6 @@ const styles = StyleSheet.create({
         // where there is some room.
         position: "absolute",
         insetInlineStart: -60,
-    },
-
-    // A lint message can contain several paragraphs. Wonder Blocks resets the
-    // margins on BodyText, so we space them out ourselves.
-    tooltipParagraph: {
-        ":not(:first-child)": {
-            marginBlockStart: sizing.size_080,
-        },
-    },
-
-    // The text "Warning" or "Recommendation" in the tooltip title
-    warning: {
-        color: semanticColor.status.warning.foreground,
-    },
-
-    // The text "Error" in the tooltip title, for publish-blocking lint
-    publishBlockingError: {
-        color: semanticColor.status.critical.foreground,
     },
 });
 

--- a/packages/perseus/src/components/lint.tsx
+++ b/packages/perseus/src/components/lint.tsx
@@ -1,10 +1,14 @@
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import Tooltip, {TooltipContent} from "@khanacademy/wonder-blocks-tooltip";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
 import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
-import ReactDOM from "react-dom";
 
 import * as constants from "../styles/constants";
 
 import InlineIcon from "./inline-icon";
+
+import type {CSSProperties} from "aphrodite";
 
 const exclamationIcon = {
     path: "M6 11a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm0-9a1 1 0 0 1 1 1v4a1 1 0 1 1-2 0V3a1 1 0 0 1 1-1z",
@@ -42,10 +46,6 @@ type Props = {
     severity?: Severity;
 };
 
-type State = {
-    tooltipAbove: boolean;
-};
-
 /**
  * This component renders "lint" nodes in a markdown parse tree. Lint nodes
  * are inserted into the tree by the Perseus linter (see
@@ -57,8 +57,8 @@ type State = {
  * is lint on (or near) that line.
  *
  * 2) The area around the circle is hoverable: when the mouse moves over it
- * the linty content is highlighted and a tooltip is displayed that explains
- * what the problem is.
+ * the linty content is highlighted and a Wonder Blocks tooltip is displayed
+ * that explains what the problem is.
  *
  * 3) The hoverable area is also an HTML <a> tag. Clicking on it opens
  * a new tab and links to additional details about the specific lint rule.
@@ -68,136 +68,111 @@ type State = {
  * that has a right margin (like anything blockquoted) the circle will appear
  * to the left of where it belongs.  And if there is more
  **/
-class Lint extends React.Component<Props, State> {
-    _positionTimeout: number | undefined;
-
-    state: State = {
-        tooltipAbove: true,
-    };
-
-    componentDidMount() {
-        // TODO(somewhatabstract): Use WB timing
-        this._positionTimeout = window.setTimeout(this.getPosition);
-    }
-
-    componentWillUnmount() {
-        // TODO(somewhatabstract): Use WB timing
-        window.clearTimeout(this._positionTimeout);
-    }
-
-    // We can't call setState in componentDidMount without risking a render
-    // thrash, and we can't call getBoundingClientRect in render, so we
-    // borrow a timeout approach from learnstorm-dashboard.jsx and set our
-    // state once the component has mounted and we can get what we need.
-    getPosition: () => void = () => {
-        // @ts-expect-error - TS2531 - Object is possibly 'null'. | TS2339 - Property 'getBoundingClientRect' does not exist on type 'Element | Text'.
-        const rect = ReactDOM.findDOMNode(this).getBoundingClientRect();
-        // NOTE(scottgrant): This is a magic number! We don't know the size
-        // of the tooltip at this point, so we're arbitrarily choosing a
-        // point at which to flip the tooltip's position.
-        this.setState({tooltipAbove: rect.top > 100});
-    };
-
-    // Render the <a> element that holds the indicator icon and the tooltip
-    // We pass different styles for the inline and block cases
-    renderLink: (arg1: any) => React.ReactElement = (style) => {
-        const tooltipAbove = this.state.tooltipAbove;
-
-        let severityStyle;
-        let warningText;
-        let warningTextStyle;
-        if (this.props.severity === Severity.Error) {
-            severityStyle = styles.indicatorError;
-            warningText = "Error";
-            warningTextStyle = styles.publishBlockingError;
-        } else if (this.props.severity === Severity.Warning) {
-            severityStyle = styles.indicatorWarning;
-            warningText = "Warning";
-            warningTextStyle = styles.warning;
+function Lint({
+    children,
+    inline,
+    message,
+    ruleName,
+    insideTable,
+    blockHighlight,
+    severity,
+}: Props): React.ReactElement {
+    // Render the <a> element that holds the indicator icon, wrapped in the
+    // tooltip that describes the lint. We pass different styles for the
+    // inline and block cases.
+    const renderLink = (style: CSSProperties): React.ReactElement => {
+        let indicatorSeverityStyle;
+        let severityLabel;
+        let severityLabelStyle;
+        if (severity === Severity.Error) {
+            indicatorSeverityStyle = styles.indicatorError;
+            severityLabel = "Error";
+            severityLabelStyle = styles.publishBlockingError;
+        } else if (severity === Severity.Warning) {
+            indicatorSeverityStyle = styles.indicatorWarning;
+            severityLabel = "Warning";
+            severityLabelStyle = styles.warning;
         } else {
-            severityStyle = styles.indicatorGuideline;
-            warningText = "Recommendation";
-            warningTextStyle = styles.warning;
+            indicatorSeverityStyle = styles.indicatorGuideline;
+            severityLabel = "Recommendation";
+            severityLabelStyle = styles.warning;
         }
 
         return (
-            <a
-                href={`https://khanacademy.org/r/linter-rules#${this.props.ruleName}`}
-                target="lint-help-window"
-                className={css(style)}
+            <Tooltip
+                // The anchor is an <a href>, which is already keyboard
+                // focusable, so the tooltip doesn't need to add a tabindex.
+                forceAnchorFocusivity={false}
+                variant="strong"
+                content={
+                    <TooltipContent
+                        title={
+                            <BodyText weight="bold" style={severityLabelStyle}>
+                                {severityLabel}
+                            </BodyText>
+                        }
+                    >
+                        {message.split("\n\n").map((paragraph, i) => (
+                            <BodyText key={i} style={styles.tooltipParagraph}>
+                                {paragraph}
+                            </BodyText>
+                        ))}
+                    </TooltipContent>
+                }
             >
-                <span className={css(styles.indicator, severityStyle)}>
-                    {this.props.severity === 1 && (
-                        <InlineIcon {...exclamationIcon} />
-                    )}
-                </span>
-                <div
-                    className={css(
-                        styles.tooltip,
-                        tooltipAbove && styles.tooltipAbove,
-                    )}
+                <a
+                    href={`https://khanacademy.org/r/linter-rules#${ruleName}`}
+                    target="lint-help-window"
+                    aria-label={`${severityLabel}: ${ruleName}`}
+                    className={css(style)}
                 >
-                    {this.props.message.split("\n\n").map((m, i) => (
-                        <p key={i} className={css(styles.tooltipParagraph)}>
-                            <span className={css(warningTextStyle)}>
-                                {warningText}:{" "}
-                            </span>
-                            {m}
-                        </p>
-                    ))}
-                    <div
+                    <span
                         className={css(
-                            styles.tail,
-                            tooltipAbove && styles.tailAbove,
+                            styles.indicator,
+                            indicatorSeverityStyle,
                         )}
-                    />
-                </div>
-            </a>
+                    >
+                        {severity === Severity.Error && (
+                            <InlineIcon {...exclamationIcon} />
+                        )}
+                    </span>
+                </a>
+            </Tooltip>
         );
     };
 
-    // The main render method surrounds linty content with a block or
-    // inline container and the link element that displays the indicator
-    // and holds the tooltip.
-    render(): React.ReactNode {
-        const {children, inline, blockHighlight, insideTable} = this.props;
-
-        if (insideTable) {
-            // If we're inside a table, then linty nodes just get
-            // a simple wrapper that allows them to be highlighted
-            if (inline) {
-                return <span data-lint-inside-table="true">{children}</span>;
-            }
-            return <div data-lint-inside-table="true">{children}</div>;
-        }
-        if (blockHighlight) {
-            return (
-                <span
-                    className={css(
-                        styles.lintContainer,
-                        styles.lintContainerBlock,
-                    )}
-                >
-                    {this.renderLink(styles.radioWidgetHoverTarget)}
-                    <span>{children}</span>
-                </span>
-            );
-        }
+    if (insideTable) {
+        // If we're inside a table, then linty nodes just get
+        // a simple wrapper that allows them to be highlighted
         if (inline) {
-            return (
-                <span className={css(styles.lintContainer)}>
-                    {this.renderLink(styles.inlineHoverTarget)}
-                    <span>{children}</span>
-                </span>
-            );
+            return <span data-lint-inside-table="true">{children}</span>;
         }
+        return <div data-lint-inside-table="true">{children}</div>;
+    }
+    if (blockHighlight) {
         return (
-            <div className={css(styles.lintContainer)}>
-                {this.renderLink(styles.hoverTarget)}
-                <div>{children}</div>
-            </div>
+            <span
+                className={css(styles.lintContainer, styles.lintContainerBlock)}
+            >
+                {renderLink(styles.radioWidgetHoverTarget)}
+                <span>{children}</span>
+            </span>
         );
     }
+    if (inline) {
+        return (
+            <span className={css(styles.lintContainer)}>
+                {renderLink(styles.inlineHoverTarget)}
+                <span>{children}</span>
+            </span>
+        );
+    }
+    return (
+        <div className={css(styles.lintContainer)}>
+            {renderLink(styles.hoverTarget)}
+            <div>{children}</div>
+        </div>
+    );
 }
 
 const styles = StyleSheet.create({
@@ -240,12 +215,6 @@ const styles = StyleSheet.create({
         // This style changes its color on hover
         ":hover > span": {
             backgroundColor: constants.warningColorHover,
-        },
-
-        // The tooltip is in a div element inside the hover target.
-        // This style displays it on hover
-        ":hover div": {
-            display: "block",
         },
 
         // The linty content is in a <div> sibling that follows the
@@ -298,12 +267,6 @@ const styles = StyleSheet.create({
             backgroundColor: constants.warningColorHover,
         },
 
-        // The tooltip is in a div element inside the hover target.
-        // This style displays it on hover. This is the same as the block case.
-        ":hover div": {
-            display: "block",
-        },
-
         // The linty content is in a <span> sibling that follows the
         // hover target. This style highlights it on hover. In this case
         // we can just set the foreground and background color to really
@@ -327,30 +290,11 @@ const styles = StyleSheet.create({
         width: 24,
         height: 24,
 
-        // By specifying a fixed minimum width, the tooltip will hover in a
-        // readable position above and to the right.
-        minInlineSize: 264,
-
         // The indicator is in a span inside the hover target.
         // This style changes its color on hover.
         // This is the same as the block case.
         ":hover > span": {
             backgroundColor: constants.warningColorHover,
-        },
-
-        // The tooltip is in a div element inside the hover target.
-        // This style displays it on hover. This is the same as the block case.
-        // We specify a fixed-width because of some parent styling.
-        ":hover > div": {
-            display: "block",
-            padding: 8,
-            width: 280,
-        },
-
-        // Move the tooltip tail to an appropriate position relative to the
-        // tooltip.
-        ":hover > div > div": {
-            insetInlineStart: 8,
         },
 
         // The linty content is in a <span> sibling that follows the
@@ -376,85 +320,34 @@ const styles = StyleSheet.create({
         width: 8,
     },
     indicatorError: {
-        backgroundColor: "#be2612",
+        backgroundColor: semanticColor.core.foreground.critical.default,
         borderRadius: 8,
         height: 16,
         width: 16,
     },
     indicatorWarning: {
-        backgroundColor: "#f86700",
+        backgroundColor: semanticColor.core.foreground.warning.strong,
     },
     indicatorGuideline: {
-        backgroundColor: "#ffbe26",
+        backgroundColor: semanticColor.core.foreground.warning.default,
     },
 
-    // These are the styles for the tooltip
-    tooltip: {
-        // Absolute positioning relative to the lint indicator circle.
-        position: "absolute",
-        insetInlineEnd: -12,
-
-        // The tooltip is hidden by default; only displayed on hover
-        display: "none",
-
-        // When it is displayed, it goes on top!
-        zIndex: 1000,
-
-        // These styles control what the tooltip looks like
-        color: constants.white,
-        backgroundColor: constants.gray17,
-        opacity: 0.9,
-        fontFamily: constants.baseFontFamily,
-        fontSize: "12px",
-        lineHeight: "15px",
-        width: "320px",
-        borderRadius: "4px",
-    },
-    // If we're going to render the tooltip above the warning circle, we use
-    // the previous rules in tooltip, but change the position slightly.
-    tooltipAbove: {
-        insetBlockEnd: 32,
-    },
-
-    // We give the tooltip a little triangular "tail" that points down at
-    // the lint indicator circle. This is inside the tooltip and positioned
-    // relative to it. It also shares the opacity of the tooltip. We're using
-    // the standard CSS trick for drawing triangles with a thick border.
-    tail: {
-        position: "absolute",
-        insetBlockStart: -12,
-        insetInlineEnd: 16,
-        width: 0,
-        height: 0,
-
-        // This is the CSS triangle trick
-        borderInlineStart: "8px solid transparent",
-        borderInlineEnd: "8px solid transparent",
-        borderBlockEnd: "12px solid " + constants.gray17,
-    },
-    tailAbove: {
-        insetBlockEnd: -12,
-        borderBlockEnd: "none",
-        borderBlockStart: "12px solid " + constants.gray17,
-        insetBlockStart: "auto",
-    },
-
-    // Each warning in the tooltip is its own <p>. They are 12 pixels from
-    // the edges of the tooltip and 12 pixels from each other.
+    // A lint message can contain several paragraphs. Wonder Blocks resets the
+    // margins on BodyText, so we space them out ourselves.
     tooltipParagraph: {
-        margin: 12,
+        ":not(:first-child)": {
+            marginBlockStart: sizing.size_080,
+        },
     },
 
-    // The text "Warning" inside the tooltip is highlighted like this
+    // The text "Warning" or "Recommendation" in the tooltip title
     warning: {
-        color: constants.warningColor,
-        fontFamily: constants.boldFontFamily,
+        color: semanticColor.status.warning.foreground,
     },
 
-    // The text "Publish-blocking error" instide the tooltip is highlighted
-    // like this
+    // The text "Error" in the tooltip title, for publish-blocking lint
     publishBlockingError: {
-        color: constants.publishBlockingErrorColor,
+        color: semanticColor.status.critical.foreground,
     },
 });
 

--- a/packages/perseus/src/components/lint.tsx
+++ b/packages/perseus/src/components/lint.tsx
@@ -1,20 +1,13 @@
+import IconButton from "@khanacademy/wonder-blocks-icon-button";
 import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
 import Tooltip, {TooltipContent} from "@khanacademy/wonder-blocks-tooltip";
 import {BodyText} from "@khanacademy/wonder-blocks-typography";
+import dotOutlineIcon from "@phosphor-icons/core/fill/dot-outline-fill.svg";
+import warningCircleIcon from "@phosphor-icons/core/fill/warning-circle-fill.svg";
 import {StyleSheet, css} from "aphrodite";
 import * as React from "react";
 
-import * as constants from "../styles/constants";
-
-import InlineIcon from "./inline-icon";
-
 import type {CSSProperties} from "aphrodite";
-
-const exclamationIcon = {
-    path: "M6 11a1 1 0 1 1 0-2 1 1 0 0 1 0 2zm0-9a1 1 0 0 1 1 1v4a1 1 0 1 1-2 0V3a1 1 0 0 1 1-1z",
-    height: 12,
-    width: 12,
-} as const;
 
 enum Severity {
     Error = 1,
@@ -81,19 +74,15 @@ function Lint({
     // tooltip that describes the lint. We pass different styles for the
     // inline and block cases.
     const renderLink = (style: CSSProperties): React.ReactElement => {
-        let indicatorSeverityStyle;
         let severityLabel;
         let severityLabelStyle;
         if (severity === Severity.Error) {
-            indicatorSeverityStyle = styles.indicatorError;
             severityLabel = "Error";
             severityLabelStyle = styles.publishBlockingError;
         } else if (severity === Severity.Warning) {
-            indicatorSeverityStyle = styles.indicatorWarning;
             severityLabel = "Warning";
             severityLabelStyle = styles.warning;
         } else {
-            indicatorSeverityStyle = styles.indicatorGuideline;
             severityLabel = "Recommendation";
             severityLabelStyle = styles.warning;
         }
@@ -120,23 +109,19 @@ function Lint({
                     </TooltipContent>
                 }
             >
-                <a
-                    href={`https://khanacademy.org/r/linter-rules#${ruleName}`}
-                    target="lint-help-window"
+                <IconButton
+                    size="small"
+                    kind="tertiary"
+                    actionType="destructive"
                     aria-label={`${severityLabel}: ${ruleName}`}
-                    className={css(style)}
-                >
-                    <span
-                        className={css(
-                            styles.indicator,
-                            indicatorSeverityStyle,
-                        )}
-                    >
-                        {severity === Severity.Error && (
-                            <InlineIcon {...exclamationIcon} />
-                        )}
-                    </span>
-                </a>
+                    href={`https://khanacademy.org/r/linter-rules#${ruleName}`}
+                    icon={
+                        severity === Severity.Error
+                            ? warningCircleIcon
+                            : dotOutlineIcon
+                    }
+                    style={style}
+                />
             </Tooltip>
         );
     };
@@ -175,6 +160,40 @@ function Lint({
     );
 }
 
+const highlightBlockContent: CSSProperties = {
+    // The linty content is in a <div> sibling that follows the
+    // hover target. This style highlights it on hover. We do an outline
+    // rather than a border so we don't affect the layout. We could also
+    // set the background color, but we don't because we can't reliably
+    // set the text color of this block element. We could use
+    // filter: invert(100%) if we want more visual change on hover here.
+    ":hover ~ div": {
+        outline: `1px solid ${semanticColor.status.warning.foreground}`,
+    },
+
+    // If the div sibling is a table, then we may be displaying
+    // lint warnings about errors inside that table. In that case
+    // we want to highlight any linty descendants of the table
+    ":hover ~ div div[data-lint-inside-table]": {
+        outline: `1px solid ${semanticColor.status.warning.foreground}`,
+    },
+    ":hover ~ div span[data-lint-inside-table]": {
+        backgroundColor: semanticColor.status.warning.background,
+        color: semanticColor.status.warning.foreground,
+    },
+};
+
+const highlightInlineContent: CSSProperties = {
+    // The linty content is in a <span> sibling that follows the
+    // hover target. This style highlights it on hover. In this case
+    // we can just set the foreground and background color to really
+    // draw attention to the linty content.
+    ":hover ~ span": {
+        backgroundColor: semanticColor.status.warning.background,
+        color: semanticColor.status.warning.foreground,
+    },
+};
+
 const styles = StyleSheet.create({
     // This is the class of the outermost element.
     // We use relative positioning so that the lint indicator can be
@@ -194,8 +213,6 @@ const styles = StyleSheet.create({
     hoverTarget: {
         // Absolute positioning relative to the lintContainer element
         position: "absolute",
-        // Top of the hover target is aligned with the top of the linty block
-        insetBlockStart: 0,
 
         // We want the hover target in the right margin. It is 24px wide, but
         // we have to offset it another 16px because of margins in the
@@ -204,40 +221,9 @@ const styles = StyleSheet.create({
         // This is the part of the CSS that doesn't work right when
         // applied to things like blockquotes that have different right
         // margins.
-        insetInlineEnd: -40,
+        insetInlineEnd: -60,
 
-        // The hover target is a 24x24 block element.
-        display: "block",
-        width: 24,
-        height: 24,
-
-        // The indicator is in a span inside the hover target.
-        // This style changes its color on hover
-        ":hover > span": {
-            backgroundColor: constants.warningColorHover,
-        },
-
-        // The linty content is in a <div> sibling that follows the
-        // hover target. This style highlights it on hover. We do an outline
-        // rather than a border so we don't affect the layout. We could also
-        // set the background color, but we don't because we can't reliably
-        // set the text color of this block element. We could use
-        // filter: invert(100%) if we want more visual change on hover here.
-        ":hover ~ div": {
-            outline: "1px solid " + constants.warningColor,
-        },
-
-        // If the div sibling is a table, then we may be displaying
-        // lint warnings about errors inside that table. In that case
-        // we want to highlight any linty descendants of the table
-        ":hover ~ div div[data-lint-inside-table]": {
-            outline: "1px solid " + constants.warningColor,
-        },
-
-        ":hover ~ div span[data-lint-inside-table]": {
-            backgroundColor: constants.warningColor,
-            color: constants.white,
-        },
+        ...highlightBlockContent,
     },
 
     // This is how we position the hover target for inline lint.
@@ -253,28 +239,9 @@ const styles = StyleSheet.create({
         position: "relative",
 
         // See the comment above about the extra 16px of offset needed here.
-        marginInlineEnd: -40,
+        marginInlineEnd: -60,
 
-        // The hover target is a 24x24 block. Same as the block case
-        display: "block",
-        width: 24,
-        height: 24,
-
-        // The indicator is in a span inside the hover target.
-        // This style changes its color on hover.
-        // This is the same as the block case.
-        ":hover > span": {
-            backgroundColor: constants.warningColorHover,
-        },
-
-        // The linty content is in a <span> sibling that follows the
-        // hover target. This style highlights it on hover. In this case
-        // we can just set the foreground and background color to really
-        // draw attention to the linty content.
-        ":hover ~ span": {
-            backgroundColor: constants.warningColor,
-            color: constants.white,
-        },
+        ...highlightInlineContent,
     },
 
     radioWidgetHoverTarget: {
@@ -283,53 +250,7 @@ const styles = StyleSheet.create({
         // overflow rule. We position these icons to the left of the block
         // where there is some room.
         position: "absolute",
-        insetInlineStart: -40,
-
-        // The hover target is a 24x24 block. Same as the block case
-        display: "block",
-        width: 24,
-        height: 24,
-
-        // The indicator is in a span inside the hover target.
-        // This style changes its color on hover.
-        // This is the same as the block case.
-        ":hover > span": {
-            backgroundColor: constants.warningColorHover,
-        },
-
-        // The linty content is in a <span> sibling that follows the
-        // hover target. This style highlights it on hover. In this case
-        // we can just set the foreground and background color to really
-        // draw attention to the linty content.
-        ":hover ~ span": {
-            backgroundColor: constants.warningColor,
-            color: constants.white,
-        },
-    },
-
-    // This is the class for the lint indicator in the margin.
-    indicator: {
-        alignItems: "center",
-        borderRadius: 4,
-        color: "white",
-        display: "flex",
-        fontSize: 12,
-        height: 8,
-        justifyContent: "center",
-        margin: 8,
-        width: 8,
-    },
-    indicatorError: {
-        backgroundColor: semanticColor.core.foreground.critical.default,
-        borderRadius: 8,
-        height: 16,
-        width: 16,
-    },
-    indicatorWarning: {
-        backgroundColor: semanticColor.core.foreground.warning.strong,
-    },
-    indicatorGuideline: {
-        backgroundColor: semanticColor.core.foreground.warning.default,
+        insetInlineStart: -60,
     },
 
     // A lint message can contain several paragraphs. Wonder Blocks resets the

--- a/packages/perseus/src/components/linter-link.tsx
+++ b/packages/perseus/src/components/linter-link.tsx
@@ -13,12 +13,13 @@ import type {CSSProperties} from "aphrodite";
  * How important a lint message is for the editor. These values
  * mirror `Rule.Severity` in perseus-linter, which is where the severities
  * on lint nodes originate.
+ *
+ * perseus-linter Severity also includes Recommendation = 3 and
+ * OfflineReportingOnly = 4, but those are not used here.
  */
 export enum Severity {
     Error = 1,
     Warning = 2,
-    Recommendation = 3,
-    OfflineReportingOnly = 4,
 }
 
 type Props = {

--- a/packages/perseus/src/components/linter-link.tsx
+++ b/packages/perseus/src/components/linter-link.tsx
@@ -1,0 +1,123 @@
+import IconButton from "@khanacademy/wonder-blocks-icon-button";
+import {semanticColor, sizing} from "@khanacademy/wonder-blocks-tokens";
+import Tooltip, {TooltipContent} from "@khanacademy/wonder-blocks-tooltip";
+import {BodyText} from "@khanacademy/wonder-blocks-typography";
+import dotOutlineIcon from "@phosphor-icons/core/fill/dot-outline-fill.svg";
+import warningCircleIcon from "@phosphor-icons/core/fill/warning-circle-fill.svg";
+import {StyleSheet} from "aphrodite";
+import * as React from "react";
+
+import type {CSSProperties} from "aphrodite";
+
+/**
+ * How important a lint message is for the editor. These values
+ * mirror `Rule.Severity` in perseus-linter, which is where the severities
+ * on lint nodes originate.
+ */
+export enum Severity {
+    Error = 1,
+    Warning = 2,
+    Recommendation = 3,
+    OfflineReportingOnly = 4,
+}
+
+type Props = {
+    /** This is the text that appears in the tooltip */
+    message: string;
+    /** This is used as the fragment id (hash) in the URL of the link */
+    ruleName: string;
+    /**
+     * Determines the icon and the label at the top of the tooltip. Anything
+     * less severe than a warning is presented as a recommendation.
+     */
+    severity?: Severity;
+    /** Positioning styles, supplied by the caller. */
+    style: CSSProperties;
+};
+
+/**
+ * The indicator for a single lint message: a small icon button that links to
+ * the documentation for the rule that fired, wrapped in a Wonder Blocks
+ * tooltip that names the severity and explains the problem.
+ **/
+export default function LinterLink({
+    message,
+    ruleName,
+    severity,
+    style,
+}: Props): React.ReactElement {
+    // Render the <a> element that holds the indicator icon, wrapped in the
+    // tooltip that describes the lint. We pass different styles for the
+    // inline and block cases.
+
+    let severityLabel;
+    let severityLabelStyle;
+    if (severity === Severity.Error) {
+        severityLabel = "Error";
+        severityLabelStyle = styles.publishBlockingError;
+    } else if (severity === Severity.Warning) {
+        severityLabel = "Warning";
+        severityLabelStyle = styles.warning;
+    } else {
+        severityLabel = "Recommendation";
+        severityLabelStyle = styles.warning;
+    }
+
+    return (
+        <Tooltip
+            // The anchor is an <a href>, which is already keyboard
+            // focusable, so the tooltip doesn't need to add a tabindex.
+            forceAnchorFocusivity={false}
+            variant="strong"
+            content={
+                <TooltipContent
+                    title={
+                        <BodyText weight="bold" style={severityLabelStyle}>
+                            {severityLabel}
+                        </BodyText>
+                    }
+                >
+                    {message.split("\n\n").map((paragraph, i) => (
+                        <BodyText key={i} style={styles.tooltipParagraph}>
+                            {paragraph}
+                        </BodyText>
+                    ))}
+                </TooltipContent>
+            }
+        >
+            <IconButton
+                size="small"
+                kind="tertiary"
+                actionType="destructive"
+                aria-label={`${severityLabel}: ${ruleName}`}
+                href={`https://khanacademy.org/r/linter-rules#${ruleName}`}
+                icon={
+                    severity === Severity.Error
+                        ? warningCircleIcon
+                        : dotOutlineIcon
+                }
+                style={style}
+            />
+        </Tooltip>
+    );
+}
+
+const styles = StyleSheet.create({
+    // A lint message can contain several paragraphs. Wonder Blocks resets the
+    // margins on BodyText, so we space them out ourselves.
+    tooltipParagraph: {
+        ":not(:first-child)": {
+            marginBlockStart: sizing.size_080,
+        },
+    },
+
+    // The text "Warning" or "Recommendation" in the tooltip title
+    warning: {
+        color: semanticColor.status.warning.foreground,
+    },
+
+    // The text "Error" in the tooltip title, for publish-blocking lint
+    publishBlockingError: {
+        color: semanticColor.status.critical.foreground,
+    },
+});

--- a/packages/perseus/src/styles/constants.ts
+++ b/packages/perseus/src/styles/constants.ts
@@ -1,15 +1,12 @@
 // TODO(LEMS-4463): Remove the hardcoded colors in this file.
 import {sizing} from "@khanacademy/wonder-blocks-tokens";
 
-// @baseFontFamily:        "Lato", sans-serif;
-export const baseFontFamily = "'Lato', sans-serif";
 // @boldFontFamily:        "Lato-Bold", "Lato", sans-serif;
 export const boldFontFamily = "'Lato-Bold', 'Lato', sans-serif";
 
 export const white = "#FFFFFF";
 export const gray76 = "#BABEC2";
 export const gray68 = "#888D93";
-export const gray17 = "#21242c";
 
 // @pure-sm-min: 568px;
 export const pureSmMin = "568px";
@@ -46,8 +43,6 @@ export const radioMarginWidth = 2;
 export const warningColor = "#f86700";
 export const warningColorHover = "#df5c00";
 export const warningColorActive = "#c75300";
-
-export const publishBlockingErrorColor = "#be2612";
 
 export const articleMaxWidthInPx = 688;
 export const articleMaxWidthTableInPx = 512;


### PR DESCRIPTION
## Summary:
Removed an unnecessary margin + updated tooltips to use Wonder Blocks.

Issue: https://khanacademy.atlassian.net/browse/LEMS-4432

## Test plan:
Storybook
- /?path=/story/editors-editorpage--with-all-widgets

### Margin before
<img width="927" height="962" alt="Screenshot 2026-09-03 at 5 01 09 PM" src="https://github.com/user-attachments/assets/df51dcb0-a25e-4750-a483-b584bb91e40e" />


### Margin after
<img width="897" height="923" alt="Screenshot 2026-09-03 at 5 01 17 PM" src="https://github.com/user-attachments/assets/34a02923-96a0-4fec-bca6-e7d72f25e428" />


### Tooltip before
<img width="503" height="224" alt="Screenshot 2026-09-03 at 5 01 29 PM" src="https://github.com/user-attachments/assets/ada2c0b8-37ab-47a1-9228-ac41b6002791" />


### Tooltip after (ignore broken placement, it's not broken in prod)
<img width="523" height="257" alt="Screenshot 2026-09-03 at 5 01 33 PM" src="https://github.com/user-attachments/assets/2ef03bdb-c3cb-456d-b32a-03655d31014a" />
