### PR TITLE
Note that Khan/webapp mirrors the tick-label geometry

### DIFF
--- a/.changeset/tick-geometry-downstream-note.md
+++ b/.changeset/tick-geometry-downstream-note.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Document that the interactive-graph tick-label geometry is mirrored by a downstream consumer (comment only, no behaviour change)

--- a/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
+++ b/packages/perseus/src/widgets/interactive-graphs/backgrounds/axis-ticks.tsx
@@ -17,6 +17,22 @@ import type {Interval, vec} from "mafs";
 // Note that we can't use semantic font tokens here, because the semantic
 // tokens are in rems, whereas we need the font size to be in px to stay
 // consistent with our graph calculations.
+//
+// MIRRORED DOWNSTREAM. `tickLabelSize` and the offsets derived from it --
+// `YGridTick`'s `xAdjustment` and `yPositionText`, and `XGridTick`'s
+// `yAdjustment` and `xAdjustment` -- are re-implemented as Go constants in
+// Khan/webapp, at
+// services/ai-guide/perseus_generation/labelplace/figures/axis.go
+//
+// That code places labels on AI-generated diagrams. To decide where a label
+// can go it models every tick number as an obstacle the label must avoid. It
+// cannot call this renderer, so it hardcodes these offsets. When they drift,
+// those obstacles sit where the ticks are not, and a generated label lands on
+// top of the content it describes. Nothing throws -- the diagram renders, it
+// is just wrong.
+//
+// If these numbers change, it would help to mention it on the PR so the Go
+// side can be updated to match.
 const tickSize = 10;
 const tickLabelSize = 14;
 


### PR DESCRIPTION
This adds a comment above `tickSize` / `tickLabelSize` in `interactive-graphs/backgrounds/axis-ticks.tsx`, and a changeset for it. That is the whole change — no runtime behaviour, no new tests.

## Why

Khan Academy's AI diagram generation (in `Khan/webapp`, `services/ai-guide/perseus_generation/labelplace/figures/axis.go`) places labels on generated coordinate-plane diagrams. To decide where a label can go it needs to know where everything else on the plane already is, including every tick number, so it models each one as an obstacle the label has to avoid. It has no way to call this renderer, so it re-implements `XGridTick` / `YGridTick`'s font-derived offsets as Go constants.

When those constants drift from these, the obstacles sit where the ticks are not: the placer rejects positions that are genuinely clear and accepts positions that are not, and a generated label ends up drawn over the curve, the axis numbers, or another label. Nothing throws — the diagram renders, it is just wrong.

This has already happened once. `generateTickLocations` changed here (the "show min tick when the axis doesn't go through it" work) and our Go port disagreed with it for a while; we only noticed because someone read the source.

## The ask

Nothing that constrains how you work on this file — these numbers are yours, and you should change them when the design needs it. If you do, it would help a lot if you mentioned it on the PR, so we can move the Go side in step.
