### PR TITLE
Remove deprecated props and methods from EditorPage and ItemEditor

### DIFF
--- a/.changeset/green-results-turn.md
+++ b/.changeset/green-results-turn.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": major
+---
+
+The deprecated, non-functional `developerMode` and `onPreviewDeviceChange` props have been removed from `EditorPage`. The `serialize()` imperative method has also been removed. Callers should use `onChange` instead of imperative APIs to receive updates.

--- a/__docs__/introduction.mdx
+++ b/__docs__/introduction.mdx
@@ -211,8 +211,6 @@ The Perseus content editing flow follows these steps:
 
 **2. As content is edited, `onChange` callbacks are triggered**
 
-**3. When serialization is needed, `editorPageRef.current.serialize()` is called to produce a `PerseusItem`**
-
 This editing flow ensures that content creators can interact with widgets and preview content as it will appear to learners.
 
 ## Project History

--- a/packages/perseus-editor/src/article-editor.tsx
+++ b/packages/perseus-editor/src/article-editor.tsx
@@ -419,6 +419,9 @@ export default class ArticleEditor extends React.Component<Props, State> {
         // To enable this, we preserve the widgets
         // object for the new section, but wipe out
         // the content.
+        // TODO(benchristel): I don't think this "magic" is needed anymore. We
+        //  now use the clipboard API to support copy-paste of widgets between
+        //  editors.
         const newSection = {
             content: "",
             images: {},

--- a/packages/perseus-editor/src/combined-hints-editor.tsx
+++ b/packages/perseus-editor/src/combined-hints-editor.tsx
@@ -49,6 +49,7 @@ type HintEditorProps = {
     isFirst: boolean;
     onMove: (direction: number) => unknown;
     onRemove: () => unknown;
+    // TODO(LEMS-3245): stop using ChangeHandler; give this a proper type.
     onChange: ChangeHandler;
     __type?: "hint";
     widgetIsOpen?: boolean;
@@ -364,10 +365,6 @@ class CombinedHintsEditor extends React.Component<CombinedHintsEditorProps> {
             .value();
     };
 
-    serialize(): Hint[] {
-        return this.props.hints.map((_, i) => this.serializeHint(i));
-    }
-
     serializeHint(index: number): Hint {
         // @ts-expect-error - TS2339 - Property 'serialize' does not exist on type 'ReactInstance'.
         return this.refs["hintEditor" + index].serialize();
@@ -387,6 +384,7 @@ class CombinedHintsEditor extends React.Component<CombinedHintsEditorProps> {
                         hint={hint}
                         pos={i}
                         imageUploader={this.props.imageUploader}
+                        // TODO(benchristel): remove .bind() and @ts-expect-error.
                         // @ts-expect-error - TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation. | TS2683 - 'this' implicitly has type 'any' because it does not have a type annotation.
                         onChange={this.handleHintChange.bind(this, i)}
                         onRemove={this.handleHintRemove.bind(this, i)}

--- a/packages/perseus-editor/src/editor-page-snapshot.test.tsx
+++ b/packages/perseus-editor/src/editor-page-snapshot.test.tsx
@@ -44,11 +44,9 @@ describe("EditorPage", () => {
                 question={comprehensiveQuestion} // question with all widgets
                 apiOptions={{editingDisabled: true}} // editing disabled
                 onChange={() => {}}
-                onPreviewDeviceChange={() => {}}
                 previewDevice="desktop"
                 previewURL=""
                 itemId="itemId"
-                developerMode={false}
                 jsonMode={false}
                 widgetsAreOpen={true}
             />,

--- a/packages/perseus-editor/src/editor-page.test.tsx
+++ b/packages/perseus-editor/src/editor-page.test.tsx
@@ -65,11 +65,9 @@ describe("EditorPage", () => {
                 dependencies={testDependenciesV2}
                 question={question}
                 onChange={(next) => (callbackValue = next)}
-                onPreviewDeviceChange={() => {}}
                 previewDevice="desktop"
                 previewURL=""
                 itemId="itemId"
-                developerMode={false}
                 jsonMode={false}
                 widgetsAreOpen={true}
             />,
@@ -89,11 +87,9 @@ describe("EditorPage", () => {
                 dependencies={testDependenciesV2}
                 question={callbackValue.question}
                 onChange={(next) => (callbackValue = next)}
-                onPreviewDeviceChange={() => {}}
                 previewDevice="desktop"
                 previewURL=""
                 itemId="itemId"
-                developerMode={false}
                 jsonMode={false}
                 widgetsAreOpen={true}
             />,
@@ -148,11 +144,9 @@ describe("EditorPage", () => {
                 dependencies={testDependenciesV2}
                 question={startRenderer}
                 onChange={onChangeMock}
-                onPreviewDeviceChange={() => {}}
                 previewDevice="desktop"
                 previewURL=""
                 itemId="itemId"
-                developerMode={false}
                 jsonMode={false}
                 widgetsAreOpen={true}
             />,
@@ -202,11 +196,9 @@ describe("EditorPage", () => {
                 question={question}
                 onChange={() => {}}
                 apiOptions={{editingDisabled: true}}
-                onPreviewDeviceChange={() => {}}
                 previewDevice="desktop"
                 previewURL=""
                 itemId="itemId"
-                developerMode={false}
                 jsonMode={false}
                 widgetsAreOpen={true}
             />,
@@ -244,11 +236,9 @@ describe("EditorPage", () => {
                 dependencies={testDependenciesV2}
                 question={initialQuestion}
                 onChange={onChangeMock}
-                onPreviewDeviceChange={() => {}}
                 previewDevice="desktop"
                 previewURL=""
                 itemId="itemId"
-                developerMode={true}
                 jsonMode={true}
                 widgetsAreOpen={true}
             />,
@@ -260,11 +250,9 @@ describe("EditorPage", () => {
                 dependencies={testDependenciesV2}
                 question={updatedQuestion}
                 onChange={onChangeMock}
-                onPreviewDeviceChange={() => {}}
                 previewDevice="desktop"
                 previewURL=""
                 itemId="itemId"
-                developerMode={true}
                 jsonMode={true}
                 widgetsAreOpen={true}
             />,
@@ -290,11 +278,9 @@ describe("EditorPage", () => {
                 dependencies={testDependenciesV2}
                 question={startRenderer}
                 onChange={onChangeMock}
-                onPreviewDeviceChange={() => {}}
                 previewDevice="desktop"
                 previewURL=""
                 itemId="itemId"
-                developerMode={false}
                 jsonMode={false}
                 widgetsAreOpen={true}
             />,
@@ -357,11 +343,9 @@ describe("EditorPage", () => {
                 dependencies={testDependenciesV2}
                 question={question}
                 onChange={onChangeMock}
-                onPreviewDeviceChange={() => {}}
                 previewDevice="desktop"
                 previewURL=""
                 itemId="itemId"
-                developerMode={false}
                 jsonMode={false}
                 widgetsAreOpen={true}
             />,

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -40,9 +40,6 @@ type Props = {
     apiOptions?: APIOptions;
     answerArea: PerseusAnswerArea; // related to the question,
     dependencies: PerseusDependenciesV2;
-    // TODO(benchristel): remove developerMode after October 1, 2026
-    /** @deprecated - has no effect */
-    developerMode?: boolean;
     hints: Hint[]; // related to the question,
     /** A function which takes a file object (guaranteed to be an image) and
      * a callback, then calls the callback with the url where the image
@@ -56,9 +53,6 @@ type Props = {
     jsonMode: boolean;
     /** A function which is called with the new JSON blob of content. */
     onChange: (changed: PerseusItem) => void;
-    // TODO(benchristel): remove onPreviewDeviceChange after October 1, 2026
-    /** @deprecated - has no effect, and is never called */
-    onPreviewDeviceChange?: (arg1: DeviceType) => unknown;
     previewDevice: DeviceType;
     /** A global control to expand/collapse all widget editors on a page. */
     widgetsAreOpen?: boolean;
@@ -130,13 +124,6 @@ class EditorPage extends React.Component<Props, State> {
                 this.props.issues,
             ),
         });
-    }
-
-    getSnapshotBeforeUpdate(prevProps: Props) {
-        if (!prevProps.jsonMode && this.props.jsonMode) {
-            return this.itemEditor.current?.serialize() ?? {};
-        }
-        return null;
     }
 
     componentDidUpdate(previousProps: Props, prevState: State, snapshot: any) {
@@ -220,22 +207,6 @@ class EditorPage extends React.Component<Props, State> {
 
     getSaveWarnings(): any {
         return this.itemEditor.current?.getSaveWarnings();
-    }
-
-    /**
-     * Returns the current version of the edited {@link PerseusItem}.
-     *
-     * @deprecated Use the {@link Props.onChange} prop instead.
-     */
-    serialize(): PerseusItem {
-        if (this.props.jsonMode) {
-            return this.state.json;
-        }
-        invariant(
-            this.itemEditor.current,
-            "cannot serialize EditorPage without ItemEditor",
-        );
-        return this.itemEditor.current.serialize();
     }
 
     handleChange = (toChange: Partial<PerseusItem>) => {

--- a/packages/perseus-editor/src/editor-page.tsx
+++ b/packages/perseus-editor/src/editor-page.tsx
@@ -4,7 +4,6 @@ import {
     parseAndMigratePerseusItem,
 } from "@khanacademy/perseus-core";
 import * as React from "react";
-import invariant from "tiny-invariant";
 import _ from "underscore";
 
 import {A11yContext, createA11yContextValue} from "./components/a11y-context";

--- a/packages/perseus-editor/src/editor.tsx
+++ b/packages/perseus-editor/src/editor.tsx
@@ -259,10 +259,6 @@ class Editor extends React.Component<Props, State> {
         }
         return (
             <WidgetEditor
-                // The order of props matters here. We need to spread the
-                // widget data before specifying the `key` prop, to ensure the
-                // key overrides any `key` field on the widget (which might not
-                // be unique.
                 widgetInfo={this.props.widgets[id]}
                 ref={id}
                 id={id}
@@ -801,15 +797,6 @@ class Editor extends React.Component<Props, State> {
         const textarea = this.textarea.current;
         if (textarea) {
             textarea.focus();
-        }
-    };
-
-    focusAndMoveToEnd: () => void = () => {
-        this.focus();
-        const textarea = this.textarea.current;
-        if (textarea) {
-            textarea.selectionStart = textarea.value.length;
-            textarea.selectionEnd = textarea.value.length;
         }
     };
 

--- a/packages/perseus-editor/src/extras-editor.tsx
+++ b/packages/perseus-editor/src/extras-editor.tsx
@@ -1,8 +1,4 @@
-import {
-    ItemExtras as ContentExtras,
-    getDefaultAnswerArea,
-    isFeatureOn,
-} from "@khanacademy/perseus-core";
+import {getDefaultAnswerArea, isFeatureOn} from "@khanacademy/perseus-core";
 import {View} from "@khanacademy/wonder-blocks-core";
 import {Checkbox, Choice, RadioGroup} from "@khanacademy/wonder-blocks-form";
 import {sizing, spacing} from "@khanacademy/wonder-blocks-tokens";

--- a/packages/perseus-editor/src/extras-editor.tsx
+++ b/packages/perseus-editor/src/extras-editor.tsx
@@ -69,15 +69,6 @@ class ExtrasEditor extends React.Component<Props> {
         }
     };
 
-    serialize(): PerseusAnswerArea {
-        const data = {...ExtrasEditor.defaultProps};
-        for (const key of ContentExtras) {
-            data[key] = !!this.props[key];
-        }
-        data.calculatorVariant = this.props.calculatorVariant;
-        return data;
-    }
-
     render(): React.ReactNode {
         const {editingDisabled, calculatorVariant} = this.props;
         return (

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -97,26 +97,6 @@ class ItemEditor extends React.Component<Props> {
         this.context?.onA11yReport(report);
     };
 
-    serialize(): PerseusItem {
-        invariant(
-            this.questionEditor.current,
-            "cannot serialize ItemEditor without Editor",
-        );
-        invariant(
-            this.extrasEditor.current,
-            "cannot serialize ItemEditor without ExtrasEditor",
-        );
-        invariant(
-            this.hintsEditor.current,
-            "cannot serialize ItemEditor without CombinedHintsEditor",
-        );
-        return {
-            question: this.questionEditor.current.serialize(),
-            answerArea: this.extrasEditor.current.serialize(),
-            hints: this.hintsEditor.current.serialize(),
-        };
-    }
-
     render(): React.ReactNode {
         const isMobile =
             this.props.deviceType === "phone" ||

--- a/packages/perseus-editor/src/item-editor.tsx
+++ b/packages/perseus-editor/src/item-editor.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import invariant from "tiny-invariant";
 import _ from "underscore";
 
 import CombinedHintsEditor from "./combined-hints-editor";


### PR DESCRIPTION
Issue: LEMS-4570

## Test plan:

- `pnpm storybook`
- `open http://localhost:6006/?path=/docs/editors-articleeditor--docs`
- Test that you can edit a question, the hints, and the "extras", and that
  edits from JSON mode are preserved.