### PR TITLE
feat(LEMS-4498): programmatically swap deprecated standin for sorters over 10 cards

### DIFF
--- a/.changeset/moody-mails-cheer.md
+++ b/.changeset/moody-mails-cheer.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-core": patch
+"@khanacademy/perseus": patch
+---
+
+same as other

--- a/.changeset/moody-mails-cheer.md
+++ b/.changeset/moody-mails-cheer.md
@@ -1,6 +1,0 @@
----
-"@khanacademy/perseus-core": patch
-"@khanacademy/perseus": patch
----
-
-same as other

--- a/.changeset/shaky-seas-say.md
+++ b/.changeset/shaky-seas-say.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-core": minor
+"@khanacademy/perseus": minor
+---
+
+Adds logic to swap deprecated standin in for sorter when sorter has more than 10 cards

--- a/packages/perseus-core/src/data-schema.ts
+++ b/packages/perseus-core/src/data-schema.ts
@@ -171,7 +171,7 @@ export interface PerseusWidgetTypes {
     "python-program": PythonProgramWidget;
     plotter: PlotterWidget;
     radio: RadioWidget;
-    sorter: SorterWidget;
+    sorter: SorterWidget | DeprecatedStandinWidget;
     table: TableWidget;
     video: VideoWidget;
 

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/sorter-widget.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/sorter-widget.test.ts
@@ -1,0 +1,56 @@
+import {parse} from "../parse";
+import {success} from "../result";
+
+import {parseSorterWidget} from "./sorter-widget";
+
+function generateCards(count: number): string[] {
+    return Array.from({length: count}, (_, index) => `card ${index}`);
+}
+
+describe("sorterWidget", () => {
+    it("keeps a sorter with ten cards", () => {
+        const widget = {
+            type: "sorter",
+            graded: true,
+            options: {
+                correct: generateCards(10),
+                layout: "horizontal",
+                padding: true,
+            },
+        };
+
+        expect(parse(widget, parseSorterWidget)).toEqual(success(widget));
+    });
+
+    it("replaces a sorter with eleven cards with a deprecated standin", () => {
+        const widget = {
+            type: "sorter",
+            graded: true,
+            options: {
+                correct: generateCards(11),
+                layout: "horizontal",
+                padding: true,
+            },
+        };
+
+        expect(parse(widget, parseSorterWidget)).toEqual(
+            success({
+                type: "deprecated-standin",
+                graded: true,
+                options: {},
+            }),
+        );
+    });
+
+    it("accepts a sorter that has already been replaced", () => {
+        const alreadyReplaced = {
+            type: "deprecated-standin",
+            graded: true,
+            options: {},
+        };
+
+        expect(parse(alreadyReplaced, parseSorterWidget)).toEqual(
+            success(alreadyReplaced),
+        );
+    });
+});

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/sorter-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/sorter-widget.ts
@@ -4,16 +4,40 @@ import {
     constant,
     enumeration,
     object,
+    pipeParsers,
     string,
+    union,
 } from "../general-purpose-parsers";
+import {convert} from "../general-purpose-parsers/convert";
 
 import {parseWidget} from "./widget";
 
-export const parseSorterWidget = parseWidget(
-    constant("sorter"),
-    object({
-        correct: array(string),
-        padding: boolean,
-        layout: enumeration("horizontal", "vertical"),
-    }),
+const MAX_SORTER_CARDS = 10;
+
+const parseDeprecatedStandin = parseWidget(
+    constant("deprecated-standin"),
+    object({}),
 );
+
+const parseSorter = pipeParsers(
+    parseWidget(
+        constant("sorter"),
+        object({
+            correct: array(string),
+            padding: boolean,
+            layout: enumeration("horizontal", "vertical"),
+        }),
+    ),
+).then(
+    convert((widget) => {
+        if (widget.options.correct.length <= MAX_SORTER_CARDS) {
+            return widget;
+        }
+
+        return {...widget, type: "deprecated-standin" as const, options: {}};
+    }),
+).parser;
+
+export const parseSorterWidget = union(parseDeprecatedStandin).or(
+    parseSorter,
+).parser;

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/sorter-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/sorter-widget.typetest.ts
@@ -9,7 +9,7 @@ import type {ParseResult} from "../parser-types";
 
 describe("the SorterWidget parser", () => {
     it("should return the widget type defined in data-schema.ts", () => {
-        expect(parseSorterWidget({}, ctx())).type.toBe<
+        expect(parseSorterWidget({}, ctx())).type.toBeAssignableTo<
             ParseResult<SorterWidget | DeprecatedStandinWidget>
         >();
     });

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/sorter-widget.typetest.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/sorter-widget.typetest.ts
@@ -4,13 +4,13 @@ import {ctx} from "../general-purpose-parsers/test-helpers";
 
 import {parseSorterWidget} from "./sorter-widget";
 
-import type {SorterWidget} from "../../data-schema";
+import type {DeprecatedStandinWidget, SorterWidget} from "../../data-schema";
 import type {ParseResult} from "../parser-types";
 
 describe("the SorterWidget parser", () => {
     it("should return the widget type defined in data-schema.ts", () => {
         expect(parseSorterWidget({}, ctx())).type.toBe<
-            ParseResult<SorterWidget>
+            ParseResult<SorterWidget | DeprecatedStandinWidget>
         >();
     });
 });

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -21943,6 +21943,66 @@ exports[`parseAndMigratePerseusItem given simulator-widget.ts returns the same r
 }
 `;
 
+exports[`parseAndMigratePerseusItem given sorter-with-more-than-ten-cards.ts returns the same result as before 1`] = `
+{
+  "answerArea": {
+    "calculator": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTimeToPayOff": false,
+    "financialCalculatorTotalAmount": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+  },
+  "hints": [],
+  "question": {
+    "content": "**Sort the numbers from smallest to largest.**
+
+[[☃ sorter 1]]",
+    "images": {},
+    "widgets": {
+      "sorter 1": {
+        "graded": true,
+        "options": {},
+        "type": "deprecated-standin",
+      },
+    },
+  },
+}
+`;
+
+exports[`parseAndMigratePerseusItem given sorter-with-more-than-ten-cards.ts returns the same result as before with answer information removed 1`] = `
+{
+  "answerArea": {
+    "calculator": false,
+    "financialCalculatorMonthlyPayment": false,
+    "financialCalculatorTimeToPayOff": false,
+    "financialCalculatorTotalAmount": false,
+    "periodicTable": false,
+    "periodicTableWithKey": false,
+  },
+  "hints": [],
+  "question": {
+    "content": "**Sort the numbers from smallest to largest.**
+
+[[☃ sorter 1]]",
+    "images": {},
+    "widgets": {
+      "sorter 1": {
+        "alignment": "default",
+        "graded": true,
+        "options": {},
+        "static": false,
+        "type": "deprecated-standin",
+        "version": {
+          "major": 0,
+          "minor": 0,
+        },
+      },
+    },
+  },
+}
+`;
+
 exports[`parseAndMigratePerseusItem given transformer-widget.ts returns the same result as before 1`] = `
 {
   "answerArea": {

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/sorter-with-more-than-ten-cards.ts
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/item-data/sorter-with-more-than-ten-cards.ts
@@ -1,0 +1,43 @@
+// WARNING: Do not change or delete this file! If you do, Perseus might become
+// unable to parse the current data format, which will break clients.
+// If you need to add more regression tests, add a new file to this directory.
+export default {
+    answerArea: {
+        calculator: false,
+        options: {
+            content: "",
+            images: {},
+            widgets: {},
+        },
+        type: "multiple",
+    },
+    hints: [],
+    question: {
+        content:
+            "**Sort the numbers from smallest to largest.**\n\n[[☃ sorter 1]]",
+        images: {},
+        widgets: {
+            "sorter 1": {
+                graded: true,
+                options: {
+                    correct: [
+                        "$1$",
+                        "$2$",
+                        "$3$",
+                        "$4$",
+                        "$5$",
+                        "$6$",
+                        "$7$",
+                        "$8$",
+                        "$9$",
+                        "$10$",
+                        "$11$",
+                    ],
+                    layout: "horizontal",
+                    padding: true,
+                },
+                type: "sorter",
+            },
+        },
+    },
+};

--- a/packages/perseus/src/widgets/sorter/serialize-sorter.test.ts
+++ b/packages/perseus/src/widgets/sorter/serialize-sorter.test.ts
@@ -30,6 +30,8 @@ import type {PerseusItem} from "@khanacademy/perseus-core";
  * This API needs to be removed and these tests need to be removed with it.
  */
 describe("Sorter serialization", () => {
+    const correctOrder = ["First", "Second", "Third"];
+
     function generateBasicSorter(): PerseusItem {
         const question = generateTestPerseusRenderer({
             content: "[[☃ sorter 1]]",
@@ -39,7 +41,7 @@ describe("Sorter serialization", () => {
                     options: {
                         padding: true,
                         layout: "horizontal",
-                        correct: ["First", "Second", "Third"],
+                        correct: correctOrder,
                     },
                 },
             },
@@ -71,9 +73,9 @@ describe("Sorter serialization", () => {
         const {renderer} = renderQuestion(generateBasicSorter());
 
         // Just making sure we're shuffling before answering
-        expect(
-            generateBasicSorter().question.widgets["sorter 1"].options.correct,
-        ).not.toEqual(renderer.getUserInput()["sorter 1"].options);
+        expect(correctOrder).not.toEqual(
+            renderer.getUserInput()["sorter 1"].options,
+        );
 
         // Put the options in the correct order
         const sorter: SorterHandle =

--- a/packages/perseus/src/widgets/sorter/sorter.test.tsx
+++ b/packages/perseus/src/widgets/sorter/sorter.test.tsx
@@ -225,10 +225,8 @@ describe("sorter widget", () => {
 
         test("safety check: the answerless data does not contain the correct answer", () => {
             expect(
-                answerlessItem.question.widgets["sorter 1"].options.correct,
-            ).not.toEqual(
-                answerfulItem.question.widgets["sorter 1"].options.correct,
-            );
+                answerlessItem.question.widgets["sorter 1"].options,
+            ).not.toEqual(answerfulItem.question.widgets["sorter 1"].options);
         });
 
         describe.each([


### PR DESCRIPTION
## Summary:
- Updates logic to swap deprecated stand in for sorters over 10 cards
- Adds unit tests to validate new logic 
- Adds regression data with new sorter/deprecated standin scenario 

Issue: LEMS-4498

## Test plan:
Validated in [ZND](https://prod-znd-260909-16024-9e11a04.khanacademy.org/math/grade-6-math-cambridge/x1977d7ef0ed7ac14:data-handling/x1977d7ef0ed7ac14:collection-of-data/e/representing-data)

### Sorter with more than 10 cards is automatically updated to deprecated stand in
https://github.com/user-attachments/assets/9d76f963-bb8d-4106-9aa9-452eb0014e20

### Sorter with 10 or less cards remains unaffected 
https://github.com/user-attachments/assets/f88b08ad-853c-464a-a6bd-75308b200277

