### PR TITLE
[Image] Clear stale image URLs after markdown image conversion

### DIFF
--- a/.changeset/pink-cows-press.md
+++ b/.changeset/pink-cows-press.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+[Image] Clear stale image URLs after markdown image conversion

--- a/packages/perseus-editor/src/util/issue-ctas-utils.test.ts
+++ b/packages/perseus-editor/src/util/issue-ctas-utils.test.ts
@@ -2,6 +2,7 @@ import {Util} from "@khanacademy/perseus";
 import {
     generateImageOptions,
     generateImageWidget,
+    generateRadioChoice,
     generateRadioOptions,
     generateRadioWidget,
     generateTestPerseusRenderer,
@@ -169,6 +170,7 @@ describe("convertImageMarkdownToImageWidget", () => {
                     }),
                 }),
             },
+            images: {},
         });
     });
 
@@ -195,6 +197,7 @@ describe("convertImageMarkdownToImageWidget", () => {
                     }),
                 }),
             },
+            images: {},
         });
     });
 
@@ -234,6 +237,7 @@ describe("convertImageMarkdownToImageWidget", () => {
                     }),
                 }),
             },
+            images: {},
         });
     });
 
@@ -266,6 +270,7 @@ describe("convertImageMarkdownToImageWidget", () => {
                     }),
                 }),
             },
+            images: {},
         });
     });
 
@@ -323,6 +328,7 @@ describe("convertImageMarkdownToImageWidget", () => {
                     }),
                 }),
             },
+            images: {},
         });
     });
 
@@ -362,6 +368,7 @@ describe("convertImageMarkdownToImageWidget", () => {
                     }),
                 }),
             },
+            images: {},
         });
     });
 
@@ -399,6 +406,84 @@ describe("convertImageMarkdownToImageWidget", () => {
                     }),
                 }),
             },
+            images: {},
+        });
+    });
+
+    it("empties the images field once the markdown is converted", async () => {
+        // Arrange: earthMoonImage is referenced by the markdown we're about to
+        // convert; frescoImage is an entry that's already stale.
+        const question = generateTestPerseusRenderer({
+            content: `![markdown 1](${earthMoonImage.url})`,
+            widgets: {},
+            images: {
+                [earthMoonImage.url]: {width: 400, height: 225},
+                [frescoImage.url]: {width: 400, height: 225},
+            },
+        });
+        const onEditorChange = jest.fn();
+
+        // Act
+        await convertImageMarkdownToImageWidget(question, onEditorChange);
+
+        // Assert
+        expect(onEditorChange).toHaveBeenCalledWith(
+            expect.objectContaining({images: {}}),
+        );
+    });
+
+    it("empties the images field once the markdown is converted and leaves nested markdown as is", async () => {
+        // Arrange
+        const nestedChoiceContent = `![nested markdown](${earthMoonImage.url})`;
+        const question = generateTestPerseusRenderer({
+            // Content includes a markdown image and a radio with a markdown choice
+            content: `![markdown 1](${earthMoonImage.url})\n\n[[☃ radio 1]]`,
+            widgets: {
+                "radio 1": generateRadioWidget({
+                    options: generateRadioOptions({
+                        choices: [
+                            generateRadioChoice(nestedChoiceContent, {
+                                id: "radio-choice-1",
+                            }),
+                        ],
+                    }),
+                }),
+            },
+            images: {
+                // Image being converted to a widget
+                [earthMoonImage.url]: {width: 400, height: 225},
+                // Stale image URL from a previously backspaced markdown image.
+                [frescoImage.url]: {width: 400, height: 225},
+            },
+        });
+        const onEditorChange = jest.fn();
+
+        // Act
+        await convertImageMarkdownToImageWidget(question, onEditorChange);
+
+        // Assert
+        expect(onEditorChange).toHaveBeenCalledWith({
+            // Markdown image has been converted to image widget
+            content: `[[☃ image 1]]\n\n[[☃ radio 1]]`,
+            widgets: {
+                "radio 1": generateRadioWidget({
+                    options: generateRadioOptions({
+                        choices: [
+                            // Radio still contains nested image
+                            generateRadioChoice(nestedChoiceContent, {
+                                id: "radio-choice-1",
+                            }),
+                        ],
+                    }),
+                }),
+                "image 1": generateImageWidget({
+                    options: generateImageOptions({
+                        backgroundImage: earthMoonImage,
+                        alt: "markdown 1",
+                    }),
+                }),
+            },
+            images: {},
         });
     });
 });

--- a/packages/perseus-editor/src/util/issue-ctas-utils.ts
+++ b/packages/perseus-editor/src/util/issue-ctas-utils.ts
@@ -104,6 +104,11 @@ export async function convertImageMarkdownToImageWidget(
     onEditorChange({
         content: newContent,
         widgets: newWidgets,
+        // The `images` field only caches dimensions for images referenced by
+        // image markdown. Since we just converted every image markdown to a
+        // widget (which carries its own dimensions), anything left in `images`
+        // is stale, so we can clear it out entirely.
+        images: {},
     });
 }
 


### PR DESCRIPTION
## Summary:
When a markdown image is used in the content, it gets added to the item’s images field. When the “convert all image markdown to widget” button is used, it doesn’t remove the image from the images field when it removes it from the content.

Update the conversion function so that it doesn’t keep stale images inside images.

Issue: https://khanacademy.atlassian.net/browse/LEMS-4456

## Test plan:
`pnpm jest packages/perseus-editor/src/util/issue-ctas-utils.test.ts`

Storybook
- `/?path=/story/widgets-image-editor-demo--with-markdown-image-linter-warning`
- Press the conversion button and then check the JSON to confirm that `images` is empty

### Before

https://github.com/user-attachments/assets/0b9ce8cf-12b7-451c-9043-283a3b5ade62


### After

https://github.com/user-attachments/assets/8da4b763-a1c8-4dc8-898a-77c7905b129f


