### PR TITLE
feat(LEMS-4498): Replaces Sorter rendering with Deprecated Stand in when cards > 10

### DIFF
--- a/.changeset/five-ravens-sing.md
+++ b/.changeset/five-ravens-sing.md
@@ -1,0 +1,6 @@
+---
+"@khanacademy/perseus-score": minor
+"@khanacademy/perseus": minor
+---
+
+Replaces Sorter with Deprecated Stand in when cards > 10

--- a/packages/perseus-score/src/widgets/sorter/score-sorter.test.ts
+++ b/packages/perseus-score/src/widgets/sorter/score-sorter.test.ts
@@ -1,8 +1,15 @@
-import {generateSorterOptions} from "@khanacademy/perseus-core";
+import {
+    generateSorterOptions,
+    SORTER_MAX_CARDS,
+} from "@khanacademy/perseus-core";
 
 import scoreSorter from "./score-sorter";
 
 import type {PerseusSorterUserInput} from "@khanacademy/perseus-core";
+
+function generateCards(count: number): string[] {
+    return Array.from({length: count}, (_, index) => `card ${index}`);
+}
 
 describe("scoreSorter", () => {
     it("is correct when the user input values are in the order defined in the rubric", () => {
@@ -31,6 +38,38 @@ describe("scoreSorter", () => {
         const rubric = generateSorterOptions({
             correct: ["$0.005$ kilograms", "$15$ grams", "$55$ grams"],
         });
+
+        // Act
+        const result = scoreSorter(userInput, rubric);
+
+        // Assert
+        expect(result).toHaveBeenAnsweredIncorrectly();
+    });
+
+    it("is correct when the rubric has more than the maximum number of cards", () => {
+        // Arrange
+        const correct = generateCards(SORTER_MAX_CARDS + 1);
+        const userInput: PerseusSorterUserInput = {
+            options: [...correct].reverse(),
+            changed: false,
+        };
+        const rubric = generateSorterOptions({correct});
+
+        // Act
+        const result = scoreSorter(userInput, rubric);
+
+        // Assert
+        expect(result).toHaveBeenAnsweredCorrectly();
+    });
+
+    it("is incorrect when the rubric has exactly the maximum number of cards", () => {
+        // Arrange
+        const correct = generateCards(SORTER_MAX_CARDS);
+        const userInput: PerseusSorterUserInput = {
+            options: [...correct].reverse(),
+            changed: true,
+        };
+        const rubric = generateSorterOptions({correct});
 
         // Act
         const result = scoreSorter(userInput, rubric);

--- a/packages/perseus-score/src/widgets/sorter/score-sorter.ts
+++ b/packages/perseus-score/src/widgets/sorter/score-sorter.ts
@@ -1,4 +1,7 @@
-import {approximateDeepEqual} from "@khanacademy/perseus-core";
+import {
+    approximateDeepEqual,
+    SORTER_MAX_CARDS,
+} from "@khanacademy/perseus-core";
 
 import type {
     PerseusSorterWidgetOptions,
@@ -10,6 +13,17 @@ function scoreSorter(
     userInput: PerseusSorterUserInput,
     rubric: PerseusSorterWidgetOptions,
 ): PerseusScore {
+    // These sorters render as the deprecated standin, so the learner was never
+    // shown anything to answer. Award the point so they aren't blocked.
+    if (rubric.correct.length > SORTER_MAX_CARDS) {
+        return {
+            type: "points",
+            earned: 1,
+            total: 1,
+            message: null,
+        };
+    }
+
     const correct = approximateDeepEqual(userInput.options, rubric.correct);
     return {
         type: "points",

--- a/packages/perseus/src/widgets/deprecated-standin/deprecated-standin.tsx
+++ b/packages/perseus/src/widgets/deprecated-standin/deprecated-standin.tsx
@@ -9,7 +9,10 @@ import type {Widget, WidgetExports} from "../../types";
 // deprecated widget
 type Props = object;
 
-class DeprecatedStandin extends React.Component<Props> implements Widget {
+export class DeprecatedStandin
+    extends React.Component<Props>
+    implements Widget
+{
     static contextType = PerseusI18nContext;
     declare context: React.ContextType<typeof PerseusI18nContext>;
 

--- a/packages/perseus/src/widgets/sorter/sorter.test.tsx
+++ b/packages/perseus/src/widgets/sorter/sorter.test.tsx
@@ -3,9 +3,10 @@ import {
     generateSorterWidget,
     generateTestPerseusItem,
     generateTestPerseusRenderer,
+    SORTER_MAX_CARDS,
     splitPerseusItem,
 } from "@khanacademy/perseus-core";
-import {act} from "@testing-library/react";
+import {act, screen} from "@testing-library/react";
 import * as React from "react";
 
 import * as Dependencies from "../../dependencies";
@@ -289,6 +290,45 @@ describe("sorter widget", () => {
                 // Assert
                 expect(score).toHaveBeenAnsweredIncorrectly();
             });
+        });
+    });
+
+    describe("legacy sorters with too many cards", () => {
+        const deprecatedStandinText =
+            "Sorry, this part of the question is no longer available. 😅 Don't worry, you won't be graded on this part. Keep going!";
+
+        function generateSorterQuestion(cardCount: number) {
+            return generateTestPerseusRenderer({
+                content: "[[☃ sorter 1]]",
+                widgets: {
+                    "sorter 1": generateSorterWidget({
+                        options: generateSorterOptions({
+                            correct: Array.from(
+                                {length: cardCount},
+                                (_, index) => `card ${index}`,
+                            ),
+                        }),
+                    }),
+                },
+            });
+        }
+
+        it("renders the deprecated standin above the card limit", () => {
+            // Arrange, Act
+            renderQuestion(generateSorterQuestion(SORTER_MAX_CARDS + 1));
+
+            // Assert
+            expect(screen.getByText(deprecatedStandinText)).toBeInTheDocument();
+        });
+
+        it("does not render the deprecated standin at the card limit", () => {
+            // Arrange, Act
+            renderQuestion(generateSorterQuestion(SORTER_MAX_CARDS));
+
+            // Assert
+            expect(
+                screen.queryByText(deprecatedStandinText),
+            ).not.toBeInTheDocument();
         });
     });
 });

--- a/packages/perseus/src/widgets/sorter/sorter.tsx
+++ b/packages/perseus/src/widgets/sorter/sorter.tsx
@@ -1,3 +1,4 @@
+import {SORTER_MAX_CARDS} from "@khanacademy/perseus-core";
 import {useOnMountEffect} from "@khanacademy/wonder-blocks-core";
 import * as React from "react";
 import {forwardRef, useImperativeHandle, useRef} from "react";
@@ -5,6 +6,7 @@ import {forwardRef, useImperativeHandle, useRef} from "react";
 import Sortable from "../../components/sortable";
 import {useDependencies} from "../../dependencies";
 import {getPromptJSON as _getPromptJSON} from "../../widget-ai-utils/sorter/sorter-ai-utils";
+import {DeprecatedStandin} from "../deprecated-standin/deprecated-standin";
 
 import type {SortableOption} from "../../components/sortable";
 import type {Widget, WidgetProps} from "../../types";
@@ -78,6 +80,13 @@ const Sorter = forwardRef<SorterHandle, Props>(function Sorter(props, ref) {
         });
 
         props.trackInteraction();
+    }
+
+    // Legacy content predates the card limit the editor now enforces. These
+    // sorters are unusable, so learners get the standin while authors keep the
+    // full editor to fix them with.
+    if (options.correct.length > SORTER_MAX_CARDS) {
+        return <DeprecatedStandin />;
     }
 
     return (


### PR DESCRIPTION
## Summary:
- Renders Deprecated Stand in when Sorter card count > Max (at this time its 10)
- Adds test to validate that its only being rendered in this specific scenario 
- Updates scoring to award a point for this specific scenario - since learners won't be able to answer the question
- Keeps sorter editable so it can be updated if necessary

Issue: LEMS-4498

Validated using [ZND](https://prod-znd-260911-16152-c62e04c.khanacademy.org/devadmin/content/exercises/calculating-the-interquartile-range--iqr-/xe91b98ba/x8b7dc878d705bdda)

## Test plan:
Learner View - Article > 10
<img width="872" height="561" alt="image" src="https://github.com/user-attachments/assets/55726274-2c93-4933-a323-dad64f9d40b9" />

Learner View - Exercise < 10 
<img width="595" height="298" alt="image" src="https://github.com/user-attachments/assets/1ca8b618-1e32-4e98-a9ee-b18c782511a3" />

Learner View - Exercise > 10 
<img width="895" height="407" alt="image" src="https://github.com/user-attachments/assets/d51ce428-30be-4f0b-bb90-1973e1873d53" />

Content Author View 
<img width="877" height="687" alt="image" src="https://github.com/user-attachments/assets/3224c9d6-4fe5-41da-8dd4-4830d673be2d" />

