### PR TITLE
Fix tooltips getting cut off in the editor preview

### DIFF
--- a/.changeset/lucky-rooms-visit.md
+++ b/.changeset/lucky-rooms-visit.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Fix tooltips getting cut off in the editor preview

--- a/packages/perseus/src/components/linter-link.tsx
+++ b/packages/perseus/src/components/linter-link.tsx
@@ -66,6 +66,9 @@ export default function LinterLink({
 
     return (
         <Tooltip
+            // Place the tooltip left of the lint dot so that it can be
+            // seen within the iframe without being cut off by the edge.
+            placement="left"
             // The anchor is an <a href>, which is already keyboard
             // focusable, so the tooltip doesn't need to add a tabindex.
             forceAnchorFocusivity={false}
@@ -98,6 +101,11 @@ export default function LinterLink({
                         : dotOutlineIcon
                 }
                 style={style}
+                // Open the rule docs in a dedicated, reused window rather
+                // than attempting to open within the iframe.
+                // eslint-disable-next-line @khanacademy/ts-no-error-suppressions
+                // @ts-expect-error - TS2322 - Type '"lint-help-window"' is not assignable to type '"_blank"'.
+                target="lint-help-window"
             />
         </Tooltip>
     );

--- a/packages/perseus/src/components/linter-link.tsx
+++ b/packages/perseus/src/components/linter-link.tsx
@@ -120,6 +120,8 @@ export default function LinterLink({
  * the gutter the indicator sits in, the tooltip tail, and the 12px of
  * viewport padding Popper keeps.
  */
+// TODO: When we are able to remove the need for an iframe preview
+// (ie. we use container queries), remove this calculated sizing.
 const tooltipMaxWidth = "min(320px, calc(100vw - 120px))";
 
 const styles = StyleSheet.create({

--- a/packages/perseus/src/components/linter-link.tsx
+++ b/packages/perseus/src/components/linter-link.tsx
@@ -110,11 +110,6 @@ export default function LinterLink({
 /**
  * How wide the tooltip bubble is allowed to get so it doesn't get cut off
  * by the edge of the preview iframe.
- *
- * `100vw` resolves against the preview iframe's own viewport (the tooltip is
- * portaled into that same document), and the subtracted slack leaves room for
- * the gutter the indicator sits in, the tooltip tail, and the 12px of
- * viewport padding Popper keeps.
  */
 // TODO: When we are able to remove the need for an iframe preview
 // (ie. we use container queries), remove this calculated sizing.

--- a/packages/perseus/src/components/linter-link.tsx
+++ b/packages/perseus/src/components/linter-link.tsx
@@ -101,11 +101,7 @@ export default function LinterLink({
                         : dotOutlineIcon
                 }
                 style={style}
-                // Open the rule docs in a dedicated, reused window rather
-                // than attempting to open within the iframe.
-                // eslint-disable-next-line @khanacademy/ts-no-error-suppressions
-                // @ts-expect-error - TS2322 - Type '"lint-help-window"' is not assignable to type '"_blank"'.
-                target="lint-help-window"
+                target="_blank"
             />
         </Tooltip>
     );

--- a/packages/perseus/src/components/linter-link.tsx
+++ b/packages/perseus/src/components/linter-link.tsx
@@ -111,10 +111,23 @@ export default function LinterLink({
     );
 }
 
+/**
+ * How wide the tooltip bubble is allowed to get so it doesn't get cut off
+ * by the edge of the preview iframe.
+ *
+ * `100vw` resolves against the preview iframe's own viewport (the tooltip is
+ * portaled into that same document), and the subtracted slack leaves room for
+ * the gutter the indicator sits in, the tooltip tail, and the 12px of
+ * viewport padding Popper keeps.
+ */
+const tooltipMaxWidth = "min(320px, calc(100vw - 120px))";
+
 const styles = StyleSheet.create({
     // A lint message can contain several paragraphs. Wonder Blocks resets the
     // margins on BodyText, so we space them out ourselves.
     tooltipParagraph: {
+        maxInlineSize: tooltipMaxWidth,
+
         ":not(:first-child)": {
             marginBlockStart: sizing.size_080,
         },


### PR DESCRIPTION
## Summary:
I updated the lint tooltips in https://github.com/Khan/perseus/pull/4183, but this introduced
a couple issues:
- The tooltip gets cut off entirely in the mobile preview
- Clicking on the lint dot attempts to open in the iframe rather than a new tab

Fixing these here.

Issue: none

## Test plan:
Storybook
- `/?path=/story/editors-editorpage--demo`

### Before
<img width="472" height="425" alt="Screenshot 2026-09-10 at 9 58 12 AM" src="https://github.com/user-attachments/assets/78520d63-aa05-4c08-9b55-7065076b040e" />

https://github.com/user-attachments/assets/e7c8ad05-c510-42e3-8042-690b7a638f83

### After
<img width="484" height="326" alt="Screenshot 2026-09-10 at 9 58 19 AM" src="https://github.com/user-attachments/assets/6eb6dd64-26f5-4d8a-9c64-8fe88441c717" />

https://github.com/user-attachments/assets/f3fc2139-8225-4781-a186-11a7013c1014

