### PR TITLE
Bump Wonder Blocks dependencies

### DIFF
--- a/.changeset/tender-toys-leave.md
+++ b/.changeset/tender-toys-leave.md
@@ -1,0 +1,7 @@
+---
+"@khanacademy/perseus-editor": patch
+"@khanacademy/math-input": patch
+"@khanacademy/perseus": patch
+---
+
+Bumps Wonder Blocks dependencies: IconButton now requires aria-label (major), Accordion, Clickable and Link improvments

--- a/packages/math-input/package.json
+++ b/packages/math-input/package.json
@@ -82,6 +82,6 @@
     },
     "keywords": [],
     "khan": {
-        "catalogHash": "ab1b0630de7db8ba"
+        "catalogHash": "abc5c36b26955e67"
     }
 }

--- a/packages/math-input/src/components/keypad/__tests__/__snapshots__/keypad.test.tsx.snap
+++ b/packages/math-input/src/components/keypad/__tests__/__snapshots__/keypad.test.tsx.snap
@@ -160,7 +160,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="1"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -191,7 +191,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="2"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -222,7 +222,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="3"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -253,7 +253,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="4"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -284,7 +284,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="5"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -315,7 +315,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="6"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -346,7 +346,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="7"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -377,7 +377,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="8"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -408,7 +408,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="9"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -439,7 +439,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="0"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -470,7 +470,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="Decimal"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -502,7 +502,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="Negative"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -535,7 +535,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="Percent"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -568,7 +568,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="Fraction, excluding the current expression"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -601,7 +601,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="Plus"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -640,7 +640,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="Minus"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -673,7 +673,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="Multiply"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -721,7 +721,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="Left parenthesis"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -754,7 +754,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="Right parenthesis"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -787,7 +787,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
             >
               <button
                 aria-label="Delete"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -826,7 +826,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
               >
                 <button
                   aria-label="Up arrow"
-                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_13937mo"
+                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_13937mo-o_O-inlineStyles_13d9y1m"
                   type="button"
                 >
                   <div
@@ -871,7 +871,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
               >
                 <button
                   aria-label="Right arrow"
-                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_13937mo"
+                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_13937mo-o_O-inlineStyles_13d9y1m"
                   type="button"
                 >
                   <div
@@ -916,7 +916,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
               >
                 <button
                   aria-label="Down arrow"
-                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_13937mo"
+                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_13937mo-o_O-inlineStyles_13d9y1m"
                   type="button"
                 >
                   <div
@@ -961,7 +961,7 @@ exports[`keypad should snapshot expanded: first render 1`] = `
               >
                 <button
                   aria-label="Left arrow"
-                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_13937mo"
+                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_13937mo-o_O-inlineStyles_13d9y1m"
                   type="button"
                 >
                   <div
@@ -1193,7 +1193,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="1"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -1224,7 +1224,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="2"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -1255,7 +1255,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="3"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -1286,7 +1286,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="4"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -1317,7 +1317,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="5"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -1348,7 +1348,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="6"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -1379,7 +1379,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="7"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -1410,7 +1410,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="8"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -1441,7 +1441,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="9"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -1472,7 +1472,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="0"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -1503,7 +1503,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="Decimal"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -1535,7 +1535,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="Negative"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -1568,7 +1568,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="Percent"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -1601,7 +1601,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="Fraction, excluding the current expression"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -1634,7 +1634,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="Plus"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -1673,7 +1673,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="Minus"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -1706,7 +1706,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="Multiply"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -1754,7 +1754,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="Left parenthesis"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -1787,7 +1787,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="Right parenthesis"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -1820,7 +1820,7 @@ exports[`keypad should snapshot unexpanded: first render 1`] = `
             >
               <button
                 aria-label="Delete"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div

--- a/packages/math-input/src/components/keypad/__tests__/__snapshots__/mobile-keypad.test.tsx.snap
+++ b/packages/math-input/src/components/keypad/__tests__/__snapshots__/mobile-keypad.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`mobile keypad should render keypad when active 1`] = `
             >
               <button
                 aria-label="1"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -83,7 +83,7 @@ exports[`mobile keypad should render keypad when active 1`] = `
             >
               <button
                 aria-label="2"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -114,7 +114,7 @@ exports[`mobile keypad should render keypad when active 1`] = `
             >
               <button
                 aria-label="3"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -145,7 +145,7 @@ exports[`mobile keypad should render keypad when active 1`] = `
             >
               <button
                 aria-label="4"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -176,7 +176,7 @@ exports[`mobile keypad should render keypad when active 1`] = `
             >
               <button
                 aria-label="5"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -207,7 +207,7 @@ exports[`mobile keypad should render keypad when active 1`] = `
             >
               <button
                 aria-label="6"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -238,7 +238,7 @@ exports[`mobile keypad should render keypad when active 1`] = `
             >
               <button
                 aria-label="7"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -269,7 +269,7 @@ exports[`mobile keypad should render keypad when active 1`] = `
             >
               <button
                 aria-label="8"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -300,7 +300,7 @@ exports[`mobile keypad should render keypad when active 1`] = `
             >
               <button
                 aria-label="9"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -331,7 +331,7 @@ exports[`mobile keypad should render keypad when active 1`] = `
             >
               <button
                 aria-label="0"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -362,7 +362,7 @@ exports[`mobile keypad should render keypad when active 1`] = `
             >
               <button
                 aria-label="Decimal"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -394,7 +394,7 @@ exports[`mobile keypad should render keypad when active 1`] = `
             >
               <button
                 aria-label="Negative"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -427,7 +427,7 @@ exports[`mobile keypad should render keypad when active 1`] = `
             >
               <button
                 aria-label="Percent"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -460,7 +460,7 @@ exports[`mobile keypad should render keypad when active 1`] = `
             >
               <button
                 aria-label="Pi"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -491,7 +491,7 @@ exports[`mobile keypad should render keypad when active 1`] = `
             >
               <button
                 aria-label="Fraction, excluding the current expression"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div
@@ -524,7 +524,7 @@ exports[`mobile keypad should render keypad when active 1`] = `
             >
               <button
                 aria-label="Delete"
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-clickable_rukhmf-o_O-inlineStyles_13d9y1m"
                 type="button"
               >
                 <div

--- a/packages/perseus-editor/package.json
+++ b/packages/perseus-editor/package.json
@@ -113,6 +113,6 @@
     },
     "keywords": [],
     "khan": {
-        "catalogHash": "ee19334b82f9ead7"
+        "catalogHash": "6f8f476b9fc77d28"
     }
 }

--- a/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/article-editor.test.tsx.snap
@@ -1941,7 +1941,7 @@ table: [[☃ table 1]]
                                       aria-controls=":r13:"
                                       aria-expanded="false"
                                       aria-label="open math keypad"
-                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4"
+                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m"
                                       id=":r13:-anchor"
                                       role="button"
                                       type="button"
@@ -2879,7 +2879,7 @@ table: [[☃ table 1]]
                               >
                                 <button
                                   aria-disabled="false"
-                                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                                   type="button"
                                 >
                                   <div
@@ -2925,7 +2925,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -2934,7 +2934,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -2994,7 +2994,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -3003,7 +3003,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -3046,7 +3046,7 @@ table: [[☃ table 1]]
                                 </div>
                                 <button
                                   aria-disabled="false"
-                                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                                   type="button"
                                 >
                                   <div
@@ -3086,7 +3086,7 @@ table: [[☃ table 1]]
                                               aria-controls=":r1o:"
                                               aria-disabled="false"
                                               aria-expanded="true"
-                                              class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f"
+                                              class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f-o_O-inlineStyles_13d9y1m"
                                               id=":r1n:"
                                               type="button"
                                             >
@@ -3159,7 +3159,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="true"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -3168,7 +3168,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -3177,7 +3177,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -3209,7 +3209,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="true"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -3218,7 +3218,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -3227,7 +3227,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -3287,7 +3287,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Integers"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -3297,7 +3297,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Decimals"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -3307,7 +3307,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Proper fractions"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -3317,7 +3317,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Improper fractions"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -3327,7 +3327,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Mixed numbers"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -3337,7 +3337,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Numbers with π"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -3361,7 +3361,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="true"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -3370,7 +3370,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -4082,7 +4082,7 @@ table: [[☃ table 1]]
                                 >
                                   <button
                                     aria-disabled="false"
-                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                                     type="button"
                                   >
                                     <div
@@ -4128,7 +4128,7 @@ table: [[☃ table 1]]
                                           <button
                                             aria-checked="true"
                                             aria-disabled="true"
-                                            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                             role="radio"
                                             type="button"
                                           >
@@ -4137,7 +4137,7 @@ table: [[☃ table 1]]
                                           <button
                                             aria-checked="false"
                                             aria-disabled="true"
-                                            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                             role="radio"
                                             type="button"
                                           >
@@ -4197,7 +4197,7 @@ table: [[☃ table 1]]
                                           <button
                                             aria-checked="true"
                                             aria-disabled="true"
-                                            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                             role="radio"
                                             type="button"
                                           >
@@ -4206,7 +4206,7 @@ table: [[☃ table 1]]
                                           <button
                                             aria-checked="false"
                                             aria-disabled="true"
-                                            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                             role="radio"
                                             type="button"
                                           >
@@ -4249,7 +4249,7 @@ table: [[☃ table 1]]
                                   </div>
                                   <button
                                     aria-disabled="false"
-                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                                     type="button"
                                   >
                                     <div
@@ -4289,7 +4289,7 @@ table: [[☃ table 1]]
                                                 aria-controls=":r24:"
                                                 aria-disabled="false"
                                                 aria-expanded="true"
-                                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f"
+                                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f-o_O-inlineStyles_13d9y1m"
                                                 id=":r23:"
                                                 type="button"
                                               >
@@ -4362,7 +4362,7 @@ table: [[☃ table 1]]
                                                     <button
                                                       aria-checked="true"
                                                       aria-disabled="true"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="radio"
                                                       type="button"
                                                     >
@@ -4371,7 +4371,7 @@ table: [[☃ table 1]]
                                                     <button
                                                       aria-checked="false"
                                                       aria-disabled="true"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="radio"
                                                       type="button"
                                                     >
@@ -4380,7 +4380,7 @@ table: [[☃ table 1]]
                                                     <button
                                                       aria-checked="false"
                                                       aria-disabled="true"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="radio"
                                                       type="button"
                                                     >
@@ -4412,7 +4412,7 @@ table: [[☃ table 1]]
                                                     <button
                                                       aria-checked="true"
                                                       aria-disabled="true"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="radio"
                                                       type="button"
                                                     >
@@ -4421,7 +4421,7 @@ table: [[☃ table 1]]
                                                     <button
                                                       aria-checked="false"
                                                       aria-disabled="true"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="radio"
                                                       type="button"
                                                     >
@@ -4430,7 +4430,7 @@ table: [[☃ table 1]]
                                                     <button
                                                       aria-checked="false"
                                                       aria-disabled="true"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="radio"
                                                       type="button"
                                                     >
@@ -4490,7 +4490,7 @@ table: [[☃ table 1]]
                                                       aria-checked="false"
                                                       aria-disabled="true"
                                                       aria-label="Integers"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="checkbox"
                                                       type="button"
                                                     >
@@ -4500,7 +4500,7 @@ table: [[☃ table 1]]
                                                       aria-checked="false"
                                                       aria-disabled="true"
                                                       aria-label="Decimals"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="checkbox"
                                                       type="button"
                                                     >
@@ -4510,7 +4510,7 @@ table: [[☃ table 1]]
                                                       aria-checked="false"
                                                       aria-disabled="true"
                                                       aria-label="Proper fractions"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="checkbox"
                                                       type="button"
                                                     >
@@ -4520,7 +4520,7 @@ table: [[☃ table 1]]
                                                       aria-checked="false"
                                                       aria-disabled="true"
                                                       aria-label="Improper fractions"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="checkbox"
                                                       type="button"
                                                     >
@@ -4530,7 +4530,7 @@ table: [[☃ table 1]]
                                                       aria-checked="false"
                                                       aria-disabled="true"
                                                       aria-label="Mixed numbers"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="checkbox"
                                                       type="button"
                                                     >
@@ -4540,7 +4540,7 @@ table: [[☃ table 1]]
                                                       aria-checked="false"
                                                       aria-disabled="true"
                                                       aria-label="Numbers with π"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="checkbox"
                                                       type="button"
                                                     >
@@ -4564,7 +4564,7 @@ table: [[☃ table 1]]
                                                     <button
                                                       aria-checked="true"
                                                       aria-disabled="true"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="radio"
                                                       type="button"
                                                     >
@@ -4573,7 +4573,7 @@ table: [[☃ table 1]]
                                                     <button
                                                       aria-checked="false"
                                                       aria-disabled="true"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="radio"
                                                       type="button"
                                                     >
@@ -6934,7 +6934,7 @@ table: [[☃ table 1]]
                               >
                                 <button
                                   aria-disabled="false"
-                                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                                   type="button"
                                 >
                                   <div
@@ -6980,7 +6980,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -6989,7 +6989,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -7049,7 +7049,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -7058,7 +7058,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -7101,7 +7101,7 @@ table: [[☃ table 1]]
                                 </div>
                                 <button
                                   aria-disabled="false"
-                                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                                   type="button"
                                 >
                                   <div
@@ -7141,7 +7141,7 @@ table: [[☃ table 1]]
                                               aria-controls=":r2k:"
                                               aria-disabled="false"
                                               aria-expanded="true"
-                                              class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f"
+                                              class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f-o_O-inlineStyles_13d9y1m"
                                               id=":r2j:"
                                               type="button"
                                             >
@@ -7214,7 +7214,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="true"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -7223,7 +7223,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -7232,7 +7232,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -7264,7 +7264,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="true"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -7273,7 +7273,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -7282,7 +7282,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -7342,7 +7342,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Integers"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -7352,7 +7352,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Decimals"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -7362,7 +7362,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Proper fractions"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -7372,7 +7372,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Improper fractions"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -7382,7 +7382,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Mixed numbers"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -7392,7 +7392,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Numbers with π"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -7416,7 +7416,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="true"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -7425,7 +7425,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -8143,7 +8143,7 @@ table: [[☃ table 1]]
                     >
                       <button
                         aria-disabled="false"
-                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                         type="button"
                       >
                         <div
@@ -8189,7 +8189,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="true"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -8198,7 +8198,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="false"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -8258,7 +8258,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="true"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -8267,7 +8267,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="false"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -8310,7 +8310,7 @@ table: [[☃ table 1]]
                       </div>
                       <button
                         aria-disabled="false"
-                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                         type="button"
                       >
                         <div
@@ -8350,7 +8350,7 @@ table: [[☃ table 1]]
                                     aria-controls=":r3n:"
                                     aria-disabled="false"
                                     aria-expanded="true"
-                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f"
+                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f-o_O-inlineStyles_13d9y1m"
                                     id=":r3m:"
                                     type="button"
                                   >
@@ -8425,7 +8425,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -8434,7 +8434,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -8443,7 +8443,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -8475,7 +8475,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -8484,7 +8484,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -8493,7 +8493,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -8553,7 +8553,7 @@ table: [[☃ table 1]]
                                           aria-checked="true"
                                           aria-disabled="true"
                                           aria-label="Integers"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -8563,7 +8563,7 @@ table: [[☃ table 1]]
                                           aria-checked="false"
                                           aria-disabled="true"
                                           aria-label="Decimals"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -8573,7 +8573,7 @@ table: [[☃ table 1]]
                                           aria-checked="true"
                                           aria-disabled="true"
                                           aria-label="Proper fractions"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -8583,7 +8583,7 @@ table: [[☃ table 1]]
                                           aria-checked="true"
                                           aria-disabled="true"
                                           aria-label="Improper fractions"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -8593,7 +8593,7 @@ table: [[☃ table 1]]
                                           aria-checked="true"
                                           aria-disabled="true"
                                           aria-label="Mixed numbers"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -8603,7 +8603,7 @@ table: [[☃ table 1]]
                                           aria-checked="false"
                                           aria-disabled="true"
                                           aria-label="Numbers with π"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -8627,7 +8627,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -8636,7 +8636,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -9440,7 +9440,7 @@ table: [[☃ table 1]]
                       class="default_7zhre1 best-practices-container"
                     >
                       <a
-                        class="shared_1y1t15t-o_O-rest_19jgcvc"
+                        class="shared_1y1t15t-o_O-rest_19jgcvc-o_O-inlineStyles_13d9y1m"
                         href="https://khanacademy.atlassian.net/wiki/spaces/LC/pages/3295281289/Interactive+Graph+Widget#Adding-a-new-Interactive-Graph-Widget"
                         rel="noopener noreferrer"
                         target="_blank"
@@ -9560,7 +9560,7 @@ table: [[☃ table 1]]
                       </label>
                       <button
                         aria-disabled="false"
-                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                         type="button"
                       >
                         <div
@@ -9626,7 +9626,7 @@ table: [[☃ table 1]]
                       </div>
                       <button
                         aria-disabled="true"
-                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-container_f36q81-o_O-notClickable_l0aty"
+                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-container_f36q81-o_O-notClickable_l0aty-o_O-inlineStyles_13d9y1m"
                         type="button"
                       >
                         <div
@@ -11023,7 +11023,7 @@ table: [[☃ table 1]]
                       >
                         <button
                           aria-disabled="false"
-                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                           type="button"
                         >
                           <div
@@ -11211,7 +11211,7 @@ table: [[☃ table 1]]
                       </div>
                       <button
                         aria-disabled="false"
-                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                         type="button"
                       >
                         <div
@@ -11467,7 +11467,7 @@ table: [[☃ table 1]]
                       </ol>
                       <button
                         aria-disabled="false"
-                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                         type="button"
                       >
                         <div
@@ -12139,7 +12139,7 @@ table: [[☃ table 1]]
                       </div>
                       <button
                         aria-disabled="false"
-                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                         type="button"
                       >
                         <div
@@ -12173,7 +12173,7 @@ table: [[☃ table 1]]
                                 aria-controls=":r50:"
                                 aria-disabled="false"
                                 aria-expanded="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f-o_O-inlineStyles_13d9y1m"
                                 id=":r4v:"
                                 type="button"
                               >
@@ -12686,7 +12686,7 @@ table: [[☃ table 1]]
                             <button
                               aria-disabled="true"
                               aria-label="Remove answer"
-                              class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 remove-button"
+                              class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m remove-button"
                               type="button"
                             >
                               <span
@@ -12714,7 +12714,7 @@ table: [[☃ table 1]]
                             <button
                               aria-disabled="true"
                               aria-label="Remove answer"
-                              class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 remove-button"
+                              class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m remove-button"
                               type="button"
                             >
                               <span
@@ -12739,7 +12739,7 @@ table: [[☃ table 1]]
                         </ul>
                         <button
                           aria-disabled="true"
-                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 add-answer"
+                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m add-answer"
                           type="button"
                         >
                           <span
@@ -13990,7 +13990,7 @@ table: [[☃ table 1]]
                     >
                       <button
                         aria-disabled="false"
-                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                         type="button"
                       >
                         <div
@@ -14036,7 +14036,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="true"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -14045,7 +14045,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="false"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -14105,7 +14105,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="true"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -14114,7 +14114,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="false"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -14157,7 +14157,7 @@ table: [[☃ table 1]]
                       </div>
                       <button
                         aria-disabled="false"
-                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                         type="button"
                       >
                         <div
@@ -14197,7 +14197,7 @@ table: [[☃ table 1]]
                                     aria-controls=":r63:"
                                     aria-disabled="false"
                                     aria-expanded="true"
-                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f"
+                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f-o_O-inlineStyles_13d9y1m"
                                     id=":r62:"
                                     type="button"
                                   >
@@ -14270,7 +14270,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -14279,7 +14279,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -14288,7 +14288,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -14320,7 +14320,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -14329,7 +14329,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -14338,7 +14338,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -14401,7 +14401,7 @@ table: [[☃ table 1]]
                                           aria-checked="false"
                                           aria-disabled="true"
                                           aria-label="Integers"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -14411,7 +14411,7 @@ table: [[☃ table 1]]
                                           aria-checked="false"
                                           aria-disabled="true"
                                           aria-label="Decimals"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -14421,7 +14421,7 @@ table: [[☃ table 1]]
                                           aria-checked="false"
                                           aria-disabled="true"
                                           aria-label="Proper fractions"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -14431,7 +14431,7 @@ table: [[☃ table 1]]
                                           aria-checked="false"
                                           aria-disabled="true"
                                           aria-label="Improper fractions"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -14441,7 +14441,7 @@ table: [[☃ table 1]]
                                           aria-checked="false"
                                           aria-disabled="true"
                                           aria-label="Mixed numbers"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -14451,7 +14451,7 @@ table: [[☃ table 1]]
                                           aria-checked="false"
                                           aria-disabled="true"
                                           aria-label="Numbers with π"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -14475,7 +14475,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -14484,7 +14484,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -15202,7 +15202,7 @@ table: [[☃ table 1]]
                       class="default_7zhre1 best-practices-container"
                     >
                       <a
-                        class="shared_1y1t15t-o_O-rest_19jgcvc"
+                        class="shared_1y1t15t-o_O-rest_19jgcvc-o_O-inlineStyles_13d9y1m"
                         href="https://www.khanacademy.org/internal-courses/content-creation-best-practices/xe46daa512cd9c644:question-writing/xe46daa512cd9c644:multiple-choice/a/stems"
                         rel="noopener noreferrer"
                         target="_blank"
@@ -15318,7 +15318,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="true"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -15327,7 +15327,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="false"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -15509,7 +15509,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="false"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -15518,7 +15518,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="true"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >

--- a/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
+++ b/packages/perseus-editor/src/__snapshots__/editor-page-snapshot.test.tsx.snap
@@ -1980,7 +1980,7 @@ table: [[☃ table 1]]
                                       aria-controls=":ru:"
                                       aria-expanded="false"
                                       aria-label="open math keypad"
-                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4"
+                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m"
                                       id=":ru:-anchor"
                                       role="button"
                                       type="button"
@@ -2918,7 +2918,7 @@ table: [[☃ table 1]]
                               >
                                 <button
                                   aria-disabled="false"
-                                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                                   type="button"
                                 >
                                   <div
@@ -2964,7 +2964,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -2973,7 +2973,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -3033,7 +3033,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -3042,7 +3042,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -3085,7 +3085,7 @@ table: [[☃ table 1]]
                                 </div>
                                 <button
                                   aria-disabled="false"
-                                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                                   type="button"
                                 >
                                   <div
@@ -3125,7 +3125,7 @@ table: [[☃ table 1]]
                                               aria-controls=":r1j:"
                                               aria-disabled="false"
                                               aria-expanded="true"
-                                              class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f"
+                                              class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f-o_O-inlineStyles_13d9y1m"
                                               id=":r1i:"
                                               type="button"
                                             >
@@ -3198,7 +3198,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="true"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -3207,7 +3207,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -3216,7 +3216,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -3248,7 +3248,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="true"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -3257,7 +3257,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -3266,7 +3266,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -3326,7 +3326,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Integers"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -3336,7 +3336,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Decimals"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -3346,7 +3346,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Proper fractions"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -3356,7 +3356,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Improper fractions"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -3366,7 +3366,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Mixed numbers"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -3376,7 +3376,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Numbers with π"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -3400,7 +3400,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="true"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -3409,7 +3409,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -4121,7 +4121,7 @@ table: [[☃ table 1]]
                                 >
                                   <button
                                     aria-disabled="false"
-                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                                     type="button"
                                   >
                                     <div
@@ -4167,7 +4167,7 @@ table: [[☃ table 1]]
                                           <button
                                             aria-checked="true"
                                             aria-disabled="true"
-                                            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                             role="radio"
                                             type="button"
                                           >
@@ -4176,7 +4176,7 @@ table: [[☃ table 1]]
                                           <button
                                             aria-checked="false"
                                             aria-disabled="true"
-                                            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                             role="radio"
                                             type="button"
                                           >
@@ -4236,7 +4236,7 @@ table: [[☃ table 1]]
                                           <button
                                             aria-checked="true"
                                             aria-disabled="true"
-                                            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                             role="radio"
                                             type="button"
                                           >
@@ -4245,7 +4245,7 @@ table: [[☃ table 1]]
                                           <button
                                             aria-checked="false"
                                             aria-disabled="true"
-                                            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                             role="radio"
                                             type="button"
                                           >
@@ -4288,7 +4288,7 @@ table: [[☃ table 1]]
                                   </div>
                                   <button
                                     aria-disabled="false"
-                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                                     type="button"
                                   >
                                     <div
@@ -4328,7 +4328,7 @@ table: [[☃ table 1]]
                                                 aria-controls=":r1v:"
                                                 aria-disabled="false"
                                                 aria-expanded="true"
-                                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f"
+                                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f-o_O-inlineStyles_13d9y1m"
                                                 id=":r1u:"
                                                 type="button"
                                               >
@@ -4401,7 +4401,7 @@ table: [[☃ table 1]]
                                                     <button
                                                       aria-checked="true"
                                                       aria-disabled="true"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="radio"
                                                       type="button"
                                                     >
@@ -4410,7 +4410,7 @@ table: [[☃ table 1]]
                                                     <button
                                                       aria-checked="false"
                                                       aria-disabled="true"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="radio"
                                                       type="button"
                                                     >
@@ -4419,7 +4419,7 @@ table: [[☃ table 1]]
                                                     <button
                                                       aria-checked="false"
                                                       aria-disabled="true"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="radio"
                                                       type="button"
                                                     >
@@ -4451,7 +4451,7 @@ table: [[☃ table 1]]
                                                     <button
                                                       aria-checked="true"
                                                       aria-disabled="true"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="radio"
                                                       type="button"
                                                     >
@@ -4460,7 +4460,7 @@ table: [[☃ table 1]]
                                                     <button
                                                       aria-checked="false"
                                                       aria-disabled="true"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="radio"
                                                       type="button"
                                                     >
@@ -4469,7 +4469,7 @@ table: [[☃ table 1]]
                                                     <button
                                                       aria-checked="false"
                                                       aria-disabled="true"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="radio"
                                                       type="button"
                                                     >
@@ -4529,7 +4529,7 @@ table: [[☃ table 1]]
                                                       aria-checked="false"
                                                       aria-disabled="true"
                                                       aria-label="Integers"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="checkbox"
                                                       type="button"
                                                     >
@@ -4539,7 +4539,7 @@ table: [[☃ table 1]]
                                                       aria-checked="false"
                                                       aria-disabled="true"
                                                       aria-label="Decimals"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="checkbox"
                                                       type="button"
                                                     >
@@ -4549,7 +4549,7 @@ table: [[☃ table 1]]
                                                       aria-checked="false"
                                                       aria-disabled="true"
                                                       aria-label="Proper fractions"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="checkbox"
                                                       type="button"
                                                     >
@@ -4559,7 +4559,7 @@ table: [[☃ table 1]]
                                                       aria-checked="false"
                                                       aria-disabled="true"
                                                       aria-label="Improper fractions"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="checkbox"
                                                       type="button"
                                                     >
@@ -4569,7 +4569,7 @@ table: [[☃ table 1]]
                                                       aria-checked="false"
                                                       aria-disabled="true"
                                                       aria-label="Mixed numbers"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="checkbox"
                                                       type="button"
                                                     >
@@ -4579,7 +4579,7 @@ table: [[☃ table 1]]
                                                       aria-checked="false"
                                                       aria-disabled="true"
                                                       aria-label="Numbers with π"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="checkbox"
                                                       type="button"
                                                     >
@@ -4603,7 +4603,7 @@ table: [[☃ table 1]]
                                                     <button
                                                       aria-checked="true"
                                                       aria-disabled="true"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="radio"
                                                       type="button"
                                                     >
@@ -4612,7 +4612,7 @@ table: [[☃ table 1]]
                                                     <button
                                                       aria-checked="false"
                                                       aria-disabled="true"
-                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                       role="radio"
                                                       type="button"
                                                     >
@@ -6973,7 +6973,7 @@ table: [[☃ table 1]]
                               >
                                 <button
                                   aria-disabled="false"
-                                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                                   type="button"
                                 >
                                   <div
@@ -7019,7 +7019,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -7028,7 +7028,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -7088,7 +7088,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -7097,7 +7097,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -7140,7 +7140,7 @@ table: [[☃ table 1]]
                                 </div>
                                 <button
                                   aria-disabled="false"
-                                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                                   type="button"
                                 >
                                   <div
@@ -7180,7 +7180,7 @@ table: [[☃ table 1]]
                                               aria-controls=":r2f:"
                                               aria-disabled="false"
                                               aria-expanded="true"
-                                              class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f"
+                                              class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f-o_O-inlineStyles_13d9y1m"
                                               id=":r2e:"
                                               type="button"
                                             >
@@ -7253,7 +7253,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="true"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -7262,7 +7262,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -7271,7 +7271,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -7303,7 +7303,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="true"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -7312,7 +7312,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -7321,7 +7321,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -7381,7 +7381,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Integers"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -7391,7 +7391,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Decimals"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -7401,7 +7401,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Proper fractions"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -7411,7 +7411,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Improper fractions"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -7421,7 +7421,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Mixed numbers"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -7431,7 +7431,7 @@ table: [[☃ table 1]]
                                                     aria-checked="false"
                                                     aria-disabled="true"
                                                     aria-label="Numbers with π"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="checkbox"
                                                     type="button"
                                                   >
@@ -7455,7 +7455,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="true"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -7464,7 +7464,7 @@ table: [[☃ table 1]]
                                                   <button
                                                     aria-checked="false"
                                                     aria-disabled="true"
-                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                                     role="radio"
                                                     type="button"
                                                   >
@@ -8133,7 +8133,7 @@ table: [[☃ table 1]]
                     >
                       <button
                         aria-disabled="false"
-                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                         type="button"
                       >
                         <div
@@ -8179,7 +8179,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="true"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -8188,7 +8188,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="false"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -8248,7 +8248,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="true"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -8257,7 +8257,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="false"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -8300,7 +8300,7 @@ table: [[☃ table 1]]
                       </div>
                       <button
                         aria-disabled="false"
-                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                         type="button"
                       >
                         <div
@@ -8340,7 +8340,7 @@ table: [[☃ table 1]]
                                     aria-controls=":r3f:"
                                     aria-disabled="false"
                                     aria-expanded="true"
-                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f"
+                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f-o_O-inlineStyles_13d9y1m"
                                     id=":r3e:"
                                     type="button"
                                   >
@@ -8415,7 +8415,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -8424,7 +8424,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -8433,7 +8433,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -8465,7 +8465,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -8474,7 +8474,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -8483,7 +8483,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -8543,7 +8543,7 @@ table: [[☃ table 1]]
                                           aria-checked="true"
                                           aria-disabled="true"
                                           aria-label="Integers"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -8553,7 +8553,7 @@ table: [[☃ table 1]]
                                           aria-checked="false"
                                           aria-disabled="true"
                                           aria-label="Decimals"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -8563,7 +8563,7 @@ table: [[☃ table 1]]
                                           aria-checked="true"
                                           aria-disabled="true"
                                           aria-label="Proper fractions"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -8573,7 +8573,7 @@ table: [[☃ table 1]]
                                           aria-checked="true"
                                           aria-disabled="true"
                                           aria-label="Improper fractions"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -8583,7 +8583,7 @@ table: [[☃ table 1]]
                                           aria-checked="true"
                                           aria-disabled="true"
                                           aria-label="Mixed numbers"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -8593,7 +8593,7 @@ table: [[☃ table 1]]
                                           aria-checked="false"
                                           aria-disabled="true"
                                           aria-label="Numbers with π"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -8617,7 +8617,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -8626,7 +8626,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -9430,7 +9430,7 @@ table: [[☃ table 1]]
                       class="default_7zhre1 best-practices-container"
                     >
                       <a
-                        class="shared_1y1t15t-o_O-rest_19jgcvc"
+                        class="shared_1y1t15t-o_O-rest_19jgcvc-o_O-inlineStyles_13d9y1m"
                         href="https://khanacademy.atlassian.net/wiki/spaces/LC/pages/3295281289/Interactive+Graph+Widget#Adding-a-new-Interactive-Graph-Widget"
                         rel="noopener noreferrer"
                         target="_blank"
@@ -9550,7 +9550,7 @@ table: [[☃ table 1]]
                       </label>
                       <button
                         aria-disabled="false"
-                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                         type="button"
                       >
                         <div
@@ -9616,7 +9616,7 @@ table: [[☃ table 1]]
                       </div>
                       <button
                         aria-disabled="true"
-                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-container_f36q81-o_O-notClickable_l0aty"
+                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-container_f36q81-o_O-notClickable_l0aty-o_O-inlineStyles_13d9y1m"
                         type="button"
                       >
                         <div
@@ -11013,7 +11013,7 @@ table: [[☃ table 1]]
                       >
                         <button
                           aria-disabled="false"
-                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                           type="button"
                         >
                           <div
@@ -11201,7 +11201,7 @@ table: [[☃ table 1]]
                       </div>
                       <button
                         aria-disabled="false"
-                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                         type="button"
                       >
                         <div
@@ -11457,7 +11457,7 @@ table: [[☃ table 1]]
                       </ol>
                       <button
                         aria-disabled="false"
-                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                         type="button"
                       >
                         <div
@@ -12129,7 +12129,7 @@ table: [[☃ table 1]]
                       </div>
                       <button
                         aria-disabled="false"
-                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                         type="button"
                       >
                         <div
@@ -12163,7 +12163,7 @@ table: [[☃ table 1]]
                                 aria-controls=":r4o:"
                                 aria-disabled="false"
                                 aria-expanded="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f-o_O-inlineStyles_13d9y1m"
                                 id=":r4n:"
                                 type="button"
                               >
@@ -12676,7 +12676,7 @@ table: [[☃ table 1]]
                             <button
                               aria-disabled="true"
                               aria-label="Remove answer"
-                              class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 remove-button"
+                              class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m remove-button"
                               type="button"
                             >
                               <span
@@ -12704,7 +12704,7 @@ table: [[☃ table 1]]
                             <button
                               aria-disabled="true"
                               aria-label="Remove answer"
-                              class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 remove-button"
+                              class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m remove-button"
                               type="button"
                             >
                               <span
@@ -12729,7 +12729,7 @@ table: [[☃ table 1]]
                         </ul>
                         <button
                           aria-disabled="true"
-                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 add-answer"
+                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m add-answer"
                           type="button"
                         >
                           <span
@@ -13980,7 +13980,7 @@ table: [[☃ table 1]]
                     >
                       <button
                         aria-disabled="false"
-                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                         type="button"
                       >
                         <div
@@ -14026,7 +14026,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="true"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -14035,7 +14035,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="false"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -14095,7 +14095,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="true"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -14104,7 +14104,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="false"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -14147,7 +14147,7 @@ table: [[☃ table 1]]
                       </div>
                       <button
                         aria-disabled="false"
-                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81"
+                        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-container_f36q81-o_O-inlineStyles_13d9y1m"
                         type="button"
                       >
                         <div
@@ -14187,7 +14187,7 @@ table: [[☃ table 1]]
                                     aria-controls=":r5r:"
                                     aria-disabled="false"
                                     aria-expanded="true"
-                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f"
+                                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-headerWrapper_1xej40y-o_O-headerWrapperWithAnimation_14an94y-o_O-roundedTop_kesvr4-o_O-accordionHeader_2cig4f-o_O-inlineStyles_13d9y1m"
                                     id=":r5q:"
                                     type="button"
                                   >
@@ -14260,7 +14260,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -14269,7 +14269,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -14278,7 +14278,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -14310,7 +14310,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -14319,7 +14319,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -14328,7 +14328,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -14391,7 +14391,7 @@ table: [[☃ table 1]]
                                           aria-checked="false"
                                           aria-disabled="true"
                                           aria-label="Integers"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -14401,7 +14401,7 @@ table: [[☃ table 1]]
                                           aria-checked="false"
                                           aria-disabled="true"
                                           aria-label="Decimals"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -14411,7 +14411,7 @@ table: [[☃ table 1]]
                                           aria-checked="false"
                                           aria-disabled="true"
                                           aria-label="Proper fractions"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -14421,7 +14421,7 @@ table: [[☃ table 1]]
                                           aria-checked="false"
                                           aria-disabled="true"
                                           aria-label="Improper fractions"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -14431,7 +14431,7 @@ table: [[☃ table 1]]
                                           aria-checked="false"
                                           aria-disabled="true"
                                           aria-label="Mixed numbers"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -14441,7 +14441,7 @@ table: [[☃ table 1]]
                                           aria-checked="false"
                                           aria-disabled="true"
                                           aria-label="Numbers with π"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="checkbox"
                                           type="button"
                                         >
@@ -14465,7 +14465,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="true"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -14474,7 +14474,7 @@ table: [[☃ table 1]]
                                         <button
                                           aria-checked="false"
                                           aria-disabled="true"
-                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                          class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                           role="radio"
                                           type="button"
                                         >
@@ -15192,7 +15192,7 @@ table: [[☃ table 1]]
                       class="default_7zhre1 best-practices-container"
                     >
                       <a
-                        class="shared_1y1t15t-o_O-rest_19jgcvc"
+                        class="shared_1y1t15t-o_O-rest_19jgcvc-o_O-inlineStyles_13d9y1m"
                         href="https://www.khanacademy.org/internal-courses/content-creation-best-practices/xe46daa512cd9c644:question-writing/xe46daa512cd9c644:multiple-choice/a/stems"
                         rel="noopener noreferrer"
                         target="_blank"
@@ -15308,7 +15308,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="true"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -15317,7 +15317,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="false"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -15499,7 +15499,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="false"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >
@@ -15508,7 +15508,7 @@ table: [[☃ table 1]]
                               <button
                                 aria-checked="true"
                                 aria-disabled="true"
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1 segment"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-disabled_1yyknr1-o_O-inlineStyles_13d9y1m segment"
                                 role="radio"
                                 type="button"
                               >

--- a/packages/perseus-editor/src/combined-hints-editor.tsx
+++ b/packages/perseus-editor/src/combined-hints-editor.tsx
@@ -147,6 +147,7 @@ class HintEditor extends React.Component<HintEditorProps> {
                             <>
                                 <IconButton
                                     icon={arrowCircleDownIcon}
+                                    aria-label="Move hint down"
                                     size="small"
                                     kind="tertiary"
                                     onClick={_.partial(this.props.onMove, 1)}
@@ -154,6 +155,7 @@ class HintEditor extends React.Component<HintEditorProps> {
                                 />
                                 <IconButton
                                     icon={arrowCircleUpIcon}
+                                    aria-label="Move hint up"
                                     size="small"
                                     kind="tertiary"
                                     onClick={_.partial(this.props.onMove, -1)}

--- a/packages/perseus-editor/src/widgets/label-image-editor/__snapshots__/label-image-editor.test.tsx.snap
+++ b/packages/perseus-editor/src/widgets/label-image-editor/__snapshots__/label-image-editor.test.tsx.snap
@@ -109,7 +109,7 @@ exports[`label-image-editor popover direction snapshots should render with DOWN 
           <button
             aria-disabled="false"
             aria-label="Remove answer"
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 remove-button"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m remove-button"
             type="button"
           >
             <span
@@ -137,7 +137,7 @@ exports[`label-image-editor popover direction snapshots should render with DOWN 
           <button
             aria-disabled="false"
             aria-label="Remove answer"
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 remove-button"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m remove-button"
             type="button"
           >
             <span
@@ -165,7 +165,7 @@ exports[`label-image-editor popover direction snapshots should render with DOWN 
           <button
             aria-disabled="false"
             aria-label="Remove answer"
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 remove-button"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m remove-button"
             type="button"
           >
             <span
@@ -190,7 +190,7 @@ exports[`label-image-editor popover direction snapshots should render with DOWN 
       </ul>
       <button
         aria-disabled="false"
-        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 add-answer"
+        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m add-answer"
         type="button"
       >
         <span
@@ -450,7 +450,7 @@ exports[`label-image-editor popover direction snapshots should render with LEFT 
           <button
             aria-disabled="false"
             aria-label="Remove answer"
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 remove-button"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m remove-button"
             type="button"
           >
             <span
@@ -478,7 +478,7 @@ exports[`label-image-editor popover direction snapshots should render with LEFT 
           <button
             aria-disabled="false"
             aria-label="Remove answer"
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 remove-button"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m remove-button"
             type="button"
           >
             <span
@@ -506,7 +506,7 @@ exports[`label-image-editor popover direction snapshots should render with LEFT 
           <button
             aria-disabled="false"
             aria-label="Remove answer"
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 remove-button"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m remove-button"
             type="button"
           >
             <span
@@ -531,7 +531,7 @@ exports[`label-image-editor popover direction snapshots should render with LEFT 
       </ul>
       <button
         aria-disabled="false"
-        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 add-answer"
+        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m add-answer"
         type="button"
       >
         <span
@@ -791,7 +791,7 @@ exports[`label-image-editor popover direction snapshots should render with NONE 
           <button
             aria-disabled="false"
             aria-label="Remove answer"
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 remove-button"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m remove-button"
             type="button"
           >
             <span
@@ -819,7 +819,7 @@ exports[`label-image-editor popover direction snapshots should render with NONE 
           <button
             aria-disabled="false"
             aria-label="Remove answer"
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 remove-button"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m remove-button"
             type="button"
           >
             <span
@@ -847,7 +847,7 @@ exports[`label-image-editor popover direction snapshots should render with NONE 
           <button
             aria-disabled="false"
             aria-label="Remove answer"
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 remove-button"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m remove-button"
             type="button"
           >
             <span
@@ -872,7 +872,7 @@ exports[`label-image-editor popover direction snapshots should render with NONE 
       </ul>
       <button
         aria-disabled="false"
-        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 add-answer"
+        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m add-answer"
         type="button"
       >
         <span
@@ -1132,7 +1132,7 @@ exports[`label-image-editor popover direction snapshots should render with RIGHT
           <button
             aria-disabled="false"
             aria-label="Remove answer"
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 remove-button"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m remove-button"
             type="button"
           >
             <span
@@ -1160,7 +1160,7 @@ exports[`label-image-editor popover direction snapshots should render with RIGHT
           <button
             aria-disabled="false"
             aria-label="Remove answer"
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 remove-button"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m remove-button"
             type="button"
           >
             <span
@@ -1188,7 +1188,7 @@ exports[`label-image-editor popover direction snapshots should render with RIGHT
           <button
             aria-disabled="false"
             aria-label="Remove answer"
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 remove-button"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m remove-button"
             type="button"
           >
             <span
@@ -1213,7 +1213,7 @@ exports[`label-image-editor popover direction snapshots should render with RIGHT
       </ul>
       <button
         aria-disabled="false"
-        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 add-answer"
+        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m add-answer"
         type="button"
       >
         <span
@@ -1473,7 +1473,7 @@ exports[`label-image-editor popover direction snapshots should render with UP po
           <button
             aria-disabled="false"
             aria-label="Remove answer"
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 remove-button"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m remove-button"
             type="button"
           >
             <span
@@ -1501,7 +1501,7 @@ exports[`label-image-editor popover direction snapshots should render with UP po
           <button
             aria-disabled="false"
             aria-label="Remove answer"
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 remove-button"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m remove-button"
             type="button"
           >
             <span
@@ -1529,7 +1529,7 @@ exports[`label-image-editor popover direction snapshots should render with UP po
           <button
             aria-disabled="false"
             aria-label="Remove answer"
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 remove-button"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m remove-button"
             type="button"
           >
             <span
@@ -1554,7 +1554,7 @@ exports[`label-image-editor popover direction snapshots should render with UP po
       </ul>
       <button
         aria-disabled="false"
-        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4 add-answer"
+        class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m add-answer"
         type="button"
       >
         <span

--- a/packages/perseus/package.json
+++ b/packages/perseus/package.json
@@ -131,6 +131,6 @@
     },
     "keywords": [],
     "khan": {
-        "catalogHash": "70cca769276cd82d"
+        "catalogHash": "f25bf2ad52d8cb2e"
     }
 }

--- a/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
+++ b/packages/perseus/src/widgets/categorizer/__snapshots__/categorizer.test.ts.snap
@@ -359,7 +359,7 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
           </span>
           <button
             aria-label="Make image bigger."
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_1l8d9fz"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_18ceig1"
             type="button"
           />
         </div>
@@ -411,7 +411,7 @@ exports[`categorizer widget should snapshot on mobile: first mobile render 1`] =
           </span>
           <button
             aria-label="Make image bigger."
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_1l8d9fz"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_18ceig1"
             type="button"
           />
         </div>
@@ -872,7 +872,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
           </span>
           <button
             aria-label="Make image bigger."
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_1l8d9fz"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_18ceig1"
             type="button"
           />
         </div>
@@ -924,7 +924,7 @@ exports[`categorizer widget should snapshot: first render 1`] = `
           </span>
           <button
             aria-label="Make image bigger."
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_1l8d9fz"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_18ceig1"
             type="button"
           />
         </div>

--- a/packages/perseus/src/widgets/definition/__snapshots__/definition.test.ts.snap
+++ b/packages/perseus/src/widgets/definition/__snapshots__/definition.test.ts.snap
@@ -30,7 +30,7 @@ exports[`Definition widget should have a default snapshot: first render 1`] = `
             aria-controls=":r0:"
             aria-expanded="false"
             aria-label="Definition of: the Pequots"
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m"
             id=":r0:-anchor"
             type="button"
           >
@@ -78,7 +78,7 @@ exports[`Definition widget should have an open state snapshot: open state 1`] = 
             aria-controls=":r2:"
             aria-expanded="true"
             aria-label="Definition of: the Pequots"
-            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4"
+            class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_13d9y1m"
             id=":r2:-anchor"
             type="button"
           >

--- a/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set.test.ts.snap
+++ b/packages/perseus/src/widgets/graded-group-set/__snapshots__/graded-group-set.test.ts.snap
@@ -47,7 +47,7 @@ exports[`graded group set widget should snapshot 1`] = `
                   <button
                     aria-current="true"
                     aria-label="Problem 1a"
-                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-indicatorButton_8uaklu"
+                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-indicatorButton_8uaklu-o_O-inlineStyles_13d9y1m"
                     role="button"
                     type="button"
                   >
@@ -62,7 +62,7 @@ exports[`graded group set widget should snapshot 1`] = `
                   <button
                     aria-current="false"
                     aria-label="Problem 1b"
-                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-indicatorButton_8uaklu"
+                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-indicatorButton_8uaklu-o_O-inlineStyles_13d9y1m"
                     role="button"
                     type="button"
                   >
@@ -77,7 +77,7 @@ exports[`graded group set widget should snapshot 1`] = `
                   <button
                     aria-current="false"
                     aria-label="Problem 1c"
-                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-indicatorButton_8uaklu"
+                    class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-indicatorButton_8uaklu-o_O-inlineStyles_13d9y1m"
                     role="button"
                     type="button"
                   >

--- a/packages/perseus/src/widgets/group/__snapshots__/group.test.tsx.snap
+++ b/packages/perseus/src/widgets/group/__snapshots__/group.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`group widget should snapshot: initial render 1`] = `
                 </span>
                 <button
                   aria-label="Make image bigger."
-                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_1l8d9fz"
+                  class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_18ceig1"
                   type="button"
                 />
               </div>
@@ -550,7 +550,7 @@ exports[`group widget should snapshot: initial render 1`] = `
                               </span>
                               <button
                                 aria-label="Make image bigger."
-                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_1l8d9fz"
+                                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_18ceig1"
                                 type="button"
                               />
                             </div>

--- a/packages/perseus/src/widgets/image/__snapshots__/image.test.ts.snap
+++ b/packages/perseus/src/widgets/image/__snapshots__/image.test.ts.snap
@@ -50,7 +50,7 @@ exports[`image widget - isMobile(false) custom alignment should render image wit
               />
               <button
                 aria-label="Make image bigger."
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_1l8d9fz"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_18ceig1"
                 type="button"
               />
             </div>
@@ -134,7 +134,7 @@ exports[`image widget - isMobile(false) custom alignment should render image wit
               />
               <button
                 aria-label="Make image bigger."
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_1l8d9fz"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_18ceig1"
                 type="button"
               />
             </div>
@@ -331,7 +331,7 @@ exports[`image widget - isMobile(false) should snapshot: first render 1`] = `
                     </span>
                     <button
                       aria-label="Make image bigger."
-                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_1l8d9fz"
+                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_18ceig1"
                       type="button"
                     />
                   </div>
@@ -491,7 +491,7 @@ exports[`image widget - isMobile(true) custom alignment should render image with
               />
               <button
                 aria-label="Make image bigger."
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_1l8d9fz"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_18ceig1"
                 type="button"
               />
             </div>
@@ -575,7 +575,7 @@ exports[`image widget - isMobile(true) custom alignment should render image with
               />
               <button
                 aria-label="Make image bigger."
-                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_1l8d9fz"
+                class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_18ceig1"
                 type="button"
               />
             </div>
@@ -772,7 +772,7 @@ exports[`image widget - isMobile(true) should snapshot: first render 1`] = `
                     </span>
                     <button
                       aria-label="Make image bigger."
-                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_1l8d9fz"
+                      class="button_vr44p2-o_O-reset_1ejugoq-o_O-link_13xlah4-o_O-inlineStyles_18ceig1"
                       type="button"
                     />
                   </div>

--- a/packages/perseus/src/widgets/video/__snapshots__/video.test.ts.snap
+++ b/packages/perseus/src/widgets/video/__snapshots__/video.test.ts.snap
@@ -54,7 +54,7 @@ exports[`video widget should snapshot on mobile: first mobile render 1`] = `
                 class="default_7zhre1-o_O-inlineStyles_sc01dy"
               />
               <a
-                class="shared_1y1t15t-o_O-rest_19jgcvc visited-no-recolor"
+                class="shared_1y1t15t-o_O-rest_19jgcvc-o_O-inlineStyles_13d9y1m visited-no-recolor"
                 href="/transcript/videoNotFound"
                 rel="noopener noreferrer"
                 target="_blank"
@@ -124,7 +124,7 @@ exports[`video widget should snapshot: first render 1`] = `
                 class="default_7zhre1-o_O-inlineStyles_sc01dy"
               />
               <a
-                class="shared_1y1t15t-o_O-rest_19jgcvc visited-no-recolor"
+                class="shared_1y1t15t-o_O-rest_19jgcvc-o_O-inlineStyles_13d9y1m visited-no-recolor"
                 href="/transcript/videoNotFound"
                 rel="noopener noreferrer"
                 target="_blank"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,23 +10,23 @@ catalogs:
       specifier: 3.2.0
       version: 3.2.0
     '@khanacademy/wonder-blocks-accordion':
-      specifier: 3.1.72
-      version: 3.1.72
+      specifier: 3.2.0
+      version: 3.2.0
     '@khanacademy/wonder-blocks-announcer':
       specifier: 1.1.2
       version: 1.1.2
     '@khanacademy/wonder-blocks-badge':
-      specifier: 1.1.24
-      version: 1.1.24
+      specifier: 1.1.25
+      version: 1.1.25
     '@khanacademy/wonder-blocks-banner':
-      specifier: 5.1.14
-      version: 5.1.14
+      specifier: 5.1.15
+      version: 5.1.15
     '@khanacademy/wonder-blocks-button':
-      specifier: 11.7.10
-      version: 11.7.10
+      specifier: 11.7.11
+      version: 11.7.11
     '@khanacademy/wonder-blocks-clickable':
-      specifier: 8.2.11
-      version: 8.2.11
+      specifier: 8.3.0
+      version: 8.3.0
     '@khanacademy/wonder-blocks-core':
       specifier: 12.5.0
       version: 12.5.0
@@ -34,17 +34,17 @@ catalogs:
       specifier: 15.1.0
       version: 15.1.0
     '@khanacademy/wonder-blocks-dropdown':
-      specifier: 10.12.4
-      version: 10.12.4
+      specifier: 10.12.5
+      version: 10.12.5
     '@khanacademy/wonder-blocks-form':
-      specifier: 7.6.13
-      version: 7.6.13
+      specifier: 7.6.14
+      version: 7.6.14
     '@khanacademy/wonder-blocks-icon':
       specifier: 6.0.2
       version: 6.0.2
     '@khanacademy/wonder-blocks-icon-button':
-      specifier: 11.5.1
-      version: 11.5.1
+      specifier: 12.0.0
+      version: 12.0.0
     '@khanacademy/wonder-blocks-labeled-field':
       specifier: 4.1.11
       version: 4.1.11
@@ -52,26 +52,26 @@ catalogs:
       specifier: 3.1.62
       version: 3.1.62
     '@khanacademy/wonder-blocks-link':
-      specifier: 10.3.12
-      version: 10.3.12
+      specifier: 10.4.0
+      version: 10.4.0
     '@khanacademy/wonder-blocks-modal':
-      specifier: 8.8.2
-      version: 8.8.2
+      specifier: 8.8.3
+      version: 8.8.3
     '@khanacademy/wonder-blocks-pill':
-      specifier: 3.1.76
-      version: 3.1.76
+      specifier: 3.1.77
+      version: 3.1.77
     '@khanacademy/wonder-blocks-popover':
-      specifier: 6.3.16
-      version: 6.3.16
+      specifier: 6.3.17
+      version: 6.3.17
     '@khanacademy/wonder-blocks-progress-spinner':
       specifier: 3.1.62
       version: 3.1.62
     '@khanacademy/wonder-blocks-switch':
-      specifier: 3.4.12
-      version: 3.4.12
+      specifier: 3.4.13
+      version: 3.4.13
     '@khanacademy/wonder-blocks-tabs':
-      specifier: 0.5.31
-      version: 0.5.31
+      specifier: 0.5.32
+      version: 0.5.32
     '@khanacademy/wonder-blocks-theming':
       specifier: 4.1.0
       version: 4.1.0
@@ -82,8 +82,8 @@ catalogs:
       specifier: 18.0.0
       version: 18.0.0
     '@khanacademy/wonder-blocks-tooltip':
-      specifier: 4.2.5
-      version: 4.2.5
+      specifier: 4.2.6
+      version: 4.2.6
     '@khanacademy/wonder-blocks-typography':
       specifier: 5.0.5
       version: 5.0.5
@@ -182,7 +182,7 @@ importers:
         version: 3.2.0
       '@khanacademy/wonder-blocks-accordion':
         specifier: catalog:devDeps
-        version: 3.1.72(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 3.2.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-core':
         specifier: catalog:devDeps
         version: 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -527,19 +527,19 @@ importers:
         version: 3.2.0
       '@khanacademy/wonder-blocks-clickable':
         specifier: catalog:devDeps
-        version: 8.2.11(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 8.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-core':
         specifier: catalog:devDeps
         version: 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon-button':
         specifier: catalog:devDeps
-        version: 11.5.1(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 12.0.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-popover':
         specifier: catalog:devDeps
-        version: 6.3.16(@phosphor-icons/core@2.0.2)(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 6.3.17(@phosphor-icons/core@2.0.2)(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tabs':
         specifier: catalog:devDeps
-        version: 0.5.31(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react-window@1.8.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 0.5.32(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react-window@1.8.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-timing':
         specifier: catalog:devDeps
         version: 7.1.0(react@18.2.0)
@@ -636,13 +636,13 @@ importers:
         version: 1.1.2(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-banner':
         specifier: catalog:devDeps
-        version: 5.1.14(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 5.1.15(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-button':
         specifier: catalog:devDeps
-        version: 11.7.10(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 11.7.11(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-clickable':
         specifier: catalog:devDeps
-        version: 8.2.11(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 8.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-core':
         specifier: catalog:devDeps
         version: 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -651,16 +651,16 @@ importers:
         version: 15.1.0(@khanacademy/wonder-stuff-core@3.0.0)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-dropdown':
         specifier: catalog:devDeps
-        version: 10.12.4(@phosphor-icons/core@2.0.2)(@popperjs/core@2.10.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.10.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react-window@1.8.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 10.12.5(@phosphor-icons/core@2.0.2)(@popperjs/core@2.10.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.10.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react-window@1.8.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-form':
         specifier: catalog:devDeps
-        version: 7.6.13(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 7.6.14(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon':
         specifier: catalog:devDeps
         version: 6.0.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon-button':
         specifier: catalog:devDeps
-        version: 11.5.1(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 12.0.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-labeled-field':
         specifier: catalog:devDeps
         version: 4.1.11(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -669,22 +669,22 @@ importers:
         version: 3.1.62(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-link':
         specifier: catalog:devDeps
-        version: 10.3.12(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 10.4.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-modal':
         specifier: catalog:devDeps
-        version: 8.8.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 8.8.3(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-pill':
         specifier: catalog:devDeps
-        version: 3.1.76(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 3.1.77(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-popover':
         specifier: catalog:devDeps
-        version: 6.3.16(@phosphor-icons/core@2.0.2)(@popperjs/core@2.10.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.10.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 6.3.17(@phosphor-icons/core@2.0.2)(@popperjs/core@2.10.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.10.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-progress-spinner':
         specifier: catalog:devDeps
         version: 3.1.62(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-switch':
         specifier: catalog:devDeps
-        version: 3.4.12(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 3.4.13(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-timing':
         specifier: catalog:devDeps
         version: 7.1.0(react@18.2.0)
@@ -693,7 +693,7 @@ importers:
         version: 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tooltip':
         specifier: catalog:devDeps
-        version: 4.2.5(@phosphor-icons/core@2.0.2)(@popperjs/core@2.10.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.10.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 4.2.6(@phosphor-icons/core@2.0.2)(@popperjs/core@2.10.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.10.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-typography':
         specifier: catalog:devDeps
         version: 5.0.5(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -803,34 +803,34 @@ importers:
         version: 3.2.0
       '@khanacademy/wonder-blocks-accordion':
         specifier: catalog:devDeps
-        version: 3.1.72(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 3.2.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-badge':
         specifier: catalog:devDeps
-        version: 1.1.24(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 1.1.25(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-banner':
         specifier: catalog:devDeps
-        version: 5.1.14(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 5.1.15(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-button':
         specifier: catalog:devDeps
-        version: 11.7.10(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 11.7.11(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-clickable':
         specifier: catalog:devDeps
-        version: 8.2.11(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 8.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-core':
         specifier: catalog:devDeps
         version: 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-dropdown':
         specifier: catalog:devDeps
-        version: 10.12.4(@phosphor-icons/core@2.0.2)(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react-window@1.8.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+        version: 10.12.5(@phosphor-icons/core@2.0.2)(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react-window@1.8.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-form':
         specifier: catalog:devDeps
-        version: 7.6.13(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 7.6.14(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon':
         specifier: catalog:devDeps
         version: 6.0.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon-button':
         specifier: catalog:devDeps
-        version: 11.5.1(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 12.0.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-labeled-field':
         specifier: catalog:devDeps
         version: 4.1.11(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -839,16 +839,16 @@ importers:
         version: 3.1.62(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-link':
         specifier: catalog:devDeps
-        version: 10.3.12(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 10.4.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-pill':
         specifier: catalog:devDeps
-        version: 3.1.76(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 3.1.77(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-popover':
         specifier: catalog:devDeps
-        version: 6.3.16(@phosphor-icons/core@2.0.2)(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 6.3.17(@phosphor-icons/core@2.0.2)(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-switch':
         specifier: catalog:devDeps
-        version: 3.4.12(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 3.4.13(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-timing':
         specifier: catalog:devDeps
         version: 7.1.0(react@18.2.0)
@@ -857,7 +857,7 @@ importers:
         version: 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tooltip':
         specifier: catalog:devDeps
-        version: 4.2.5(@phosphor-icons/core@2.0.2)(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+        version: 4.2.6(@phosphor-icons/core@2.0.2)(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-typography':
         specifier: catalog:devDeps
         version: 5.0.5(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -2418,8 +2418,8 @@ packages:
     resolution: {integrity: sha512-9njJGqo8RBE8OK2e6bwRa8dwwqklY0D1jRVmyYjKUJGhIlEql0YRRR5LxmuTTSitGSkLuYPpDeHeQIdLLsiKMg==}
     engines: {node: '>=24.18 <25'}
 
-  '@khanacademy/wonder-blocks-accordion@3.1.72':
-    resolution: {integrity: sha512-TM44S8nLrweSj4kvwcVoW9Na3B3EeWcEvOe90XWkAFtwXI4841liHogVTRUDgLlUUvtLGZEO1kcxvfVRiL7kPg==}
+  '@khanacademy/wonder-blocks-accordion@3.2.0':
+    resolution: {integrity: sha512-cQXRT2LtmJn1u4TZ/JgGN1gH86czQNLtepW4Xa2JtHKX8bo70dKuB+tv+06Uqqt3OEUX5h+m1KUqD89G50aE/g==}
     peerDependencies:
       '@phosphor-icons/core': ^2.0.2
       aphrodite: ^1.2.5
@@ -2431,15 +2431,15 @@ packages:
       aphrodite: ^1.2.5
       react: 18.2.0
 
-  '@khanacademy/wonder-blocks-badge@1.1.24':
-    resolution: {integrity: sha512-urh1YrCepqyVeDd+jWikwxcBLaJkRE6I/bkQtWWq9rFZmernAoxRcaOSSTlzGLseycVURWLvHN9hgB58PqiuWQ==}
+  '@khanacademy/wonder-blocks-badge@1.1.25':
+    resolution: {integrity: sha512-7nU7rWfdVPNGSjPb8dl0HX1Q2w+f+ZfyJnw69SlakVwvcfahWM/15e6EGNgYItC6K6cSJBm7YR0cQQivHgIasA==}
     peerDependencies:
       '@phosphor-icons/core': ^2.0.2
       aphrodite: ^1.2.5
       react: 18.2.0
 
-  '@khanacademy/wonder-blocks-banner@5.1.14':
-    resolution: {integrity: sha512-5t5VupZ+MVA0hPGCo+08q30BINK+rUICOqm0mWWatpUmTp0fzNWJRAfR01uq+Yr/yQczv4dDWpaZan1x8qDbeA==}
+  '@khanacademy/wonder-blocks-banner@5.1.15':
+    resolution: {integrity: sha512-zwIZZ11BBh3T2KP6L8Kt5W6toCh67mTQdSY2q3fjlvnZiH2UAJO79JyT99u8WaBA1EBQvAjjpQ8vxYm4kZ/K/Q==}
     peerDependencies:
       '@phosphor-icons/core': ^2.0.2
       aphrodite: ^1.2.5
@@ -2451,8 +2451,8 @@ packages:
       aphrodite: ^1.2.5
       react: 18.2.0
 
-  '@khanacademy/wonder-blocks-button@11.7.10':
-    resolution: {integrity: sha512-2M7s8Dm+X5gY3+n3k/3SzxzMejRCVCd1R8OIJe90o16LcgZJYZ8RuliRwxXiGzLZa1wZ38xvZwPa2WzCX8nhnQ==}
+  '@khanacademy/wonder-blocks-button@11.7.11':
+    resolution: {integrity: sha512-FoFL6jnCFv/dhkcHaFipNgG4AYx+rcKyZneGRtt6OWxajnN/Y2/ghc3nPaSoCZ6QMQAp7AtEIT14Dc2E77vrSg==}
     peerDependencies:
       aphrodite: ^1.2.5
       react: 18.2.0
@@ -2460,14 +2460,14 @@ packages:
       react-router-dom: 5.3.4
       react-router-dom-v5-compat: ^6.30.0
 
-  '@khanacademy/wonder-blocks-cell@6.2.12':
-    resolution: {integrity: sha512-zo2APbvuddqmqBazn/lN4Xd6w5/zm9CD9WGqrqf8tRrnDLF9IApGoL0wPXxheigFtiLiRENpIhq2CfYVxnIjjg==}
+  '@khanacademy/wonder-blocks-cell@6.2.13':
+    resolution: {integrity: sha512-xS3IuE2tFW5grU8iexmFpjUJ0yv9XiFbiEJbQY/2wGPK8VjQDvQZPtR5KFfwflw4x8Z25IixJLianNSqoHkygw==}
     peerDependencies:
       aphrodite: ^1.2.5
       react: 18.2.0
 
-  '@khanacademy/wonder-blocks-clickable@8.2.11':
-    resolution: {integrity: sha512-Z/SHo8Xh4cGorhbn1fxvKdyj5JhhMIECYPDmAOcIAbt2mAC4qPkSj9ov9s6RZKjDRYBW5+7C9r+MUBIeE2nIjw==}
+  '@khanacademy/wonder-blocks-clickable@8.3.0':
+    resolution: {integrity: sha512-NQlsMVd1UZInrBWGCT+0fa9wGbRE/oZZ7YWeXT2v9yMEbrZmrW8PB8W7yRD6ExWXiZxUyR+Y8UdPpTB3eJ2ZJQ==}
     peerDependencies:
       aphrodite: ^1.2.5
       react: 18.2.0
@@ -2492,8 +2492,8 @@ packages:
       '@khanacademy/wonder-stuff-core': ^3.0.0
       react: 18.2.0
 
-  '@khanacademy/wonder-blocks-dropdown@10.12.4':
-    resolution: {integrity: sha512-3rTSh8oWoVJhWy+L2woL3JN6ynR1UXWWbGGYrF9sRWgMUlEkWak17Pry5Tuf4Hk2MUVDfMa5wovKz/s2gs+boA==}
+  '@khanacademy/wonder-blocks-dropdown@10.12.5':
+    resolution: {integrity: sha512-yDZQFkO/d1oDyXCkOP2lsiWfdcBzyyM932VB8aqDKd7YSfIych0Pevya6EoLEsdz1oT/HKk2qGmuYPzY/B5msQ==}
     peerDependencies:
       '@phosphor-icons/core': ^2.0.2
       '@popperjs/core': ^2.10.1
@@ -2506,15 +2506,15 @@ packages:
       react-router-dom-v5-compat: ^6.30.0
       react-window: ^1.8.11
 
-  '@khanacademy/wonder-blocks-form@7.6.13':
-    resolution: {integrity: sha512-3XzTE76P8dGVx6uvX0wyEP6ONk/BW2e4s8cZEgeuwaNYShoe0AMQA9KAcuLB+Yx6q3B9Da4NmRQzqHRXaimVCw==}
+  '@khanacademy/wonder-blocks-form@7.6.14':
+    resolution: {integrity: sha512-mHRAiR6H/BzPn17DyLCM0VME75fLDSKk9umYnujn5Y3TGyu3LqpgLnBBmBTPws3oNb1tbMK8meXwbFKOOIoGdA==}
     peerDependencies:
       '@phosphor-icons/core': ^2.0.2
       aphrodite: ^1.2.5
       react: 18.2.0
 
-  '@khanacademy/wonder-blocks-icon-button@11.5.1':
-    resolution: {integrity: sha512-tWYT+lWoJGUE3wEeMFdG8R8lJnIDHxahtCU/h/dWNgY8d+9yVzY04xrU9dX67cHAdh4hcNr6Qi1PgfEnyjk5IQ==}
+  '@khanacademy/wonder-blocks-icon-button@12.0.0':
+    resolution: {integrity: sha512-eT4YBXbBuBJQxgFfhL+Dwcgs/DRUeL3flIkzUFQdSoKYaBwF7ZX+g/pMJpfFZO0YtZR2UIJkiIdNBqjmKV1+rw==}
     peerDependencies:
       aphrodite: ^1.2.5
       react: 18.2.0
@@ -2542,8 +2542,8 @@ packages:
       aphrodite: ^1.2.5
       react: 18.2.0
 
-  '@khanacademy/wonder-blocks-link@10.3.12':
-    resolution: {integrity: sha512-jE316vb64EXdBvJpOmvD9eW0IpJvIO8XRO3rVotadMOFcCBtOYYDlEShrGsurN5IDQ6xDhul/luSA/HAHozm8Q==}
+  '@khanacademy/wonder-blocks-link@10.4.0':
+    resolution: {integrity: sha512-lTN0hp/3M/gnwPl53iMxOEJiNYsHYYmFxGTPE0FVc6FKYCq7fpEf9eR4UDVxqY1xUiLlCmgWk9QJl428R7w/HQ==}
     peerDependencies:
       '@phosphor-icons/core': ^2.0.2
       aphrodite: ^1.2.5
@@ -2552,22 +2552,22 @@ packages:
       react-router-dom: 5.3.4
       react-router-dom-v5-compat: ^6.30.0
 
-  '@khanacademy/wonder-blocks-modal@8.8.2':
-    resolution: {integrity: sha512-mmf1Gm3rJFVmuNqmx7cnPW/J3ljfLC3oREMFgyomCzJlbZbMPGd4kAl0TlgrH8iUR1WMvQkAUnW/TDPOWvn6zQ==}
+  '@khanacademy/wonder-blocks-modal@8.8.3':
+    resolution: {integrity: sha512-XWdzKHkt6K/VgybwBLXDskc0npwLLG0AR6ZIyL0X03OxhP1b3IlynlyorkXPpSYgA0r5itpdH3qdnqauENv9kw==}
     peerDependencies:
       '@phosphor-icons/core': ^2.0.2
       aphrodite: ^1.2.5
       react: 18.2.0
       react-dom: 18.2.0
 
-  '@khanacademy/wonder-blocks-pill@3.1.76':
-    resolution: {integrity: sha512-8flclbF7fODrqfCDoZIg2g9gQI197fQjCcczzvjSZ4J5CuTo9RJ9EB9jlwyKOICdiTFmVxRwOjJV6IzCb1juvA==}
+  '@khanacademy/wonder-blocks-pill@3.1.77':
+    resolution: {integrity: sha512-x3/5Z8AlXEG3sBZ0nLdBvl/wuu7siRyflVi7UskEhUvHrA5V+OTvxFMOLeICA+dbgRQFujWFRDXSFk6YZqWS1g==}
     peerDependencies:
       aphrodite: ^1.2.5
       react: 18.2.0
 
-  '@khanacademy/wonder-blocks-popover@6.3.16':
-    resolution: {integrity: sha512-LfIncmZMZohy9GWhSpHHoV/WEmSLAR2OJ+w7PSllG668AC2/u3gLpy/qLvcicS9NFkmYi8yhfUA7DDN3Y5mn8g==}
+  '@khanacademy/wonder-blocks-popover@6.3.17':
+    resolution: {integrity: sha512-IPOOK+Slfw9iwJ7W0Qdtg22YHNMjLkx/glQJsK1xjlBg4ED/8Bc0sonxkaaPidEsYhPdbR0DB/OjP8OqEAQoDg==}
     peerDependencies:
       '@phosphor-icons/core': ^2.0.2
       '@popperjs/core': ^2.10.1
@@ -2582,24 +2582,24 @@ packages:
       aphrodite: ^1.2.5
       react: 18.2.0
 
-  '@khanacademy/wonder-blocks-search-field@5.1.83':
-    resolution: {integrity: sha512-B1Er9VPflktzIiTs26Evv0cArLI7D+pN0r5WPElrvlv9WQSPQXoj6r2KdWsmRTuQ6W6iyQmafjOalmyXP6j9wA==}
+  '@khanacademy/wonder-blocks-search-field@5.1.84':
+    resolution: {integrity: sha512-FFI1V88ABikT5eAUHuxes2t/ZIeQCyv+ygeFSVLi8rSDcDDkp3x9lDB4Bdkrb6H1eOmJCNx7rn+yJWBjxHjf6w==}
     peerDependencies:
       '@phosphor-icons/core': ^2.0.2
       aphrodite: ^1.2.5
       react: 18.2.0
 
-  '@khanacademy/wonder-blocks-styles@0.2.54':
-    resolution: {integrity: sha512-ra2CMOa9czi3D8Jo5Is2B2gthShr7wSjazWN5Yge29DabVUXoxbEI6P2WmZaBM5Qo5IuDjXjq2387qaVrNCozA==}
+  '@khanacademy/wonder-blocks-styles@0.3.0':
+    resolution: {integrity: sha512-Zsn7ricgb3K2ub/IDemufk1xetVJho0OTs+u6SxySeJbwfIqU9NB99xIvjZu6TcXnSfsS+RDzTMF//tqA57iFg==}
 
-  '@khanacademy/wonder-blocks-switch@3.4.12':
-    resolution: {integrity: sha512-E5xUrYvvJhA5bEE6FTrZDR3Ld5N+62rzBFEQ91TQFZ+O42LiOGJ423kUGam3/gdFfPUUh/z0lsxlh6DdnhbyJw==}
+  '@khanacademy/wonder-blocks-switch@3.4.13':
+    resolution: {integrity: sha512-BoPxV4kMJ4h7GhlTLOr8MzfA1m4QqAs5GVUa9S3oiEnZ7w0w4qoRbY68zq6OwDIkcx1dRx5cQ3t2v5ueMCw5FQ==}
     peerDependencies:
       aphrodite: ^1.2.5
       react: 18.2.0
 
-  '@khanacademy/wonder-blocks-tabs@0.5.31':
-    resolution: {integrity: sha512-oaKnRW7ozpNRz7S+bILEsUyHo6xBFUHxZOrk/uBIypHfbPi9DZuBtxCdo3yW59D9lMv/a01dZiwUtglGfGyjdQ==}
+  '@khanacademy/wonder-blocks-tabs@0.5.32':
+    resolution: {integrity: sha512-Q9lfrI9Bcvq4tjwvdPptVmVX7FsQH5nYpojRyLzmOEZaZJOnMtupZl2Mv1hkkb6znaDPDqME6vtM6+4RmIWdQQ==}
     peerDependencies:
       aphrodite: ^1.2.5
       react: 18.2.0
@@ -2620,8 +2620,8 @@ packages:
     resolution: {integrity: sha512-j5JxU+2/1YxeStQ+4cXjhsbom+nYZC9TUl0IiKn2rmsp/7Jc4PIqhndCBod4wdgYjrtcrc22hc67DIu4XTmCWQ==}
     hasBin: true
 
-  '@khanacademy/wonder-blocks-tooltip@4.2.5':
-    resolution: {integrity: sha512-xhsXc26K6I8zaplkwAvA7L/kg1OXM5lplKZueMYoLfGGe1jIp2BYXKjwEwn+yylaPN7ouBsoBRMkqI2Hf+c+VQ==}
+  '@khanacademy/wonder-blocks-tooltip@4.2.6':
+    resolution: {integrity: sha512-HoGiHdJ7bxWx1ps5/SaPFlbkCR/kIj/c7E6LGczcCIsHDmiNsswsyM2VdZ6EVx+KUCM2I9SF4bRG8sl6eZX8dA==}
     peerDependencies:
       '@popperjs/core': ^2.10.1
       aphrodite: ^1.2.5
@@ -11454,9 +11454,9 @@ snapshots:
       mathjax-full: 3.2.2
       mu-lambda: 0.0.3
 
-  '@khanacademy/wonder-blocks-accordion@3.1.72(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-accordion@3.2.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@khanacademy/wonder-blocks-clickable': 8.2.11(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-clickable': 8.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon': 6.0.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -11481,11 +11481,11 @@ snapshots:
       - react-router-dom
       - react-router-dom-v5-compat
 
-  '@khanacademy/wonder-blocks-badge@1.1.24(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-badge@1.1.25(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon': 6.0.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-styles': 0.2.54(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-styles': 0.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-typography': 5.0.5(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@phosphor-icons/core': 2.0.2
@@ -11497,13 +11497,13 @@ snapshots:
       - react-router-dom
       - react-router-dom-v5-compat
 
-  '@khanacademy/wonder-blocks-banner@5.1.14(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-banner@5.1.15(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@khanacademy/wonder-blocks-button': 11.7.10(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-button': 11.7.11(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon': 6.0.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-icon-button': 11.5.1(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-link': 10.3.12(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-icon-button': 12.0.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-link': 10.4.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-typography': 5.0.5(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@phosphor-icons/core': 2.0.2
@@ -11527,13 +11527,13 @@ snapshots:
       - react-router-dom
       - react-router-dom-v5-compat
 
-  '@khanacademy/wonder-blocks-button@11.7.10(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-button@11.7.11(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@khanacademy/wonder-blocks-clickable': 8.2.11(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-clickable': 8.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon': 6.0.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-progress-spinner': 3.1.62(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-styles': 0.2.54(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-styles': 0.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-typography': 5.0.5(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       aphrodite: 1.2.5
@@ -11545,11 +11545,11 @@ snapshots:
       - '@phosphor-icons/core'
       - react-dom
 
-  '@khanacademy/wonder-blocks-cell@6.2.12(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-cell@6.2.13(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@khanacademy/wonder-blocks-clickable': 8.2.11(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-clickable': 8.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-styles': 0.2.54(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-styles': 0.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-typography': 5.0.5(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       aphrodite: 1.2.5
@@ -11560,9 +11560,10 @@ snapshots:
       - react-router-dom
       - react-router-dom-v5-compat
 
-  '@khanacademy/wonder-blocks-clickable@8.2.11(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-clickable@8.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-styles': 0.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       aphrodite: 1.2.5
       react: 18.2.0
@@ -11592,19 +11593,19 @@ snapshots:
       - react-router-dom
       - react-router-dom-v5-compat
 
-  '@khanacademy/wonder-blocks-dropdown@10.12.4(@phosphor-icons/core@2.0.2)(@popperjs/core@2.10.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.10.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react-window@1.8.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-dropdown@10.12.5(@phosphor-icons/core@2.0.2)(@popperjs/core@2.10.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.10.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react-window@1.8.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@khanacademy/wonder-blocks-announcer': 1.1.2(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-cell': 6.2.12(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-clickable': 8.2.11(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-cell': 6.2.13(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-clickable': 8.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-form': 7.6.13(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-form': 7.6.14(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon': 6.0.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-icon-button': 11.5.1(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-modal': 8.8.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-pill': 3.1.76(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-search-field': 5.1.83(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-styles': 0.2.54(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-icon-button': 12.0.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-modal': 8.8.3(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-pill': 3.1.77(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-search-field': 5.1.84(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-styles': 0.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-timing': 7.1.0(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-typography': 5.0.5(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -11619,19 +11620,19 @@ snapshots:
       react-router-dom-v5-compat: 6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0)
       react-window: 1.8.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
-  '@khanacademy/wonder-blocks-dropdown@10.12.4(@phosphor-icons/core@2.0.2)(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react-window@1.8.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-dropdown@10.12.5(@phosphor-icons/core@2.0.2)(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react-window@1.8.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@khanacademy/wonder-blocks-announcer': 1.1.2(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-cell': 6.2.12(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-clickable': 8.2.11(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-cell': 6.2.13(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-clickable': 8.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-form': 7.6.13(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-form': 7.6.14(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon': 6.0.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-icon-button': 11.5.1(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-modal': 8.8.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-pill': 3.1.76(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-search-field': 5.1.83(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-styles': 0.2.54(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-icon-button': 12.0.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-modal': 8.8.3(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-pill': 3.1.77(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-search-field': 5.1.84(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-styles': 0.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-timing': 7.1.0(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-typography': 5.0.5(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -11646,9 +11647,9 @@ snapshots:
       react-router-dom-v5-compat: 6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0)
       react-window: 1.8.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
-  '@khanacademy/wonder-blocks-form@7.6.13(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-form@7.6.14(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@khanacademy/wonder-blocks-clickable': 8.2.11(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-clickable': 8.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon': 6.0.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-layout': 3.1.62(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -11663,12 +11664,12 @@ snapshots:
       - react-router-dom
       - react-router-dom-v5-compat
 
-  '@khanacademy/wonder-blocks-icon-button@11.5.1(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-icon-button@12.0.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@khanacademy/wonder-blocks-clickable': 8.2.11(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-clickable': 8.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon': 6.0.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-styles': 0.2.54(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-styles': 0.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-theming': 4.1.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-typography': 5.0.5(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -11721,12 +11722,12 @@ snapshots:
       - react-router-dom
       - react-router-dom-v5-compat
 
-  '@khanacademy/wonder-blocks-link@10.3.12(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-link@10.4.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@khanacademy/wonder-blocks-clickable': 8.2.11(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-clickable': 8.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon': 6.0.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-styles': 0.2.54(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-styles': 0.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-typography': 5.0.5(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@phosphor-icons/core': 2.0.2
@@ -11738,14 +11739,14 @@ snapshots:
     transitivePeerDependencies:
       - react-dom
 
-  '@khanacademy/wonder-blocks-modal@8.8.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-modal@8.8.3(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@khanacademy/wonder-blocks-announcer': 1.1.2(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-breadcrumbs': 3.2.29(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-icon-button': 11.5.1(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-icon-button': 12.0.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-layout': 3.1.62(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-styles': 0.2.54(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-styles': 0.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-timing': 7.1.0(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-typography': 5.0.5(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
@@ -11758,12 +11759,12 @@ snapshots:
       - react-router-dom
       - react-router-dom-v5-compat
 
-  '@khanacademy/wonder-blocks-pill@3.1.76(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-pill@3.1.77(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@khanacademy/wonder-blocks-clickable': 8.2.11(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-clickable': 8.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-link': 10.3.12(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-styles': 0.2.54(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-link': 10.4.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-styles': 0.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-typography': 5.0.5(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       aphrodite: 1.2.5
@@ -11775,14 +11776,14 @@ snapshots:
       - react-router-dom
       - react-router-dom-v5-compat
 
-  '@khanacademy/wonder-blocks-popover@6.3.16(@phosphor-icons/core@2.0.2)(@popperjs/core@2.10.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.10.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-popover@6.3.17(@phosphor-icons/core@2.0.2)(@popperjs/core@2.10.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.10.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-icon-button': 11.5.1(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-modal': 8.8.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-styles': 0.2.54(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-icon-button': 12.0.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-modal': 8.8.3(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-styles': 0.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-tooltip': 4.2.5(@phosphor-icons/core@2.0.2)(@popperjs/core@2.10.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.10.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-tooltip': 4.2.6(@phosphor-icons/core@2.0.2)(@popperjs/core@2.10.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.10.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-typography': 5.0.5(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@phosphor-icons/core': 2.0.2
       '@popperjs/core': 2.10.2
@@ -11795,14 +11796,14 @@ snapshots:
       - react-router-dom
       - react-router-dom-v5-compat
 
-  '@khanacademy/wonder-blocks-popover@6.3.16(@phosphor-icons/core@2.0.2)(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-popover@6.3.17(@phosphor-icons/core@2.0.2)(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-icon-button': 11.5.1(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-modal': 8.8.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-styles': 0.2.54(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-icon-button': 12.0.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-modal': 8.8.3(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-styles': 0.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-tooltip': 4.2.5(@phosphor-icons/core@2.0.2)(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-tooltip': 4.2.6(@phosphor-icons/core@2.0.2)(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-typography': 5.0.5(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@phosphor-icons/core': 2.0.2
       '@popperjs/core': 2.11.8
@@ -11827,12 +11828,12 @@ snapshots:
       - react-router-dom
       - react-router-dom-v5-compat
 
-  '@khanacademy/wonder-blocks-search-field@5.1.83(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-search-field@5.1.84(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-form': 7.6.13(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-form': 7.6.14(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon': 6.0.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-icon-button': 11.5.1(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-icon-button': 12.0.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-typography': 5.0.5(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@phosphor-icons/core': 2.0.2
@@ -11844,7 +11845,7 @@ snapshots:
       - react-router-dom
       - react-router-dom-v5-compat
 
-  '@khanacademy/wonder-blocks-styles@0.2.54(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-styles@0.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     transitivePeerDependencies:
@@ -11852,11 +11853,11 @@ snapshots:
       - react
       - react-dom
 
-  '@khanacademy/wonder-blocks-switch@3.4.12(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-switch@3.4.13(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon': 6.0.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-styles': 0.2.54(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-styles': 0.3.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-theming': 4.1.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       aphrodite: 1.2.5
@@ -11868,13 +11869,13 @@ snapshots:
       - react-router-dom
       - react-router-dom-v5-compat
 
-  '@khanacademy/wonder-blocks-tabs@0.5.31(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react-window@1.8.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-tabs@0.5.32(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react-window@1.8.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)':
     dependencies:
-      '@khanacademy/wonder-blocks-button': 11.7.10(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-button': 11.7.11(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-dropdown': 10.12.4(@phosphor-icons/core@2.0.2)(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react-window@1.8.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-dropdown': 10.12.5(@phosphor-icons/core@2.0.2)(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react-window@1.8.10(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-icon': 6.0.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-link': 10.3.12(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-link': 10.4.0(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-typography': 5.0.5(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@phosphor-icons/core': 2.0.2
@@ -11907,11 +11908,11 @@ snapshots:
       - react
       - react-dom
 
-  '@khanacademy/wonder-blocks-tooltip@4.2.5(@phosphor-icons/core@2.0.2)(@popperjs/core@2.10.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.10.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-tooltip@4.2.6(@phosphor-icons/core@2.0.2)(@popperjs/core@2.10.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.10.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-layout': 3.1.62(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-modal': 8.8.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-modal': 8.8.3(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-typography': 5.0.5(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@popperjs/core': 2.10.2
@@ -11925,11 +11926,11 @@ snapshots:
       - react-router-dom
       - react-router-dom-v5-compat
 
-  '@khanacademy/wonder-blocks-tooltip@4.2.5(@phosphor-icons/core@2.0.2)(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
+  '@khanacademy/wonder-blocks-tooltip@4.2.6(@phosphor-icons/core@2.0.2)(@popperjs/core@2.11.8)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-popper@2.3.0(@popperjs/core@2.11.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)':
     dependencies:
       '@khanacademy/wonder-blocks-core': 12.5.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-layout': 3.1.62(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
-      '@khanacademy/wonder-blocks-modal': 8.8.2(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
+      '@khanacademy/wonder-blocks-modal': 8.8.3(@phosphor-icons/core@2.0.2)(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-tokens': 18.0.0(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@khanacademy/wonder-blocks-typography': 5.0.5(aphrodite@1.2.5)(react-dom@18.2.0(react@18.2.0))(react-router-dom-v5-compat@6.30.0(react-dom@18.2.0(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react@18.2.0))(react-router-dom@5.3.4(react@18.2.0))(react-router@5.3.4(react@18.2.0))(react@18.2.0)
       '@popperjs/core': 2.11.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,33 +62,33 @@ catalogs:
         "@phosphor-icons/core": ^2.0.2
         "@popperjs/core": ^2.10.2
         "@khanacademy/mathjax-renderer": ^3.2.0
-        "@khanacademy/wonder-blocks-accordion": ^3.1.72
+        "@khanacademy/wonder-blocks-accordion": ^3.2.0
         "@khanacademy/wonder-blocks-announcer": ^1.1.2
-        "@khanacademy/wonder-blocks-badge": ^1.1.24
-        "@khanacademy/wonder-blocks-banner": ^5.1.14
-        "@khanacademy/wonder-blocks-button": ^11.7.10
-        "@khanacademy/wonder-blocks-clickable": ^8.2.11
+        "@khanacademy/wonder-blocks-badge": ^1.1.25
+        "@khanacademy/wonder-blocks-banner": ^5.1.15
+        "@khanacademy/wonder-blocks-button": ^11.7.11
+        "@khanacademy/wonder-blocks-clickable": ^8.3.0
         "@khanacademy/wonder-blocks-core": ^12.5.0
         "@khanacademy/wonder-blocks-data": ^15.1.0
-        "@khanacademy/wonder-blocks-dropdown": ^10.12.4
-        "@khanacademy/wonder-blocks-form": ^7.6.13
-        "@khanacademy/wonder-blocks-icon-button": ^11.5.1
+        "@khanacademy/wonder-blocks-dropdown": ^10.12.5
+        "@khanacademy/wonder-blocks-form": ^7.6.14
+        "@khanacademy/wonder-blocks-icon-button": ^12.0.0
         "@khanacademy/wonder-blocks-icon": ^6.0.2
         "@khanacademy/wonder-blocks-labeled-field": ^4.1.11
         "@khanacademy/wonder-blocks-layout": ^3.1.62
-        "@khanacademy/wonder-blocks-link": ^10.3.12
-        "@khanacademy/wonder-blocks-modal": ^8.8.2
-        "@khanacademy/wonder-blocks-pill": ^3.1.76
-        "@khanacademy/wonder-blocks-popover": ^6.3.16
+        "@khanacademy/wonder-blocks-link": ^10.4.0
+        "@khanacademy/wonder-blocks-modal": ^8.8.3
+        "@khanacademy/wonder-blocks-pill": ^3.1.77
+        "@khanacademy/wonder-blocks-popover": ^6.3.17
         "@khanacademy/wonder-blocks-progress-spinner": ^3.1.62
-        "@khanacademy/wonder-blocks-search-field": ^5.1.83
-        "@khanacademy/wonder-blocks-switch": ^3.4.12
-        "@khanacademy/wonder-blocks-tabs": ^0.5.31
+        "@khanacademy/wonder-blocks-search-field": ^5.1.84
+        "@khanacademy/wonder-blocks-switch": ^3.4.13
+        "@khanacademy/wonder-blocks-tabs": ^0.5.32
         "@khanacademy/wonder-blocks-theming": ^4.1.0
         "@khanacademy/wonder-blocks-timing": ^7.1.0
         "@khanacademy/wonder-blocks-tokens": ^18.0.0
         "@khanacademy/wonder-blocks-toolbar": ^5.1.64
-        "@khanacademy/wonder-blocks-tooltip": ^4.2.5
+        "@khanacademy/wonder-blocks-tooltip": ^4.2.6
         "@khanacademy/wonder-blocks-typography": ^5.0.5
         "@khanacademy/wonder-stuff-core": ^3.0.0
     devDeps:
@@ -103,33 +103,33 @@ catalogs:
         "@phosphor-icons/core": 2.0.2
         "@popperjs/core": 2.10.2
         "@khanacademy/mathjax-renderer": 3.2.0
-        "@khanacademy/wonder-blocks-accordion": 3.1.72
+        "@khanacademy/wonder-blocks-accordion": 3.2.0
         "@khanacademy/wonder-blocks-announcer": 1.1.2
-        "@khanacademy/wonder-blocks-badge": 1.1.24
-        "@khanacademy/wonder-blocks-banner": 5.1.14
-        "@khanacademy/wonder-blocks-button": 11.7.10
-        "@khanacademy/wonder-blocks-clickable": 8.2.11
+        "@khanacademy/wonder-blocks-badge": 1.1.25
+        "@khanacademy/wonder-blocks-banner": 5.1.15
+        "@khanacademy/wonder-blocks-button": 11.7.11
+        "@khanacademy/wonder-blocks-clickable": 8.3.0
         "@khanacademy/wonder-blocks-core": 12.5.0
         "@khanacademy/wonder-blocks-data": 15.1.0
-        "@khanacademy/wonder-blocks-dropdown": 10.12.4
-        "@khanacademy/wonder-blocks-form": 7.6.13
-        "@khanacademy/wonder-blocks-icon-button": 11.5.1
+        "@khanacademy/wonder-blocks-dropdown": 10.12.5
+        "@khanacademy/wonder-blocks-form": 7.6.14
+        "@khanacademy/wonder-blocks-icon-button": 12.0.0
         "@khanacademy/wonder-blocks-icon": 6.0.2
         "@khanacademy/wonder-blocks-labeled-field": 4.1.11
         "@khanacademy/wonder-blocks-layout": 3.1.62
-        "@khanacademy/wonder-blocks-link": 10.3.12
-        "@khanacademy/wonder-blocks-modal": 8.8.2
-        "@khanacademy/wonder-blocks-pill": 3.1.76
-        "@khanacademy/wonder-blocks-popover": 6.3.16
+        "@khanacademy/wonder-blocks-link": 10.4.0
+        "@khanacademy/wonder-blocks-modal": 8.8.3
+        "@khanacademy/wonder-blocks-pill": 3.1.77
+        "@khanacademy/wonder-blocks-popover": 6.3.17
         "@khanacademy/wonder-blocks-progress-spinner": 3.1.62
-        "@khanacademy/wonder-blocks-search-field": 5.1.83
-        "@khanacademy/wonder-blocks-switch": 3.4.12
-        "@khanacademy/wonder-blocks-tabs": 0.5.31
+        "@khanacademy/wonder-blocks-search-field": 5.1.84
+        "@khanacademy/wonder-blocks-switch": 3.4.13
+        "@khanacademy/wonder-blocks-tabs": 0.5.32
         "@khanacademy/wonder-blocks-theming": 4.1.0
         "@khanacademy/wonder-blocks-timing": 7.1.0
         "@khanacademy/wonder-blocks-tokens": 18.0.0
         "@khanacademy/wonder-blocks-toolbar": 5.1.64
-        "@khanacademy/wonder-blocks-tooltip": 4.2.5
+        "@khanacademy/wonder-blocks-tooltip": 4.2.6
         "@khanacademy/wonder-blocks-typography": 5.0.5
         "@khanacademy/wonder-stuff-core": 3.0.0
     prodDeps:


### PR DESCRIPTION
## Summary:

Bumps the Wonder Blocks catalog entries in `pnpm-workspace.yaml` to their latest releases. Two of them needed follow-up:

- **`icon-button` 12.0.0** makes `aria-label` required. Added it to the two hint move buttons in the combined hints editor.
- **`clickable` 8.3.0 / `link` 10.4.0** add a WCAG 2.5.8 24×24 pointer target via a transparent `::after`, which appends an Aphrodite class to every Clickable- and Link-derived element. The 24 refreshed snapshots are that class and nothing else — no markup, attribute, or text changed.

### Related PRs
- Frontend integration PR: https://github.com/Khan/frontend/pull/16146
- WB release PR: https://github.com/Khan/wonder-blocks/pull/3212

Issue: "none"

## Test plan:

- `pnpm tsc` — clean
- `pnpm test` — 559 suites / 7,916 tests pass
- The hit area also sets `position: relative`. Checked the two places that position against a `Clickable`: the zoom-image overlay still wins with `position: absolute`, and label-image markers set no insets so they resolve by static position.
- Worth a visual pass in Storybook on the keypad, label-image markers, and graded-group-set indicators — Jest can't render the `::after` hit area.
