### PR TITLE
Memoize i18n context provider values to prevent unnecessary re-renders

### DIFF
--- a/.changeset/memoize-i18n-context-value.md
+++ b/.changeset/memoize-i18n-context-value.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+---
+
+Memoize the i18n context provider values so consumers no longer re-render whenever the provider's parent renders

--- a/packages/math-input/src/components/i18n-context.tsx
+++ b/packages/math-input/src/components/i18n-context.tsx
@@ -4,7 +4,7 @@
  *
  */
 import * as React from "react";
-import {useContext} from "react";
+import {useContext, useMemo} from "react";
 
 import {mockStrings} from "../strings";
 
@@ -36,8 +36,12 @@ export function MathInputI18nContextProvider({
     strings,
     locale,
 }: Props) {
+    // Memoize so consumers don't re-render every time this provider's parent
+    // renders; a fresh object literal would be a new context value each time.
+    const value = useMemo(() => ({strings, locale}), [strings, locale]);
+
     return (
-        <MathInputI18nContext.Provider value={{strings, locale}}>
+        <MathInputI18nContext.Provider value={value}>
             {children}
         </MathInputI18nContext.Provider>
     );

--- a/packages/perseus/src/components/i18n-context.tsx
+++ b/packages/perseus/src/components/i18n-context.tsx
@@ -4,7 +4,7 @@
  *
  */
 import * as React from "react";
-import {useContext} from "react";
+import {useContext, useMemo} from "react";
 
 import {mockStrings} from "../strings";
 
@@ -34,8 +34,12 @@ export const PerseusI18nContext: React.Context<I18nContextType> =
 type Props = React.PropsWithChildren<I18nContextType>;
 
 export function PerseusI18nContextProvider({children, strings, locale}: Props) {
+    // Memoize so consumers don't re-render every time this provider's parent
+    // renders; a fresh object literal would be a new context value each time.
+    const value = useMemo(() => ({strings, locale}), [strings, locale]);
+
     return (
-        <PerseusI18nContext.Provider value={{strings, locale}}>
+        <PerseusI18nContext.Provider value={value}>
             {children}
         </PerseusI18nContext.Provider>
     );


### PR DESCRIPTION
## Summary
Issue: FEI-8245

Memoize the context values in both `MathInputI18nContextProvider` and `PerseusI18nContextProvider` to prevent consumer components from re-rendering whenever the provider's parent component renders.

## Changes
- Added `useMemo` import to both i18n context files
- Wrapped `{strings, locale}` object in `useMemo` with `[strings, locale]` dependency array in both providers
- This ensures the context value object reference remains stable across renders unless `strings` or `locale` actually change

## Implementation Details
Without memoization, a fresh object literal was created on every render, causing all context consumers to re-render even when the actual `strings` and `locale` values hadn't changed. By memoizing the value object, we maintain referential equality and only trigger consumer updates when the dependencies actually change.

This is a performance optimization that prevents unnecessary cascading re-renders in applications using these i18n context providers.

https://claude.ai/code/session_01Aum1qnYJKcbqa2V78i4oLc