### PR TITLE
Wait for Graphie callbacks in async tests

### DIFF
--- a/packages/perseus/src/util/graphie-utils.test.ts
+++ b/packages/perseus/src/util/graphie-utils.test.ts
@@ -10,6 +10,18 @@ import {
 } from "./graphie-utils";
 import {typicalCase, edgeCases} from "./graphie-utils.testdata";
 
+// Test helper to wait for loadGraphie callback
+async function waitForLoadGraphie(url: string) {
+    return new Promise<{
+        data: unknown;
+        localized: boolean;
+    }>((resolve) => {
+        loadGraphie(url, (data, localized) => {
+            resolve({data, localized});
+        });
+    });
+}
+
 describe("graphie utils", () => {
     const errorCallback = jest.fn((error) => {
         // Do nothing
@@ -108,14 +120,7 @@ describe("graphie utils", () => {
         );
 
         // Act
-        const loadedData = await new Promise<{
-            data: unknown;
-            localized: boolean;
-        }>((resolve) => {
-            loadGraphie(typicalCase.url, (data, localized) => {
-                resolve({data, localized});
-            });
-        });
+        const loadedData = await waitForLoadGraphie(typicalCase.url);
 
         // Assert
         expect(loadedData).toEqual({
@@ -153,14 +158,7 @@ describe("graphie utils", () => {
         }) as jest.Mock;
 
         // Act
-        const loadedData = await new Promise<{
-            data: unknown;
-            localized: boolean;
-        }>((resolve) => {
-            loadGraphie(typicalCase.url, (data, localized) => {
-                resolve({data, localized});
-            });
-        });
+        const loadedData = await waitForLoadGraphie(typicalCase.url);
 
         // Assert
         expect(loadedData).toEqual({

--- a/packages/perseus/src/util/graphie-utils.test.ts
+++ b/packages/perseus/src/util/graphie-utils.test.ts
@@ -108,13 +108,20 @@ describe("graphie utils", () => {
         );
 
         // Act
-        await loadGraphie(typicalCase.url, (data, localized) => {
-            // Assert - should get English data with localized=false
-            expect(data).toEqual({labels: [], range: null});
-            expect(localized).toEqual(false);
+        const loadedData = await new Promise<{
+            data: unknown;
+            localized: boolean;
+        }>((resolve) => {
+            loadGraphie(typicalCase.url, (data, localized) => {
+                resolve({data, localized});
+            });
         });
 
         // Assert
+        expect(loadedData).toEqual({
+            data: {labels: [], range: null},
+            localized: false,
+        });
         expect(Log.error).not.toHaveBeenCalled();
     });
 
@@ -146,10 +153,19 @@ describe("graphie utils", () => {
         }) as jest.Mock;
 
         // Act
-        await loadGraphie(typicalCase.url, (data, localized) => {
-            // Assert - should get localized data with localized=true
-            expect(data).toEqual({labels: [], range: null});
-            expect(localized).toEqual(true);
+        const loadedData = await new Promise<{
+            data: unknown;
+            localized: boolean;
+        }>((resolve) => {
+            loadGraphie(typicalCase.url, (data, localized) => {
+                resolve({data, localized});
+            });
+        });
+
+        // Assert
+        expect(loadedData).toEqual({
+            data: {labels: [], range: null},
+            localized: true,
         });
     });
 });


### PR DESCRIPTION
## Summary

This PR fixes unit tests that involve Graphie waiting for callbacks before checking loaded data. It fixes them by moving assertions outside callbacks so asynchronous failures cannot produce false-positive test passes (ie. we didn't wait so the condition couldn't fail). I have only updated tests to avoid making production changes that could be risky.

`loadGraphie` returns immediately, so awaiting it did not wait for its callback.

Issue: LEMS-4578 

## Test plan

- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`