### PR TITLE
Add onJsonModeChange callback to EditorPage

### DIFF
--- a/.changeset/social-knives-write.md
+++ b/.changeset/social-knives-write.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+`EditorPage` now accepts an `onJsonModeChange` prop to inform clients of when JSON mode is toggled. The `jsonMode` parameter to `onChange` is deprecated.

--- a/packages/perseus-editor/src/editor-page.test.tsx
+++ b/packages/perseus-editor/src/editor-page.test.tsx
@@ -323,6 +323,62 @@ describe("EditorPage", () => {
         expect(onChangeMock).toHaveBeenCalledWith({jsonMode: true});
     });
 
+    it("calls onJsonModeChange when JSON mode is toggled on", async () => {
+        const onJsonModeChange = jest.fn();
+
+        // Arrange: EditorPage with jsonMode={false}
+        render(
+            <EditorPage
+                dependencies={testDependenciesV2}
+                question={{content: "", widgets: {}, images: {}}}
+                onJsonModeChange={onJsonModeChange}
+                onPreviewDeviceChange={() => {}}
+                previewDevice="desktop"
+                previewURL=""
+                itemId="itemId"
+                developerMode={true}
+                jsonMode={false}
+            />,
+        );
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("checkbox", {name: /Developer JSON Mode/i}),
+        );
+
+        // Assert
+        expect(onJsonModeChange).toHaveBeenLastCalledWith(true);
+        expect(onJsonModeChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onJsonModeChange when JSON mode is toggled off", async () => {
+        const onJsonModeChange = jest.fn();
+
+        // Arrange: EditorPage with jsonMode={true}
+        render(
+            <EditorPage
+                dependencies={testDependenciesV2}
+                question={{content: "", widgets: {}, images: {}}}
+                onJsonModeChange={onJsonModeChange}
+                onPreviewDeviceChange={() => {}}
+                previewDevice="desktop"
+                previewURL=""
+                itemId="itemId"
+                developerMode={true}
+                jsonMode={true}
+            />,
+        );
+
+        // Act
+        await userEvent.click(
+            screen.getByRole("checkbox", {name: /Developer JSON Mode/i}),
+        );
+
+        // Assert
+        expect(onJsonModeChange).toHaveBeenLastCalledWith(false);
+        expect(onJsonModeChange).toHaveBeenCalledTimes(1);
+    });
+
     it("should call initializeWidgetOptions if available", async () => {
         const onChangeMock = jest.fn();
 

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -34,6 +34,7 @@ import type {
 const {HUD} = components;
 
 type OnChangeParams = {
+    /** @deprecated - use the `onJsonModeChange` prop instead */
     jsonMode?: boolean;
     question?: PerseusRenderer;
     hints?: Hint[];
@@ -66,6 +67,7 @@ type Props = {
     jsonMode: boolean;
     /** A function which is called with the new JSON blob of content. */
     onChange: (changed: OnChangeParams) => void;
+    onJsonModeChange?: (jsonMode: boolean) => void;
     /** A function which is called when the preview device changes. */
     onPreviewDeviceChange: (arg1: DeviceType) => unknown;
     previewDevice: DeviceType;
@@ -235,9 +237,11 @@ class EditorPage extends React.Component<Props, State> {
                 json: this.serialize(),
             },
             () => {
+                const newJsonMode = !this.props.jsonMode;
                 this.props.onChange({
-                    jsonMode: !this.props.jsonMode,
+                    jsonMode: newJsonMode,
                 });
+                this.props.onJsonModeChange?.(newJsonMode);
             },
         );
     };


### PR DESCRIPTION
## Summary:
The plan is to remove `jsonMode` from `onChange`, so `onChange` can just accept
a `PerseusItem`.

Issue: LEMS-4570

## Test plan:

CI checks should pass.