### PR TITLE
Deduplicate the `PairEditor` and `PairsEditor` components

### DIFF
--- a/.changeset/vast-dogs-strive.md
+++ b/.changeset/vast-dogs-strive.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-editor": patch
+---
+
+Internal: deduplicate the `PairEditor` and `PairsEditor` components across the CS Program and Iframe widget editors.

--- a/packages/perseus-editor/src/components/blur-input.tsx
+++ b/packages/perseus-editor/src/components/blur-input.tsx
@@ -25,6 +25,13 @@ type State = {
  * Enough melodrama. Its an input that only sends changes
  * to its parent on blur.
  */
+// TODO(benchristel): this is not an ideal user experience, because changes you
+//  make to the input aren't reflected anywhere else until you blur the input.
+//  This means you can't preview intermediate changes without moving focus away
+//  from the thing you want to change! Instead, we should take the approach used
+//  in ScrolllessNumberTextField: take the input's value from state while it's
+//  focused, and from props while it's not focused, and call onChange on every
+//  input event.
 class BlurInput extends React.Component<Props, State> {
     input = React.createRef<HTMLInputElement>();
 

--- a/packages/perseus-editor/src/components/pairs-editor.tsx
+++ b/packages/perseus-editor/src/components/pairs-editor.tsx
@@ -1,0 +1,73 @@
+import * as React from "react";
+
+import BlurInput from "./blur-input";
+
+interface Pair {
+    name: string;
+    value: string;
+}
+
+interface Props {
+    pairs: Pair[];
+    onChange: (pairs: Pair[]) => void;
+}
+
+export class PairsEditor extends React.Component<Props> {
+    handlePairChange = (pairIndex: number, pair: Pair) => {
+        const pairsCopy = [...this.props.pairs];
+        pairsCopy[pairIndex] = pair;
+
+        // If the last pair has both name and value set, add a new one.
+        const lastPair = pairsCopy[pairsCopy.length - 1];
+        if (lastPair.name && lastPair.value) {
+            pairsCopy.push({name: "", value: ""});
+        }
+        this.props.onChange(pairsCopy);
+    };
+
+    render(): React.ReactNode {
+        return (
+            <div>
+                {this.props.pairs.map((pair, i) => (
+                    <PairEditor
+                        key={i}
+                        pair={pair}
+                        onChange={(pair) => this.handlePairChange(i, pair)}
+                    />
+                ))}
+            </div>
+        );
+    }
+}
+
+interface PairEditorProps {
+    pair: Pair;
+    onChange: (pair: Pair) => void;
+}
+
+class PairEditor extends React.Component<PairEditorProps> {
+    render(): React.ReactNode {
+        const {onChange} = this.props;
+        const {name, value} = this.props.pair;
+
+        return (
+            <fieldset className="pair-editor">
+                <label>
+                    Name:{" "}
+                    <BlurInput
+                        value={name}
+                        onChange={(newName) => onChange({name: newName, value})}
+                    />
+                </label>
+                <label>
+                    {" "}
+                    Value:{" "}
+                    <BlurInput
+                        value={value}
+                        onChange={(newVal) => onChange({name, value: newVal})}
+                    />
+                </label>
+            </fieldset>
+        );
+    }
+}

--- a/packages/perseus-editor/src/styles/perseus-editor.css
+++ b/packages/perseus-editor/src/styles/perseus-editor.css
@@ -988,7 +988,7 @@ code {
     color: green;
 }
 .pair-editor input {
-    width: 120px;
+    width: 115px;
 }
 .marvel-device.iphone6.silver:after {
     z-index: 1;

--- a/packages/perseus-editor/src/widgets/cs-program-editor/cs-program-editor.tsx
+++ b/packages/perseus-editor/src/widgets/cs-program-editor/cs-program-editor.tsx
@@ -31,11 +31,6 @@ interface PairEditorProps extends PerseusCSProgramSetting, ChangeableProps {}
  * we should consolidate them
  */
 class PairEditor extends React.Component<PairEditorProps> {
-    static defaultProps: PerseusCSProgramSetting = {
-        name: "",
-        value: "",
-    };
-
     change: ChangeFn = (...args) => {
         return deprecatedChangeableChange.apply(this, args);
     };
@@ -79,7 +74,7 @@ class PairsEditor extends React.Component<PairsEditorProps> {
         return deprecatedChangeableChange.apply(this, args);
     };
 
-    handlePairChange = (pairIndex, pair: any) => {
+    handlePairChange = (pairIndex: any, pair: any) => {
         // If they're both non empty, add a new one
         const pairs = this.props.pairs.slice();
         pairs[pairIndex] = pair;

--- a/packages/perseus-editor/src/widgets/cs-program-editor/cs-program-editor.tsx
+++ b/packages/perseus-editor/src/widgets/cs-program-editor/cs-program-editor.tsx
@@ -9,15 +9,12 @@ import * as React from "react";
 
 import BlurInput from "../../components/blur-input";
 import InfoTip from "../../components/info-tip";
+import {PairsEditor} from "../../components/pairs-editor";
 import {deprecatedChangeableChange} from "../../mixins/changeable";
 import EditorJsonify from "../../mixins/editor-jsonify";
 
-import type {ChangeableProps, ChangeFn} from "../../mixins/changeable";
-import type {
-    PerseusCSProgramWidgetOptions,
-    PerseusCSProgramSetting,
-} from "@khanacademy/perseus-core";
-import {PairsEditor} from "../../components/pairs-editor";
+import type {ChangeableProps} from "../../mixins/changeable";
+import type {PerseusCSProgramWidgetOptions} from "@khanacademy/perseus-core";
 
 const DEFAULT_WIDTH = 400;
 const DEFAULT_HEIGHT = 400;

--- a/packages/perseus-editor/src/widgets/cs-program-editor/cs-program-editor.tsx
+++ b/packages/perseus-editor/src/widgets/cs-program-editor/cs-program-editor.tsx
@@ -17,89 +17,10 @@ import type {
     PerseusCSProgramWidgetOptions,
     PerseusCSProgramSetting,
 } from "@khanacademy/perseus-core";
+import {PairsEditor} from "../../components/pairs-editor";
 
 const DEFAULT_WIDTH = 400;
 const DEFAULT_HEIGHT = 400;
-
-interface PairEditorProps extends PerseusCSProgramSetting, ChangeableProps {}
-
-/**
- * This is used for editing a name/value pair.
- *
- * TODO: PairsEditor and PairEditor are duplicated
- * between iframe-editor and cs-program-editor;
- * we should consolidate them
- */
-class PairEditor extends React.Component<PairEditorProps> {
-    change: ChangeFn = (...args) => {
-        return deprecatedChangeableChange.apply(this, args);
-    };
-
-    render(): React.ReactNode {
-        return (
-            <fieldset className="pair-editor">
-                <label>
-                    Name:{" "}
-                    <BlurInput
-                        value={this.props.name}
-                        onChange={this.change("name")}
-                    />
-                </label>
-                <label>
-                    {" "}
-                    Value:{" "}
-                    <BlurInput
-                        value={this.props.value}
-                        onChange={this.change("value")}
-                    />
-                </label>
-            </fieldset>
-        );
-    }
-}
-
-interface PairsEditorProps extends ChangeableProps {
-    pairs: PerseusCSProgramSetting[];
-}
-
-/**
- * This is used for editing a set of name/value pairs.
- *
- * TODO: PairsEditor and PairEditor are duplicated
- * between iframe-editor and cs-program-editor;
- * we should consolidate them
- */
-class PairsEditor extends React.Component<PairsEditorProps> {
-    change: ChangeFn = (...args) => {
-        return deprecatedChangeableChange.apply(this, args);
-    };
-
-    handlePairChange = (pairIndex: any, pair: any) => {
-        // If they're both non empty, add a new one
-        const pairs = this.props.pairs.slice();
-        pairs[pairIndex] = pair;
-
-        const lastPair = pairs[pairs.length - 1];
-        if (lastPair.name && lastPair.value) {
-            pairs.push({name: "", value: ""});
-        }
-        this.change("pairs", pairs);
-    };
-
-    render(): React.ReactNode {
-        const editors = this.props.pairs.map((pair, i) => {
-            return (
-                <PairEditor
-                    key={i}
-                    name={pair.name}
-                    value={pair.value}
-                    onChange={this.handlePairChange.bind(this, i)}
-                />
-            );
-        });
-        return <div>{editors}</div>;
-    }
-}
 
 const KA_PROGRAM_URL = /khanacademy\.org\/computer-programming\/[^/]+\/(\d+)/;
 
@@ -128,10 +49,6 @@ class CSProgramEditor extends React.Component<CSProgramEditorProps> {
     change: (...args: ReadonlyArray<unknown>) => any = (...args) => {
         // @ts-expect-error - TS2345 - Argument of type 'readonly unknown[]' is not assignable to parameter of type 'any[]'.
         return deprecatedChangeableChange.apply(this, args);
-    };
-
-    _handleSettingsChange: (arg1: any) => void = (settings) => {
-        this.change({settings: settings.pairs});
     };
 
     _handleProgramIDChange: (arg1: string) => void = (programID) => {
@@ -228,7 +145,7 @@ class CSProgramEditor extends React.Component<CSProgramEditorProps> {
                     Settings:
                     <PairsEditor
                         pairs={this.props.settings}
-                        onChange={this._handleSettingsChange}
+                        onChange={(settings) => this.change({settings})}
                     />
                     <InfoTip>
                         Settings that you add here are available to the program

--- a/packages/perseus-editor/src/widgets/iframe-editor/iframe-editor.tsx
+++ b/packages/perseus-editor/src/widgets/iframe-editor/iframe-editor.tsx
@@ -29,16 +29,17 @@ class PairEditor extends React.Component<PairEditorProps> {
 
     render(): React.ReactNode {
         return (
-            <fieldset>
+            <fieldset className="pair-editor">
                 <label>
-                    Name:
+                    Name:{" "}
                     <BlurInput
                         value={this.props.name}
                         onChange={this.change("name")}
                     />
                 </label>
                 <label>
-                    Value:
+                    {" "}
+                    Value:{" "}
                     <BlurInput
                         value={this.props.value}
                         onChange={this.change("value")}

--- a/packages/perseus-editor/src/widgets/iframe-editor/iframe-editor.tsx
+++ b/packages/perseus-editor/src/widgets/iframe-editor/iframe-editor.tsx
@@ -1,17 +1,16 @@
-/* eslint-disable @khanacademy/ts-no-error-suppressions */
 import {
-    iframeLogic, PerseusCSProgramSetting,
+    iframeLogic,
     type PerseusIFrameWidgetOptions,
 } from "@khanacademy/perseus-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import * as React from "react";
 
 import BlurInput from "../../components/blur-input";
+import {PairsEditor} from "../../components/pairs-editor";
 import {deprecatedChangeableChange} from "../../mixins/changeable";
 import EditorJsonify from "../../mixins/editor-jsonify";
 
 import type {ChangeableProps} from "../../mixins/changeable";
-import {PairsEditor} from "../../components/pairs-editor";
 
 interface IframeEditorProps
     extends PerseusIFrameWidgetOptions,

--- a/packages/perseus-editor/src/widgets/iframe-editor/iframe-editor.tsx
+++ b/packages/perseus-editor/src/widgets/iframe-editor/iframe-editor.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable @khanacademy/ts-no-error-suppressions */
 import {
-    iframeLogic,
+    iframeLogic, PerseusCSProgramSetting,
     type PerseusIFrameWidgetOptions,
-    type PerseusCSProgramSetting,
 } from "@khanacademy/perseus-core";
 import {Checkbox} from "@khanacademy/wonder-blocks-form";
 import * as React from "react";
@@ -11,87 +10,8 @@ import BlurInput from "../../components/blur-input";
 import {deprecatedChangeableChange} from "../../mixins/changeable";
 import EditorJsonify from "../../mixins/editor-jsonify";
 
-import type {ChangeableProps, ChangeFn} from "../../mixins/changeable";
-
-interface PairEditorProps extends PerseusCSProgramSetting, ChangeableProps {}
-
-/**
- * This is used for editing a name/value pair.
- *
- * TODO: PairsEditor and PairEditor are duplicated
- * between iframe-editor and cs-program-editor;
- * we should consolidate them
- */
-class PairEditor extends React.Component<PairEditorProps> {
-    change: ChangeFn = (...args) => {
-        return deprecatedChangeableChange.apply(this, args);
-    };
-
-    render(): React.ReactNode {
-        return (
-            <fieldset className="pair-editor">
-                <label>
-                    Name:{" "}
-                    <BlurInput
-                        value={this.props.name}
-                        onChange={this.change("name")}
-                    />
-                </label>
-                <label>
-                    {" "}
-                    Value:{" "}
-                    <BlurInput
-                        value={this.props.value}
-                        onChange={this.change("value")}
-                    />
-                </label>
-            </fieldset>
-        );
-    }
-}
-
-interface PairsEditorProps extends ChangeableProps {
-    pairs: PerseusCSProgramSetting[];
-}
-
-/**
- * This is used for editing a set of name/value pairs.
- *
- * TODO: PairsEditor and PairEditor are duplicated
- * between iframe-editor and cs-program-editor;
- * we should consolidate them
- */
-class PairsEditor extends React.Component<PairsEditorProps> {
-    change: ChangeFn = (...args) => {
-        return deprecatedChangeableChange.apply(this, args);
-    };
-
-    handlePairChange = (pairIndex: any, pair: any) => {
-        // If they're both non empty, add a new one
-        const pairs = this.props.pairs.slice();
-        pairs[pairIndex] = pair;
-
-        const lastPair = pairs[pairs.length - 1];
-        if (lastPair.name && lastPair.value) {
-            pairs.push({name: "", value: ""});
-        }
-        this.change("pairs", pairs);
-    };
-
-    render(): React.ReactNode {
-        const editors = this.props.pairs.map((pair, i) => {
-            return (
-                <PairEditor
-                    key={i}
-                    name={pair.name}
-                    value={pair.value}
-                    onChange={this.handlePairChange.bind(this, i)}
-                />
-            );
-        });
-        return <div>{editors}</div>;
-    }
-}
+import type {ChangeableProps} from "../../mixins/changeable";
+import {PairsEditor} from "../../components/pairs-editor";
 
 interface IframeEditorProps
     extends PerseusIFrameWidgetOptions,
@@ -104,13 +24,8 @@ class IframeEditor extends React.Component<IframeEditorProps> {
     static defaultProps: PerseusIFrameWidgetOptions =
         iframeLogic.defaultWidgetOptions;
 
-    change: (arg1: any, arg2: any, arg3: any) => any = (...args) => {
+    change: (arg1: any) => any = (...args) => {
         return deprecatedChangeableChange.apply(this, args);
-    };
-
-    handleSettingsChange: (arg1: any) => void = (settings) => {
-        // @ts-expect-error - TS2554 - Expected 3 arguments, but got 1.
-        this.change({settings: settings.pairs});
     };
 
     serialize: () => any = () => {
@@ -128,7 +43,6 @@ class IframeEditor extends React.Component<IframeEditorProps> {
                     Url or Program ID:
                     <BlurInput
                         value={this.props.url}
-                        // @ts-expect-error - TS2554 - Expected 3 arguments, but got 1.
                         onChange={this.change("url")}
                     />
                 </label>
@@ -138,7 +52,7 @@ class IframeEditor extends React.Component<IframeEditorProps> {
                     Settings:
                     <PairsEditor
                         pairs={this.props.settings ?? []}
-                        onChange={this.handleSettingsChange}
+                        onChange={(settings) => this.change({settings})}
                     />
                 </label>
                 <br />
@@ -146,7 +60,6 @@ class IframeEditor extends React.Component<IframeEditorProps> {
                     Width:
                     <BlurInput
                         value={String(this.props.width)}
-                        // @ts-expect-error - TS2554 - Expected 3 arguments, but got 1.
                         onChange={this.change("width")}
                     />
                 </label>
@@ -154,7 +67,6 @@ class IframeEditor extends React.Component<IframeEditorProps> {
                     Height:
                     <BlurInput
                         value={String(this.props.height)}
-                        // @ts-expect-error - TS2554 - Expected 3 arguments, but got 1.
                         onChange={this.change("height")}
                     />
                 </label>


### PR DESCRIPTION
## Summary:
These components were duplicated in `cs-program-editor.tsx` and `iframe-editor.tsx`.
I moved them to `components/` and also cleaned up some legacy ChangeHandler stuff
and `@ts-expect-error`s.

This fixes a TODO comment.

Issue: none

## Test plan:

- `pnpm storybook`
- `open http://localhost:6006/?path=/docs/editors-editorpage--docs`
- Edit a CS Program widget and an Iframe widget. You should be able to add
  settings.  Your changes should be reflected in the JSON.