### PR TITLE
Let MathJax inherit its default foreground color from its parent element

### DIFF
--- a/.changeset/floppy-beds-stare.md
+++ b/.changeset/floppy-beds-stare.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus": patch
+---
+
+Math notation rendered by MathJax now inherits its color from its context, so it matches surrounding text.

--- a/packages/perseus/src/styles/styles.css
+++ b/packages/perseus/src/styles/styles.css
@@ -162,7 +162,6 @@
     .framework-perseus.perseus-mobile mjx-container:not(.mafs-graph *) {
         font-size: 21px;
         line-height: 1.2;
-        color: var(--wb-semanticColor-core-foreground-neutral-strong);
     }
     .framework-perseus.perseus-mobile .perseus-block-math mjx-container {
         font-size: 21px;
@@ -238,7 +237,6 @@
     .framework-perseus.perseus-mobile mjx-container:not(.mafs-graph *) {
         font-size: 23px;
         line-height: 1.3;
-        color: var(--wb-semanticColor-core-foreground-neutral-strong);
     }
     .framework-perseus.perseus-mobile .perseus-block-math mjx-container {
         font-size: 30px;
@@ -314,7 +312,6 @@
     .framework-perseus.perseus-mobile mjx-container:not(.mafs-graph *) {
         font-size: 25px;
         line-height: 1.2;
-        color: var(--wb-semanticColor-core-foreground-neutral-strong);
     }
     .framework-perseus.perseus-mobile .perseus-block-math mjx-container {
         font-size: 30px;


### PR DESCRIPTION
## Summary:
This fixes a bug where math did not have the correct color in selected Radio
widget choices on mobile. The text of the selected choice should be blue, but
the math was white.

Issue: LEMS-3896

## Test plan:

Deploy to a ZND. The bug should be fixed, and math should have the expected
color in all other contexts.