### PR TITLE
[Sorter] Add linter error for cards with image and other content type

### DIFF
--- a/.changeset/mighty-goats-admire.md
+++ b/.changeset/mighty-goats-admire.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-linter": patch
+---
+
+[Sorter] Add linter error for cards with image and other content type

--- a/packages/perseus-linter/src/rules/sorter-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/sorter-widget-error.test.ts
@@ -81,6 +81,90 @@ describe("sorter-widget-error", () => {
         );
     });
 
+    it("warns for a sorter card with text before an image", () => {
+        expectWarning(
+            sorterWidgetErrorRule,
+            "[[☃ sorter 1]]",
+            {
+                widgets: {
+                    "sorter 1": {
+                        options: {
+                            correct: [
+                                "Cat",
+                                "Dog ![a dog](https://example.com/dog.png)",
+                            ],
+                        },
+                    },
+                },
+            },
+            {
+                message:
+                    "Sorter cards cannot mix images with other content. A card with an image cannot contain anything else.",
+            },
+        );
+    });
+
+    it("warns for a sorter card with math alongside an image", () => {
+        expectWarning(
+            sorterWidgetErrorRule,
+            "[[☃ sorter 1]]",
+            {
+                widgets: {
+                    "sorter 1": {
+                        options: {
+                            correct: [
+                                "$x^2$ ![a graph](https://example.com/graph.png)",
+                                "Dog",
+                            ],
+                        },
+                    },
+                },
+            },
+            {
+                message:
+                    "Sorter cards cannot mix images with other content. A card with an image cannot contain anything else.",
+            },
+        );
+    });
+
+    it("warns for a sorter card holding more than one image", () => {
+        expectWarning(
+            sorterWidgetErrorRule,
+            "[[☃ sorter 1]]",
+            {
+                widgets: {
+                    "sorter 1": {
+                        options: {
+                            correct: [
+                                "![a cat](https://example.com/cat.png)![a dog](https://example.com/dog.png)",
+                                "Emu",
+                            ],
+                        },
+                    },
+                },
+            },
+            {
+                message:
+                    "Sorter cards cannot mix images with other content. A card with an image cannot contain anything else.",
+            },
+        );
+    });
+
+    it("passes for a sorter widget whose cards are each a single image", () => {
+        expectPass(sorterWidgetErrorRule, "[[☃ sorter 1]]", {
+            widgets: {
+                "sorter 1": {
+                    options: {
+                        correct: [
+                            "![a cat](https://example.com/cat.png)",
+                            "  ![a dog](https://example.com/dog.png)  ",
+                        ],
+                    },
+                },
+            },
+        });
+    });
+
     it("passes for a sorter widget whose cards all have text", () => {
         expectPass(sorterWidgetErrorRule, "[[☃ sorter 1]]", {
             widgets: {

--- a/packages/perseus-linter/src/rules/sorter-widget-error.test.ts
+++ b/packages/perseus-linter/src/rules/sorter-widget-error.test.ts
@@ -98,8 +98,7 @@ describe("sorter-widget-error", () => {
                 },
             },
             {
-                message:
-                    "Sorter cards cannot mix images with other content. A card with an image cannot contain anything else.",
+                message: "Sorter cards cannot mix images with other content.",
             },
         );
     });
@@ -121,8 +120,7 @@ describe("sorter-widget-error", () => {
                 },
             },
             {
-                message:
-                    "Sorter cards cannot mix images with other content. A card with an image cannot contain anything else.",
+                message: "Sorter cards cannot mix images with other content.",
             },
         );
     });
@@ -144,8 +142,7 @@ describe("sorter-widget-error", () => {
                 },
             },
             {
-                message:
-                    "Sorter cards cannot mix images with other content. A card with an image cannot contain anything else.",
+                message: "Sorter cards cannot mix images with other content.",
             },
         );
     });

--- a/packages/perseus-linter/src/rules/sorter-widget-error.ts
+++ b/packages/perseus-linter/src/rules/sorter-widget-error.ts
@@ -1,7 +1,28 @@
+import {parse, traverseContent} from "@khanacademy/pure-markdown";
+
 import Rule from "../rule";
 
 // There's nothing to sort with fewer than two cards.
 const minCards = 2;
+
+// A card holding an image must hold nothing else: an image next to text,
+// math, or another image is not allowed.
+function hasMixedContent(card: string): boolean {
+    const contentNodes: any[] = [];
+
+    traverseContent(parse(card.trim(), {}), (node: any) => {
+        // Markdown always wraps a card in a paragraph, so that wrapper
+        // doesn't count as content.
+        if (node.type !== "paragraph") {
+            contentNodes.push(node);
+        }
+    });
+
+    return (
+        contentNodes.length > 1 &&
+        contentNodes.some((node) => node.type === "image")
+    );
+}
 
 // eslint-disable-next-line no-restricted-syntax
 export default Rule.makeRule({
@@ -34,6 +55,10 @@ export default Rule.makeRule({
 
         if (correct.some((card) => card.trim() === "")) {
             warnings.push("Sorter cards cannot be blank.");
+        }
+
+        if (correct.some(hasMixedContent)) {
+            warnings.push("Sorter cards cannot mix images with other content.");
         }
 
         return warnings.join("\n\n");


### PR DESCRIPTION
## Summary:
We are no longer allowing Sorter cards to have both images and text in them.

From the Drag and Drop project overview:
> Different content types should not be mixed with one another, especially in Answer Tiles. Text and TeX content types can be mixed within answer zones or answer tiles when warranted, but images should not be mixed with non-image content types.

Issue: none

## Test plan:
`pnpm jest packages/perseus-linter/src/rules/sorter-widget-error.test.ts`


<img width="438" height="525" alt="image" src="https://github.com/user-attachments/assets/14789aa3-277a-4e71-8b8f-94cc09427ada" />
