### PR TITLE
Stop SvgImage re-running loadResources on every update

### DIFF
--- a/.changeset/svg-image-no-reload-loop.md
+++ b/.changeset/svg-image-no-reload-loop.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix `SvgImage` re-running `loadResources` (and calling `setState` during React's commit phase) on every update while a labeled SVG's image was still loading, which could trip React's "Maximum update depth exceeded" limit

--- a/packages/perseus/src/components/__tests__/svg-image.test.tsx
+++ b/packages/perseus/src/components/__tests__/svg-image.test.tsx
@@ -150,6 +150,100 @@ describe("SvgImage", () => {
         ).toEqual("https://www.khanacademy.org/my-test-img.png");
     });
 
+    describe("componentDidUpdate", () => {
+        // Stand-in for loadGraphie answering synchronously from its cache.
+        const mockCachedLoadGraphie = () =>
+            jest
+                .spyOn(GraphieUtils, "loadGraphie")
+                .mockImplementation((url, onDataLoaded) => {
+                    onDataLoaded(
+                        {
+                            labels: [],
+                            range: [
+                                [-10, 10],
+                                [-10, 10],
+                            ],
+                        },
+                        false,
+                    );
+                });
+
+        beforeEach(() => {
+            jest.spyOn(Dependencies, "getDependencies").mockReturnValue(
+                testDependencies,
+            );
+            // The <img> never finishes loading, so imageLoaded stays false
+            // for the whole test while the label data is already loaded.
+            unmockImageLoading();
+            jest.spyOn(globalThis, "Image").mockImplementation(
+                // eslint-disable-next-line no-restricted-syntax
+                () => ({}) as HTMLImageElement,
+            );
+        });
+
+        it("should not reload label data on re-render while the image is still loading", () => {
+            // Arrange
+            const loadGraphie = mockCachedLoadGraphie();
+            const {rerender} = render(
+                <SvgImage
+                    src={graphieImage.url}
+                    alt="svg image"
+                    allowZoom={false}
+                    width={graphieImage.width}
+                    height={graphieImage.height}
+                />,
+            );
+            loadGraphie.mockClear();
+
+            // Act
+            rerender(
+                <SvgImage
+                    src={graphieImage.url}
+                    alt="a different alt"
+                    allowZoom={false}
+                    width={graphieImage.width}
+                    height={graphieImage.height}
+                />,
+            );
+
+            // Assert
+            expect(loadGraphie).not.toHaveBeenCalled();
+        });
+
+        it("should reload label data when the src changes", () => {
+            // Arrange
+            const loadGraphie = mockCachedLoadGraphie();
+            const {rerender} = render(
+                <SvgImage
+                    src={graphieImage.url}
+                    alt="svg image"
+                    allowZoom={false}
+                    width={graphieImage.width}
+                    height={graphieImage.height}
+                />,
+            );
+            loadGraphie.mockClear();
+
+            // Act
+            rerender(
+                <SvgImage
+                    src={typicalCase.url}
+                    alt="svg image"
+                    allowZoom={false}
+                    width={graphieImage.width}
+                    height={graphieImage.height}
+                />,
+            );
+
+            // Assert
+            expect(loadGraphie).toHaveBeenCalledTimes(1);
+            expect(loadGraphie).toHaveBeenCalledWith(
+                typicalCase.url,
+                expect.any(Function),
+            );
+        });
+    });
+
     describe("Graphie label scaling", () => {
         const mockLabels = [
             {

--- a/packages/perseus/src/components/svg-image.tsx
+++ b/packages/perseus/src/components/svg-image.tsx
@@ -224,11 +224,18 @@ class SvgImage extends React.Component<Props, State> {
         const wasLoaded = this.isLoadedInState(prevState);
         const isLoaded = this.isLoadedInState(this.state);
 
-        // Only call loadResources if we're not already loading,
-        // This prevents infinite loops when async loading triggers re-renders
+        // Only (re)load the label data when it is actually missing: the src
+        // changed (UNSAFE_componentWillReceiveProps reset dataLoaded), or a
+        // previous attempt never produced data. Do NOT key this off
+        // `isLoaded`: once the data is in state but the <img> is still
+        // loading, every update would re-run loadResources, and loadGraphie
+        // answers synchronously from its cache, so we would call setState
+        // inside React's commit phase on every render. That nested update
+        // is what tripped React's "Maximum update depth exceeded" limit in
+        // production.
         if (
             Util.isLabeledSVG(this.props.src) &&
-            !isLoaded &&
+            !this.state.dataLoaded &&
             !this._isLoadingGraphie
         ) {
             this.loadResources();


### PR DESCRIPTION
## Summary

`SvgImage.componentDidUpdate` called `loadResources()` whenever a labeled SVG was not fully loaded and no load was in flight. Once the graphie label data had loaded but the `<img>` had not, that condition was true on **every** update, so each re-render re-ran `loadResources`, got the cached data back synchronously from `loadGraphie`, and called `setState` inside React's commit phase. That nested update on every render is what trips React's "Maximum update depth exceeded" limit in production:

- Classroom: https://khanacademyorg.sentry.io/issues/CLASSROOM-RC
- www: https://khanacademyorg.sentry.io/issues/PROD-JS-DAJ5

This change only reloads when the label data is actually missing (`dataLoaded` is false). The src-change case is still covered because `UNSAFE_componentWillReceiveProps` resets `dataLoaded`.

Prior work on this error: LEMS-3743 / LEMS-3853 (#3110, #3123, #3168, #3329) reduced it but did not eliminate it. #3168's `_isLoadingGraphie` guard covers the in-flight fetch; this covers the already-cached case, where the callback is synchronous.

Companion change: #4184 memoizes the i18n context values, which is what was force-updating every `SvgImage` (it uses `contextType`, so context changes bypass `shouldComponentUpdate`).

Issue: FEI-8245

## Test plan

- New unit tests: re-rendering `SvgImage` with cached label data while the image is still loading no longer calls `loadGraphie`; changing `src` still reloads. The first test fails on `main` and passes with this change.
- Manually: render an exercise containing a `web+graphie://` image (e.g. `identifying_points_1`), throttle the network so the `.svg` is slow, and interact with the page while it loads. No "Unhandled Perseus error" is logged and the image renders once loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EutvpgzZeN6mSXkZh3dbLr