### PR TITLE
Remove unused zoomToFullSizeOnMobile prop from SvgImage

### DIFF
--- a/.changeset/empty-melons-tan.md
+++ b/.changeset/empty-melons-tan.md
@@ -1,5 +1,0 @@
----
-"@khanacademy/perseus": major
----
-
-Remove ignored `zoomToFullSizeOnMobile` prop from `SvgImage`

--- a/.changeset/empty-melons-tan.md
+++ b/.changeset/empty-melons-tan.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": major
+---
+
+Remove ignored `zoomToFullSizeOnMobile` prop from `SvgImage`

--- a/.changeset/ready-hotels-see.md
+++ b/.changeset/ready-hotels-see.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Remove the unused `zoomToFullSizeOnMobile` prop from `SvgImage`

--- a/packages/perseus/src/components/svg-image.tsx
+++ b/packages/perseus/src/components/svg-image.tsx
@@ -85,14 +85,6 @@ export type Props = {
     trackInteraction?: () => void;
     width?: number;
     /**
-     * Whether clicking this image will allow it to be fully zoomed in to
-     * its original size on click, and allow the user to scroll in that
-     * state. This also does some hacky viewport meta tag changing to
-     * ensure this works on mobile devices, so I (david@) don't recommend
-     * enabling this on desktop yet.
-     */
-    zoomToFullSizeOnMobile?: boolean;
-    /**
      * If provided, use AssetContext.Consumer, see renderer.jsx.
      * If not, it defaults to a no-op.
      */
@@ -119,7 +111,6 @@ type DefaultProps = {
     scale: NonNullable<Props["scale"]>;
     setAssetStatus: NonNullable<Props["setAssetStatus"]>;
     src: NonNullable<Props["src"]>;
-    zoomToFullSizeOnMobile: NonNullable<Props["zoomToFullSizeOnMobile"]>;
 };
 
 type Label = {
@@ -164,7 +155,6 @@ class SvgImage extends React.Component<Props, State> {
         responsive: true,
         src: "",
         scale: 1,
-        zoomToFullSizeOnMobile: false,
         setAssetStatus: (src: string, status: boolean) => {},
     };
 

--- a/packages/perseus/src/renderer.new.tsx
+++ b/packages/perseus/src/renderer.new.tsx
@@ -1147,9 +1147,6 @@ class Renderer
                                 title={node.title}
                                 responsive={responsive}
                                 onUpdate={this.props.onRender}
-                                zoomToFullSizeOnMobile={
-                                    apiOptions.isMobile && apiOptions.isArticle
-                                }
                                 {...extraAttrs}
                             />
                         )}

--- a/packages/perseus/src/renderer.old.tsx
+++ b/packages/perseus/src/renderer.old.tsx
@@ -1140,9 +1140,6 @@ class Renderer
                                 title={node.title}
                                 responsive={responsive}
                                 onUpdate={this.props.onRender}
-                                zoomToFullSizeOnMobile={
-                                    apiOptions.isMobile && apiOptions.isArticle
-                                }
                                 {...extraAttrs}
                             />
                         )}

--- a/packages/perseus/src/widgets/image/components/explore-image-modal-content.tsx
+++ b/packages/perseus/src/widgets/image/components/explore-image-modal-content.tsx
@@ -130,7 +130,6 @@ export default function ExploreImageModalContent({
                                 range: range,
                                 labels: labels ?? [],
                             }}
-                            zoomToFullSizeOnMobile={apiOptions.isMobile}
                             constrainHeight={apiOptions.isMobile}
                             allowFullBleed={apiOptions.isMobile}
                             setAssetStatus={setAssetStatus}

--- a/packages/perseus/src/widgets/image/image.tsx
+++ b/packages/perseus/src/widgets/image/image.tsx
@@ -113,7 +113,6 @@ const ImageWidget = forwardRef<Widget, ImageWidgetProps>(
                             labels: labels,
                         }}
                         trackInteraction={trackInteraction}
-                        zoomToFullSizeOnMobile={apiOptions.isMobile}
                         constrainHeight={apiOptions.isMobile}
                         allowFullBleed={apiOptions.isMobile}
                         // Only allow zooming if the image is not decorative and not a GIF.


### PR DESCRIPTION
## Summary:

`SvgImage` has carried a `zoomToFullSizeOnMobile` prop since 2016. It has been a no-op since #3009 replaced the old zoom service with a Wonder Blocks modal: `SvgImage` still declared and defaulted it, and four call sites still set it from `apiOptions.isMobile`, but nothing read it. This PR deletes the prop and those call sites. No behavior changes.

Issue: LEMS-4588 

## Test plan:

- `pnpm test`
- `pnpm typecheck`