### PR TITLE
Remove 'All Widgets' template from the editor

### DIFF
--- a/.changeset/olive-nails-find.md
+++ b/.changeset/olive-nails-find.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": minor
+---
+
+The "All Widgets" template has been removed from the Perseus editor. It was broken, and crashed the editor if selected.

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -493,16 +493,6 @@ table: [[☃ table 1]]
                     >
                       Piecewise function
                     </option>
-                    <option
-                      disabled=""
-                    >
-                      --
-                    </option>
-                    <option
-                      value="allWidgets"
-                    >
-                      All widgets (for testing)
-                    </option>
                   </select>
                 </div>
                 <div
@@ -2344,16 +2334,6 @@ table: [[☃ table 1]]
                                 >
                                   Piecewise function
                                 </option>
-                                <option
-                                  disabled=""
-                                >
-                                  --
-                                </option>
-                                <option
-                                  value="allWidgets"
-                                >
-                                  All widgets (for testing)
-                                </option>
                               </select>
                             </div>
                           </div>
@@ -2820,16 +2800,6 @@ table: [[☃ table 1]]
                                 value="piecewise"
                               >
                                 Piecewise function
-                              </option>
-                              <option
-                                disabled=""
-                              >
-                                --
-                              </option>
-                              <option
-                                value="allWidgets"
-                              >
-                                All widgets (for testing)
                               </option>
                             </select>
                           </div>
@@ -3623,16 +3593,6 @@ table: [[☃ table 1]]
                                 >
                                   Piecewise function
                                 </option>
-                                <option
-                                  disabled=""
-                                >
-                                  --
-                                </option>
-                                <option
-                                  value="allWidgets"
-                                >
-                                  All widgets (for testing)
-                                </option>
                               </select>
                             </div>
                           </div>
@@ -4043,16 +4003,6 @@ table: [[☃ table 1]]
                                   value="piecewise"
                                 >
                                   Piecewise function
-                                </option>
-                                <option
-                                  disabled=""
-                                >
-                                  --
-                                </option>
-                                <option
-                                  value="allWidgets"
-                                >
-                                  All widgets (for testing)
                                 </option>
                               </select>
                             </div>
@@ -6905,16 +6855,6 @@ table: [[☃ table 1]]
                                 value="piecewise"
                               >
                                 Piecewise function
-                              </option>
-                              <option
-                                disabled=""
-                              >
-                                --
-                              </option>
-                              <option
-                                value="allWidgets"
-                              >
-                                All widgets (for testing)
                               </option>
                             </select>
                           </div>

--- a/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
@@ -526,16 +526,6 @@ table: [[☃ table 1]]
                     >
                       Piecewise function
                     </option>
-                    <option
-                      disabled=""
-                    >
-                      --
-                    </option>
-                    <option
-                      value="allWidgets"
-                    >
-                      All widgets (for testing)
-                    </option>
                   </select>
                   <span
                     class="perseus-editor-word-count"
@@ -2383,16 +2373,6 @@ table: [[☃ table 1]]
                                 >
                                   Piecewise function
                                 </option>
-                                <option
-                                  disabled=""
-                                >
-                                  --
-                                </option>
-                                <option
-                                  value="allWidgets"
-                                >
-                                  All widgets (for testing)
-                                </option>
                               </select>
                             </div>
                           </div>
@@ -2859,16 +2839,6 @@ table: [[☃ table 1]]
                                 value="piecewise"
                               >
                                 Piecewise function
-                              </option>
-                              <option
-                                disabled=""
-                              >
-                                --
-                              </option>
-                              <option
-                                value="allWidgets"
-                              >
-                                All widgets (for testing)
                               </option>
                             </select>
                           </div>
@@ -3662,16 +3632,6 @@ table: [[☃ table 1]]
                                 >
                                   Piecewise function
                                 </option>
-                                <option
-                                  disabled=""
-                                >
-                                  --
-                                </option>
-                                <option
-                                  value="allWidgets"
-                                >
-                                  All widgets (for testing)
-                                </option>
                               </select>
                             </div>
                           </div>
@@ -4082,16 +4042,6 @@ table: [[☃ table 1]]
                                   value="piecewise"
                                 >
                                   Piecewise function
-                                </option>
-                                <option
-                                  disabled=""
-                                >
-                                  --
-                                </option>
-                                <option
-                                  value="allWidgets"
-                                >
-                                  All widgets (for testing)
                                 </option>
                               </select>
                             </div>
@@ -6944,16 +6894,6 @@ table: [[☃ table 1]]
                                 value="piecewise"
                               >
                                 Piecewise function
-                              </option>
-                              <option
-                                disabled=""
-                              >
-                                --
-                              </option>
-                              <option
-                                value="allWidgets"
-                              >
-                                All widgets (for testing)
                               </option>
                             </select>
                           </div>

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -740,10 +740,6 @@ class Editor extends React.Component<Props, State> {
                 "7 & \\text{if }x=1 \\\\\n" +
                 "f(x-1)+5 & \\text{if }x > 1\n" +
                 "\\end{cases}$";
-        } else if (templateType === "allWidgets") {
-            template = Widgets.getAllWidgetTypes()
-                .map((type) => `[[${Util.snowman} ${type} 1]]`)
-                .join("\n\n");
         } else if (templateType in this.props.additionalTemplates) {
             template = this.props.additionalTemplates[templateType];
         } else {
@@ -931,10 +927,6 @@ class Editor extends React.Component<Props, State> {
                             </option>
                         ),
                     )}
-                    <option disabled>--</option>
-                    <option value="allWidgets">
-                        All widgets (for testing)
-                    </option>
                 </select>
             );
 


### PR DESCRIPTION
## Summary:
This template crashed the editor if selected. According to the
linked ticket, it's been broken for almost a year at least.

Since it seems like no one is using this feature, I opted to remove it.

Issue: LEMS-3642

## Test plan:

- `pnpm storybook`
- `open http://localhost:6006/?path=/docs/editors-editorpage--docs`
- Click "Insert template"
- You should not see an "All widgets" option.