### PR TITLE
Use parser to set `static` to undefined for visual-only widgets

### DIFF
--- a/.changeset/loose-rockets-smile.md
+++ b/.changeset/loose-rockets-smile.md
@@ -1,0 +1,5 @@
+---
+"@khanacademy/perseus-core": patch
+---
+
+Use parser to set `static` to undefined for visual-only widgets

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/definition-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/definition-widget.ts
@@ -8,4 +8,6 @@ export const parseDefinitionWidget = parseWidget(
         togglePrompt: string,
         definition: string,
     }),
+    // Definitions take no user input, so `static` has no answer to reveal.
+    {supportsStatic: false},
 );

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/explanation-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/explanation-widget.ts
@@ -18,4 +18,7 @@ export const parseExplanationWidget = parseWidget(
             () => ({}),
         ),
     }),
+    // An explanation takes no user input of its own. Its nested widgets each
+    // carry their own `static`, so dropping this one doesn't affect them.
+    {supportsStatic: false},
 );

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/image-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/image-widget.ts
@@ -43,4 +43,7 @@ export const parseImageWidget = parseWidget(
         ),
         box: defaulted(pairOfNumbers, (): [number, number] => [400, 400]),
     }),
+    // Images take no user input, so there's no answer to fill in and nothing
+    // to make immutable. Any `static` in the data is dropped.
+    {supportsStatic: false},
 );

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interaction-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/interaction-widget.ts
@@ -167,4 +167,7 @@ export const parseInteractionWidget = parseWidget(
                 .withBranch("rectangle", parseRectangleElement).parser,
         ),
     }),
+    // Interaction graphs are explorable but never scored: the learner's
+    // manipulations aren't collected, so `static` has no answer to reveal.
+    {supportsStatic: false},
 );

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/measurer-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/measurer-widget.ts
@@ -36,6 +36,9 @@ const parseMeasurerWidgetV1 = parseWidgetWithVersion(
         rulerLength: number,
         box: pair(number, number),
     }),
+    // The ruler and protractor are tools, not answers: nothing the learner
+    // does with them is collected, so `static` has no answer to reveal.
+    {supportsStatic: false},
 );
 
 const parseMeasurerWidgetV0 = parseWidget(
@@ -52,6 +55,8 @@ const parseMeasurerWidgetV0 = parseWidget(
         rulerLength: number,
         box: pair(number, number),
     }),
+    // See parseMeasurerWidgetV1.
+    {supportsStatic: false},
 );
 
 function migrateV0ToV1(

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/phet-simulation-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/phet-simulation-widget.ts
@@ -8,4 +8,7 @@ export const parsePhetSimulationWidget = parseWidget(
         url: string,
         description: string,
     }),
+    // The embedded simulation is never scored, so `static` has no answer to
+    // reveal.
+    {supportsStatic: false},
 );

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/python-program-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/python-program-widget.ts
@@ -8,4 +8,7 @@ export const parsePythonProgramWidget = parseWidget(
         programID: string,
         height: number,
     }),
+    // The embedded program is never scored, so `static` has no answer to
+    // reveal. (Unlike `cs-program`, this widget reports no user input back.)
+    {supportsStatic: false},
 );

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/video-widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/video-widget.ts
@@ -7,4 +7,6 @@ export const parseVideoWidget = parseWidget(
     object({
         location: string,
     }),
+    // Videos take no user input, so `static` has no answer to reveal.
+    {supportsStatic: false},
 );

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.test.ts
@@ -1,0 +1,163 @@
+import {constant, object, number} from "../general-purpose-parsers";
+import {parse} from "../parse";
+import {assertSuccess} from "../result";
+
+import {parseDefinitionWidget} from "./definition-widget";
+import {parseExplanationWidget} from "./explanation-widget";
+import {parseImageWidget} from "./image-widget";
+import {parseInteractionWidget} from "./interaction-widget";
+import {parseMeasurerWidget} from "./measurer-widget";
+import {parsePhetSimulationWidget} from "./phet-simulation-widget";
+import {parsePythonProgramWidget} from "./python-program-widget";
+import {parseVideoWidget} from "./video-widget";
+import {parseWidget, parseWidgetWithVersion} from "./widget";
+
+import type {Parser} from "../parser-types";
+
+const parseVersion = object({major: number, minor: number});
+
+describe("parseWidget", () => {
+    it("keeps `static` by default", () => {
+        const parser = parseWidget(constant("mock"), object({}));
+
+        const result = parse({type: "mock", static: true, options: {}}, parser);
+
+        assertSuccess(result);
+        expect(result.value.static).toBe(true);
+    });
+
+    it.each([true, false])(
+        "drops `static: %s` when supportsStatic is false",
+        (isStatic) => {
+            const parser = parseWidget(constant("mock"), object({}), {
+                supportsStatic: false,
+            });
+
+            const result = parse(
+                {type: "mock", static: isStatic, options: {}},
+                parser,
+            );
+
+            assertSuccess(result);
+            expect(result.value.static).toBe(undefined);
+        },
+    );
+});
+
+describe("parseWidgetWithVersion", () => {
+    it("keeps `static` by default", () => {
+        const parser = parseWidgetWithVersion(
+            parseVersion,
+            constant("mock"),
+            object({}),
+        );
+
+        const result = parse(
+            {
+                type: "mock",
+                static: true,
+                options: {},
+                version: {major: 1, minor: 0},
+            },
+            parser,
+        );
+
+        assertSuccess(result);
+        expect(result.value.static).toBe(true);
+    });
+
+    it("drops `static` when supportsStatic is false", () => {
+        const parser = parseWidgetWithVersion(
+            parseVersion,
+            constant("mock"),
+            object({}),
+            {supportsStatic: false},
+        );
+
+        const result = parse(
+            {
+                type: "mock",
+                static: true,
+                options: {},
+                version: {major: 1, minor: 0},
+            },
+            parser,
+        );
+
+        assertSuccess(result);
+        expect(result.value.static).toBe(undefined);
+    });
+});
+
+/**
+ * These widgets collect no user input and are never scored, so `static` — "show
+ * the correct answer and freeze the widget" — has no meaning for them. Their
+ * parsers drop it. Adding a widget here is a data-format change: check that it
+ * really takes no user input before doing so.
+ */
+describe.each([
+    ["definition", parseDefinitionWidget, {togglePrompt: "", definition: ""}],
+    [
+        "explanation",
+        parseExplanationWidget,
+        {showPrompt: "", hidePrompt: "", explanation: "", widgets: {}},
+    ],
+    ["image", parseImageWidget, {backgroundImage: {}}],
+    [
+        "interaction",
+        parseInteractionWidget,
+        {
+            graph: {
+                box: [1, 1],
+                range: [
+                    [-10, 10],
+                    [-10, 10],
+                ],
+                gridStep: [1, 1],
+                markings: "graph",
+                tickStep: [1, 1],
+                labels: [],
+            },
+            elements: [],
+        },
+    ],
+    [
+        "measurer",
+        parseMeasurerWidget,
+        {
+            image: {},
+            showProtractor: false,
+            showRuler: false,
+            rulerLabel: "",
+            rulerTicks: 1,
+            rulerPixels: 1,
+            rulerLength: 1,
+            box: [1, 1],
+        },
+    ],
+    ["phet-simulation", parsePhetSimulationWidget, {url: "", description: ""}],
+    ["python-program", parsePythonProgramWidget, {programID: "", height: 1}],
+    ["video", parseVideoWidget, {location: ""}],
+])("the %s widget parser", (type, parser: Parser<any>, options) => {
+    it("drops `static`, which the widget takes no user input to honor", () => {
+        // Arrange, Act
+        const result = parse(
+            {type, static: true, options, version: {major: 1, minor: 0}},
+            parser,
+        );
+
+        assertSuccess(result);
+        expect(result.value.static).toBe(undefined);
+    });
+
+    it("parses successfully when `static` is missing", () => {
+        // Arrange, Act
+        const result = parse(
+            {type, options, version: {major: 1, minor: 0}},
+            parser,
+        );
+
+        assertSuccess(result);
+        expect(result.value.static).toBe(undefined);
+    });
+});

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.ts
@@ -31,13 +31,46 @@ const parseAlignment = pipeParsers(optional(string)).then(
     convert(toValidAlignment),
 ).parser;
 
+/**
+ * `static: true` means "render this widget non-interactively, with the correct
+ * answer already filled in". That only means something for a widget that takes
+ * user input: no user input means no answer to fill in and nothing to freeze.
+ * Visual-only widgets have never read the flag, but plenty of existing content
+ * data sets it anyway, so we drop it here rather than carry a value whose
+ * meaning no widget honors.
+ *
+ * Note that this accepts any raw value without validating it. A widget that
+ * can't be static has no stake in whether the flag was well-formed, and
+ * failing the parse would reject content that renders fine. This matches how
+ * `object` silently ignores properties that a schema doesn't mention.
+ *
+ * One caveat: `widget-container` in @khanacademy/perseus applies a generic
+ * click-blocking overlay to *any* widget whose `static` is true, without
+ * asking the widget. Content that set `static: true` on a visual-only widget
+ * with its own affordances (a PhET sim, a measurer's ruler) therefore loses
+ * that overlay once the flag is dropped, and the affordance becomes usable
+ * again. That combination doesn't appear anywhere in our regression corpus.
+ */
+const parseUnsupportedStatic: Parser<boolean | undefined> = (_rawValue, ctx) =>
+    ctx.success(undefined);
+
+type WidgetParserOptions = {
+    /**
+     * Whether `static` is meaningful for this widget. Defaults to `true`; pass
+     * `false` for presentational widgets so that `static` parses to
+     * `undefined`. See `parseUnsupportedStatic`.
+     */
+    supportsStatic?: boolean;
+};
+
 export function parseWidget<Type extends string, Options extends object>(
     parseType: Parser<Type>,
     parseOptions: Parser<Options>,
+    {supportsStatic = true}: WidgetParserOptions = {},
 ) {
     return object({
         type: parseType,
-        static: optional(boolean),
+        static: supportsStatic ? optional(boolean) : parseUnsupportedStatic,
         graded: optional(boolean),
         alignment: parseAlignment,
         options: parseOptions,
@@ -58,10 +91,11 @@ export function parseWidgetWithVersion<
     parseVersion: Parser<{major: number; minor: number} | undefined>,
     parseType: Parser<Type>,
     parseOptions: Parser<Options>,
+    {supportsStatic = true}: WidgetParserOptions = {},
 ) {
     return object({
         type: parseType,
-        static: optional(boolean),
+        static: supportsStatic ? optional(boolean) : parseUnsupportedStatic,
         graded: optional(boolean),
         alignment: parseAlignment,
         options: parseOptions,

--- a/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widgets-map.test.ts
+++ b/packages/perseus-core/src/parse-perseus-json/perseus-parsers/widgets-map.test.ts
@@ -147,6 +147,9 @@ describe("parseWidgetsMap", () => {
     it("accepts a definition widget", () => {
         const widgetsMap: PerseusWidgetsMap = {
             "definition 1": generateDefinitionWidget({
+                // Definitions take no user input, so the parser drops
+                // `static`. See widget.test.ts.
+                static: undefined,
                 options: generateDefinitionOptions({
                     togglePrompt: "",
                     definition: "",
@@ -829,7 +832,9 @@ describe("parseWidgetsMap", () => {
 
     it("accepts a video widget", () => {
         const widgetsMap: unknown = {
-            "video 1": generateVideoWidget(),
+            // Videos take no user input, so the parser drops `static`.
+            // See widget.test.ts.
+            "video 1": generateVideoWidget({static: undefined}),
         };
 
         const result = parse(widgetsMap, parseWidgetsMap);

--- a/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
+++ b/packages/perseus-core/src/parse-perseus-json/regression-tests/__snapshots__/parse-perseus-json-regression.test.ts.snap
@@ -46,7 +46,7 @@ Whether or not we have specific numbers, conceptually we can measure the opportu
           "showPrompt": "The PPF looks a bit like a budget constraint. How is it different?",
           "widgets": {},
         },
-        "static": false,
+        "static": undefined,
         "type": "explanation",
         "version": {
           "major": 0,
@@ -84,7 +84,7 @@ Whether or not we have specific numbers, conceptually we can measure the opportu
           "scale": 1,
           "title": "A Healthcare vs. Education Production Possibilities Frontier ",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -163,7 +163,7 @@ The particular mix of goods and services being produced—that is, the specific 
           "scale": 1,
           "title": "Productive and Allocative Efficiency ",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -227,7 +227,7 @@ The slope of the PPF gives the opportunity cost of producing an additional unit 
           "scale": 1,
           "title": "Production Possibility Frontier for the U.S. and Brazil ",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -276,7 +276,7 @@ Because of the improvement in technology, the vertical intercept of the PPF woul
           "showPrompt": "Show Solution",
           "widgets": {},
         },
-        "static": false,
+        "static": undefined,
         "type": "explanation",
         "version": {
           "major": 0,
@@ -294,7 +294,7 @@ No. Allocative efficiency requires productive efficiency, because it pertains to
           "showPrompt": "Show Solution",
           "widgets": {},
         },
-        "static": false,
+        "static": undefined,
         "type": "explanation",
         "version": {
           "major": 0,
@@ -312,7 +312,7 @@ Both the budget constraint and the PPF show the constraint that each operates un
           "showPrompt": "Show Solution",
           "widgets": {},
         },
-        "static": false,
+        "static": undefined,
         "type": "explanation",
         "version": {
           "major": 0,
@@ -350,7 +350,7 @@ Both the budget constraint and the PPF show the constraint that each operates un
           "scale": 1,
           "title": "Productive and Allocative Efficiency ",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -419,7 +419,7 @@ The modified article is licensed under a [CC BY-NC-SA 4.0](https://creativecommo
           "showPrompt": "Attribution",
           "widgets": {},
         },
-        "static": false,
+        "static": undefined,
         "type": "explanation",
         "version": {
           "major": 0,
@@ -1070,7 +1070,7 @@ exports[`parseAndMigratePerseusItem given definition-missing-static.ts returns t
           "definition": "",
           "togglePrompt": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "definition",
         "version": {
           "major": 0,
@@ -2379,7 +2379,7 @@ more explanation",
           "showPrompt": "Show Avogadro's number",
           "widgets": {},
         },
-        "static": false,
+        "static": undefined,
         "type": "explanation",
         "version": {
           "major": 0,
@@ -2395,7 +2395,7 @@ more explanation",
           "showPrompt": "Show Avogadro's number",
           "widgets": {},
         },
-        "static": false,
+        "static": undefined,
         "type": "explanation",
         "version": {
           "major": 0,
@@ -2485,7 +2485,7 @@ more explanation",
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -2571,7 +2571,7 @@ more explanation",
           "showPrompt": "Show Avogadro's number",
           "widgets": {},
         },
-        "static": false,
+        "static": undefined,
         "type": "explanation",
         "version": {
           "major": 0,
@@ -2587,7 +2587,7 @@ more explanation",
           "showPrompt": "Show Avogadro's number",
           "widgets": {},
         },
-        "static": false,
+        "static": undefined,
         "type": "explanation",
         "version": {
           "major": 0,
@@ -2655,7 +2655,7 @@ more explanation",
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -2706,7 +2706,7 @@ For example, for $\\vec{v}=(a,b)$ and $\\vec{u}=(c,d)$, we have $\\vec{v}\\cdot\
             "showPrompt": "I don't know what "vector dot product" is!",
             "widgets": {},
           },
-          "static": false,
+          "static": undefined,
           "type": "explanation",
           "version": {
             "major": 0,
@@ -4243,7 +4243,7 @@ exports[`parseAndMigratePerseusItem given image-missing-defaulted-fields.ts retu
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -4300,7 +4300,7 @@ exports[`parseAndMigratePerseusItem given image-missing-defaulted-fields.ts retu
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -4372,7 +4372,7 @@ exports[`parseAndMigratePerseusItem given image-with-null-dimensions.ts returns 
             "scale": 1,
             "title": "",
           },
-          "static": false,
+          "static": undefined,
           "type": "image",
           "version": {
             "major": 0,
@@ -4423,7 +4423,7 @@ exports[`parseAndMigratePerseusItem given image-with-null-dimensions.ts returns 
             "scale": 1,
             "title": "",
           },
-          "static": false,
+          "static": undefined,
           "type": "image",
           "version": {
             "major": 0,
@@ -4474,7 +4474,7 @@ exports[`parseAndMigratePerseusItem given image-with-null-dimensions.ts returns 
             "scale": 1,
             "title": "",
           },
-          "static": false,
+          "static": undefined,
           "type": "image",
           "version": {
             "major": 0,
@@ -4532,7 +4532,7 @@ exports[`parseAndMigratePerseusItem given image-with-null-dimensions.ts returns 
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -4673,7 +4673,7 @@ exports[`parseAndMigratePerseusItem given image-with-null-dimensions.ts returns 
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -5547,7 +5547,7 @@ exports[`parseAndMigratePerseusItem given interaction-element-missing-constraint
             "valid": true,
           },
         },
-        "static": false,
+        "static": undefined,
         "type": "interaction",
         "version": {
           "major": 0,
@@ -6165,7 +6165,7 @@ Next, we'll look at some other representations of functions!",
             "valid": true,
           },
         },
-        "static": false,
+        "static": undefined,
         "type": "interaction",
         "version": {
           "major": 0,
@@ -6252,7 +6252,7 @@ Next, we'll look at some other representations of functions!",
             "valid": true,
           },
         },
-        "static": false,
+        "static": undefined,
         "type": "interaction",
         "version": {
           "major": 0,
@@ -6339,7 +6339,7 @@ Next, we'll look at some other representations of functions!",
             "valid": true,
           },
         },
-        "static": false,
+        "static": undefined,
         "type": "interaction",
         "version": {
           "major": 0,
@@ -6426,7 +6426,7 @@ Next, we'll look at some other representations of functions!",
             "valid": true,
           },
         },
-        "static": false,
+        "static": undefined,
         "type": "interaction",
         "version": {
           "major": 0,
@@ -6513,7 +6513,7 @@ Next, we'll look at some other representations of functions!",
             "valid": true,
           },
         },
-        "static": false,
+        "static": undefined,
         "type": "interaction",
         "version": {
           "major": 0,
@@ -9961,7 +9961,7 @@ As we can see the direction of the vertical component is downwards $(\\downarrow
             "scale": 1,
             "title": "",
           },
-          "static": false,
+          "static": undefined,
           "type": "image",
           "version": {
             "major": 0,
@@ -10030,7 +10030,7 @@ $\\begin{align}
                   "scale": 1,
                   "title": "",
                 },
-                "static": false,
+                "static": undefined,
                 "type": "image",
                 "version": {
                   "major": 0,
@@ -10094,7 +10094,7 @@ $\\begin{align}
               },
             },
           },
-          "static": false,
+          "static": undefined,
           "type": "explanation",
           "version": {
             "major": 0,
@@ -11750,7 +11750,7 @@ ___
           "definition": "A trophy awarded each year to the top college football player in the United States",
           "togglePrompt": "Heisman Trophy",
         },
-        "static": false,
+        "static": undefined,
         "type": "definition",
         "version": {
           "major": 0,
@@ -11767,7 +11767,7 @@ ___
           "showPrompt": "Attribution",
           "widgets": {},
         },
-        "static": false,
+        "static": undefined,
         "type": "explanation",
         "version": {
           "major": 0,
@@ -11810,7 +11810,7 @@ ___
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -11912,7 +11912,7 @@ ___
           "definition": "A trophy awarded each year to the top college football player in the United States",
           "togglePrompt": "Heisman Trophy",
         },
-        "static": false,
+        "static": undefined,
         "type": "definition",
         "version": {
           "major": 0,
@@ -11929,7 +11929,7 @@ ___
           "showPrompt": "Attribution",
           "widgets": {},
         },
-        "static": false,
+        "static": undefined,
         "type": "explanation",
         "version": {
           "major": 0,
@@ -11969,7 +11969,7 @@ ___
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -13079,7 +13079,7 @@ $x_1\\cdot\\left[\\begin{array}{c}1\\\\\\\\0\\\\\\\\0\\\\\\\\0\\end{array}\\righ
             "showPrompt": "Why is this true?",
             "widgets": {},
           },
-          "static": false,
+          "static": undefined,
           "type": "explanation",
           "version": {
             "major": 0,
@@ -13565,7 +13565,7 @@ exports[`parseAndMigratePerseusItem given measurer-missing-image.ts returns the 
           "showProtractor": true,
           "showRuler": false,
         },
-        "static": false,
+        "static": undefined,
         "type": "measurer",
         "version": {
           "major": 1,
@@ -13653,7 +13653,7 @@ exports[`parseAndMigratePerseusItem given measurer-missing-static.ts returns the
           "showProtractor": true,
           "showRuler": true,
         },
-        "static": false,
+        "static": undefined,
         "type": "measurer",
         "version": {
           "major": 1,
@@ -13876,7 +13876,7 @@ exports[`parseAndMigratePerseusItem given measurer-missing-version.ts returns th
           "showProtractor": true,
           "showRuler": false,
         },
-        "static": false,
+        "static": undefined,
         "type": "measurer",
         "version": {
           "major": 1,
@@ -16028,7 +16028,7 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-null-answerForms.ts
             "scale": 1,
             "title": "",
           },
-          "static": false,
+          "static": undefined,
           "type": "image",
           "version": {
             "major": 0,
@@ -16079,7 +16079,7 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-null-answerForms.ts
             "scale": 1,
             "title": "",
           },
-          "static": false,
+          "static": undefined,
           "type": "image",
           "version": {
             "major": 0,
@@ -16130,7 +16130,7 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-null-answerForms.ts
             "scale": 1,
             "title": "",
           },
-          "static": false,
+          "static": undefined,
           "type": "image",
           "version": {
             "major": 0,
@@ -16209,7 +16209,7 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-null-answerForms.ts
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -16438,7 +16438,7 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-null-answerForms.ts
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -16635,7 +16635,7 @@ We are given the measure of an angle and the length of the $\\purpleC{\\text{hyp
             "scale": 1,
             "title": "",
           },
-          "static": false,
+          "static": undefined,
           "type": "image",
           "version": {
             "major": 0,
@@ -16711,7 +16711,7 @@ Stella landed $1.68$ kilometers from the skydiving center.",
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -16856,7 +16856,7 @@ exports[`parseAndMigratePerseusItem given numeric-input-with-simplify-accepted.t
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -17314,7 +17314,7 @@ A **unit fraction** is a fraction with a numerator of $1$. [[☃ explanation 2]]
             "showPrompt": "Show me an example",
             "widgets": {},
           },
-          "static": false,
+          "static": undefined,
           "type": "explanation",
           "version": {
             "major": 0,
@@ -17330,7 +17330,7 @@ A **unit fraction** is a fraction with a numerator of $1$. [[☃ explanation 2]]
             "showPrompt": "Show me an example",
             "widgets": {},
           },
-          "static": false,
+          "static": undefined,
           "type": "explanation",
           "version": {
             "major": 0,
@@ -17373,7 +17373,7 @@ $\\dfrac59$ can be broken up into $\\dfrac19+\\dfrac19+\\dfrac19+\\dfrac19+\\dfr
             "showPrompt": "Show solution",
             "widgets": {},
           },
-          "static": false,
+          "static": undefined,
           "type": "explanation",
           "version": {
             "major": 0,
@@ -17508,7 +17508,7 @@ How can we decompose $\\dfrac38$?
             "showPrompt": "Show solution",
             "widgets": {},
           },
-          "static": false,
+          "static": undefined,
           "type": "explanation",
           "version": {
             "major": 0,
@@ -17603,7 +17603,7 @@ How can we decompose $\\dfrac64$?
             "showPrompt": "Show solution",
             "widgets": {},
           },
-          "static": false,
+          "static": undefined,
           "type": "explanation",
           "version": {
             "major": 0,
@@ -17759,7 +17759,7 @@ How can we decompose $\\dfrac64$?
             "showPrompt": "Show solution",
             "widgets": {},
           },
-          "static": false,
+          "static": undefined,
           "type": "explanation",
           "version": {
             "major": 0,
@@ -17775,7 +17775,7 @@ How can we decompose $\\dfrac64$?
             "showPrompt": "Show solution",
             "widgets": {},
           },
-          "static": false,
+          "static": undefined,
           "type": "explanation",
           "version": {
             "major": 0,
@@ -17792,7 +17792,7 @@ How can we decompose $\\dfrac64$?
             "showPrompt": "Show solution",
             "widgets": {},
           },
-          "static": false,
+          "static": undefined,
           "type": "explanation",
           "version": {
             "major": 0,
@@ -17814,7 +17814,7 @@ $\\dfrac23$ | $\\dfrac13+\\dfrac13$",
             "showPrompt": "Show solution",
             "widgets": {},
           },
-          "static": false,
+          "static": undefined,
           "type": "explanation",
           "version": {
             "major": 0,
@@ -18522,7 +18522,7 @@ A free body diagram of the **box** is shown below.
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -18560,7 +18560,7 @@ A free body diagram of the **box** is shown below.
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -18726,7 +18726,7 @@ A free body diagram of the **box** is shown below.
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -18764,7 +18764,7 @@ A free body diagram of the **box** is shown below.
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -20728,7 +20728,7 @@ exports[`parseAndMigratePerseusItem given radio-with-extra-fields-from-go-schema
           "definition": "Phy·si·cal (fih-sic-ull): Having to do with the body",
           "togglePrompt": "physical",
         },
-        "static": false,
+        "static": undefined,
         "type": "definition",
         "version": {
           "major": 0,
@@ -20743,7 +20743,7 @@ exports[`parseAndMigratePerseusItem given radio-with-extra-fields-from-go-schema
           "definition": "Life·long (life-long): Lasting your whole life",
           "togglePrompt": "lifelong",
         },
-        "static": false,
+        "static": undefined,
         "type": "definition",
         "version": {
           "major": 0,
@@ -20758,7 +20758,7 @@ exports[`parseAndMigratePerseusItem given radio-with-extra-fields-from-go-schema
           "definition": "Men·tal (men-tull): Having to do with the mind",
           "togglePrompt": "mental",
         },
-        "static": false,
+        "static": undefined,
         "type": "definition",
         "version": {
           "major": 0,
@@ -20775,7 +20775,7 @@ exports[`parseAndMigratePerseusItem given radio-with-extra-fields-from-go-schema
           "showPrompt": "Attribution",
           "widgets": {},
         },
-        "static": false,
+        "static": undefined,
         "type": "explanation",
         "version": {
           "major": 0,
@@ -20818,7 +20818,7 @@ exports[`parseAndMigratePerseusItem given radio-with-extra-fields-from-go-schema
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -20943,7 +20943,7 @@ exports[`parseAndMigratePerseusItem given radio-with-extra-fields-from-go-schema
           "definition": "Phy·si·cal (fih-sic-ull): Having to do with the body",
           "togglePrompt": "physical",
         },
-        "static": false,
+        "static": undefined,
         "type": "definition",
         "version": {
           "major": 0,
@@ -20958,7 +20958,7 @@ exports[`parseAndMigratePerseusItem given radio-with-extra-fields-from-go-schema
           "definition": "Life·long (life-long): Lasting your whole life",
           "togglePrompt": "lifelong",
         },
-        "static": false,
+        "static": undefined,
         "type": "definition",
         "version": {
           "major": 0,
@@ -20973,7 +20973,7 @@ exports[`parseAndMigratePerseusItem given radio-with-extra-fields-from-go-schema
           "definition": "Men·tal (men-tull): Having to do with the mind",
           "togglePrompt": "mental",
         },
-        "static": false,
+        "static": undefined,
         "type": "definition",
         "version": {
           "major": 0,
@@ -20990,7 +20990,7 @@ exports[`parseAndMigratePerseusItem given radio-with-extra-fields-from-go-schema
           "showPrompt": "Attribution",
           "widgets": {},
         },
-        "static": false,
+        "static": undefined,
         "type": "explanation",
         "version": {
           "major": 0,
@@ -21030,7 +21030,7 @@ exports[`parseAndMigratePerseusItem given radio-with-extra-fields-from-go-schema
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -21113,7 +21113,7 @@ exports[`parseAndMigratePerseusItem given radio-with-null-options.ts returns the
             "showPrompt": "Explain",
             "widgets": {},
           },
-          "static": false,
+          "static": undefined,
           "type": "explanation",
           "version": {
             "major": 0,
@@ -21359,7 +21359,7 @@ ___
           "showPrompt": "Attribution",
           "widgets": {},
         },
-        "static": false,
+        "static": undefined,
         "type": "explanation",
         "version": {
           "major": 0,
@@ -21402,7 +21402,7 @@ ___
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -21534,7 +21534,7 @@ ___
           "showPrompt": "Attribution",
           "widgets": {},
         },
-        "static": false,
+        "static": undefined,
         "type": "explanation",
         "version": {
           "major": 0,
@@ -21574,7 +21574,7 @@ ___
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -21681,7 +21681,7 @@ exports[`parseAndMigratePerseusItem given radio-with-weird-alignment.ts returns 
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,
@@ -21779,7 +21779,7 @@ exports[`parseAndMigratePerseusItem given radio-with-weird-alignment.ts returns 
           "scale": 1,
           "title": "",
         },
-        "static": false,
+        "static": undefined,
         "type": "image",
         "version": {
           "major": 0,


### PR DESCRIPTION
## Summary:
There are some widgets that should never be allowed to have the `static` prop
set, whether true or false. It wouldn't make any sense to consider disallowing
interactions on these widgets.

To avoid `static` mistakenly being used for these widgets, I'm updating the
parser so that it automatically sets `static` to undefined.

Issue: https://khanacademy.atlassian.net/browse/LEMS-4551

## Test plan:
`pnpm jest packages/perseus-core/src/parse-perseus-json/perseus-parsers/widget.test.ts`